### PR TITLE
[v0.91.4][PVF][quality] Integrate PVF with CI coverage and release gates

### DIFF
--- a/adl/tools/run_pvf_ci_release_policy_fixture.sh
+++ b/adl/tools/run_pvf_ci_release_policy_fixture.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${PVF_LANE_ID:-}" in
+  docs_only_pr)
+    echo "lane pass"
+    ;;
+  docs_only_reuse_candidate)
+    echo "PVF_STATUS=reused"
+    ;;
+  runtime_pr_fast)
+    echo "lane pass"
+    ;;
+  authoritative_release_gate)
+    echo "lane pass"
+    ;;
+  *)
+    echo "unknown PVF policy fixture lane: ${PVF_LANE_ID:-unset}" >&2
+    exit 2
+    ;;
+esac

--- a/adl/tools/run_pvf_validation_lane.sh
+++ b/adl/tools/run_pvf_validation_lane.sh
@@ -287,7 +287,7 @@ for lane_id in "${lane_ids[@]}"; do
   fi
 done
 
-aggregate_status="passed"
+aggregate_status="skipped"
 for lane_id in "${lane_ids[@]}"; do
   status="$(get_lane_value "$lane_id" status)"
   case "$status" in
@@ -311,13 +311,16 @@ for lane_id in "${lane_ids[@]}"; do
       fi
       ;;
     skipped)
-      if [ "$aggregate_status" = "passed" ]; then
-        aggregate_status="skipped"
-      fi
       ;;
     reused)
+      if [ "$aggregate_status" = "skipped" ]; then
+        aggregate_status="passed"
+      fi
       ;;
     passed)
+      if [ "$aggregate_status" = "skipped" ]; then
+        aggregate_status="passed"
+      fi
       ;;
   esac
 done

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -248,6 +248,49 @@ and then emits one coverage summary report. Skills should treat
 `bounded_policy_surface_pr` as bounded PR governance validation, not as full
 release evidence.
 
+## PVF Integration Mapping
+
+The first PVF integration does not replace stable checks. It adds a truthful
+lane vocabulary beneath them.
+
+The bounded v0.91.4 policy slice should distinguish at least:
+
+- `docs_only_pr`
+  : ordinary PR docs-only validation for docs/planning/operator-policy changes
+- `docs_only_reuse_candidate`
+  : explicit reuse-capable docs-only proof lane for unchanged docs-only inputs
+- `runtime_pr_fast`
+  : ordinary PR runtime/source validation using the existing PR-fast posture
+- `authoritative_release_gate`
+  : release-gate-only proof that stays visible as required future work on an
+    ordinary PR and becomes runnable proof on release-mode execution
+
+This matters for two reasons:
+
+1. docs-only work must not be forced to impersonate runtime validation
+2. release-gate-only proof must not disappear into a generic skip
+
+Truthful ordinary PR interpretation under the bounded policy fixture:
+
+- docs-only lanes may `pass` and/or `reuse`
+- runtime PR-fast lane may `pass` or `skip` based on changed surfaces
+- authoritative release lane should report `release_gate_required`, not
+  `skipped`
+
+Truthful release-mode interpretation under PVF:
+
+- the same authoritative release lane becomes runnable proof and should report
+  ordinary success/failure status
+
+The bounded manifest and proof packet for this lane live at:
+
+- `docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md`
+- `docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json`
+
+Those tracked commands are intentionally policy-fixture commands. They prove
+lane routing and aggregate truth, not the complete production docs-only
+validator bundle or full authoritative coverage workflow.
+
 ### Failed-Closed Classification
 
 Observed:

