### PR TITLE
[v0.91.4][PVF][quality] Repair PVF closeout truth and manifest contract drift

### DIFF
--- a/adl/tools/run_pvf_validation_lane.sh
+++ b/adl/tools/run_pvf_validation_lane.sh
@@ -106,6 +106,11 @@ else
   : > "$changed_paths_txt"
 fi
 
+if ! python3 "$ROOT_DIR/adl/tools/validate_pvf_manifest.py" "$MANIFEST_PATH" >/dev/null; then
+  echo "run_pvf_validation_lane: manifest contract validation failed: $MANIFEST_PATH" >&2
+  exit 2
+fi
+
 python3 - "$MANIFEST_PATH" "$plan_tsv" <<'PY'
 import json
 import sys
@@ -136,6 +141,7 @@ path_matches_hints() {
   python3 - "$changed_paths_txt" "$hints_json" <<'PY'
 import json
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
 
 changed = [line.strip() for line in Path(sys.argv[1]).read_text().splitlines() if line.strip()]
@@ -147,7 +153,7 @@ if not changed:
 
 for path in changed:
     for hint in hints:
-        if path == hint or path.startswith(hint):
+        if path == hint or path.startswith(hint) or fnmatch(path, hint):
             print("match")
             raise SystemExit(0)
 
@@ -202,6 +208,15 @@ while IFS=$'\t' read -r lane_id lane_class release_gate_class default_trigger re
     continue
   fi
 
+  if [ "$changed_hints_json" != "[]" ]; then
+    match_result="$(path_matches_hints "$changed_hints_json")"
+    if [ "$match_result" = "no_match" ]; then
+      set_lane_value "$lane_id" status "skipped"
+      set_lane_value "$lane_id" reason "changed_paths_not_matched"
+      continue
+    fi
+  fi
+
   if [ "$default_trigger" = "manual" ]; then
     set_lane_value "$lane_id" status "deferred"
     set_lane_value "$lane_id" reason "manual_trigger_not_selected"
@@ -214,14 +229,6 @@ while IFS=$'\t' read -r lane_id lane_class release_gate_class default_trigger re
     continue
   fi
 
-  if [ "$default_trigger" = "changed_paths" ]; then
-    match_result="$(path_matches_hints "$changed_hints_json")"
-    if [ "$match_result" = "no_match" ]; then
-      set_lane_value "$lane_id" status "skipped"
-      set_lane_value "$lane_id" reason "changed_paths_not_matched"
-      continue
-    fi
-  fi
 done < "$plan_tsv"
 
 if [ "$PRINT_PLAN" = true ]; then
@@ -301,7 +308,7 @@ for lane_id in "${lane_ids[@]}"; do
       fi
       ;;
     release_gate_required)
-      if [ "$aggregate_status" = "passed" ] || [ "$aggregate_status" = "reused" ] || [ "$aggregate_status" = "skipped" ]; then
+      if [ "$aggregate_status" = "passed" ] || [ "$aggregate_status" = "reused" ] || [ "$aggregate_status" = "skipped" ] || [ "$aggregate_status" = "deferred" ]; then
         aggregate_status="release_gate_required"
       fi
       ;;
@@ -405,7 +412,7 @@ else
   cat "$report_json"
 fi
 
-if [ "$aggregate_status" = "failed" ] || [ "$aggregate_status" = "blocked" ]; then
+if [ "$aggregate_status" = "failed" ] || [ "$aggregate_status" = "blocked" ] || [ "$aggregate_status" = "release_gate_required" ]; then
   exit 1
 fi
 

--- a/adl/tools/test_run_pvf_validation_lane.sh
+++ b/adl/tools/test_run_pvf_validation_lane.sh
@@ -75,7 +75,7 @@ cat >"$manifest" <<'EOF'
       "cache_strategy": "none",
       "release_gate_class": "required_on_pr",
       "default_trigger": "changed_paths",
