### PR TITLE
docs: stabilize planning template packet

### DIFF
--- a/docs/templates/planning/1.0.0/decisions.md
+++ b/docs/templates/planning/1.0.0/decisions.md
@@ -1,4 +1,4 @@
-# Decisions Template
+# <milestone> Decisions
 
 ## Metadata
 - Milestone: `<milestone>`

--- a/docs/templates/planning/1.0.0/demo_matrix.md
+++ b/docs/templates/planning/1.0.0/demo_matrix.md
@@ -1,4 +1,8 @@
-# Demo Matrix Template
+# <milestone> Demo Matrix
+
+## Status
+
+`<status>`
 
 ## Metadata
 - Milestone: `<milestone>`
@@ -81,7 +85,7 @@ Status guidance:
 
 Repeat one block per demo in the coverage summary.
 
-### <demo_id_1>) <demo_title_1>
+### <demo_id_1> - <demo_title_1>
 
 Description:
 - <demo_description_1>
@@ -126,7 +130,7 @@ Known limits / caveats:
 
 ---
 
-### <demo_id_2>) <demo_title_2>
+### <demo_id_2> - <demo_title_2>
 
 Description:
 - <demo_description_2>
@@ -161,7 +165,7 @@ Known limits / caveats:
 
 ---
 
-### <demo_id_3>) <demo_title_3>
+### <demo_id_3> - <demo_title_3>
 
 Description:
 - <demo_description_3>

--- a/docs/templates/planning/1.0.0/design.md
+++ b/docs/templates/planning/1.0.0/design.md
@@ -1,4 +1,4 @@
-# Design Template
+# <milestone> Design
 
 ## Metadata
 - Milestone: `<milestone>`
@@ -22,11 +22,11 @@ Define what we are building, why, and how we validate it — concisely, with lin
 - <non_goal_2>
 
 ## Scope
-### In scope
+### In Scope
 - <in_scope_1>
 - <in_scope_2>
 
-### Out of scope
+### Out Of Scope
 - <out_of_scope_1>
 - <out_of_scope_2>
 
@@ -35,7 +35,7 @@ Define what we are building, why, and how we validate it — concisely, with lin
 - <functional_requirement_1>
 - <functional_requirement_2>
 
-### Non-functional
+### Non-Functional
 - Deterministic behavior and reproducible outputs.
 - Clear failure semantics and observability.
 - <non_functional_requirement_1>
@@ -44,14 +44,14 @@ Define what we are building, why, and how we validate it — concisely, with lin
 ### Overview
 <architecture_summary>
 
-### Interfaces / Data contracts
+### Interfaces And Contracts
 - <interface_or_contract_1>
 - <interface_or_contract_2>
 
-### Execution semantics
+### Execution Semantics
 <execution_semantics>
 
-## Risks and Mitigations
+## Risks And Mitigations
 - Risk: <risk_1>
   - Mitigation: <mitigation_1>
 - Risk: <risk_2>

--- a/docs/templates/planning/1.0.0/milestone_checklist.md
+++ b/docs/templates/planning/1.0.0/milestone_checklist.md
@@ -1,4 +1,4 @@
-# Milestone Checklist Template
+# <milestone> Milestone Checklist
 
 ## Metadata
 - Milestone: `<milestone>`

--- a/docs/templates/planning/1.0.0/readme.md
+++ b/docs/templates/planning/1.0.0/readme.md
@@ -1,132 +1,137 @@
-
-
-# Milestone README Template
+# <milestone> Milestone README
 
 ## Metadata
 - Milestone: `<milestone>`
 - Version: `<version>`
 - Date: `<date>`
 - Owner: `<owner>`
+- Status: `<status>`
+
+## Status
+
+Current status: `<status>`
+
+- Planning: `<planning_status>`
+- Execution: `<execution_status>`
+- Validation: `<validation_status>`
+- Release readiness: `<release_status>`
 
 ## Purpose
-Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
 
-## How To Use
-- Start here before reading individual milestone documents.
-- Use this README to locate the canonical design, execution, and validation surfaces.
-- Keep this document concise and navigational; detailed content belongs in the linked docs.
-- Keep links up to date as files move or are renamed.
+Provide the canonical entry point for `<milestone>`: why it exists, what it changes, what is in and out of scope, and where reviewers should go for design, execution, demo, proof, and release evidence.
 
-## Overview
+## Milestone Role
 
-`<milestone>` represents the stage where `<project_name>` moves from `<previous_state>` to `<target_state>`.
+`<milestone>` moves `<project_name>` from `<previous_state>` to `<target_state>`.
 
-This milestone focuses on:
-- <focus_1>
-- <focus_2>
-- <focus_3>
+This milestone exists to:
 
-Key outcomes:
-- <outcome_1>
-- <outcome_2>
-- <outcome_3>
+- `<focus_1>`
+- `<focus_2>`
+- `<focus_3>`
 
-## Scope Summary
+Expected outcomes:
 
-### In scope
-- <in_scope_1>
-- <in_scope_2>
-- <in_scope_3>
+- `<outcome_1>`
+- `<outcome_2>`
+- `<outcome_3>`
 
-### Out of scope
-- <out_of_scope_1>
-- <out_of_scope_2>
+## Boundaries
 
-## Document Map
+In scope:
 
-Canonical milestone documents:
+- `<in_scope_1>`
+- `<in_scope_2>`
+- `<in_scope_3>`
+
+Out of scope:
+
+- `<out_of_scope_1>`
+- `<out_of_scope_2>`
+
+Known risks:
+
+- `<risk_1>`
+- `<risk_2>`
+
+Open questions:
+
+- `<open_question_1>`
+- `<open_question_2>`
+
+## Source Map
+
+Primary planning and proof sources:
 
 - Vision: `<vision_doc>`
 - Design: `<design_doc>`
-- Work Breakdown Structure (WBS): `<wbs_doc>`
+- Work Breakdown Structure: `<wbs_doc>`
 - Sprint plan: `<sprint_doc>`
 - Decisions log: `<decisions_doc>`
 - Demo matrix: `<demo_matrix_doc>`
 - Milestone checklist: `<checklist_doc>`
-- Release plan / process: `<release_process_doc>`
+- Release plan: `<release_process_doc>`
 - Release notes: `<release_notes_doc>`
 
 Supporting / domain-specific docs:
-- <supporting_doc_1>
-- <supporting_doc_2>
-- <supporting_doc_3>
+
+- `<supporting_doc_1>`
+- `<supporting_doc_2>`
+- `<supporting_doc_3>`
+
+## Document Map
+
+Use the source map above as the canonical navigation surface. Keep this README concise; details belong in the linked milestone documents.
+
+## <sidecar_heading>
+
+If this milestone includes a sidecar, record it here rather than hiding it in chat or issue comments.
+
+- Sidecar scope: `<sidecar_scope>`
+- Sidecar boundary: `<sidecar_boundary>`
+- Sidecar proof surface: `<sidecar_proof_surface>`
+
+If no sidecar exists, set these values to `not applicable`.
 
 ## Execution Model
 
