### PR TITLE
[v0.91.4][PVF][docs] Update test authoring policy and migration guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ These rules are mandatory for ADL issue work.
 - Keep milestone claims, proof claims, and review claims evidence-bound.
 - Prefer repo-relative paths in artifacts and records.
 - Do not silently widen issue scope.
+- New tests must be PVF-classifiable at authoring time. When adding a new test
+  surface, make lane class, proof role, determinism posture, resource profile,
+  and release-gate status explicit in the same issue/PR through the tracked
+  manifest, inventory, or tightly-coupled proof packet.
+- Keep tests boring. Do not push shard mechanics, CI/release-mode branching, or
+  hidden routing policy down into ordinary test logic; that belongs in manifests,
+  runners, and policy docs.
 - Preserve the canonical card lifecycle: `SIP -> STP -> SPP -> SRP -> SOR`.
   `SRP` is the Structured Review Prompt and review-result surface; `SOR` is the
   truthful execution and integration record.
@@ -97,6 +104,8 @@ For a normal tracked issue:
 - Do not skip required proof just because the change is small.
 - Do not run broad validation reflexively when focused proof is enough.
 - Keep review records and output cards truthful about what was and was not run.
+- Docs-only and policy-only PVF work should prefer focused docs/path/contract/
+  guardrail proof unless tracked runtime behavior changed.
 
 ## Review And Publication Rules
 

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -291,6 +291,34 @@ Those tracked commands are intentionally policy-fixture commands. They prove
 lane routing and aggregate truth, not the complete production docs-only
 validator bundle or full authoritative coverage workflow.
 
+## PVF Test Authoring Guardrails
+
+Future tests should enter the repository already classifiable into the PVF lane
+model.
+
+At authoring time, new test surfaces should have explicit tracked metadata for:
+
+- `lane_class`
+- `proof_role`
+- `determinism`
+- `resource_profile`
+- `release_gate_class`
+
+This metadata may live in a manifest, inventory, or tightly-coupled proof
+packet. It does not need to be embedded directly into every test file.
+
+Reviewer rule:
+
+- block new uncategorized test surfaces
+- allow existing uncategorized tests only with a bounded migration rationale or
+  follow-on when the current issue is not the right place to classify them
+
+Authoring rule:
+
+- keep tests boring
+- keep shard/routing/release mechanics in manifests, runners, and policy
+  surfaces rather than inside ordinary test logic
+
 ### Failed-Closed Classification
 
 Observed:

--- a/docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md
+++ b/docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md
@@ -44,6 +44,8 @@ evidence exists.
 - [x] Every currently opened issue bundle uses `SIP -> STP -> SPP -> SRP -> SOR`.
 - [x] `SPP` records design-time issue-local operative plan truth before execution
   for the currently opened batch.
+- [ ] New tests or test families land with explicit PVF lane/proof metadata;
+  migration rationale is only for pre-existing uncategorized tests.
 - [ ] Card edits use editor skills.
 - [ ] Work executes in bound worktrees.
 - [ ] Draft PR opens before merge for each issue.
@@ -57,6 +59,8 @@ evidence exists.
   [DEMO_MATRIX](DEMO_MATRIX_v0.91.4.md)
 - [ ] Quality gate is complete:
   [QUALITY_GATE](QUALITY_GATE_v0.91.4.md)
+- [ ] Review checklist for new tests and C-SDLC proof includes PVF lane,
+  proof role, determinism, resource profile, and release-gate checks.
 - [ ] Lifecycle, doctor, conductor, and editor focused tests pass.
 - [ ] Signed trace verification passes.
 - [ ] Process-drift regression fixtures pass.

--- a/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
+++ b/docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md
@@ -194,6 +194,8 @@ What is landed:
   runtime PR-fast lanes, and authoritative release-only lanes
 - bounded policy treatment for artifact reuse so reused proof remains visible as
   `reused` instead of being collapsed into silent success
+- explicit test-authoring policy and migration guardrails so future tests are
+  introduced with lane/proof metadata instead of relying on later cleanup
 - explicit distinction between passed, pending, deferred, blocked, and failed
   proof
 - evidence-backed demonstration that validation-tail drag can dominate merged

