### PR TITLE
[v0.91.4][tools-tests] Fix Sprint 2 validator and test hygiene

### DIFF
--- a/adl/tools/test_v0914_csdlc_evidence_bundle.sh
+++ b/adl/tools/test_v0914_csdlc_evidence_bundle.sh
@@ -10,9 +10,14 @@ PUBLIC_KEY="$PACKET_DIR/fixtures/minimal_transition_trace_public_key.b64"
 
 python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$PACKET_DIR"
 
+(
+  cd /private/tmp
+  python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$PACKET_DIR"
+)
+
 cargo run --quiet --manifest-path "$REPO_ROOT/adl/Cargo.toml" -- verify "$SIGNED_TRACE" --key "$PUBLIC_KEY" >/dev/null
 
-tmpdir="$(mktemp -d)"
+tmpdir="$(mktemp -d "$REPO_ROOT/.tmp-csdlc-evidence-bundle.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 tampered="$tmpdir/tampered.adl.yaml"
 cp "$SIGNED_TRACE" "$tampered"
@@ -29,9 +34,16 @@ if cargo run --quiet --manifest-path "$REPO_ROOT/adl/Cargo.toml" -- verify "$tam
   exit 1
 fi
 
-bad_bundle="$tmpdir/bad_bundle.json"
-cp "$EVIDENCE_BUNDLE" "$bad_bundle"
-python3 - "$bad_bundle" <<'PY'
+digest_tmpdir="$tmpdir/digest_drift"
+mkdir -p "$digest_tmpdir/fixtures"
+cp "$PACKET_DIR/README.md" "$digest_tmpdir/README.md"
+cp "$PACKET_DIR/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md" "$digest_tmpdir/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md"
+cp "$EVIDENCE_BUNDLE" "$digest_tmpdir/ct_demo_001_transition_evidence_bundle.json"
+cp "$REVIEW_SYNTHESIS" "$digest_tmpdir/ct_demo_001_review_synthesis.json"
+cp "$PACKET_DIR/fixtures/minimal_transition_trace_unsigned.adl.yaml" "$digest_tmpdir/fixtures/minimal_transition_trace_unsigned.adl.yaml"
+cp "$SIGNED_TRACE" "$digest_tmpdir/fixtures/minimal_transition_trace_signed.adl.yaml"
+cp "$PUBLIC_KEY" "$digest_tmpdir/fixtures/minimal_transition_trace_public_key.b64"
+python3 - "$digest_tmpdir/ct_demo_001_transition_evidence_bundle.json" <<'PY'
 from pathlib import Path
 import json, sys
 path = Path(sys.argv[1])
@@ -39,14 +51,21 @@ data = json.loads(path.read_text())
 data["evidence_inputs"][0]["sha256"] = "0" * 64
 path.write_text(json.dumps(data, indent=2) + "\n")
 PY
-if python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$tmpdir" >/dev/null 2>&1; then
+if python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$digest_tmpdir" >/dev/null 2>&1; then
   echo "FAIL: digest-drift bundle unexpectedly validated" >&2
   exit 1
 fi
 
-bad_synthesis="$tmpdir/ct_demo_001_review_synthesis.json"
-cp "$REVIEW_SYNTHESIS" "$bad_synthesis"
-python3 - "$bad_synthesis" <<'PY'
+synthesis_tmpdir="$tmpdir/review_drift"
+mkdir -p "$synthesis_tmpdir/fixtures"
+cp "$PACKET_DIR/README.md" "$synthesis_tmpdir/README.md"
+cp "$PACKET_DIR/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md" "$synthesis_tmpdir/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md"
+cp "$EVIDENCE_BUNDLE" "$synthesis_tmpdir/ct_demo_001_transition_evidence_bundle.json"
+cp "$REVIEW_SYNTHESIS" "$synthesis_tmpdir/ct_demo_001_review_synthesis.json"
+cp "$PACKET_DIR/fixtures/minimal_transition_trace_unsigned.adl.yaml" "$synthesis_tmpdir/fixtures/minimal_transition_trace_unsigned.adl.yaml"
+cp "$SIGNED_TRACE" "$synthesis_tmpdir/fixtures/minimal_transition_trace_signed.adl.yaml"
+cp "$PUBLIC_KEY" "$synthesis_tmpdir/fixtures/minimal_transition_trace_public_key.b64"
+python3 - "$synthesis_tmpdir/ct_demo_001_review_synthesis.json" <<'PY'
 from pathlib import Path
 import json, sys
 path = Path(sys.argv[1])
