### PR TITLE
[v0.91.4][Sprint 3][quality] Repair sprint closeout truth and helper closure gates

### DIFF
--- a/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
@@ -41,6 +41,19 @@ def require_clean_close_boundary(state: dict) -> None:
         )
 
 
+def require_closeout_artifact(state: dict) -> None:
+    closeout = state.get('closeout') or {}
+    closeout_artifact_path = closeout.get('closeout_artifact_path')
+    if not closeout_artifact_path:
+        raise SystemExit('Cannot close sprint-management issue because no retained sprint closeout artifact is recorded in state.')
+    artifact_path = Path(closeout_artifact_path)
+    if not artifact_path.exists():
+        raise SystemExit(
+            'Cannot close sprint-management issue because the retained sprint closeout artifact is missing: '
+            f'{closeout_artifact_path}.'
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--state', required=True)
@@ -55,6 +68,7 @@ def main() -> int:
         raise SystemExit('Cannot close sprint-management issue because sprint_issue_number is missing from state.')
     require_child_closeout_truth(state)
     require_clean_close_boundary(state)
+    require_closeout_artifact(state)
 
     subprocess.check_call(
         [

--- a/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
@@ -79,10 +79,17 @@ def select_next_issue(state: dict[str, Any]) -> None:
         state['current_issue_number'] = state['blocked_issue_number']
         state['continuation'] = 'ask_operator'
         return
+    issue_statuses = {
+        record.get('issue_number'): record.get('status', 'pending')
+        for record in state.get('issue_records', [])
+    }
     for issue in state.get('ordered_issue_numbers', []):
         if issue not in completed:
             state['current_issue_number'] = issue
-            state['continuation'] = 'continue'
+            if issue_statuses.get(issue) in {'blocked', 'deferred'}:
+                state['continuation'] = 'ask_operator'
+            else:
+                state['continuation'] = 'continue'
             return
     follow_ups = state.get('follow_up_issues', [])
     if any(item.get('disposition') == 'must_land_before_sprint_close' for item in follow_ups):

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -571,6 +571,51 @@ assert state["continuation"] == "continue"
 assert state["truth_check"]["gate_passed"] is False
 PY
 
+deferred_state_path="${tmpdir}/sprint-state-deferred-next.json"
+cp "${state_path}" "${deferred_state_path}"
+python3 - "${deferred_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+state["completed_issue_numbers"] = []
+state["current_issue_number"] = 2827
+state["continuation"] = "continue"
+state["truth_check"] = {
+    "status": "matched",
+    "source": "github_live",
+    "gate_passed": True,
+    "checked_issue_numbers": [2827, 2828],
+    "checked_pr_urls": [],
+    "notes": [],
+}
+record_2827 = next(record for record in state["issue_records"] if record["issue_number"] == 2827)
+record_2827["status"] = "pending"
+record_2828 = next(record for record in state["issue_records"] if record["issue_number"] == 2828)
+record_2828["status"] = "deferred"
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py" \
+  --state "${deferred_state_path}" \
+  --issue-number 2827 \
+  --issue-closed true \
+  --pr-state merged \
+  --root-sor-status done \
+  --worktree-status pruned >/dev/null
+
+python3 - "${deferred_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+assert state["current_issue_number"] == 2828
+assert state["continuation"] == "ask_operator"
+PY
+
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
   --repo-root "${fake_repo}" \
   --state "${state_path}" \
@@ -743,6 +788,26 @@ if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_
   --state "${must_land_state_path}" \
   --summary "Should fail because must-land follow-ups remain." >/dev/null 2>&1; then
   echo "expected close_sprint_issue.py to refuse sprint close when must-land follow-up issues remain" >&2
+  exit 1
+fi
+
+missing_artifact_state_path="${tmpdir}/sprint-state-missing-artifact.json"
+cp "${state_path}" "${missing_artifact_state_path}"
+python3 - "${missing_artifact_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+state.pop("closeout", None)
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+  --state "${missing_artifact_state_path}" \
+  --summary "Should fail because no closeout artifact is recorded." >/dev/null 2>&1; then
+  echo "expected close_sprint_issue.py to refuse sprint close when no retained closeout artifact is recorded" >&2
   exit 1
 fi
 

--- a/docs/milestones/v0.91.4/FIVE_MINUTE_SPRINT_REPEATABILITY_REPORT_2026-05-27.md
+++ b/docs/milestones/v0.91.4/FIVE_MINUTE_SPRINT_REPEATABILITY_REPORT_2026-05-27.md
@@ -32,7 +32,7 @@ is GitHub PR timing plus the tracked issue proof shape.
 
 | Issue / PR | Surface | Commit authored | PR opened | PR merged | Prep-to-open | Open-to-merge | Validation / proof shape | Takeaway |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `#3420` / `#3420` | Real infra/product-sidecar lane | `2026-05-27T18:24:07Z` | `2026-05-27T18:24:22Z` | `2026-05-27T18:31:58Z` | `15s` | `7m36s` | Terraform/apply and live HTTPS verification; real AWS substrate work | Substantive product/infrastructure work can still publish quickly when the proof surface is narrow and the substrate is already reachable. |
+| `#3375` / `#3420` | Real infra/product-sidecar lane | `2026-05-27T18:24:07Z` | `2026-05-27T18:24:22Z` | `2026-05-27T18:31:58Z` | `15s` | `7m36s` | Terraform/apply and live HTTPS verification; real AWS substrate work | Substantive product/infrastructure work can still publish quickly when the proof surface is narrow and the substrate is already reachable. |
 | `#3423` / `#3427` | Docs/process lane | `2026-05-27T18:41:17Z` | `2026-05-27T18:41:21Z` | `2026-05-27T18:43:00Z` | `4s` | `1m39s` | Docs-only issue with bounded review and focused doc-truth checks | Docs/process transitions can complete well inside a five-minute claim envelope when no broad validation tail is required. |
 | `#3358` / `#3440` | Core C-SDLC tools lane | `2026-05-27T19:58:31Z` | `2026-05-27T19:58:34Z` | `2026-05-27T20:34:28Z` | `3s` | `35m54s` | Focused sprint-conductor helper proof passed quickly; default publish lane widened into monolithic Rust validation and nextest | The local issue work can be quick while the validation tail remains long. Counting the whole tail as “five-minute sprint” would be misleading. |
 


### PR DESCRIPTION
## Summary
- repair Sprint 3 helper closure behavior for deferred-next-issue and missing closeout-artifact cases
- add focused regression coverage for those two control-plane paths
- correct the repeatability packet issue/PR identity row and close Sprint 3 cleanly in local retained/canonical .adl state

## Validation
- `bash adl/tools/test_sprint_conductor_helpers.sh`
- `git diff --check`
- local Sprint 3 closeout flow using repaired sprint-conductor scripts against `.adl/reviews/sprint-3357-state.json`

Closes #3466