--- a/docs/milestones/v0.91.4/features/PVF_TEST_AUTHORING_POLICY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_TEST_AUTHORING_POLICY_v0.91.4.md
@@ -1,0 +1,160 @@
+# PVF Test Authoring Policy
+
+## Purpose
+
+Keep future tests compatible with the Parallel Validation Fabric from the moment
+they are introduced.
+
+This policy is the cultural lock-in layer for PVF. It does not shard tests by
+itself. It makes sure new tests are authored in a way that keeps lane
+classification, reuse policy, and release-gate truth explicit instead of
+letting the suite collapse back into one large serial validation tail.
+
+## Core Rule
+
+New tests must be *classifiable* into a PVF lane at authoring time.
+
+That means every new test or test-family addition must have an explicit answer
+to these questions:
+
+1. What lane class does this test belong to?
+2. What proof role does it serve?
+3. What determinism posture does it require?
+4. What resource profile does it assume?
+5. Is it required on ordinary PRs or only as a release gate?
+
+If the author cannot answer those questions, the test is not ready to land.
+
+## Required Metadata At Authoring Time
+
+The minimum required authoring metadata for a new test surface is:
+
+- `lane_class`
+  - examples: `docs`, `fast_unit`, `cli_workflow`, `integration_worktree`,
+    `release_gate`, `provider_live`
+- `proof_role`
+  - what claim the test proves, such as ordinary PR validation, policy
+    guardrail, merge/readiness guard, release evidence, or live-provider proof
+- `determinism`
+  - `strict`, `fixture_bound`, or `live`
+- `resource_profile`
+  - `low`, `medium`, or `high`
+- `release_gate_class`
+  - `required_on_pr`, `optional`, or `manual_release_gate`
+
+This metadata does not have to live as inline comments inside every test file.
+It may live in:
+
+- a PVF manifest entry
+- a tracked inventory or policy packet
+- a tightly-coupled test-family doc or fixture packet
+
+What matters is that the metadata is explicit, tracked, and reviewable in the
+same issue/PR that introduces the new test surface.
+
+## Boring-Test Rule
+
+Tests should stay boring.
+
+Sharding, lane routing, and orchestration belong in:
+
+- manifests
+- runner entrypoints
+- CI policy
+- proof packets
+
+They do **not** belong inside ordinary test logic.
+
+So:
+
+- individual tests should not become aware of shard IDs
+- individual tests should not branch on CI/release mode
+- individual tests should not carry hidden scheduling policy
+
+The test proves behavior. The manifest/runner proves routing.
+
+## New-Test Authoring Rules
+
+When adding a new test or test family:
+
+1. attach it to an existing PVF lane if one already fits
+2. if no existing lane fits, add or update the tracked lane metadata in the
+   same issue/PR
+3. record the proof role clearly enough that reviewers know whether the test is
+   ordinary PR proof, release-only proof, migration-only proof, or live
+   provider proof
+4. keep the validation command as small and deterministic as the proof surface
+   allows
+
+Do not merge a new test that is only “obviously important” but still uncategorized.
+
+## Migration Guardrails For Existing Uncategorized Tests
+
+Existing uncategorized tests are not an immediate stop-the-world blocker.
+
+Migration policy:
+
+- existing tests may remain temporarily uncategorized
+- newly added tests may not
+- when an existing uncategorized test is materially edited, split, or elevated
+  into a milestone proof surface, the touching issue should either:
+  - classify it into a lane, or
+  - record a bounded migration note explaining why classification is deferred
+
+Acceptable defer reasons:
+
+- the issue is docs-only and does not touch the runtime test itself
+- the current work is a narrow janitor change and classification would be the
+  larger scope
+- a follow-on issue is already created for that exact classification work
+
+Unacceptable defer reasons:
+
+- “we will remember later”
+- “the lane is obvious”
+- “CI will sort it out”
+
+## Reviewer Rejection Rules
+
+Reviewers should block or bounce the change when:
+
+- a new test surface lacks lane metadata
+- the proof role is not explicit
+- determinism posture is absent or contradictory
+- resource profile is absent for a non-trivial test family
+- release-gate status is unclear
+- the change pushes shard/orchestration mechanics down into ordinary test logic
+- a migration deferral is claimed without a bounded rationale
+
+## Review Checklist For New Tests And C-SDLC Proof
+
+Use this checklist during pre-PR review:
+
+- Is the new or modified test surface attached to a named PVF lane?
+- Is the proof role explicit?
+- Is the determinism posture explicit and believable?
+- Is the resource profile explicit enough to guide routing?
+- Is the release-gate class explicit?
+- Does the change keep tests boring and push routing into manifests/runners?
+- If the test remains uncategorized, is there a bounded migration rationale or
+  follow-on?
+- Do the `SPP`, `SRP`, and `SOR` surfaces describe the proof lane truthfully?
+
+## Non-claims
+
+- This policy does not claim every historical ADL test is already classified.
+- This policy does not require immediate full-suite migration before ordinary
+  work can continue.
+- This policy does not turn docs-only issues into mandatory broad Rust reruns.
+
+## Relationship To Other PVF Surfaces
+
+This policy complements:
+
+- `docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md`
+- `docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_TAXONOMY_v0.91.4.md`
+- `docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md`
+- `docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md`
+
+Those documents define lane structure and routing truth. This document defines
+how future tests enter that world without creating new ambiguity.


### PR DESCRIPTION
Closes #3404

## Summary
Added the PVF test-authoring lock-in packet so future tests must be
classifiable at authoring time, updated agent/tooling guidance to require the
same metadata, and tightened the milestone checklist so reviewers can reject
new uncategorized test surfaces without stopping all historical work.

## Artifacts
- `docs/milestones/v0.91.4/features/PVF_TEST_AUTHORING_POLICY_v0.91.4.md`
- `AGENTS.md`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md`
- `docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified patch hygiene for the touched docs and guidance surfaces.
  - `rg -n 'file://|OPENAI_API_KEY|ANTHROPIC_API_KEY' docs/milestones/v0.91.4/features/PVF_TEST_AUTHORING_POLICY_v0.91.4.md AGENTS.md adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md docs/milestones/v0.91.4/features/PARALLEL_VALIDATION_FABRIC.md docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md`
    Verified no URI-style or credential-name leakage in the touched docs.
  - Focused manual content review over the same touched files
    Verified no absolute-host-path leakage in the touched docs.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3404__v0-91-4-pvf-docs-update-test-authoring-policy-and-migration-guardrails/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3404__v0-91-4-pvf-docs-update-test-authoring-policy-and-migration-guardrails/sor.md
- Idempotency-Key: v0-91-4-pvf-docs-update-test-authoring-policy-and-migration-guardrails-adl-v0-91-4-tasks-issue-3404-v0-91-4-pvf-docs-update-test-authoring-policy-and-migration-guardrails-sip-md-adl-v0-91-4-tasks-issue-3404-v0-91-4-pvf-docs-update-test-authoring-policy-and-migration-guardrails-sor-md