### PR TITLE
[v0.91.3][quality] Harden proof-validation lane after second review

### DIFF
--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -114,6 +114,7 @@ mark_policy_surface_full_coverage() {
 }
 
 mark_v0913_proof_required() {
+  rust_required=true
   v0913_proof_required=true
   proof_validation_scope="v0_91_3"
   if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
@@ -220,6 +221,7 @@ is_v0913_proof_surface() {
   local path="$1"
   case "$path" in
     docs/milestones/v0.91.3/review/*|\
+    docs/milestones/v0.91.3/features/*|\
     docs/milestones/v0.91.3/DEMO_MATRIX_v0.91.3.md|\
     docs/milestones/v0.91.3/FEATURE_PROOF_COVERAGE_v0.91.3.md|\
     docs/milestones/v0.91.3/QUALITY_GATE_v0.91.3.md|\
@@ -247,7 +249,8 @@ is_v0913_proof_surface() {
     adl/tools/validate_v0913_quality_gate_review_surfaces.py|\
     adl/tools/demo_v0913_quality_gate.sh|\
     adl/tools/run_v0913_proof_validation_lane.sh|\
-    adl/tools/test_run_v0913_proof_validation_lane.sh)
+    adl/tools/test_run_v0913_proof_validation_lane.sh|\
+    workflow/c-sdlc/v0.91.3/issues/*)
       return 0
       ;;
   esac
@@ -404,7 +407,7 @@ elif [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
   fail_closed=true
   mark_authoritative_full_coverage "fail_closed" "missing_pull_request_sha_runs_full_validation"
 else
-  changed_rows="$(git diff --name-status --diff-filter=ACMR "$base_sha" "$head_sha" 2>/dev/null | normalize_changed_rows || true)"
+  changed_rows="$(git diff --name-status --diff-filter=ACMRD "$base_sha" "$head_sha" 2>/dev/null | normalize_changed_rows || true)"
   changed_files="$(printf '%s\n' "$changed_rows" | awk -F '\t' 'NF >= 2 { print $2 }')"
   if [ -z "$changed_rows" ]; then
     fail_closed=true

--- a/adl/tools/run_v0913_proof_validation_lane.sh
+++ b/adl/tools/run_v0913_proof_validation_lane.sh
@@ -15,11 +15,36 @@ run_check() {
   "$@"
 }
 
+validate_card_lifecycle_bundle() {
+  bash "$ROOT_DIR/adl/tools/validate_structured_prompt.sh" --type sip --phase bootstrap \
+    --input "$ROOT_DIR/workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/cards/sip.md"
+  bash "$ROOT_DIR/adl/tools/validate_structured_prompt.sh" --type stp \
+    --input "$ROOT_DIR/workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/cards/stp.md"
+  bash "$ROOT_DIR/adl/tools/validate_structured_prompt.sh" --type spp --phase final \
+    --input "$ROOT_DIR/workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/cards/spp.md"
+  bash "$ROOT_DIR/adl/tools/validate_structured_prompt.sh" --type srp --phase final \
+    --input "$ROOT_DIR/workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/cards/srp.md"
+  bash "$ROOT_DIR/adl/tools/validate_structured_prompt.sh" --type sor --phase final \
+    --input "$ROOT_DIR/workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/cards/sor.md"
+}
+
+validate_card_lifecycle_contract() {
+  cargo test --manifest-path "$ROOT_DIR/adl/Cargo.toml" tracked_csdlc_card_bundle -- --nocapture
+  cargo test --manifest-path "$ROOT_DIR/adl/Cargo.toml" card_lifecycle_accepts_tracked_csdlc_bundle -- --nocapture
+}
+
 run_check transition_dag_packet \
   python3 "$ROOT_DIR/adl/tools/validate_transition_dag_packet.py" \
   "$ROOT_DIR/docs/milestones/v0.91.3/review/transition_dag"
 run_check transition_dag_contract \
   bash "$ROOT_DIR/adl/tools/test_transition_dag_packet.sh"
+
+run_check transition_manifest_schema \
+  cargo test --manifest-path "$ROOT_DIR/adl/Cargo.toml" cognitive_transition_schema -- --nocapture
+
+run_check card_lifecycle_bundle validate_card_lifecycle_bundle
+
+run_check card_lifecycle_contract validate_card_lifecycle_contract
 
 run_check evidence_bundle_packet \
   python3 "$ROOT_DIR/adl/tools/validate_evidence_bundle_packet.py" \

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -286,7 +286,7 @@ PY
   v0913_proof_head="$(git rev-parse HEAD)"
 
   v0913_proof_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$v0913_proof_head" --ref "refs/pull/1/merge")"
-  assert_has "$v0913_proof_output" "rust_required=false"
+  assert_has "$v0913_proof_output" "rust_required=true"
   assert_has "$v0913_proof_output" "coverage_required=false"
   assert_has "$v0913_proof_output" "full_coverage_required=false"
   assert_has "$v0913_proof_output" "demo_smoke_required=false"
@@ -294,6 +294,43 @@ PY
   assert_has "$v0913_proof_output" "proof_validation_scope=v0_91_3"
   assert_has "$v0913_proof_output" "reason=v0913_proof_surface_change_runs_targeted_packet_validation"
   assert_has "$workflow_policy_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+
+  git checkout -q -b v0913-feature-proof-surface "$base_sha"
+  mkdir -p docs/milestones/v0.91.3/features workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo
+  printf '# feature proof\n' > docs/milestones/v0.91.3/features/CARD_LIFECYCLE_INTEGRATION.md
+  printf '# tracked bundle\n' > workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/README.md
+  git add docs/milestones/v0.91.3/features/CARD_LIFECYCLE_INTEGRATION.md workflow/c-sdlc/v0.91.3/issues/issue-3201-card-lifecycle-demo/README.md
+  git commit -q -m v0913-feature-proof-surface
+  v0913_feature_proof_head="$(git rev-parse HEAD)"
+
+  v0913_feature_proof_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$v0913_feature_proof_head" --ref "refs/pull/1/merge")"
+  assert_has "$v0913_feature_proof_output" "rust_required=true"
+  assert_has "$v0913_feature_proof_output" "coverage_required=false"
+  assert_has "$v0913_feature_proof_output" "full_coverage_required=false"
+  assert_has "$v0913_feature_proof_output" "demo_smoke_required=false"
+  assert_has "$v0913_feature_proof_output" "v0913_proof_required=true"
+  assert_has "$v0913_feature_proof_output" "proof_validation_scope=v0_91_3"
+  assert_has "$v0913_feature_proof_output" "reason=v0913_proof_surface_change_runs_targeted_packet_validation"
+
+  git checkout -q -b v0913-proof-surface-deletion "$base_sha"
+  mkdir -p docs/milestones/v0.91.3/review/demo_coverage
+  printf '# proof packet\n' > docs/milestones/v0.91.3/review/demo_coverage/DEMO_COVERAGE_PACKET_v0.91.3.md
+  git add docs/milestones/v0.91.3/review/demo_coverage/DEMO_COVERAGE_PACKET_v0.91.3.md
+  git commit -q -m seed-v0913-proof-surface-deletion
+  deletion_base="$(git rev-parse HEAD)"
+  rm docs/milestones/v0.91.3/review/demo_coverage/DEMO_COVERAGE_PACKET_v0.91.3.md
+  git add -A docs/milestones/v0.91.3/review/demo_coverage/DEMO_COVERAGE_PACKET_v0.91.3.md
+  git commit -q -m delete-v0913-proof-surface
+  deletion_head="$(git rev-parse HEAD)"
+
+  deletion_output="$("$POLICY" --event-name pull_request --base "$deletion_base" --head "$deletion_head" --ref "refs/pull/1/merge")"
+  assert_has "$deletion_output" "rust_required=true"
+  assert_has "$deletion_output" "coverage_required=false"
+  assert_has "$deletion_output" "full_coverage_required=false"
+  assert_has "$deletion_output" "demo_smoke_required=false"
+  assert_has "$deletion_output" "v0913_proof_required=true"
+  assert_has "$deletion_output" "proof_validation_scope=v0_91_3"
+  assert_has "$deletion_output" "reason=v0913_proof_surface_change_runs_targeted_packet_validation"
 
   git checkout -q -b runtime-policy-surface-change "$base_sha"
   mkdir -p adl/tools

--- a/adl/tools/test_run_v0913_proof_validation_lane.sh
+++ b/adl/tools/test_run_v0913_proof_validation_lane.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-ADL_V0913_PROOF_ONLY_CHECKS="merge_readiness_packet,merge_readiness_contract,quality_gate_doc_surface,quality_gate_packet_surface,demo_coverage_surface" \
+ADL_V0913_PROOF_ONLY_CHECKS="transition_manifest_schema,card_lifecycle_bundle,card_lifecycle_contract,merge_readiness_packet,merge_readiness_contract,quality_gate_doc_surface,quality_gate_packet_surface,demo_coverage_surface" \
   bash "$ROOT_DIR/adl/tools/run_v0913_proof_validation_lane.sh" >/dev/null
 
 echo "PASS test_run_v0913_proof_validation_lane"

--- a/adl/tools/validate_v0913_quality_gate_review_surfaces.py
+++ b/adl/tools/validate_v0913_quality_gate_review_surfaces.py
@@ -18,6 +18,30 @@ def require_text(path: Path, snippets: list[str]) -> str | None:
     return None
 
 
+def require_demo_map_routes(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    required_routes = {
+        "Cognitive Transition Manifest": "cargo test --manifest-path adl/Cargo.toml cognitive_transition_schema -- --nocapture",
+        "Card Lifecycle Integration": "adl/tools/pr.sh doctor 3201 --version v0.91.3 --json",
+        "Transition DAG And Shard Coordination": "python3 adl/tools/validate_transition_dag_packet.py docs/milestones/v0.91.3/review/transition_dag",
+        "Evidence Bundle And Review Synthesis": "python3 adl/tools/validate_evidence_bundle_packet.py docs/milestones/v0.91.3/review/evidence_bundle",
+        "Governed Merge-Readiness Gate": "python3 adl/tools/validate_merge_readiness_packet.py docs/milestones/v0.91.3/review/merge_readiness",
+        "SRP/SOR ObsMem Handoff": "python3 adl/tools/validate_obsmem_handoff_packet.py docs/milestones/v0.91.3/review/obsmem_handoff",
+        "Integrated Process Lessons And Proof Readiness": "python3 adl/tools/validate_first_proof_readiness_packet.py docs/milestones/v0.91.3/review/first_proof_readiness",
+        "Five-Minute Sprint First Proof": "python3 adl/tools/demo_v0913_first_proof_demo.py",
+        "C-SDLC Demo Proof Contract": "python3 adl/tools/validate_csdlc_demo_proof_contract_packet.py docs/milestones/v0.91.3/review/csdlc_demo_proof_contract",
+    }
+    missing: list[str] = []
+    for feature, route in required_routes.items():
+        if feature not in text or route not in text:
+            missing.append(f"{feature} -> {route}")
+    if missing:
+        return "demo coverage map missing executable proof routes: " + "; ".join(missing)
+    if "Missing feature with no truthful demo/proof route: none found" not in text:
+        return "demo coverage map must record the missing-feature verdict"
+    return None
+
+
 def main() -> int:
     if len(sys.argv) != 3:
         return fail(
@@ -86,6 +110,9 @@ def main() -> int:
         linked = docs_root / "review/demo_coverage/ct_demo_006_feature_demo_map.md"
         if not linked.is_file():
             return fail(f"missing linked demo-coverage map: {linked}")
+        error = require_demo_map_routes(linked)
+        if error:
+            return fail(error)
     else:
         return fail(f"unknown surface: {surface}")
 


### PR DESCRIPTION
Closes #3326

## Summary
Hardened the v0.91.3 proof-validation lane so proof-surface changes cannot bypass the documented quality gate categories. The lane now includes transition-manifest schema validation and card-lifecycle proof checks, path policy triggers the lane for v0.91.3 feature/proof surfaces including deletions, and the demo-coverage validator checks concrete proof routes rather than only file existence.

## Artifacts
- Updated proof runner: `adl/tools/run_v0913_proof_validation_lane.sh`
- Updated proof runner contract test: `adl/tools/test_run_v0913_proof_validation_lane.sh`
- Updated CI path policy: `adl/tools/ci_path_policy.sh`
- Updated path-policy contract test: `adl/tools/test_ci_path_policy.sh`
- Updated quality-gate surface validator: `adl/tools/validate_v0913_quality_gate_review_surfaces.py`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/run_v0913_proof_validation_lane.sh adl/tools/test_run_v0913_proof_validation_lane.sh adl/tools/ci_path_policy.sh adl/tools/test_ci_path_policy.sh`
    Verified edited shell scripts parse.
  - `python3 -m py_compile adl/tools/validate_v0913_quality_gate_review_surfaces.py`
    Verified the edited Python validator compiles.
  - `python3 adl/tools/validate_v0913_quality_gate_review_surfaces.py . demo_coverage`
    Verified the demo-coverage validator now checks concrete proof routes and passes.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified CI path-policy proof triggers, deletion handling, and Rust setup behavior.
  - `bash adl/tools/test_run_v0913_proof_validation_lane.sh`
    Verified the proof lane contract passes with transition-manifest and card-lifecycle checks included.
  - `bash adl/tools/test_demo_v0913_quality_gate.sh`
    Verified the quality-gate demo contract still passes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3326__v0-91-3-quality-harden-proof-validation-lane-after-second-review/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3326__v0-91-3-quality-harden-proof-validation-lane-after-second-review/sor.md
- Idempotency-Key: v0-91-3-quality-harden-proof-validation-lane-after-second-review-adl-tools-run-v0913-proof-validation-lane-sh-adl-tools-test-run-v0913-proof-validation-lane-sh-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-tools-validate-v0913-quality-gate-review-surfaces-py-adl-v0-91-3-tasks-issue-3326-v0-91-3-quality-harden-proof-validation-lane-after-second-review-sip-md-adl-v0-91-3-tasks-issue-3326-v0-91-3-quality-harden-proof-validation-lane-after-second-review-sor-md