@@ -54,14 +73,7 @@ data = json.loads(path.read_text())
 data["findings"][0]["disposition"] = "unfixed"
 path.write_text(json.dumps(data, indent=2) + "\n")
 PY
-mkdir -p "$tmpdir/fixtures"
-cp "$PACKET_DIR/README.md" "$tmpdir/README.md"
-cp "$PACKET_DIR/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md" "$tmpdir/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md"
-cp "$EVIDENCE_BUNDLE" "$tmpdir/ct_demo_001_transition_evidence_bundle.json"
-cp "$PACKET_DIR/fixtures/minimal_transition_trace_unsigned.adl.yaml" "$tmpdir/fixtures/minimal_transition_trace_unsigned.adl.yaml"
-cp "$SIGNED_TRACE" "$tmpdir/fixtures/minimal_transition_trace_signed.adl.yaml"
-cp "$PUBLIC_KEY" "$tmpdir/fixtures/minimal_transition_trace_public_key.b64"
-if python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$tmpdir" >/dev/null 2>&1; then
+if python3 "$REPO_ROOT/adl/tools/validate_v0914_csdlc_evidence_bundle.py" "$synthesis_tmpdir" >/dev/null 2>&1; then
   echo "FAIL: review-synthesis drift unexpectedly validated" >&2
   exit 1
 fi

--- a/adl/tools/test_v0914_obsmem_transition_memory.sh
+++ b/adl/tools/test_v0914_obsmem_transition_memory.sh
@@ -7,6 +7,12 @@ cd "$repo_root"
 python3 adl/tools/validate_v0914_obsmem_transition_memory.py \
   docs/milestones/v0.91.4/review/obsmem_transition_memory
 
+(
+  cd /private/tmp
+  python3 "$repo_root/adl/tools/validate_v0914_obsmem_transition_memory.py" \
+    "$repo_root/docs/milestones/v0.91.4/review/obsmem_transition_memory"
+)
+
 tmpdir="$(mktemp -d "$repo_root/.tmp-obsmem-transition-memory.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 cp -R docs/milestones/v0.91.4/review/obsmem_transition_memory "$tmpdir/packet"
@@ -28,11 +34,7 @@ fi
 
 rm -rf "$tmpdir/packet"
 cp -R docs/milestones/v0.91.4/review/obsmem_transition_memory "$tmpdir/packet"
-python3 - <<'PY' docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json "$tmpdir/original_bundle.json"
-import shutil
-import sys
-shutil.copyfile(sys.argv[1], sys.argv[2])
-PY
+cp docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json "$tmpdir/original_bundle.json"
 python3 - <<'PY' "$tmpdir/original_bundle.json"
 import json
 import sys
@@ -43,15 +45,24 @@ data = json.loads(path.read_text())
 data["evidence_inputs"][0]["sha256"] = "0" * 64
 path.write_text(json.dumps(data, indent=2) + "\n")
 PY
-backup="docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json.bak.wp08"
-cp docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json "$backup"
-cp "$tmpdir/original_bundle.json" docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json
+python3 - <<'PY' "$tmpdir/packet/ct_demo_001_obsmem_transition_memory_handoff.json" "$tmpdir/original_bundle.json" "$repo_root"
+import json
+import sys
+from pathlib import Path
+
+handoff_path = Path(sys.argv[1])
+bundle_path = Path(sys.argv[2]).resolve()
+repo_root = Path(sys.argv[3]).resolve()
+
+data = json.loads(handoff_path.read_text())
+data["evidence_bundle_path"] = bundle_path.relative_to(repo_root).as_posix()
+data["outcome_truth_path"] = (Path(handoff_path.parent) / "ct_demo_001_transition_outcome_truth.json").resolve().relative_to(repo_root).as_posix()
+handoff_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
 if python3 adl/tools/validate_v0914_obsmem_transition_memory.py "$tmpdir/packet"; then
   echo "expected evidence digest mismatch to fail" >&2
-  mv "$backup" docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json
   exit 1
 fi
-mv "$backup" docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json
 
 cargo test --manifest-path adl/Cargo.toml transition_handoff -- --nocapture
 cargo test --manifest-path adl/Cargo.toml file_store_round_trips_structured_review_fields -- --nocapture

--- a/adl/tools/validate_v0914_csdlc_evidence_bundle.py
+++ b/adl/tools/validate_v0914_csdlc_evidence_bundle.py
@@ -27,10 +27,26 @@ def extract_signed_public_key(signed_trace_path: Path) -> str:
     fail("signed trace fixture is missing embedded public_key_b64")
 
 
