### PR TITLE
[v0.91.4][WP-04][tools] Editor skill repair reliability

### DIFF
--- a/adl/tools/test_card_editor_repair_examples.sh
+++ b/adl/tools/test_card_editor_repair_examples.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
+EXAMPLES_DIR="$ROOT_DIR/docs/tooling/csdlc-prompt-editor/repair_examples"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/adl-card-editor-repair-examples.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+"$VALIDATOR" --type sip --phase bootstrap --input "$EXAMPLES_DIR/sip_repaired_pre_run.md"
+"$VALIDATOR" --type stp --input "$EXAMPLES_DIR/stp_repaired_issue_ready.md"
+"$VALIDATOR" --type spp --input "$EXAMPLES_DIR/spp_repaired_issue_plan.md"
+"$VALIDATOR" --type srp --input "$EXAMPLES_DIR/srp_repaired_review_truth.md"
+"$VALIDATOR" --type sor --phase final --input "$EXAMPLES_DIR/sor_repaired_pr_open.md"
+
+cp "$EXAMPLES_DIR/stp_repaired_issue_ready.md" "$tmpdir/stp_invalid_card_status.md"
+perl -0pi -e 's/card_status: "ready"/card_status: "nearly-ready"/' "$tmpdir/stp_invalid_card_status.md"
+if "$VALIDATOR" --type stp --input "$tmpdir/stp_invalid_card_status.md" >"$tmpdir/stp_invalid_card_status.out" 2>&1; then
+  echo "expected repaired STP with invalid card_status mutation to fail validation" >&2
+  exit 1
+fi
+grep -Fq "card_status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded" "$tmpdir/stp_invalid_card_status.out"
+
+cp "$EXAMPLES_DIR/srp_repaired_review_truth.md" "$tmpdir/srp_legacy_policy.md"
+perl -0pi -e 's/artifact_type: "structured_review_prompt"/artifact_type: "structured_review_policy"/; s/# Structured Review Prompt/# Structured Review Policy/' "$tmpdir/srp_legacy_policy.md"
+if "$VALIDATOR" --type srp --input "$tmpdir/srp_legacy_policy.md" >"$tmpdir/srp_legacy_policy.out" 2>&1; then
+  echo "expected legacy SRP policy mutation to fail validation" >&2
+  exit 1
+fi
+grep -Fq "artifact_type must be structured_review_prompt; legacy structured_review_policy scaffolds must be routed through srp-editor before validation passes" "$tmpdir/srp_legacy_policy.out"
+
+cp "$EXAMPLES_DIR/sor_repaired_pr_open.md" "$tmpdir/sor_completed_without_closeout.md"
+perl -0pi -e 's/Card Status: ready/Card Status: completed/' "$tmpdir/sor_completed_without_closeout.md"
+if "$VALIDATOR" --type sor --phase final --input "$tmpdir/sor_completed_without_closeout.md" >"$tmpdir/sor_completed_without_closeout.out" 2>&1; then
+  echo "expected completed SOR without terminal closeout to fail validation" >&2
+  exit 1
+fi
+grep -Fq "Card Status completed requires terminal Integration state: merged or closed_no_pr" "$tmpdir/sor_completed_without_closeout.out"
+
+echo "PASS test_card_editor_repair_examples"

--- a/adl/tools/test_card_editor_skill_contracts.sh
+++ b/adl/tools/test_card_editor_skill_contracts.sh
@@ -35,5 +35,9 @@ grep -Fq "sip-editor" "${skills_root}/pr-ready/SKILL.md"
 grep -Fq "sor-editor" "${skills_root}/pr-run/SKILL.md"
 grep -Fq "sor-editor" "${skills_root}/pr-finish/SKILL.md"
 grep -Fq "srp-editor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "repair_examples" "$repo_root/docs/tooling/csdlc-prompt-editor/README.md"