--- a/adl/tools/test_pvf_ci_release_policy.sh
+++ b/adl/tools/test_pvf_ci_release_policy.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/adl/tools/run_pvf_validation_lane.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+manifest="$ROOT_DIR/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json"
+docs_changed="$tmpdir/docs.changed"
+runtime_changed="$tmpdir/runtime.changed"
+docs_report="$tmpdir/docs.report.json"
+runtime_report="$tmpdir/runtime.report.json"
+release_report="$tmpdir/release.report.json"
+
+printf 'M\tadl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md\n' > "$docs_changed"
+printf 'M\tadl/src/lib.rs\n' > "$runtime_changed"
+
+"$RUNNER" --manifest "$manifest" --changed-files "$docs_changed" --report-out "$docs_report" >"$tmpdir/docs.stdout"
+"$RUNNER" --manifest "$manifest" --changed-files "$runtime_changed" --report-out "$runtime_report" >"$tmpdir/runtime.stdout"
+"$RUNNER" --manifest "$manifest" --changed-files "$docs_changed" --mode release --report-out "$release_report" >"$tmpdir/release.stdout"
+
+python3 - <<'PY' "$docs_report" "$runtime_report" "$release_report"
+import json
+import sys
+from pathlib import Path
+
+docs = json.loads(Path(sys.argv[1]).read_text())
+runtime = json.loads(Path(sys.argv[2]).read_text())
+release = json.loads(Path(sys.argv[3]).read_text())
+
+assert docs["aggregate_status"] == "release_gate_required"
+assert docs["lanes"]["docs_only_pr"]["status"] == "passed"
+assert docs["lanes"]["docs_only_reuse_candidate"]["status"] == "reused"
+assert docs["lanes"]["runtime_pr_fast"]["status"] == "skipped"
+assert docs["lanes"]["authoritative_release_gate"]["status"] == "release_gate_required"
+
+assert runtime["aggregate_status"] == "release_gate_required"
+assert runtime["lanes"]["docs_only_pr"]["status"] == "skipped"
+assert runtime["lanes"]["docs_only_reuse_candidate"]["status"] == "skipped"
+assert runtime["lanes"]["runtime_pr_fast"]["status"] == "passed"
+assert runtime["lanes"]["authoritative_release_gate"]["status"] == "release_gate_required"
+
+assert release["aggregate_status"] == "passed"
+assert release["lanes"]["docs_only_pr"]["status"] == "passed"
+assert release["lanes"]["docs_only_reuse_candidate"]["status"] == "reused"
+assert release["lanes"]["runtime_pr_fast"]["status"] == "skipped"
+assert release["lanes"]["authoritative_release_gate"]["status"] == "passed"
+PY
+
+grep -q "aggregate_status=release_gate_required" "$tmpdir/docs.stdout"
+grep -q "aggregate_status=release_gate_required" "$tmpdir/runtime.stdout"
+grep -q "aggregate_status=passed" "$tmpdir/release.stdout"
+grep -q "docs_only_reuse_candidate status=reused" "$tmpdir/release.stdout"
+
+echo "PASS test_pvf_ci_release_policy"

--- a/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
@@ -18,6 +18,8 @@ The milestone must run:
 - repeated five-minute-sprint metrics capture, including validation-tail and
   proof-latency measurement
 - explicit Parallel Validation Fabric feature/proof evidence
+- explicit PVF docs-only PR lane proof showing that docs-only, runtime PR-fast,
+  and release-gate-only lanes are distinguished truthfully
 - explicit multi-agent workcell proof or truthful blocked handoff showing
   shard admission, worker/reviewer/janitor lanes, and serialized merge/closeout
   gates
@@ -52,6 +54,8 @@ The milestone is blocked if:
 - validation-tail handling hides pending or deferred proof instead of recording
   it truthfully
 - parallel validation hides failures or pending proof behind aggregate success
+- docs-only PVF lanes can still disappear into a generic skip instead of
+  remaining explicit proof with truthful release-gate separation
 - Parallel Validation Fabric remains only an implied repeatability subsection
   instead of an owned feature/proof surface
 - active issues can remain in an ambiguous lifecycle state without an explicit

--- a/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
+++ b/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
@@ -190,6 +190,10 @@ What is landed:
 - explicit lane categories for focused issue-local proof, docs-only proof,
   broad integration proof, merge-gate CI, deferred proof, and sprint closeout
   truth
+- explicit ordinary-PR versus release-gate routing for docs-only lanes,
+  runtime PR-fast lanes, and authoritative release-only lanes
+- bounded policy treatment for artifact reuse so reused proof remains visible as
+  `reused` instead of being collapsed into silent success
 - explicit distinction between passed, pending, deferred, blocked, and failed
   proof
 - evidence-backed demonstration that validation-tail drag can dominate merged

