### PR TITLE
[v0.91.4][PVF][quality] Remove stale v0.91.3 proof-lane labels from adl-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         run: bash adl/tools/test_ci_path_policy.sh
         working-directory: .
 
-      - name: v0.91.3 proof-validation lane contract
+      - name: tracked proof-validation lane contract
         if: steps.path-policy.outputs.ci_contracts_required == 'true'
         run: bash adl/tools/test_run_v0913_proof_validation_lane.sh
         working-directory: .
@@ -233,7 +233,7 @@ jobs:
         run: bash adl/tools/demo_smoke_v07_story.sh
         working-directory: .
 
-      - name: v0.91.3 proof validation lane
+      - name: tracked proof validation lane
         if: steps.path-policy.outputs.v0913_proof_required == 'true'
         run: bash adl/tools/run_v0913_proof_validation_lane.sh
         working-directory: .
@@ -245,10 +245,10 @@ jobs:
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
         working-directory: .
 
-      - name: v0.91.3 proof validation skipped by path policy
+      - name: tracked proof validation skipped by path policy
         if: steps.path-policy.outputs.v0913_proof_required != 'true'
         run: |
-          echo "v0.91.3 proof validation skipped because changed paths do not touch tracked v0.91.3 proof/demo packet surfaces."
+          echo "Tracked proof validation skipped because changed paths do not touch tracked proof/demo packet surfaces."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
           echo "Proof validation scope: ${{ steps.path-policy.outputs.proof_validation_scope }}"
         working-directory: .


### PR DESCRIPTION
Closes #3456

## Summary
Updated the active `adl-ci` workflow wording so the tracked proof-validation
lane no longer presents itself as a `v0.91.3` lane in step labels or skip
messages, without changing any underlying commands or path-policy conditions.

## Artifacts
- `.github/workflows/ci.yaml`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified patch hygiene for the tiny workflow wording change.
  - `rg -n 'tracked proof|v0\.91\.3 proof' .github/workflows/ci.yaml`
    Verified the stale lane labels/messages were replaced by tracked-proof wording.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3456__v0-91-4-pvf-quality-remove-stale-v0-91-3-proof-lane-labels-from-adl-ci/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3456__v0-91-4-pvf-quality-remove-stale-v0-91-3-proof-lane-labels-from-adl-ci/sor.md
- Idempotency-Key: v0-91-4-pvf-quality-remove-stale-v0-91-3-proof-lane-labels-from-adl-ci-adl-v0-91-4-tasks-issue-3456-v0-91-4-pvf-quality-remove-stale-v0-91-3-proof-lane-labels-from-adl-ci-sip-md-adl-v0-91-4-tasks-issue-3456-v0-91-4-pvf-quality-remove-stale-v0-91-3-proof-lane-labels-from-adl-ci-sor-md