+grep -Fq "repair_examples" "$repo_root/docs/tooling/csdlc-prompt-editor/repair_examples/README.md"
+
+bash "$repo_root/adl/tools/test_card_editor_repair_examples.sh"
 
 echo "PASS test_card_editor_skill_contracts"

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -69,6 +69,16 @@ sample cards, verifies the browser sample renderer/validator, and checks that
 the browser editor is consuming the generated Rust-owned model instead of
 carrying independent card semantics.
 
+For durable post-repair examples that match the current prompt-template family,
+see:
+
+- `docs/tooling/csdlc-prompt-editor/repair_examples/`
+
+Those examples are intentionally separate from the browser-generated samples:
+they show validator-clean repaired shapes that model what truthful `sip-editor`,
+`stp-editor`, `spp-editor`, `srp-editor`, and `sor-editor` output should look
+like.
+
 ## Boundaries
 
 This editor is a human review and recovery surface. Agent-authored card changes
@@ -81,3 +91,9 @@ still route through the card editor skills:
 - `sor-editor`
 
 The canonical template set remains `docs/templates/prompts/current.json`.
+
+Use the focused repair-example proof when validating the editor-skill boundary:
+
+```sh
+bash adl/tools/test_card_editor_repair_examples.sh
+```

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/README.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/README.md
@@ -1,0 +1,41 @@
+## Card Repair Examples
+
+This directory contains durable, validator-clean examples of the card shapes we
+expect after bounded editor-skill repair.
+
+These examples are intentionally small, but they are not placeholders. Each one
+matches the current `docs/templates/prompts/current.json` family closely enough
+to pass the structured-prompt validator. Where the validator currently consumes
+an explicit `--phase` flag, the proof lane passes it; otherwise the examples
+are validated without claiming extra phase-aware enforcement.
+
+Included repaired examples:
+
+- `sip_repaired_pre_run.md`
+- `stp_repaired_issue_ready.md`
+- `spp_repaired_issue_plan.md`
+- `srp_repaired_review_truth.md`
+- `sor_repaired_pr_open.md`
+
+These examples are for:
+
+- operator orientation
+- editor-skill boundary clarification
+- focused proof in `adl/tools/test_card_editor_repair_examples.sh`
+
+They are not authoritative lifecycle records for a real issue. They are
+repaired shape examples that show what truthful cards should look like. Real
+issue work must still be grounded in the bound issue bundle and normalized
+through the matching editor skill.
+
+Boundary notes:
+
+- `sip-editor` owns truthful pre-run input-card normalization.
+- `stp-editor` owns design-time task-shape repair.
+- `spp-editor` owns issue-local planning truth and `codex_plan` hygiene.
+- `srp-editor` owns Structured Review Prompt semantics and review-result truth.
+- `sor-editor` owns execution and integration truth, but not PR publication or
+  merge.
+
+The browser prompt editor remains a human drafting/recovery surface. It does
+not replace the editor skills required by `AGENTS.md`.

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/sip_repaired_pre_run.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/sip_repaired_pre_run.md
@@ -1,0 +1,180 @@
+# ADL Input Card
+
+Semantic role: Structured Issue Prompt (`SIP`).
+Canonical Template Source: `docs/templates/prompts/1.0.0/sip.md`
+
+Task ID: issue-4001
+Run ID: issue-4001
+Version: v0.91.4
+Title: [example][SIP] Pre-run repair
+Branch: not bound yet
+Card Status: ready
+Generated: 2026-05-26T12:00:00Z
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/4001
+- PR:
+- Source Issue Prompt: .adl/v0.91.4/bodies/example-sip-repair.md
+- Docs: docs/tooling/csdlc-prompt-editor/README.md
+- Other: none
+
+## Agent Execution Rules
+- This issue is not started yet; do not assume a branch or worktree already exists.
+- Do not run `pr start`; use the current issue-mode `pr run` flow only if execution later becomes necessary.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Lifecycle Semantics
+- Lifecycle stage: `SIP`
+- Activation state: active after issue-intent review.
+- Next stage: `STP`, where the selected task or solution is made explicit.
+- Legacy compatibility: older references may call this an input card, but new
+  issue work should treat it as the Structured Issue Prompt.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.91.4/tasks/issue-4001__example-sip-repair/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+## Execution
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug: example-sip-repair
+- Required outcome type: code
+- Demo required: false
+
+## Goal
+
+Repair a pre-run input card so it is specific, validator-clean, and does not
+invent execution.
+
+## Required Outcome
+
+Produce a truthful `SIP` that can hand off to `STP` without branch, target, or
+validation-plan drift.
+
+## Acceptance Criteria
+
+The repaired card keeps `Branch: not bound yet`, points at concrete repo
+surfaces, and gives a bounded validation plan.
+
+## Inputs
+
+Linked source issue prompt, task bundle path, and repository-local editor docs.
+
+## Target Files / Surfaces
+
+`docs/tooling/csdlc-prompt-editor/`; `.adl/v0.91.4/tasks/issue-4001__example-sip-repair/`
+
+## Validation Plan
+
+Run the matching structured prompt validator for `sip` at bootstrap phase.
+
+## Demo / Proof Requirements
+
+None. Proof is the repaired card plus validator pass.
+
+## Constraints / Policies
+
+- Follow `AGENTS.md`.
+- Use workflow-conductor for lifecycle routing.
+- Edit cards only with editor skills.
+- Work only in the bound issue worktree after `pr run`.
+- Keep validation focused on the touched surface.
+
+## System Invariants (must remain true)
+
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: false
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical SIP content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+Do not claim the issue is already branch-bound or execution-complete.
+
+## Notes / Risks
+
+If issue routing changes materially, this card should be re-edited before
+execution begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do not create a branch or worktree from this card alone.
+- When execution is approved, run the repo-native issue-mode `pr run` flow and then perform the work described above.
+- Write execution outcome truth to the paired `sor.md` file during execution.

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/sor_repaired_pr_open.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/sor_repaired_pr_open.md
@@ -1,0 +1,144 @@
+# example-sor-repair
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/sor.md`
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-4005
+Run ID: issue-4005
+Version: v0.91.4
+Title: [example][SOR] Repaired PR-open truth
+Branch: codex/4005-example-sor-repair
+Card Status: ready
+Status: DONE
+Generated: 2026-05-26T12:00:00Z
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: OpenAI Codex desktop
+- Start Time: 2026-05-26T12:00:00Z
+- End Time: 2026-05-26T12:15:00Z
+
+## Summary
+
+Illustrative repaired execution record showing the correct `pr_open` shape
+without prematurely claiming merge or closeout. This is an example surface, not
+a live issue closeout record.
+
+## Artifacts produced
+- Updated repair-example docs:
+  - `docs/tooling/csdlc-prompt-editor/repair_examples/README.md`
+  - `docs/tooling/csdlc-prompt-editor/repair_examples/sor_repaired_pr_open.md`
+- Focused proof script:
+  - `adl/tools/test_card_editor_repair_examples.sh`
+
+## Actions taken
+- Normalized the output record to the correct `pr_open` shape for an
+  illustrative repaired example.
+- Removed premature completion language and absolute-path leakage.
+- Recorded only the commands that actually ran for the example proof lane.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; this illustrative example intentionally stops before merge or closeout truth
+- Worktree-only paths remaining: example tracked changes still model a branch-local `pr_open` state
+  - `docs/tooling/csdlc-prompt-editor/repair_examples/README.md`
+  - `adl/tools/test_card_editor_repair_examples.sh`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: illustrative repaired `SOR` shape showing how an open-PR execution record should read before terminal closeout; no live GitHub issue or PR is implied by this example
+- Verification performed:
+  - `bash adl/tools/test_card_editor_repair_examples.sh`
+    Verified the repaired examples pass validation and the overclaim cases fail closed.
+  - `git diff --check`
+    Verified the example diff is patch-clean.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout BRANCH -- PATH` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/test_card_editor_repair_examples.sh`
+    Verified repaired-card examples for SIP, STP, SPP, SRP, and SOR, plus fail-closed overclaim cases for SRP and SOR.
+  - `git diff --check`
+    Verified no whitespace or patch-formatting defects in the tracked example surfaces.
+- Results:
+  - PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/test_card_editor_repair_examples.sh"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: focused repair-example proof script.
+- Fixtures or scripts used: `adl/tools/test_card_editor_repair_examples.sh`.
+- Replay verification (same inputs -> same artifacts/order): verified through repeated validator checks over tracked examples and deterministic fail-closed mutations.
+- Ordering guarantees (sorting / tie-break rules used): the script validates the same example set in a fixed order each run.
+- Artifact stability notes: the examples use repository-relative paths only and avoid machine-local assumptions.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: bounded content review only; no secrets or credentials were introduced.
+- Prompt / tool argument redaction verified: yes; recorded commands use repository-relative paths only.
+- Absolute path leakage check: pass; no unjustified host absolute paths are recorded in this example.
+- Sandbox / policy invariants preserved: yes; example remains at `pr_open` and does not invent merge truth.
+
+## Replay Artifacts
+- Trace bundle path(s): not_applicable
+- Run artifact root: not_applicable
+- Replay command used for verification: not_applicable; the focused proof script already covers deterministic replayability for this example surface.
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: the focused repair-example validator script.
+- Required artifacts present: yes; all tracked repaired examples and the proof script exist.
+- Artifact schema/version checks: the structured prompt validator passed for the repaired examples.
+- Hash/byte-stability checks: not_run
+- Missing/optional artifacts and rationale: no browser demo or production artifact is required for this example-only proof surface.
+
+## Decisions / Deviations
+- This example intentionally stops at `pr_open` shape to show the correct non-terminal SOR state after repair.
+- It does not claim merge, closeout, or main-branch integration.
+
+## Follow-ups / Deferred work
+- Use the real issue-local `SOR` during publication and closeout instead of reusing this example.

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/spp_repaired_issue_plan.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/spp_repaired_issue_plan.md
@@ -1,0 +1,155 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+name: "example-spp-repair-execution-plan"
+issue: 4003
+task_id: "issue-4003"
+run_id: "issue-4003"
+version: "v0.91.4"
+title: "[example][SPP] Repaired issue-local plan"
+branch: "codex/4003-example-spp-repair"
+generated_at: "2026-05-26T12:00:00Z"
+card_status: "approved"
+status: "reviewed"
+activation_state: "ready_for_execution_binding"
+plan_revision: 2
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/danielbaustin/agent-design-language/issues/4003"
+  - kind: "source_issue_prompt"
+    ref: ".adl/v0.91.4/bodies/example-spp-repair.md"
+  - kind: "stp"
+    ref: ".adl/v0.91.4/tasks/issue-4003__example-spp-repair/stp.md"
+  - kind: "sip"
+    ref: ".adl/v0.91.4/tasks/issue-4003__example-spp-repair/sip.md"
+scope:
+  files:
+    - "docs/tooling/csdlc-prompt-editor/repair_examples/"
+  components:
+    - "example-spp-repair"
+  out_of_scope:
+    - "Do not turn SPP into a retrospective execution log."
+constraints:
+  - "design_time_plan_must_be_reviewed_before_execution"
+  - "runtime_execution_must_update_spp_if_plan_changes"
+  - "no_hidden_scope_expansion"
+confidence: "medium"
+plan_summary: "Example issue-local plan showing the approved design-time shape expected after SPP repair."
+assumptions:
+  - "The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+proposed_steps:
+  - id: "step-1"
+    description: "Confirm the repaired card bundle still matches the source issue intent."
+    expected_output: ".adl/v0.91.4/tasks/issue-4003__example-spp-repair/sip.md"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-2"
+    description: "Inspect the bounded repair-example surfaces before editing."
+    expected_output: ".adl/v0.91.4/tasks/issue-4003__example-spp-repair/stp.md"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-3"
+    description: "Implement only the bounded example and validation surfaces."
+    expected_output: "tracked issue work product"
+    allowed_mode: "execution_after_approval"
+  - id: "step-4"
+    description: "Run focused proof gates for the repaired card surfaces."
+    expected_output: "validation evidence recorded in SOR"
+    allowed_mode: "execution_after_approval"
+  - id: "step-5"
+    description: "Record issue-specific SRP findings and SOR outcome truth, then update this SPP if execution diverges."
+    expected_output: "reviewed SRP and truthful SOR"
+    allowed_mode: "execution_after_approval"
+codex_plan:
+  - step: "Confirm dependencies and starting state from the source issue prompt."
+    status: "completed"
+  - step: "Inspect repo inputs and target surfaces before editing."
+    status: "completed"
+  - step: "Implement the bounded deliverables only."
+    status: "pending"
+  - step: "Run focused validation and proof gates."
+    status: "pending"
+  - step: "Record issue-specific SRP findings and SOR outcome truth."
+    status: "pending"
+affected_areas:
+  - "example-spp-repair"
+invariants_to_preserve:
+  - "Keep SPP issue-local; do not turn it into sprint orchestration."
+  - "Keep SRP as review-result truth and SOR as output truth."
+risks_and_edge_cases:
+  - "Execution-time drift should demote plan state back to draft if the plan materially changes."
+test_strategy:
+  - "Run the matching structured prompt validator for `spp` at final phase."
+execution_handoff: "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
+required_permissions:
+  - "workspace-write after execution approval"
+stop_conditions:
+  - "Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+  - "Stop and update SPP if touched files, proof gates, or validation commands change materially."
+  - "Stop and route follow-on work if acceptance requires scope outside this issue."
+alternatives_considered:
+  - description: "Leave the plan generic."
+    reason_not_chosen: "Generic plans do not provide durable issue-local execution truth."
+review_hooks:
+  - "Check dependency truth, scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
+notes: "Example repaired SPP showing approved pre-execution planning truth."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/spp.md`
+
+# Structured Plan Prompt
+
+## Plan Summary
+
+Design-time operative plan for `[example][SPP] Repaired issue-local plan`.
+
+Example issue-local plan showing the approved design-time shape expected after SPP repair.
+
+## Codex Plan
+
+1. [completed] Confirm dependencies and starting state from the source issue prompt.
+2. [completed] Inspect repo inputs and target surfaces before editing.
+3. [pending] Implement the bounded deliverables only.
+4. [pending] Run focused validation and proof gates.
+5. [pending] Record issue-specific SRP findings and SOR outcome truth.
+
+## Assumptions
+
+- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs.
+
+## Proposed Steps
+
+1. Confirm the repaired card bundle still matches the source issue intent.
+2. Inspect the bounded repair-example surfaces before editing.
+3. Implement only the bounded example and validation surfaces.
+4. Run focused proof gates for the repaired card surfaces.
+5. Record issue-specific SRP findings and SOR outcome truth, then update this SPP if execution diverges.
+
+## Affected Areas
+
+- example-spp-repair
+
+## Invariants To Preserve
+
+- Keep SPP issue-local; do not turn it into sprint orchestration.
+- Keep SRP as review-result truth and SOR as output truth.
+
+## Risks And Edge Cases
+
+- Execution-time drift should demote plan state back to draft if the plan materially changes.
+
+## Test Strategy
+
+- Run the matching structured prompt validator for `spp` at final phase.
+
+## Execution Handoff
+
+Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes.
+
+## Stop Conditions
+
+- Stop and re-plan if dependencies are unmet or materially different from this design-time plan.
+- Stop and update SPP if touched files, proof gates, or validation commands change materially.
+- Stop and route follow-on work if acceptance requires scope outside this issue.
+
+## Notes
+
+Example repaired SPP showing approved pre-execution planning truth.

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/srp_repaired_review_truth.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/srp_repaired_review_truth.md
@@ -1,0 +1,136 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "example-srp-repair-review-prompt"
+issue: 4004
+task_id: "issue-4004"
+version: "v0.91.4"
+title: "[example][SRP] Repaired review truth"
+branch: "codex/4004-example-srp-repair"
+generated_at: "2026-05-26T12:00:00Z"
+card_status: "ready"
+status: "approved"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/danielbaustin/agent-design-language/issues/4004"
+  - kind: "stp"
+    ref: ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/stp.md"
+  - kind: "sip"
+    ref: ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/sip.md"
+  - kind: "spp"
+    ref: ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/spp.md"
+  - kind: "sor"
+    ref: ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/sor.md"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/stp.md"
+  - ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/sip.md"
+in_scope_surfaces:
+  - "tracked changes for this issue branch"
+evidence_policy:
+  - "Use repository evidence, targeted validation output, and linked issue-bundle artifacts only."
+validation_inputs:
+  - "Issue-local proofs recorded in the SOR."
+allowed_dispositions:
+  - "PASS"
+  - "BLOCK"
+  - "NEEDS_FOLLOWUP"
+reviewer_constraints:
+  - "Do not widen issue scope."
+  - "Do not merge, publish, or close the issue."
+refusal_policy:
+  - "Refuse claims that are unsupported by repository evidence."
+  - "Refuse approving behavior outside the recorded issue scope."
+follow_up_routing:
+  - "Route actionable defects back to the issue branch before PR publication."
+non_claims:
+  - "This prompt does not claim review has already run."
+  - "This prompt does not guarantee review quality by itself."
+policy_refs:
+  - ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/stp.md"
+  - ".adl/v0.91.4/tasks/issue-4004__example-srp-repair/sip.md"
+review_results:
+  findings_status: "findings_present"
+  recommended_outcome: "pass"
+notes: "Example repaired SRP showing truthful findings and disposition recording after bounded review."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/srp.md`
+
+# Structured Review Prompt
+
+## Review Summary
+
+Bounded pre-PR review completed for the example card-repair slice. Review
+surfaced one medium documentation-truth issue, which was fixed before
+publication.
+
+## Scope Basis
+
+- .adl/v0.91.4/tasks/issue-4004__example-srp-repair/stp.md
+- .adl/v0.91.4/tasks/issue-4004__example-srp-repair/sip.md
+
+## In-Scope Surfaces
+
+- tracked changes for this issue branch
+
+## Evidence Rules
+
+- Use repository evidence, targeted validation output, and linked issue-bundle artifacts only.
+
+## Validation Inputs
+
+- `bash adl/tools/test_card_editor_repair_examples.sh`
+- `git diff --check`
+
+## Allowed Dispositions
+
+- PASS
+- BLOCK
+- NEEDS_FOLLOWUP
+
+## Reviewer Constraints
+
+- Do not widen issue scope.
+- Do not merge, publish, or close the issue.
+
+## Refusal Policy
+
+- Refuse claims that are unsupported by repository evidence.
+- Refuse approving behavior outside the recorded issue scope.
+
+## Follow-up Routing
+
+- Route actionable defects back to the issue branch before PR publication.
+
+## Non-Claims
+
+- This prompt does not claim review has already run.
+- This prompt does not guarantee review quality by itself.
+
+## Review Results
+
+When finalizing review, record the machine-readable review result in frontmatter:
+
+```yaml
+review_results:
+  findings_status: "no_findings | findings_present"
+  recommended_outcome: "pass | block | needs_followup"
+```
+
+### Findings
+
+- `Medium` The original example text implied the browser prompt editor could replace editor-skill repair. Fixed by clarifying the human-editor boundary and adding durable repair examples.
+
+### Dispositions
+
+- Fixed the actionable finding in scope before publication and tied proof to the focused repair-example test lane.
+
+### Recommended Outcome
+
+- PASS
+
+## Notes
+
+This example shows truthful review-result recording without inventing review coverage beyond the bounded evidence listed above.

--- a/docs/tooling/csdlc-prompt-editor/repair_examples/stp_repaired_issue_ready.md
+++ b/docs/tooling/csdlc-prompt-editor/repair_examples/stp_repaired_issue_ready.md
@@ -1,0 +1,95 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "WP-EX"
+slug: "example-stp-repair"
+title: "[example][STP] Ready task repair"
+labels:
+  - "track:roadmap"
+issue_number: 4002
+generated_at: "2026-05-26T12:00:00Z"
+card_status: "ready"
+status: "draft"
+action: "edit"
+supersedes: []
+duplicates: []
+depends_on:
+  - "#4001"
+milestone_sprint: "v0.91.4"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - ".adl/v0.91.4/bodies/example-stp-repair.md"
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Example STP showing issue-specific deliverables and non-goals after bounded repair."
+pr_start:
+  enabled: true
+  slug: "example-stp-repair"
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/stp.md`
+Generated: 2026-05-26T12:00:00Z
+
+# Structured Task Prompt
+
+## Summary
+
+Repair a generic STP into a bounded, issue-specific task card.
+
+## Goal
+
+Make the task executable without changing the source issue intent.
+
+## Required Outcome
+
+Deliver an issue-specific `STP` with concrete deliverables, scoped repo inputs,
+clear acceptance criteria, and explicit non-goals.
+
+## Deliverables
+
+Validator-clean task wording; explicit repo inputs; clear acceptance criteria;
+and an issue-local validation plan.
+
+## Acceptance Criteria
+
+The repaired `STP` is specific enough for design-time readiness and does not
+silently widen scope.
+
+## Repo Inputs
+
+`docs/templates/prompts/1.0.0/`; `docs/tooling/csdlc-prompt-editor/`
+
+## Dependencies
+
+`#4001`
+
+## Target Files / Surfaces
+
+`docs/tooling/csdlc-prompt-editor/repair_examples/`
+
+## Validation Plan
+
+Run the matching structured prompt validator for `stp`.
+
+## Demo Expectations
+
+None. Proof is the repaired card plus validator pass.
+
+## Non-goals
+
+Do not invent implementation results or rewrite unrelated cards.
+
+## Issue-Graph Notes
+
+This example models the shape expected after bounded `stp-editor` repair.
+
+## Notes
+
+Keep the card specific enough for execution planning, but do not turn it into a
+full execution log.
+
+## Tooling Notes
+
+Use `workflow-conductor`, then route only the STP surface through `stp-editor`.


