### PR TITLE
[v0.91.3][review] Clean portability and redaction issues from pass-2 review

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -169,10 +169,10 @@ For deterministic use, prefer structured invocation over loose prose.
 The general pattern is:
 
 ```yaml
-Use $<skill-name> at /Users/daniel/git/agent-design-language/adl/tools/skills/<skill-name>/SKILL.md with this validated input:
+Use $<skill-name> at <repo-root>/adl/tools/skills/<skill-name>/SKILL.md with this validated input:
 skill_input_schema: <schema-id>
 mode: <mode>
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   ...
 policy:
@@ -395,7 +395,7 @@ Minimum:
   - `target.task_bundle_path`
   - `target.branch`
   - `target.worktree_path`
-- `target.pr_number`
+  - `target.pr_number`
 - explicit routing `mode`
 - explicit `policy`
 - optional `observed_state.subagent_assigned`
@@ -408,11 +408,11 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $workflow-conductor at /Users/daniel/git/agent-design-language/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
+Use $workflow-conductor at <repo-root>/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
 
 skill_input_schema: workflow_conductor.v1
 mode: route_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1647
   slug: add-lightweight-workflow-conductor-skill
@@ -742,11 +742,11 @@ required source-prompt sections up front and reports the complete missing
 section set in one failure.
 
 ```yaml
-Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+Use $pr-init at <repo-root>/adl/tools/skills/pr-init/SKILL.md with this validated input:
 
 skill_input_schema: pr_init.v1
 mode: create_and_bootstrap
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 issue:
   number: null
   title: "[v0.87][tools] Example issue"
@@ -851,11 +851,11 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-ready at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-ready/SKILL.md with this validated input:
+Use $pr-ready at <repo-root>/adl/tools/skills/pr-ready/SKILL.md with this validated input:
 
 skill_input_schema: pr_ready.v1
 mode: diagnose_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1299
   task_bundle_path: null
@@ -963,11 +963,11 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-run at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-run/SKILL.md with this validated input:
+Use $pr-run at <repo-root>/adl/tools/skills/pr-run/SKILL.md with this validated input:
 
 skill_input_schema: pr_run.v1
 mode: run_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1299
   task_bundle_path: null
@@ -1071,11 +1071,11 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-janitor at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-janitor/SKILL.md with this validated input:
+Use $pr-janitor at <repo-root>/adl/tools/skills/pr-janitor/SKILL.md with this validated input:
 
 skill_input_schema: pr_janitor.v1
 mode: watch_pr
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   pr_number: 1338
   pr_url: null
@@ -1185,16 +1185,16 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $pr-closeout at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-closeout/SKILL.md with this validated input:
+Use $pr-closeout at <repo-root>/adl/tools/skills/pr-closeout/SKILL.md with this validated input:
 
 skill_input_schema: pr_closeout.v1
 mode: closeout_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1443
   pr_number: 1433
   branch: codex/1443-v0-87-1-tools-add-post-merge-issue-closeout-skill-for-pr-workflow
-  worktree_path: /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1443
+  worktree_path: <repo-root>/.worktrees/adl-wp-<issue>
   root_stp_path: .adl/v0.87.1/tasks/issue-1443__v0-87-1-tools-add-post-merge-issue-closeout-skill-for-pr-workflow/stp.md
   root_sip_path: .adl/v0.87.1/tasks/issue-1443__v0-87-1-tools-add-post-merge-issue-closeout-skill-for-pr-workflow/sip.md
   root_sor_path: .adl/v0.87.1/tasks/issue-1443__v0-87-1-tools-add-post-merge-issue-closeout-skill-for-pr-workflow/sor.md
@@ -1567,11 +1567,11 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $spp-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/spp-editor/SKILL.md with this validated input:
+Use $spp-editor at <repo-root>/adl/tools/skills/spp-editor/SKILL.md with this validated input:
 
 skill_input_schema: spp_editor.v1
 mode: tighten_for_review
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   spp_path: .adl/v0.91/tasks/issue-2701__example/spp.md
   issue_number: 2701
@@ -1635,11 +1635,11 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $srp-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/srp-editor/SKILL.md with this validated input:
+Use $srp-editor at <repo-root>/adl/tools/skills/srp-editor/SKILL.md with this validated input:
 
 skill_input_schema: srp_editor.v1
 mode: record_review_results
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   srp_path: .adl/v0.91.2/tasks/issue-3066__example/srp.md
   issue_number: 3066
@@ -1710,11 +1710,11 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $stp-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/stp-editor/SKILL.md with this validated input:
+Use $stp-editor at <repo-root>/adl/tools/skills/stp-editor/SKILL.md with this validated input:
 
 skill_input_schema: stp_editor.v1
 mode: tighten_for_review
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   stp_path: .adl/v0.87.1/tasks/issue-1419__v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces/stp.md
   issue_number: 1419
