### PR TITLE
[v0.91.3][tools] Enforce C-SDLC card-status transitions

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -214,7 +214,8 @@ fn run_doctor_preflight(
             url: pr.url.clone(),
         })
         .collect::<Vec<_>>();
-    if open_prs.is_empty() {
+    let card_run_readiness = preflight_card_run_readiness(repo_root, issue_ref);
+    if open_prs.is_empty() && card_run_readiness != Some("blocked") {
         Ok(DoctorPreflightResult {
             target_queue: target_queue.queue,
             target_queue_source: target_queue.source,
@@ -231,6 +232,21 @@ fn run_doctor_preflight(
             status: "BLOCK",
         })
     }
+}
+
+fn preflight_card_run_readiness(repo_root: &Path, issue_ref: &IssueRef) -> Option<&'static str> {
+    let sip = issue_ref.task_bundle_input_path(repo_root);
+    let stp = issue_ref.task_bundle_stp_path(repo_root);
+    let spp = issue_ref.task_bundle_plan_path(repo_root);
+    let srp = issue_ref.task_bundle_review_policy_path(repo_root);
+    let sor = issue_ref.task_bundle_output_path(repo_root);
+    if [&sip, &stp, &spp, &srp, &sor]
+        .iter()
+        .any(|path| !path.is_file())
+    {
+        return None;
+    }
+    Some(build_doctor_card_lifecycle(repo_root, &sip, &stp, &spp, &srp, &sor).pr_run_readiness)
 }
 
 pub(super) fn run_doctor_ready(
@@ -346,6 +362,15 @@ pub(super) fn run_doctor_ready(
     }
     if !worktree_path.is_dir() {
         if root_indicates_pre_run {
+            let card_lifecycle = build_doctor_card_lifecycle(
+                repo_root,
+                &root_bundle_input,
+                &root_stp,
+                &root_bundle_plan,
+                &root_bundle_review_policy,
+                &root_bundle_output,
+            );
+            let status = doctor_ready_status_for(&card_lifecycle);
             return Ok(DoctorReadyResult {
                 lifecycle_state: "pre_run",
                 worktree: None,
@@ -356,15 +381,8 @@ pub(super) fn run_doctor_ready(
                 wt_stp: None,
                 wt_input: None,
                 wt_output: None,
-                card_lifecycle: build_doctor_card_lifecycle(
-                    repo_root,
-                    &root_bundle_input,
-                    &root_stp,
-                    &root_bundle_plan,
-                    &root_bundle_review_policy,
-                    &root_bundle_output,
-                ),
-                status: "PASS",
+                card_lifecycle,
+                status,
             });
         }
         bail!("doctor: missing worktree: {}", worktree_path.display());
@@ -372,6 +390,15 @@ pub(super) fn run_doctor_ready(
     if root_indicates_pre_run
         && (!wt_stp.is_file() || !wt_bundle_input.is_file() || !wt_bundle_output.is_file())
     {
+        let card_lifecycle = build_doctor_card_lifecycle(
+            repo_root,
+            &root_bundle_input,
+            &root_stp,
+            &root_bundle_plan,
+            &root_bundle_review_policy,
+            &root_bundle_output,
+        );
+        let status = doctor_ready_status_for(&card_lifecycle);
         return Ok(DoctorReadyResult {
             lifecycle_state: "pre_run",
             worktree: None,
@@ -382,15 +409,8 @@ pub(super) fn run_doctor_ready(
             wt_stp: None,
             wt_input: None,
             wt_output: None,
-            card_lifecycle: build_doctor_card_lifecycle(
-                repo_root,
-                &root_bundle_input,
-                &root_stp,
-                &root_bundle_plan,
-                &root_bundle_review_policy,
-                &root_bundle_output,
-            ),
-            status: "PASS",
+            card_lifecycle,
+            status,
         });
     }
     let wt_branch = run_capture(
@@ -439,6 +459,16 @@ pub(super) fn run_doctor_ready(
         },
     )?;
 
+    let card_lifecycle = build_doctor_card_lifecycle(
+        repo_root,
+        &wt_bundle_input,
+        &wt_stp,
+        &wt_bundle_plan,
+        &wt_bundle_review_policy,
+        &wt_bundle_output,
+    );
+    let status = doctor_ready_status_for(&card_lifecycle);
+
     Ok(DoctorReadyResult {
         lifecycle_state: "run_bound",
         worktree: Some(path_relative_to_repo(repo_root, &worktree_path)),
@@ -449,15 +479,8 @@ pub(super) fn run_doctor_ready(
         wt_stp: Some(path_relative_to_repo(repo_root, &wt_stp)),
         wt_input: Some(path_relative_to_repo(repo_root, &wt_bundle_input)),
         wt_output: Some(path_relative_to_repo(repo_root, &wt_bundle_output)),
-        card_lifecycle: build_doctor_card_lifecycle(
-            repo_root,
-            &wt_bundle_input,
-            &wt_stp,
-            &wt_bundle_plan,
-            &wt_bundle_review_policy,
-            &wt_bundle_output,
-        ),
-        status: "PASS",
+        card_lifecycle,
+        status,
     })
 }
 
@@ -568,10 +591,32 @@ fn build_doctor_card_lifecycle(
     }
 }
 
+fn doctor_ready_status_for(lifecycle: &DoctorCardLifecycleJson) -> &'static str {
+    if lifecycle.pr_run_readiness == "ready" {
+        "PASS"
+    } else {
+        "BLOCK"
+    }
+}
+
 fn classify_sip_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let Some(text) = read_card_text(path) else {
         return missing_stage(repo_root, "SIP", path, "sip-editor");
     };
+    if !design_time_card_status_allows_execution(&text) {
+        return card_stage(
+            repo_root,
+            "SIP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("sip-editor"),
+                "SIP card_status must be ready or approved before execution binding.",
+            ),
+        );
+    }
     if has_generic_sip_design_time_scaffold(&text) {
         return card_stage(
             repo_root,
@@ -604,6 +649,20 @@ fn classify_stp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let Some(text) = read_card_text(path) else {
         return missing_stage(repo_root, "STP", path, "stp-editor");
     };
+    if !design_time_card_status_allows_execution(&text) {
+        return card_stage(
+            repo_root,
+            "STP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("stp-editor"),
+                "STP card_status must be ready or approved before execution binding.",
+            ),
+        );
+    }
     if text.contains("## Required Outcome") && text.contains("## Acceptance Criteria") {
         return card_stage(
             repo_root,
@@ -637,6 +696,20 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
         return missing_stage(repo_root, "SPP", path, "spp-editor");
     };
     let status = line_value_after_prefix(&text, "status:").unwrap_or_default();
+    if !design_time_card_status_allows_execution(&text) {
+        return card_stage(
+            repo_root,
+            "SPP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("spp-editor"),
+                "SPP card_status must be ready or approved before execution binding.",
+            ),
+        );
+    }
     if has_generic_spp_design_time_scaffold(&text) {
         return card_stage(
             repo_root,
@@ -713,6 +786,19 @@ fn has_truncation_sentinel_line(text: &str) -> bool {
         .any(|line| matches!(line, "..." | "- ..." | "* ..." | "<...>"))
 }
 
+fn card_status_value(text: &str) -> Option<String> {
+    line_value_after_prefix(text, "card_status:")
+        .or_else(|| line_value_after_prefix(text, "Card Status:"))
+}
+
+fn design_time_card_status_allows_execution(text: &str) -> bool {
+    match card_status_value(text).as_deref() {
+        Some("ready" | "approved") => true,
+        Some(_) => false,
+        None => true,
+    }
+}
+
 fn classify_srp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let Some(text) = read_card_text(path) else {
         return missing_stage(repo_root, "SRP", path, "srp-editor");
@@ -728,6 +814,22 @@ fn classify_srp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
         || text.contains("artifact_type: \"structured_review_policy\"");
     let structured_review_prompt = text.contains("# Structured Review Prompt")
         && text.contains("artifact_type: \"structured_review_prompt\"");
+    if card_status_value(&text).as_deref() == Some("completed")
+        && !(has_review_results || (has_policy_exception && !pre_execution_review_state))
+    {
+        return card_stage(
+            repo_root,
+            "SRP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("srp-editor"),
+                "SRP card_status completed requires review findings, dispositions, or an explicit final policy exception.",
+            ),
+        );
+    }
     if has_review_results || (has_policy_exception && !pre_execution_review_state) {
         return card_stage(
             repo_root,
@@ -879,6 +981,27 @@ fn classify_sor_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let result = line_value_after_prefix(&text, "- Result:").unwrap_or_default();
     let worktree_only =
         line_value_after_prefix(&text, "- Worktree-only paths remaining:").unwrap_or_default();
+    let terminal_closeout = ["merged", "closed_no_pr"].contains(&integration_state.as_str())
+        && matches!(
+            (status.as_str(), result.as_str()),
+            ("DONE", "PASS") | ("FAILED", "FAIL")
+        )
+        && worktree_only == "none"
+        && text.contains("## Validation");
+    if card_status_value(&text).as_deref() == Some("completed") && !terminal_closeout {
+        return card_stage(
+            repo_root,
+            "SOR",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("sor-editor"),
+                "SOR card_status completed requires terminal closeout truth.",
+            ),
+        );
+    }
     if status == "NOT_STARTED" || text.contains("No implementation has started yet") {
         return card_stage(
             repo_root,
@@ -893,14 +1016,7 @@ fn classify_sor_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             ),
         );
     }
-    if ["merged", "closed_no_pr"].contains(&integration_state.as_str())
-        && matches!(
-            (status.as_str(), result.as_str()),
-            ("DONE", "PASS") | ("FAILED", "FAIL")
-        )
-        && worktree_only == "none"
-        && text.contains("## Validation")
-    {
+    if terminal_closeout {
         return card_stage(
             repo_root,
             "SOR",
@@ -1438,6 +1554,124 @@ mod tests {
                 .find(|stage| stage.stage == "SIP")
                 .and_then(|stage| stage.next_editor),
             Some("sip-editor")
+        );
+    }
+
+    #[test]
+    fn card_lifecycle_blocks_draft_design_time_card_status_before_execution() {
+        let repo = lifecycle_temp_repo("draft-card-status");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Card Status: draft\nBranch: not bound yet\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
+                sor: "Branch: not bound yet\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
+        assert_eq!(doctor_ready_status_for(&lifecycle), "BLOCK");
+        assert_stage(&lifecycle, "SIP", "active", false, false);
+        assert_eq!(
+            lifecycle
+                .stages
+                .iter()
+                .find(|stage| stage.stage == "SIP")
+                .and_then(|stage| stage.next_editor),
+            Some("sip-editor")
+        );
+    }
+
+    #[test]
+    fn card_lifecycle_blocks_completed_srp_without_review_results() {
+        let repo = lifecycle_temp_repo("completed-srp-without-results");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Card Status: ready\nBranch: codex/3065-test\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- Not run yet.\n",
+                sor: "# output\n\nBranch: codex/3065-test\nCard Status: ready\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_finish_readiness, "blocked");
+        assert_stage(&lifecycle, "SRP", "active", false, false);
+    }
+
+    #[test]
+    fn card_lifecycle_blocks_completed_sor_before_terminal_closeout() {
+        let repo = lifecycle_temp_repo("completed-sor-before-closeout");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Card Status: ready\nBranch: codex/3065-test\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"approved\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- pass\n",
+                sor: "# output\n\nBranch: codex/3065-test\nCard Status: completed\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_finish_readiness, "blocked");
+        assert_stage(&lifecycle, "SOR", "active", false, false);
+    }
+
+    #[test]
+    fn preflight_card_readiness_reports_blocked_for_draft_design_time_card() {
+        let repo = lifecycle_temp_repo("preflight-draft-card-status");
+        let issue_ref = IssueRef::new(
+            3296,
+            "v0.91.3".to_string(),
+            "v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills".to_string(),
+        )
+        .expect("issue ref");
+        let bundle = issue_ref.task_bundle_dir_path(&repo);
+        fs::create_dir_all(&bundle).expect("create bundle");
+        fs::write(
+            issue_ref.task_bundle_input_path(&repo),
+            "Card Status: draft\nBranch: not bound yet\n",
+        )
+        .expect("write sip");
+        fs::write(
+            issue_ref.task_bundle_stp_path(&repo),
+            "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+        )
+        .expect("write stp");
+        fs::write(
+            issue_ref.task_bundle_plan_path(&repo),
+            "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+        )
+        .expect("write spp");
+        fs::write(
+            issue_ref.task_bundle_review_policy_path(&repo),
+            "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
+        )
+        .expect("write srp");
+        fs::write(
+            issue_ref.task_bundle_output_path(&repo),
+            "Branch: not bound yet\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+        )
+        .expect("write sor");
+
+        assert_eq!(
+            preflight_card_run_readiness(&repo, &issue_ref),
+            Some("blocked")
         );
     }
 

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -45,7 +45,7 @@ use review_surface::{decision_for, ReviewCheck};
 #[cfg(test)]
 use structured_prompt::{
     extract_prompt_spec_yaml, prompt_spec_bool, prompt_spec_sections, validate_prompt_spec,
-    validate_sip_text, validate_sor_text, validate_stp_text,
+    validate_sip_text, validate_sor_text, validate_srp_text, validate_stp_text,
 };
 
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -45,7 +45,7 @@ use review_surface::{decision_for, ReviewCheck};
 #[cfg(test)]
 use structured_prompt::{
     extract_prompt_spec_yaml, prompt_spec_bool, prompt_spec_sections, validate_prompt_spec,
-    validate_sip_text, validate_sor_text, validate_srp_text, validate_stp_text,
+    validate_sip_text, validate_sor_text, validate_stp_text,
 };
 
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -16,6 +16,16 @@ use super::markdown::{
 };
 use super::tooling_usage;
 
+const ALLOWED_CARD_STATUS: &[&str] = &[
+    "draft",
+    "ready",
+    "reviewed",
+    "approved",
+    "completed",
+    "blocked",
+    "superseded",
+];
+
 pub(super) fn real_lint_prompt_spec(args: &[String]) -> Result<()> {
     let input = resolve_issue_or_input_arg(args)?;
     ensure_file(&input, "input card")?;
@@ -351,6 +361,52 @@ fn validate_reference_sequence(fm: &serde_yaml::Mapping, key: &str) -> Result<()
     Ok(())
 }
 
+fn validate_optional_front_matter_card_status(fm: &serde_yaml::Mapping) -> Result<()> {
+    if let Some(card_status) = mapping_string(fm, "card_status") {
+        ensure!(
+            ALLOWED_CARD_STATUS.contains(&card_status.as_str()),
+            "card_status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded"
+        );
+    }
+    Ok(())
+}
+
+fn validate_completed_srp_card_status(fm: &serde_yaml::Mapping) -> Result<()> {
+    if mapping_string(fm, "card_status").as_deref() != Some("completed") {
+        return Ok(());
+    }
+    let has_review_results = fm
+        .get(Value::String("review_results".to_string()))
+        .and_then(Value::as_mapping)
+        .map(|mapping| {
+            mapping_string(mapping, "findings_status")
+                .map(|v| matches!(v.as_str(), "no_findings" | "findings_present"))
+                .unwrap_or(false)
+                && mapping_string(mapping, "recommended_outcome")
+                    .map(|v| matches!(v.as_str(), "pass" | "block" | "needs_followup"))
+                    .unwrap_or(false)
+        })
+        .unwrap_or(false);
+    let has_final_exception = mapping_string(fm, "review_results_exception")
+        .map(|v| !v.trim().is_empty() && !v.contains("pre-execution review results are absent"))
+        .unwrap_or(false);
+    ensure!(
+        has_review_results || has_final_exception,
+        "card_status completed requires review_results with findings_status and recommended_outcome, or a final review_results_exception"
+    );
+    Ok(())
+}
+
+fn validate_optional_markdown_card_status(text: &str) -> Result<()> {
+    if let Some(card_status) = markdown_field(text, "Card Status") {
+        ensure!(
+            ALLOWED_CARD_STATUS.contains(&card_status.as_str()),
+            "Card Status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded"
+        );
+    }
+    Ok(())
+}
+
 pub(super) fn validate_stp_text(text: &str) -> Result<()> {
     let (fm_text, body_text) = split_front_matter(text)?;
     let fm_yaml: Value = serde_yaml::from_str(&fm_text)?;
@@ -406,6 +462,7 @@ pub(super) fn validate_stp_text(text: &str) -> Result<()> {
         ["draft", "active", "complete"].contains(&status.as_str()),
         "status must be one of: draft, active, complete"
     );
+    validate_optional_front_matter_card_status(fm)?;
     let action = mapping_string(fm, "action").unwrap_or_default();
     ensure!(
         ["create", "edit", "close", "split", "supersede"].contains(&action.as_str()),
@@ -485,6 +542,7 @@ pub(super) fn validate_sip_text(text: &str, path: &Path, phase: Option<&str>) ->
         valid_task_id(&markdown_field(text, "Run ID").unwrap_or_default()),
         "Run ID must match issue-0000"
     );
+    validate_optional_markdown_card_status(text)?;
     ensure!(
         valid_version(&markdown_field(text, "Version").unwrap_or_default()),
         "Version must match milestone version format (for example v0.85 or v0.87.1)"
@@ -569,6 +627,7 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         valid_task_id(&markdown_field(text, "Run ID").unwrap_or_default()),
         "Run ID must match issue-0000"
     );
+    validate_optional_markdown_card_status(text)?;
     ensure!(
         valid_version(&markdown_field(text, "Version").unwrap_or_default()),
         "Version must match milestone version format (for example v0.85 or v0.87.1)"
@@ -640,6 +699,35 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         result.is_empty() || ["PASS", "FAIL"].contains(&result.as_str()),
         "Main Repo Integration.Result must be one of: PASS, FAIL"
     );
+    if markdown_field(text, "Card Status").as_deref() == Some("completed") {
+        let worktree_only = markdown_block_field(
+            text,
+            "Main Repo Integration (REQUIRED)",
+            "Worktree-only paths remaining",
+        )
+        .unwrap_or_default();
+        let validation_body = markdown_section_body(text, "Validation").unwrap_or_default();
+        ensure!(
+            ["merged", "closed_no_pr"].contains(&integration_state.as_str()),
+            "Card Status completed requires terminal Integration state: merged or closed_no_pr"
+        );
+        ensure!(
+            ["DONE", "FAILED"].contains(&status.as_str()),
+            "Card Status completed requires terminal Status: DONE or FAILED"
+        );
+        ensure!(
+            ["PASS", "FAIL"].contains(&result.as_str()),
+            "Card Status completed requires terminal Main Repo Integration.Result: PASS or FAIL"
+        );
+        ensure!(
+            worktree_only == "none",
+            "Card Status completed requires Worktree-only paths remaining: none"
+        );
+        ensure!(
+            !validation_body.trim().is_empty(),
+            "Card Status completed requires validation truth"
+        );
+    }
 
     if phase == Some("completed") {
         ensure!(
@@ -762,6 +850,7 @@ pub(super) fn validate_spp_text(text: &str) -> Result<()> {
             .contains(&mapping_string(fm, "status").unwrap_or_default().as_str()),
         "status must be one of: draft, reviewed, approved"
     );
+    validate_optional_front_matter_card_status(fm)?;
     ensure!(
         mapping_string(fm, "plan_revision")
             .and_then(|v| v.parse::<u32>().ok())
@@ -931,6 +1020,8 @@ pub(super) fn validate_srp_text(text: &str) -> Result<()> {
             .contains(&mapping_string(fm, "status").unwrap_or_default().as_str()),
         "status must be one of: draft, ready, approved"
     );
+    validate_optional_front_matter_card_status(fm)?;
+    validate_completed_srp_card_status(fm)?;
     validate_reference_sequence(fm, "source_refs")?;
     ensure!(
         mapping_string(fm, "review_mode").as_deref() == Some("pre_pr_independent_review"),

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -1,3 +1,4 @@
+pub(super) use super::structured_prompt::validate_srp_text;
 pub(super) use super::*;
 pub(super) use crate::cli::tooling_cmd::common::{
     ensure_bool, is_repo_review_finding_title, mapping_bool, mapping_contains, mapping_mapping,

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -98,6 +98,75 @@ fn structured_prompt_completed_sor_closed_no_pr_still_rejects_non_retrospective_
 }
 
 #[test]
+fn structured_prompt_validators_reject_invalid_card_status_values() {
+    let stp = valid_stp_text().replace(
+        "status: \"draft\"",
+        "status: \"draft\"\ncard_status: \"almost\"",
+    );
+    let err = validate_stp_text(&stp).expect_err("invalid STP card_status should fail");
+    assert!(err.to_string().contains("card_status must be one of"));
+
+    let sip = valid_sip_text(1374, Path::new("/Users/daniel/git/agent-design-language"));
+    let sip = sip.replace(
+        "Branch: codex/1374-tooling-test",
+        "Card Status: almost\nBranch: codex/1374-tooling-test",
+    );
+    let err = validate_sip_text(&sip, Path::new("sip.md"), None)
+        .expect_err("invalid SIP Card Status should fail");
+    assert!(err.to_string().contains("Card Status must be one of"));
+}
+
+#[test]
+fn structured_prompt_srp_completed_card_status_requires_final_review_truth() {
+    let srp = valid_srp_text(1374)
+        .replace("status: \"draft\"", "card_status: \"completed\"\nstatus: \"approved\"")
+        .replace(
+            "review_results_exception: \"explicit policy exception: fixture review results are not run.\"\n",
+            "",
+        );
+
+    let err = validate_srp_text(&srp).expect_err("completed SRP without review truth should fail");
+    assert!(err
+        .to_string()
+        .contains("card_status completed requires review_results"));
+
+    let final_srp = srp.replace(
+        "notes: \"test note\"",
+        "review_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\nnotes: \"test note\"",
+    );
+    validate_srp_text(&final_srp).expect("completed SRP with final review truth should pass");
+}
+
+#[test]
+fn structured_prompt_sor_completed_card_status_requires_full_closeout_truth() {
+    let sor = valid_sor_text().replace(
+        "Status: DONE",
+        "Card Status: completed\nStatus: NOT_STARTED",
+    );
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("completed SOR without terminal execution status should fail");
+    assert!(err
+        .to_string()
+        .contains("Card Status completed requires terminal Status"));
+
+    let sor = valid_sor_text()
+        .replace("Status: DONE", "Card Status: completed\nStatus: DONE")
+        .replace(
+            "Worktree-only paths remaining: none",
+            "Worktree-only paths remaining: tracked change still on PR branch",
+        );
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("completed SOR with worktree residue should fail");
+    assert!(err
+        .to_string()
+        .contains("Card Status completed requires Worktree-only paths remaining"));
+
+    let sor = valid_sor_text().replace("Status: DONE", "Card Status: completed\nStatus: DONE");
+    validate_sor_text(&sor, Some("completed"))
+        .expect("completed SOR with terminal closeout truth should pass");
+}
+
+#[test]
 fn validate_structured_prompt_accepts_all_supported_prompt_types() {
     let repo = TempRepo::new("structured");
     let stp = repo.write_rel(".tmp/tooling_cmd_tests/stp.md", &valid_stp_text());

--- a/adl/tools/skills/sip-editor/SKILL.md
+++ b/adl/tools/skills/sip-editor/SKILL.md
@@ -43,6 +43,9 @@ Useful additional inputs:
 
 This skill may:
 - fix truthful `Branch` state such as `not bound yet` vs bound execution branch
+- set `Card Status` to `draft`, `ready`, `blocked`, or `superseded` according
+  to observed SIP truth; pre-run execution readiness requires `ready` or
+  `approved`
 - normalize target-file and validation-plan sections
 - align SIP wording with current lifecycle state
 - replace generic bootstrap intent with issue-specific design-time intent,
@@ -53,6 +56,8 @@ This skill may:
 This skill must not:
 - create or bind the branch/worktree itself
 - claim work is complete
+- set `Card Status: completed`; SIP completion is lifecycle truth owned by the
+  broader issue closeout path
 - author the final output record
 - widen issue scope
 

--- a/adl/tools/skills/sor-editor/SKILL.md
+++ b/adl/tools/skills/sor-editor/SKILL.md
@@ -44,16 +44,22 @@ Useful additional inputs:
 
 This skill may:
 - fix integration wording such as `worktree_only`, `pr_open`, or main-repo claims
+- set `Card Status` to `draft`, `ready`, `blocked`, or `superseded` according
+  to observed execution truth before closeout
 - replace placeholders with concrete paths or commands when evidence is supplied
 - normalize validation sections to reflect only checks actually run
 - preserve the design-time boundary between a pre-execution scaffold and a
   post-execution output record; do not mark output, validation, PR, merge, or
   closeout truth as complete before it exists
+- set `Card Status: completed` only when terminal closeout truth exists:
+  integration state is `merged` or `closed_no_pr`, validation result is
+  terminal, and no worktree-only paths remain
 - tighten artifact and determinism wording for truthfulness
 
 This skill must not:
 - invent validation that did not happen
 - claim merge or main-repo integration prematurely
+- set `Card Status: completed` for an open PR or active worktree
 - silently change issue scope
 - publish the PR itself
 

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -64,6 +64,9 @@ This skill may:
   `Test Strategy`, `Execution Handoff`, `Stop Conditions`, and `Notes`
 - fix invalid `codex_plan` statuses so they are only `pending`,
   `in_progress`, or `completed`
+- set `card_status` to `draft`, `ready`, `approved`, `blocked`, or
+  `superseded` according to observed planning truth; pre-run execution
+  readiness requires `ready` or `approved`
 - demote unsupported completed implementation steps back to pending planning
   state when execution evidence is absent
 - normalize assumptions, dependencies, source references, scope, risks, test
@@ -74,11 +77,14 @@ This skill may:
 - mark an SPP `reviewed` or `approved` only after the issue-local plan is
   specific enough to execute from tracked state; generic or truncated generated
   plans remain editor blockers
+- return `card_status` to `draft` when actual execution materially diverges
+  from the tracked plan and the plan must be revised before continuing
 - remove placeholders and stale execution or branch-binding claims
 
 This skill must not:
 - create or bind a branch or worktree
 - claim implementation is complete without explicit execution evidence
+- set `card_status: "completed"` merely because the plan is executable
 - erase concrete manual planning detail by collapsing issue-specific plans into
   generic boilerplate
 - rewrite `STP`, `SIP`, or `SOR` instead of handing off

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -157,6 +157,11 @@ This skill enforces:
 - no sprint-state advancement without a fresh matched live GitHub truth check
 - no next-child advancement without explicit child-closeout gate satisfaction
 - no live sprint execution without an explicit installed-skill parity/readiness result when sprint policy requires it
+- no child issue execution when `SIP`, `STP`, or `SPP` has a `card_status`
+  other than `ready` or `approved`
+- no child closeout acceptance when `SRP` or `SOR` overclaims
+  `card_status: completed` / `Card Status: completed` without review or
+  terminal closeout truth
 - healthy child waiting states are monitored issue-local lifecycle states, not default operator stop states
 - merged-but-not-closeouted children are immediate closeout work, not natural pause points
 

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -97,9 +97,61 @@ def line_value_after_prefix(text: str, prefix: str) -> str:
     return ''
 
 
+def card_status_value(text: str) -> str:
+    return (
+        line_value_after_prefix(text, 'card_status:') or
+        line_value_after_prefix(text, 'Card Status:')
+    )
+
+
+def design_time_card_status_defect(card_name: str, text: str) -> str | None:
+    status = card_status_value(text)
+    if not status:
+        return None
+    if card_name in {'sip.md', 'stp.md', 'spp.md'} and status not in {'ready', 'approved'}:
+        return f'{card_name} card_status must be ready or approved before execution binding'
+    return None
+
+
+def completed_srp_without_review_results(text: str) -> bool:
+    if card_status_value(text) != 'completed':
+        return False
+    findings_status = line_value_after_prefix(text, 'findings_status:')
+    recommended_outcome = line_value_after_prefix(text, 'recommended_outcome:')
+    has_review_results = (
+        findings_status in {'no_findings', 'findings_present'} and
+        recommended_outcome in {'pass', 'block', 'needs_followup'}
+    )
+    exception = line_value_after_prefix(text, 'review_results_exception:')
+    has_final_exception = (
+        bool(exception) and
+        'pre-execution review results are absent' not in exception
+    )
+    return not (has_review_results or has_final_exception)
+
+
+def completed_sor_without_terminal_closeout(text: str) -> bool:
+    if card_status_value(text) != 'completed':
+        return False
+    integration_state = line_value_after_prefix(text, '- Integration state:')
+    status = line_value_after_prefix(text, 'Status:')
+    result = line_value_after_prefix(text, '- Result:')
+    worktree_only = line_value_after_prefix(text, '- Worktree-only paths remaining:')
+    validation_body = text.split('## Validation', 1)[1].split('\n## ', 1)[0].strip() if '## Validation' in text else ''
+    return not (
+        integration_state in {'merged', 'closed_no_pr'} and
+        (status, result) in {('DONE', 'PASS'), ('FAILED', 'FAIL')} and
+        worktree_only == 'none' and
+        bool(validation_body)
+    )
+
+
 def design_time_defect(card_name: str, text: str) -> str | None:
     if has_unfilled_v1_placeholder(text):
         return 'unfilled prompt-template placeholder'
+    status_defect = design_time_card_status_defect(card_name, text)
+    if status_defect:
+        return status_defect
     if card_name == 'sip.md' and contains_any(text, GENERIC_SIP_MARKERS):
         return 'generic design-time SIP scaffold'
     if card_name == 'stp.md':
@@ -118,6 +170,11 @@ def design_time_defect(card_name: str, text: str) -> str | None:
             return 'legacy SRP policy scaffold'
         if '# Structured Review Prompt' not in text or 'artifact_type: "structured_review_prompt"' not in text:
             return 'missing Structured Review Prompt semantics'
+        if completed_srp_without_review_results(text):
+            return 'completed SRP lacks review results or a final policy exception'
+    if card_name == 'sor.md':
+        if completed_sor_without_terminal_closeout(text):
+            return 'completed SOR lacks terminal closeout truth'
     return None
 
 

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -46,6 +46,8 @@ Useful additional inputs:
 
 This skill may:
 - normalize `artifact_type` to `structured_review_prompt`
+- set `card_status` to `draft`, `ready`, `approved`, `completed`, `blocked`,
+  or `superseded` according to observed review truth
 - update headings and wording from legacy Structured Review Policy scaffolding
   to Structured Review Prompt semantics
 - prepare a complete review prompt before review while explicitly preserving
@@ -55,6 +57,9 @@ This skill may:
   dispositions, reviewer notes, residual risks, and recommended outcome
 - record review findings only when explicit review evidence is supplied
 - mark no-findings review results only when an actual review was performed
+- set `card_status: "completed"` only after review findings, dispositions,
+  reviewer notes, residual risks, or an explicit final policy exception are
+  recorded
 - preserve unresolved findings and route them back to implementation or
   follow-on issue creation
 - remove placeholders and stale review-completion claims

--- a/adl/tools/skills/stp-editor/SKILL.md
+++ b/adl/tools/skills/stp-editor/SKILL.md
@@ -42,6 +42,9 @@ Useful additional inputs:
 
 This skill may:
 - improve goal wording without changing intent
+- set `card_status` to `draft`, `ready`, `blocked`, or `superseded` according
+  to observed STP truth; pre-run execution readiness requires `ready` or
+  `approved`
 - tighten required outcome and acceptance criteria
 - make the selected task explicit enough for design-time readiness, including
   deliverables, touched surfaces, proof shape, invariants, and non-goals
@@ -52,6 +55,7 @@ This skill may:
 This skill must not:
 - create or bind branches/worktrees
 - invent implementation results
+- set `card_status: "completed"` without explicit lifecycle closeout evidence
 - rewrite SIP/SOR content except by explicit handoff to those skills
 - widen issue scope
 - silently change source-prompt meaning

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -143,6 +143,10 @@ Important rule:
   matching card editor before execution or publication continues; generic
   `SIP`, incomplete `STP`, generic/truncated `SPP`, and legacy/incomplete
   `SRP` surfaces are not safe to treat as ready merely because the files exist
+- card-status blockers from `pr doctor` should route to the matching card
+  editor: `SIP`, `STP`, and `SPP` must be `ready` or `approved` before
+  execution binding; `SRP` completion requires review truth; `SOR` completion
+  requires terminal closeout truth
 - planning-document defects such as placeholder residue, missing required
   planning sections, stale planning status claims, or generated-vs-reviewed
   truth drift should route to `planning-doc-editor`; do not send those defects

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -214,6 +214,113 @@ EOF
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_valid.md"
 "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_valid.md"
 
+cp "$tmpdir/stp_valid.md" "$tmpdir/stp_invalid_card_status.md"
+perl -0pi -e 's/status: "draft"/status: "draft"\ncard_status: "nearly-ready"/' "$tmpdir/stp_invalid_card_status.md"
+if "$VALIDATOR" --type stp --input "$tmpdir/stp_invalid_card_status.md" >"$tmpdir/stp_invalid_card_status.out" 2>&1; then
+  echo "expected STP with invalid card_status to fail validation" >&2
+  exit 1
+fi
+grep -Fq "card_status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded" "$tmpdir/stp_invalid_card_status.out"
+
+cp "$tmpdir/sor_valid.md" "$tmpdir/sor_invalid_card_status.md"
+perl -0pi -e 's/Status: NOT_STARTED/Card Status: nearly-ready\nStatus: NOT_STARTED/' "$tmpdir/sor_invalid_card_status.md"
+if "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_invalid_card_status.md" >"$tmpdir/sor_invalid_card_status.out" 2>&1; then
+  echo "expected SOR with invalid Card Status to fail validation" >&2
+  exit 1
+fi
+grep -Fq "Card Status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded" "$tmpdir/sor_invalid_card_status.out"
+
+cp "$tmpdir/sor_valid.md" "$tmpdir/sor_completed_without_closeout.md"
+perl -0pi -e 's/Status: NOT_STARTED/Card Status: completed\nStatus: DONE/; s/- Integration state:/- Integration state: pr_open/; s/- Result:/- Result: PASS/' "$tmpdir/sor_completed_without_closeout.md"
+if "$VALIDATOR" --type sor --input "$tmpdir/sor_completed_without_closeout.md" >"$tmpdir/sor_completed_without_closeout.out" 2>&1; then
+  echo "expected completed SOR without terminal closeout to fail validation" >&2
+  exit 1
+fi
+grep -Fq "Card Status completed requires terminal Integration state: merged or closed_no_pr" "$tmpdir/sor_completed_without_closeout.out"
+
+cp "$tmpdir/sor_valid.md" "$tmpdir/sor_completed_without_terminal_status.md"
+perl -0pi -e 's/Status: NOT_STARTED/Card Status: completed\nStatus: NOT_STARTED/; s/- Worktree-only paths remaining:/- Worktree-only paths remaining: none/; s/- Integration state:/- Integration state: merged/; s/- Result:/- Result: PASS/' "$tmpdir/sor_completed_without_terminal_status.md"
+if "$VALIDATOR" --type sor --input "$tmpdir/sor_completed_without_terminal_status.md" >"$tmpdir/sor_completed_without_terminal_status.out" 2>&1; then
+  echo "expected completed SOR without terminal execution status to fail validation" >&2
+  exit 1
+fi
+grep -Fq "Card Status completed requires terminal Status: DONE or FAILED" "$tmpdir/sor_completed_without_terminal_status.out"
+
+cat >"$tmpdir/srp_completed_without_results.md" <<'EOF'
+---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "invalid-completed-srp"
+issue: 898
+task_id: "issue-0898"
+version: "v0.85"
+title: "Invalid completed SRP"
+branch: "codex/898-invalid-completed-srp"
+card_status: "completed"
+status: "approved"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/danielbaustin/agent-design-language/issues/898"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - "stp.md"
+in_scope_surfaces:
+  - "tracked changes"
+evidence_policy:
+  - "repo evidence only"
+validation_inputs:
+  - "focused checks"
+allowed_dispositions:
+  - "PASS"
+reviewer_constraints:
+  - "do not widen scope"
+refusal_policy:
+  - "refuse unsupported claims"
+follow_up_routing:
+  - "route findings back"
+non_claims:
+  - "review has not run"
+policy_refs:
+  - "stp.md"
+---
+
+# Structured Review Prompt
+
+## Review Summary
+x
+## Scope Basis
+x
+## In-Scope Surfaces
+x
+## Evidence Rules
+x
+## Validation Inputs
+x
+## Allowed Dispositions
+x
+## Reviewer Constraints
+x
+## Refusal Policy
+x
+## Follow-up Routing
+x
+## Non-Claims
+x
+## Review Results
+
+- Not run yet.
+
+## Notes
+x
+EOF
+
+if "$VALIDATOR" --type srp --input "$tmpdir/srp_completed_without_results.md" >"$tmpdir/srp_completed_without_results.out" 2>&1; then
+  echo "expected completed SRP without review results to fail validation" >&2
+  exit 1
+fi
+grep -Fq "card_status completed requires review_results with findings_status and recommended_outcome, or a final review_results_exception" "$tmpdir/srp_completed_without_results.out"
+
 cat >"$tmpdir/stp_missing_multiple_sections.md" <<'EOF'
 ---
 issue_card_schema: adl.issue.v1

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -53,6 +53,7 @@ Every filled prompt card uses this small lifecycle enum:
 
 - `draft`: the card exists but is incomplete or locally invalid
 - `ready`: the card is filled and locally validator-clean
+- `reviewed`: the card has been reviewed but is not yet an execution gate
 - `approved`: the required review gate has accepted the card for use
 - `completed`: the card has fulfilled its lifecycle role and is now audit truth
 - `blocked`: the card cannot advance until an upstream condition changes
@@ -61,6 +62,15 @@ Every filled prompt card uses this small lifecycle enum:
 The local browser editor derives `draft` or `ready` from form validation.
 Lifecycle tooling should set `approved`, `completed`, `blocked`, or
 `superseded` only at the corresponding C-SDLC state transition.
+
+Execution preflight is intentionally stricter than enum validation:
+
+- `SIP`, `STP`, and `SPP` must be `ready` or `approved` before execution binds.
+- `SPP` may return to `draft` when the real execution path materially diverges.
+- `SRP` may be `completed` only after review results, dispositions, or an
+  explicit final policy exception are recorded.
+- `SOR` may be `completed` only after terminal closeout truth is present.
+- `SOR` execution `Status` remains separate from card lifecycle `Card Status`.
 
 ## Compatibility
 

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -18,6 +18,11 @@ The editor is intentionally small:
 - Exported Markdown remains the reviewable card truth that validators and
   issue worktrees consume.
 
+The editor shows `card_status` as local form state, not as operator authority.
+Execution tooling still enforces the phase rules: `SIP`, `STP`, and `SPP` must
+be `ready` or `approved` before execution starts; `SRP` completion requires
+review truth; and `SOR` completion requires closeout truth.
+
 ## Generate The Model
 
 Run this after template or field-model changes:


### PR DESCRIPTION
Closes #3296

## Summary
Implemented the first enforceable C-SDLC card-status transition slice for
issue `#3296`. The work adds enum validation, doctor/readiness gates,
sprint-preflight checks, focused regression coverage, and skill/documentation
guidance for transition ownership.

## Artifacts
- `adl/src/cli/tooling_cmd/structured_prompt.rs`
- `adl/src/cli/tooling_cmd.rs`
- `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`
- `adl/src/cli/pr_cmd/doctor.rs`
- `adl/tools/test_structured_prompt_validation.sh`
- `adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/sip-editor/SKILL.md`
- `adl/tools/skills/stp-editor/SKILL.md`
- `adl/tools/skills/spp-editor/SKILL.md`
- `adl/tools/skills/srp-editor/SKILL.md`
- `adl/tools/skills/sor-editor/SKILL.md`
- `docs/templates/prompts/README.md`
- `docs/tooling/csdlc-prompt-editor/README.md`

## Validation
- Validation commands and their purpose:
- `cargo fmt --manifest-path adl/Cargo.toml --check`
  Verified Rust formatting.
- `bash adl/tools/test_structured_prompt_validation.sh`
  Verified structured-prompt validation, including invalid `card_status` and premature SOR completion failures.
- `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root . --ordered-issues 3296 --print-json`
  Verified sprint-preflight status readiness for this issue bundle.
- `cargo test --manifest-path adl/Cargo.toml card_lifecycle_blocks -- --nocapture`
  Verified focused doctor lifecycle blocking behavior.
- `cargo test --manifest-path adl/Cargo.toml structured_prompt_ -- --nocapture`
  Verified focused Rust structured-prompt validator regression coverage.
- `cargo clippy --manifest-path adl/Cargo.toml --all-targets --all-features -- -D warnings`
  Verified Rust warning cleanliness after the validator and doctor changes.
- `cargo llvm-cov --manifest-path adl/Cargo.toml --workspace --summary-only --json --output-path adl/target/coverage-impact-summary.json -- cmd`
  Produced focused coverage data for the changed Rust command/tooling surfaces.
- `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
  Verified the changed Rust files meet coverage-impact policy.
- `git diff --check`
  Verified whitespace hygiene.
- `adl/tools/pr.sh doctor 3296 --version v0.91.3 --json`
  Verified issue lifecycle state; expected open-PR-wave block was handled truthfully.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3296__v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3296__v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills/sor.md
- Idempotency-Key: v0-91-3-tools-enforce-c-sdlc-card-status-transitions-adl-src-cli-pr-cmd-doctor-rs-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-structured-prompt-rs-adl-src-cli-tooling-cmd-tests-structured-prompt-rs-adl-tools-test-structured-prompt-validation-sh-adl-tools-skills-sprint-conductor-scripts-check-sprint-structured-prompt-readiness-py-adl-tools-skills-workflow-conductor-skill-md-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sip-editor-skill-md-adl-tools-skills-stp-editor-skill-md-adl-tools-skills-spp-editor-skill-md-adl-tools-skills-srp-editor-skill-md-adl-tools-skills-sor-editor-skill-md-docs-templates-prompts-readme-md-docs-tooling-csdlc-prompt-editor-readme-md-adl-v0-91-3-tasks-issue-3296-v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills-sip-md-adl-v0-91-3-tasks-issue-3296-v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills-sor-md