-This milestone is executed as a sequence of work packages (WPs). The exact WP count is milestone-specific.
+This milestone is executed as an ordered issue/PR sequence. The exact WP count is milestone-specific.
 
-Sequencing expectations:
+Execution expectations:
+
 - WP-01 is the design/planning pass.
 - Feature and system work occupy the middle of the sequence.
 - Demo/proof, quality, docs/review convergence, and release ceremony work happen at the tail.
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Each WP records focused validation and merge/readiness proof.
 - Do not hard-code a 16-WP shape unless that milestone explicitly uses it.
-
-Execution expectations:
-- Each WP is tracked by an issue and implemented via PRs.
-- Each issue follows the structured card lifecycle
-  `SIP -> STP -> SPP -> SRP -> SOR`, plus any required reports.
-- Each WP records its own focused validation and merge/readiness proof.
 
 ## Demo and Validation Surface
 
-Primary validation is defined in:
-- Demo matrix: `<demo_matrix_doc>`
+Primary validation is defined in `<demo_matrix_doc>`.
 
 Additional validation surfaces:
+
 - Test suite results
 - Generated artifacts under `.adl/runs/`
 - Trace and replay outputs
 
-Success criteria:
-- <success_criteria_1>
-- <success_criteria_2>
-- <success_criteria_3>
+Determinism evidence:
 
-## Determinism and Reproducibility
+- `<determinism_evidence_path_1>`
+- `<determinism_evidence_path_2>`
 
-The milestone should demonstrate:
-- Deterministic or bounded-repeatable execution where required
-- Replayable traces and inspectable artifacts
-- Stable command entry points for demos
+## Success Criteria
 
-Evidence locations:
-- <determinism_evidence_path_1>
-- <determinism_evidence_path_2>
-
-## Risks and Open Questions
-
-Known risks:
-- <risk_1>
-- <risk_2>
-
-Open questions:
-- <open_question_1>
-- <open_question_2>
-
-## Status
-
-Current status: <status>
-
-- Planning: <planning_status>
-- Execution: <execution_status>
-- Validation: <validation_status>
-- Release readiness: <release_status>
+- `<success_criteria_1>`
+- `<success_criteria_2>`
+- `<success_criteria_3>`
 
 ## Exit Criteria
 
 - All canonical milestone documents are complete and internally consistent.
 - All WBS items are implemented or explicitly deferred.
 - Demo matrix is runnable and validated.
-- Quality gates (fmt, clippy, test, CI) are passing.
+- Quality gates relevant to touched surfaces are passing or exceptions are documented.
 - Milestone checklist is complete or exceptions are documented.
-- Release artifacts (notes, tag, docs) are ready.
+- Release artifacts are ready.

--- a/docs/templates/planning/1.0.0/release_notes.md
+++ b/docs/templates/planning/1.0.0/release_notes.md
@@ -1,4 +1,4 @@
-# Release Notes Template
+# <milestone> Release Notes
 
 ## Metadata
 - Product: `<product_name>`

--- a/docs/templates/planning/1.0.0/release_plan.md
+++ b/docs/templates/planning/1.0.0/release_plan.md
@@ -1,4 +1,4 @@
-# Release Process Template
+# <milestone> Release Plan
 
 ## Metadata
 - Milestone: `<milestone>`
@@ -13,7 +13,7 @@
 - Ceremony is a confirmation and publication phase, not a hidden implementation
   phase.
 
-## 0) Release-Tail Convergence
+## 0. Release-Tail Convergence
 - [ ] Live trackers refreshed and reflected honestly:
   - coverage/test tracker
   - Rust module watch / refactoring tracker
@@ -35,31 +35,31 @@
 - [ ] Next-milestone handoff prepared before ceremony starts
 - [ ] Any remaining work is either landed, explicitly deferred, or routed
 
-## 1) Release Readiness
+## 1. Release Readiness
 - [ ] Milestone checklist complete (`<milestone_checklist_link>`)
 - [ ] Release notes approved (`<release_notes_link>`)
 - [ ] Go/no-go decision recorded (`<decision_link>`)
 
-## 2) Branch And Tag Preparation
+## 2. Branch And Tag Preparation
 - [ ] Target branch confirmed (`<target_branch>`)
 - [ ] Working tree clean
 - [ ] Version string(s) validated (`<version_validation_link>`)
 - [ ] Tag created: `<tag_name>`
 - [ ] Tag pushed and verified
 
-## 3) GitHub Release Steps
+## 3. GitHub Release Steps
 - [ ] GitHub Release draft created from `<tag_name>` (`<release_draft_link>`)
 - [ ] Release body populated from approved notes
 - [ ] Links to key PRs/issues included
 - [ ] Release visibility confirmed (draft/prerelease/final)
 - [ ] Release published
 
-## 4) Verification
+## 4. Verification
 - [ ] Post-release CI status checked (`<ci_run_link>`)
 - [ ] Release links tested (docs, artifacts, notes)
 - [ ] Immediate regressions triaged and tracked (`<triage_link>`)
 
-## 5) Communication
+## 5. Communication
 - [ ] Community announcement published (`<announcement_link>`)
 - [ ] Internal update posted (`<internal_update_link>`)
 - [ ] Roadmap/status updated (`<roadmap_update_link>`)

--- a/docs/templates/planning/1.0.0/sprint.md
+++ b/docs/templates/planning/1.0.0/sprint.md
@@ -1,4 +1,4 @@
-# Sprint Template
+# <milestone> Sprint Plan
 
 ## Metadata
 - Sprint: `<sprint_id>`
@@ -6,44 +6,94 @@
 - Start date: `<start_date>`
 - End date: `<end_date>`
 - Owner: `<owner>`
+- Status: `<status>`
+
+## Status
+
+`<status>`
 
 ## How To Use
-- Keep scope small enough to finish with green CI and merged PRs.
-- List work items in planned execution order.
-- Track blockers here (not scattered chat notes).
+
+- List work in planned execution order.
+- Track blockers here rather than scattered chat notes.
+- Keep sidecar or support work visible and bounded.
+- Record closeout expectations before execution begins.
+
+## Sprint Overview
+
+`<sprint_goal>`
+
+Planned scope:
+
+- `<scope_item_1>`
+- `<scope_item_2>`
+- `<scope_item_3>`
+
+## <sidecar_sprint_heading>
+
+- Scope: `<sidecar_scope>`
+- Boundary: `<sidecar_boundary>`
+- Proof surface: `<sidecar_proof_surface>`
+
+## Sprint Goals
+
+- `<work_item_1>`
+- `<work_item_2>`
+- `<work_item_3>`
 
 ## Sprint Goal
-<sprint_goal>
+
+`<sprint_goal>`
 
 ## Planned Scope
-- <scope_item_1>
-- <scope_item_2>
-- <scope_item_3>
+
+- `<scope_item_1>`
+- `<scope_item_2>`
+- `<scope_item_3>`
 
 ## Work Plan