@@ -1783,16 +1783,16 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $sip-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/sip-editor/SKILL.md with this validated input:
+Use $sip-editor at <repo-root>/adl/tools/skills/sip-editor/SKILL.md with this validated input:
 
 skill_input_schema: sip_editor.v1
 mode: repair_lifecycle_drift
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   sip_path: .adl/v0.87.1/tasks/issue-1419__v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces/sip.md
   issue_number: 1419
   branch: codex/1419-v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces
-  worktree_path: /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1419
+  worktree_path: <repo-root>/.worktrees/adl-wp-<issue>
   source_prompt_path: .adl/v0.87.1/bodies/issue-1419-v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces.md
 policy:
   lifecycle_state: run_bound
@@ -1858,16 +1858,16 @@ Structured schema:
 ### Example Invocation
 
 ```yaml
-Use $sor-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/sor-editor/SKILL.md with this validated input:
+Use $sor-editor at <repo-root>/adl/tools/skills/sor-editor/SKILL.md with this validated input:
 
 skill_input_schema: sor_editor.v1
 mode: prepare_for_finish
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   sor_path: .adl/v0.87.1/tasks/issue-1419__v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces/sor.md
   issue_number: 1419
   branch: codex/1419-v0-87-1-tools-add-dedicated-card-editor-skills-for-stp-sip-and-sor-surfaces
-  worktree_path: /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1419
+  worktree_path: <repo-root>/.worktrees/adl-wp-<issue>
   pr_number: null
 evidence:
   commands_run:
@@ -1992,10 +1992,10 @@ This skill is findings-only and must not edit code.
 ### Example Invocation
 
 ```yaml
-Use $repo-code-review at /Users/daniel/git/agent-design-language/adl/tools/skills/repo-code-review/SKILL.md with:
+Use $repo-code-review at <repo-root>/adl/tools/skills/repo-code-review/SKILL.md with:
 skill_input_schema: repo_code_review.v1
 mode: review_repository
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   target_path: null
   branch: null
@@ -2091,10 +2091,10 @@ It must stop before broader implementation, janitoring, or finish.
 ### Example Invocation
 
 ```yaml
-Use $test-generator at /Users/daniel/git/agent-design-language/adl/tools/skills/test-generator/SKILL.md with:
+Use $test-generator at <repo-root>/adl/tools/skills/test-generator/SKILL.md with:
 skill_input_schema: test_generator.v1
 mode: generate_for_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1769
   diff_base: null
@@ -2191,10 +2191,10 @@ It must stop before demo implementation, release-evidence assembly, or unrelated
 ### Example Invocation
 
 ```yaml
-Use $demo-operator at /Users/daniel/git/agent-design-language/adl/tools/skills/demo-operator/SKILL.md with:
+Use $demo-operator at <repo-root>/adl/tools/skills/demo-operator/SKILL.md with:
 skill_input_schema: demo_operator.v1
 mode: operate_named_demo
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   demo_name: gemma4_issue_clerk
   demo_command: bash adl/tools/demo_v089_gemma4_issue_clerk.sh --dry-run
@@ -2384,10 +2384,10 @@ unbounded research.
 ### Example Invocation
 
 ```yaml
-Use $arxiv-paper-writer at /Users/daniel/git/agent-design-language/adl/tools/skills/arxiv-paper-writer/SKILL.md with:
+Use $arxiv-paper-writer at <repo-root>/adl/tools/skills/arxiv-paper-writer/SKILL.md with:
 skill_input_schema: arxiv_paper_writer.v1
 mode: draft_from_source_packet
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   source_packet_path: demos/v0.89.1/arxiv_manuscript_workflow_demo.md
   source_packet_text: null
@@ -2524,10 +2524,10 @@ unsupported visual claims.
 ### Example Invocation
 
 ```yaml
-Use $diagram-author at /Users/daniel/git/agent-design-language/adl/tools/skills/diagram-author/SKILL.md with:
+Use $diagram-author at <repo-root>/adl/tools/skills/diagram-author/SKILL.md with:
 skill_input_schema: diagram_author.v1
 mode: draft_from_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   source_packet_path: null
   source_packet_text: null

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -400,6 +400,9 @@ Minimum:
 - explicit `policy`
 - optional `observed_state.subagent_assigned`
 
+`target.pr_number` is the required target identifier for `route_pr`; other
+routing modes may use any one concrete target identifier from the list above.
+
 Structured schema:
 
 - `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`

