### PR TITLE
[v0.91.4][WP-02][tools] Lifecycle validator hardening

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -651,7 +651,7 @@ fn classify_stp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             ),
         );
     }
-    if text.contains("## Required Outcome") && text.contains("## Acceptance Criteria") {
+    if has_complete_stp_design_time_surface(&text) {
         return card_stage(
             repo_root,
             "STP",
@@ -661,7 +661,7 @@ fn classify_stp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
                 true,
                 false,
                 None,
-                "STP has the required task intent and acceptance surfaces.",
+                "STP has the required issue-specific task intent, acceptance, and dependency surfaces.",
             ),
         );
     }
@@ -677,6 +677,41 @@ fn classify_stp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             "STP exists but is not complete enough to anchor execution.",
         ),
     )
+}
+
+fn has_complete_stp_design_time_surface(text: &str) -> bool {
+    const REQUIRED_HEADINGS: &[&str] = &[
+        "Summary",
+        "Goal",
+        "Required Outcome",
+        "Deliverables",
+        "Acceptance Criteria",
+        "Repo Inputs",
+        "Dependencies",
+        "Demo Expectations",
+        "Non-goals",
+        "Issue-Graph Notes",
+        "Notes",
+        "Tooling Notes",
+    ];
+    REQUIRED_HEADINGS
+        .iter()
+        .all(|heading| doctor_markdown_has_heading(text, heading))
+}
+
+fn doctor_markdown_has_heading(text: &str, heading: &str) -> bool {
+    let mut in_fence = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence && line.trim_end() == format!("## {heading}") {
+            return true;
+        }
+    }
+    false
 }
 
 fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
@@ -1208,7 +1243,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n\n## Review Summary\n\npolicy only\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1234,7 +1269,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\nreview_results:\n  findings_status: \"not_run | findings_present | no_findings\"\n  recommended_outcome: \"pass | block | needs_followup | not_run\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- <pass, block, needs_followup, or not_run>\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1258,7 +1293,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"todo\"\n  recommended_outcome: \"ship_it\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- ship_it\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1281,7 +1316,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results_exception: \"explicit policy exception: docs-only no-op review\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\nexplicit policy exception recorded\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1303,7 +1338,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1333,7 +1368,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent until implementation exists\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1356,7 +1391,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results_exception: \"explicit policy exception: docs-only no-op review\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\nexplicit policy exception recorded\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1390,7 +1425,10 @@ mod tests {
             issue = issue_ref.issue_number(),
             bundle = issue_ref.task_bundle_dir_name(),
         );