-      "changed_path_hints": ["docs/"],
+      "changed_path_hints": ["docs/*.md"],
       "evidence_outputs": ["stdout:pass"]
     },
     "reuse_lane": {
@@ -252,5 +252,148 @@ assert report["aggregate_status"] == "blocked"
 assert report["lanes"]["credential_lane"]["status"] == "blocked"
 assert report["lanes"]["credential_lane"]["reason"] == "credential_lane_requires_explicit_opt_in"
 PY
+
+release_gate_manifest="$tmpdir/release-gate-manifest.json"
+release_gate_report="$tmpdir/release-gate-report.json"
+cat >"$release_gate_manifest" <<'EOF'
+{
+  "manifest_version": "v0.91.4",
+  "lane_classes": [
+    "docs",
+    "release_gate"
+  ],
+  "lanes": {
+    "manual_docs_lane": {
+      "lane_class": "docs",
+      "owner_surface": "manual docs lane",
+      "command": "pass_lane.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "optional",
+      "default_trigger": "manual",
+      "changed_path_hints": [],
+      "evidence_outputs": ["stdout:manual"]
+    },
+    "release_gate_lane": {
+      "lane_class": "release_gate",
+      "owner_surface": "release gate lane",
+      "command": "pass_lane.sh",
+      "resource_profile": "high",
+      "determinism": "fixture_bound",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "manual_release_gate",
+      "default_trigger": "release_only",
+      "changed_path_hints": ["docs/*.md"],
+      "evidence_outputs": ["stdout:release"]
+    }
+  }
+}
+EOF
+
+set +e
+"$RUNNER" --manifest "$release_gate_manifest" --changed-files "$changed" --report-out "$release_gate_report" >"$tmpdir/release-gate.stdout"
+release_gate_status=$?
+set -e
+if [ "$release_gate_status" -eq 0 ]; then
+  echo "expected release-gate-required aggregate run to exit nonzero" >&2
+  exit 1
+fi
+python3 - <<'PY' "$release_gate_report"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text())
+assert report["aggregate_status"] == "release_gate_required"
+assert report["lanes"]["manual_docs_lane"]["status"] == "deferred"
+assert report["lanes"]["release_gate_lane"]["status"] == "release_gate_required"
+PY
+
+grep -q "aggregate_status=release_gate_required" "$tmpdir/release-gate.stdout"
+
+nonmatching_release_gate_manifest="$tmpdir/nonmatching-release-gate-manifest.json"
+nonmatching_release_gate_report="$tmpdir/nonmatching-release-gate-report.json"
+cat >"$nonmatching_release_gate_manifest" <<'EOF'
+{
+  "manifest_version": "v0.91.4",
+  "lane_classes": [
+    "docs",
+    "release_gate"
+  ],
+  "lanes": {
+    "pass_lane": {
+      "lane_class": "docs",
+      "owner_surface": "pass lane",
+      "command": "pass_lane.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "changed_paths",
+      "changed_path_hints": ["docs/*.md"],
+      "evidence_outputs": ["stdout:pass"]
+    },
+    "release_gate_lane": {
+      "lane_class": "release_gate",
+      "owner_surface": "release gate lane",
+      "command": "pass_lane.sh",
+      "resource_profile": "high",
+      "determinism": "fixture_bound",
+      "cache_strategy": "artifact_reuse",
+      "release_gate_class": "manual_release_gate",
+      "default_trigger": "release_only",
+      "changed_path_hints": ["adl/src/*"],
+      "evidence_outputs": ["stdout:release"]
+    }
+  }
+}
+EOF
+
+"$RUNNER" --manifest "$nonmatching_release_gate_manifest" --changed-files "$changed" --report-out "$nonmatching_release_gate_report" >"$tmpdir/nonmatching-release-gate.stdout"
+python3 - <<'PY' "$nonmatching_release_gate_report"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text())
+assert report["aggregate_status"] == "passed"
+assert report["lanes"]["pass_lane"]["status"] == "passed"
+assert report["lanes"]["release_gate_lane"]["status"] == "skipped"
+PY
+
+invalid_manifest="$tmpdir/invalid-manifest.json"
+cat >"$invalid_manifest" <<'EOF'
+{
+  "manifest_version": "v0.91.4",
+  "lane_classes": [
+    "docs"
+  ],
+  "lanes": {
+    "pass_lane": {
+      "lane_class": "fast_unit",
+      "owner_surface": "pass lane",
+      "command": "pass_lane.sh",
+      "resource_profile": "low",
+      "determinism": "strict",
+      "cache_strategy": "none",
+      "release_gate_class": "required_on_pr",
+      "default_trigger": "always",
+      "changed_path_hints": [],
+      "evidence_outputs": ["stdout:pass"]
+    }
+  }
+}
+EOF
+
+set +e
+"$RUNNER" --manifest "$invalid_manifest" >"$tmpdir/invalid.stdout" 2>"$tmpdir/invalid.stderr"
+invalid_status=$?
+set -e
+if [ "$invalid_status" -eq 0 ]; then
+  echo "expected invalid manifest run to fail fast" >&2
+  exit 1
+fi
+grep -q "manifest contract validation failed" "$tmpdir/invalid.stderr"
 
 echo "PASS test_run_pvf_validation_lane"

