### PR TITLE
[v0.91.4][PVF][docs] Add pre-PR validation evidence reuse to PVF plan

### DIFF
--- a/docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md
@@ -15,7 +15,7 @@ Planned proof map for C-SDLC completion.
 | ObsMem transition memory integration | `features/OBSMEM_TRANSITION_MEMORY_INTEGRATION.md` | Tracked review truth, promoted outcome truth, and signed-trace evidence feed replayable memory handoff records. | landed |
 | Sprint conductor default C-SDLC lane | `features/SPRINT_CONDUCTOR_DEFAULT_CSDL_LANE.md` | Sprint execution cannot skip child closeout, umbrella truth, or combined-lane validation. | planned |
 | Five-minute-sprint repeatability | `features/FIVE_MINUTE_SPRINT_REPEATABILITY.md` | More than one transition records coordination, validation-tail/proof-latency, Parallel Validation Fabric, and repeatability metrics. | planned |
-| Parallel Validation Fabric | `features/PARALLEL_VALIDATION_FABRIC.md` | Validation is decomposed into truthful issue-local, shardable, cache-aware, deferred, pending, and blocking proof lanes without hiding failures. | planned |
+| Parallel Validation Fabric | `features/PARALLEL_VALIDATION_FABRIC.md` | Validation is decomposed into truthful issue-local, shardable, cache-aware, pre-PR evidence-reuse, deferred, pending, and blocking proof lanes without hiding failures. | planned |
 | Multi-agent C-SDLC workcell proof | `SPRINT_v0.91.4.md` and workcell proof packet from `#3415` through `#3419` | C-SDLC demonstrates bounded conductor-managed parallel worker/reviewer/janitor lanes with explicit shard admission and serialized merge/closeout gates. | planned |
 | Active issue migration policy | `features/ACTIVE_ISSUE_MIGRATION_POLICY.md` | Open issues and future issues have a safe migration/defaulting path. | planned |
 | Process drift regression fixtures | `features/PROCESS_DRIFT_REGRESSION_FIXTURES.md` | Known card, closeout, state, and proof drift modes fail closed. | planned |
@@ -61,6 +61,9 @@ still have a truthful completion or blocked-state record before release:
   measurements and Parallel Validation Fabric planning evidence
 - Parallel Validation Fabric feature/proof packet showing owned proof lanes,
   synchronization barriers, blocked-state handling, and reviewer-visible status
+- pre-PR validation evidence reuse plan from `#3437`, including exact
+  commit/tree identity checks and automatic full-Rust fallback when evidence is
+  absent, stale, mismatched, or invalid under current policy
 - multi-agent workcell proof packet showing shard admission, worker/reviewer
   assignment, branch/worktree boundaries, serialized merge/closeout gates, and
   coordination timing

--- a/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
+++ b/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
@@ -116,6 +116,12 @@ rule stays reviewable:
   MA-CSDL-01 through MA-CSDL-04 as `#3416` through `#3419`; this is added
   C-SDLC proof scope and should feed WP-10/WP-13/WP-14/WP-15 without changing
   the closeout-tail sequence.
+- Batch 8 added PVF docs-only follow-on `#3437` for pre-PR validation evidence
+  reuse. This issue updates the PVF plan so the later CI/release-gate work can
+  avoid rerunning the same full Rust cycle immediately after PR creation when
+  the PR head commit and tree exactly match a recorded validation artifact. It
+  does not implement CI changes and must fail closed to full validation in the
+  future if evidence is absent, stale, mismatched, or invalid under policy.
 - Standalone first-birthday readiness side issue `#3377` is promoted for v0.92
   launch preparation and should feed WP-19/WP-20; it is not a sprint child and
   does not alter the v0.91.4 release-tail sequence.

--- a/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
+++ b/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
@@ -50,6 +50,8 @@ lanes and records each lane's status in C-SDLC surfaces:
 - issue-local proof that can run immediately
 - shardable proof that can run in parallel
 - cache-aware proof that can be reused only with valid inputs
+- pre-PR validation evidence that can satisfy CI only when commit and tree
+  identity prove the exact same code was tested
 - deferred proof that does not block the current transition
 - blocking proof that must pass before continuation
 
@@ -67,6 +69,34 @@ Each validation lane should declare:
 Aggregated status must be derived from lane truth. A green aggregate cannot
 hide a failing, pending, or blocked lane.
 