+
 | Order | Item | Issue | Owner | Status |
 |---|---|---|---|---|
-| 1 | <work_item_1> | <issue_1> | <owner_1> | <status_1> |
-| 2 | <work_item_2> | <issue_2> | <owner_2> | <status_2> |
-| 3 | <work_item_3> | <issue_3> | <owner_3> | <status_3> |
+| 1 | `<work_item_1>` | `<issue_1>` | `<owner_1>` | `<status_1>` |
+| 2 | `<work_item_2>` | `<issue_2>` | `<owner_2>` | `<status_2>` |
+| 3 | `<work_item_3>` | `<issue_3>` | `<owner_3>` | `<status_3>` |
+
+## Execution Policy
+
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run the smallest meaningful validation for each touched surface.
+- Record proof truthfully in issue-local output records or review docs.
 
 ## Cadence Expectations
-- Use the structured card lifecycle (`SIP -> STP -> SPP -> SRP -> SOR`) for each tracked issue.
-- Keep changes scoped per issue; use draft PRs until checks pass.
-- Run the smallest meaningful validation for each touched surface and record proof truthfully.
+
+- Preserve ordered execution where dependencies matter.
+- Do not merge hidden sidecar work into unrelated issues.
+- Escalate blockers as findings or follow-on issues.
 
 ## Risks / Dependencies
-- Dependency: <dependency_1>
-  - Risk: <risk_1>
-  - Mitigation: <mitigation_1>
+
+- Dependency: `<dependency_1>`
+- Risk: `<risk_1>`
+- Mitigation: `<mitigation_1>`
 
 ## Demo / Review Plan
-- Demo artifact: <demo_artifact>
-- Review date: <review_date>
-- Sign-off owners: <signoff_owners>
+
+- Demo artifact: `<demo_artifact>`
+- Review date: `<review_date>`
+- Sign-off owners: `<signoff_owners>`
+
+## Closeout Bar
+
+- All planned scope items are completed or explicitly deferred with rationale.
+- Linked issues and PRs are updated and traceable.
+- Focused validation is recorded for every touched surface.
+- Sprint summary is captured in milestone docs.
 
 ## Exit Criteria
+
 - All planned scope items completed or explicitly deferred with rationale.
 - Linked issues/PRs updated and traceable.
-- CI is green for merged work.
+- CI is green for merged work, or exceptions are documented.
 - Sprint summary captured in milestone docs.

--- a/docs/templates/planning/1.0.0/vision.md
+++ b/docs/templates/planning/1.0.0/vision.md
@@ -1,4 +1,4 @@
-# Vision Template
+# <milestone> Vision
 
 ## Metadata
 - Project: `<project_name>`
@@ -48,7 +48,7 @@ This milestone should strengthen the architectural or strategic pillars of:
 
 ---
 
-# Core Goals
+## Core Goals
 
 `<version>` advances `<project_name>` in five major areas:
 
@@ -60,7 +60,9 @@ This milestone should strengthen the architectural or strategic pillars of:
 
 ---
 
-# 1. <goal_area_1>
+## <goal_heading_1>
+
+### 1. <goal_area_1>
 
 `<version>` improves `<goal_area_1>` so the project can `<outcome_1>`.
 
@@ -81,7 +83,9 @@ The system or product should guarantee:
 
 ---
 
-# 2. <goal_area_2>
+## <goal_heading_2>
+
+### 2. <goal_area_2>
 
 `<goal_area_2>` must improve without sacrificing `<constraint_2>`.
 
@@ -101,7 +105,9 @@ These changes should help users:
 
 ---
 
-# 3. <goal_area_3>
+## <goal_heading_3>
+
+### 3. <goal_area_3>
 
 A central principle of `<project_name>` is **<principle_3>**.
 
@@ -124,7 +130,9 @@ The result should make the project more:
 
 ---
 
-# 4. <goal_area_4>
+## <goal_heading_4>
+
+### 4. <goal_area_4>
 
 `<version>` continues development of `<goal_area_4>`.
 
@@ -147,7 +155,7 @@ These improvements should guide the system toward `<desired_state_4>`.
 
 ---
 
-# 5. <goal_area_5>
+### 5. <goal_area_5>
 
 To support real-world use, `<version>` must improve `<goal_area_5>`.
 
@@ -168,7 +176,7 @@ This work should strengthen the development and operating workflow by improving:
 
 ---
 
-# Special Focus: `<special_focus_title>`
+## Special Focus: `<special_focus_title>`
 
 `<special_focus_title>` becomes a central focus of `<version>`.
 
@@ -191,7 +199,7 @@ This keeps the project aligned with `<alignment_principle>`.
 
 ---
 
-# Milestone Context
+## Milestone Context
 
 `<previous_milestone>` represents `<previous_milestone_significance>`.
 
@@ -207,7 +215,7 @@ The goal is to have `<future_goal>` by **<future_target_milestone>**.
 
 ---
 
-# Long-Term Direction
+## Long-Term Direction
 
 `<project_name>` is being designed as `<long_term_identity>`.
 
@@ -222,7 +230,7 @@ These principles aim to move the project beyond `<old_mode>` toward `<new_mode>`
 
 ---
 
-# Summary
+## Summary
 
 `<version>` is the milestone where `<project_name>` becomes:
 

--- a/docs/templates/planning/1.0.0/wbs.md
+++ b/docs/templates/planning/1.0.0/wbs.md
@@ -1,67 +1,93 @@
-# Work Breakdown Structure (WBS) Template
+# <milestone> Work Breakdown Structure
 
 ## Metadata
 - Milestone: `<milestone>`
 - Version: `<version>`
 - Date: `<date>`
 - Owner: `<owner>`
+- Status: `<status>`
+
+## Status
+
+`<status>`
 
 ## How To Use
-- Break work into independently-mergeable issues.
+
+- Break work into independently mergeable issues.
 - Keep each item measurable and testable.
-- Include deliverables + dependencies + issue links.
-- `WP-01` is the milestone design pass (canonical docs + WBS + decisions + sprint plan + checklist).
-- Use as many middle WPs as the milestone needs; current milestones often need more than 16 total WPs.
-- Reserve the final WPs for the release tail in this order: demos/proof, quality gate, docs/review convergence, release ceremony.
-- Do not hard-code exact tail WP numbers unless the milestone WBS has already fixed them.
+- Include deliverables, dependencies, and issue links.
+- Use as many middle WPs as the milestone needs.
+- Reserve the final WPs for demos/proof, quality gate, docs/review convergence, and release ceremony.
+- Do not hard-code exact tail WP numbers unless the milestone WBS has fixed them.
 
 ## WBS Summary
-<wbs_summary>
 
-## Work Packages
+`<wbs_summary>`
+
+## Candidate WP Sequence
+
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
 |---|---|---|---|---|---|