--- a/adl/tools/validate_pvf_manifest.py
+++ b/adl/tools/validate_pvf_manifest.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate PVF manifest contracts for v0.91.4."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+EXPECTED_VERSION = "v0.91.4"
+LANE_CLASSES = {
+    "fast_unit",
+    "contract_schema_card",
+    "docs",
+    "cli_workflow",
+    "integration_worktree",
+    "provider_live",
+    "release_gate",
+}
+RESOURCE_PROFILES = {"low", "medium", "high"}
+DETERMINISM_MODES = {"strict", "fixture_bound", "live"}
+CACHE_STRATEGIES = {"none", "local_reuse", "artifact_reuse"}
+RELEASE_GATE_CLASSES = {
+    "required_on_pr",
+    "release_candidate",
+    "manual_release_gate",
+    "optional",
+}
+DEFAULT_TRIGGERS = {"always", "changed_paths", "manual", "release_only"}
+
+
+def fail(message: str) -> None:
+    print(f"validate_pvf_manifest: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def expect_type(value: object, expected: type, label: str) -> None:
+    if not isinstance(value, expected):
+        fail(f"{label} must be {expected.__name__}")
+
+
+def expect_non_empty_string(value: object, label: str) -> str:
+    expect_type(value, str, label)
+    if not value:
+        fail(f"{label} must be non-empty")
+    return value
+
+
+def expect_enum(value: object, allowed: set[str], label: str) -> str:
+    value = expect_non_empty_string(value, label)
+    if value not in allowed:
+        allowed_list = ", ".join(sorted(allowed))
+        fail(f"{label} must be one of: {allowed_list}")
+    return value
+
+
+def expect_string_array(value: object, label: str) -> list[str]:
+    expect_type(value, list, label)
+    result: list[str] = []
+    for idx, item in enumerate(value):
+        result.append(expect_non_empty_string(item, f"{label}[{idx}]"))
+    return result
+
+
+def validate_lane(lane_id: str, lane: object) -> str:
+    expect_type(lane, dict, f"lanes.{lane_id}")
+    lane = dict(lane)
+    allowed_keys = {
+        "lane_class",
+        "owner_surface",
+        "command",
+        "resource_profile",
+        "determinism",
+        "cache_strategy",
+        "release_gate_class",
+        "default_trigger",
+        "changed_path_hints",
+        "evidence_outputs",
+        "timeout_minutes",
+        "requires_credentials",
+        "requires_worktree",
+        "notes",
+    }
+    unknown = sorted(set(lane) - allowed_keys)
+    if unknown:
+        fail(f"lanes.{lane_id} has unknown keys: {', '.join(unknown)}")
+
+    for required in (
+        "lane_class",
+        "owner_surface",
+        "command",
+        "resource_profile",
+        "determinism",
+        "cache_strategy",
+        "release_gate_class",
+        "default_trigger",
+        "changed_path_hints",
+        "evidence_outputs",
+    ):
+        if required not in lane:
+            fail(f"lanes.{lane_id} is missing required key: {required}")
+
+    lane_class = expect_enum(lane["lane_class"], LANE_CLASSES, f"lanes.{lane_id}.lane_class")
+    expect_non_empty_string(lane["owner_surface"], f"lanes.{lane_id}.owner_surface")
+    expect_non_empty_string(lane["command"], f"lanes.{lane_id}.command")
+    expect_enum(lane["resource_profile"], RESOURCE_PROFILES, f"lanes.{lane_id}.resource_profile")
+    expect_enum(lane["determinism"], DETERMINISM_MODES, f"lanes.{lane_id}.determinism")
+    expect_enum(lane["cache_strategy"], CACHE_STRATEGIES, f"lanes.{lane_id}.cache_strategy")
+    expect_enum(lane["release_gate_class"], RELEASE_GATE_CLASSES, f"lanes.{lane_id}.release_gate_class")
+    expect_enum(lane["default_trigger"], DEFAULT_TRIGGERS, f"lanes.{lane_id}.default_trigger")
+    expect_string_array(lane["changed_path_hints"], f"lanes.{lane_id}.changed_path_hints")
+    expect_string_array(lane["evidence_outputs"], f"lanes.{lane_id}.evidence_outputs")
+
+    if "timeout_minutes" in lane:
+        expect_type(lane["timeout_minutes"], int, f"lanes.{lane_id}.timeout_minutes")
+        if lane["timeout_minutes"] < 1:
+            fail(f"lanes.{lane_id}.timeout_minutes must be >= 1")
+    if "requires_credentials" in lane:
+        expect_type(lane["requires_credentials"], bool, f"lanes.{lane_id}.requires_credentials")
+    if "requires_worktree" in lane:
+        expect_type(lane["requires_worktree"], bool, f"lanes.{lane_id}.requires_worktree")
+    if "notes" in lane:
+        expect_non_empty_string(lane["notes"], f"lanes.{lane_id}.notes")
+
+    return lane_class
+
+
+def validate_manifest(path: Path) -> None:
+    manifest = json.loads(path.read_text())
+    expect_type(manifest, dict, str(path))
+
+    allowed_keys = {"manifest_version", "lane_classes", "lanes"}
+    unknown = sorted(set(manifest) - allowed_keys)
+    if unknown:
+        fail(f"{path}: unknown top-level keys: {', '.join(unknown)}")
+
+    for required in ("manifest_version", "lane_classes", "lanes"):
+        if required not in manifest:
+            fail(f"{path}: missing required key: {required}")
+
+    version = expect_non_empty_string(manifest["manifest_version"], f"{path}.manifest_version")
+    if version != EXPECTED_VERSION:
+        fail(f"{path}: manifest_version must be {EXPECTED_VERSION}")
+
+    lane_classes = expect_string_array(manifest["lane_classes"], f"{path}.lane_classes")
+    if not lane_classes:
+        fail(f"{path}: lane_classes must not be empty")
+    if len(set(lane_classes)) != len(lane_classes):
+        fail(f"{path}: lane_classes must contain unique values")
+    for lane_class in lane_classes:
+        if lane_class not in LANE_CLASSES:
+            allowed_list = ", ".join(sorted(LANE_CLASSES))
+            fail(f"{path}: lane_classes contains unsupported value '{lane_class}' (allowed: {allowed_list})")
+
+    lanes = manifest["lanes"]
+    expect_type(lanes, dict, f"{path}.lanes")
+    if not lanes:
+        fail(f"{path}: lanes must not be empty")
+
+    used_lane_classes: set[str] = set()
+    for lane_id, lane in lanes.items():
+        if not lane_id or any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789_" for ch in lane_id):
+            fail(f"{path}: lane id '{lane_id}' must match ^[a-z0-9_]+$")
+        used_lane_classes.add(validate_lane(lane_id, lane))
+
+    declared = set(lane_classes)
+    if used_lane_classes != declared:
+        missing = sorted(used_lane_classes - declared)
+        unused = sorted(declared - used_lane_classes)
+        details = []
+        if missing:
+            details.append(f"missing used classes: {', '.join(missing)}")
+        if unused:
+            details.append(f"declared but unused classes: {', '.join(unused)}")
+        fail(f"{path}: lane_classes must equal the subset actually used by lanes ({'; '.join(details)})")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: validate_pvf_manifest.py <manifest.json> [manifest.json ...]", file=sys.stderr)
+        return 2
+    for arg in argv[1:]:
+        validate_manifest(Path(arg))
+        print(f"PASS: pvf manifest valid for {arg}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json
@@ -33,13 +33,14 @@
     "structured_prompt_contract": {
       "lane_class": "contract_schema_card",
       "owner_surface": "Structured prompt, schema, and manifest contracts",
-      "command": "bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input <card> && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json >/dev/null && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json >/dev/null",
+      "command": "bash adl/tools/test_structured_prompt_validation.sh && python3 adl/tools/validate_pvf_manifest.py docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json >/dev/null",
       "resource_profile": "low",
       "determinism": "strict",
       "cache_strategy": "none",
       "release_gate_class": "required_on_pr",
       "default_trigger": "changed_paths",
       "changed_path_hints": [
+        "adl/tools/validate_pvf_manifest.py",
         ".adl/",
         "docs/templates/prompts/",
         "adl/tools/validate_structured_prompt.sh",

--- a/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md
@@ -35,7 +35,7 @@ map instead of an implicit shell-script pile.
 | Rust lint gate | `cargo clippy --all-targets -- -D warnings` | `fast_unit` | medium | run when `rust_required=true` | compile-backed but still ordinary PR proof |
 | Rust doc tests | `cargo test --doc` | `fast_unit` | medium | run on Rust-affecting PRs unless replaced by authoritative lane policy | bounded compared with full nextest/coverage |
 | PR-fast Rust test lane | `bash adl/tools/run_pr_fast_test_lane.sh` | `fast_unit` | medium | ordinary runtime PR lane | already policy-aware and may focus or fail closed |
-| Structured prompt / manifest validation | `bash adl/tools/validate_structured_prompt.sh ...` plus PVF schema/manifest parse checks | `contract_schema_card` | low | ordinary PR-ready proof for card, schema, and manifest changes | canonical contract lane for cards, schemas, and manifest fixtures |
+| Structured prompt / manifest validation | `bash adl/tools/test_structured_prompt_validation.sh` plus `python3 adl/tools/validate_pvf_manifest.py ...` and schema parse checks | `contract_schema_card` | low | ordinary PR-ready proof for card, schema, and manifest changes | canonical contract lane for cards, schemas, and manifest fixtures |
 | Prompt-template contract suite | `bash adl/tools/test_prompt_templates_1_0_0.sh` | `contract_schema_card` | low | run when prompt-template surfaces change | schema/template contract proof |
 | Structured prompt validation suite | `bash adl/tools/test_structured_prompt_validation.sh` | `contract_schema_card` | low | run when validator surfaces change | contract behavior proof |
 | CI path-policy contract | `bash adl/tools/test_ci_path_policy.sh` | `cli_workflow` | low | ordinary tooling PR lane | validates changed-path routing behavior |

--- a/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json
+++ b/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json
@@ -9,13 +9,14 @@
     "pvf_manifest_contract": {
       "lane_class": "contract_schema_card",
       "owner_surface": "PVF manifest schema and example fixtures",
-      "command": "python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json",
+      "command": "python3 adl/tools/validate_pvf_manifest.py docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json && python3 -m json.tool docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json >/dev/null",
       "resource_profile": "low",
       "determinism": "strict",
       "cache_strategy": "none",
       "release_gate_class": "required_on_pr",
       "default_trigger": "changed_paths",
       "changed_path_hints": [
+        "adl/tools/validate_pvf_manifest.py",
         "docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json",
         "docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json"
       ],

--- a/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json
+++ b/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json
@@ -15,7 +15,7 @@
       "const": "v0.91.4"
     },
     "lane_classes": {
-      "description": "Subset of canonical lane classes actually used by entries in this manifest.",
+      "description": "Subset of canonical lane classes actually used by entries in this manifest. Equality with the classes used by `lanes` is enforced by `adl/tools/validate_pvf_manifest.py`.",
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,

--- a/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_TAXONOMY_v0.91.4.md
+++ b/docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_TAXONOMY_v0.91.4.md
@@ -94,7 +94,7 @@ manifest's `lanes` map and must define:
 - `cache_strategy`: `none`, `local_reuse`, or `artifact_reuse`
 - `release_gate_class`: `required_on_pr`, `release_candidate`, `manual_release_gate`, or `optional`
 - `default_trigger`: `always`, `changed_paths`, `manual`, or `release_only`
-- `changed_path_hints`: zero or more path prefixes or glob-style hints
+- `changed_path_hints`: zero or more path prefixes or shell-glob hints
 - `evidence_outputs`: zero or more files or artifact classes produced by the lane
 
 Optional but encouraged:


### PR DESCRIPTION
Closes #3464

## Summary
Repaired the merged PVF mini-sprint’s post-closeout drift by syncing the canonical sprint state and adding the missing canonical closeout artifact, then hardened the first PVF runner slice so manifests are validator-backed, release-only lanes honor changed-path scope before escalating, `release_gate_required` remains explicit in aggregate/exit truth, and glob-style `changed_path_hints` are actually supported.

## Artifacts
- `adl/tools/validate_pvf_manifest.py`
- `adl/tools/run_pvf_validation_lane.sh`
- `adl/tools/test_run_pvf_validation_lane.sh`
- `docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json`
- `docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json`
- `docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_TAXONOMY_v0.91.4.md`
- `docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_SCHEMA_v0.91.4.json`
- `docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md`
- `.adl/v0.91.4/sprints/issue-3399__v0-91-4-pvf-test-sharding-mini-sprint-state.json`
- `.adl/v0.91.4/sprints/issue-3399__v0-91-4-pvf-test-sharding-mini-sprint-closeout.md`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/validate_pvf_manifest.py docs/milestones/v0.91.4/features/PVF_VALIDATION_LANE_MANIFEST_EXAMPLE_v0.91.4.json docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_MANIFEST_v0.91.4.json`
    Verified the validator-backed PVF manifest contract.
  - `bash adl/tools/test_run_pvf_validation_lane.sh`
    Verified the PVF runner regression suite, including the new release-gate and invalid-manifest cases.
  - `cmp -s .adl/reviews/sprint-3399-state.json .adl/v0.91.4/sprints/issue-3399__v0-91-4-pvf-test-sharding-mini-sprint-state.json`
    Verified the canonical PVF sprint state matches retained closeout truth.
  - `git diff --check`
    Verified the tracked patch is diff-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3464__v0-91-4-pvf-quality-repair-pvf-closeout-truth-and-manifest-contract-drift/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3464__v0-91-4-pvf-quality-repair-pvf-closeout-truth-and-manifest-contract-drift/sor.md
- Idempotency-Key: v0-91-4-pvf-quality-repair-pvf-closeout-truth-and-manifest-contract-drift-adl-v0-91-4-tasks-issue-3464-v0-91-4-pvf-quality-repair-pvf-closeout-truth-and-manifest-contract-drift-sip-md-adl-v0-91-4-tasks-issue-3464-v0-91-4-pvf-quality-repair-pvf-closeout-truth-and-manifest-contract-drift-sor-md