--- a/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json
+++ b/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json
@@ -1,0 +1,86 @@
+{
+  "manifest_version": "v0.91.4",
+  "lane_classes": [
+    "docs",
+    "cli_workflow",
+    "release_gate"
+  ],
+  "lanes": {
+    "docs_only_pr": {
+      "lane_class": "docs",
+      "owner_surface": "docs-only PR validation",
+      "command": "bash adl/tools/run_pvf_ci_release_policy_fixture.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "docs/",
+        "docs/planning/",
+        "README.md",
+        ".adl/",
+        "adl/tools/skills/docs/"
+      ],
+      "evidence_outputs": [
+        "bounded policy-fixture stdout"
+      ]
+    },
+    "docs_only_reuse_candidate": {
+      "lane_class": "docs",
+      "owner_surface": "artifact-reuse candidate for docs-only proof",
+      "command": "bash adl/tools/run_pvf_ci_release_policy_fixture.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "docs/",
+        "docs/planning/",
+        "README.md",
+        ".adl/",
+        "adl/tools/skills/docs/"
+      ],
+      "evidence_outputs": [
+        "runner-level reused status"
+      ]
+    },
+    "runtime_pr_fast": {
+      "lane_class": "cli_workflow",
+      "owner_surface": "ordinary runtime PR-fast validation",
+      "command": "bash adl/tools/run_pvf_ci_release_policy_fixture.sh",
+      "resource_profile": "medium",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": [
+        "adl/src/",
+        "adl/tests/",
+        "adl/build.rs"
+      ],
+      "evidence_outputs": [
+        "ordinary PR-fast Rust validation summary"
+      ]
+    },
+    "authoritative_release_gate": {
+      "lane_class": "release_gate",
+      "owner_surface": "authoritative coverage or release-gate proof",
+      "command": "bash adl/tools/run_pvf_ci_release_policy_fixture.sh",
+      "resource_profile": "high",
+      "determinism": "fixture_bound",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "manual_release_gate",
+      "default_trigger": "release_only",
+      "changed_path_hints": [
+        "adl/src/",
+        "adl/tests/",
+        "docs/milestones/"
+      ],
+      "evidence_outputs": [
+        "bounded release-fixture stdout"
+      ]
+    }
+  }
+}

--- a/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md
@@ -1,0 +1,153 @@
+# PVF CI and Release Policy
+
+## Purpose
+
+Define how the first bounded Parallel Validation Fabric integrates with ordinary
+PR validation, docs-only validation, cache/reuse posture, and release-gate-only
+proof.
+
+This packet is intentionally narrow. It does not claim a complete CI scheduler
+or a final release-orchestration system. It records the minimum truthful policy
+needed to route ordinary PRs without confusing skipped work, deferred work,
+reused work, and release-only proof.
+
+## Scope
+
+This policy covers:
+
+- docs-only PR validation as a first-class PVF lane
+- runtime/source PR validation as a first-class PVF lane
+- release-gate-only proof lanes that must remain visible on ordinary PRs
+- bounded artifact reuse semantics for unchanged proof lanes
+
+This policy does not:
+
+- replace branch protection or stable GitHub check names
+- weaken authoritative coverage or release evidence rules
+- treat reuse as a waiver when inputs are different
+
+## Lane Mapping
+
+### Docs-only PR lanes
+
+- lane ids:
+  - `docs_only_pr`
+  - `docs_only_reuse_candidate`
+- lane class: `docs`
+- ordinary PR status when docs/planning/operator-policy files changed:
+  `passed` and/or `reused`
+- ordinary PR status when docs/planning/operator-policy files did not change:
+  `skipped`
+- release interpretation: still a bounded ordinary lane, not release evidence by
+  itself
+
+These are the newly explicit docs-only lanes added to the PVF policy surface.
+Docs-only work
+must not be forced to masquerade as runtime validation, but it also must not be
+treated as "nothing happened."
+
+The `docs_only_reuse_candidate` lane exists so the first bounded policy packet
+can prove reuse status explicitly rather than describing reuse only in prose.
+
+### Runtime PR lane
+
+- lane id: `runtime_pr_fast`
+- lane class: `cli_workflow`
+- ordinary PR status when runtime-affecting surfaces changed: `passed`
+- ordinary PR status when runtime-affecting surfaces did not change: `skipped`
+
+This lane represents the existing focused PR-fast validation posture. It is the
+ordinary PR proof lane for runtime-affecting changes, not the release-evidence
+lane.
+
+### Release coverage lane
+
+- lane id: `authoritative_release_gate`
+- lane class: `release_gate`
+- ordinary PR status: `release_gate_required`
+- release-mode status: `passed` when its command succeeds
+
+This is the key distinction the policy must preserve:
+
+- on an ordinary PR, the release-gate lane is not "skipped"
+- it remains explicit as required future proof
+- on release-mode execution, the same lane becomes runnable proof
+
+## Reuse Policy
+
+Artifact reuse is allowed only as bounded proof with explicit invalidation
+inputs.
+
+For the first PVF policy slice, reuse is only truthful when all of the
+following remain stable:
+
+- lane identity
+- lane command
+- lane mode (`pr` versus `release`)
+- changed-path trigger class for the lane
+- the underlying proof inputs named by the lane
+
+If any of those change, the lane must rerun and must not report `reused`.
+
+The first bounded runner expresses reuse through lane status:
+
+- `reused`
+
+and reason:
+
+- `artifact_reuse_confirmed`
+
+That is enough for the first policy packet. Richer provenance storage remains
+future work.
+
+## Policy Fixture Boundary
+
+The tracked manifest for this issue is a bounded policy fixture, not the final
+production CI workflow. Its commands are intentionally deterministic local
+fixture commands so the manifest itself can be executed and verified without
+needing live release credentials or heavyweight coverage runs.
+
+That means:
+
+- the manifest proves truthful lane routing and aggregate status semantics
+- it does not claim that the full docs-only production validator bundle has
+  already been collapsed into one PVF command
+- broader production validation posture remains described in the CI runtime
+  policy guide
+
+## Ordinary PR Interpretation
+
+An ordinary PR may legitimately end with aggregate state
+`release_gate_required` even when all runnable ordinary lanes passed.
+
+That is healthy when:
+
+- docs-only or runtime PR lanes ran truthfully
+- release-gate-only proof remained explicit
+- no failed or blocked lanes are hidden
+
+The ordinary PR aggregate must not reinterpret release-gate-only proof as
+`skipped`, because that would erase required future evidence.
+
+## Release Interpretation
+
+A release-mode PVF run should convert the release-gate lane from
+`release_gate_required` into a runnable lane with ordinary success/failure
+truth.
+
+For this bounded issue, the release-mode proof is limited to showing that the
+same manifest can distinguish:
+
+- PR-mode release-gate requirement
+- release-mode runnable proof
+
+It does not claim the full release stack is yet driven by PVF.
+
+## Non-claims
+
+- This packet does not claim that GitHub CI has already been rewritten to call
+  the PVF runner for every check.
+- This packet does not claim that authoritative coverage can be replaced by a
+  docs-only or PR-fast lane.
+- This packet does not claim that reuse is sound across changed commands,
+  changed manifests, or changed release policy.


