### PR TITLE
[v0.91.4][multi-agent][tools] Implement shard admission and assignment planner

### DIFF
--- a/adl/tools/plan_multi_agent_workcell.py
+++ b/adl/tools/plan_multi_agent_workcell.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+READY_CARD_STATUSES = {"ready", "approved"}
+STATUS_ORDER = [
+    "ready",
+    "serial_only",
+    "review_ready",
+    "janitor_ready",
+    "closeout_ready",
+    "blocked",
+]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def paths_overlap(left: str, right: str) -> bool:
+    left_clean = left.rstrip("/")
+    right_clean = right.rstrip("/")
+    return (
+        left_clean == right_clean
+        or left_clean.startswith(right_clean + "/")
+        or right_clean.startswith(left_clean + "/")
+    )
+
+
+def worker_cards_ready(cards: dict[str, str]) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    for card_name in ("sip", "stp", "spp"):
+        if cards.get(card_name) not in READY_CARD_STATUSES:
+            reasons.append(f"{card_name.upper()} not ready")
+    return (not reasons, reasons)
+
+
+def dependency_blockers(shard: dict[str, Any], shards_by_id: dict[str, dict[str, Any]]) -> list[str]:
+    reasons: list[str] = []
+    shard_dependency_state = shard.get("dependency_state", "none")
+    if shard_dependency_state not in {"none", "satisfied", "independent"}:
+        reasons.append(f"dependency state is {shard_dependency_state}")
+    for dep_id in shard.get("dependencies", []):
+        dep = shards_by_id.get(dep_id)
+        if dep is None:
+            reasons.append(f"missing dependency {dep_id}")
+            continue
+        if dep.get("_classification") == "blocked":
+            reasons.append(f"dependency {dep_id} is blocked")
+            continue
+        if dep.get("_base_blocked") is True:
+            reasons.append(f"dependency {dep_id} is blocked")
+            continue
+        dep_state = dep.get("dependency_state", "unknown")
+        if dep_state not in {"none", "satisfied", "independent"}:
+            reasons.append(f"dependency {dep_id} is {dep_state}")
+    return reasons
+
+
+def worker_base_blockers(shard: dict[str, Any], conflicts: dict[str, list[str]]) -> list[str]:
+    shard_id = shard["shard_id"]
+    if conflicts.get(shard_id):
+        return conflicts[shard_id]
+    cards_ok, card_reasons = worker_cards_ready(shard.get("cards", {}))
+    if not cards_ok:
+        return card_reasons
+    if not shard.get("write_paths"):
+        return ["worker shard missing write_paths"]
+    return []
+
+
+def collect_conflicts(shards: list[dict[str, Any]]) -> dict[str, list[str]]:
+    conflicts: dict[str, list[str]] = {shard["shard_id"]: [] for shard in shards}
+    for index, left in enumerate(shards):
+        for right in shards[index + 1 :]:
+            for left_path in left.get("write_paths", []):
+                for right_path in right.get("write_paths", []):
+                    if paths_overlap(left_path, right_path):
+                        conflicts[left["shard_id"]].append(
+                            f"write-set conflict with {right['shard_id']} ({left_path} vs {right_path})"
+                        )
+                        conflicts[right["shard_id"]].append(
+                            f"write-set conflict with {left['shard_id']} ({right_path} vs {left_path})"
+                        )
+    return conflicts
+
+
+def classify_shard(
+    shard: dict[str, Any],
+    shards_by_id: dict[str, dict[str, Any]],
+    conflicts: dict[str, list[str]],
+) -> tuple[str, list[str]]:
+    shard_id = shard["shard_id"]
+    role = shard.get("role", "worker")
+    reasons: list[str] = []
+
+    if role == "worker":
+        base_blockers = worker_base_blockers(shard, conflicts)
+        if base_blockers:
+            return "blocked", base_blockers
+        dep_reasons = dependency_blockers(shard, shards_by_id)
+        if dep_reasons:
+            return "blocked", dep_reasons
+        validation_lane = shard.get("validation_lane", "")
+        if validation_lane == "manual" or shard.get("serialized_gate") is True:
+            reasons.append("requires serialized validation/review gate")
+            return "serial_only", reasons
+        return "ready", ["worker shard is assignment-ready"]
+
+    if role == "reviewer":
+        if shard.get("review_input_state") == "ready":
+            return "review_ready", ["review lane has published shard input"]
+        return "blocked", ["review lane missing reviewable input"]
+
+    if role == "janitor":
+        if shard.get("pr_blocker_state") == "blocked_pr":
+            return "janitor_ready", ["PR blocker present for janitor lane"]
+        return "blocked", ["janitor lane has no explicit PR blocker"]
+
+    if role == "closeout":
+        if shard.get("closeout_state") == "ready":
+            return "closeout_ready", ["closeout lane has merged/closed shard truth to finalize"]
+        return "blocked", ["closeout lane not yet ready"]
+
+    return "blocked", [f"unknown role {role}"]
+
+
+def plan_parallel_workers(results: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    ready_workers = [item["shard_id"] for item in results if item["classification"] == "ready"]
+    serial_workers = [item["shard_id"] for item in results if item["classification"] == "serial_only"]
+    return ready_workers, serial_workers
+
+
+def build_report(data: dict[str, Any]) -> dict[str, Any]:
+    shards = data.get("shards", [])
+    if not isinstance(shards, list) or not shards:
+        raise SystemExit("manifest must contain a non-empty shards list")
+
+    shards_by_id = {shard["shard_id"]: shard for shard in shards}
+    conflicts = collect_conflicts(shards)
+    for shard in shards:
+        if shard.get("role", "worker") == "worker":
+            shard["_base_blocked"] = bool(worker_base_blockers(shard, conflicts))
+            shard["_classification"] = "blocked" if shard["_base_blocked"] else "unknown"
+        else:
+            shard["_base_blocked"] = False
+            shard["_classification"] = "unknown"
+
+    for _ in range(len(shards) + 1):
+        changed = False
+        for shard in shards:
+            classification, reasons = classify_shard(shard, shards_by_id, conflicts)
+            if (
+                shard.get("_classification") != classification
+                or shard.get("_reasons") != reasons
+            ):
+                shard["_classification"] = classification
+                shard["_reasons"] = reasons
+                changed = True
+        if not changed:
+            break
+
+    results = []
+    for shard in shards:
+        results.append(
+            {
+                "shard_id": shard["shard_id"],
+                "issue_number": shard.get("issue_number"),
+                "role": shard.get("role", "worker"),
+                "execution_backend": shard.get("execution_backend"),
+                "model_hint": shard.get("model_hint"),
+                "classification": shard.get("_classification"),
+                "reasons": shard.get("_reasons", []),
+                "write_paths": shard.get("write_paths", []),
+            }
+        )
+
+    ordered_results = sorted(results, key=lambda item: (STATUS_ORDER.index(item["classification"]), item["shard_id"]))
+    ready_workers, serial_workers = plan_parallel_workers(ordered_results)
+    return {
+        "manifest_id": data.get("manifest_id", "unknown-manifest"),
+        "safe_parallel_workers": ready_workers,
+        "serial_only_workers": serial_workers,
+        "results": ordered_results,
+        "limitations": [
+            "planner does not assign or launch agents automatically",
+            "write-set safety depends on declared write_paths, not inferred edits",
+            "review/janitor/closeout lanes remain bounded lifecycle states rather than autonomous execution",
+        ],
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = []
+    lines.append(f"Multi-Agent Workcell Assignment Plan: {report['manifest_id']}")
+    lines.append("")
+    if report["safe_parallel_workers"]:
+        lines.append("Safe parallel worker set:")
+        for shard_id in report["safe_parallel_workers"]:
+            lines.append(f"- {shard_id}")
+    else:
+        lines.append("Safe parallel worker set: none")
+    lines.append("")
+    if report["serial_only_workers"]:
+        lines.append("Serial-only worker set:")
+        for shard_id in report["serial_only_workers"]:
+            lines.append(f"- {shard_id}")
+        lines.append("")
+    lines.append("Shard classifications:")
+    for item in report["results"]:
+        reason_text = "; ".join(item["reasons"]) if item["reasons"] else "no notes"
+        backend_suffix = ""
+        if item.get("execution_backend") or item.get("model_hint"):
+            backend = item.get("execution_backend") or "unspecified-backend"
+            model = item.get("model_hint") or "unspecified-model"
+            backend_suffix = f", backend={backend}, model={model}"
+        lines.append(
+            f"- {item['shard_id']} (issue #{item.get('issue_number')}, role={item['role']}{backend_suffix}): "
+            f"{item['classification']} — {reason_text}"
+        )
+    lines.append("")
+    lines.append("Planner limitations:")
+    for limitation in report["limitations"]:
+        lines.append(f"- {limitation}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest")
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    report = build_report(load_json(manifest_path))
+    print(render_text(report))
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_plan_multi_agent_workcell.sh
+++ b/adl/tools/test_plan_multi_agent_workcell.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+planner="$repo_root/adl/tools/plan_multi_agent_workcell.py"
+allowed_fixture="$repo_root/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_allowed.json"
+blocked_fixture="$repo_root/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_blocked.json"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+allowed_json="$tmpdir/allowed.json"
+blocked_json="$tmpdir/blocked.json"
+
+python3 "$planner" "$allowed_fixture" --json-out "$allowed_json" > "$tmpdir/allowed.txt"
+python3 "$planner" "$blocked_fixture" --json-out "$blocked_json" > "$tmpdir/blocked.txt"
+
+grep -Fq 'Safe parallel worker set:' "$tmpdir/allowed.txt"
+grep -Fq -- '- ollama-worker-a' "$tmpdir/allowed.txt"
+grep -Fq -- '- codex-worker-b' "$tmpdir/allowed.txt"
+grep -Fq 'serialized-worker-c (issue #4003, role=worker, backend=local_ollama, model=mistral-small3.2:24b): serial_only' "$tmpdir/allowed.txt"
+grep -Fq 'independent-reviewer (issue #4004, role=reviewer): review_ready' "$tmpdir/allowed.txt"
+grep -Fq 'pr-janitor (issue #4005, role=janitor): janitor_ready' "$tmpdir/allowed.txt"
+grep -Fq 'closeout-lane (issue #4006, role=closeout): closeout_ready' "$tmpdir/allowed.txt"
+grep -Fq 'codex-worker-b (issue #4002, role=worker, backend=hosted_codex, model=gpt-5.5-codex): ready' "$tmpdir/allowed.txt"
+grep -Fq 'ollama-worker-a (issue #4001, role=worker, backend=local_ollama, model=qwen2.5-coder:32b): ready' "$tmpdir/allowed.txt"
+
+grep -Fq 'conflict-worker-a (issue #4011, role=worker, backend=local_ollama, model=qwen2.5-coder:32b): blocked' "$tmpdir/blocked.txt"
+grep -Fq 'conflict-worker-b (issue #4012, role=worker, backend=hosted_codex, model=gpt-5.5-codex): blocked' "$tmpdir/blocked.txt"
+grep -Fq 'not-ready-worker (issue #4013, role=worker, backend=local_ollama, model=mistral-small3.2:24b): blocked' "$tmpdir/blocked.txt"
+grep -Fq 'blocked-dependency-worker (issue #4014, role=worker, backend=hosted_codex, model=gpt-5.5-codex): blocked' "$tmpdir/blocked.txt"
+grep -Fq 'transitive-dependent-worker (issue #4015, role=worker, backend=local_ollama, model=qwen2.5-coder:32b): blocked' "$tmpdir/blocked.txt"
+
+python3 - "$allowed_json" "$blocked_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+allowed = json.loads(Path(sys.argv[1]).read_text())
+blocked = json.loads(Path(sys.argv[2]).read_text())
+assert allowed["safe_parallel_workers"] == ["codex-worker-b", "ollama-worker-a"]
+assert allowed["serial_only_workers"] == ["serialized-worker-c"]
+status_map = {item["shard_id"]: item["classification"] for item in allowed["results"]}
+backend_map = {item["shard_id"]: item["execution_backend"] for item in allowed["results"]}
+model_map = {item["shard_id"]: item["model_hint"] for item in allowed["results"]}
+assert status_map["independent-reviewer"] == "review_ready"
+assert status_map["pr-janitor"] == "janitor_ready"
+assert status_map["closeout-lane"] == "closeout_ready"
+assert backend_map["ollama-worker-a"] == "local_ollama"
+assert backend_map["codex-worker-b"] == "hosted_codex"
+assert model_map["codex-worker-b"] == "gpt-5.5-codex"
+blocked_map = {item["shard_id"]: item["classification"] for item in blocked["results"]}
+assert set(blocked_map.values()) == {"blocked"}
+assert blocked_map["transitive-dependent-worker"] == "blocked"
+PY
+
+echo "PASS test_plan_multi_agent_workcell"

--- a/docs/milestones/v0.91.4/features/MULTI_AGENT_SHARD_ASSIGNMENT_PLANNER.md
+++ b/docs/milestones/v0.91.4/features/MULTI_AGENT_SHARD_ASSIGNMENT_PLANNER.md
@@ -1,0 +1,121 @@
+# Multi-Agent Shard Assignment Planner
+
+## Status
+
+Planned `v0.91.4` feature and the bounded admission surface for the multi-agent
+C-SDLC workcell proof.
+
+## Purpose
+
+Provide a simple, auditable planner that helps the conductor decide which shards
+are safe to assign in parallel and which must remain blocked or serialized.
+
+The planner is advisory. It does not launch agents, merge work, or close issues.
+
+## Entry Surface
+
+- CLI: `adl/tools/plan_multi_agent_workcell.py <manifest.json> [--json-out <path>]`
+- Input: one small JSON manifest describing candidate shards
+- Output:
+  - human-readable assignment plan on stdout
+  - optional machine-readable JSON report
+
+## Manifest Contract
+
+Each shard record may declare:
+- `shard_id`
+- `issue_number`
+- `role`: `worker`, `reviewer`, `janitor`, or `closeout`
+- `execution_backend` for bounded provider/runtime identity such as
+  `local_ollama` or `hosted_codex`
+- `model_hint` for the intended local or hosted model lane
+- `cards` readiness for worker lanes
+- `write_paths`
+- `dependencies`
+- `dependency_state`
+- lane-specific readiness fields such as:
+  - `review_input_state`
+  - `pr_blocker_state`
+  - `closeout_state`
+  - `validation_lane`
+  - `serialized_gate`
+
+## Classification Vocabulary
+
+The planner classifies each shard as one of:
+- `ready`
+- `serial_only`
+- `review_ready`
+- `janitor_ready`
+- `closeout_ready`
+- `blocked`
+
+## Current Rules
+
+### Worker lanes
+
+A worker lane is `ready` only when:
+- `SIP`, `STP`, and `SPP` are all `ready` or `approved`
+- it has at least one declared `write_path`
+- its declared dependencies are satisfied
+- its write set does not overlap any other candidate worker write set
+- it does not require a serialized validation or review gate
+
+A worker lane becomes `serial_only` when it is otherwise admissible but carries a
+manual or explicitly serialized validation gate.
+
+A worker lane becomes `blocked` when:
+- a required readiness card is not ready
+- a dependency is missing or blocked
+- its write set overlaps another candidate write set
+- it omits required write-scope declaration
+
+### Reviewer lanes
+
+Reviewer lanes become `review_ready` only when reviewable shard input already
+exists. Otherwise they are `blocked`.
+
+### Janitor lanes
+
+Janitor lanes become `janitor_ready` only when there is an explicit PR blocker
+for a bounded repair. Otherwise they are `blocked`.
+
+### Closeout lanes
+
+Closeout lanes become `closeout_ready` only when merged/closed shard truth is
+ready to finalize. Otherwise they are `blocked`.
+
+## Safe Parallel Set
+
+The planner emits a `safe_parallel_workers` set containing worker shards that can
+run concurrently under the current manifest.
+
+The planner also emits `serial_only_workers` for worker shards that are valid
+but must remain behind a serialized gate.
+
+## Limitations
+
+- The planner trusts declared `write_paths`; it does not infer edits from code.
+- It is a conductor aid, not an autonomous scheduler.
+- It does not replace sprint-conductor or workflow-conductor lifecycle routing.
+- Reviewer, janitor, and closeout lanes remain explicit lifecycle lanes rather
+  than general-purpose worker execution.
+
+## Fixtures
+
+- allowed fixture:
+  - `docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_allowed.json`
+- blocked fixture:
+  - `docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_blocked.json`
+
+The allowed fixture is intentionally shaped like the later bounded proof goal:
+- one local Ollama-style worker lane
+- one hosted Codex-style worker lane
+- one serialized worker lane
+- one independent reviewer lane
+- one janitor lane
+- one closeout lane
+
+These provider/runtime distinctions are carried as explicit manifest data so the
+later proof sprint can demonstrate heterogeneous lane planning without
+pretending that the planner itself launches those agents.

--- a/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_allowed.json
+++ b/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_allowed.json
@@ -1,0 +1,63 @@
+{
+  "manifest_id": "ma-csdlc-allowed",
+  "shards": [
+    {
+      "shard_id": "ollama-worker-a",
+      "issue_number": 4001,
+      "role": "worker",
+      "execution_backend": "local_ollama",
+      "model_hint": "qwen2.5-coder:32b",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/worker-a.md"],
+      "dependencies": [],
+      "dependency_state": "none",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "codex-worker-b",
+      "issue_number": 4002,
+      "role": "worker",
+      "execution_backend": "hosted_codex",
+      "model_hint": "gpt-5.5-codex",
+      "cards": {"sip": "ready", "stp": "approved", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/worker-b.md"],
+      "dependencies": [],
+      "dependency_state": "none",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "serialized-worker-c",
+      "issue_number": 4003,
+      "role": "worker",
+      "execution_backend": "local_ollama",
+      "model_hint": "mistral-small3.2:24b",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["adl/tools/run_sensitive_lane.sh"],
+      "dependencies": ["ollama-worker-a"],
+      "dependency_state": "satisfied",
+      "validation_lane": "manual",
+      "serialized_gate": true
+    },
+    {
+      "shard_id": "independent-reviewer",
+      "issue_number": 4004,
+      "role": "reviewer",
+      "review_input_state": "ready",
+      "write_paths": []
+    },
+    {
+      "shard_id": "pr-janitor",
+      "issue_number": 4005,
+      "role": "janitor",
+      "pr_blocker_state": "blocked_pr",
+      "write_paths": []
+    },
+    {
+      "shard_id": "closeout-lane",
+      "issue_number": 4006,
+      "role": "closeout",
+      "closeout_state": "ready",
+      "write_paths": []
+    }
+  ]
+}

--- a/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_blocked.json
+++ b/docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_blocked.json
@@ -1,0 +1,65 @@
+{
+  "manifest_id": "ma-csdlc-blocked",
+  "shards": [
+    {
+      "shard_id": "conflict-worker-a",
+      "issue_number": 4011,
+      "role": "worker",
+      "execution_backend": "local_ollama",
+      "model_hint": "qwen2.5-coder:32b",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/shared-surface.md"],
+      "dependencies": [],
+      "dependency_state": "none",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "conflict-worker-b",
+      "issue_number": 4012,
+      "role": "worker",
+      "execution_backend": "hosted_codex",
+      "model_hint": "gpt-5.5-codex",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/shared-surface.md"],
+      "dependencies": [],
+      "dependency_state": "none",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "not-ready-worker",
+      "issue_number": 4013,
+      "role": "worker",
+      "execution_backend": "local_ollama",
+      "model_hint": "mistral-small3.2:24b",
+      "cards": {"sip": "ready", "stp": "draft", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/not-ready.md"],
+      "dependencies": [],
+      "dependency_state": "none",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "blocked-dependency-worker",
+      "issue_number": 4014,
+      "role": "worker",
+      "execution_backend": "hosted_codex",
+      "model_hint": "gpt-5.5-codex",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/dependency.md"],
+      "dependencies": ["conflict-worker-a"],
+      "dependency_state": "blocked",
+      "validation_lane": "focused_docs"
+    },
+    {
+      "shard_id": "transitive-dependent-worker",
+      "issue_number": 4015,
+      "role": "worker",
+      "execution_backend": "local_ollama",
+      "model_hint": "qwen2.5-coder:32b",
+      "cards": {"sip": "ready", "stp": "ready", "spp": "approved"},
+      "write_paths": ["docs/milestones/v0.91.4/features/transitive.md"],
+      "dependencies": ["blocked-dependency-worker"],
+      "dependency_state": "satisfied",
+      "validation_lane": "focused_docs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a bounded multi-agent workcell planner CLI that classifies worker, reviewer, janitor, and closeout lanes for conductor review
- add allowed and blocked fixtures, including local Ollama and hosted Codex worker-lane representation plus transitive dependency blocking
- document the planner contract and add focused planner regression coverage

## Validation
- `bash -n adl/tools/test_plan_multi_agent_workcell.sh`
- `python3 adl/tools/plan_multi_agent_workcell.py docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_allowed.json --json-out /tmp/ma_allowed.json`
- `python3 adl/tools/plan_multi_agent_workcell.py docs/milestones/v0.91.4/review/multi_agent_workcell/fixtures/workcell_assignment_blocked.json --json-out /tmp/ma_blocked.json`
- `bash adl/tools/test_plan_multi_agent_workcell.sh`
- `git diff --check`
- bounded subagent review

Closes #3417
