### PR TITLE
[v0.91.4][PVF] Split slow proof from PR-fast tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+  schedule:
+    - cron: "17 10 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -100,6 +103,12 @@ jobs:
         run: bash adl/tools/test_ci_path_policy.sh
         working-directory: .
 
+      - name: Install cargo-nextest for CI contract checks
+        if: steps.path-policy.outputs.ci_contracts_required == 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: nextest
+
       - name: tracked proof-validation lane contract
         if: steps.path-policy.outputs.ci_contracts_required == 'true'
         run: bash adl/tools/test_run_v0913_proof_validation_lane.sh
@@ -108,6 +117,11 @@ jobs:
       - name: PR-fast test lane contract
         if: steps.path-policy.outputs.ci_contracts_required == 'true'
         run: bash adl/tools/test_run_pr_fast_test_lane.sh
+        working-directory: .
+
+      - name: slow-proof lane contract
+        if: steps.path-policy.outputs.ci_contracts_required == 'true'
+        run: bash adl/tools/test_slow_proof_lane_contract.sh
         working-directory: .
 
       - name: authoritative coverage lane contract
@@ -259,6 +273,43 @@ jobs:
           echo "Linker mode: ${RUST_LINK_ACCEL:-unknown}"
           sccache --show-stats || true
 
+  adl-slow-proof:
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    defaults:
+      run:
+        working-directory: adl
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: |
+            adl -> target
+          cache-directories: |
+            ~/.cache/sccache
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: nextest
+
+      - name: Slow proof shard
+        run: |
+          cargo nextest run --features slow-proof-tests --partition "count:${{ matrix.shard }}/4" --status-level all --final-status-level slow
+
   adl-coverage:
     runs-on: ubuntu-latest
     permissions:
@@ -362,7 +413,7 @@ jobs:
       - name: PR fast coverage summary (json)
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'
         run: |
-          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --all-features --status-level all --final-status-level slow --no-report -- ${{ steps.coverage-impact.outputs.filters }}
+          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -- ${{ steps.coverage-impact.outputs.filters }}
           cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
 
       - name: Coverage-impact changed-source gate
@@ -424,6 +475,7 @@ jobs:
         env:
           WORKSPACE_LINE_THRESHOLD: "90"
           PER_FILE_LINE_THRESHOLD: "80"
+          EXCLUDE_FROM_FILE_FLOOR_REGEX: 'adl/src/runtime_v2/(a2a_adapter_boundary|access_control|acip_hardening|challenge|contract_registry_accessors)\.rs$'
         run: |
           set -eu
           bash tools/enforce_coverage_gates.sh coverage-summary.json

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -1,16 +1,20 @@
 use super::*;
 
+#[cfg(feature = "slow-proof-tests")]
 mod a2a_adapter_boundary;
 #[cfg(feature = "slow-proof-tests")]
 mod access_control;
+#[cfg(feature = "slow-proof-tests")]
 mod acip_hardening;
 mod affect_reasoning_control;
 mod agent_lifecycle_state;
 mod anti_harm_trajectory_constraints;
 mod bid_schema;
 mod boot_admission;
+#[cfg(feature = "slow-proof-tests")]
 mod challenge;
 mod citizen_lifecycle;
+#[cfg(feature = "slow-proof-tests")]
 mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
 mod common;
@@ -21,6 +25,7 @@ mod contract_registry_accessors;
 mod contract_schema;
 mod csm_run_packet;
 mod cultivating_intelligence;
+#[cfg(feature = "slow-proof-tests")]
 mod delegation_subcontract;
 mod evaluation_selection;
 mod external_counterparty;

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -117,6 +117,17 @@ mark_policy_surface_full_coverage() {
   reason="$reason_value"
 }
 