-        let stp_text = "## Required Outcome\n\n- closed-ready validation stays read-only when canonical closeout truth is stale\n\n## Acceptance Criteria\n\n- stale closeout truth causes a blocking validation error\n- no bundle files are mutated on failure\n";
+        let stp_text = complete_stp_fixture_with(
+            "- closed-ready validation stays read-only when canonical closeout truth is stale",
+            "- stale closeout truth causes a blocking validation error\n- no bundle files are mutated on failure",
+        );
         let spp_text = format!(
             "---\nschema_version: \"0.1\"\nartifact_type: \"structured_planning_prompt\"\nname: \"fixture-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: v0.91.2\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\nstatus: \"reviewed\"\nactivation_state: \"reviewed\"\nplan_revision: 1\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nscope:\n  files:\n    - \".adl/v0.91.2/tasks/{bundle}/sip.md\"\nconstraints:\n  - \"read_only_until_execution_is_approved\"\nconfidence: \"medium\"\nplan_summary: \"Fixture plan for closed-ready validation.\"\nassumptions:\n  - \"The canonical bundle already exists.\"\nproposed_steps:\n  - id: \"step-1\"\n    description: \"Validate closed-ready truth without mutation.\"\n    expected_output: \".adl/v0.91.2/tasks/{bundle}/spp.md\"\n    allowed_mode: \"execution_after_approval\"\ncodex_plan:\n  - step: \"Validate closed-ready truth without mutation.\"\n    status: \"pending\"\naffected_areas:\n  - \"doctor\"\ninvariants_to_preserve:\n  - \"Do not mutate stale closeout truth during validation.\"\nrisks_and_edge_cases:\n  - \"Closed issue bundles can still drift.\"\ntest_strategy:\n  - \"Run the focused doctor regression test.\"\nexecution_handoff: \"Use this artifact as the durable plan-of-record before execution.\"\nrequired_permissions:\n  - \"workspace-write after execution approval\"\nstop_conditions:\n  - \"Stop if validation would mutate the stale bundle.\"\nalternatives_considered:\n  - description: \"Use transient planning only.\"\n    reason_not_chosen: \"That would not leave durable reviewable plan truth.\"\nreview_hooks:\n  - \"Check read-only behavior.\"\nnotes: \"fixture\"\n---\n\n# Structured Plan Prompt\n\n## Plan Summary\n\nFixture plan.\n\n## Codex Plan\n\n1. [pending] Validate closed-ready truth without mutation.\n",
             issue = issue_ref.issue_number(),
@@ -1433,7 +1471,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n\n## Validation\n\nInspect provider output like `downloading... done` without treating it as truncation.\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1455,7 +1493,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: not bound yet\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"not bound yet\"\nstatus: \"draft\"\n---\n\nBootstrap-generated SPP; revise before use if planning review is required.\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1494,7 +1532,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: not bound yet\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"not bound yet\"\nstatus: \"approved\"\n---\n\n# Structured Plan Prompt\n\n## Plan Summary\n\nDesign-time execution plan for generated issue.\n\n## Proposed Steps\n\n- Use deliverables from the linked source issue prompt\n- Satisfy the linked source issue prompt acceptance criteria\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1524,7 +1562,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: not bound yet\n\n## Goal\n\nPrepare the linked issue prompt and review surfaces for truthful pre-run review before execution is bound.\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"not bound yet\"\nstatus: \"approved\"\n---\n\n# Structured Plan Prompt\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1554,7 +1592,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Card Status: draft\nBranch: not bound yet\n",
-                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
                 spp: "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1585,7 +1623,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Card Status: ready\nBranch: codex/3065-test\n",
-                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
                 spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- Not run yet.\n",
                 sor: "# output\n\nBranch: codex/3065-test\nCard Status: ready\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1607,7 +1645,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Card Status: ready\nBranch: codex/3065-test\n",
-                stp: "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
                 spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"approved\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nCard Status: completed\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1640,7 +1678,7 @@ mod tests {
         .expect("write sip");
         fs::write(
             issue_ref.task_bundle_stp_path(&repo),
-            "---\ncard_status: \"ready\"\n---\n\n## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+            "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
         )
         .expect("write stp");
         fs::write(
@@ -1672,7 +1710,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\ncodex_plan:\n  - step: \"implement\"\n    status: \"in_progress\"\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
                 sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
@@ -1715,13 +1753,61 @@ mod tests {
     }
 
     #[test]
+    fn card_lifecycle_blocks_sparse_stp_before_execution() {
+        let repo = lifecycle_temp_repo("sparse-stp");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
+                sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.active_stage, "STP");
+        assert_eq!(lifecycle.next_required_stage, Some("STP"));
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
+        assert_stage(&lifecycle, "STP", "active", false, false);
+    }
+
+    #[test]
+    fn card_lifecycle_does_not_treat_embedded_heading_text_as_complete_stp() {
+        let repo = lifecycle_temp_repo("embedded-heading-text-stp");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: "## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\n```md\n## Tooling Notes\n```\n",
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
+                sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.active_stage, "STP");
+        assert_eq!(lifecycle.next_required_stage, Some("STP"));
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
+        assert_stage(&lifecycle, "STP", "active", false, false);
+    }
+
+    #[test]
     fn card_lifecycle_reports_final_review_and_output_truth() {
         let repo = lifecycle_temp_repo("final-srp-sor");
         let paths = write_lifecycle_fixture(
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: none\n- Integration state: merged\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
@@ -1746,7 +1832,7 @@ mod tests {
             &repo,
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
-                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                stp: complete_stp_fixture(),
                 spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: none\n- Integration state: merged\n- Result: FAIL\n\n## Validation\n- focused validation failed\n",
@@ -1837,6 +1923,26 @@ mod tests {
         fs::write(&paths.srp, fixture.srp).expect("write srp");
         fs::write(&paths.sor, fixture.sor).expect("write sor");
         paths
+    }
+
+    fn complete_stp_fixture() -> &'static str {
+        Box::leak(
+            "## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n"
+                .to_string()
+                .into_boxed_str(),
+        )
+    }
+
+    fn complete_stp_fixture_with(
+        required_outcome: &str,
+        acceptance_criteria: &str,
+    ) -> &'static str {
+        Box::leak(
+            format!(
+                "## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\n{required_outcome}\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n{acceptance_criteria}\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n"
+            )
+            .into_boxed_str(),
+        )
     }
 
     fn assert_stage(

--- a/adl/src/cli/tooling_cmd/markdown.rs
+++ b/adl/src/cli/tooling_cmd/markdown.rs
@@ -20,8 +20,18 @@ pub(super) fn split_front_matter(text: &str) -> Result<(String, String)> {
 }
 
 pub(super) fn markdown_has_heading(text: &str, heading: &str) -> bool {
-    text.lines()
-        .any(|line| line.trim_end() == format!("## {heading}"))
+    let mut in_fence = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence && line.trim_end() == format!("## {heading}") {
+            return true;
+        }
+    }
+    false
 }
 
 pub(super) fn markdown_headings(text: &str) -> Vec<&str> {

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -977,11 +977,8 @@ pub(super) fn validate_srp_text(text: &str) -> Result<()> {
         "schema_version must be 0.1"
     );
     ensure!(
-        matches!(
-            mapping_string(fm, "artifact_type").as_deref(),
-            Some("structured_review_policy" | "structured_review_prompt")
-        ),
-        "artifact_type must be structured_review_policy or structured_review_prompt"
+        mapping_string(fm, "artifact_type").as_deref() == Some("structured_review_prompt"),
+        "artifact_type must be structured_review_prompt; legacy structured_review_policy scaffolds must be routed through srp-editor before validation passes"
     );
     ensure!(
         !mapping_string(fm, "name").unwrap_or_default().is_empty(),

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -138,6 +138,20 @@ fn structured_prompt_srp_completed_card_status_requires_final_review_truth() {
 }
 
 #[test]
+fn structured_prompt_srp_rejects_legacy_review_policy_artifact_type() {
+    let srp = valid_srp_text(1374).replace(
+        "artifact_type: \"structured_review_prompt\"",
+        "artifact_type: \"structured_review_policy\"",
+    );
+
+    let err = validate_srp_text(&srp)
+        .expect_err("legacy structured_review_policy SRP should fail validator");
+    assert!(err
+        .to_string()
+        .contains("artifact_type must be structured_review_prompt"));
+}
+
+#[test]
 fn structured_prompt_sor_completed_card_status_requires_full_closeout_truth() {
     let sor = valid_sor_text().replace(
         "Status: DONE",

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -27,7 +27,8 @@ Options:
                                   "path" or "STATUS<TAB>path".
   --threshold <percent>           Per-file line threshold. Defaults to PER_FILE_LINE_THRESHOLD or 80.
   --require-summary-for-risk      Fail when risky changed Rust files lack summary evidence.
-  --print-risk-filters            Print one candidate test filter per risky changed Rust file and exit.
+  --print-risk-filters            Print one candidate test filter per changed Rust file that
+                                  may need summary evidence and exit.
   -h, --help                      Show this help.
 
 This is a fast authoring-time guard. It does not replace the full GitHub
@@ -237,7 +238,7 @@ file_has_no_executable_surface() {
   local path="$1"
   [ -f "$ROOT/$path" ] || return 1
 
-  ! grep -Eq '^[[:space:]]*(pub[[:space:]]+)?fn[[:space:]]+|^[[:space:]]*impl([[:space:][:alnum:]_<>,:&]+)?[[:space:]]*\{' "$ROOT/$path"
+  ! grep -Eq '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?fn[[:space:]]+|^[[:space:]]*impl([[:space:][:alnum:]_<>,:&]+)?[[:space:]]*\{' "$ROOT/$path"
 }
 
 risk_rows=""
@@ -335,16 +336,16 @@ EOF
 fi
 
 if [ "$PRINT_RISK_FILTERS" = true ]; then
-  if [ -z "$risk_rows" ]; then
-    exit 0
-  fi
-  printf '%s' "$risk_rows" \
-    | while IFS=$'\t' read -r _status path _lines _delta _reason; do
+  printf '%s\n' "$changed_source_rows" \
+    | while IFS=$'\t' read -r _status path; do
         [ -n "$path" ] || continue
+        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path"; then
+          continue
+        fi
         candidate_filter_for_path "$path"
         printf '\n'
       done \
-    | awk '!seen[$0]++'
+    | awk 'NF && !seen[$0]++'
   exit 0
 fi
 

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -51,7 +51,7 @@ bash "$SCRIPT" --changed-files "$changed" --print-risk-filters >"$risk_filters"
 grep -Fx "new_large_surface" "$risk_filters" >/dev/null
 
 control_plane_changed="$TMP/control-plane-changed.txt"
-printf 'A\tadl/src/cli/pr_cmd_cards.rs\n' >"$control_plane_changed"
+printf 'A\tadl/src/cli/pr_cmd/doctor.rs\n' >"$control_plane_changed"
 control_plane_filters="$TMP/control-plane-filters.txt"
 bash "$SCRIPT" --changed-files "$control_plane_changed" --print-risk-filters >"$control_plane_filters"
 grep -Fx "pr_cmd" "$control_plane_filters" >/dev/null
@@ -122,6 +122,18 @@ grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base release/base
 docs_filters="$TMP/docs-filters.txt"
 bash "$SCRIPT" --changed-files "$docs_only" --print-risk-filters >"$docs_filters"
 [ ! -s "$docs_filters" ]
+
+mixed_fast_lane_changed="$TMP/mixed-fast-lane-changed.txt"
+cat >"$mixed_fast_lane_changed" <<'EOF'
+M	adl/src/cli/pr_cmd/doctor.rs
+M	adl/src/cli/tooling_cmd/structured_prompt.rs
+M	adl/src/cli/tooling_cmd/markdown.rs
+EOF
+mixed_fast_lane_filters="$TMP/mixed-fast-lane-filters.txt"
+bash "$SCRIPT" --changed-files "$mixed_fast_lane_changed" --print-risk-filters >"$mixed_fast_lane_filters"
+grep -Fx "pr_cmd" "$mixed_fast_lane_filters" >/dev/null
+grep -Fx "structured_prompt" "$mixed_fast_lane_filters" >/dev/null
+grep -Fx "markdown" "$mixed_fast_lane_filters" >/dev/null
 
 low_summary="$TMP/low-summary.json"
 make_summary "adl/src/runtime_v2/new_large_surface.rs" 77 100 "$low_summary"

--- a/docs/tooling/structured-prompt-contracts.md
+++ b/docs/tooling/structured-prompt-contracts.md
@@ -221,10 +221,11 @@ triggers before work starts. In contrast, branch-bound SPP/SRP drift with a
 `next_editor` remains a real card-local blocker and must be routed through the
 matching editor skill.
 
-Legacy SRP policy scaffolds remain validator-compatible while migration is in
-progress, but doctor output must classify them as `legacy_compatible` rather
-than final review readiness unless review results or an explicit policy
-exception are present.
+Legacy SRP policy scaffolds are not valid new SRP prompt artifacts. The
+structured-prompt validator should fail them closed, while `pr doctor` may
+still classify retained historical scaffolds as `legacy_compatible` so they can
+be routed through `srp-editor` instead of being mistaken for final review
+readiness.
 
 ## SRP/SOR Finish And Closeout Handoff
 


### PR DESCRIPTION
Closes #3348

## Summary
Hardened the `v0.91.4` lifecycle validator surface so legacy SRP policy scaffolds fail closed, sparse STP cards no longer become execution-ready in doctor, and doctor-side STP completeness now matches the canonical STP validator including `Tooling Notes` and exact heading detection outside fenced code blocks.

## Artifacts
- Updated validator and lifecycle code:
  - `adl/src/cli/tooling_cmd/structured_prompt.rs`
  - `adl/src/cli/tooling_cmd/markdown.rs`
  - `adl/src/cli/pr_cmd/doctor.rs`
- Added and expanded focused regression coverage:
  - `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`
- Updated user-facing contract note:
  - `docs/tooling/structured-prompt-contracts.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_srp_rejects_legacy_review_policy_artifact_type -- --nocapture`
    Verified legacy SRP policy artifacts fail closed in the structured-prompt validator.
  - `cargo test --manifest-path adl/Cargo.toml tracked_csdlc_card_bundle_validates -- --nocapture`
    Verified the tracked reference C-SDLC card bundle still validates after the validator changes.
  - `cargo test --manifest-path adl/Cargo.toml card_lifecycle_ -- --nocapture`
    Verified the doctor lifecycle regression slice, including sparse STP blocking, legacy SRP handling, completed SRP/SOR truth, and embedded-heading rejection.
  - `cargo test --manifest-path adl/Cargo.toml preflight_card_readiness_reports_blocked_for_draft_design_time_card -- --nocapture`
    Verified preflight still blocks draft design-time cards.
  - `cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture`
    Verified closed-ready doctor validation remains read-only when closeout truth is stale.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for the touched lifecycle-validator code paths.
  - `git diff --check`
    Verified there are no whitespace or patch-formatting defects in the worktree diff.
  - `bash adl/tools/pr.sh doctor 3348 --version v0.91.4 --json`
    Verified the issue bundle is doctor-pass after the focused changes and review fixes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3348__v0-91-4-wp-02-lifecycle-validator-hardening/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.91.4/tasks/issue-3348__v0-91-4-wp-02-lifecycle-validator-hardening/sor.md
- Idempotency-Key: v0-91-4-wp-02-tools-lifecycle-validator-hardening-adl-v0-91-4-tasks-issue-3348-v0-91-4-wp-02-lifecycle-validator-hardening-sip-md-users-daniel-git-agent-design-language-adl-v0-91-4-tasks-issue-3348-v0-91-4-wp-02-lifecycle-validator-hardening-sor-md