+### Pre-PR Validation Evidence Reuse
+
+The duplicate-test-cycle case is a first-class PVF target. Today a runtime PR
+can run the full Rust validation profile during `pr finish`, open or update the
+PR, and then immediately run the same expensive profile again in GitHub CI even
+though the code has not changed.
+
+The future PVF lane for this should convert the pre-PR validation run into a
+structured evidence artifact that CI may accept only when all trust inputs still
+match:
+
+- PR head commit matches the validated commit
+- tree identity matches the validated tree
+- changed-path and validation-policy inputs match the current policy
+- command list, tool versions, timestamps, exit codes, and log hashes are
+  recorded
+- evidence is fresh enough under the release policy
+- workflow, CI, coverage, or validation-tooling changes do not force remote
+  proof
+
+If any check fails, CI must fall back to the full Rust validation lane. Evidence
+reuse is a cache-aware proof lane, not a validation waiver. It must preserve
+branch protection, human review, and closeout truth.
+
+Issue `#3437` records this docs-only planning addition. The implementation
+belongs with the PVF CI/release-gate work, currently represented by `#3403` or a
+future dedicated implementation issue.
+
 ## Execution Flow
 
 1. `SPP` identifies required proof lanes and stop/replan conditions.
@@ -82,6 +112,9 @@ hide a failing, pending, or blocked lane.
 
 - Proof lanes must be reproducible from tracked inputs whenever possible.
 - Cache reuse must name the inputs that make reuse valid.
+- Pre-PR validation evidence reuse must require exact commit/tree identity and
+  must fail closed to full CI whenever identity, policy, workflow, tooling, or
+  freshness checks do not prove equivalence.
 - Async proof cannot be treated as passed until evidence exists.
 - Pending/deferred proof must remain visible to reviewers.
 - PVF must not weaken the existing C-SDLC review, merge, or closeout gates.
@@ -101,6 +134,8 @@ WP-10 should produce a PVF runbook or fixture proof. WP-14 should validate that:
 
 - each lane has an owner, input, proof artifact, and status
 - aggregate status does not hide failed, pending, deferred, or blocked proof
+- pre-PR validation evidence reuse is treated as a strict equivalence proof with
+  full-CI fallback, not as a skip
 - C-SDLC cards record proof status consistently
 - release evidence cites the PVF proof surface before making completion claims
 
@@ -110,6 +145,9 @@ WP-10 should produce a PVF runbook or fixture proof. WP-14 should validate that:
   proof packet.
 - The fabric names proof lanes, owners, synchronization barriers, cache inputs,
   and blocked-state rules.
+- The fabric includes pre-PR validation evidence reuse as a cache-aware lane
+  whose acceptance requires exact commit/tree identity and automatic full-Rust
+  fallback on mismatch, staleness, or policy/tooling drift.
 - `SPP` records required proof and stop/replan conditions before execution.
 - `SRP` records review findings and pending/deferred proof without converting
   them into success.


### PR DESCRIPTION
Closes #3437

## Summary
Added pre-PR validation evidence reuse to the v0.91.4 Parallel Validation Fabric planning surface as a docs-only follow-on. The docs now explain that future CI may reuse a local full-Rust validation artifact only when commit/tree identity and policy inputs prove that the exact PR head was already tested, with fail-closed fallback to full Rust validation whenever evidence is absent, stale, mismatched, or invalid.

## Artifacts
- `docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md`
- `docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md`
- `docs/milestones/v0.91.4/SPRINT_v0.91.4.md`
- Local issue cards under `.adl/v0.91.4/tasks/issue-3437__v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan/`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace cleanliness for the docs-only change.
  - `rg -n "#3437|pre-PR validation evidence reuse|commit/tree identity|full-Rust fallback|full CI|full Rust validation" docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md docs/milestones/v0.91.4/SPRINT_v0.91.4.md`
    Verified the scoped docs contain the required PVF evidence-reuse issue reference and fail-closed validation language.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3437__v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3437__v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan/sor.md
- Idempotency-Key: v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan-docs-milestones-v0-91-4-features-parallel-validation-fabric-md-docs-milestones-v0-91-4-feature-proof-coverage-v0-91-4-md-docs-milestones-v0-91-4-sprint-v0-91-4-md-adl-v0-91-4-tasks-issue-3437-v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan-sip-md-adl-v0-91-4-tasks-issue-3437-v0-91-4-pvf-docs-add-pre-pr-validation-evidence-reuse-to-pvf-plan-sor-md