### PR TITLE
[v0.91.4][CodeFriend][sprint] Pre-alpha site setup

### DIFF
--- a/docs/milestones/v0.91.4/CODEFRIEND_PRE_ALPHA_CLOSEOUT_v0.91.4.md
+++ b/docs/milestones/v0.91.4/CODEFRIEND_PRE_ALPHA_CLOSEOUT_v0.91.4.md
@@ -1,0 +1,61 @@
+# CodeFriend Pre-Alpha Closeout
+
+Date: `2026-05-27`
+
+Umbrella issue: `#3372`
+
+## Outcome
+
+Completed the CodeFriend sidecar mini-sprint as a real product-setup lane.
+
+The sprint outcome is:
+
+- private product/site repository established
+- reviewed coming-soon page established
+- Terraform-managed AWS static-site infrastructure established
+- `https://codefriend.ai` live over HTTPS
+- `https://www.codefriend.ai` live over HTTPS
+- publication-safety and handoff documentation established
+
+## Child issue results
+
+1. `#3373` CF-PRE-01
+- created the private `agent-logic/codefriend.ai` repository
+- seeded the narrow product/site scaffold and Terraform split
+
+2. `#3374` CF-PRE-02
+- refined the static coming-soon page
+- preserved the approved copy and no-product-availability boundary
+
+3. `#3375` CF-PRE-03
+- provisioned the S3, CloudFront, ACM, Route 53, and deploy-role substrate
+- published the static page live over HTTPS
+
+4. `#3376` CF-PRE-04
+- verified publication safety and redaction/path hygiene
+- recorded the handoff for later CodeFriend alpha work
+
+## What this mini-sprint proves
+
+- Agent Logic can stand up a real CodeFriend product/site repository
+- the approved pre-alpha coming-soon page can be served from a private S3
+  origin through CloudFront over HTTPS
+- the route from planning to live static publication is now documented and
+  reusable
+
+## What this mini-sprint does not prove
+
+- it does not deliver the CodeFriend alpha product
+- it does not create application runtime, user flows, or customer state
+- it does not justify broader product-availability claims
+- it does not make CodeFriend part of v0.91.4 C-SDLC core proof
+
+## Handoff
+
+The next CodeFriend milestone should pick up from the live static-site surface
+and decide:
+
+- the real alpha runtime and architecture
+- user/account flows, if any
+- release/deploy shape beyond the static site
+- public messaging beyond the current coming-soon posture

--- a/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
+++ b/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
@@ -41,7 +41,16 @@ benchmark spike run as bounded sidecar mini-sprints in v0.91.4:
 
 Current sidecar state:
 
-- CodeFriend remains a separate bounded sidecar lane.
+- CodeFriend is now complete as a bounded pre-alpha product-setup lane:
+  - `#3373` created and scaffolded the private `agent-logic/codefriend.ai`
+    repository
+  - `#3374` refined the static coming-soon page
+  - `#3375` provisioned the Terraform-managed AWS static-site substrate and
+    made `https://codefriend.ai` and `https://www.codefriend.ai` live over
+    HTTPS
+  - `#3376` recorded publication-safety review, verification, and handoff
+  - the sidecar outcome is a real live coming-soon surface, not a CodeFriend
+    alpha-product claim
 - WildClawBench is in final publication state as a bounded docs-and-evidence
   spike:
   - `#3379` published setup and smoke-baseline notes
@@ -146,8 +155,8 @@ Every sprint must preserve:
 - Sprint 1 must land before later sprints rely on default C-SDLC state truth.
 - Signed trace and tracked workflow-state proof must land before release
   readiness is claimed.
-- The CodeFriend sidecar depends on AWS/DNS approval and may end in a truthful
-  blocked handoff.
+- The CodeFriend sidecar is complete with a verified HTTPS landing surface and
+  truthful handoff; later CodeFriend alpha work remains outside this mini-sprint.
 
 ## Demo / Review Plan
 


### PR DESCRIPTION
Closes #3372\n\nCloses out the CodeFriend sidecar mini-sprint after repo bootstrap, page refinement, live HTTPS publication, and publication handoff all completed.