--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -116,11 +116,11 @@ belong in the input payload rather than being guessed by the conductor.
 ## Example Invocation
 
 ```yaml
-Use $workflow-conductor at /Users/daniel/git/agent-design-language/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
+Use $workflow-conductor at <repo-root>/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
 
 skill_input_schema: workflow_conductor.v1
 mode: route_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 target:
   issue_number: 1647
   slug: add-lightweight-workflow-conductor-skill

--- a/docs/milestones/v0.91.3/review/CSDLC_PROMPT_TEMPLATE_DOGFOOD_FINDINGS_2026-05-23.md
+++ b/docs/milestones/v0.91.3/review/CSDLC_PROMPT_TEMPLATE_DOGFOOD_FINDINGS_2026-05-23.md
@@ -14,6 +14,10 @@ Practice targets:
 
 The new template bootstrap path is useful, but the first dogfood pass found several follow-up fixes needed before the process feels deterministic enough for routine C-SDLC use.
 
+Path note: machine-local absolute paths in this dogfood review artifact have
+been normalized to `<repo-root>` so the findings remain portable. The original
+review evidence was local execution evidence, not a portable contract.
+
 ## Findings
 
 ### P1: Existing bundles are preserved instead of normalized to the new template contract
@@ -53,8 +57,8 @@ Expected behavior:
 After creating `#3291` and `#3296` bundles in the `#3286` worktree, `pr doctor` looked for source issue prompts under the primary checkout:
 
 ```text
-/Users/daniel/git/agent-design-language/.adl/v0.91.3/bodies/issue-3291-issue-3291.md
-/Users/daniel/git/agent-design-language/.adl/v0.91.3/bodies/issue-3296-issue-3296.md
+<repo-root>/.adl/v0.91.3/bodies/issue-3291-issue-3291.md
+<repo-root>/.adl/v0.91.3/bodies/issue-3296-issue-3296.md
 ```
 
 Those paths do not match the worktree-local source prompts that `pr init` created.

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -25,11 +25,11 @@ This template is a caller artifact. It does not replace the underlying schema in
 Copy this shape and replace the placeholder values.
 
 ```yaml
-Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+Use $pr-init at <repo-root>/adl/tools/skills/pr-init/SKILL.md with this validated input:
 
 skill_input_schema: pr_init.v1
 mode: create_and_bootstrap | bootstrap_existing_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 
 issue:
   number: null | <issue number>
@@ -152,11 +152,11 @@ Typical choices:
 ## Example: New Issue Bootstrap
 
 ```yaml
-Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+Use $pr-init at <repo-root>/adl/tools/skills/pr-init/SKILL.md with this validated input:
 
 skill_input_schema: pr_init.v1
 mode: create_and_bootstrap
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 issue:
   number: null
   title: "[v0.87][tools] Example issue"
@@ -176,11 +176,11 @@ policy:
 ## Example: Existing Issue Bootstrap
 
 ```yaml
-Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+Use $pr-init at <repo-root>/adl/tools/skills/pr-init/SKILL.md with this validated input:
 
 skill_input_schema: pr_init.v1
 mode: bootstrap_existing_issue
-repo_root: /Users/daniel/git/agent-design-language
+repo_root: <repo-root>
 issue:
   number: 1374
   title: null


### PR DESCRIPTION
Closes #3328

## Summary
Cleaned portability and redaction issues in reusable skill invocation docs and the v0.91.3 dogfood review artifact. Operator-specific absolute paths were replaced with `REPO_ROOT` placeholders, brittle numbered worktree examples were generalized, and the dogfood findings now explain that original local execution evidence has been normalized for portability.

## Artifacts
- Updated `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
- Updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- Updated `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
- Updated `docs/milestones/v0.91.3/review/CSDLC_PROMPT_TEMPLATE_DOGFOOD_FINDINGS_2026-05-23.md`

## Validation
- Validation commands and their purpose:
  - `rg -n "host-specific path markers|temp-path markers|numbered worktree markers" docs/templates/PR_INIT_INVOCATION_TEMPLATE.md adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md docs/milestones/v0.91.3/review/CSDLC_PROMPT_TEMPLATE_DOGFOOD_FINDINGS_2026-05-23.md`
    Verified no remaining operator-specific path, temp-path, or numbered worktree markers in touched surfaces.
  - `git diff --check`
    Verified the documentation diff has no whitespace errors.
  - Bounded independent portability/redaction review by subagent `Planck`
    Reported one `P2` finding, which was fixed before PR publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3328__v0-91-3-review-clean-portability-and-redaction-issues-from-pass-2-review/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3328__v0-91-3-review-clean-portability-and-redaction-issues-from-pass-2-review/sor.md
- Idempotency-Key: v0-91-3-review-clean-portability-and-redaction-issues-from-pass-2-review-adl-tools-skills-docs-operational-skills-guide-md-adl-v0-91-3-tasks-issue-3328-v0-91-3-review-clean-portability-and-redaction-issues-from-pass-2-review-sip-md-adl-v0-91-3-tasks-issue-3328-v0-91-3-review-clean-portability-and-redaction-issues-from-pass-2-review-sor-md