-| WP-01 | Design pass (milestone docs + planning) | <description_01> | <deliverable_01> | <deps_01> | <issue_01> |
-| WP-02 | <package_02> | <description_02> | <deliverable_02> | <deps_02> | <issue_02> |
-| WP-03 | <package_03> | <description_03> | <deliverable_03> | <deps_03> | <issue_03> |
-| WP-04 | <package_04> | <description_04> | <deliverable_04> | <deps_04> | <issue_04> |
-| WP-05 | <package_05> | <description_05> | <deliverable_05> | <deps_05> | <issue_05> |
-| WP-06 | <package_06> | <description_06> | <deliverable_06> | <deps_06> | <issue_06> |
-| WP-07 | <package_07> | <description_07> | <deliverable_07> | <deps_07> | <issue_07> |
-| WP-08 | <package_08> | <description_08> | <deliverable_08> | <deps_08> | <issue_08> |
-| WP-09 | <package_09> | <description_09> | <deliverable_09> | <deps_09> | <issue_09> |
-| WP-10 | <package_10> | <description_10> | <deliverable_10> | <deps_10> | <issue_10> |
-| WP-11 | <package_11> | <description_11> | <deliverable_11> | <deps_11> | <issue_11> |
-| WP-12 | <package_12> | <description_12> | <deliverable_12> | <deps_12> | <issue_12> |
-| WP-N-3 | Demo matrix + integration demos | <description_demo_tail> | <deliverable_demo_tail> | <deps_demo_tail> | <issue_demo_tail> |
-| WP-N-2 | Quality gate (focused proof + exceptions) | <description_quality_tail> | <deliverable_quality_tail> | <deps_quality_tail> | <issue_quality_tail> |
-| WP-N-1 | Docs + review pass (repo-wide alignment) | <description_docs_tail> | <deliverable_docs_tail> | <deps_docs_tail> | <issue_docs_tail> |
-| WP-N | Release ceremony (final validation + tag + notes + cleanup) | <description_release_tail> | <deliverable_release_tail> | <deps_release_tail> | <issue_release_tail> |
+| WP-01 | Design pass (milestone docs + planning) | `<description_01>` | `<deliverable_01>` | `<deps_01>` | `<issue_01>` |
+| WP-02 | `<package_02>` | `<description_02>` | `<deliverable_02>` | `<deps_02>` | `<issue_02>` |
+| WP-03 | `<package_03>` | `<description_03>` | `<deliverable_03>` | `<deps_03>` | `<issue_03>` |
+| WP-04 | `<package_04>` | `<description_04>` | `<deliverable_04>` | `<deps_04>` | `<issue_04>` |
+| WP-05 | `<package_05>` | `<description_05>` | `<deliverable_05>` | `<deps_05>` | `<issue_05>` |
+| WP-06 | `<package_06>` | `<description_06>` | `<deliverable_06>` | `<deps_06>` | `<issue_06>` |
+| WP-07 | `<package_07>` | `<description_07>` | `<deliverable_07>` | `<deps_07>` | `<issue_07>` |
+| WP-08 | `<package_08>` | `<description_08>` | `<deliverable_08>` | `<deps_08>` | `<issue_08>` |
+| WP-09 | `<package_09>` | `<description_09>` | `<deliverable_09>` | `<deps_09>` | `<issue_09>` |
+| WP-10 | `<package_10>` | `<description_10>` | `<deliverable_10>` | `<deps_10>` | `<issue_10>` |
+| WP-11 | `<package_11>` | `<description_11>` | `<deliverable_11>` | `<deps_11>` | `<issue_11>` |
+| WP-12 | `<package_12>` | `<description_12>` | `<deliverable_12>` | `<deps_12>` | `<issue_12>` |
+| WP-N-3 | Demo matrix + integration demos | `<description_demo_tail>` | `<deliverable_demo_tail>` | `<deps_demo_tail>` | `<issue_demo_tail>` |
+| WP-N-2 | Quality gate | `<description_quality_tail>` | `<deliverable_quality_tail>` | `<deps_quality_tail>` | `<issue_quality_tail>` |
+| WP-N-1 | Docs + review pass | `<description_docs_tail>` | `<deliverable_docs_tail>` | `<deps_docs_tail>` | `<issue_docs_tail>` |
+| WP-N | Release ceremony | `<description_release_tail>` | `<deliverable_release_tail>` | `<deps_release_tail>` | `<issue_release_tail>` |
+
+## Work Packages
+
+The candidate sequence above is the executable work-package surface. Expand or collapse middle rows as needed for the milestone; keep the tail semantics stable.
+
+## <sidecar_wbs_heading>
+
+If present, sidecar work is tracked separately from the main WP sequence.
+
+- Scope: `<sidecar_scope>`
+- Boundary: `<sidecar_boundary>`
+- Proof surface: `<sidecar_proof_surface>`
 
 ## Sequencing
-- Phase 1: <phase_1>
-- Phase 2: <phase_2>
-- Phase 3: <phase_3>
+
+- Phase 1: `<phase_1>`
+- Phase 2: `<phase_2>`
+- Phase 3: `<phase_3>`
+
+## Sequencing Notes
+
+`<sequencing_notes>`
 
 ## Acceptance Mapping
-- WP-01 (Design pass) -> <acceptance_criteria_01>
-- WP-02 -> <acceptance_criteria_02>
-- WP-03 -> <acceptance_criteria_03>
-- WP-04 -> <acceptance_criteria_04>
-- WP-05 -> <acceptance_criteria_05>
-- WP-06 -> <acceptance_criteria_06>
-- WP-07 -> <acceptance_criteria_07>
-- WP-08 -> <acceptance_criteria_08>
-- WP-09 -> <acceptance_criteria_09>
-- WP-10 -> <acceptance_criteria_10>
-- WP-11 -> <acceptance_criteria_11>
-- WP-12 -> <acceptance_criteria_12>
-- WP-N-3 (Demos/proof) -> <acceptance_criteria_demo_tail>
-- WP-N-2 (Quality gate) -> <acceptance_criteria_quality_tail>
-- WP-N-1 (Docs/review) -> <acceptance_criteria_docs_tail>
-- WP-N (Release ceremony) -> <acceptance_criteria_release_tail>
+
+- WP-01 -> `<acceptance_criteria_01>`
+- WP-02 -> `<acceptance_criteria_02>`
+- WP-03 -> `<acceptance_criteria_03>`
+- WP-04 -> `<acceptance_criteria_04>`
+- WP-05 -> `<acceptance_criteria_05>`
+- WP-06 -> `<acceptance_criteria_06>`
+- WP-07 -> `<acceptance_criteria_07>`
+- WP-08 -> `<acceptance_criteria_08>`
+- WP-09 -> `<acceptance_criteria_09>`
+- WP-10 -> `<acceptance_criteria_10>`
+- WP-11 -> `<acceptance_criteria_11>`
+- WP-12 -> `<acceptance_criteria_12>`
+- WP-N-3 -> `<acceptance_criteria_demo_tail>`
+- WP-N-2 -> `<acceptance_criteria_quality_tail>`
+- WP-N-1 -> `<acceptance_criteria_docs_tail>`
+- WP-N -> `<acceptance_criteria_release_tail>`
 
 ## Exit Criteria