### PR DESCRIPTION
Closes #3403

## Summary
Integrated PVF policy with CI/release-gate truth by adding a bounded policy
packet, a tracked manifest, a tracked fixture helper, and a focused shell proof
that distinguishes docs-only PR lanes, runtime PR-fast lanes, reuse status, and
release-gate-only routing.

## Artifacts
- `docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md`
- `docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json`
- `docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md`
- `docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `adl/tools/run_pvf_ci_release_policy_fixture.sh`
- `adl/tools/test_pvf_ci_release_policy.sh`
- `adl/tools/run_pvf_validation_lane.sh`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/run_pvf_validation_lane.sh adl/tools/run_pvf_ci_release_policy_fixture.sh adl/tools/test_run_pvf_validation_lane.sh adl/tools/test_pvf_ci_release_policy.sh`
    Verified shell syntax across the touched PVF runner, fixture helper, and focused proof scripts.
  - `python3 -m json.tool docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_MANIFEST_v0.91.4.json >/dev/null`
    Verified the tracked PVF CI/release policy manifest parses cleanly.
  - `bash adl/tools/test_run_pvf_validation_lane.sh`
    Verified the core PVF runner status vocabulary and aggregate behavior remain correct after the aggregate-precedence fix.
  - `bash adl/tools/test_pvf_ci_release_policy.sh`
    Verified the tracked manifest distinguishes docs-only PR lanes, runtime PR-fast lanes, reuse, and release-mode authoritative routing.
  - `git diff --check`
    Verified patch hygiene for the tracked docs and shell surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3403__v0-91-4-pvf-quality-integrate-pvf-with-ci-coverage-and-release-gates/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3403__v0-91-4-pvf-quality-integrate-pvf-with-ci-coverage-and-release-gates/sor.md
- Idempotency-Key: v0-91-4-pvf-quality-integrate-pvf-with-ci-coverage-and-release-gates-adl-v0-91-4-tasks-issue-3403-v0-91-4-pvf-quality-integrate-pvf-with-ci-coverage-and-release-gates-sip-md-adl-v0-91-4-tasks-issue-3403-v0-91-4-pvf-quality-integrate-pvf-with-ci-coverage-and-release-gates-sor-md