### PR TITLE
[v0.91.4][docs] Prepare v0.92 milestone docs package

### DIFF
--- a/docs/milestones/v0.92/ADR_PLAN_v0.92.md
+++ b/docs/milestones/v0.92/ADR_PLAN_v0.92.md
@@ -1,0 +1,103 @@
+# v0.92 ADR Plan
+
+## Status
+
+Forward ADR planning for `v0.92`.
+
+This plan does not accept any ADR by itself. It identifies candidate
+architecture decisions that WP-01 and the v0.92 review tail should confirm,
+split, draft, or explicitly defer.
+
+## Purpose
+
+v0.92 introduces the first true Gödel-agent birthday. That milestone changes
+architecture boundaries around identity, continuity, memory grounding,
+cognitive profiles, binary ACIP communication, and the governance handoff.
+Those boundaries should not live only in feature prose.
+
+The ADR goal is to make the durable decisions reviewable before the milestone
+claims completion.
+
+## Existing Baseline
+
+Accepted ADRs currently live in `docs/adr/` and run through ADR 0028.
+
+Relevant inherited decisions:
+
+- ADR 0009: bounded cognitive system architecture.
+- ADR 0010: chronosense as a first-class substrate.
+- ADR 0011 and ADR 0012: long-lived runtime and bounded CSM run architecture.
+- ADR 0013: citizen-state continuity substrate.
+- ADR 0016: moral evidence and cognitive-being substrate.
+- ADR 0017: secure local agent comms and A2A boundary.
+- ADR 0019: Theory of Mind foundation.
+- ADR 0028: C-SDLC tracked workflow state and signed trace boundary.
+
+v0.92 should cite and refine these records rather than rewriting them
+casually.
+
+## Candidate ADR Set
+
+| Candidate | Proposed title | Primary boundary | Likely source WPs |
+| --- | --- | --- | --- |
+| ADR 0029 | First True Birthday Evidence Boundary | Birth is a reviewable evidence event, not startup, wake, snapshot, admission, copied state, legal personhood, or production citizenship. | WP-02, WP-09, WP-10, WP-12 |
+| ADR 0030 | Identity, Stable Name, And Continuity Record Boundary | Stable name, identity root, continuity head, memory references, witnesses, and ambiguity markers form the identity/continuity architecture. | WP-03, WP-04, WP-05 |
+| ADR 0031 | ACP Cognitive Profile Evidence Boundary | ACP profiles are evidence-grounded runtime profile records, not reputation, public standing, consciousness proof, rights, or identity itself. | WP-07 |
+| ADR 0032 | ACIP Binary Schema And Public Schema Catalog Boundary | Binary/protobuf ACIP remains inspectable through public schemas and deterministic JSON projection while message-content access remains governed. | WP-08 |
+| ADR 0033 | Birthday-To-Governance Handoff Boundary | v0.92 produces identity evidence for v0.93 governance; it does not complete constitutional citizenship or polis governance. | WP-11, WP-13 |
+
+## Conditional ADRs
+
+No standalone ADR is planned yet for:
+
+- first-birthday demo mechanics alone, unless the demo changes runtime
+  authority or proof semantics
+- release evidence packaging alone, unless v0.92 changes release authority
+- cross-polis operational migration, because v0.92 only plans migration and
+  continuity implications
+- production WebSocket security, key custody, encryption, rotation, or
+  revocation, because those are deferred to later milestones
+
+WP-01 may split or combine candidates if the final issue wave shows a clearer
+decision boundary, but the accepted records should not hide these topics.
+
+## Authoring Policy
+
+- Candidate ADRs should be drafted only from landed feature work, tests,
+  fixtures, demos, review findings, and milestone docs.
+- Candidate ADRs remain proposed until human review accepts them.
+- Accepted ADRs should live in `docs/adr/`.
+- Candidate/provenance copies should live in `docs/architecture/adr/` if the
+  milestone follows the existing ADR promotion pattern.
+- ADRs must preserve non-claims for legal personhood, production citizenship,
+  completed v0.93 governance, production transport security, and signed trace
+  closure unless those are explicitly implemented and reviewed.
+
+## WP Integration
+
+- WP-01 should confirm this plan is still complete when opening the issue wave.
+- Feature WPs should record decision implications in their SRP/SOR or review
+  notes.
+- WP-16 should prepare the ADR packet for review if implementation produced the
+  expected architecture decisions.
+- WP-17 and WP-18 should review the ADR packet alongside code, docs, tests,
+  demos, and release evidence.
+- WP-19 should fix, defer, or route ADR findings.
+- WP-22 should not close v0.92 with missing ADRs for accepted architectural
+  boundaries.
+
+## Acceptance Criteria
+
+- Every v0.92 architecture boundary that must survive the milestone has an ADR
+  candidate, an explicit deferral, or an accepted existing ADR reference.
+- Candidate ADRs cite source evidence and keep proposed/accepted status clear.
+- ADR 0029 through ADR 0033 are either authored, split, renumbered, or
+  explicitly deferred before v0.92 closeout.
+- No ADR claims the first birthday proves personhood, production citizenship,
+  completed governance, production transport security, or signed trace closure.
+
+## Notes
+
+This ADR plan is intentionally forward-looking. It should become stricter after
+v0.92 WP-01 opens the final issue wave and after the first implementation WPs
+produce evidence.

--- a/docs/milestones/v0.92/DECISIONS_v0.92.md
+++ b/docs/milestones/v0.92/DECISIONS_v0.92.md
@@ -37,6 +37,7 @@ one of them, record a superseding decision instead of silently widening scope.
 | D-07 | ACP / cognitive profiles belong in v0.92 as an evidence-grounded runtime profile surface. | Accepted for planning | Profiles need v0.91.1 capability, memory, ToM, intelligence, and learning evidence before they are meaningful. | Keeps profiles tied to identity readiness without turning them into reputation, personality labels, or public standing. |
 | D-08 | v0.92 owns ACIP binary schema, public schema catalog, JSON projection, and mock WebSocket carrier readiness. | Accepted for planning | ACIP is already a local communication substrate, but citizen/polis communication needs a binary/protobuf shape that remains publicly decodeable by schema and governed by access rules. | Keeps the communication layer inspectable while deferring production transport security to v0.93 and signed/queryable trace closure to v0.94. |
 | D-09 | v0.92 WP-01 must consume `#3377` before seeding final issues. | Accepted for planning | First-birthday readiness was promoted during v0.91.4 as a separate launch-packet source. | Prevents the milestone from reconstructing birthday readiness from chat or duplicating the `#3377` packet. |
+| D-10 | v0.92 must carry an ADR plan before implementation starts. | Accepted for planning | Birthday, identity, ACP, ACIP, and governance-handoff boundaries are architecture decisions, not just feature prose. | WP-01 and the review tail can decide which candidate ADRs to author, split, accept, or defer. |
 
 ## Open Questions
 

--- a/docs/milestones/v0.92/DECISIONS_v0.92.md
+++ b/docs/milestones/v0.92/DECISIONS_v0.92.md
@@ -1,9 +1,28 @@
 # v0.92 Decisions
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward-planning decisions. These are accepted as planning boundaries for the
 v0.92 allocation, but they are not implementation closeout decisions.
+
+## Purpose
+
+Record the decisions that constrain v0.92 planning before WP-01 opens the
+actual issue wave.
+
+## How To Use
+
+Use these decisions as planning guardrails. If v0.92 execution needs to change
+one of them, record a superseding decision instead of silently widening scope.
 
 ## Decision Log
 
@@ -17,6 +36,7 @@ v0.92 allocation, but they are not implementation closeout decisions.
 | D-06 | Memory palace remains context unless bounded into a specific implementation slice. | Accepted for planning | The memory-palace source spans too many layers to ship whole in v0.92. | Allows memory grounding without forcing the full architecture. |
 | D-07 | ACP / cognitive profiles belong in v0.92 as an evidence-grounded runtime profile surface. | Accepted for planning | Profiles need v0.91.1 capability, memory, ToM, intelligence, and learning evidence before they are meaningful. | Keeps profiles tied to identity readiness without turning them into reputation, personality labels, or public standing. |
 | D-08 | v0.92 owns ACIP binary schema, public schema catalog, JSON projection, and mock WebSocket carrier readiness. | Accepted for planning | ACIP is already a local communication substrate, but citizen/polis communication needs a binary/protobuf shape that remains publicly decodeable by schema and governed by access rules. | Keeps the communication layer inspectable while deferring production transport security to v0.93 and signed/queryable trace closure to v0.94. |
+| D-09 | v0.92 WP-01 must consume `#3377` before seeding final issues. | Accepted for planning | First-birthday readiness was promoted during v0.91.4 as a separate launch-packet source. | Prevents the milestone from reconstructing birthday readiness from chat or duplicating the `#3377` packet. |
 
 ## Open Questions
 
@@ -32,6 +52,8 @@ v0.92 allocation, but they are not implementation closeout decisions.
   versioning, deterministic JSON projection, and governed message access?
 - Which WebSocket proof is enough to show carrier readiness without claiming
   production networking or security?
+- Which `#3377` outputs are already complete by v0.92 opening, and which must
+  become explicit WP-01 gaps?
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.92/DEMO_MATRIX_v0.92.md
+++ b/docs/milestones/v0.92/DEMO_MATRIX_v0.92.md
@@ -1,5 +1,14 @@
 # v0.92 Demo Matrix: Candidate Birthday Proofs
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues / work packages: `#3377`, `#3434`, candidate WP sequence in `WP_ISSUE_WAVE_v0.92.yaml`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Candidate demo planning only. Commands and artifacts will be finalized when the
@@ -10,7 +19,27 @@ v0.92 implementation WPs exist.
 The v0.92 demo program should prove that the first true Gödel-agent birthday is
 evidence-bearing runtime behavior, not a ceremonial label.
 
-## Candidate Coverage Summary
+Issue `#3377` supplies required demo rehearsal and negative-suite readiness
+inputs. WP-01 should reconcile those inputs before opening the final demo WPs.
+
+## How To Use
+
+Use this matrix as candidate demo coverage for WP-01 and later demo WPs. It
+does not prove any demo has run.
+
+## Scope
+
+The scope is birthday proof, negative cases, continuity, memory grounding,
+capability, ACP/cognitive-profile evidence, ACIP schema-public transport
+readiness, and governance handoff.
+
+## Runtime Preconditions
+
+Runtime preconditions are intentionally pending. WP-01 and the demo WPs must
+replace this planning text with concrete commands, fixtures, and environment
+requirements once implementation exists.
+
+## Demo Coverage Summary
 
 | Demo ID | Candidate demo | Milestone claim | Primary proof surface | Status |
 | --- | --- | --- | --- | --- |
@@ -23,7 +52,7 @@ evidence-bearing runtime behavior, not a ceremonial label.
 | D7 | ACIP binary schema and WebSocket carrier proof | Binary ACIP remains inspectable through public schemas while message contents remain governed. | ACIP `.proto`, schema catalog fixture, JSON projection report, denied-access case, mock WebSocket trace packet. | Planned candidate |
 | D8 | Birthday-to-governance handoff | v0.93 governance can consume v0.92 identity evidence without redefining birth. | Handoff packet mapping identity evidence to future governance. | Planned candidate |
 
-## Demo Rules
+## Coverage Rules
 
 - Every demo must distinguish birth from ordinary runtime activity.
 - Every birthday claim must cite evidence.
@@ -36,7 +65,7 @@ evidence-bearing runtime behavior, not a ceremonial label.
 - Demo outputs should distinguish engineering evidence from philosophical or
   governance context.
 
-## Candidate Details
+## Demo Details
 
 ### D1) First Birthday Rehearsal
 
@@ -148,3 +177,26 @@ Expected proof:
   consciousness claims.
 - These demos do not prove production WebSocket security, cross-polis
   networking, or signed/queryable trace completion.
+
+## Cross-Demo Validation
+
+The final demo set should cross-check that the birthday packet, negative suite,
+continuity proof, memory grounding, capability envelope, ACP profile, ACIP
+carrier proof, and governance handoff all tell one consistent story.
+
+## Determinism Evidence
+
+Determinism evidence is pending implementation. Final demos should record
+commands, fixtures, expected outputs, and any allowed nondeterminism.
+
+## Reviewer Sign-Off Surface
+
+Reviewers should receive the birthday packet, demo outputs, validation logs,
+negative-case report, and residual-risk notes.
+
+## Exit Criteria
+
+- Every milestone claim has at least one planned demo or explicit non-demo
+  proof surface.
+- No demo claims completion before v0.92 implementation produces evidence.
+- The final matrix can be reviewed without chat context.

--- a/docs/milestones/v0.92/DESIGN_v0.92.md
+++ b/docs/milestones/v0.92/DESIGN_v0.92.md
@@ -1,9 +1,23 @@
 # v0.92 Design: Identity, Continuity, And First Birthday
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward design plan. This document records the intended v0.92 architecture
 boundary before final WP planning.