+
 - Every in-scope requirement maps to at least one WBS item.
 - Every WBS item has an owner, issue reference, and concrete deliverable.
 - Dependency order is explicit enough to execute deterministically.

--- a/docs/templates/planning/current.json
+++ b/docs/templates/planning/current.json
@@ -20,7 +20,19 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/README_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "How To Use", "Overview", "Scope Summary", "Document Map", "Execution Model", "Demo and Validation Surface", "Status", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Status",
+        "Purpose",
+        "Milestone Role",
+        "Boundaries",
+        "Source Map",
+        "Document Map",
+        "Execution Model",
+        "Demo and Validation Surface",
+        "Success Criteria",
+        "Exit Criteria"
+      ]
     },
     "wbs": {
       "object_kind": "planning_template",
@@ -29,7 +41,18 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/WBS_TEMPLATE.md",
-      "required_sections": ["Metadata", "How To Use", "WBS Summary", "Work Packages", "Sequencing", "Acceptance Mapping", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Status",
+        "How To Use",
+        "WBS Summary",
+        "Candidate WP Sequence",
+        "Work Packages",
+        "Sequencing",
+        "Sequencing Notes",
+        "Acceptance Mapping",
+        "Exit Criteria"
+      ]
     },
     "sprint": {
       "object_kind": "planning_template",
@@ -38,7 +61,22 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/SPRINT_TEMPLATE.md",
-      "required_sections": ["Metadata", "How To Use", "Sprint Goal", "Planned Scope", "Work Plan", "Risks / Dependencies", "Demo / Review Plan", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Status",
+        "How To Use",
+        "Sprint Overview",
+        "Sprint Goals",
+        "Sprint Goal",
+        "Planned Scope",
+        "Work Plan",
+        "Execution Policy",
+        "Cadence Expectations",
+        "Risks / Dependencies",
+        "Demo / Review Plan",
+        "Closeout Bar",
+        "Exit Criteria"
+      ]
     },
     "vision": {
       "object_kind": "planning_template",
@@ -47,7 +85,17 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/VISION_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "How To Use", "Overview", "Core Goals", "Milestone Context", "Long-Term Direction", "Summary", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Purpose",
+        "How To Use",
+        "Overview",
+        "Core Goals",
+        "Milestone Context",
+        "Long-Term Direction",
+        "Summary",
+        "Exit Criteria"
+      ]
     },
     "design": {
       "object_kind": "planning_template",
@@ -56,7 +104,19 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/DESIGN_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "Problem Statement", "Goals", "Non-Goals", "Scope", "Requirements", "Proposed Design", "Validation Plan", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Purpose",
+        "Problem Statement",
+        "Goals",
+        "Non-Goals",
+        "Scope",
+        "Requirements",
+        "Proposed Design",
+        "Interfaces And Contracts",
+        "Validation Plan",
+        "Exit Criteria"
+      ]
     },
     "decisions": {
       "object_kind": "planning_template",
@@ -65,7 +125,14 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/DECISIONS_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "How To Use", "Decision Log", "Open Questions", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Purpose",
+        "How To Use",
+        "Decision Log",
+        "Open Questions",
+        "Exit Criteria"
+      ]
     },
     "demo_matrix": {
       "object_kind": "planning_template",
@@ -74,7 +141,21 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/DEMO_MATRIX_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "How To Use", "Scope", "Runtime Preconditions", "Demo Coverage Summary", "Coverage Rules", "Demo Details", "Cross-Demo Validation", "Determinism Evidence", "Reviewer Sign-Off Surface", "Exit Criteria"]
+      "required_sections": [
+        "Status",
+        "Metadata",
+        "Purpose",
+        "How To Use",
+        "Scope",
+        "Runtime Preconditions",
+        "Demo Coverage Summary",
+        "Coverage Rules",
+        "Demo Details",
+        "Cross-Demo Validation",
+        "Determinism Evidence",
+        "Reviewer Sign-Off Surface",
+        "Exit Criteria"
+      ]
     },
     "feature_doc": {
       "object_kind": "planning_template",
@@ -83,7 +164,23 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/FEATURE_DOC_TEMPLATE.md",
-      "required_sections": ["Metadata", "Template Rules", "Purpose", "Context", "Coverage / Ownership", "Overview", "Design", "Execution Flow", "Determinism and Constraints", "Integration Points", "Validation", "Acceptance Criteria", "Risks", "Future Work", "Notes"]
+      "required_sections": [
+        "Metadata",
+        "Template Rules",
+        "Purpose",
+        "Context",
+        "Coverage / Ownership",
+        "Overview",
+        "Design",
+        "Execution Flow",
+        "Determinism and Constraints",
+        "Integration Points",
+        "Validation",
+        "Acceptance Criteria",
+        "Risks",
+        "Future Work",
+        "Notes"
+      ]
     },
     "milestone_checklist": {
       "object_kind": "planning_template",
@@ -92,7 +189,16 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/MILESTONE_CHECKLIST_TEMPLATE.md",
-      "required_sections": ["Metadata", "Purpose", "Planning", "Execution Discipline", "Quality Gates", "Release Packaging", "Post-Release", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "Purpose",
+        "Planning",
+        "Execution Discipline",
+        "Quality Gates",
+        "Release Packaging",
+        "Post-Release",
+        "Exit Criteria"
+      ]
     },
     "release_plan": {
       "object_kind": "planning_template",
@@ -101,7 +207,17 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/RELEASE_PLAN_TEMPLATE.md",
-      "required_sections": ["Metadata", "How To Use", "0) Release-Tail Convergence", "1) Release Readiness", "2) Branch And Tag Preparation", "3) GitHub Release Steps", "4) Verification", "5) Communication", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "How To Use",
+        "0. Release-Tail Convergence",
+        "1. Release Readiness",
+        "2. Branch And Tag Preparation",
+        "3. GitHub Release Steps",
+        "4. Verification",
+        "5. Communication",
+        "Exit Criteria"
+      ]
     },
     "release_notes": {
       "object_kind": "planning_template",
@@ -110,7 +226,18 @@
       "version": "1.0.0",
       "status": "active",
       "legacy_path": "docs/templates/RELEASE_NOTES_TEMPLATE.md",
-      "required_sections": ["Metadata", "How To Use", "Summary", "Highlights", "What's New In Detail", "Upgrade Notes", "Known Limitations", "Validation Notes", "What's Next", "Exit Criteria"]
+      "required_sections": [
+        "Metadata",
+        "How To Use",
+        "Summary",
+        "Highlights",
+        "What's New In Detail",
+        "Upgrade Notes",
+        "Known Limitations",
+        "Validation Notes",
+        "What's Next",
+        "Exit Criteria"
+      ]
     }
   },
   "compatibility_fallbacks": {

--- a/docs/templates/planning/fixtures/minimal/readme.md
+++ b/docs/templates/planning/fixtures/minimal/readme.md
@@ -1,104 +1,137 @@
-# Milestone README Template
+# fixture-milestone Milestone README
 
 ## Metadata
 - Milestone: `fixture-milestone`
 - Version: `v0.0.0-fixture`
 - Date: `2026-05-23`
 - Owner: `fixture-owner`
+- Status: `generated fixture`
+
+## Status
+
+Current status: `generated fixture`
+
+- Planning: `generated fixture only`
+- Execution: `not applicable`
+- Validation: `structurally valid when validator passes`
+- Release readiness: `not applicable`
 
 ## Purpose
-Provide a single entry point for a filled planning-template fixture.
 
-## How To Use
-- Use this fixture only to prove the planning README shape validates.
+Provide the canonical entry point for `fixture-milestone`: why it exists, what it changes, what is in and out of scope, and where reviewers should go for design, execution, demo, proof, and release evidence.
 
-## Overview
+## Milestone Role
 
-`fixture-milestone` represents a minimal generated planning packet fixture.
+`fixture-milestone` moves `ADL planning-template fixture` from `legacy flat templates` to `versioned planning templates`.
 
-This milestone focuses on:
-- fixture scope
-- fixture validation
-- fixture portability
+This milestone exists to:
 
-Key outcomes:
-- placeholder-free output
-- required-section coverage
-- no approval claim
+- `fixture scope`
+- `fixture validation`
+- `fixture portability`
 
-## Scope Summary
+Expected outcomes:
 
-### In scope
-- fixture validation
+- `placeholder-free output`
+- `required-section coverage`
+- `no approval claim`
 
-### Out of scope
-- release truth
+## Boundaries
 
-## Document Map
+In scope:
 
-Canonical milestone documents:
+- `fixture validation`
+- `registry resolution`
+- `portable paths`
+
+Out of scope:
+
+- `release truth`
+- `live milestone migration`
+
+Known risks:
+
+- `fixture proves only README generation`
+- `fixture is not live milestone truth`
+
+Open questions:
+
+- `none`
+- `none`
+
+## Source Map
+
+Primary planning and proof sources:
 
 - Vision: `VISION.md`
 - Design: `DESIGN.md`
-- Work Breakdown Structure (WBS): `WBS.md`
+- Work Breakdown Structure: `WBS.md`
 - Sprint plan: `SPRINT.md`
 - Decisions log: `DECISIONS.md`
 - Demo matrix: `DEMO_MATRIX.md`
 - Milestone checklist: `MILESTONE_CHECKLIST.md`
-- Release plan / process: `RELEASE_PLAN.md`
+- Release plan: `RELEASE_PLAN.md`
 - Release notes: `RELEASE_NOTES.md`
 
 Supporting / domain-specific docs:
-- none
+
+- `none`
+- `none`
+- `none`
+
+## Document Map
+
+Use the source map above as the canonical navigation surface. Keep this README concise; details belong in the linked milestone documents.
+
+## Sidecar Work
+
+If this milestone includes a sidecar, record it here rather than hiding it in chat or issue comments.
+
+- Sidecar scope: `not applicable for fixture`
+- Sidecar boundary: `not applicable for fixture`
+- Sidecar proof surface: `not applicable for fixture`
+
+If no sidecar exists, set these values to `not applicable`.
 
 ## Execution Model
 
-This fixture is not executable milestone truth.
+This milestone is executed as an ordered issue/PR sequence. The exact WP count is milestone-specific.
 
 Execution expectations:
-- none; this is a validation fixture
+
+- WP-01 is the design/planning pass.
+- Feature and system work occupy the middle of the sequence.
+- Demo/proof, quality, docs/review convergence, and release ceremony work happen at the tail.
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Each WP records focused validation and merge/readiness proof.
+- Do not hard-code a 16-WP shape unless that milestone explicitly uses it.
 
 ## Demo and Validation Surface
 
-Primary validation is defined by the planning-template validator.
+Primary validation is defined in `DEMO_MATRIX.md`.
 
 Additional validation surfaces:
-- none
 
-Success criteria:
-- required sections are present
-- unresolved placeholders are absent
-- no review or approval status is claimed
+- Test suite results
+- Generated artifacts under `.adl/runs/`
+- Trace and replay outputs
 
-## Determinism and Reproducibility
+Determinism evidence:
 
-The fixture should validate consistently with the same registry and input file.
+- `docs/templates/planning/fixtures/minimal/readme_generated.md`
+- `docs/templates/planning/current.json`
 
-Evidence locations:
-- `docs/templates/planning/fixtures/minimal/readme.md`
+## Success Criteria
 
-## Risks and Open Questions
-
-Known risks:
-- this fixture proves only the README template contract
-
-Open questions:
-- none
-
-## Status
-
-Current status: generated fixture
-
-- Planning: generated fixture only
-- Execution: not applicable
-- Validation: structurally valid when validator passes
-- Release readiness: not applicable
+- `required sections are present`
+- `unresolved placeholders are absent`
+- `no review or approval status is claimed`
 
 ## Exit Criteria
 
 - All canonical milestone documents are complete and internally consistent.
 - All WBS items are implemented or explicitly deferred.
 - Demo matrix is runnable and validated.
-- Quality gates are passing or explicitly scoped out.
+- Quality gates relevant to touched surfaces are passing or exceptions are documented.
 - Milestone checklist is complete or exceptions are documented.
-- Release artifacts are ready or explicitly scoped out.
+- Release artifacts are ready.

--- a/docs/templates/planning/fixtures/minimal/readme_generated.md
+++ b/docs/templates/planning/fixtures/minimal/readme_generated.md
@@ -10,135 +10,140 @@ claim_boundary: generated draft only; not reviewed or approved
 > Generated planning draft. This file proves only template filling;
 > it is not reviewed, approved, released, merged, or lifecycle-true.
 
-
-# Milestone README Template
+# fixture-milestone Milestone README
 
 ## Metadata
 - Milestone: `fixture-milestone`
 - Version: `v0.0.0-fixture`
 - Date: `2026-05-23`
 - Owner: `fixture-owner`
+- Status: `generated fixture`
+
+## Status
+
+Current status: `generated fixture`
+
+- Planning: `generated fixture only`
+- Execution: `not applicable`
+- Validation: `structurally valid when validator passes`
+- Release readiness: `not applicable`
 
 ## Purpose
-Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
 
-## How To Use
-- Start here before reading individual milestone documents.
-- Use this README to locate the canonical design, execution, and validation surfaces.
-- Keep this document concise and navigational; detailed content belongs in the linked docs.
-- Keep links up to date as files move or are renamed.
+Provide the canonical entry point for `fixture-milestone`: why it exists, what it changes, what is in and out of scope, and where reviewers should go for design, execution, demo, proof, and release evidence.
 
-## Overview
+## Milestone Role
 
-`fixture-milestone` represents the stage where `ADL planning-template fixture` moves from `legacy flat templates` to `versioned planning templates`.
+`fixture-milestone` moves `ADL planning-template fixture` from `legacy flat templates` to `versioned planning templates`.
 
-This milestone focuses on:
-- fixture scope
-- fixture validation
-- fixture portability
+This milestone exists to:
 
-Key outcomes:
-- placeholder-free output
-- required-section coverage
-- no approval claim
+- `fixture scope`
+- `fixture validation`
+- `fixture portability`
 
-## Scope Summary
+Expected outcomes:
 
-### In scope
-- fixture validation
-- registry resolution
-- portable paths
+- `placeholder-free output`
+- `required-section coverage`
+- `no approval claim`
 
-### Out of scope
-- release truth
-- live milestone migration
+## Boundaries
 
-## Document Map
+In scope:
 
-Canonical milestone documents:
+- `fixture validation`
+- `registry resolution`
+- `portable paths`
+
+Out of scope:
+
+- `release truth`
+- `live milestone migration`
+
+Known risks:
+
+- `fixture proves only README generation`
+- `fixture is not live milestone truth`
+
+Open questions:
+
+- `none`
+- `none`
+
+## Source Map
+
+Primary planning and proof sources:
 
 - Vision: `VISION.md`
 - Design: `DESIGN.md`
-- Work Breakdown Structure (WBS): `WBS.md`
+- Work Breakdown Structure: `WBS.md`
 - Sprint plan: `SPRINT.md`
 - Decisions log: `DECISIONS.md`
 - Demo matrix: `DEMO_MATRIX.md`
 - Milestone checklist: `MILESTONE_CHECKLIST.md`
-- Release plan / process: `RELEASE_PLAN.md`
+- Release plan: `RELEASE_PLAN.md`
 - Release notes: `RELEASE_NOTES.md`
 
 Supporting / domain-specific docs:
-- none
-- none
-- none
+
+- `none`
+- `none`
+- `none`
+
+## Document Map
+
+Use the source map above as the canonical navigation surface. Keep this README concise; details belong in the linked milestone documents.
+
+## Sidecar Work
+
+If this milestone includes a sidecar, record it here rather than hiding it in chat or issue comments.
+
+- Sidecar scope: `not applicable for fixture`
+- Sidecar boundary: `not applicable for fixture`
+- Sidecar proof surface: `not applicable for fixture`
+
+If no sidecar exists, set these values to `not applicable`.
 
 ## Execution Model
 
-This milestone is executed as a sequence of work packages (WPs):
-
-- WP-01: Design pass (docs + planning)
-- WP-02 – WP-12: Feature and system work
-- WP-13: Demo matrix and integration demos
-- WP-14: Coverage / quality gate
-- WP-15: Docs and review convergence
-- WP-16: Release ceremony
+This milestone is executed as an ordered issue/PR sequence. The exact WP count is milestone-specific.
 
 Execution expectations:
-- Each WP is tracked by an issue and implemented via PRs.
-- Each issue follows the structured card lifecycle
-  `SIP -> STP -> SPP -> SRP -> SOR`, plus any required reports.
-- All work merges under green CI and passes quality gates.
+
+- WP-01 is the design/planning pass.
+- Feature and system work occupy the middle of the sequence.
+- Demo/proof, quality, docs/review convergence, and release ceremony work happen at the tail.
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Each WP records focused validation and merge/readiness proof.
+- Do not hard-code a 16-WP shape unless that milestone explicitly uses it.
 
 ## Demo and Validation Surface
 
-Primary validation is defined in:
-- Demo matrix: `DEMO_MATRIX.md`
+Primary validation is defined in `DEMO_MATRIX.md`.
 
 Additional validation surfaces:
+
 - Test suite results
 - Generated artifacts under `.adl/runs/`
 - Trace and replay outputs
 
-Success criteria:
-- required sections are present
-- unresolved placeholders are absent
-- no review or approval status is claimed
+Determinism evidence:
 
-## Determinism and Reproducibility
+- `docs/templates/planning/fixtures/minimal/readme_generated.md`
+- `docs/templates/planning/current.json`
 
-The milestone should demonstrate:
-- Deterministic or bounded-repeatable execution where required
-- Replayable traces and inspectable artifacts
-- Stable command entry points for demos
+## Success Criteria
 
-Evidence locations:
-- docs/templates/planning/fixtures/minimal/readme_generated.md
-- docs/templates/planning/current.json
-
-## Risks and Open Questions
-
-Known risks:
-- fixture proves only README generation
-- fixture is not live milestone truth
-
-Open questions:
-- none
-- none
-
-## Status
-
-Current status: generated fixture
-
-- Planning: generated fixture only
-- Execution: not applicable
-- Validation: structurally valid when validator passes
-- Release readiness: not applicable
+- `required sections are present`
+- `unresolved placeholders are absent`
+- `no review or approval status is claimed`
 
 ## Exit Criteria
 
 - All canonical milestone documents are complete and internally consistent.
 - All WBS items are implemented or explicitly deferred.
 - Demo matrix is runnable and validated.
-- Quality gates (fmt, clippy, test, CI) are passing.
+- Quality gates relevant to touched surfaces are passing or exceptions are documented.
 - Milestone checklist is complete or exceptions are documented.
-- Release artifacts (notes, tag, docs) are ready.
+- Release artifacts are ready.

--- a/docs/templates/planning/fixtures/minimal/readme_values.json
+++ b/docs/templates/planning/fixtures/minimal/readme_values.json
@@ -42,5 +42,9 @@
   "planning_status": "generated fixture only",
   "execution_status": "not applicable",
   "validation_status": "structurally valid when validator passes",
-  "release_status": "not applicable"
+  "release_status": "not applicable",
+  "sidecar_heading": "Sidecar Work",
+  "sidecar_scope": "not applicable for fixture",
+  "sidecar_boundary": "not applicable for fixture",
+  "sidecar_proof_surface": "not applicable for fixture"
 }

