### PR TITLE
[v0.91.3][tools] Improve C-SDLC issue bootstrap UX

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -273,11 +273,14 @@ fn real_pr_create(args: &[String]) -> Result<()> {
         "  BUNDLE     {}",
         path_relative_to_repo(&repo_root, &bundle_dir)
     );
-    println!("  READY      {}", ready.status);
+    println!(
+        "  READY      {}",
+        bootstrap_ready_status_label(ready.status)
+    );
     println!("  LIFECYCLE  {}", ready.lifecycle_state);
     println!("  NEXT       qualitative SIP/STP/SPP/SRP design-time review, then adl/tools/pr.sh run {issue} --slug {slug} --version {version}");
     println!("  STATE      ISSUE_AND_BUNDLE_READY");
-    eprintln!("• Done.");
+    println!("• Done.");
     Ok(())
 }
 
@@ -500,7 +503,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         parsed.issue
     );
     println!("  STATE  FULLY_STARTED");
-    eprintln!("• Done.");
+    println!("• Done.");
     Ok(())
 }
 
@@ -770,8 +773,29 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     println!("  ISSUE    #{issue}");
     println!("  CONTRACT validated source prompt + root SIP/STP/SPP/SRP/SOR task bundle");
     println!("  STATE    ISSUE_AND_BUNDLE_READY");
-    eprintln!("• Done.");
+    println!("• Done.");
     Ok(())
+}
+
+fn bootstrap_ready_status_label(status: &str) -> &str {
+    match status {
+        "BLOCK" => "BLOCKED_PENDING_CARD_REVIEW",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_output_tests {
+    use super::bootstrap_ready_status_label;
+
+    #[test]
+    fn bootstrap_ready_status_explains_card_review_blockers() {
+        assert_eq!(
+            bootstrap_ready_status_label("BLOCK"),
+            "BLOCKED_PENDING_CARD_REVIEW"
+        );
+        assert_eq!(bootstrap_ready_status_label("PASS"), "PASS");
+    }
 }
 
 fn bootstrap_root_task_bundle(

--- a/adl/tools/test_pr_init.sh
+++ b/adl/tools/test_pr_init.sh
@@ -7,6 +7,7 @@ PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
 CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
 PROMPT_LINT_SRC="$ROOT_DIR/adl/tools/lint_prompt_spec.sh"
 PROMPT_VALIDATOR_SRC="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
+PROMPT_TEMPLATES_SRC="$ROOT_DIR/docs/templates/prompts"
 INPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/input_card_template.md"
 OUTPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/output_card_template.md"
 STP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_task_prompt.contract.yaml"
@@ -29,6 +30,7 @@ mkdir -p \
   "$repo/adl/tools" \
   "$repo/adl/templates/cards" \
   "$repo/adl/schemas" \
+  "$repo/docs/templates" \
   "$repo/.adl/issues/v0.85/bodies" \
   "$bindir"
 
@@ -36,6 +38,7 @@ cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
 cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
 cp "$PROMPT_LINT_SRC" "$repo/adl/tools/lint_prompt_spec.sh"
 cp "$PROMPT_VALIDATOR_SRC" "$repo/adl/tools/validate_structured_prompt.sh"
+cp -R "$PROMPT_TEMPLATES_SRC" "$repo/docs/templates/prompts"
 cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
 cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
 cp "$STP_CONTRACT_SRC" "$repo/adl/schemas/structured_task_prompt.contract.yaml"
@@ -162,9 +165,11 @@ assert_contains() {
 
   out1="$("$BASH_BIN" adl/tools/pr.sh init 42 --slug test-init --no-fetch-issue --version v0.85)"
   assert_contains "STP      .adl/v0.85/tasks/issue-0042__test-init/stp.md" "$out1" "stp path"
+  assert_contains "SPP      .adl/v0.85/tasks/issue-0042__test-init/spp.md" "$out1" "spp path"
+  assert_contains "SRP      .adl/v0.85/tasks/issue-0042__test-init/srp.md" "$out1" "srp path"
   assert_contains "READ     .adl/v0.85/tasks/issue-0042__test-init/sip.md" "$out1" "read path"
   assert_contains "WRITE    .adl/v0.85/tasks/issue-0042__test-init/sor.md" "$out1" "write path"
-  assert_contains "CONTRACT minimum v0.86 init = validated source prompt + root stp/sip/sor bundle" "$out1" "contract line"
+  assert_contains "CONTRACT validated source prompt + root SIP/STP/SPP/SRP/SOR task bundle" "$out1" "contract line"
   assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out1" "state line"
 
   stp_path="$repo/.adl/v0.85/tasks/issue-0042__test-init/stp.md"


### PR DESCRIPTION
Closes #3322

## Summary
Implemented the bounded C-SDLC issue bootstrap UX fix. Bootstrap output now
keeps `Done` on stdout after the full summary, maps raw `BLOCK` to the clearer
`BLOCKED_PENDING_CARD_REVIEW` label for create output, and updates the shell
`pr init` fixture to copy the current versioned prompt templates and assert the
five-card contract.

## Artifacts
- Tracked implementation artifact: `adl/src/cli/pr_cmd.rs`
- Tracked validation artifact: `adl/tools/test_pr_init.sh`
- Local ignored lifecycle records under `.adl/v0.91.3/tasks/issue-3322__v0-91-3-tools-improve-csdlc-issue-bootstrap-ux/`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.3/tasks/issue-3322__v0-91-3-tools-improve-csdlc-issue-bootstrap-ux/spp.md`
    Verified the SPP after design-time readiness normalization.
  - `cargo test --manifest-path adl/Cargo.toml bootstrap_ready_status_explains_card_review_blockers -- --nocapture`
    Verified the new bootstrap readiness label helper.
  - `bash adl/tools/test_pr_init.sh`
    Verified the shell `pr init` output contract and current prompt-template fixture setup.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified patch whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3322__v0-91-3-tools-improve-csdlc-issue-bootstrap-ux/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3322__v0-91-3-tools-improve-csdlc-issue-bootstrap-ux/sor.md
- Idempotency-Key: v0-91-3-tools-improve-c-sdlc-issue-bootstrap-ux-adl-src-cli-pr-cmd-rs-adl-tools-test-pr-init-sh-adl-v0-91-3-tasks-issue-3322-v0-91-3-tools-improve-csdlc-issue-bootstrap-ux-sip-md-adl-v0-91-3-tasks-issue-3322-v0-91-3-tools-improve-csdlc-issue-bootstrap-ux-sor-md