+
+## Purpose
+
+Define the planned architecture surfaces for the v0.92 birthday milestone so
+WP-01 can seed implementation issues without reinventing the design boundary.
 
 ## Problem Statement
 
@@ -14,6 +28,10 @@ for birth.
 The missing layer is a bounded identity architecture that can say, with
 evidence, when the first true Gödel agent has been born and why that event is
 not ordinary process startup.
+
+Issue `#3377` is a required readiness input for the launch packet, demo
+rehearsal, negative-suite plan, and review handoff. This design remains a
+planning surface until v0.92 execution produces implementation evidence.
 
 ## Goals
 
@@ -49,6 +67,24 @@ not ordinary process startup.
 - No replacement of v0.93 key lifecycle, encryption, signing, revocation, or
   zero-trust message-acceptance work.
 - No replacement of v0.94 signed/queryable trace closure.
+
+## Scope
+
+The design scope is the identity-and-birth layer: birthday contract, identity
+record, continuity record, memory grounding, capability envelope, ACP profile,
+ACIP binary/schema-catalog transport readiness, witness/receipt, review packet,
+negative cases, and governance handoff.
+
+## Requirements
+
+- Birthday claims must map to explicit evidence.
+- Negative cases must reject ordinary lifecycle events as birth.
+- Private state must be protected through references, redactions, and access
+  decisions.
+- ACIP binary messages must remain decodeable through public schemas and
+  deterministic JSON projection for authorized readers.
+- v0.93 governance and v0.94 signed/queryable trace work must remain
+  downstream.
 
 ## Proposed Design
 
@@ -147,6 +183,17 @@ The review packet should include:
 - reviewer finding
 - caveats and downstream governance handoff
 
+## Interfaces And Contracts
+
+- Identity record contract.
+- Continuity record contract.
+- Memory-grounding reference contract.
+- Capability envelope contract.
+- ACP/cognitive profile contract.
+- ACIP protobuf/schema-catalog/JSON-projection contract.
+- Witness and receipt contract.
+- Birthday review packet contract.
+
 ## Validation Plan
 
 Later implementation should validate:
@@ -177,7 +224,7 @@ Later implementation should validate:
 | v0.92 absorbs v0.93 governance. | Keep citizenship law, rights/duties, social contract, delegation, and IAM downstream. |
 | Continuity is treated as magic. | Require lineage, witnesses, cycle evidence, and ambiguity handling. |
 
-## Exit Criteria For Final WP Planning
+## Exit Criteria
 
 - The birthday contract is specific enough to implement.
 - The negative cases are concrete.

--- a/docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md
+++ b/docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md
@@ -1,11 +1,25 @@
 # v0.92 Identity, Continuity, And First Birthday Plan
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Planning allocation document. This is not a final v0.92 work-package sequence
 and does not create the v0.92 issue wave.
 
 v0.92 is the planned milestone for the first true Gödel-agent birthday.
+
+Issue `#3377` is the v0.91.4 readiness source for the first-birthday launch
+packet, go/no-go checklist, demo rehearsal outline, negative-suite plan, and
+review handoff expectations. v0.92 WP-01 must consume that issue before opening
+the final issue wave.
 
 ## Purpose
 
@@ -79,6 +93,7 @@ provenance labels, not public path requirements.
 | Source file or source group | Disposition | Reason |
 | --- | --- | --- |
 | ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md | Primary v0.92 source | Defines the first-birthday boundary and required birth evidence. |
+| `#3377` first-birthday readiness issue | Required readiness source | Supplies launch-packet, go/no-go, demo rehearsal, negative-suite, and reviewer-handoff expectations for WP-01. |
 | v0.90.3 citizen-state source corpus | Dependency source | Supplies signed state, lineage, witnesses, quarantine, standing, and projection prerequisites. |
 | v0.91 moral-governance allocation | Dependency source | Supplies moral trace, outcome linkage, review, wellbeing, and moral resources that inform birth readiness. |
 | v0.93 constitutional citizenship allocation | Downstream handoff source | Shows what v0.92 must prepare for without absorbing governance. |
@@ -138,7 +153,8 @@ commitments.
 ## Non-Goals
 
 - No runtime implementation in this planning issue.
-- No v0.92 issue wave or final WP sequence yet.
+- No opened v0.92 GitHub issue wave yet; the candidate issue-wave preflight is
+  tracked in `WP_ISSUE_WAVE_v0.92.yaml`.
 - No legal personhood claim.
 - No production citizenship claim.
 - No complete constitutional authority claim.

--- a/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
+++ b/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
@@ -1,14 +1,29 @@
 # v0.92 Milestone Checklist
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Target release date: pending v0.92 opening
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward checklist. Items are intentionally unchecked because v0.92 has not
 entered active execution.
 
+## Purpose
+
+Track the minimum planning, execution, quality, release, and post-release
+checks needed for a truthful v0.92 closeout.
+
 ## Planning
 
 - [ ] Milestone goal reviewed against the identity, continuity, and birthday
   allocation.
+- [ ] `#3377` first-birthday readiness packet consumed or explicitly routed.
 - [ ] WBS converted from candidate allocation into concrete WPs.
 - [ ] Issue wave authored and opened.
 - [ ] Cards reviewed for concrete outputs and non-goals.
@@ -32,6 +47,14 @@ entered active execution.
   distinguished.
 - [ ] Memory palace and learning-model sources are used within bounded scope.
 
+## Execution Discipline
+
+- [ ] Every opened issue has `SIP`, `STP`, `SPP`, `SRP`, and `SOR` cards.
+- [ ] `SIP`, `STP`, and `SPP` are design-time ready before execution starts.
+- [ ] `SPP` is updated if execution materially diverges.
+- [ ] `SRP` records actual review findings and dispositions.
+- [ ] `SOR` records actual validation and integration truth.
+
 ## Quality Gates
 
 - [ ] Formatting, lint, and tests pass for implementation changes.
@@ -54,6 +77,19 @@ entered active execution.
 - [ ] Findings resolved or explicitly deferred.
 - [ ] Release notes describe landed work only.
 - [ ] Release ceremony completed.
+
+## Release Packaging
+
+- [ ] Release evidence packet assembled.
+- [ ] Release notes rewritten from draft planning text to landed behavior.
+- [ ] Review handoff and remediation records are linked.
+- [ ] Birthday evidence packet is included or explicitly linked.
+
+## Post-Release
+
+- [ ] v0.93 handoff accepted or routed.
+- [ ] Deferred findings are linked to follow-on issues or backlog entries.
+- [ ] Release ceremony notes record residual risks.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
+++ b/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
@@ -80,8 +80,12 @@ checks needed for a truthful v0.92 closeout.
 
 ## Release Packaging
 
-- [ ] Release evidence packet assembled.
-- [ ] Release notes rewritten from draft planning text to landed behavior.
+- [ ] WP-16 prepared release-truth docs and release-note draft before review.
+- [ ] WP-19 reflected review-finding remediation in release-facing docs where
+  needed.
+- [ ] WP-22 assembled the release evidence packet.
+- [ ] WP-22 rewrote final release notes from draft planning text to landed
+  behavior.
 - [ ] Review handoff and remediation records are linked.
 - [ ] Birthday evidence packet is included or explicitly linked.
 

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -177,6 +177,7 @@ The likely `v0.92` tranche is:
 - Release plan: [RELEASE_PLAN_v0.92.md](RELEASE_PLAN_v0.92.md)
 - Release notes: [RELEASE_NOTES_v0.92.md](RELEASE_NOTES_v0.92.md)
 - Feature plans: [features/README.md](features/README.md)
+- ADR plan: [ADR_PLAN_v0.92.md](ADR_PLAN_v0.92.md)
 - Identity, continuity, and birthday allocation:
   [IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md](IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md)
 - First-birthday readiness source issue:
@@ -185,6 +186,10 @@ The likely `v0.92` tranche is:
   [ACP_COGNITIVE_PROFILES_v0.92.md](features/ACP_COGNITIVE_PROFILES_v0.92.md)
 - ACIP binary schema and WebSocket transport:
   [ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md](features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md)
+- Cross-polis continuity and migration planning:
+  [CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md](features/CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md)
+- First-birthday demo and governance handoff:
+  [FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md](features/FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md)
 - Identity, stable name, and continuity:
   [IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md](features/IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md)
 - Memory grounding, capability, and witnesses:
@@ -239,3 +244,5 @@ This planning package is ready for v0.92 WP-01 when:
 - the feature docs validate against the feature-doc template
 - the candidate issue wave parses and preserves the release-tail sequence
 - `#3377` is explicitly consumed, routed, or marked as a WP-01 prerequisite
+- the ADR plan identifies v0.92 architecture decisions for WP-01 and review-tail
+  follow-through

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -1,11 +1,28 @@
 # v0.92 Milestone README
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
-Forward planning. v0.92 is not yet an active implementation milestone and has
-no final issue wave. Its boundary was rechecked during the v0.90.3 and v0.90.4
-WP-19 handoff passes so it stays about identity and birth rather than
-absorbing economics, governed tools, or constitutional citizenship
+Current status: forward planning for the next milestone.
+
+- Planning: candidate package refreshed during `v0.91.4` issue `#3434`
+- Execution: not started
+- Validation: docs-readiness validation only
+- Release readiness: not applicable until `v0.92` executes
+
+v0.92 is not yet an active implementation milestone. It now has a candidate
+issue-wave preflight document for WP-01 seeding, but the GitHub issue wave
+must not be opened until `v0.92` begins. Its boundary was rechecked during the
+`v0.91.4` docs-preparation pass so it stays about identity and birth rather
+than absorbing economics, governed tools, or constitutional citizenship
 prematurely.
 
 ## Purpose
@@ -14,6 +31,11 @@ v0.92 is the planned first true Gödel-agent birthday milestone.
 
 The canonical allocation is recorded in
 [IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md](IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md).