--- a/docs/templates/planning/fixtures/minimal/sprint.md
+++ b/docs/templates/planning/fixtures/minimal/sprint.md
@@ -1,4 +1,4 @@
-# Sprint Template
+# fixture-milestone Sprint Plan
 
 ## Metadata
 - Sprint: `fixture-sprint`
@@ -6,33 +6,94 @@
 - Start date: `2026-05-23`
 - End date: `2026-05-23`
 - Owner: `fixture-owner`
+- Status: `generated fixture`
+
+## Status
+
+`generated fixture`
 
 ## How To Use
-- Fixture only; proves required section shape.
+
+- List work in planned execution order.
+- Track blockers here rather than scattered chat notes.
+- Keep sidecar or support work visible and bounded.
+- Record closeout expectations before execution begins.
+
+## Sprint Overview
+
+`Validate sprint template structure.`
+
+Planned scope:
+
+- `fixture scope`
+- `fixture validation`
+- `fixture portability`
+
+## Sidecar Work
+
+- Scope: `not applicable for fixture`
+- Boundary: `not applicable for fixture`
+- Proof surface: `not applicable for fixture`
+
+## Sprint Goals
+
+- `fixture work`
+- `fixture validation`
+- `fixture closeout`
 
 ## Sprint Goal
-Validate sprint template structure.
+
+`Validate sprint template structure.`
 
 ## Planned Scope