+def find_repo_root(start: Path) -> Path:
+    for candidate in [start, *start.parents]:
+        if (candidate / "adl").is_dir() and (candidate / "docs").is_dir():
+            return candidate
+    fail(f"could not determine repo root from {start}")
+
+
+def resolve_existing_ancestor_path(start: Path, rel_path: str) -> Path:
+    for candidate in [start, *start.parents]:
+        probe = candidate / rel_path
+        if probe.exists():
+            return probe
+    fail(f"required tracked/retained artifact missing across ancestor roots: {rel_path}")
+
+
 def ensure_sor_links(repo_root: Path) -> None:
-    sor_path = repo_root / ".adl/v0.91.4/tasks/issue-3354__v0-91-4-wp-06-evidence-convergence-review-synthesis-and-signed-trace-proof/sor.md"
-    if not sor_path.exists():
-        fail("WP-06 SOR is missing; cannot prove evidence/trace linkage")
+    sor_path = resolve_existing_ancestor_path(
+        repo_root,
+        ".adl/v0.91.4/tasks/issue-3354__v0-91-4-wp-06-evidence-convergence-review-synthesis-and-signed-trace-proof/sor.md",
+    )
     sor_text = sor_path.read_text()
     required_refs = [
         "docs/milestones/v0.91.4/review/evidence/csdlc/C_SDLC_EVIDENCE_BUNDLE_PACKET_v0.91.4.md",
@@ -47,7 +63,7 @@ def main() -> None:
     if len(sys.argv) != 2:
         fail("usage: validate_v0914_csdlc_evidence_bundle.py <packet_dir>")
     packet_dir = Path(sys.argv[1]).resolve()
-    repo_root = Path.cwd().resolve()
+    repo_root = find_repo_root(packet_dir)
 
     required = [
         packet_dir / "README.md",
@@ -92,8 +108,10 @@ def main() -> None:
         fail("review synthesis path missing")
 
     synthesis = json.loads((packet_dir / "ct_demo_001_review_synthesis.json").read_text())
-    if synthesis.get("source_issue_number") != 3353 or synthesis.get("source_pr_number") != 3387:
-        fail("review synthesis source truth drift")
+    if synthesis.get("source_issue_number") != bundle.get("issue_number"):
+        fail("review synthesis source issue must align with bundle issue_number")
+    if not isinstance(synthesis.get("source_pr_number"), int) or synthesis.get("source_pr_number", 0) <= 0:
+        fail("review synthesis source_pr_number must be a positive integer")
     findings = synthesis.get("findings", [])
     if len(findings) != 4:
         fail("expected four preserved review findings")

--- a/adl/tools/validate_v0914_obsmem_transition_memory.py
+++ b/adl/tools/validate_v0914_obsmem_transition_memory.py
@@ -37,6 +37,14 @@ def find_repo_root(start: Path) -> Path:
     fail(f"could not determine repo root from {start}")
 
 
+def require_repo_relative_path(repo_root: Path, rel: str, key: str) -> Path:
+    require(repo_relative(rel), f"{key} must be repo-relative without traversal")
+    require(not rel.startswith(".adl/"), f"{key} must not point into local-only .adl state")
+    target = repo_root / rel
+    require(target.exists(), f"{key} target missing: {rel}")
+    return target
+
+
 def main() -> None:
     if len(sys.argv) != 2:
         fail("usage: validate_v0914_obsmem_transition_memory.py <packet_dir>")
@@ -55,32 +63,28 @@ def main() -> None:
 
     handoff = load_json(packet_dir / "ct_demo_001_obsmem_transition_memory_handoff.json")
     outcome = load_json(packet_dir / "ct_demo_001_transition_outcome_truth.json")
-    review = load_json(
-        repo_root
-        / "docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_review_synthesis.json"
-    )
-    evidence = load_json(
-        repo_root
-        / "docs/milestones/v0.91.4/review/evidence/csdlc/ct_demo_001_transition_evidence_bundle.json"
-    )
-
     require(handoff.get("schema_version") == 1, "handoff schema_version must be 1")
     require(outcome.get("schema_version") == 1, "outcome schema_version must be 1")
     require(handoff.get("workflow_id") == "v0914_csdlc_transition_memory", "unexpected workflow_id")
     require(len(handoff.get("follow_ons", [])) >= 2, "handoff must preserve visible follow-ons")
 
-    path_keys = [
-        "outcome_truth_path",
-        "evidence_bundle_path",
-        "review_synthesis_path",
-        "signed_trace_path",
+    outcome_truth_path = require_repo_relative_path(repo_root, handoff.get("outcome_truth_path", ""), "outcome_truth_path")
+    evidence_bundle_path = require_repo_relative_path(repo_root, handoff.get("evidence_bundle_path", ""), "evidence_bundle_path")
+    review_synthesis_path = require_repo_relative_path(repo_root, handoff.get("review_synthesis_path", ""), "review_synthesis_path")
+    signed_trace_path = require_repo_relative_path(repo_root, handoff.get("signed_trace_path", ""), "signed_trace_path")
+    signed_trace_public_key_path = require_repo_relative_path(
+        repo_root,
+        handoff.get("signed_trace_public_key_path", ""),
         "signed_trace_public_key_path",
-    ]
-    for key in path_keys:
-        rel = handoff.get(key, "")
-        require(repo_relative(rel), f"{key} must be repo-relative without traversal")
-        require(not rel.startswith(".adl/"), f"{key} must not point into local-only .adl state")
-        require((repo_root / rel).exists(), f"{key} target missing: {rel}")
+    )
+
+    require(
+        outcome_truth_path.resolve() == (packet_dir / "ct_demo_001_transition_outcome_truth.json").resolve(),
+        "outcome_truth_path must point at the tracked packet-local outcome truth file",
+    )
+
+    review = load_json(review_synthesis_path)
+    evidence = load_json(evidence_bundle_path)
 
     signed_trace = evidence.get("signed_trace", {})
     require(
@@ -94,6 +98,14 @@ def main() -> None:
     require(
         signed_trace.get("verification_mode") == "explicit_key",
         "signed trace verification_mode must be explicit_key",
+    )
+    require(
+        signed_trace_path == (repo_root / signed_trace.get("signed_path", "")),
+        "signed trace path must align with the evidence bundle signed trace path",
+    )
+    require(
+        signed_trace_public_key_path == (repo_root / signed_trace.get("public_key_path", "")),
+        "signed trace public key path must align with the evidence bundle public key path",
     )
 
     evidence_inputs = evidence.get("evidence_inputs", [])


### PR DESCRIPTION
Closes #3425

## Summary
Hardened the Sprint 2 evidence-bundle and ObsMem validator/test surfaces so repo-root discovery no longer depends on caller cwd, negative packet checks run on copied repo-local fixtures instead of mutating tracked evidence in place, and the focused shell proof now explicitly exercises the foreign-cwd validator paths.

## Artifacts
- Updated validator/test surfaces:
  - `adl/tools/validate_v0914_csdlc_evidence_bundle.py`
  - `adl/tools/validate_v0914_obsmem_transition_memory.py`
  - `adl/tools/test_v0914_csdlc_evidence_bundle.sh`
  - `adl/tools/test_v0914_obsmem_transition_memory.sh`
- Finalized issue-local review and output truth:
  - `.adl/v0.91.4/tasks/issue-3425__v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene/srp.md`
  - `.adl/v0.91.4/tasks/issue-3425__v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type spp --phase final --input .adl/v0.91.4/tasks/issue-3425__v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene/spp.md`
    Verified the issue-local `SPP` is structurally valid after `spp-editor` style normalization.
  - `bash adl/tools/pr.sh doctor 3425 --version v0.91.4 --json`
    Verified the issue bundle is execution-ready after `SPP` normalization.
  - `bash adl/tools/test_v0914_csdlc_evidence_bundle.sh`
    Verified the evidence-bundle validator passes for the tracked packet, passes from a foreign cwd, and fail-closes on copied digest-drift and review-synthesis-drift fixtures.
  - `bash adl/tools/test_v0914_obsmem_transition_memory.sh`
    Verified the ObsMem transition-memory validator passes for the tracked packet, passes from a foreign cwd, fail-closes on signed-trace binding mismatch and copied evidence-digest mismatch, and preserves the focused Rust regression checks.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the touched Python/shell support diff leaves the Rust workspace formatting lane clean.
  - `git diff --check`
    Verified there are no whitespace or patch-formatting defects in the bounded diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3425__v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3425__v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene/sor.md
- Idempotency-Key: v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene-adl-tools-validate-v0914-csdlc-evidence-bundle-py-adl-tools-validate-v0914-obsmem-transition-memory-py-adl-tools-test-v0914-csdlc-evidence-bundle-sh-adl-tools-test-v0914-obsmem-transition-memory-sh-adl-v0-91-4-tasks-issue-3425-v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene-sip-md-adl-v0-91-4-tasks-issue-3425-v0-91-4-tools-tests-fix-sprint-2-validator-and-test-hygiene-sor-md