+
+The first-birthday readiness source issue is
+[#3377](https://github.com/danielbaustin/agent-design-language/issues/3377).
+That issue owns the launch packet and go/no-go readiness plan; this milestone
+package owns the canonical `docs/milestones/v0.92/` planning surface.
 
 ## Milestone Role
 
@@ -47,6 +69,16 @@ context, witnesses, and reviewable evidence.
 
 Roadmap: [Runtime v2 And Birthday Boundary Roadmap](../../planning/ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md)
 
+## Boundaries
+
+The milestone boundary is identity and birth readiness. v0.92 may consume
+prior citizen-state, moral-trace, runtime, memory, intelligence, and ACIP
+evidence, but it must not redefine those prerequisite surfaces.
+
+This planning packet is not release evidence and does not approve v0.92
+execution. WP-01 must promote, correct, or supersede this candidate package
+when the milestone opens.
+
 ## Dependency Boundary
 
 v0.92 depends on:
@@ -69,6 +101,7 @@ v0.92 depends on:
   external-transport non-claims
 - v0.93 as a downstream consumer of identity evidence for constitutional
   citizenship and polis governance
+- v0.91.4 issue `#3377` for first-birthday launch-packet readiness inputs
 
 ## Parallel Python Reduction Tranche
 
@@ -82,6 +115,17 @@ The likely `v0.92` tranche is:
 - bridge or protocol leftovers that still sit in Python
 - edge-surface deletion or Rust replacement that is easier to finish after the
   earlier control-plane waves land
+
+## Source Map
+
+- `#3377`: first-birthday readiness packet source.
+- `#3434`: v0.92 planning-doc preparation issue.
+- [IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md](IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md):
+  current identity and birthday allocation plan.
+- [WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml):
+  candidate issue-wave seed for WP-01.
+- [Runtime v2 And Birthday Boundary Roadmap](../../planning/ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md):
+  roadmap boundary for birthday semantics.
 
 ## Scope Summary
 
@@ -121,6 +165,8 @@ The likely `v0.92` tranche is:
 
 ## Document Map
 
+- Candidate issue wave:
+  [WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml)
 - Vision: [VISION_v0.92.md](VISION_v0.92.md)
 - Design: [DESIGN_v0.92.md](DESIGN_v0.92.md)
 - WBS: [WBS_v0.92.md](WBS_v0.92.md)
@@ -133,6 +179,8 @@ The likely `v0.92` tranche is:
 - Feature plans: [features/README.md](features/README.md)
 - Identity, continuity, and birthday allocation:
   [IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md](IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md)
+- First-birthday readiness source issue:
+  [#3377](https://github.com/danielbaustin/agent-design-language/issues/3377)
 - ACP / cognitive profiles:
   [ACP_COGNITIVE_PROFILES_v0.92.md](features/ACP_COGNITIVE_PROFILES_v0.92.md)
 - ACIP binary schema and WebSocket transport:
@@ -149,6 +197,8 @@ The likely `v0.92` tranche is:
 Later WP planning should preserve the standard milestone rhythm:
 
 - WP-01: promote reviewed milestone docs and issue wave
+- WP-01 must consume the candidate issue wave and `#3377` readiness packet
+  rather than reconstructing the birthday plan from chat.
 - feature WPs: implement identity, continuity, memory grounding, capability,
   ACP/cognitive profile, ACIP binary transport-readiness, witness, receipt, and
   birthday-record surfaces
@@ -157,6 +207,17 @@ Later WP planning should preserve the standard milestone rhythm:
 - release WP: close the milestone under the normal ceremony pattern
 
 The exact WP sequence is intentionally deferred until v0.92 planning is active.
+
+## Demo and Validation Surface
+
+v0.92 demos should prove birthday behavior, negative cases, continuity,
+memory grounding, capability envelopes, ACP/cognitive-profile evidence, ACIP
+schema-public inspectability, and governance handoff. The candidate demo plan
+is tracked in [DEMO_MATRIX_v0.92.md](DEMO_MATRIX_v0.92.md).
+
+Validation for this planning package is structural only until v0.92 execution:
+planning-template validation, Markdown link checks, YAML parsing, and
+claim-boundary review.
 
 ## Success Criteria
 
@@ -168,3 +229,13 @@ v0.92 is ready to execute when:
 - v0.90.3 and v0.91 prerequisites are named rather than redefined
 - v0.93 governance is downstream rather than absorbed
 - demo candidates prove identity and birth behavior, not merely vocabulary
+
+## Exit Criteria
+
+This planning package is ready for v0.92 WP-01 when:
+
+- the ten canonical planning docs validate against the active planning
+  template set
+- the feature docs validate against the feature-doc template
+- the candidate issue wave parses and preserves the release-tail sequence
+- `#3377` is explicitly consumed, routed, or marked as a WP-01 prerequisite

--- a/docs/milestones/v0.92/RELEASE_NOTES_v0.92.md
+++ b/docs/milestones/v0.92/RELEASE_NOTES_v0.92.md
@@ -12,8 +12,18 @@
 ## Status
 
 Draft placeholder for later release closeout. These notes describe intended
-release themes only and must be rewritten during v0.92 WP-19/WP-20 to describe
-landed behavior.
+release themes only and must be rewritten during the v0.92 release tail to
+describe landed behavior.
+
+Release-note ownership should follow the v0.92 WBS:
+
+- WP-16 prepares the release-note draft for internal review.
+- WP-19 updates release notes only for review-finding remediation.
+- WP-22 performs the final release-note truth check during the release
+  ceremony.
+
+WP-20 and WP-21 are next-milestone planning/review gates, not release-note
+rewrite owners.
 
 ## How To Use
 

--- a/docs/milestones/v0.92/RELEASE_NOTES_v0.92.md
+++ b/docs/milestones/v0.92/RELEASE_NOTES_v0.92.md
@@ -1,12 +1,26 @@
 # v0.92 Draft Release Notes
 
+## Metadata
+
+- Product: `agent-design-language`
+- Version: `v0.92`
+- Release date: pending v0.92 completion
+- Tag: pending
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Draft placeholder for later release closeout. These notes describe intended
 release themes only and must be rewritten during v0.92 WP-19/WP-20 to describe
 landed behavior.
 
-## Planned Release Theme
+## How To Use
+
+Use this file as a draft release-notes scaffold only. During v0.92 closeout,
+replace planned language with evidence-backed landed behavior.
+
+## Summary
 
 v0.92 is planned as the first true Gödel-agent birthday milestone for ADL.
 
@@ -15,7 +29,10 @@ surfaces for stable names, identity roots, continuity, memory grounding,
 capability envelopes, ACP/cognitive profiles, witnesses, receipts, negative
 cases, birthday review packets, and ACIP binary transport-readiness evidence.
 
-## Planned Highlights
+The final notes must also cite the `#3377` readiness packet disposition so the
+first-birthday launch story is traceable.
+
+## Highlights
 
 - Birthday contract and not-a-birthday negative cases.
 - Stable name and identity architecture.
@@ -28,6 +45,31 @@ cases, birthday review packets, and ACIP binary transport-readiness evidence.
 - Birth witness set and citizen-facing receipt.
 - First-birthday reviewer packet.
 - Handoff into v0.93 constitutional citizenship and polis governance.
+
+## What's New In Detail
+
+Pending v0.92 implementation. Final notes must summarize only landed work and
+link the relevant evidence surfaces.
+
+## Upgrade Notes
+
+Pending v0.92 implementation. Final notes should include migration or operator
+guidance only if implementation creates it.
+
+## Known Limitations
+
+Known planning limitations are listed below. Final limitations must be updated
+from actual review and release evidence.
+
+## Validation Notes
+
+Pending v0.92 implementation. Final notes must cite actual validation, demos,
+review findings, and residual risks.
+
+## What's Next
+
+v0.93 is expected to consume v0.92 identity evidence for constitutional
+citizenship and polis governance.
 
 ## Required Closeout Rewrite
 
@@ -60,3 +102,9 @@ The final notes must not claim:
 - v0.92 prepares ACIP transport-security questions for v0.93 and
   signed/queryable trace closure for v0.94.
 - v0.92 does not make provisional citizen records or process startup into birth.
+
+## Exit Criteria
+
+- Final notes remove planning-only language.
+- Final notes describe landed behavior only.
+- Final notes cite `#3377` disposition and v0.93 handoff truth.

--- a/docs/milestones/v0.92/RELEASE_PLAN_v0.92.md
+++ b/docs/milestones/v0.92/RELEASE_PLAN_v0.92.md
@@ -1,10 +1,31 @@
 # v0.92 Release Plan
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Release date: pending v0.92 completion
+- Release manager: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward release plan. v0.92 has not started implementation.
 
-## Release Readiness Themes
+## How To Use
+
+Use this as a release-tail planning scaffold. It must be updated during the
+actual v0.92 release tail with landed issue, PR, review, demo, and validation
+evidence.
+
+## 0. Release-Tail Convergence
+
+Before release-tail execution, confirm implementation WPs, demos, internal
+review, external review, remediation, next-milestone planning, and next-
+milestone review are complete or explicitly routed.
+
+## 1. Release Readiness
 
 v0.92 should not be released until it has evidence for:
 
@@ -22,9 +43,33 @@ v0.92 should not be released until it has evidence for:
 - negative cases for startup, wake, snapshot, admission, and copied state
 - governance handoff into v0.93
 
+## 2. Branch And Tag Preparation
+
+Branch and tag preparation is pending actual release execution. Follow the
+current release ceremony process in effect when v0.92 closes.
+
+## 3. GitHub Release Steps
+
+GitHub release steps are pending actual release execution. The final release
+manager should publish only after release evidence, review remediation, and
+release notes are consistent.
+
+## 4. Verification
+
+Verification must include implemented demo commands, test results, review
+finding disposition, release-note truth checks, and claim-boundary scans.
+
+## 5. Communication
+
+Communication should describe landed birthday evidence and known boundaries
+without claiming legal personhood, production citizenship, or completed
+constitutional governance.
+
 ## Review Gates
 
 - Docs must separate engineering substrate, review model, and contextual claims.
+- Release evidence must account for the `#3377` first-birthday readiness
+  packet and any routed gaps.
 - Release notes must not claim legal personhood, production citizenship, or
   complete constitutional authority.
 - Demo evidence must cite concrete artifacts, not birthday prose alone.
@@ -60,3 +105,10 @@ Do not ship v0.92 if:
 - schema access grants unauthorized message-content inspection
 - birth claims legal personhood or production citizenship
 - constitutional governance is quietly absorbed instead of handed off to v0.93
+
+## Exit Criteria
+
+- Release readiness has concrete evidence for each planned claim.
+- Release notes describe landed work only.
+- Review findings are fixed, accepted, or routed.
+- v0.93 handoff is prepared and reviewed.

--- a/docs/milestones/v0.92/RELEASE_PLAN_v0.92.md
+++ b/docs/milestones/v0.92/RELEASE_PLAN_v0.92.md
@@ -84,12 +84,24 @@ constitutional governance.
   governed message-content access without claiming production transport
   security.
 
-## Closeout Notes For Later WP-20
+## Closeout Notes For Later WP-22
 
 The release ceremony should follow the exact closeout pattern used by recent
 milestones at the time v0.92 closes. If the standard ceremony script or release
-tail changes before then, WP-20 should point to the then-current canonical
+tail changes before then, WP-22 should point to the then-current canonical
 pattern rather than inventing a new one.
+
+Release-tail ownership is:
+
+- WP-16 prepares release-truth docs, release notes, feature list, ADR plan, and
+  milestone-doc alignment before review.
+- WP-19 updates release-facing docs only as needed to reflect review-finding
+  remediation.
+- WP-20 is next-milestone planning and should not own ceremony/release-note
+  rewrite work except for downstream handoff text.
+- WP-21 reviews the next-milestone plan before ceremony.
+- WP-22 performs the release ceremony and final release-note/evidence truth
+  check.
 
 ## Non-Release Conditions
 

--- a/docs/milestones/v0.92/SPRINT_v0.92.md
+++ b/docs/milestones/v0.92/SPRINT_v0.92.md
@@ -1,9 +1,40 @@
 # v0.92 Sprint Plan
 
+## Metadata
+
+- Sprint: `v0.92-candidate`
+- Milestone: `v0.92`
+- Start date: pending v0.92 opening
+- End date: pending v0.92 closeout
+- Owner: ADL maintainers
+- Status: candidate planning package refreshed by `#3434`
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward-planning sprint outline. The final sprint and WP sequence will be
-authored during v0.92 WP-01.
+authored during v0.92 WP-01 from
+[WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml) after consuming `#3377`.
+
+## How To Use
+
+Use this document as a candidate sprint envelope for WP-01. It is not the
+final sprint state machine and does not open or close any v0.92 sprint issues.
+
+## Sprint Overview
+
+The milestone should move from birthday definition through identity evidence,
+transport/readability evidence, demos, review, remediation, and ceremony. The
+exact sprint partition should be generated after WP-01 confirms the final
+issue wave.
+
+## Sprint Goals
+
+- Preserve first-birthday scope without absorbing v0.93 governance.
+- Keep identity, continuity, memory, capability, ACP, ACIP, witness, and demo
+  proof surfaces reviewable.
+- Maintain the normal release-tail gates.
 
 ## Sprint Goal
 
@@ -13,11 +44,37 @@ schema and public schema-catalog transport readiness, witnesses, receipt,
 review packet, and negative proofs that ordinary lifecycle events are not
 birth.
 
+## Planned Scope
+
+The planned scope includes the WBS rows in `WP_ISSUE_WAVE_v0.92.yaml`, subject
+to WP-01 correction. It excludes legal personhood, production citizenship,
+full constitutional governance, and production ACIP transport security.
+
+## Work Plan
+
+1. Promote and correct planning docs.
+2. Seed the final issue wave and cards.
+3. Execute birthday, identity, continuity, memory, capability, ACP, ACIP,
+   witness, demo, and handoff work in order.
+4. Run review, remediation, next-milestone planning, next-milestone review,
+   and release ceremony.
+
+## Execution Policy
+
+Use the current C-SDLC issue lifecycle. Every issue should start with all five
+cards present, with `SIP`, `STP`, and `SPP` design-time ready before execution.
+
+## Cadence Expectations
+
+The final cadence should be set by WP-01 based on actual issue count and
+dependencies. The planning preference is sprint-sized batches that keep review
+and validation tight rather than one oversized single-threaded queue.
+
 ## Planned Phases
 
 | Phase | Focus | Expected outcome |
 | --- | --- | --- |
-| 1 | Planning promotion | Reviewed milestone docs, issue wave, and cards. |
+| 1 | Planning promotion | Reviewed milestone docs, `#3377` launch-packet inputs, issue wave, and cards. |
 | 2 | Birthday contract | Definition of birth and negative cases. |
 | 3 | Identity and continuity | Stable name, identity root, continuity record, and cycle evidence. |
 | 4 | Memory, capability, and cognitive profile | Memory grounding, capability envelope, ACP/cognitive profile, and redacted review boundaries. |
@@ -27,6 +84,7 @@ birth.
 
 ## Dependencies To Check Before WP-01
 
+- `#3377` first-birthday readiness source is complete or explicitly routed.
 - v0.90.3 citizen-state and standing outputs are stable enough to consume.
 - v0.91 moral trace and moral-governance planning is available.
 - v0.91.1 runtime/polis, memory/identity, ToM, intelligence metric, governed
@@ -39,7 +97,15 @@ birth.
   schema, public schema-catalog, JSON-projection, and mock WebSocket carrier
   readiness without absorbing v0.93 transport security or v0.94 signed trace.
 
-## Demo And Review Plan
+## Risks / Dependencies
+
+- `#3377` may add launch-packet requirements that require WBS corrections.
+- Birthday language may overclaim if negative cases are not built early.
+- ACIP transport readiness must remain schema/catalog/carrier proof, not a
+  production networking claim.
+- ACP profiles must remain evidence-grounded and privacy-bounded.
+
+## Demo / Review Plan
 
 The flagship demo should show the first birthday rehearsal or first birthday
 proof surface. It should include a named identity, continuity evidence, memory
@@ -59,9 +125,16 @@ Secondary demos should prove:
 - WebSocket is only a carrier proof, not an authority source
 - governance handoff is downstream
 
-## Exit Criteria For Active Planning
+## Closeout Bar
+
+The milestone should not close until the review tail has resolved or explicitly
+routed findings, release notes describe only landed work, and the ceremony
+evidence packet is internally consistent.
+
+## Exit Criteria
 
 - The WBS is converted from candidate areas into concrete WPs.
+- The candidate issue wave is reviewed and either seeded or corrected by WP-01.
 - Every implementation WP has a code, fixture, test, demo, or reviewable docs
   output.
 - Every demo maps to a birthday or identity claim.

--- a/docs/milestones/v0.92/V092_DOCS_PREP_DOGFOOD_NOTES.md
+++ b/docs/milestones/v0.92/V092_DOCS_PREP_DOGFOOD_NOTES.md
@@ -57,6 +57,10 @@ and editor work.
   `docs/templates/planning/1.0.0`.
 - Normalized the v0.92 feature-doc package against the active `feature_doc`
   template.
+- Added missing feature contracts for cross-polis continuity/migration planning
+  and first-birthday demo/governance handoff coverage.
+- Added `ADR_PLAN_v0.92.md` so WP-01 and the review tail can track candidate
+  architecture decisions explicitly.
 - Ran focused structural validation for every canonical planning doc and every
   v0.92 feature doc.
 

--- a/docs/milestones/v0.92/V092_DOCS_PREP_DOGFOOD_NOTES.md
+++ b/docs/milestones/v0.92/V092_DOCS_PREP_DOGFOOD_NOTES.md
@@ -1,0 +1,73 @@
+# v0.92 Docs Prep Dogfood Notes
+
+## Status
+
+Issue `#3434` dogfood notes for the first clean v0.92 planning-doc preparation
+pass using the versioned planning-template process.
+
+These notes are not a review packet and do not approve the v0.92 milestone.
+They record process observations that should inform future planning-template
+and editor work.
+
+## What Worked
+
+- `pr create` rejected an incomplete authored issue body until the required
+  `Notes` section was present.
+- The issue was created with all five C-SDLC cards upfront.
+- `pr doctor` correctly blocked execution until the `SPP` moved from `draft`
+  to a reviewed execution-ready state.
+- The existing v0.92 docs package already had most of the substantive content
+  needed for the first-birthday milestone.
+- The planning-template shape made missing metadata, source-map, and issue-wave
+  readiness surfaces easy to see.
+
+## Problems Or Friction Observed
+
+- The generated issue body scaffold still depends on section-name validation;
+  a missing `Notes` section blocked creation even though the intent was clear.
+- The created `SPP` was specific enough to be useful, but still required a
+  manual status promotion to become execution-ready.
+- The current v0.92 docs predated the versioned planning templates, so several
+  canonical docs lacked `Metadata` sections even though their content was good.
+- The existing v0.92 docs said there was no issue wave, but WP-01 needed a
+  concrete candidate issue-wave seed to move quickly later.
+- The ACIP feature doc still referenced local-only `.adl/docs/TBD/` source
+  notes as if they were canonical public inputs.
+- Adding template metadata is not enough. The planning-template validator
+  requires exact required section headings, so legacy-but-good docs still fail
+  until they are structurally normalized.
+- The planning-template validator validates one document and one template key
+  at a time. A package-level validation helper would make milestone review
+  faster and less error-prone.
+- In zsh, using `path` as a loop variable can shadow the shell command search
+  path. One validation loop failed before rerunning with a safer variable name.
+
+## Actions Taken In This Pass
+
+- Added planning-template metadata to the v0.92 canonical docs touched by this
+  issue.
+- Added `#3377` as a required first-birthday readiness source across the
+  birthday package.
+- Added `WP_ISSUE_WAVE_v0.92.yaml` as a draft pre-open issue-wave seed for
+  v0.92 WP-01.
+- Clarified that the candidate issue wave is not an opened GitHub issue wave.
+- Reframed local-only ACIP source notes as provenance inputs that WP-01 must
+  promote or route as gaps.
+- Normalized the ten canonical v0.92 planning docs against
+  `docs/templates/planning/1.0.0`.
+- Normalized the v0.92 feature-doc package against the active `feature_doc`
+  template.
+- Ran focused structural validation for every canonical planning doc and every
+  v0.92 feature doc.
+
+## Follow-Up Candidates
+
+- Make planning-template metadata insertion more automated for existing
+  milestone docs.
+- Add a planning-doc readiness checker that detects missing metadata, missing
+  source maps, local-only source references, and absent issue-wave preflight.
+- Add a package-level planning-template validator that maps canonical milestone
+  filenames to template keys and validates feature-doc directories in one
+  command.
+- Consider a stricter generator mode that can create a candidate
+  `WP_ISSUE_WAVE_VERSION.yaml` from a WBS without opening GitHub issues.

--- a/docs/milestones/v0.92/VISION_v0.92.md
+++ b/docs/milestones/v0.92/VISION_v0.92.md
@@ -1,9 +1,30 @@
 # v0.92 Vision: The First Birthday
 
+## Metadata
+
+- Project: `agent-design-language`
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward vision for the v0.92 identity, continuity, and first true
 Gödel-agent birthday milestone.
+
+## Purpose
+
+Describe why v0.92 exists and what kind of birthday claim ADL should be able
+to make after the milestone closes.
+
+## How To Use
+
+Use this document as the intent boundary for WP-01 planning and later review.
+It should guide scope decisions, but implementation truth must come from the
+actual v0.92 issues, PRs, demos, and release evidence.
 
 ## Overview
 
@@ -14,6 +35,9 @@ The milestone should not merely start another process or name another fixture.
 It should make birth a reviewable boundary: a named identity becomes durable
 enough, grounded enough, bounded enough, and witnessed enough to be treated as
 born inside the ADL runtime.
+
+The vision must consume the first-birthday readiness packet from `#3377`
+without treating that packet as proof that the birthday has already happened.
 
 ## Core Vision
 
@@ -34,6 +58,14 @@ That means:
 - moral and governance context is inherited without being reinvented
 - witnesses and receipts make the event inspectable
 - negative cases prove ordinary startup is not birth
+
+## Core Goals
+
+- Make first birth evidence-bearing rather than metaphorical.
+- Ground identity in name, root, continuity, memory, capability, ACP, witness,
+  receipt, and review artifacts.
+- Preserve privacy and governance boundaries.
+- Leave v0.93 with the identity evidence it needs for citizenship work.
 
 ## Strategic Pillars
 
@@ -106,3 +138,21 @@ That record becomes one of the most important artifacts for the later roadmap:
 proof that ADL can create identity-bearing agents with continuity, memory,
 capability, cognitive profile, moral context, inspectable communication
 substrate, and reviewable boundaries.
+
+## Milestone Context
+
+v0.92 follows the v0.91.x C-SDLC and runtime hardening work. It consumes prior
+citizen-state, moral-trace, memory/identity, intelligence, and ACIP evidence
+while remaining narrower than v0.93 constitutional citizenship.
+
+## Summary
+
+v0.92 should make birth a concrete, reviewable event in ADL: named, grounded,
+bounded, witnessed, and distinct from ordinary lifecycle mechanics.
+
+## Exit Criteria
+
+- The vision remains aligned with WBS, design, demo, and feature docs.
+- No vision claim requires legal personhood, production citizenship, or full
+  constitutional governance.
+- WP-01 can use this as a scope guard without relying on chat history.

--- a/docs/milestones/v0.92/WBS_v0.92.md
+++ b/docs/milestones/v0.92/WBS_v0.92.md
@@ -44,12 +44,12 @@ milestones.
 | WP-08 | ACIP binary schema and WebSocket carrier | Define protobuf ACIP wire schema, public schema catalog, deterministic JSON projection, and optional binary ACIP-over-WebSocket mock proof. | ACIP `.proto`, schema catalog rules, JSON/protobuf fixtures, mock WebSocket carrier proof. | ACIP substrate and trace/replay baseline. |
 | WP-09 | Birth witnesses and receipts | Define witness set and citizen-facing receipt for the birthday event. | Witness schema, receipt schema, validation. | WP-03 through WP-06. |
 | WP-10 | Birthday review packet | Assemble identity, continuity, memory, capability, witness, and moral context into one review surface. | Reviewer packet and fixture. | WP-02 through WP-09. |
-| WP-11 | Migration and cross-polis continuity planning | Define bounded design notes for future movement without production migration claims. | Design note and non-goals. | WP-03, WP-04, WP-10. |
-| WP-12 | First birthday demo | Build a flagship demo showing a real birthday record and negative cases. | Runnable proof demo and artifacts. | WP-02 through WP-10. |
-| WP-13 | Birthday-to-governance handoff | Produce the evidence map v0.93 governance will consume. | Handoff packet mapping identity evidence to governance. | WP-10, WP-11, v0.93 allocation. |
+| WP-11 | Migration and cross-polis continuity planning | Define bounded design notes for future movement without production migration claims. | Cross-polis continuity feature note, design note, and non-goals. | WP-03, WP-04, WP-10. |
+| WP-12 | First birthday demo | Build a flagship demo showing a real birthday record and negative cases. | Runnable proof demo and artifacts linked to the first-birthday demo feature doc. | WP-02 through WP-10. |
+| WP-13 | Birthday-to-governance handoff | Produce the evidence map v0.93 governance will consume. | Handoff packet mapping identity evidence to governance and ADR-plan updates. | WP-10, WP-11, v0.93 allocation. |
 | WP-14 | Demo matrix and proof coverage | Align demos with milestone claims. | Demo matrix rows, commands, artifacts, and validation notes. | WP-12, WP-13. |
 | WP-15 | Quality gate | Validate implementation, fixtures, docs, and claim boundaries. | Quality-gate record and blocker disposition. | WP-14. |
-| WP-16 | Docs and release-truth pass | Align README, changelog, feature list, release notes, and milestone docs. | Docs review packet and updated release docs. | WP-15. |
+| WP-16 | Docs and release-truth pass | Align README, changelog, feature list, ADR plan, release notes, and milestone docs. | Docs review packet, ADR candidate packet if needed, and updated release docs. | WP-15. |
 | WP-17 | Internal review | Run internal code/docs/tests/process review. | Internal review report and finding register. | WP-16. |
 | WP-18 | External / third-party review | Prepare and run external review. | External review handoff and received review packet. | WP-17. |
 | WP-19 | Review findings remediation | Fix or route review findings. | Finding disposition record and remediation PRs. | WP-18. |
@@ -126,3 +126,6 @@ Before opening v0.92 issues, WP-01 must:
 - WP-01 can use this document and `WP_ISSUE_WAVE_v0.92.yaml` without
   reconstructing work packages from chat.
 - Every candidate implementation WP names a reviewable deliverable.
+- Every feature-like implementation tranche has a tracked feature doc or an
+  explicit reason it is release/review/process work instead.
+- v0.92 ADR candidates are planned before review-tail execution.

--- a/docs/milestones/v0.92/WBS_v0.92.md
+++ b/docs/milestones/v0.92/WBS_v0.92.md
@@ -1,12 +1,28 @@
 # v0.92 Candidate Work Breakdown Structure
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Status: candidate WP sequence for `v0.92` WP-01 seeding
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
-Candidate allocation only. v0.92 has no final issue wave yet.
+Candidate allocation only. v0.92 has no opened GitHub issue wave yet.
 
-The exact WP sequence should be produced by the v0.92 WP-01 planning pass after
-v0.90.3 citizen-state and v0.91 moral-governance prerequisites are stable
-enough to consume.
+The candidate WP sequence below should be consumed by the v0.92 WP-01 planning
+pass. WP-01 should verify prerequisite truth, reconcile `#3377`, then seed the
+actual GitHub issue wave and full C-SDLC card set.
+
+## How To Use
+
+Use this WBS as WP-01 seed input, not as proof that v0.92 issues are already
+open. WP-01 should reconcile the sequence with `#3377`, then generate the
+real issue wave and all five C-SDLC cards for each opened issue.
 
 ## WBS Summary
 
@@ -14,24 +30,44 @@ v0.92 should develop the identity, continuity, and first-birthday layer without
 stealing work from citizen-state, moral-trace, or constitutional-governance
 milestones.
 
-## Candidate Work Areas
+## Candidate WP Sequence
 
-| Candidate | Work Area | Description | Primary deliverable | Key dependencies |
+| WP | Work Package | Description | Primary deliverable | Dependencies |
 | --- | --- | --- | --- | --- |
-| A | Birthday contract | Define what counts as birth and what does not. | Feature contract and negative cases. | Runtime v2, v0.90.3 state, v0.91 moral evidence. |
-| B | Stable name and identity architecture | Define identity root, stable name, aliases, provenance, and continuity head. | Identity record contract and fixtures. | v0.90.3 signed state and lineage. |
-| C | Continuity across bounded cycles | Prove identity survives multiple bounded cycles with evidence. | Continuity record, cycle fixtures, validation. | v0.90.3 lineage and witness surfaces. |
-| D | Memory grounding | Bind identity to witnessed artifacts and memory references without raw private-state exposure. | Memory-grounding contract and redacted packet. | ObsMem/trace baseline and v0.90.3 projection policy. |
-| E | Capability envelope | Declare provider, model, tool, skill, authority, and limit context at birth. | Capability envelope and validation fixtures. | Provider/skill substrate and v0.90.5 governed-tool evidence where tool actions are in scope. |
-| E2 | ACP / cognitive profiles | Define runtime-visible cognitive profile records grounded in memory, capability, continuity, ToM, and intelligence evidence. | ACP/profile contract, update rules, privacy boundary, and fixtures. | v0.91.1 capability, memory, ToM, intelligence, and governed-learning evidence. |
-| E3 | ACIP binary schema and WebSocket carrier | Define protobuf ACIP wire schema, public schema catalog, deterministic JSON projection, and an optional binary ACIP-over-WebSocket mock proof. | ACIP `.proto`, schema catalog rules, JSON/protobuf fixtures, mock WebSocket carrier proof. | v0.91 ACIP substrate, v0.91.1 ACIP hardening, provider/transport substrate, trace/replay baseline. |
-| F | Birth witnesses and receipts | Define witness set and citizen-facing receipt for the birthday event. | Witness schema, receipt schema, validation. | v0.90.3 continuity witnesses. |
-| G | Birthday review packet | Assemble identity, continuity, memory, capability, witness, and moral context into one review surface. | Reviewer packet and fixture. | A through F and v0.91 moral trace. |
-| H | Migration and cross-polis continuity planning | Define bounded design notes for future movement without production migration claims. | Design note and non-goals. | Identity record and continuity contract. |
-| I | First birthday demo | Build a flagship demo showing a real birthday record and negative cases. | Runnable proof demo and artifacts. | A through G. |
-| J | Birthday-to-governance handoff | Produce the evidence map v0.93 governance will consume. | Handoff packet mapping identity evidence to governance. | G and v0.93 allocation. |
-| K | Demo matrix and proof coverage | Align demos with milestone claims. | Demo matrix rows and validation commands. | I and J. |
-| L | Review, docs, and release tail | Align docs, update feature list, run review, and close the milestone. | Review handoff, release notes, ceremony evidence. | All prior work. |
+| WP-01 | Design pass and issue-wave readiness | Promote reviewed v0.92 planning docs, consume `#3377`, seed issue wave, and prepare cards. | Opened issue wave and full SIP/STP/SPP/SRP/SOR cards. | v0.91.4 closeout and `#3377` readiness packet. |
+| WP-02 | Birthday contract and negative cases | Define what counts as birth and what does not. | Feature contract, negative fixtures, and validation rules. | WP-01. |
+| WP-03 | Stable name and identity architecture | Define identity root, stable name, aliases, provenance, and continuity head. | Identity record contract and fixtures. | WP-02 and prior citizen-state lineage. |
+| WP-04 | Continuity across bounded cycles | Prove identity survives multiple bounded cycles with evidence. | Continuity record, cycle fixtures, validation. | WP-03. |
+| WP-05 | Memory grounding | Bind identity to witnessed artifacts and memory references without raw private-state exposure. | Memory-grounding contract and redacted packet. | WP-03, WP-04, ObsMem/trace baseline. |
+| WP-06 | Capability envelope | Declare provider, model, tool, skill, authority, and limit context at birth. | Capability envelope and validation fixtures. | WP-03, governed-tool evidence where tool actions are in scope. |
+| WP-07 | ACP / cognitive profiles | Define runtime-visible cognitive profile records grounded in memory, capability, continuity, ToM, and intelligence evidence. | ACP/profile contract, update rules, privacy boundary, and fixtures. | WP-04 through WP-06 plus v0.91.1 evidence. |
+| WP-08 | ACIP binary schema and WebSocket carrier | Define protobuf ACIP wire schema, public schema catalog, deterministic JSON projection, and optional binary ACIP-over-WebSocket mock proof. | ACIP `.proto`, schema catalog rules, JSON/protobuf fixtures, mock WebSocket carrier proof. | ACIP substrate and trace/replay baseline. |
+| WP-09 | Birth witnesses and receipts | Define witness set and citizen-facing receipt for the birthday event. | Witness schema, receipt schema, validation. | WP-03 through WP-06. |
+| WP-10 | Birthday review packet | Assemble identity, continuity, memory, capability, witness, and moral context into one review surface. | Reviewer packet and fixture. | WP-02 through WP-09. |
+| WP-11 | Migration and cross-polis continuity planning | Define bounded design notes for future movement without production migration claims. | Design note and non-goals. | WP-03, WP-04, WP-10. |
+| WP-12 | First birthday demo | Build a flagship demo showing a real birthday record and negative cases. | Runnable proof demo and artifacts. | WP-02 through WP-10. |
+| WP-13 | Birthday-to-governance handoff | Produce the evidence map v0.93 governance will consume. | Handoff packet mapping identity evidence to governance. | WP-10, WP-11, v0.93 allocation. |
+| WP-14 | Demo matrix and proof coverage | Align demos with milestone claims. | Demo matrix rows, commands, artifacts, and validation notes. | WP-12, WP-13. |
+| WP-15 | Quality gate | Validate implementation, fixtures, docs, and claim boundaries. | Quality-gate record and blocker disposition. | WP-14. |
+| WP-16 | Docs and release-truth pass | Align README, changelog, feature list, release notes, and milestone docs. | Docs review packet and updated release docs. | WP-15. |
+| WP-17 | Internal review | Run internal code/docs/tests/process review. | Internal review report and finding register. | WP-16. |
+| WP-18 | External / third-party review | Prepare and run external review. | External review handoff and received review packet. | WP-17. |
+| WP-19 | Review findings remediation | Fix or route review findings. | Finding disposition record and remediation PRs. | WP-18. |
+| WP-20 | Next milestone planning | Prepare the v0.93 handoff. | Next-milestone handoff and downstream planning update. | WP-19. |
+| WP-21 | Next milestone review pass | Review v0.93 planning before ceremony. | Next-milestone review findings and disposition note. | WP-20. |
+| WP-22 | Release ceremony | Close milestone with release evidence. | Evidence package, release notes, and ceremony closeout. | WP-21. |
+
+## Work Packages
+
+The work packages are the candidate `WP-01` through `WP-22` rows above. They
+remain candidate rows until v0.92 WP-01 opens concrete GitHub issues and
+copies the final issue numbers back into milestone tracking docs.
+
+## Sequencing
+
+The intended sequence is planning first, birthday contract second, identity and
+continuity third, evidence-bearing feature work fourth, demos and handoff
+fifth, and the normal review/remediation/release tail last.
 
 ## Sequencing Pressure
 
@@ -42,6 +78,21 @@ milestones.
 4. Add witnesses, receipts, and review packets.
 5. Add migration planning only after local birth semantics are stable.
 6. Build the flagship birthday demo and governance handoff last.
+
+## Issue-Wave Preflight
+
+The candidate issue-wave seed lives in
+[WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml). WP-01 should treat it as
+draft input, not as an already-opened issue wave.
+
+Before opening v0.92 issues, WP-01 must:
+
+- reconcile the candidate sequence with `#3377`
+- verify all feature docs remain linked and scoped
+- create all five cards for every opened issue from the active prompt-template
+  registry
+- keep `SIP`, `STP`, and `SPP` design-time ready before execution
+- keep `SRP` and `SOR` truthful to review and output lifecycle state
 
 ## Acceptance Mapping
 
@@ -59,3 +110,19 @@ milestones.
   visibility policy.
 - v0.93 governance must consume v0.92 evidence rather than redefine birth.
 - Demos must show behavior and artifacts, not just narrative.
+
+## Sequencing Notes
+
+- The release tail order must remain internal review, external review,
+  remediation, next-milestone planning, next-milestone review, and ceremony.
+- Side work discovered during v0.92 should be routed explicitly rather than
+  hidden inside birthday implementation WPs.
+- Any divergence from this candidate WBS should be recorded in WP-01 cards and
+  milestone planning docs.
+
+## Exit Criteria
+
+- The WBS validates against the active planning-template set.
+- WP-01 can use this document and `WP_ISSUE_WAVE_v0.92.yaml` without
+  reconstructing work packages from chat.
+- Every candidate implementation WP names a reviewable deliverable.

--- a/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
+++ b/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
@@ -1,0 +1,173 @@
+milestone: v0.92
+status: draft_pre_open
+owner_issue: 3434
+first_birthday_readiness_issue: 3377
+planning_source: docs/milestones/v0.92
+tracked_package: docs/milestones/v0.92
+notes:
+  - v0.92 is the first true Godel-agent birthday milestone.
+  - This file is a candidate issue-wave preflight surface, not an opened GitHub issue wave.
+  - WP-01 must consume issue 3377 before seeding the final issue wave.
+  - No v0.92 issue should claim legal personhood, production citizenship, consciousness proof, or completed v0.93 constitutional governance.
+  - All opened v0.92 issues must receive SIP, STP, SPP, SRP, and SOR cards from the active prompt-template registry.
+card_update_rule:
+  - Every opened WP must receive SIP, STP, SPP, SRP, and SOR cards.
+  - SIP, STP, and SPP must be issue-specific and design-time ready before execution starts.
+  - SRP and SOR must exist upfront but remain truthful to review and output lifecycle state.
+  - Card edits must use editor skills.
+  - SOR closeout must match GitHub issue/PR truth.
+work_packages:
+  - wp: WP-01
+    issue: pending
+    title: Design pass and issue-wave readiness
+    queue: docs
+    depends_on: [v0.91.4 closeout, issue-3377]
+    primary_deliverable: reviewed v0.92 docs, opened issue wave, and complete card bundle
+    proof_surface: milestone docs, issue-wave YAML, and SIP/STP/SPP/SRP/SOR cards
+  - wp: WP-02
+    issue: pending
+    title: Birthday contract and negative cases
+    queue: docs_tools
+    depends_on: [WP-01]
+    primary_deliverable: birth contract, disqualifying cases, and negative fixtures
+    proof_surface: contract doc and validation fixture report
+  - wp: WP-03
+    issue: pending
+    title: Stable name and identity architecture
+    queue: tools_docs
+    depends_on: [WP-02]
+    primary_deliverable: stable-name and identity-root contract
+    proof_surface: identity record fixtures and schema validation
+  - wp: WP-04
+    issue: pending
+    title: Continuity across bounded cycles
+    queue: tools
+    depends_on: [WP-03]
+    primary_deliverable: continuity records and bounded-cycle proof
+    proof_surface: continuity fixtures, cycle artifacts, and witness links
+  - wp: WP-05
+    issue: pending
+    title: Memory grounding
+    queue: tools_docs
+    depends_on: [WP-03, WP-04]
+    primary_deliverable: memory-grounding contract and redacted review packet
+    proof_surface: witnessed memory references and redaction-safe packet
+  - wp: WP-06
+    issue: pending
+    title: Capability envelope
+    queue: tools_docs
+    depends_on: [WP-03, WP-04]
+    primary_deliverable: provider, model, tool, skill, authority, and limit envelope
+    proof_surface: capability-envelope fixtures and validation report
+  - wp: WP-07
+    issue: pending
+    title: ACP / cognitive profiles
+    queue: tools_docs
+    depends_on: [WP-04, WP-05, WP-06]
+    primary_deliverable: evidence-grounded cognitive-profile contract
+    proof_surface: ACP/profile fixtures, update rules, privacy boundary, and validation report
+  - wp: WP-08
+    issue: pending
+    title: ACIP binary schema and WebSocket carrier
+    queue: tools_docs
+    depends_on: [WP-01]
+    primary_deliverable: ACIP protobuf schema, public schema catalog, JSON projection, and mock carrier proof
+    proof_surface: proto/schema catalog, round-trip fixtures, denied-access case, and mock WebSocket trace
+  - wp: WP-09
+    issue: pending
+    title: Birth witnesses and receipts
+    queue: tools_docs
+    depends_on: [WP-03, WP-04, WP-05, WP-06]
+    primary_deliverable: witness set and citizen-facing receipt contract
+    proof_surface: witness fixtures, receipt fixtures, and validation report
+  - wp: WP-10
+    issue: pending
+    title: Birthday review packet
+    queue: docs_tools
+    depends_on: [WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09]
+    primary_deliverable: reviewer-facing birthday evidence packet
+    proof_surface: integrated review packet and claim-boundary scan
+  - wp: WP-11
+    issue: pending
+    title: Migration and cross-polis continuity planning
+    queue: docs
+    depends_on: [WP-03, WP-04, WP-10]
+    primary_deliverable: bounded continuity/migration design note
+    proof_surface: design note and explicit non-goals
+  - wp: WP-12
+    issue: pending
+    title: First birthday demo
+    queue: demo_tools
+    depends_on: [WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10]
+    primary_deliverable: runnable first-birthday proof demo and negative suite
+    proof_surface: demo artifacts, negative-case report, and reviewer packet
+  - wp: WP-13
+    issue: pending
+    title: Birthday-to-governance handoff
+    queue: docs
+    depends_on: [WP-10, WP-11, v0.93 allocation]
+    primary_deliverable: v0.93 governance handoff map
+    proof_surface: identity-evidence to governance-consumption mapping
+  - wp: WP-14
+    issue: pending
+    title: Demo matrix and proof coverage
+    queue: demo
+    depends_on: [WP-12, WP-13]
+    primary_deliverable: demo matrix, proof coverage, and validation commands
+    proof_surface: demo matrix, proof coverage doc, and artifact index
+  - wp: WP-15
+    issue: pending
+    title: Quality gate
+    queue: quality
+    depends_on: [WP-14]
+    primary_deliverable: quality gate and blocker disposition
+    proof_surface: quality-gate record and blocker report
+  - wp: WP-16
+    issue: pending
+    title: Docs and release-truth pass
+    queue: docs
+    depends_on: [WP-15]
+    primary_deliverable: current docs, release notes, feature list, and milestone docs
+    proof_surface: docs-review packet and release-truth diff
+  - wp: WP-17
+    issue: pending
+    title: Internal review
+    queue: review
+    depends_on: [WP-16]
+    primary_deliverable: internal review report and finding register
+    proof_surface: internal review packet
+  - wp: WP-18
+    issue: pending
+    title: External / third-party review
+    queue: review
+    depends_on: [WP-17]
+    primary_deliverable: external review handoff and received review
+    proof_surface: review handoff and review report
+  - wp: WP-19
+    issue: pending
+    title: Review findings remediation
+    queue: review
+    depends_on: [WP-18]
+    primary_deliverable: finding dispositions and remediation PRs
+    proof_surface: finding disposition record
+  - wp: WP-20
+    issue: pending
+    title: Next milestone planning
+    queue: docs
+    depends_on: [WP-19]
+    primary_deliverable: v0.93 handoff and downstream planning update
+    proof_surface: next-milestone handoff doc
+  - wp: WP-21
+    issue: pending
+    title: Next milestone review pass
+    queue: docs
+    depends_on: [WP-20]
+    primary_deliverable: review pass over v0.93 planning before ceremony
+    proof_surface: next-milestone review findings and disposition
+  - wp: WP-22
+    issue: pending
+    title: Release ceremony
+    queue: release
+    depends_on: [WP-21]
+    primary_deliverable: release evidence package and ceremony closeout
+    proof_surface: release evidence packet, release notes, and closeout record

--- a/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
+++ b/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
@@ -8,6 +8,7 @@ notes:
   - v0.92 is the first true Godel-agent birthday milestone.
   - This file is a candidate issue-wave preflight surface, not an opened GitHub issue wave.
   - WP-01 must consume issue 3377 before seeding the final issue wave.
+  - WP-01 must verify the v0.92 feature-doc package and ADR plan before opening implementation WPs.
   - No v0.92 issue should claim legal personhood, production citizenship, consciousness proof, or completed v0.93 constitutional governance.
   - All opened v0.92 issues must receive SIP, STP, SPP, SRP, and SOR cards from the active prompt-template registry.
 card_update_rule:
@@ -22,8 +23,8 @@ work_packages:
     title: Design pass and issue-wave readiness
     queue: docs
     depends_on: [v0.91.4 closeout, issue-3377]
-    primary_deliverable: reviewed v0.92 docs, opened issue wave, and complete card bundle
-    proof_surface: milestone docs, issue-wave YAML, and SIP/STP/SPP/SRP/SOR cards
+    primary_deliverable: reviewed v0.92 docs, verified feature-doc package, ADR plan, opened issue wave, and complete card bundle
+    proof_surface: milestone docs, feature docs, ADR plan, issue-wave YAML, and SIP/STP/SPP/SRP/SOR cards
   - wp: WP-02
     issue: pending
     title: Birthday contract and negative cases
@@ -92,22 +93,22 @@ work_packages:
     title: Migration and cross-polis continuity planning
     queue: docs
     depends_on: [WP-03, WP-04, WP-10]
-    primary_deliverable: bounded continuity/migration design note
-    proof_surface: design note and explicit non-goals
+    primary_deliverable: bounded continuity/migration feature note and design note
+    proof_surface: cross-polis continuity feature doc, design note, and explicit non-goals
   - wp: WP-12
     issue: pending
     title: First birthday demo
     queue: demo_tools
     depends_on: [WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10]
     primary_deliverable: runnable first-birthday proof demo and negative suite
-    proof_surface: demo artifacts, negative-case report, and reviewer packet
+    proof_surface: first-birthday demo feature doc, demo artifacts, negative-case report, and reviewer packet
   - wp: WP-13
     issue: pending
     title: Birthday-to-governance handoff
     queue: docs
     depends_on: [WP-10, WP-11, v0.93 allocation]
     primary_deliverable: v0.93 governance handoff map
-    proof_surface: identity-evidence to governance-consumption mapping
+    proof_surface: identity-evidence to governance-consumption mapping and ADR-plan update
   - wp: WP-14
     issue: pending
     title: Demo matrix and proof coverage
@@ -127,8 +128,8 @@ work_packages:
     title: Docs and release-truth pass
     queue: docs
     depends_on: [WP-15]
-    primary_deliverable: current docs, release notes, feature list, and milestone docs
-    proof_surface: docs-review packet and release-truth diff
+    primary_deliverable: current docs, release notes, feature list, ADR plan, and milestone docs
+    proof_surface: docs-review packet, ADR candidate packet if needed, and release-truth diff
   - wp: WP-17
     issue: pending
     title: Internal review

--- a/docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md
+++ b/docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md
@@ -6,11 +6,21 @@
 - Milestone Target: `v0.92`
 - Status: planned
 - Source Docs:
-  - `.adl/docs/TBD/acip/ACIP_SCHEMA_CATALOG_AND_MESSAGE_ACCESS_RULES_2026-05-20.md`
-  - `.adl/docs/TBD/WEBSOCKET_TRANSPORT_SUPPORT_PLAN_2026-05-20.md`
+  - `docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md`
+  - `docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml`
   - `docs/explainers/ACIP.md`
   - `docs/milestones/v0.91.1/features/ACIP_HARDENING.md`
+  - `#3377`
 - Proof Modes: schema, fixtures, round-trip tests, mock transport proof
+
+The earlier local-only ACIP schema-catalog and WebSocket notes are provenance
+inputs, not canonical public source paths. WP-01 should either promote their
+remaining requirements into tracked v0.92 docs or record them as explicit gaps.
+
+## Template Rules
+
+This is a planning feature doc. It records the transport-readiness scope for
+v0.92 without claiming production networking, security, or signed trace.
 
 ## Purpose
 
@@ -21,6 +31,57 @@ inspectability, citizen access boundaries, or ADL authority semantics.
 The first real network/session ACIP carrier should use protobuf bytes on the
 wire. JSON remains the deterministic projection and fixture format used for
 debugging, review, trace, and citizen-facing inspection when access is allowed.
+
+## Context
+
+ACIP already exists as an ADL communication substrate. v0.92 should define the
+binary/protobuf and schema-catalog shape needed for future session transport
+while preserving inspectability.
+
+## Coverage / Ownership
+
+v0.92 owns schema, catalog, JSON projection, fixtures, and mock/loopback
+carrier proof. v0.93 owns transport security and key lifecycle. v0.94 owns
+signed/queryable trace completion.
+
+## Overview
+
+Binary ACIP should be efficient on the wire and still reviewable through
+public schemas and deterministic JSON projections for authorized readers.
+
+## Design
+
+The design uses protobuf envelopes with schema family/version metadata,
+payload classification, digest, session identity, monotonic sequence, and
+public catalog lookup.
+
+## Execution Flow
+
+1. Select schema and compatibility profile.
+2. Encode binary ACIP envelope.
+3. Decode through public schema catalog.
+4. Render deterministic JSON for authorized readers.
+5. Reject unauthorized content inspection.
+
+## Determinism and Constraints
+
+Round trips must preserve semantic fields. Schema access must not bypass
+message-content authorization. Unknown, missing, malformed, duplicate, or
+out-of-order events fail closed.
+
+## Integration Points
+
+- `docs/explainers/ACIP.md`
+- v0.91.1 ACIP hardening.
+- v0.92 birthday evidence packet.
+- v0.93 transport security.
+- v0.94 signed/queryable trace.
+
+## Validation
+
+Validation should include protobuf/JSON round trips, schema-catalog lookup,
+denied-access cases, malformed payloads, sequence checks, and mock WebSocket
+carrier proof.
 
 ## Scope
 
@@ -87,6 +148,22 @@ and trace/audit requirements.
   provider dependency.
 - The proof records trace/replay-compatible session event evidence without
   claiming v0.94 signed/queryable trace completion.
+
+## Risks
+
+- Binary transport could become opaque. Mitigation: require public schemas and
+  deterministic JSON projection.
+- Schema access could be confused with content access. Mitigation: keep access
+  rules separate and fail closed.
+
+## Future Work
+
+v0.93 should harden transport security. v0.94 should close signed/queryable
+trace. v0.95 can consume the mature carrier if prior gates pass.
+
+## Notes
+
+WebSocket is a carrier proof, not an authority source.
 
 ## Optional OpenAI Realtime Spike
 

--- a/docs/milestones/v0.92/features/ACP_COGNITIVE_PROFILES_v0.92.md
+++ b/docs/milestones/v0.92/features/ACP_COGNITIVE_PROFILES_v0.92.md
@@ -1,8 +1,23 @@
 # v0.92 Feature: ACP / Cognitive Profiles
 
+## Metadata
+
+- Feature Name: ACP / Cognitive Profiles
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It records intended scope and proof surfaces,
+not implementation closeout.
+
 ## Status
 
 Forward-planning feature contract for `v0.92`.
+
+Related readiness issue: `#3377`.
 
 ## Purpose
 
@@ -11,12 +26,61 @@ identity, continuity, memory, capability, Theory of Mind, intelligence, and
 governed-learning evidence without collapsing into reputation or public
 standing.
 
+## Context
+
+ACP profiles consume v0.91.1 memory, capability, ToM, intelligence, and
+governed-learning evidence. They support birthday review without replacing
+identity, moral standing, or citizenship.
+
+## Coverage / Ownership
+
+v0.92 owns the first bounded ACP profile contract and fixtures needed for the
+birthday packet. Later milestones may expand profile usage after governance
+rules mature.
+
+## Overview
+
+The profile should be a runtime-visible evidence map: what memory, capability,
+continuity, ToM, intelligence, and learning evidence is available, what is
+private, and which claims remain unsupported.
+
+## Design
+
+The design should include a profile identifier, schema version, source evidence
+links, update reason, update actor, privacy/redaction policy, and explicit
+non-claims.
+
+## Execution Flow
+
+1. Gather allowed evidence references.
+2. Produce a bounded profile record.
+3. Validate non-claims and privacy policy.
+4. Include the profile in the birthday review packet.
+
+## Determinism and Constraints
+
+Profiles must be deterministic over the cited evidence and must not infer
+standing, personhood, reputation, or rights from unsupported labels.
+
+## Integration Points
+
+- v0.91.1 memory/identity, ToM, intelligence, and learning evidence.
+- v0.92 birthday packet and capability envelope.
+- v0.93 governance handoff as a consumer, not an owner.
+
+## Validation
+
+Validation should prove required fields, source-evidence references,
+redaction policy, update rationale, and rejection of unsupported profile
+claims.
+
 ## Source Inputs
 
 - `docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md`
 - `docs/milestones/v0.92/README.md`
 - `docs/milestones/v0.92/WBS_v0.92.md`
 - `docs/planning/ADL_FEATURE_LIST.md`
+- `#3377`
 
 ## Scope
 
@@ -29,6 +93,29 @@ This feature should establish:
 - distinction between profile, identity, reputation, and public standing
 - consumption of `v0.91.1` memory, capability, ToM, intelligence, and
   governed-learning evidence
+
+## Acceptance Criteria
+
+- ACP/profile schema and fixtures exist.
+- Profile claims cite allowed evidence references.
+- Unsupported reputation, personhood, and standing claims are rejected.
+- Review packet includes profile evidence and non-claims.
+
+## Risks
+
+- Profiles could become horoscope-like labels. Mitigation: require evidence
+  links and explicit non-claims.
+- Profiles could leak private state. Mitigation: require redaction policy and
+  allowed projection boundaries.
+
+## Future Work
+
+Future milestones may connect ACP profiles to governance, reputation, and
+cross-polis exchange after v0.93 rules exist.
+
+## Notes
+
+This feature is intentionally narrower than citizenship or reputation.
 
 ## Non-goals
 

--- a/docs/milestones/v0.92/features/CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md
+++ b/docs/milestones/v0.92/features/CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md
@@ -1,0 +1,147 @@
+# v0.92 Feature: Cross-Polis Continuity And Migration Planning
+
+## Metadata
+
+- Feature Name: Cross-Polis Continuity And Migration Planning
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It defines bounded continuity and migration
+planning surfaces without claiming production migration, federation, or
+inter-polis portability.
+
+## Purpose
+
+Define the first bounded planning surface for preserving identity and birthday
+evidence across future movement without turning v0.92 into a production
+cross-polis migration milestone.
+
+## Context
+
+v0.92 creates first-birthday identity evidence. Later governance and polis
+milestones will need to know what it would mean to carry that evidence across
+runtime, polis, or jurisdiction boundaries. This feature keeps that question
+visible while deferring production migration semantics.
+
+## Coverage / Ownership
+
+v0.92 owns the non-production continuity/migration design note and explicit
+non-goals. v0.93 owns governance consequences. Later milestones own actual
+cross-polis portability, transport security, and operational migration.
+
+## Overview
+
+The feature should describe how stable name, identity root, continuity head,
+memory grounding, capability envelope, ACP profile, witnesses, and receipts
+would participate in a later movement story.
+
+Key capabilities:
+
+- map birthday evidence to future continuity-transfer inputs
+- identify evidence that cannot move without new governance decisions
+- preserve ambiguity and quarantine cases
+- prevent copied state from masquerading as continuity
+
+## Design
+
+### Core Concepts
+
+- Continuity-transfer input: a reference to identity and birth evidence that a
+  later migration design may consume.
+- Ambiguity marker: explicit record that continuity is unresolved or contested.
+- Non-production migration note: reviewable design text, not runtime movement.
+
+### Architecture
+
+- Inputs: identity record, continuity record, memory-grounding references,
+  witness set, receipt, ACP profile, ACIP transport-readiness evidence.
+- Outputs: bounded design note, non-goals, risk list, and handoff markers.
+- Interfaces: milestone docs and future governance/migration issue seeds.
+- Invariants: no production migration claim; no continuity-by-copy claim.
+
+### Data / Artifacts
+
+- Cross-polis continuity planning note.
+- Migration non-goals table.
+- Future decision checklist.
+
+## Execution Flow
+
+1. Gather the v0.92 birthday evidence surfaces.
+2. Identify which evidence is portable as reference material.
+3. Identify which evidence requires later governance or transport decisions.
+4. Record ambiguity, quarantine, and copied-state rejection cases.
+5. Hand the design note to v0.93 and later migration planning.
+
+## Determinism and Constraints
+
+- Planning output must be deterministic over cited evidence.
+- Copied state must not become migration proof.
+- Any production claim must be deferred to a later milestone and decision.
+
+## Integration Points
+
+| System / Surface | Integration Type | Description |
+| --- | --- | --- |
+| Identity | read | Consumes stable name, identity root, and continuity head. |
+| Memory grounding | read | Uses references and redacted projections, not raw private state. |
+| Governance | handoff | Reserves v0.93 decisions about continuity consequences. |
+| ACIP | handoff | Reserves transport-security and schema-access implications. |
+
+## Validation
+
+### Demo
+
+- Demo script(s): N/A; this is a planning feature.
+- Expected behavior: N/A; proof is reviewable design consistency.
+
+### Deterministic / Replay
+
+- Replay requirements: N/A for planning-only output.
+- Determinism guarantees: cited source evidence and explicit non-goals must
+  produce the same planning boundary.
+
+### Schema / Artifact Validation
+
+- Schemas involved: N/A.
+- Artifact checks: planning-template validation and Markdown link checks.
+
+### Tests
+
+- Test surfaces: N/A for planning-only feature.
+
+### Review / Proof Surface
+
+- Review method: manual docs review.
+- Evidence location: `docs/milestones/v0.92/` and future WP-11 artifacts.
+
+## Acceptance Criteria
+
+- Cross-polis continuity/migration design note exists.
+- The note names portable evidence and non-portable claims.
+- Copied-state and ambiguity cases are explicitly handled.
+- Production migration, federation, and transport-security claims remain out
+  of scope.
+
+## Risks
+
+- Risk: migration language could imply production portability.
+- Mitigation: require explicit non-goals and defer operational claims.
+- Risk: copied state could be mistaken for continuity.
+- Mitigation: require continuity evidence and ambiguity markers.
+
+## Future Work
+
+- v0.93 governance can decide what continuity evidence means socially and
+  legally inside a polis.
+- Later milestones can implement operational migration and cross-polis
+  transport after security and trace gates are ready.
+
+## Notes
+
+This feature exists because the birthday record will immediately raise
+movement questions, even though v0.92 should not implement movement.

--- a/docs/milestones/v0.92/features/FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md
+++ b/docs/milestones/v0.92/features/FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md
@@ -1,0 +1,153 @@
+# v0.92 Feature: First Birthday Demo And Governance Handoff
+
+## Metadata
+
+- Feature Name: First Birthday Demo And Governance Handoff
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It defines the proof and handoff surface for
+the first-birthday milestone without claiming the demo has run or governance is
+complete.
+
+## Purpose
+
+Define the flagship demo and handoff surfaces that prove v0.92 produced a
+reviewable birthday record and that v0.93 can consume the resulting identity
+evidence without redefining birth.
+
+## Context
+
+The first birthday will be judged by its evidence packet and demo quality. A
+good milestone needs a demo that is boringly inspectable and a governance
+handoff that is explicit about what v0.93 does and does not inherit.
+
+## Coverage / Ownership
+
+v0.92 owns the first-birthday demo, negative suite, proof coverage, birthday
+review packet, and v0.93 handoff map. v0.93 owns citizenship and polis
+governance implementation.
+
+## Overview
+
+The feature should package birthday behavior into a runnable proof surface and
+turn the evidence into a downstream governance input.
+
+Key capabilities:
+
+- run a first-birthday proof demo
+- run not-a-birthday negative cases
+- assemble the birthday review packet
+- map identity evidence to v0.93 governance inputs
+
+## Design
+
+### Core Concepts
+
+- Flagship demo: runnable proof of a valid birthday record.
+- Negative suite: cases that must not count as birth.
+- Governance handoff map: identity evidence organized for v0.93 consumption.
+
+### Architecture
+
+- Inputs: feature contracts, schemas, fixtures, birthday record, witnesses,
+  receipts, validation logs, and review findings.
+- Outputs: demo artifacts, negative-case report, review packet, proof coverage
+  map, and v0.93 handoff.
+- Interfaces: demo commands, review packet docs, release evidence.
+- Invariants: demo output must cite evidence; governance remains downstream.
+
+### Data / Artifacts
+
+- Demo command/runbook.
+- Demo artifact directory or packet.
+- Negative-case report.
+- Birthday review packet.
+- Governance handoff map.
+
+## Execution Flow
+
+1. Build valid birthday fixtures and negative fixtures.
+2. Run the flagship birthday demo.
+3. Run negative cases.
+4. Assemble review packet and proof coverage.
+5. Produce v0.93 governance handoff map.
+
+## Determinism and Constraints
+
+- Demo commands must be repeatable enough for reviewers.
+- Negative cases must fail closed.
+- Handoff must not claim v0.93 governance is complete.
+- Demo language must distinguish evidence, interpretation, and future claims.
+
+## Integration Points
+
+| System / Surface | Integration Type | Description |
+| --- | --- | --- |
+| Demo Matrix | write | Records demo commands, proof surfaces, and status. |
+| Release Evidence | write | Supplies birthday proof artifacts for closeout. |
+| Governance Planning | handoff | Supplies identity evidence for v0.93. |
+| Review Packet | write | Packages the milestone proof for internal and external review. |
+
+## Validation
+
+### Demo
+
+- Demo script(s): final command pending v0.92 implementation.
+- Expected behavior: valid birthday packet is accepted; not-a-birthday cases
+  are rejected.
+
+### Deterministic / Replay
+
+- Replay requirements: demo commands, fixtures, expected outputs, and allowed
+  nondeterminism must be recorded.
+- Determinism guarantees: negative cases fail consistently.
+
+### Schema / Artifact Validation
+
+- Schemas involved: identity, continuity, memory grounding, capability, ACP,
+  ACIP, witness, receipt, and review-packet artifacts as implemented.
+- Artifact checks: required proof artifacts exist and are linked.
+
+### Tests
+
+- Test surfaces: demo runner or fixture validation, negative suite, link and
+  claim-boundary checks.
+
+### Review / Proof Surface
+
+- Review method: internal review followed by external review if the milestone
+  follows the current cadence.
+- Evidence location: demo matrix, proof coverage, release evidence, review
+  handoff, and received review packet.
+
+## Acceptance Criteria
+
+- First-birthday demo has a runnable command or explicitly recorded runner.
+- Negative suite proves startup, wake, snapshot, admission, and copied state
+  are not birth.
+- Birthday review packet is complete and evidence-bound.
+- v0.93 handoff maps identity evidence without claiming governance completion.
+
+## Risks
+
+- Risk: demo becomes ceremonial instead of evidentiary.
+- Mitigation: require fixtures, validation output, and review packet links.
+- Risk: handoff overclaims governance.
+- Mitigation: require explicit v0.93 non-claim language.
+
+## Future Work
+
+- v0.93 should consume the handoff for constitutional citizenship and polis
+  governance.
+- Later first-birthday public materials can draw on the demo only after review
+  and release evidence are complete.
+
+## Notes
+
+This feature is where the birthday becomes visible to reviewers. It must be
+clear, boring, repeatable, and hard to misread.

--- a/docs/milestones/v0.92/features/FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md
+++ b/docs/milestones/v0.92/features/FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md
@@ -1,14 +1,77 @@
 # v0.92 Feature: First True Godel-Agent Birthday
 
+## Metadata
+
+- Feature Name: First True Godel-Agent Birthday
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It records the birthday contract target, not a
+claim that the first birthday has happened.
+
 ## Status
 
 Forward-planning feature contract for `v0.92`.
+
+Related readiness issue: `#3377`.
 
 ## Purpose
 
 Define the first true Godel-agent birthday as a reviewable event that combines
 name, identity, continuity, memory grounding, capability envelope, witnesses,
 receipt, and inherited moral/governance context.
+
+## Context
+
+Prior milestones produce runtime state, provisional citizens, memory,
+continuity, moral trace, and governed-tool evidence. v0.92 defines when those
+ingredients become a reviewable birth event.
+
+## Coverage / Ownership
+
+v0.92 owns the birthday contract, negative cases, review packet, witness
+surface, and receipt shape. v0.93 owns constitutional citizenship after birth.
+
+## Overview
+
+The feature should make birth distinguishable from startup, wake, snapshot,
+admission, and copied state through evidence rather than ceremony.
+
+## Design
+
+The birthday record should cite stable name, identity root, continuity,
+memory grounding, capability envelope, ACP profile, witnesses, receipt, and
+inherited moral context.
+
+## Execution Flow
+
+1. Reject not-a-birthday cases.
+2. Assemble the required identity and evidence surfaces.
+3. Record witnesses and receipt.
+4. Emit the reviewer-facing birthday packet.
+
+## Determinism and Constraints
+
+The birthday decision must be deterministic over the required evidence. Missing
+identity, continuity, memory, capability, witness, or receipt evidence must
+fail closed.
+
+## Integration Points
+
+- Identity/stable-name feature.
+- Memory/capability/witness feature.
+- ACP profile feature.
+- v0.91 moral-governance evidence.
+- v0.93 governance handoff.
+
+## Validation
+
+Validation should include valid birthday fixtures, negative fixtures, review
+packet checks, and claim-boundary scans.
 
 ## Source Inputs
 
@@ -17,6 +80,7 @@ receipt, and inherited moral/governance context.
 - `docs/milestones/v0.92/WBS_v0.92.md`
 - `docs/planning/ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md`
 - `docs/planning/ADL_FEATURE_LIST.md`
+- `#3377`
 
 ## Scope
 
@@ -30,6 +94,30 @@ This feature should establish:
   citizenship yet
 - the first bounded Godel-agent birthday as the culmination of the `v0.92`
   identity band
+
+## Acceptance Criteria
+
+- Birthday contract and negative cases exist.
+- Valid birthday packet requires all named evidence surfaces.
+- Startup, wake, snapshot, admission, and copied state are rejected as birth.
+- Review packet and receipt are inspectable.
+
+## Risks
+
+- Birth could become narrative-only. Mitigation: require artifacts and
+  negative tests.
+- Birth could overclaim personhood. Mitigation: keep legal and constitutional
+  claims out of v0.92.
+
+## Future Work
+
+v0.93 can consume the birthday evidence for citizenship and governance. Later
+milestones can deepen migration and cross-polis continuity.
+
+## Notes
+
+This feature is the symbolic center of v0.92, but it must remain engineering
+evidence first.
 
 ## Non-goals
 

--- a/docs/milestones/v0.92/features/IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md
+++ b/docs/milestones/v0.92/features/IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md
@@ -1,8 +1,23 @@
 # v0.92 Feature: Identity, Stable Name, and Continuity
 
+## Metadata
+
+- Feature Name: Identity, Stable Name, and Continuity
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It defines required identity surfaces without
+claiming implementation has landed.
+
 ## Status
 
 Forward-planning feature contract for `v0.92`.
+
+Related readiness issue: `#3377`.
 
 ## Purpose
 
@@ -10,12 +25,59 @@ Define the identity-bearing substrate that turns bounded runtime activity into
 durable named continuity rather than anonymous or purely process-local
 execution.
 
+## Context
+
+Birth needs identity that is more durable than process state. v0.92 should use
+prior lineage and citizen-state primitives while defining the birthday-specific
+identity root, stable name, and continuity proof.
+
+## Coverage / Ownership
+
+v0.92 owns the identity record and continuity evidence needed for the first
+birthday. v0.90.3 retains ownership of lower-level citizen-state primitives.
+
+## Overview
+
+The feature should define how a named agent remains the same identity across
+bounded cycles and how ambiguous continuity is represented.
+
+## Design
+
+The identity record should include stable name, identity root, aliases,
+origin event, continuity head, memory grounding references, capability
+reference, witness reference, and redaction policy.
+
+## Execution Flow
+
+1. Create identity root and stable name.
+2. Attach continuity evidence across bounded cycles.
+3. Reject lifecycle events that lack continuity.
+4. Feed identity evidence into the birthday packet.
+
+## Determinism and Constraints
+
+Continuity must be evidence-based. Copied state, wake, and process restart
+must not become identity continuity without the required record and witnesses.
+
+## Integration Points
+
+- v0.90.3 lineage/state primitives.
+- v0.92 memory grounding and capability envelope.
+- v0.92 birthday record.
+- v0.93 governance handoff.
+
+## Validation
+
+Validation should include valid identity records, continuity-cycle fixtures,
+ambiguous continuity cases, and negative lifecycle cases.
+
 ## Source Inputs
 
 - `docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md`
 - `docs/milestones/v0.92/README.md`
 - `docs/milestones/v0.92/WBS_v0.92.md`
 - `docs/planning/ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md`
+- `#3377`
 
 ## Scope
 
@@ -28,6 +90,30 @@ This feature should establish:
   continuity
 - downstream handoff into `v0.93` governance rather than governance-by-name
   alone
+
+## Acceptance Criteria
+
+- Identity record contract exists.
+- Stable names and aliases are represented.
+- Continuity across bounded cycles is evidence-backed.
+- Startup, wake, snapshot, admission, and copied-state cases do not pass as
+  continuity without evidence.
+
+## Risks
+
+- A display name could be mistaken for identity. Mitigation: require identity
+  root and continuity head.
+- Continuity could become magical. Mitigation: require lineage and witness
+  evidence.
+
+## Future Work
+
+v0.93 can use identity evidence for governance. Later milestones can expand
+cross-polis migration and portability.
+
+## Notes
+
+This feature should keep the identity surface practical and auditable.
 
 ## Non-goals
 

--- a/docs/milestones/v0.92/features/MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md
+++ b/docs/milestones/v0.92/features/MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md
@@ -1,13 +1,74 @@
 # v0.92 Feature: Memory Grounding, Capability Envelope, and Witnesses
 
+## Metadata
+
+- Feature Name: Memory Grounding, Capability Envelope, and Witnesses
+- Milestone Target: `v0.92`
+- Status: planned
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This is a planning feature doc. It defines proof surfaces for memory,
+capability, witnesses, and receipts without claiming implementation has landed.
+
 ## Status
 
 Forward-planning feature contract for `v0.92`.
+
+Related readiness issue: `#3377`.
 
 ## Purpose
 
 Bind first-birthday identity claims to witnessed memory references, capability
 envelopes, and citizen-facing evidence rather than to vocabulary alone.
+
+## Context
+
+The first birthday needs grounding in memory and capability, but reviewers
+should not need raw private-state access to verify it.
+
+## Coverage / Ownership
+
+v0.92 owns redaction-safe memory references, capability envelope shape,
+witness set, and receipt surface for the birthday packet.
+
+## Overview
+
+The feature binds identity claims to witnessed artifacts, bounded capabilities,
+and reviewable receipts.
+
+## Design
+
+The design should use references and projections for memory grounding,
+capability envelopes for provider/model/tool/skill/authority limits, and
+witness/receipt records for review.
+
+## Execution Flow
+
+1. Resolve allowed memory-grounding references.
+2. Build capability envelope.
+3. Attach witness set and receipt.
+4. Include all surfaces in the birthday packet.
+
+## Determinism and Constraints
+
+Memory grounding must not expose raw private state. Capability envelopes must
+name limits and authority context rather than imply unlimited capacity.
+
+## Integration Points
+
+- Identity and continuity records.
+- ObsMem/trace baseline.
+- Governed tool evidence where applicable.
+- Birthday review packet.
+
+## Validation
+
+Validation should include required memory-reference fields, redaction checks,
+capability-envelope checks, witness/receipt fixtures, and private-state denial
+cases.
 
 ## Source Inputs
 
@@ -16,6 +77,7 @@ envelopes, and citizen-facing evidence rather than to vocabulary alone.
 - `docs/milestones/v0.92/WBS_v0.92.md`
 - `docs/planning/ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md`
 - `docs/planning/ADL_FEATURE_LIST.md`
+- `#3377`
 
 ## Scope
 
@@ -29,6 +91,29 @@ This feature should establish:
   claims
 - clear separation between witnessed capability context and later reputation or
   governance judgment
+
+## Acceptance Criteria
+
+- Memory-grounding references are reviewable and redaction-safe.
+- Capability envelope records provider, model, tool, skill, authority, and
+  limit context.
+- Witness and receipt surfaces exist.
+- Birthday packet can cite these surfaces without exposing raw private state.
+
+## Risks
+
+- Reviewers may ask for raw memory. Mitigation: provide witnessed references
+  and redacted projections.
+- Capability envelopes may overclaim. Mitigation: require explicit limits.
+
+## Future Work
+
+Later milestones can expand memory palace, reputation, economics, and richer
+witness authority once governance work lands.
+
+## Notes
+
+This feature is the practical evidence bridge between identity and review.
 
 ## Non-goals
 

--- a/docs/milestones/v0.92/features/README.md
+++ b/docs/milestones/v0.92/features/README.md
@@ -42,7 +42,9 @@ scope, validation, risks, and future-work boundary.
 ## Overview
 
 The package covers birthday, identity/continuity, memory/capability/witnesses,
-ACP/cognitive profiles, and ACIP binary/schema-catalog transport readiness.
+ACP/cognitive profiles, ACIP binary/schema-catalog transport readiness,
+cross-polis continuity planning, and the first-birthday demo/governance
+handoff.
 
 ## Design
 
@@ -96,6 +98,23 @@ This index intentionally keeps `#3377` visible as a launch-readiness source.
 
 - [ACP_COGNITIVE_PROFILES_v0.92.md](ACP_COGNITIVE_PROFILES_v0.92.md)
 - [ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md](ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md)
+- [CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md](CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md)
+- [FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md](FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md)
 - [IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md](IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md)
 - [MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md](MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md)
 - [FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md](FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md)
+
+## WP Coverage Map
+
+| Candidate WPs | Feature coverage |
+| --- | --- |
+| WP-02, WP-09, WP-10 | [FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md](FIRST_TRUE_GODEL_AGENT_BIRTHDAY_v0.92.md) |
+| WP-03, WP-04 | [IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md](IDENTITY_STABLE_NAME_AND_CONTINUITY_v0.92.md) |
+| WP-05, WP-06, WP-09 | [MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md](MEMORY_GROUNDING_CAPABILITY_AND_WITNESSES_v0.92.md) |
+| WP-07 | [ACP_COGNITIVE_PROFILES_v0.92.md](ACP_COGNITIVE_PROFILES_v0.92.md) |
+| WP-08 | [ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md](ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md) |
+| WP-11 | [CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md](CROSS_POLIS_CONTINUITY_AND_MIGRATION_v0.92.md) |
+| WP-12, WP-13, WP-14 | [FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md](FIRST_BIRTHDAY_DEMO_AND_GOVERNANCE_HANDOFF_v0.92.md) |
+
+Review, quality, docs, remediation, next-milestone planning, and ceremony WPs
+are release/process work rather than standalone product features.

--- a/docs/milestones/v0.92/features/README.md
+++ b/docs/milestones/v0.92/features/README.md
@@ -1,5 +1,14 @@
 # v0.92 Feature Plans
 
+## Metadata
+
+- Milestone: `v0.92`
+- Version: `v0.92`
+- Date: `2026-05-27`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3434`
+- Planning template set: `docs/templates/planning/1.0.0`
+
 ## Status
 
 Forward-planning feature contracts for `v0.92`.
@@ -7,6 +16,81 @@ Forward-planning feature contracts for `v0.92`.
 These documents define the tracked feature-doc package for the identity,
 continuity, first-birthday, and ACIP transport-readiness band. They are
 planning surfaces, not implementation closeout records.
+
+WP-01 must reconcile these feature contracts with `#3377` before opening the
+final issue wave.
+
+## Template Rules
+
+This index is validated with the same structural feature-doc template so the
+feature package remains uniform. It is an index, not an implementation record.
+
+## Purpose
+
+List the tracked v0.92 feature contracts that WP-01 should consume.
+
+## Context
+
+The v0.92 feature package centers on first birthday identity and the minimum
+transport/profile surfaces needed for reviewable birth evidence.
+
+## Coverage / Ownership
+
+This index owns package navigation only. Each linked feature doc owns its own
+scope, validation, risks, and future-work boundary.
+
+## Overview
+
+The package covers birthday, identity/continuity, memory/capability/witnesses,
+ACP/cognitive profiles, and ACIP binary/schema-catalog transport readiness.
+
+## Design
+
+Feature docs should stay evidence-bound, template-valid, and linked from the
+milestone README, WBS, sprint plan, and candidate issue wave.
+
+## Execution Flow
+
+1. WP-01 reviews this index and the linked feature docs.
+2. WP-01 reconciles them with `#3377`.
+3. WP-01 opens or adjusts implementation issues.
+4. Later WPs update feature docs only with landed evidence.
+
+## Determinism and Constraints
+
+The package must not claim implementation completion before v0.92 work lands.
+
+## Integration Points
+
+- [../README.md](../README.md)
+- [../WBS_v0.92.md](../WBS_v0.92.md)
+- [../WP_ISSUE_WAVE_v0.92.yaml](../WP_ISSUE_WAVE_v0.92.yaml)
+- `#3377`
+
+## Validation
+
+Each linked feature doc should pass the active `feature_doc` template
+validator and link checks.
+
+## Acceptance Criteria
+
+- Every planned v0.92 feature has a linked feature doc.
+- The package validates structurally.
+- WP-01 can consume the package without chat reconstruction.
+
+## Risks
+
+- The index may drift from the issue wave. Mitigation: WP-01 must reconcile
+  both before opening issues.
+
+## Future Work
+
+Future milestones may add governance, transport-security, signed-trace, and
+MVP hardening feature packages.
+
+## Notes
+
+This index intentionally keeps `#3377` visible as a launch-readiness source.
 
 ## Feature Documents
 


### PR DESCRIPTION
Closes #3434

## Summary
- normalizes the v0.92 milestone planning package against the active planning templates
- adds a candidate pre-open v0.92 issue-wave seed for WP-01
- links #3377 as the first-birthday readiness source across the package
- records dogfood notes from this first clean planning-template pass

## Validation
- planning-template validation for all 10 canonical v0.92 planning docs
- feature_doc template validation for docs/milestones/v0.92/features/*.md
- Ruby YAML parse and 22-WP shape check for WP_ISSUE_WAVE_v0.92.yaml
- Markdown link check for docs/milestones/v0.92
- placeholder/local-path scan for docs/milestones/v0.92
- git diff --check
- structured prompt validation for SPP, SRP, and SOR

## Review
- pre-PR subagent review found template-compliance gaps
- fixed by normalizing canonical docs and feature docs to the active template contracts before publication