-- fixture scope
+
+- `fixture scope`
+- `fixture validation`
+- `fixture portability`
 
 ## Work Plan
+
 | Order | Item | Issue | Owner | Status |
 |---|---|---|---|---|
-| 1 | fixture work | #fixture | fixture-owner | generated fixture |
+| 1 | `fixture work` | `#fixture` | `fixture-owner` | `generated fixture` |
+| 2 | `fixture validation` | `#fixture` | `fixture-owner` | `generated fixture` |
+| 3 | `fixture closeout` | `#fixture` | `fixture-owner` | `generated fixture` |
+
+## Execution Policy
+
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run the smallest meaningful validation for each touched surface.
+- Record proof truthfully in issue-local output records or review docs.
 
 ## Cadence Expectations
-- Use `SIP -> STP -> SPP -> SRP -> SOR` for tracked issues.
+
+- Preserve ordered execution where dependencies matter.
+- Do not merge hidden sidecar work into unrelated issues.
+- Escalate blockers as findings or follow-on issues.
 
 ## Risks / Dependencies
-- Dependency: none
-  - Risk: fixture only
-  - Mitigation: no live claim
+
+- Dependency: `none`
+- Risk: `fixture only`
+- Mitigation: `no live claim`
 
 ## Demo / Review Plan