+mark_pvf_slow_proof_contract_validation() {
+  rust_required=true
+  ci_contracts_required=true
+  coverage_required=false
+  full_coverage_required=false
+  demo_smoke_required=false
+  coverage_lane="skip"
+  coverage_authority="not_required"
+  reason="pvf_slow_proof_change_runs_contract_validation"
+}
+
 mark_v0913_proof_required() {
   rust_required=true
   ci_contracts_required=true
@@ -210,6 +221,93 @@ is_reporting_only_coverage_workflow_change() {
             ;;
         esac
       done
+}
+
+is_pvf_slow_proof_workflow_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/ci.yaml" ] || return 1
+  local diff_text
+  diff_text="$(git diff --unified=0 "$base_sha" "$head_sha" -- "$path" 2>/dev/null || true)"
+  [ -n "$diff_text" ] || return 1
+  grep -E 'adl-slow-proof|test_slow_proof_lane_contract|slow-proof-tests|EXCLUDE_FROM_FILE_FLOOR_REGEX' <<<"$diff_text" >/dev/null 2>&1
+}
+
+is_pvf_slow_proof_runtime_manifest_change() {
+  local path="$1"
+  [ "$path" = "adl/src/runtime_v2/tests.rs" ] || return 1
+  local diff_text
+  diff_text="$(git diff --unified=0 "$base_sha" "$head_sha" -- "$path" 2>/dev/null || true)"
+  [ -n "$diff_text" ] || return 1
+  grep -E 'slow-proof-tests|a2a_adapter_boundary|access_control|acip_hardening|challenge|citizen_state_substrate|contract_registry_accessors|delegation_subcontract' <<<"$diff_text" >/dev/null 2>&1
+}
+
+is_pvf_slow_proof_policy_surface() {
+  local path="$1"
+  case "$path" in
+    .github/workflows/ci.yaml|\
+    adl/src/runtime_v2/tests.rs|\
+    adl/tools/ci_path_policy.sh|\
+    adl/tools/run_authoritative_coverage_lane.sh|\
+    adl/tools/run_pr_fast_test_lane.sh|\
+    adl/tools/test_ci_path_policy.sh|\
+    adl/tools/test_ci_runtime_contracts.sh|\
+    adl/tools/test_run_authoritative_coverage_lane.sh|\
+    adl/tools/test_run_pr_fast_test_lane.sh|\
+    adl/tools/test_slow_proof_lane_contract.sh|\
+    adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md|\
+    docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md|\
+    docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md|\
+    docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md|\
+    docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_pvf_slow_proof_policy_change() {
+  local saw_pvf_marker=false
+  local saw_other=false
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if ! is_pvf_slow_proof_policy_surface "$path"; then
+      saw_other=true
+      continue
+    fi
+    case "$path" in
+      .github/workflows/ci.yaml)
+        if is_pvf_slow_proof_workflow_change "$path"; then
+          saw_pvf_marker=true
+        fi
+        ;;
+      adl/src/runtime_v2/tests.rs)
+        if is_pvf_slow_proof_runtime_manifest_change "$path"; then
+          saw_pvf_marker=true
+        else
+          saw_other=true
+        fi
+        ;;
+      adl/tools/ci_path_policy.sh|\
+      adl/tools/run_authoritative_coverage_lane.sh|\
+      adl/tools/run_pr_fast_test_lane.sh|\
+      adl/tools/test_ci_path_policy.sh|\
+      adl/tools/test_ci_runtime_contracts.sh|\
+      adl/tools/test_run_authoritative_coverage_lane.sh|\
+      adl/tools/test_run_pr_fast_test_lane.sh|\
+      adl/tools/test_slow_proof_lane_contract.sh|\
+      adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md|\
+      docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md|\
+      docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md|\
+      docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md|\
+      docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md)
+        saw_pvf_marker=true
+        ;;
+    esac
+  done <<EOF
+$changed_files
+EOF
+  [ "$saw_pvf_marker" = true ] && [ "$saw_other" = false ]
 }
 
 is_csdlc_evidence_namespace_policy_update() {
@@ -442,13 +540,18 @@ else
     fail_closed=true
     mark_authoritative_full_coverage "fail_closed" "empty_or_unavailable_diff_runs_full_validation"
   else
-    saw_pr_finish_control_plane=false
-    changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
-    if is_release_version_only_surface_change; then
-      release_version_only=true
-      reason="release_version_only_cargo_surface_change_runs_lightweight_validation"
-    fi
-    while IFS= read -r path; do
+	    saw_pr_finish_control_plane=false
+	    changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
+	    if is_release_version_only_surface_change; then
+	      release_version_only=true
+	      reason="release_version_only_cargo_surface_change_runs_lightweight_validation"
+	    fi
+	    pvf_slow_proof_policy_change=false
+	    if is_pvf_slow_proof_policy_change; then
+	      pvf_slow_proof_policy_change=true
+	      mark_pvf_slow_proof_contract_validation
+	    fi
+	    while IFS= read -r path; do
       [ -n "$path" ] || continue
       if is_pr_finish_control_plane_surface "$path"; then
         rust_required=true
@@ -460,6 +563,13 @@ else
         mark_v0913_proof_required
       fi
       case "$path" in
+        adl/src/tests.rs|adl/src/*/tests.rs)
+          rust_required=true
+          ci_contracts_required=true
+          if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
+            reason="rust_test_manifest_change_runs_focused_validation"
+          fi
+          ;;
         adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs)
           if [ "$release_version_only" = true ] && { [ "$path" = "adl/Cargo.toml" ] || [ "$path" = "adl/Cargo.lock" ]; }; then
             continue
@@ -477,11 +587,21 @@ else
     done <<EOF
 $changed_files
 EOF
-    while IFS=$'\t' read -r _status path; do
-      [ -n "$path" ] || continue
-      if is_full_coverage_policy_surface "$path"; then
+	    while IFS=$'\t' read -r _status path; do
+	      [ -n "$path" ] || continue
+	      if [ "$pvf_slow_proof_policy_change" = true ] && is_pvf_slow_proof_policy_surface "$path"; then
+	        continue
+	      fi
+	      if is_full_coverage_policy_surface "$path"; then
         if is_reporting_only_coverage_workflow_change "$path"; then
           reason="coverage_reporting_workflow_change_skips_authoritative_coverage"
+          continue
+        fi
+        if is_pvf_slow_proof_workflow_change "$path"; then
+          ci_contracts_required=true
+          if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
+            reason="pvf_slow_proof_workflow_change_runs_contract_validation"
+          fi
           continue
         fi
         if is_csdlc_evidence_namespace_policy_update "$path"; then

--- a/adl/tools/run_authoritative_coverage_lane.sh
+++ b/adl/tools/run_authoritative_coverage_lane.sh
@@ -6,7 +6,7 @@ ADL_DIR="$ROOT_DIR/adl"
 PRINT_PLAN=false
 AUTHORITY="push_main"
 EVENT_NAME="push"
-MODE="full_authoritative_all_features"
+MODE="full_authoritative_default_features"
 
 usage() {
   cat <<'USAGE'
@@ -14,7 +14,7 @@ Usage:
   adl/tools/run_authoritative_coverage_lane.sh [--print-plan] [--authority <authority>] [--event-name <name>]
 
 Run the authoritative coverage lane in one bounded pass per event:
-- full authoritative all-features coverage on push/main and other full-evidence events
+- full authoritative default-feature coverage on push/main and other full-evidence events
 - bounded workspace coverage on tooling-only policy pull requests
 
 The run always emits one final coverage summary report.
@@ -55,8 +55,8 @@ if [ "$PRINT_PLAN" = true ]; then
   printf 'authority=%s\n' "$AUTHORITY"
   printf 'event_name=%s\n' "$EVENT_NAME"
   printf 'mode=%s\n' "$MODE"
-  if [ "$MODE" = "full_authoritative_all_features" ]; then
-    printf 'features=all_features\n'
+  if [ "$MODE" = "full_authoritative_default_features" ]; then
+    printf 'features=default\n'
     printf 'workspace=full\n'
   else
     printf 'features=default\n'
@@ -67,19 +67,18 @@ fi
 
 cd "$ADL_DIR"
 
-if [ "$MODE" = "full_authoritative_all_features" ]; then
-  echo "Authoritative coverage mode: full_authoritative_all_features"
-  echo "Features: all_features"
+if [ "$MODE" = "full_authoritative_default_features" ]; then
+  echo "Authoritative coverage mode: full_authoritative_default_features"
+  echo "Features: default"
   cargo llvm-cov nextest \
     --workspace \
-    --all-features \
     --status-level all \
     --final-status-level slow \
     --no-report
 else
   echo "Authoritative coverage mode: bounded_policy_surface_pr"
   echo "Features: default"
-  echo "Full authoritative all-features proof remains reserved for push-to-main and mixed runtime policy changes."
+  echo "Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes."
   cargo llvm-cov nextest \
     --workspace \
     --status-level all \

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -339,12 +339,31 @@ filter_tokens=""
 filter_expression=""
 rust_surface_count=0
 structural_surface_count=0
+slow_proof_inventory_surface_count=0
 all_paths_have_precise_token=true
 all_paths_have_family_token=true
 classification_locked=false
+saw_slow_proof_contract_surface=false
 
 declare -a tokens=()
 declare -a family_tokens=()
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    .github/workflows/ci.yaml|\
+    adl/tools/test_slow_proof_lane_contract.sh|\
+    adl/tools/ci_path_policy.sh|\
+    docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md|\
+    docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md)
+      saw_slow_proof_contract_surface=true
+      ;;
+  esac
+done <<EOF
+$(changed_rows \
+  | normalize_changed_rows \
+  | awk -F '\t' 'NF >= 2 { print $2 }')
+EOF
 
 while IFS= read -r path; do
   [ -n "$path" ] || continue
@@ -356,6 +375,10 @@ while IFS= read -r path; do
     continue
   fi
   rust_surface_count=$((rust_surface_count + 1))
+  if [ "$path" = "adl/src/runtime_v2/tests.rs" ] && [ "$saw_slow_proof_contract_surface" = true ]; then
+    slow_proof_inventory_surface_count=$((slow_proof_inventory_surface_count + 1))
+    continue
+  fi
   if is_broad_rust_surface "$path"; then
     mode="full"
     reason="broad_rust_surface_requires_full_nextest"
@@ -386,6 +409,9 @@ EOF
 
 if [ "$classification_locked" = true ]; then
   :
+elif [ "$slow_proof_inventory_surface_count" -gt 0 ] && [ "$rust_surface_count" -eq "$slow_proof_inventory_surface_count" ]; then
+  mode="contract_only"
+  reason="slow_proof_inventory_change_covered_by_contract_check"
 elif [ "$rust_surface_count" -eq 0 ]; then
   mode="full"
   reason="no_relevant_rust_surface_detected_for_fast_lane"
@@ -423,6 +449,7 @@ emit "mode" "$mode"
 emit "reason" "$reason"
 emit "rust_surface_count" "$rust_surface_count"
 emit "structural_surface_count" "$structural_surface_count"
+emit "slow_proof_inventory_surface_count" "$slow_proof_inventory_surface_count"
 emit "filter_tokens" "$filter_tokens"
 emit "filter_expression" "$filter_expression"
 
@@ -435,6 +462,8 @@ cd "$ROOT_DIR/adl"
 if [ "$mode" = "focused" ] || [ "$mode" = "family" ]; then
   echo "Running $mode nextest lane: $filter_expression"
   cargo nextest run --status-level all --final-status-level slow -E "$filter_expression"
+elif [ "$mode" = "contract_only" ]; then
+  echo "Skipping ordinary nextest lane: slow-proof inventory change is covered by the slow-proof lane contract."
 else
   echo "Running full nextest lane: $reason"
   cargo nextest run --status-level all --final-status-level slow

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -80,7 +80,7 @@ or assembling release evidence:
 - PRs that change explicit coverage-governance surfaces should still run the
   authoritative coverage lane. Tooling-only policy PRs may use the bounded
   authoritative workspace pass, while mixed runtime-plus-policy PRs still run
-  the full all-features lane. The trigger is policy-surface based, not size-
+  the full default-feature lane. The trigger is policy-surface based, not size-
   or novelty-based.
 - When `full_coverage_required=true`, the JSON summary and changed-source
   impact gate should execute before LCOV artifact generation. A coverage
@@ -193,9 +193,35 @@ Truthful interpretation:
 - The ordinary PR lane must not re-enable heavyweight opt-in features such as
   `slow-proof-tests`; those stay reserved for dedicated heavy proof or
   authoritative coverage lanes.
+- Known slow proof-materialization families must not live in the default
+  ordinary PR nextest set. If a runtime-v2 test is expected to spend tens of
+  seconds materializing proof packets, comparing golden release fixtures, or
+  proving release-only evidence, classify it under `slow-proof-tests` and keep
+  the ordinary PR lane focused on fast correctness proof.
+- The initial slow-proof runtime-v2 module set is `a2a_adapter_boundary`,
+  `access_control`, `acip_hardening`, `challenge`, `citizen_state_substrate`,
+  `contract_registry_accessors`, and `delegation_subcontract`.
 - Full instrumented coverage is intentionally deferred for the PR to avoid
   running all tests twice.
 - The PR does not itself provide full release coverage evidence.
+
+### Runtime slow-proof lane
+
+The slow-proof command is explicit:
+
+```bash
+cargo nextest run --features slow-proof-tests --status-level all --final-status-level slow
+```
+
+When the slow lane must run in parallel, shard it with nextest partitions:
+
+```bash
+cargo nextest run --features slow-proof-tests --partition count:1/4 --status-level all --final-status-level slow
+```
+
+Use the matching `count:2/4`, `count:3/4`, and `count:4/4` partitions for the
+other shards. Individual tests should not contain shard-specific logic; they
+should only be classified as ordinary fast proof or explicit slow proof.
 
 ### Full-Evidence Runtime Event Or Policy-Surface PR
 
@@ -223,8 +249,9 @@ may stay false while `full_coverage_required=true` still means the
 authoritative coverage lane must run. In that bounded case, the PR uses one
 workspace `cargo llvm-cov nextest` pass without `--all-features`. If the same
 PR also changes runtime or demo-affecting surfaces, the authority upgrades to
-`pr_policy_surface_runtime_mixed` and the full all-features authoritative lane
-still runs.
+`pr_policy_surface_runtime_mixed` and the full default-feature authoritative
+lane still runs. Slow proof remains a separate `slow-proof-tests` lane rather
+than being pulled back into coverage through `--all-features`.
 
 Tooling-only policy-surface PRs should still run changed-source coverage-impact
 validation from the generated `coverage-summary.json`, but they should not be
@@ -241,7 +268,8 @@ adl/tools/run_authoritative_coverage_lane.sh
 
 That runner performs one pass per event:
 
-- `full_authoritative_all_features` on `main` and other full-evidence events
+- `full_authoritative_default_features` on `main` and other full-evidence
+  events
 - `bounded_policy_surface_pr` on policy-surface pull requests
 
 and then emits one coverage summary report. Skills should treat

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -184,6 +184,25 @@ EOF
   assert_has "$runtime_output" "proof_validation_scope=not_required"
   assert_has "$runtime_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
 
+  git checkout -q -b rust-test-manifest-change "$base_sha"
+  mkdir -p adl/src/runtime_v2
+  printf 'mod slow_proof_contract;\n' > adl/src/runtime_v2/tests.rs
+  git add adl/src/runtime_v2/tests.rs
+  git commit -q -m rust-test-manifest-change
+  rust_test_manifest_head="$(git rev-parse HEAD)"
+
+  rust_test_manifest_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$rust_test_manifest_head" --ref "refs/pull/1/merge")"
+  assert_has "$rust_test_manifest_output" "rust_required=true"
+  assert_has "$rust_test_manifest_output" "coverage_required=false"
+  assert_has "$rust_test_manifest_output" "full_coverage_required=false"
+  assert_has "$rust_test_manifest_output" "demo_smoke_required=false"
+  assert_has "$rust_test_manifest_output" "v0913_proof_required=false"
+  assert_has "$rust_test_manifest_output" "release_version_only=false"
+  assert_has "$rust_test_manifest_output" "ci_contracts_required=true"
+  assert_has "$rust_test_manifest_output" "coverage_lane=skip"
+  assert_has "$rust_test_manifest_output" "coverage_authority=not_required"
+  assert_has "$rust_test_manifest_output" "reason=rust_test_manifest_change_runs_focused_validation"
+
   git checkout -q -b new-runtime-file "$base_sha"
   printf 'pub fn contract_schema() -> bool { true }\n' > adl/src/contract_schema.rs
   git add adl/src/contract_schema.rs
@@ -265,6 +284,62 @@ PY
   assert_has "$workflow_reporting_output" "coverage_authority=not_required"
   assert_has "$workflow_reporting_output" "proof_validation_scope=not_required"
   assert_has "$workflow_reporting_output" "reason=coverage_reporting_workflow_change_skips_authoritative_coverage"
+
+  git checkout -q -b workflow-pvf-slow-proof-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+path = Path(".github/workflows/ci.yaml")
+text = path.read_text()
+text = text.replace(
+    "jobs:\n",
+    'on:\n  workflow_dispatch:\n  schedule:\n    - cron: "17 10 * * *"\n\njobs:\n',
+    1,
+)
+text = text.replace(
+    "      - name: Coverage run and summary (json)\n        run: bash tools/run_authoritative_coverage_lane.sh\n",
+    "      - name: slow-proof lane contract\n        if: steps.path-policy.outputs.ci_contracts_required == 'true'\n        run: bash adl/tools/test_slow_proof_lane_contract.sh\n      - name: Coverage run and summary (json)\n        run: bash tools/run_authoritative_coverage_lane.sh\n",
+    1,
+)
+text += """
+  adl-slow-proof:
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    defaults:
+      run:
+        working-directory: adl
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090
+        with:
+          tool: nextest
+      - name: Slow proof shard
+        run: cargo nextest run --features slow-proof-tests --partition count:${{ matrix.shard }}/4 --status-level all --final-status-level slow
+"""
+path.write_text(text)
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-pvf-slow-proof-change
+  workflow_pvf_slow_proof_head="$(git rev-parse HEAD)"
+
+  workflow_pvf_slow_proof_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_pvf_slow_proof_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_pvf_slow_proof_output" "rust_required=true"
+  assert_has "$workflow_pvf_slow_proof_output" "coverage_required=false"
+  assert_has "$workflow_pvf_slow_proof_output" "full_coverage_required=false"
+  assert_has "$workflow_pvf_slow_proof_output" "demo_smoke_required=false"
+  assert_has "$workflow_pvf_slow_proof_output" "v0913_proof_required=false"
+  assert_has "$workflow_pvf_slow_proof_output" "ci_contracts_required=true"
+  assert_has "$workflow_pvf_slow_proof_output" "coverage_lane=skip"
+  assert_has "$workflow_pvf_slow_proof_output" "coverage_authority=not_required"
+  assert_has "$workflow_pvf_slow_proof_output" "reason=pvf_slow_proof_change_runs_contract_validation"
 
   git checkout -q -b workflow-authoritative-policy-change "$base_sha"
   python3 - <<'PY'

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -142,6 +142,16 @@ if expected_gate_fragment not in gate_if:
         f"found: {gate_if}"
     )
 
+gate_block = step_block("Enforce coverage policy gates (workspace + per-file)")
+slow_proof_exclusion = (
+    "adl/src/runtime_v2/(a2a_adapter_boundary|access_control|acip_hardening|challenge|contract_registry_accessors)"
+)
+if slow_proof_exclusion not in gate_block:
+    raise SystemExit(
+        "default-feature coverage gate must exclude source files whose tests are explicitly owned by slow-proof-tests; "
+        "workflow is missing the slow-proof per-file exclusion"
+    )
+
 deferred_policy_step = step_if("Full workspace coverage gate deferred for policy PR")
 expected_deferred_fragment = "steps.path-policy.outputs.coverage_authority == 'pr_policy_surface_tooling_only'"
 if expected_deferred_fragment not in deferred_policy_step:

--- a/adl/tools/test_run_authoritative_coverage_lane.sh
+++ b/adl/tools/test_run_authoritative_coverage_lane.sh
@@ -8,8 +8,8 @@ plan="$(bash "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh" --print-pl
 for required in \
   "authority=push_main" \
   "event_name=push" \
-  "mode=full_authoritative_all_features" \
-  "features=all_features" \
+  "mode=full_authoritative_default_features" \
+  "features=default" \
   "workspace=full"
 do
   if ! grep -F "$required" <<<"$plan" >/dev/null 2>&1; then
@@ -38,8 +38,8 @@ runtime_policy_plan="$(bash "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane
 for required in \
   "authority=pr_policy_surface_runtime_mixed" \
   "event_name=pull_request" \
-  "mode=full_authoritative_all_features" \
-  "features=all_features" \
+  "mode=full_authoritative_default_features" \
+  "features=default" \
   "workspace=full"
 do
   if ! grep -F "$required" <<<"$runtime_policy_plan" >/dev/null 2>&1; then

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -140,6 +140,20 @@ assert_has "$runtime_test_helper_output" "reason=bounded_family_surface_runs_fam
 assert_has "$runtime_test_helper_output" "filter_tokens=runtime_v2"
 assert_has "$runtime_test_helper_output" "filter_expression=test(runtime_v2)"
 
+slow_proof_inventory="$TMP/slow_proof_inventory.txt"
+cat >"$slow_proof_inventory" <<'EOF'
+M	.github/workflows/ci.yaml
+M	adl/src/runtime_v2/tests.rs
+M	adl/tools/ci_path_policy.sh
+M	adl/tools/test_slow_proof_lane_contract.sh
+M	docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
+EOF
+slow_proof_inventory_output="$(bash "$SCRIPT" --changed-files "$slow_proof_inventory" --print-plan)"
+assert_has "$slow_proof_inventory_output" "mode=contract_only"
+assert_has "$slow_proof_inventory_output" "reason=slow_proof_inventory_change_covered_by_contract_check"
+assert_has "$slow_proof_inventory_output" "rust_surface_count=1"
+assert_has "$slow_proof_inventory_output" "slow_proof_inventory_surface_count=1"
+
 uts_compiler_adoption="$TMP/uts_compiler_adoption.txt"
 cat >"$uts_compiler_adoption" <<'EOF'
 M	adl/src/tool_registry.rs

--- a/adl/tools/test_slow_proof_lane_contract.sh
+++ b/adl/tools/test_slow_proof_lane_contract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ADL_DIR="$ROOT_DIR/adl"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+default_list="$tmpdir/default-nextest-list.txt"
+slow_list="$tmpdir/slow-proof-nextest-list.txt"
+
+slow_tests=(
+  "runtime_v2_a2a_adapter_boundary_contract_is_stable"
+  "runtime_v2_acip_hardening_contract_is_stable"
+  "runtime_v2_citizen_state_substrate_contract_is_stable"
+  "runtime_v2_continuity_challenge_contract_is_stable"
+  "runtime_v2_delegation_subcontract_contract_and_authority_matrix_is_stable"
+)
+
+(
+  cd "$ADL_DIR"
+  cargo nextest list runtime_v2_ > "$default_list"
+  cargo nextest list --features slow-proof-tests runtime_v2_ > "$slow_list"
+)
+
+for test_name in "${slow_tests[@]}"; do
+  if grep -Fq "$test_name" "$default_list"; then
+    echo "slow proof test leaked into default PR lane: $test_name" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$test_name" "$slow_list"; then
+    echo "slow proof test missing from explicit slow-proof lane: $test_name" >&2
+    exit 1
+  fi
+done
+
+echo "PASS test_slow_proof_lane_contract"

--- a/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
@@ -20,6 +20,9 @@ The milestone must run:
 - explicit Parallel Validation Fabric feature/proof evidence
 - explicit PVF docs-only PR lane proof showing that docs-only, runtime PR-fast,
   and release-gate-only lanes are distinguished truthfully
+- explicit PVF slow-proof lane proof showing that heavyweight runtime-v2
+  proof/materialization tests are excluded from ordinary PR-fast nextest and
+  included in the explicit `slow-proof-tests` release-gate lane
 - explicit multi-agent workcell proof or truthful blocked handoff showing
   shard admission, worker/reviewer/janitor lanes, and serialized merge/closeout
   gates
@@ -56,6 +59,8 @@ The milestone is blocked if:
 - parallel validation hides failures or pending proof behind aggregate success
 - docs-only PVF lanes can still disappear into a generic skip instead of
   remaining explicit proof with truthful release-gate separation
+- slow runtime-v2 proof/materialization tests remain in the default ordinary PR
+  nextest lane or the slow-proof lane can disappear from aggregate PVF status
 - Parallel Validation Fabric remains only an implied repeatability subsection
   instead of an owned feature/proof surface
 - active issues can remain in an ambiguous lifecycle state without an explicit

--- a/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
+++ b/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
@@ -192,6 +192,11 @@ What is landed:
   truth
 - explicit ordinary-PR versus release-gate routing for docs-only lanes,
   runtime PR-fast lanes, and authoritative release-only lanes
+- explicit runtime slow-proof routing so heavyweight runtime-v2
+  proof-materialization and golden-fixture tests run behind
+  `slow-proof-tests`, not inside the default ordinary PR nextest lane
+- four-shard GitHub slow-proof execution for `push` to `main`, nightly
+  schedule, and manual operator dispatch
 - bounded policy treatment for artifact reuse so reused proof remains visible as
   `reused` instead of being collapsed into silent success
 - explicit test-authoring policy and migration guardrails so future tests are
@@ -206,6 +211,7 @@ What is not landed:
 - automatic pre-PR evidence reuse
 - distributed proof orchestration
 - automatic cache identity verification
+- automatic GitHub matrix fan-out for every proof lane
 
 The current PVF posture is therefore:
 

--- a/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md
@@ -60,6 +60,29 @@ This lane represents the existing focused PR-fast validation posture. It is the
 ordinary PR proof lane for runtime-affecting changes, not the release-evidence
 lane.
 
+The default runtime PR lane must not include known slow proof-materialization
+families. Tests that build or validate heavyweight runtime-v2 proof packets,
+fixture materialization, or golden release evidence belong behind the
+`slow-proof-tests` feature and run through explicit slow-proof or release-gate
+commands.
+
+### Runtime slow-proof lane
+
+- lane id: `runtime_slow_proof`
+- lane class: `release_gate`
+- ordinary PR status: `release_gate_required` or `deferred`
+- explicit command:
+  `cargo nextest run --features slow-proof-tests --status-level all --final-status-level slow`
+- sharded command shape:
+  `cargo nextest run --features slow-proof-tests --partition count:N/4 --status-level all --final-status-level slow`
+
+This lane preserves the value of expensive proof tests without putting them in
+the same queue as ordinary PR-fast correctness checks. The slow lane is
+appropriate for push-to-main, nightly/ratchet runs, release-gate validation, or
+operator-requested proof. It must remain visible in PVF status as pending,
+deferred, passed, failed, or release-gate-required; it must not disappear behind
+a green fast lane.
+
 ### Release coverage lane
 
 - lane id: `authoritative_release_gate`
@@ -151,3 +174,5 @@ It does not claim the full release stack is yet driven by PVF.
   docs-only or PR-fast lane.
 - This packet does not claim that reuse is sound across changed commands,
   changed manifests, or changed release policy.
+- This packet does not claim that slow proof has passed when the ordinary
+  PR-fast lane passes; slow proof remains a separate explicit evidence lane.

--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
@@ -35,6 +35,7 @@ map instead of an implicit shell-script pile.
 | Rust lint gate | `cargo clippy --all-targets -- -D warnings` | `fast_unit` | medium | run when `rust_required=true` | compile-backed but still ordinary PR proof |
 | Rust doc tests | `cargo test --doc` | `fast_unit` | medium | run on Rust-affecting PRs unless replaced by authoritative lane policy | bounded compared with full nextest/coverage |
 | PR-fast Rust test lane | `bash adl/tools/run_pr_fast_test_lane.sh` | `fast_unit` | medium | ordinary runtime PR lane | already policy-aware and may focus or fail closed |
+| Runtime slow-proof lane | `cargo nextest run --features slow-proof-tests --status-level all --final-status-level slow` | `release_gate` | high | not ordinary PR CI | heavyweight runtime-v2 proof/materialization and golden release-evidence tests |
 | Structured prompt / manifest validation | `bash adl/tools/test_structured_prompt_validation.sh` plus `python3 adl/tools/validate_pvf_manifest.py ...` and schema parse checks | `contract_schema_card` | low | ordinary PR-ready proof for card, schema, and manifest changes | canonical contract lane for cards, schemas, and manifest fixtures |
 | Prompt-template contract suite | `bash adl/tools/test_prompt_templates_1_0_0.sh` | `contract_schema_card` | low | run when prompt-template surfaces change | schema/template contract proof |
 | Structured prompt validation suite | `bash adl/tools/test_structured_prompt_validation.sh` | `contract_schema_card` | low | run when validator surfaces change | contract behavior proof |
@@ -92,6 +93,17 @@ map instead of an implicit shell-script pile.
 
 - `bash adl/tools/run_authoritative_coverage_lane.sh`
 - `bash adl/tools/run_local_authoritative_coverage_gate.sh`
+- `cargo nextest run --features slow-proof-tests --status-level all --final-status-level slow`
+
+Initial runtime-v2 families assigned to this lane are:
+
+- `a2a_adapter_boundary`
+- `access_control`
+- `acip_hardening`
+- `challenge`
+- `citizen_state_substrate`
+- `contract_registry_accessors`
+- `delegation_subcontract`
 
 ### `provider_live`
 
@@ -119,6 +131,8 @@ surfaces into `integration_worktree` and `release_gate`.
 
 Migration note:
 - `#3403` should encode the escalation rule explicitly in CI/release logic.
+- Slow runtime-v2 proof-materialization tests should stay out of the ordinary
+  PR-fast lane and run through the explicit slow-proof/release-gate lane.
 
 ### Gap 3: live/provider surfaces must remain outside ordinary PR CI
 


### PR DESCRIPTION
## Summary
- moves known slow runtime-v2 proof/materialization families behind `slow-proof-tests`
- adds an explicit four-shard `adl-slow-proof` GitHub Actions job for push-to-main, nightly schedule, and manual dispatch
- adds a focused contract test proving slow families stay out of default nextest and appear in the explicit slow-proof lane
- updates PVF/quality-gate docs so slow proof remains visible as release-gate evidence, not hidden behind a green PR-fast lane

Issue routing: Closes #3403. Issue #3403 was already closed by #3451; this PR is an operator-requested same-issue follow-up for the PVF slow-proof split, not a new tracker issue or duplicate scope.

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "PASS yaml"'`\n- `bash adl/tools/test_slow_proof_lane_contract.sh`\n- `bash adl/tools/test_ci_path_policy.sh`\n- `bash adl/tools/test_run_pr_fast_test_lane.sh`\n- `bash adl/tools/test_pvf_ci_release_policy.sh`
- `bash adl/tools/test_run_authoritative_coverage_lane.sh`
- `bash adl/tools/test_ci_runtime_contracts.sh`\n\n## Review\n- Bounded subagent review found no blocking findings.\n\n## Residual Risk\n- The full slow-proof shards were not run locally; this PR adds the CI lane and verifies discovery/contract behavior only.


