### PR TITLE
[v0.91.4][tools] Tighten sprint-conductor state and closeout gates

### DIFF
--- a/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
@@ -7,6 +7,40 @@ import subprocess
 from pathlib import Path
 
 
+def require_child_closeout_truth(state: dict) -> None:
+    ordered_issues = state.get('ordered_issue_numbers', [])
+    records = {record.get('issue_number'): record for record in state.get('issue_records', [])}
+    stale = [
+        issue for issue in ordered_issues
+        if records.get(issue, {}).get('status') != 'closed_out'
+    ]
+    if stale:
+        formatted = ', '.join(f'#{issue}' for issue in stale)
+        raise SystemExit(
+            'Cannot close sprint-management issue because child closeout truth is incomplete for '
+            f'{formatted}.'
+        )
+
+
+def require_clean_close_boundary(state: dict) -> None:
+    if state.get('blocked_issue_number') is not None:
+        raise SystemExit('Cannot close sprint-management issue because a blocked child issue is still recorded in sprint state.')
+    if state.get('deferred_issue_numbers'):
+        raise SystemExit('Cannot close sprint-management issue because deferred child issues are still recorded in sprint state.')
+    follow_ups = state.get('follow_up_issues', [])
+    must_land = [
+        item.get('issue_number')
+        for item in follow_ups
+        if item.get('disposition') == 'must_land_before_sprint_close'
+    ]
+    if must_land:
+        formatted = ', '.join(f'#{issue}' for issue in must_land if issue is not None)
+        raise SystemExit(
+            'Cannot close sprint-management issue because must-land-before-close follow-up issues remain: '
+            f'{formatted}.'
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--state', required=True)
@@ -19,6 +53,8 @@ def main() -> int:
     sprint_issue_number = state.get('sprint_issue_number')
     if sprint_issue_number is None:
         raise SystemExit('Cannot close sprint-management issue because sprint_issue_number is missing from state.')
+    require_child_closeout_truth(state)
+    require_clean_close_boundary(state)
 
     subprocess.check_call(
         [

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -305,6 +305,14 @@ def main() -> int:
             'continuation': 'continue',
             'local_bundle': local_bundle,
             'issue_records': default_issue_records(ordered),
+            'structured_prompt_preflight': {
+                'status': 'not_run',
+                'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'srp.md'],
+                'issue_results': [],
+                'notes': [
+                    'Run sprint-wide structured prompt preflight before starting issue execution, including SPP and SRP design-time readiness.',
+                ],
+            },
             'truth_check': {
                 'status': 'not_run',
                 'source': 'sprint_state_only',

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -42,9 +42,11 @@ def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, A
         'issue_records': default_issue_records(ordered),
         'structured_prompt_preflight': {
             'status': 'not_run',
-            'required_card_types': ['stp.md', 'sip.md', 'sor.md'],
+            'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'srp.md'],
             'issue_results': [],
-            'notes': ['Run sprint-wide structured prompt preflight before starting issue execution.'],
+            'notes': [
+                'Run sprint-wide structured prompt preflight before starting issue execution, including SPP and SRP design-time readiness.',
+            ],
         },
         'truth_check': {
             'status': 'not_run',
@@ -160,11 +162,16 @@ def main() -> int:
 
     state_path = Path(args.state)
     state_preexisted = state_path.exists()
+    if not state_preexisted and mutation_requested(args):
+        raise SystemExit(
+            'Refusing to create and mutate sprint state in one step. '
+            'Create the state artifact first, then run structured prompt preflight and a matched live GitHub truth check before the first sprint-state transition.'
+        )
     ordered = parse_csv_ints(args.ordered_issues)
     state = load_state(state_path, args.sprint_issue, ordered)
     state['sprint_issue_number'] = args.sprint_issue
     state['ordered_issue_numbers'] = ordered
-    if state_preexisted and mutation_requested(args):
+    if mutation_requested(args):
         require_structured_prompt_preflight(state)
         require_truth_gate(state)
 
@@ -179,7 +186,12 @@ def main() -> int:
                 state['completed_issue_numbers'] = sorted(completed)
                 if state.get('blocked_issue_number') == issue_number:
                     state['blocked_issue_number'] = None
-            elif args.mark_status == 'blocked':
+            else:
+                completed = set(state.setdefault('completed_issue_numbers', []))
+                if issue_number in completed:
+                    completed.remove(issue_number)
+                    state['completed_issue_numbers'] = sorted(completed)
+            if args.mark_status == 'blocked':
                 state['blocked_issue_number'] = issue_number
             else:
                 if state.get('blocked_issue_number') == issue_number:
@@ -201,7 +213,7 @@ def main() -> int:
         state['blocked_issue_number'] = None
 
     select_next_issue(state)
-    if state_preexisted and mutation_requested(args):
+    if mutation_requested(args):
         consume_truth_gate(state)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')

--- a/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
+++ b/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 
 def closure_cleanliness(state: dict) -> str:
+    records = {record.get('issue_number'): record for record in state.get('issue_records', [])}
+    for issue in state.get('ordered_issue_numbers', []):
+        record = records.get(issue, {})
+        if record.get('status') != 'closed_out':
+            return 'residual_debt'
     if state.get('blocked_issue_number') is not None:
         return 'residual_debt'
     if state.get('deferred_issue_numbers'):

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -225,6 +225,7 @@ assert state["sprint_issue_number"] == 3001
 assert state["sprint_issue_created_by_skill"] is True
 assert state["current_issue_number"] == 2827
 assert len(state["issue_records"]) == 2
+assert state["structured_prompt_preflight"]["required_card_types"] == ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"]
 assert state["truth_check"]["status"] == "not_run"
 assert state["truth_check"]["gate_passed"] is False
 bundle = state["local_bundle"]
@@ -405,6 +406,17 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_str
   --repo-root "${fake_repo}" \
   --ordered-issues "2827,2828" \
   --state "${state_path}" >/dev/null
+
+brand_new_state_path="${tmpdir}/brand-new-sprint-state.json"
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
+  --state "${brand_new_state_path}" \
+  --sprint-issue 3001 \
+  --ordered-issues "2827,2828" \
+  --current-issue 2827 \
+  --mark-status active >/dev/null 2>&1; then
+  echo "expected update_sprint_state.py to refuse creating and mutating a new sprint state in one step" >&2
+  exit 1
+fi
 
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
   --state "${state_path}" \
@@ -615,6 +627,51 @@ if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint
   exit 1
 fi
 
+reopened_state_path="${tmpdir}/sprint-state-reopened.json"
+cp "${state_path}" "${reopened_state_path}"
+python3 - "${reopened_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+record = next(record for record in state["issue_records"] if record["issue_number"] == 2827)
+record["status"] = "closed_out"
+state["completed_issue_numbers"] = [2827]
+state["current_issue_number"] = 2828
+state["continuation"] = "continue"
+state["truth_check"] = {
+    "status": "matched",
+    "source": "github_live",
+    "gate_passed": True,
+    "checked_issue_numbers": [2827, 2828],
+    "checked_pr_urls": [],
+    "notes": [],
+}
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
+  --state "${reopened_state_path}" \
+  --sprint-issue 3001 \
+  --ordered-issues "2827,2828" \
+  --current-issue 2827 \
+  --mark-status pending >/dev/null
+
+python3 - "${reopened_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+record = next(record for record in state["issue_records"] if record["issue_number"] == 2827)
+assert record["status"] == "pending"
+assert 2827 not in state["completed_issue_numbers"]
+assert state["current_issue_number"] == 2827
+assert state["continuation"] == "continue"
+PY
+
 printf 'CLOSED\n' > "${issue_2828_state_file}"
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
   --repo-root "${fake_repo}" \
@@ -634,6 +691,60 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_child_iss
   --worktree-note "Retained for post-sprint audio inspection." \
   --follow-up-issue 5001 \
   --follow-up-summary "Document one post-sprint conductor follow-up." >/dev/null
+
+incomplete_close_state_path="${tmpdir}/sprint-state-incomplete-close.json"
+cp "${state_path}" "${incomplete_close_state_path}"
+python3 - "${incomplete_close_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+record = next(record for record in state["issue_records"] if record["issue_number"] == 2828)
+record["status"] = "pending"
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+incomplete_closeout_artifact="${tmpdir}/sprint-closeout-incomplete.md"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py" \
+  --state "${incomplete_close_state_path}" \
+  --out "${incomplete_closeout_artifact}" >/dev/null
+
+grep -Fq 'closure cleanliness: `residual_debt`' "${incomplete_closeout_artifact}"
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+  --state "${incomplete_close_state_path}" \
+  --summary "Should fail because one child is still stale." >/dev/null 2>&1; then
+  echo "expected close_sprint_issue.py to refuse sprint close when any child lacks closeout truth" >&2
+  exit 1
+fi
+
+must_land_state_path="${tmpdir}/sprint-state-must-land.json"
+cp "${state_path}" "${must_land_state_path}"
+python3 - "${must_land_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+state["follow_up_issues"] = [
+    {
+        "issue_number": 6001,
+        "disposition": "must_land_before_sprint_close",
+        "summary": "Blocking post-sprint repair.",
+    }
+]
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+  --state "${must_land_state_path}" \
+  --summary "Should fail because must-land follow-ups remain." >/dev/null 2>&1; then
+  echo "expected close_sprint_issue.py to refuse sprint close when must-land follow-up issues remain" >&2
+  exit 1
+fi
 
 python3 - "${state_path}" <<'PY'
 import json


### PR DESCRIPTION
Closes #3358

## Summary
Tightened the sprint-conductor default lane so sprint state cannot be created-and-mutated in one step, reopened child issues are removed from `completed_issue_numbers`, and sprint close refuses incomplete child truth or must-land residual debt. Added focused helper regressions covering the new gate behavior. Implementation and focused proof are complete; PR publication is the remaining lifecycle step.

## Artifacts
- Updated sprint-conductor helpers:
  - `adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py`
  - `adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py`
  - `adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py`
  - `adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py`
- Focused regression coverage:
  - `adl/tools/test_sprint_conductor_helpers.sh`
- Sprint 3 state artifact created during activation:
  - `.adl/reviews/sprint-3357-state.json`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified the focused sprint-conductor helper contract, including brand-new state gating, reopened-child state correction, deterministic closeout, and residual-debt close refusal.
  - `git diff --check`
    Verified the tracked patch has no whitespace or malformed diff residue.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3358__v0-91-4-wp-09-sprint-conductor-default-csdlc-lane/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3358__v0-91-4-wp-09-sprint-conductor-default-csdlc-lane/sor.md
- Idempotency-Key: v0-91-4-tools-tighten-sprint-conductor-state-and-closeout-gates-adl-v0-91-4-tasks-issue-3358-v0-91-4-wp-09-sprint-conductor-default-csdlc-lane-sip-md-adl-v0-91-4-tasks-issue-3358-v0-91-4-wp-09-sprint-conductor-default-csdlc-lane-sor-md