-- Demo artifact: none
-- Review date: not applicable
-- Sign-off owners: none
+
+- Demo artifact: `none`
+- Review date: `not applicable`
+- Sign-off owners: `none`
+
+## Closeout Bar
+
+- All planned scope items are completed or explicitly deferred with rationale.
+- Linked issues and PRs are updated and traceable.
+- Focused validation is recorded for every touched surface.
+- Sprint summary is captured in milestone docs.
 
 ## Exit Criteria
-- Fixture validates structurally.
+
+- All planned scope items completed or explicitly deferred with rationale.
+- Linked issues/PRs updated and traceable.
+- CI is green for merged work, or exceptions are documented.
+- Sprint summary captured in milestone docs.

--- a/docs/templates/planning/fixtures/minimal/wbs.md
+++ b/docs/templates/planning/fixtures/minimal/wbs.md
@@ -1,31 +1,93 @@
-# Work Breakdown Structure (WBS) Template
+# fixture-milestone Work Breakdown Structure
 
 ## Metadata
 - Milestone: `fixture-milestone`
 - Version: `v0.0.0-fixture`
 - Date: `2026-05-23`
 - Owner: `fixture-owner`
+- Status: `generated fixture`
+
+## Status
+
+`generated fixture`
 
 ## How To Use
-- Fixture only; proves required section shape.
+
+- Break work into independently mergeable issues.
+- Keep each item measurable and testable.
+- Include deliverables, dependencies, and issue links.
+- Use as many middle WPs as the milestone needs.
+- Reserve the final WPs for demos/proof, quality gate, docs/review convergence, and release ceremony.
+- Do not hard-code exact tail WP numbers unless the milestone WBS has fixed them.
 
 ## WBS Summary
-Fixture WBS with flexible WP count and release-tail placeholders.
 
-## Work Packages
+`Fixture WBS with flexible WP count and release-tail placeholders.`
+
+## Candidate WP Sequence
+
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
 |---|---|---|---|---|---|
-| WP-01 | Design pass | Fixture design | Fixture docs | none | #fixture |
-| WP-N | Release ceremony | Fixture release tail | Fixture note | previous WPs | #fixture |
+| WP-01 | Design pass (milestone docs + planning) | `Fixture design` | `Fixture docs` | `none` | `#fixture` |
+| WP-02 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-03 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-04 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-05 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-06 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-07 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-08 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-09 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-10 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-11 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-12 | `Fixture work package` | `Fixture work` | `Fixture artifact` | `previous fixture work` | `#fixture` |
+| WP-N-3 | Demo matrix + integration demos | `Fixture demo tail` | `Fixture demo note` | `previous WPs` | `#fixture` |
+| WP-N-2 | Quality gate | `Fixture quality tail` | `Fixture quality note` | `previous WPs` | `#fixture` |
+| WP-N-1 | Docs + review pass | `Fixture docs tail` | `Fixture review note` | `previous WPs` | `#fixture` |
+| WP-N | Release ceremony | `Fixture release tail` | `Fixture release note` | `previous WPs` | `#fixture` |
+
+## Work Packages
+
+The candidate sequence above is the executable work-package surface. Expand or collapse middle rows as needed for the milestone; keep the tail semantics stable.
+
+## Sidecar Work
+
+If present, sidecar work is tracked separately from the main WP sequence.
+
+- Scope: `not applicable for fixture`
+- Boundary: `not applicable for fixture`
+- Proof surface: `not applicable for fixture`
 
 ## Sequencing
-- Phase 1: design
-- Phase 2: implementation
-- Phase 3: release tail
+
+- Phase 1: `design`
+- Phase 2: `implementation`
+- Phase 3: `release tail`
+
+## Sequencing Notes
+
+`Fixture sequencing is illustrative only.`
 
 ## Acceptance Mapping
-- WP-01 -> design fixture exists
-- WP-N -> release fixture is explicitly non-live
+
+- WP-01 -> `fixture validates structurally`
+- WP-02 -> `fixture validates structurally`
+- WP-03 -> `fixture validates structurally`
+- WP-04 -> `fixture validates structurally`
+- WP-05 -> `fixture validates structurally`
+- WP-06 -> `fixture validates structurally`
+- WP-07 -> `fixture validates structurally`
+- WP-08 -> `fixture validates structurally`
+- WP-09 -> `fixture validates structurally`
+- WP-10 -> `fixture validates structurally`
+- WP-11 -> `fixture validates structurally`
+- WP-12 -> `fixture validates structurally`
+- WP-N-3 -> `fixture validates structurally`
+- WP-N-2 -> `fixture validates structurally`
+- WP-N-1 -> `fixture validates structurally`
+- WP-N -> `fixture validates structurally`
 
 ## Exit Criteria
-- Fixture validates structurally.
+
+- Every in-scope requirement maps to at least one WBS item.
+- Every WBS item has an owner, issue reference, and concrete deliverable.
+- Dependency order is explicit enough to execute deterministically.


### PR DESCRIPTION
Closes #3315.\n\nStabilizes the canonical planning-template packet as a separate issue before rerunning #3312.\n\nValidation:\n- validate_planning_template.py for readme/readme_generated/wbs/sprint/milestone_checklist fixtures\n- 10-template generation/validation smoke\n- git diff --check\n- bounded review found no blockers