### PR TITLE
[v0.91.4][PVF][tests] Inventory existing tests and classify initial lanes

### DIFF
--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json
@@ -1,0 +1,225 @@
+{
+  "manifest_version": "v0.91.4",
+  "lane_classes": [
+    "fast_unit",
+    "contract_schema_card",
+    "docs",
+    "cli_workflow",
+    "integration_worktree",
+    "provider_live",
+    "release_gate"
+  ],
+  "lanes": {
+    "rust_fmt": {
+      "lane_class": "fast_unit",
+      "owner_surface": "Rust formatting gate",
+      "command": "cargo fmt --all -- --check",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "adl/src/",
+        "adl/tests/"
+      ],
+      "evidence_outputs": [
+        "stdout:fmt_check_clean"
+      ],
+      "timeout_minutes": 5,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "structured_prompt_contract": {
+      "lane_class": "contract_schema_card",
+      "owner_surface": "Structured prompt, schema, and manifest contracts",
+      "command": "bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input <card> && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json >/dev/null && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json >/dev/null",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        ".adl/",
+        "docs/templates/prompts/",
+        "adl/tools/validate_structured_prompt.sh",
+        "docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json",
+        "docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json",
+        "docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json"
+      ],
+      "evidence_outputs": [
+        "stdout:card_contract_pass"
+      ],
+      "timeout_minutes": 3,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "release_notes_commands": {
+      "lane_class": "docs",
+      "owner_surface": "Release-notes command surfaces",
+      "command": "bash tools/check_release_notes_commands.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "docs/",
+        "README.md",
+        "CHANGELOG.md"
+      ],
+      "evidence_outputs": [
+        "stdout:release_notes_commands_pass"
+      ],
+      "timeout_minutes": 3,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "legacy_swarm_refs_guard": {
+      "lane_class": "docs",
+      "owner_surface": "Publication-boundary and stale-term guardrails",
+      "command": "bash adl/tools/check_no_new_legacy_swarm_refs.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "docs/",
+        "README.md",
+        ".adl/",
+        "adl/tools/skills/"
+      ],
+      "evidence_outputs": [
+        "stdout:legacy_swarm_refs_guard_pass"
+      ],
+      "timeout_minutes": 3,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "pr_closing_linkage_guard": {
+      "lane_class": "docs",
+      "owner_surface": "Issue and PR closing-linkage truth",
+      "command": "bash adl/tools/check_pr_closing_linkage.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "always",
+      "changed_path_hints": [
+        ".github/workflows/ci.yaml",
+        "adl/tools/check_pr_closing_linkage.sh",
+        ".adl/",
+        "docs/"
+      ],
+      "evidence_outputs": [
+        "stdout:pr_closing_linkage_guard_pass"
+      ],
+      "timeout_minutes": 3,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "ci_path_policy_contract": {
+      "lane_class": "cli_workflow",
+      "owner_surface": "Changed-path classification and CI routing contracts",
+      "command": "bash adl/tools/test_ci_path_policy.sh",
+      "resource_profile": "low",
+      "determinism": "fixture_bound",
+      "cache_strategy": "local_reuse",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        ".github/workflows/ci.yaml",
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh"
+      ],
+      "evidence_outputs": [
+        "stdout:ci_path_policy_contract_pass"
+      ],
+      "timeout_minutes": 5,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "sprint_helper_regression": {
+      "lane_class": "cli_workflow",
+      "owner_surface": "Sprint conductor helper behavior",
+      "command": "bash adl/tools/test_sprint_conductor_helpers.sh",
+      "resource_profile": "medium",
+      "determinism": "fixture_bound",
+      "cache_strategy": "local_reuse",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "adl/tools/skills/sprint-conductor/",
+        "adl/tools/test_sprint_conductor_helpers.sh"
+      ],
+      "evidence_outputs": [
+        "stdout:sprint_helper_regression_pass"
+      ],
+      "timeout_minutes": 10,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "proof_validation_lane": {
+      "lane_class": "integration_worktree",
+      "owner_surface": "v0.91.3 proof validation packet",
+      "command": "bash adl/tools/run_v0913_proof_validation_lane.sh",
+      "resource_profile": "high",
+      "determinism": "fixture_bound",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "release_candidate",
+      "default_trigger": "manual",
+      "changed_path_hints": [
+        "docs/milestones/v0.91.3/",
+        "adl/tools/run_v0913_proof_validation_lane.sh"
+      ],
+      "evidence_outputs": [
+        "stdout:proof_validation_lane_pass"
+      ],
+      "timeout_minutes": 20,
+      "requires_credentials": false,
+      "requires_worktree": true
+    },
+    "authoritative_coverage": {
+      "lane_class": "release_gate",
+      "owner_surface": "Authoritative coverage authority",
+      "command": "bash adl/tools/run_authoritative_coverage_lane.sh",
+      "resource_profile": "high",
+      "determinism": "fixture_bound",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "manual_release_gate",
+      "default_trigger": "release_only",
+      "changed_path_hints": [
+        ".github/workflows/ci.yaml",
+        "adl/tools/run_authoritative_coverage_lane.sh"
+      ],
+      "evidence_outputs": [
+        "coverage-summary.json",
+        "coverage-summary.txt",
+        "lcov.info"
+      ],
+      "timeout_minutes": 30,
+      "requires_credentials": false,
+      "requires_worktree": false
+    },
+    "uts_benchmark": {
+      "lane_class": "provider_live",
+      "owner_surface": "Hosted benchmark provider execution",
+      "command": "bash adl/tools/run_uts_benchmark.sh",
+      "resource_profile": "high",
+      "determinism": "live",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "manual_release_gate",
+      "default_trigger": "manual",
+      "changed_path_hints": [
+        "adl/tools/run_uts_benchmark.sh"
+      ],
+      "evidence_outputs": [
+        "stdout:uts_benchmark_summary"
+      ],
+      "timeout_minutes": 60,
+      "requires_credentials": true,
+      "requires_worktree": false
+    }
+  }
+}

--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
@@ -1,0 +1,156 @@
+# PVF Initial Lane Inventory v0.91.4
+
+Status: proposed
+
+## Purpose
+
+Provide the first bounded inventory of ADL validation and proof surfaces using
+the PVF lane taxonomy from `#3400`.
+
+This packet is intentionally a first-pass inventory, not a complete executor.
+It identifies the primary validation surfaces already exercised by CI, PR
+publication, card validation, docs checks, workflow helpers, and heavy release
+or live-provider flows so later PVF runner work can start from a truthful lane
+map instead of an implicit shell-script pile.
+
+## Classification policy used
+
+- `fast_unit`: cheap, deterministic Rust validation or similarly fast local
+  compile/test proof
+- `contract_schema_card`: structured prompt, schema, manifest, or contract
+  validation
+- `docs`: docs-only truth and formatting checks
+- `cli_workflow`: deterministic workflow/helper validation in repo-local shell
+  scripts
+- `integration_worktree`: composed local proof across multiple helpers or
+  milestone/demo surfaces
+- `provider_live`: networked or credential-backed proof
+- `release_gate`: heavy milestone or release evidence lane
+
+## Initial representative inventory
+
+| Surface | Current command or entrypoint | Proposed lane class | Resource profile | Ordinary PR posture | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Rust format gate | `cargo fmt --all -- --check` | `fast_unit` | low | run when `rust_required=true` | deterministic compile-surface hygiene |
+| Rust lint gate | `cargo clippy --all-targets -- -D warnings` | `fast_unit` | medium | run when `rust_required=true` | compile-backed but still ordinary PR proof |
+| Rust doc tests | `cargo test --doc` | `fast_unit` | medium | run on Rust-affecting PRs unless replaced by authoritative lane policy | bounded compared with full nextest/coverage |
+| PR-fast Rust test lane | `bash adl/tools/run_pr_fast_test_lane.sh` | `fast_unit` | medium | ordinary runtime PR lane | already policy-aware and may focus or fail closed |
+| Structured prompt / manifest validation | `bash adl/tools/validate_structured_prompt.sh ...` plus PVF schema/manifest parse checks | `contract_schema_card` | low | ordinary PR-ready proof for card, schema, and manifest changes | canonical contract lane for cards, schemas, and manifest fixtures |
+| Prompt-template contract suite | `bash adl/tools/test_prompt_templates_1_0_0.sh` | `contract_schema_card` | low | run when prompt-template surfaces change | schema/template contract proof |
+| Structured prompt validation suite | `bash adl/tools/test_structured_prompt_validation.sh` | `contract_schema_card` | low | run when validator surfaces change | contract behavior proof |
+| CI path-policy contract | `bash adl/tools/test_ci_path_policy.sh` | `cli_workflow` | low | ordinary tooling PR lane | validates changed-path routing behavior |
+| Coverage-impact contract | `bash adl/tools/test_check_coverage_impact.sh` | `cli_workflow` | low | ordinary tooling/runtime governance lane | validates changed-source coverage classification |
+| Sprint conductor helper suite | `bash adl/tools/test_sprint_conductor_helpers.sh` | `cli_workflow` | medium | ordinary PR lane for sprint tooling | deterministic fixture-bound shell proofs |
+| Workflow conductor skill contracts | `bash adl/tools/test_workflow_conductor_skill_contracts.sh` | `cli_workflow` | medium | ordinary PR lane for conductor changes | validates routing contracts |
+| PR run / issue-mode workflow | `bash adl/tools/test_pr_run_issue_mode.sh` | `cli_workflow` | medium | ordinary PR lane for PR lifecycle tooling | representative issue binding proof |
+| PR finish relative-path guard | `bash adl/tools/test_pr_finish_relative_card_paths.sh` | `cli_workflow` | medium | ordinary PR lane for finish-path changes | catches publication-path regressions |
+| Docs command truth | `bash tools/check_release_notes_commands.sh` | `docs` | low | docs or release-tail PR lane | command-surfaces truth check |
+| Legacy-swarm reference guardrail | `bash adl/tools/check_no_new_legacy_swarm_refs.sh` | `docs` | low | ordinary PR lane when docs/publication language changes | publication-boundary and stale-term guardrail |
+| PR closing linkage guardrail | `bash adl/tools/check_pr_closing_linkage.sh` | `docs` | low | ordinary PR lane for issue/PR truth, not only docs changes | issue/PR truth surface |
+| v0.91.3 proof validation lane | `bash adl/tools/run_v0913_proof_validation_lane.sh` | `integration_worktree` | high | not ordinary unless proof surfaces changed | composed milestone proof lane |
+| Demo smoke lane | `bash adl/tools/demo_smoke_v07_story.sh` | `integration_worktree` | medium | conditional ordinary PR lane for demo surfaces | bounded composed demo proof |
+| Authoritative coverage lane | `bash adl/tools/run_authoritative_coverage_lane.sh` | `release_gate` | high | no, except policy-authority cases | full or bounded authoritative coverage authority |
+| Local authoritative coverage gate | `bash adl/tools/run_local_authoritative_coverage_gate.sh` | `release_gate` | high | local heavy proof only | release-tail or explicit coverage-governance lane |
+| UTS benchmark runner | `bash adl/tools/run_uts_benchmark.sh` | `provider_live` | high | never ordinary PR CI | live benchmark/provider dependency |
+
+## Initial lane groups for the first PVF runner fixture
+
+### `fast_unit`
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --doc`
+- `bash adl/tools/run_pr_fast_test_lane.sh`
+
+### `contract_schema_card`
+
+- `bash adl/tools/validate_structured_prompt.sh`
+- `bash adl/tools/test_prompt_templates_1_0_0.sh`
+- `bash adl/tools/test_structured_prompt_validation.sh`
+
+### `docs`
+
+- `bash tools/check_release_notes_commands.sh`
+- `bash adl/tools/check_no_new_legacy_swarm_refs.sh`
+- `bash adl/tools/check_pr_closing_linkage.sh`
+
+### `cli_workflow`
+
+- `bash adl/tools/test_ci_path_policy.sh`
+- `bash adl/tools/test_check_coverage_impact.sh`
+- `bash adl/tools/test_sprint_conductor_helpers.sh`
+- `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
+- `bash adl/tools/test_pr_run_issue_mode.sh`
+- `bash adl/tools/test_pr_finish_relative_card_paths.sh`
+
+### `integration_worktree`
+
+- `bash adl/tools/run_v0913_proof_validation_lane.sh`
+- `bash adl/tools/demo_smoke_v07_story.sh`
+
+### `release_gate`
+
+- `bash adl/tools/run_authoritative_coverage_lane.sh`
+- `bash adl/tools/run_local_authoritative_coverage_gate.sh`
+
+### `provider_live`
+
+- `bash adl/tools/run_uts_benchmark.sh`
+
+## Gaps and migration notes
+
+### Gap 1: large unclassified contract-script tail
+
+The repo contains many additional `adl/tools/test_*.sh` scripts, especially
+skill-contract checks, demo packets, and milestone proof surfaces. They are not
+yet fully classified in this first pass.
+
+Migration note:
+- `#3402` should let the runner accept partial manifests without requiring the
+  full repo inventory on day one.
+- Follow-on inventory work should classify remaining contract suites by
+  ownership domain rather than by filename prefix alone.
+
+### Gap 2: release-gate versus integration-worktree boundary still needs policy tightening
+
+Some milestone/demo proof packets are heavier than ordinary `cli_workflow`, but
+lighter than full release evidence. This first pass places only the clearest
+surfaces into `integration_worktree` and `release_gate`.
+
+Migration note:
+- `#3403` should encode the escalation rule explicitly in CI/release logic.
+
+### Gap 3: live/provider surfaces must remain outside ordinary PR CI
+
+The `run_uts_benchmark.sh` lane is clearly provider/live. Additional benchmark,
+demo, or hosted execution surfaces may belong here too, but they were not
+expanded in this initial pass.
+
+Migration note:
+- Future PVF policy should require explicit operator or release authority before
+  any `provider_live` lane is selected.
+
+### Gap 4: path-policy outputs are not yet emitted as PVF manifest entries
+
+Current CI already computes stable policy signals such as `coverage_lane`,
+`coverage_authority`, and `reason`, but it does not yet emit a PVF manifest.
+
+Migration note:
+- `#3402` should consume this inventory into a first manifest-driven runner.
+- `#3403` should wire CI classification to PVF lane selection rather than
+  duplicating lane logic in multiple shell scripts.
+
+## Manifest-shape notes
+
+- The initial manifest keeps docs-oriented guardrails as separate entries rather
+  than collapsing them into one synthetic lane. That preserves their different
+  trigger semantics for later runner work.
+- The `contract_schema_card` lane must trigger on PVF schema and manifest files
+  themselves, not only on `.adl` card or prompt-template surfaces.
+
+## Non-claims
+
+- This packet does not claim the full repo test inventory is complete.
+- This packet does not weaken existing validation requirements.
+- This packet does not authorize provider/live tests in ordinary PR CI.
+- This packet does not replace authoritative release evidence.

--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
@@ -45,7 +45,7 @@ map instead of an implicit shell-script pile.
 | PR run / issue-mode workflow | `bash adl/tools/test_pr_run_issue_mode.sh` | `cli_workflow` | medium | ordinary PR lane for PR lifecycle tooling | representative issue binding proof |
 | PR finish relative-path guard | `bash adl/tools/test_pr_finish_relative_card_paths.sh` | `cli_workflow` | medium | ordinary PR lane for finish-path changes | catches publication-path regressions |
 | Docs command truth | `bash tools/check_release_notes_commands.sh` | `docs` | low | docs or release-tail PR lane | command-surfaces truth check |
-| Legacy-swarm reference guardrail | `bash adl/tools/check_no_new_legacy_swarm_refs.sh` | `docs` | low | ordinary PR lane when docs/publication language changes | publication-boundary and stale-term guardrail |
+| Stale-term reference guardrail | `bash adl/tools/check_no_new_legacy_swarm_refs.sh` | `docs` | low | ordinary PR lane when docs/publication language changes | publication-boundary and stale-term guardrail |
 | PR closing linkage guardrail | `bash adl/tools/check_pr_closing_linkage.sh` | `docs` | low | ordinary PR lane for issue/PR truth, not only docs changes | issue/PR truth surface |
 | v0.91.3 proof validation lane | `bash adl/tools/run_v0913_proof_validation_lane.sh` | `integration_worktree` | high | not ordinary unless proof surfaces changed | composed milestone proof lane |
 | Demo smoke lane | `bash adl/tools/demo_smoke_v07_story.sh` | `integration_worktree` | medium | conditional ordinary PR lane for demo surfaces | bounded composed demo proof |


### PR DESCRIPTION
Closes #3401

## Summary
Produced the first bounded PVF inventory packet by classifying representative
ADL validation surfaces into the canonical lane taxonomy and emitting an
initial manifest fixture that later PVF runner work can consume. This issue
intentionally inventories a truthful first slice; it does not claim the full
repo test universe is exhaustively classified.

## Artifacts
- `docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md`
- `docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json`

## Validation
- Validation commands and their purpose:
  - `python3 -m json.tool docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json >/dev/null`
    Verified the initial inventory manifest parses cleanly.
  - `git diff --check`
    Verified patch hygiene for the inventory doc and manifest.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3401__v0-91-4-pvf-tests-inventory-existing-tests-and-classify-initial-lanes/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3401__v0-91-4-pvf-tests-inventory-existing-tests-and-classify-initial-lanes/sor.md
- Idempotency-Key: v0-91-4-pvf-tests-inventory-existing-tests-and-classify-initial-lanes-adl-v0-91-4-tasks-issue-3401-v0-91-4-pvf-tests-inventory-existing-tests-and-classify-initial-lanes-sip-md-adl-v0-91-4-tasks-issue-3401-v0-91-4-pvf-tests-inventory-existing-tests-and-classify-initial-lanes-sor-md