### PR DESCRIPTION
Closes #3350

## Summary
Added durable repaired examples for all five C-SDLC card types, tightened the
prompt-editor docs so they stop implying the browser editor replaces the editor
skills, and added a focused proof lane that validates repaired examples and
fail-closed overclaim mutations.

## Artifacts
- New repaired card examples:
  - `docs/tooling/csdlc-prompt-editor/repair_examples/README.md`
  - `docs/tooling/csdlc-prompt-editor/repair_examples/sip_repaired_pre_run.md`
  - `docs/tooling/csdlc-prompt-editor/repair_examples/stp_repaired_issue_ready.md`
  - `docs/tooling/csdlc-prompt-editor/repair_examples/spp_repaired_issue_plan.md`
  - `docs/tooling/csdlc-prompt-editor/repair_examples/srp_repaired_review_truth.md`
  - `docs/tooling/csdlc-prompt-editor/repair_examples/sor_repaired_pr_open.md`
- New focused proof script:
  - `adl/tools/test_card_editor_repair_examples.sh`
- Updated contract/docs surfaces:
  - `adl/tools/test_card_editor_skill_contracts.sh`
  - `docs/tooling/csdlc-prompt-editor/README.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_card_editor_repair_examples.sh`
    Verified repaired card examples across all five card types and confirmed representative overclaim mutations fail closed.
  - `bash adl/tools/test_card_editor_skill_contracts.sh`
    Verified the editor-skill bundle contract and the presence/use of the new repaired examples.
  - `bash adl/tools/test_csdlc_prompt_editor.sh`
    Verified the browser editor and rendered sample cards remain aligned with the Rust-owned prompt-template model.
  - `git diff --check`
    Verified the tracked diff is patch-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3350__v0-91-4-wp-04-editor-skill-repair-reliability/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3350__v0-91-4-wp-04-editor-skill-repair-reliability/sor.md
- Idempotency-Key: v0-91-4-wp-04-tools-editor-skill-repair-reliability-adl-v0-91-4-tasks-issue-3350-v0-91-4-wp-04-editor-skill-repair-reliability-sip-md-adl-v0-91-4-tasks-issue-3350-v0-91-4-wp-04-editor-skill-repair-reliability-sor-md