### PR TITLE
[v0.91.4][provider] Implement Rust hosted and Ollama provider adapter

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/bin/adl_remote.rs"
 
 [[bin]]
 name = "adl-provider-adapter"
-path = "src/bin/adl_provider_adapter.rs"
+path = "tools/adl_provider_adapter.rs"
 
 [features]
 # Heavy runtime_v2 proof-materialization and CLI proof-smoke tests stay out of

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/main.rs"
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 
+[[bin]]
+name = "adl-provider-adapter"
+path = "src/bin/adl_provider_adapter.rs"
+
 [features]
 # Heavy runtime_v2 proof-materialization and CLI proof-smoke tests stay out of
 # ordinary `cargo test` but remain covered by authoritative `--all-features`

--- a/adl/src/bin/adl_provider_adapter.rs
+++ b/adl/src/bin/adl_provider_adapter.rs
@@ -20,7 +20,10 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    let args = Args::parse();
+    run(Args::parse())
+}
+
+fn run(args: Args) -> Result<()> {
     let request_text = fs::read_to_string(&args.request)
         .with_context(|| format!("read request file {}", args.request.display()))?;
     let request: ProviderInvocationRequestV1 = serde_json::from_str(&request_text)
@@ -38,4 +41,89 @@ fn main() -> Result<()> {
     println!("run_log={}", args.log.display());
     println!("watch=tail -f {}", args.log.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use adl::provider_communication::ProviderInvocationFinalStatusV1;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("adl-provider-adapter-cli-{name}-{stamp}.json"))
+    }
+
+    #[test]
+    fn cli_run_writes_result_and_tail_log_for_normalized_failure() {
+        let request = temp_path("request");
+        let out = temp_path("result");
+        let log = temp_path("log");
+        fs::write(
+            &request,
+            r#"{
+  "route": {
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "runtime_surface": "hosted_api",
+    "provider_model_id": "test-model",
+    "credential_ref": "env:ADL_PROVIDER_ADAPTER_CLI_MISSING_KEY"
+  },
+  "model_identity": {
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "model_ref": "test-model",
+    "provider_model_id": "test-model",
+    "runtime_surface": "hosted_api",
+    "identity_strength": "provider_asserted",
+    "observed_at": "unix:1"
+  },
+  "prompt_contract_ref": "test.prompt.v1",
+  "lane_ref": "regular",
+  "run_id": "run-cli-test",
+  "request_id": "req-cli-test",
+  "attempt_policy": {
+    "max_attempts": 1,
+    "timeout_ms": 1000,
+    "retry_backoff_ms": 1
+  },
+  "input_text": "secret prompt should not enter logs"
+}
+"#,
+        )
+        .unwrap();
+
+        run(Args {
+            request: request.clone(),
+            out: out.clone(),
+            log: log.clone(),
+        })
+        .unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(
+            result
+                .get("final_status")
+                .and_then(serde_json::Value::as_str),
+            Some("failed")
+        );
+        assert_eq!(
+            result
+                .pointer("/failure/kind")
+                .and_then(serde_json::Value::as_str),
+            Some("provider_auth_missing")
+        );
+        let log_text = fs::read_to_string(&log).unwrap();
+        assert!(log_text.contains("run-cli-test"));
+        assert!(!log_text.contains("secret prompt"));
+
+        let _ = fs::remove_file(request);
+        let _ = fs::remove_file(out);
+        let _ = fs::remove_file(log);
+        let _ = ProviderInvocationFinalStatusV1::Failed;
+    }
 }

--- a/adl/src/bin/adl_provider_adapter.rs
+++ b/adl/src/bin/adl_provider_adapter.rs
@@ -1,0 +1,41 @@
+use adl::provider_adapter::execute_provider_invocation;
+use adl::provider_communication::{ProviderInvocationRequestV1, ProviderRunLoggerV1};
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(name = "adl-provider-adapter")]
+#[command(about = "Run one ADL provider invocation through the Rust provider adapter")]
+struct Args {
+    #[arg(long)]
+    request: PathBuf,
+
+    #[arg(long)]
+    out: PathBuf,
+
+    #[arg(long)]
+    log: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let request_text = fs::read_to_string(&args.request)
+        .with_context(|| format!("read request file {}", args.request.display()))?;
+    let request: ProviderInvocationRequestV1 = serde_json::from_str(&request_text)
+        .with_context(|| format!("parse request file {}", args.request.display()))?;
+    let run_id = request
+        .run_id
+        .clone()
+        .unwrap_or_else(|| format!("{}:{}", request.lane_ref, request.route.provider_model_id));
+    let mut logger = ProviderRunLoggerV1::create(&args.log, run_id)
+        .with_context(|| format!("open run log {}", args.log.display()))?;
+    let result = execute_provider_invocation(request, &mut logger);
+    fs::write(&args.out, serde_json::to_string_pretty(&result)? + "\n")
+        .with_context(|| format!("write result file {}", args.out.display()))?;
+    println!("result={}", args.out.display());
+    println!("run_log={}", args.log.display());
+    println!("watch=tail -f {}", args.log.display());
+    Ok(())
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -62,6 +62,7 @@ pub mod plan;
 pub mod policy_authority;
 pub mod prompt;
 pub mod provider;
+pub mod provider_adapter;
 pub mod provider_communication;
 pub mod provider_extension_packaging;
 pub mod provider_native_tool_call_comparison;

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -63,6 +63,7 @@ pub mod policy_authority;
 pub mod prompt;
 pub mod provider;
 pub mod provider_adapter;
+pub mod provider_adapter_cli;
 pub mod provider_communication;
 pub mod provider_extension_packaging;
 pub mod provider_native_tool_call_comparison;

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -387,37 +387,81 @@ fn refresh_ollama_identity(
     request: &mut ProviderInvocationRequestV1,
     policy: &ProviderAttemptPolicyV1,
 ) {
-    let url = ollama_show_url(request.route.endpoint_ref.as_deref());
-    let Ok(response) = client(policy).and_then(|client| {
-        client
-            .post(url)
-            .json(&json!({"model": request.route.provider_model_id}))
-            .send()
-            .map_err(map_reqwest_error)
-    }) else {
-        return;
-    };
-    if !response.status().is_success() {
-        return;
-    }
-    let Ok(body) = response.text() else {
-        return;
-    };
-    let Ok(json) = serde_json::from_str::<Value>(&body) else {
-        return;
-    };
-    let digest = json
-        .get("digest")
-        .and_then(Value::as_str)
-        .or_else(|| json.pointer("/details/digest").and_then(Value::as_str));
+    let digest =
+        ollama_show_digest(request, policy).or_else(|| ollama_tags_digest(request, policy));
     if digest.is_some() {
         request.model_identity = ollama_model_identity(
             request.route.provider_model_id.clone(),
             request.route.provider_model_id.clone(),
-            digest,
+            digest.as_deref(),
             request.route.source_registry.clone(),
         );
     }
+}
+
+fn ollama_show_digest(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> Option<String> {
+    let response = client(policy)
+        .ok()?
+        .post(ollama_show_url(request.route.endpoint_ref.as_deref()))
+        .json(&json!({"model": request.route.provider_model_id}))
+        .send()
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let json = serde_json::from_str::<Value>(&response.text().ok()?).ok()?;
+    json.get("digest")
+        .and_then(Value::as_str)
+        .or_else(|| json.pointer("/details/digest").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn ollama_tags_digest(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> Option<String> {
+    let response = client(policy)
+        .ok()?
+        .get(ollama_tags_url(request.route.endpoint_ref.as_deref()))
+        .send()
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let json = serde_json::from_str::<Value>(&response.text().ok()?).ok()?;
+    json.get("models")?
+        .as_array()?
+        .iter()
+        .find(|model| {
+            model.get("name").and_then(Value::as_str) == Some(&request.route.provider_model_id)
+                || model.get("model").and_then(Value::as_str)
+                    == Some(&request.route.provider_model_id)
+        })
+        .and_then(|model| model.get("digest").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn ollama_tags_url(endpoint_ref: Option<&str>) -> String {
+    if let Some(endpoint) = endpoint_ref {
+        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+            let trimmed = endpoint.trim_end_matches('/');
+            if trimmed.ends_with("/api/tags") {
+                return trimmed.to_string();
+            }
+            if trimmed.ends_with("/api/generate") {
+                return trimmed.trim_end_matches("/api/generate").to_string() + "/api/tags";
+            }
+            if trimmed.ends_with("/api/show") {
+                return trimmed.trim_end_matches("/api/show").to_string() + "/api/tags";
+            }
+            return format!("{trimmed}/api/tags");
+        }
+    }
+    let base = env::var("OLLAMA_HOST").unwrap_or_else(|_| DEFAULT_OLLAMA_BASE_URL.to_string());
+    format!("{}/api/tags", base.trim_end_matches('/'))
 }
 
 fn ollama_show_url(endpoint_ref: Option<&str>) -> String {
@@ -637,8 +681,9 @@ mod tests {
     #[test]
     fn ollama_adapter_returns_output_and_redacts_log() {
         let endpoint = scripted_server(vec![
+            (r#"{}"#, "200 OK"),
             (
-                r#"{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+                r#"{"models":[{"name":"test-model","digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}"#,
                 "200 OK",
             ),
             (r#"{"response":"ollama success"}"#, "200 OK"),
@@ -695,6 +740,7 @@ mod tests {
     fn ollama_missing_model_is_not_reported_as_busy() {
         let endpoint = scripted_server(vec![
             (r#"{}"#, "200 OK"),
+            (r#"{"models":[]}"#, "200 OK"),
             (r#"{"error":"model test-model not found"}"#, "404 Not Found"),
         ]);
         let path = temp_log("ollama-missing-model");

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -615,14 +615,13 @@ mod tests {
 
     #[test]
     fn hosted_openai_adapter_returns_output_and_redacts_log() {
-        env::set_var("ADL_PROVIDER_ADAPTER_TEST_KEY", "test-key");
+        env::set_var("ADL_PROVIDER_ADAPTER_HOSTED_SUCCESS_KEY", "test-key");
         let endpoint = one_shot_server(r#"{"output_text":"adapter success"}"#, "200 OK");
         let path = temp_log("hosted");
         let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
-        let result = execute_provider_invocation(
-            request(RuntimeSurfaceV1::HostedApi, endpoint),
-            &mut logger,
-        );
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_HOSTED_SUCCESS_KEY".to_string());
+        let result = execute_provider_invocation(req, &mut logger);
         drop(logger);
 
         assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
@@ -632,7 +631,7 @@ mod tests {
         assert!(!log.contains("secret prompt"));
         assert!(!log.contains("adapter success"));
         let _ = fs::remove_file(path);
-        env::remove_var("ADL_PROVIDER_ADAPTER_TEST_KEY");
+        env::remove_var("ADL_PROVIDER_ADAPTER_HOSTED_SUCCESS_KEY");
     }
 
     #[test]
@@ -662,6 +661,55 @@ mod tests {
         assert!(log.contains("attempt_success"));
         assert!(!log.contains("secret prompt"));
         assert!(!log.contains("ollama success"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn openai_output_array_shape_is_supported() {
+        env::set_var("ADL_PROVIDER_ADAPTER_OPENAI_ARRAY_KEY", "test-key");
+        let endpoint = one_shot_server(
+            r#"{"output":[{"content":[{"text":"array success"}]}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("openai-array");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_OPENAI_ARRAY_KEY".to_string());
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("array success"));
+        assert_eq!(
+            result
+                .attempts
+                .first()
+                .and_then(|attempt| attempt.http_status),
+            Some(200)
+        );
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_OPENAI_ARRAY_KEY");
+    }
+
+    #[test]
+    fn ollama_missing_model_is_not_reported_as_busy() {
+        let endpoint = scripted_server(vec![
+            (r#"{}"#, "200 OK"),
+            (r#"{"error":"model test-model not found"}"#, "404 Not Found"),
+        ]);
+        let path = temp_log("ollama-missing-model");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let result = execute_provider_invocation(
+            request(RuntimeSurfaceV1::OllamaHttp, endpoint),
+            &mut logger,
+        );
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderModelUnavailable)
+        );
         let _ = fs::remove_file(path);
     }
 

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -14,6 +14,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const DEFAULT_OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
+const DEFAULT_ANTHROPIC_MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
+const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
 const DEFAULT_BACKOFF_MS: u64 = 1_000;
 
@@ -50,7 +52,7 @@ pub fn execute_provider_invocation(
         let _ = logger.event(event("attempt_start", &request).with_attempt(attempt_index));
 
         let outcome = match request.route.runtime_surface {
-            RuntimeSurfaceV1::HostedApi => execute_hosted_openai(&request, &policy),
+            RuntimeSurfaceV1::HostedApi => execute_hosted(&request, &policy),
             RuntimeSurfaceV1::OllamaHttp => execute_ollama_http(&mut request, &policy),
             RuntimeSurfaceV1::OllamaCli | RuntimeSurfaceV1::Mock | RuntimeSurfaceV1::Unknown => {
                 Err(provider_failure_from_note(
@@ -216,19 +218,28 @@ struct ProviderTextResponse {
     http_status: u16,
 }
 
+fn execute_hosted(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    match request.route.provider.to_ascii_lowercase().as_str() {
+        "openai" | "chatgpt" => execute_hosted_openai(request, policy),
+        "anthropic" | "claude" => execute_hosted_anthropic(request, policy),
+        "google" | "gemini" => execute_hosted_gemini(request, policy),
+        _ => Err(ProviderFailureV1 {
+            kind: ProviderFailureKindV1::ProviderError,
+            retryable: false,
+            message: "unsupported hosted provider".to_string(),
+            provider_error_excerpt: None,
+            http_status: None,
+        }),
+    }
+}
+
 fn execute_hosted_openai(
     request: &ProviderInvocationRequestV1,
     policy: &ProviderAttemptPolicyV1,
 ) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
-    if !request.route.provider.eq_ignore_ascii_case("openai") {
-        return Err(ProviderFailureV1 {
-            kind: ProviderFailureKindV1::ProviderError,
-            retryable: false,
-            message: "hosted adapter currently supports provider=openai only".to_string(),
-            provider_error_excerpt: None,
-            http_status: None,
-        });
-    }
     let key = resolve_credential(request.route.credential_ref.as_deref(), "OPENAI_API_KEY")?;
     let url = request
         .route
@@ -248,6 +259,72 @@ fn execute_hosted_openai(
     decode_text_response(
         response,
         extract_openai_output_text,
+        RuntimeSurfaceV1::HostedApi,
+    )
+}
+
+fn execute_hosted_anthropic(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let key = resolve_credential(request.route.credential_ref.as_deref(), "ANTHROPIC_API_KEY")?;
+    let url = request
+        .route
+        .endpoint_ref
+        .as_deref()
+        .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
+        .unwrap_or(DEFAULT_ANTHROPIC_MESSAGES_URL);
+    let response = client(policy)?
+        .post(url)
+        .header("x-api-key", key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&json!({
+            "model": request.route.provider_model_id,
+            "max_tokens": 256,
+            "messages": [{
+                "role": "user",
+                "content": request.input_text.as_deref().unwrap_or_default(),
+            }],
+        }))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        extract_anthropic_output_text,
+        RuntimeSurfaceV1::HostedApi,
+    )
+}
+
+fn execute_hosted_gemini(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let key = resolve_credential(
+        request.route.credential_ref.as_deref(),
+        if env::var("GEMINI_API_KEY").is_ok() {
+            "GEMINI_API_KEY"
+        } else {
+            "GOOGLE_API_KEY"
+        },
+    )?;
+    let url = gemini_generate_url(
+        request.route.endpoint_ref.as_deref(),
+        &request.route.provider_model_id,
+        &key,
+    );
+    let response = client(policy)?
+        .post(url)
+        .json(&json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": request.input_text.as_deref().unwrap_or_default()}],
+            }],
+        }))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        extract_gemini_output_text,
         RuntimeSurfaceV1::HostedApi,
     )
 }
@@ -326,6 +403,29 @@ fn resolve_credential(
         provider_error_excerpt: None,
         http_status: None,
     })
+}
+
+fn gemini_generate_url(endpoint_ref: Option<&str>, model: &str, key: &str) -> String {
+    let encoded_model = model.trim_start_matches("models/");
+    let base = endpoint_ref
+        .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
+        .unwrap_or(DEFAULT_GEMINI_BASE_URL)
+        .trim_end_matches('/');
+    if base.contains(":generateContent") {
+        append_query_key(base, key)
+    } else if base.ends_with(&format!("models/{encoded_model}")) {
+        append_query_key(&format!("{base}:generateContent"), key)
+    } else {
+        append_query_key(
+            &format!("{base}/models/{encoded_model}:generateContent"),
+            key,
+        )
+    }
+}
+
+fn append_query_key(url: &str, key: &str) -> String {
+    let separator = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{separator}key={key}")
 }
 
 fn ollama_generate_url(endpoint_ref: Option<&str>) -> String {
@@ -502,6 +602,54 @@ fn extract_openai_output_text(json: &Value) -> Option<String> {
         }
     }
     (!chunks.is_empty()).then(|| chunks.join("\n"))
+}
+
+fn extract_anthropic_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    if let Some(content) = json.get("content").and_then(Value::as_array) {
+        for part in content {
+            if part.get("type").and_then(Value::as_str) == Some("text") {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    if !text.trim().is_empty() {
+                        chunks.push(text.to_string());
+                    }
+                }
+            }
+        }
+    }
+    (!chunks.is_empty()).then(|| {
+        chunks.join(
+            "
+",
+        )
+    })
+}
+
+fn extract_gemini_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    if let Some(candidates) = json.get("candidates").and_then(Value::as_array) {
+        for candidate in candidates {
+            if let Some(parts) = candidate
+                .get("content")
+                .and_then(|content| content.get("parts"))
+                .and_then(Value::as_array)
+            {
+                for part in parts {
+                    if let Some(text) = part.get("text").and_then(Value::as_str) {
+                        if !text.trim().is_empty() {
+                            chunks.push(text.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (!chunks.is_empty()).then(|| {
+        chunks.join(
+            "
+",
+        )
+    })
 }
 
 fn redacted_response_marker(text: &str) -> String {
@@ -760,12 +908,74 @@ mod tests {
     }
 
     #[test]
-    fn non_openai_hosted_route_is_rejected_not_misrouted() {
-        let endpoint = one_shot_server(r#"{"output_text":"should not happen"}"#, "200 OK");
-        let path = temp_log("non-openai");
+    fn claude_hosted_adapter_returns_output_and_redacts_log() {
+        env::set_var("ADL_PROVIDER_ADAPTER_CLAUDE_KEY", "test-key");
+        let endpoint = one_shot_server(
+            r#"{"content":[{"type":"text","text":"claude success"}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("claude");
         let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
         let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
         req.route.provider = "anthropic".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_CLAUDE_KEY".to_string());
+        req.model_identity = hosted_model_identity(
+            "anthropic",
+            "claude-test",
+            "test-model",
+            Some("test".to_string()),
+        );
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("claude success"));
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("claude success"));
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_CLAUDE_KEY");
+    }
+
+    #[test]
+    fn gemini_hosted_adapter_returns_output_and_redacts_log() {
+        env::set_var("ADL_PROVIDER_ADAPTER_GEMINI_KEY", "test-key");
+        let endpoint = one_shot_server(
+            r#"{"candidates":[{"content":{"parts":[{"text":"gemini success"}]}}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("gemini");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "gemini".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_GEMINI_KEY".to_string());
+        req.model_identity = hosted_model_identity(
+            "gemini",
+            "gemini-test",
+            "test-model",
+            Some("test".to_string()),
+        );
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("gemini success"));
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("gemini success"));
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_GEMINI_KEY");
+    }
+
+    #[test]
+    fn unsupported_hosted_provider_is_rejected_not_misrouted() {
+        let endpoint = one_shot_server(r#"{"output_text":"should not happen"}"#, "200 OK");
+        let path = temp_log("unsupported-hosted");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "unknown-hosted".to_string();
         let result = execute_provider_invocation(req, &mut logger);
         drop(logger);
 

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -1,0 +1,713 @@
+use crate::model_identity::observed_at_now_v1;
+use crate::provider_communication::{
+    hosted_model_identity, ollama_model_identity, provider_failure_from_note,
+    validate_provider_request, ProviderAttemptPolicyV1, ProviderAttemptStatusV1, ProviderAttemptV1,
+    ProviderFailureKindV1, ProviderFailureV1, ProviderInvocationFinalStatusV1,
+    ProviderInvocationRequestV1, ProviderInvocationResultV1, ProviderRunLogEventV1,
+    ProviderRunLoggerV1, RuntimeSurfaceV1, PROVIDER_COMMUNICATION_SCHEMA_VERSION,
+};
+use anyhow::{anyhow, Result};
+use reqwest::blocking::Client;
+use serde_json::{json, Value};
+use std::env;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const DEFAULT_OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
+const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
+const DEFAULT_BACKOFF_MS: u64 = 1_000;
+
+pub fn execute_provider_invocation(
+    mut request: ProviderInvocationRequestV1,
+    logger: &mut ProviderRunLoggerV1,
+) -> ProviderInvocationResultV1 {
+    ensure_request_identity(&mut request);
+    let started = Instant::now();
+
+    if let Err(error) = validate_adapter_request(&request) {
+        let failure = provider_failure_from_note(&error.to_string(), None);
+        let _ = logger.event(
+            event("run_finish", &request)
+                .with_failure(&failure)
+                .with_status("failed"),
+        );
+        return failed_result(
+            request,
+            Vec::new(),
+            failure,
+            started.elapsed().as_millis() as u64,
+        );
+    }
+
+    let _ = logger.event(event("run_start", &request).with_status("started"));
+    let policy = request.attempt_policy.clone();
+    let mut attempts = Vec::new();
+    let mut final_failure = None;
+
+    for attempt_index in 1..=policy.max_attempts {
+        let attempt_started_at = observed_at_now_v1();
+        let attempt_started = Instant::now();
+        let _ = logger.event(event("attempt_start", &request).with_attempt(attempt_index));
+
+        let outcome = match request.route.runtime_surface {
+            RuntimeSurfaceV1::HostedApi => execute_hosted_openai(&request, &policy),
+            RuntimeSurfaceV1::OllamaHttp => execute_ollama_http(&mut request, &policy),
+            RuntimeSurfaceV1::OllamaCli | RuntimeSurfaceV1::Mock | RuntimeSurfaceV1::Unknown => {
+                Err(provider_failure_from_note(
+                    "unsupported provider runtime surface",
+                    None,
+                ))
+            }
+        };
+
+        let duration_ms = attempt_started.elapsed().as_millis() as u64;
+        match outcome {
+            Ok(provider_response) => {
+                let output_text = provider_response.output_text;
+                attempts.push(ProviderAttemptV1 {
+                    attempt_index,
+                    started_at: attempt_started_at,
+                    duration_ms,
+                    status: ProviderAttemptStatusV1::Ok,
+                    retryable: false,
+                    http_status: Some(provider_response.http_status),
+                    failure: None,
+                    raw_response_excerpt: Some(redacted_response_marker(&output_text)),
+                });
+                let _ = logger.event(
+                    event("attempt_success", &request)
+                        .with_attempt(attempt_index)
+                        .with_status("ok"),
+                );
+                let _ = logger.event(event("run_finish", &request).with_status("ok"));
+                return ProviderInvocationResultV1 {
+                    schema_version: PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string(),
+                    route: request.route,
+                    model_identity: request.model_identity,
+                    attempts,
+                    final_status: ProviderInvocationFinalStatusV1::Ok,
+                    duration_ms: started.elapsed().as_millis() as u64,
+                    output_text: Some(output_text.clone()),
+                    output_text_excerpt: Some(redacted_response_marker(&output_text)),
+                    failure: None,
+                    artifact_ref: None,
+                    trace_ref: None,
+                };
+            }
+            Err(mut failure) => {
+                let retryable = failure.retryable && attempt_index < policy.max_attempts;
+                failure.retryable = retryable;
+                let status = if matches!(failure.kind, ProviderFailureKindV1::ProviderTimeout) {
+                    ProviderAttemptStatusV1::Timeout
+                } else {
+                    ProviderAttemptStatusV1::Error
+                };
+                attempts.push(ProviderAttemptV1 {
+                    attempt_index,
+                    started_at: attempt_started_at,
+                    duration_ms,
+                    status,
+                    retryable,
+                    http_status: failure.http_status,
+                    failure: Some(failure.clone()),
+                    raw_response_excerpt: None,
+                });
+                let _ = logger.event(
+                    event("attempt_failure", &request)
+                        .with_attempt(attempt_index)
+                        .with_failure(&failure)
+                        .with_status("failed"),
+                );
+                final_failure = Some(failure.clone());
+                if retryable {
+                    thread::sleep(Duration::from_millis(
+                        policy.retry_backoff_ms.unwrap_or(DEFAULT_BACKOFF_MS),
+                    ));
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    let failure = final_failure.unwrap_or_else(|| {
+        provider_failure_from_note("provider adapter ended without a result", None)
+    });
+    let _ = logger.event(
+        event("run_finish", &request)
+            .with_failure(&failure)
+            .with_status("failed"),
+    );
+    failed_result(
+        request,
+        attempts,
+        failure,
+        started.elapsed().as_millis() as u64,
+    )
+}
+
+fn failed_result(
+    request: ProviderInvocationRequestV1,
+    attempts: Vec<ProviderAttemptV1>,
+    failure: ProviderFailureV1,
+    duration_ms: u64,
+) -> ProviderInvocationResultV1 {
+    ProviderInvocationResultV1 {
+        schema_version: PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string(),
+        route: request.route,
+        model_identity: request.model_identity,
+        attempts,
+        final_status: ProviderInvocationFinalStatusV1::Failed,
+        duration_ms,
+        output_text: None,
+        output_text_excerpt: None,
+        failure: Some(failure),
+        artifact_ref: None,
+        trace_ref: None,
+    }
+}
+
+fn validate_adapter_request(request: &ProviderInvocationRequestV1) -> Result<()> {
+    validate_provider_request(request)?;
+    let input = request
+        .input_text
+        .as_deref()
+        .ok_or_else(|| anyhow!("provider adapter request requires input_text"))?;
+    if input.trim().is_empty() {
+        return Err(anyhow!(
+            "provider adapter request requires non-empty input_text"
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_request_identity(request: &mut ProviderInvocationRequestV1) {
+    let expected_runtime = match request.route.runtime_surface {
+        RuntimeSurfaceV1::HostedApi => "hosted_api",
+        RuntimeSurfaceV1::OllamaHttp => "ollama_http",
+        RuntimeSurfaceV1::OllamaCli => "ollama_cli",
+        RuntimeSurfaceV1::Mock => "mock",
+        RuntimeSurfaceV1::Unknown => "unknown",
+    };
+    if !request.model_identity.model_ref.trim().is_empty()
+        && request.model_identity.runtime_surface == expected_runtime
+    {
+        return;
+    }
+    request.model_identity = match request.route.runtime_surface {
+        RuntimeSurfaceV1::HostedApi => hosted_model_identity(
+            request.route.provider.clone(),
+            request.route.provider_model_id.clone(),
+            request.route.provider_model_id.clone(),
+            request.route.source_registry.clone(),
+        ),
+        RuntimeSurfaceV1::OllamaHttp => ollama_model_identity(
+            request.route.provider_model_id.clone(),
+            request.route.provider_model_id.clone(),
+            None,
+            request.route.source_registry.clone(),
+        ),
+        _ => request.model_identity.clone(),
+    };
+}
+
+struct ProviderTextResponse {
+    output_text: String,
+    http_status: u16,
+}
+
+fn execute_hosted_openai(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    if !request.route.provider.eq_ignore_ascii_case("openai") {
+        return Err(ProviderFailureV1 {
+            kind: ProviderFailureKindV1::ProviderError,
+            retryable: false,
+            message: "hosted adapter currently supports provider=openai only".to_string(),
+            provider_error_excerpt: None,
+            http_status: None,
+        });
+    }
+    let key = resolve_credential(request.route.credential_ref.as_deref(), "OPENAI_API_KEY")?;
+    let url = request
+        .route
+        .endpoint_ref
+        .as_deref()
+        .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
+        .unwrap_or(DEFAULT_OPENAI_RESPONSES_URL);
+    let response = client(policy)?
+        .post(url)
+        .bearer_auth(key)
+        .json(&json!({
+            "model": request.route.provider_model_id,
+            "input": request.input_text.as_deref().unwrap_or_default(),
+        }))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        extract_openai_output_text,
+        RuntimeSurfaceV1::HostedApi,
+    )
+}
+
+fn execute_ollama_http(
+    request: &mut ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    refresh_ollama_identity(request, policy);
+    let response = client(policy)?
+        .post(ollama_generate_url(request.route.endpoint_ref.as_deref()))
+        .json(&json!({
+            "model": request.route.provider_model_id,
+            "prompt": request.input_text.as_deref().unwrap_or_default(),
+            "stream": false,
+            "think": false,
+        }))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        |json| {
+            json.get("response")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        },
+        RuntimeSurfaceV1::OllamaHttp,
+    )
+}
+
+fn decode_text_response(
+    response: reqwest::blocking::Response,
+    extractor: impl Fn(&Value) -> Option<String>,
+    runtime_surface: RuntimeSurfaceV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let status = response.status();
+    let body = response.text().map_err(map_reqwest_error)?;
+    if !status.is_success() {
+        return Err(map_http_failure(status.as_u16(), &body, runtime_surface));
+    }
+    let json: Value = serde_json::from_str(&body).map_err(|error| {
+        provider_failure_from_note(
+            &format!("provider invalid_json: {error}"),
+            Some(status.as_u16()),
+        )
+    })?;
+    let output_text = extractor(&json)
+        .filter(|text| !text.trim().is_empty())
+        .ok_or_else(|| {
+            provider_failure_from_note("empty provider output", Some(status.as_u16()))
+        })?;
+    Ok(ProviderTextResponse {
+        output_text,
+        http_status: status.as_u16(),
+    })
+}
+
+fn client(policy: &ProviderAttemptPolicyV1) -> std::result::Result<Client, ProviderFailureV1> {
+    Client::builder()
+        .timeout(Duration::from_millis(policy.timeout_ms))
+        .build()
+        .map_err(|error| provider_failure_from_note(&error.to_string(), None))
+}
+
+fn resolve_credential(
+    credential_ref: Option<&str>,
+    default_env: &str,
+) -> std::result::Result<String, ProviderFailureV1> {
+    let env_name = credential_ref
+        .and_then(|credential| credential.strip_prefix("env:"))
+        .unwrap_or(default_env);
+    env::var(env_name).map_err(|_| ProviderFailureV1 {
+        kind: ProviderFailureKindV1::ProviderAuthMissing,
+        retryable: false,
+        message: "missing provider credential".to_string(),
+        provider_error_excerpt: None,
+        http_status: None,
+    })
+}
+
+fn ollama_generate_url(endpoint_ref: Option<&str>) -> String {
+    if let Some(endpoint) = endpoint_ref {
+        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+            let trimmed = endpoint.trim_end_matches('/');
+            if trimmed.ends_with("/api/generate") {
+                return trimmed.to_string();
+            }
+            return format!("{trimmed}/api/generate");
+        }
+    }
+    let base = env::var("OLLAMA_HOST").unwrap_or_else(|_| DEFAULT_OLLAMA_BASE_URL.to_string());
+    format!("{}/api/generate", base.trim_end_matches('/'))
+}
+
+fn map_reqwest_error(error: reqwest::Error) -> ProviderFailureV1 {
+    if error.is_timeout() {
+        provider_failure_from_note(
+            "provider timeout",
+            error.status().map(|status| status.as_u16()),
+        )
+    } else if error.is_connect() {
+        provider_failure_from_note(
+            "connection refused talking to local runtime",
+            error.status().map(|status| status.as_u16()),
+        )
+    } else {
+        provider_failure_from_note(
+            &error.to_string(),
+            error.status().map(|status| status.as_u16()),
+        )
+    }
+}
+
+fn map_http_failure(
+    status: u16,
+    body: &str,
+    runtime_surface: RuntimeSurfaceV1,
+) -> ProviderFailureV1 {
+    let note = if runtime_surface == RuntimeSurfaceV1::OllamaHttp {
+        let lower = body.to_ascii_lowercase();
+        if lower.contains("not found") || lower.contains("does not exist") {
+            format!("model not found: {body}")
+        } else if lower.contains("stopping") || lower.contains("hung") {
+            format!("local_runtime_hung: {body}")
+        } else if matches!(status, 500..=599) {
+            format!("local_runtime_busy http {status}: {body}")
+        } else {
+            format!("ollama http {status}: {body}")
+        }
+    } else {
+        format!("provider http {status}: {body}")
+    };
+    provider_failure_from_note(&note, Some(status))
+}
+
+fn refresh_ollama_identity(
+    request: &mut ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) {
+    let url = ollama_show_url(request.route.endpoint_ref.as_deref());
+    let Ok(response) = client(policy).and_then(|client| {
+        client
+            .post(url)
+            .json(&json!({"model": request.route.provider_model_id}))
+            .send()
+            .map_err(map_reqwest_error)
+    }) else {
+        return;
+    };
+    if !response.status().is_success() {
+        return;
+    }
+    let Ok(body) = response.text() else {
+        return;
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&body) else {
+        return;
+    };
+    let digest = json
+        .get("digest")
+        .and_then(Value::as_str)
+        .or_else(|| json.pointer("/details/digest").and_then(Value::as_str));
+    if digest.is_some() {
+        request.model_identity = ollama_model_identity(
+            request.route.provider_model_id.clone(),
+            request.route.provider_model_id.clone(),
+            digest,
+            request.route.source_registry.clone(),
+        );
+    }
+}
+
+fn ollama_show_url(endpoint_ref: Option<&str>) -> String {
+    if let Some(endpoint) = endpoint_ref {
+        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+            let trimmed = endpoint.trim_end_matches('/');
+            if trimmed.ends_with("/api/show") {
+                return trimmed.to_string();
+            }
+            if trimmed.ends_with("/api/generate") {
+                return trimmed.trim_end_matches("/api/generate").to_string() + "/api/show";
+            }
+            return format!("{trimmed}/api/show");
+        }
+    }
+    let base = env::var("OLLAMA_HOST").unwrap_or_else(|_| DEFAULT_OLLAMA_BASE_URL.to_string());
+    format!("{}/api/show", base.trim_end_matches('/'))
+}
+
+fn extract_openai_output_text(json: &Value) -> Option<String> {
+    if let Some(text) = json.get("output_text").and_then(Value::as_str) {
+        if !text.trim().is_empty() {
+            return Some(text.to_string());
+        }
+    }
+    let mut chunks = Vec::new();
+    if let Some(output) = json.get("output").and_then(Value::as_array) {
+        for item in output {
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for part in content {
+                    if let Some(text) = part.get("text").and_then(Value::as_str) {
+                        if !text.trim().is_empty() {
+                            chunks.push(text.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (!chunks.is_empty()).then(|| chunks.join("\n"))
+}
+
+fn redacted_response_marker(text: &str) -> String {
+    format!("[redacted provider text len={}]", text.len())
+}
+
+fn event(event_type: &str, request: &ProviderInvocationRequestV1) -> ProviderRunLogEventV1 {
+    ProviderRunLogEventV1::new(event_type)
+        .with_route(&request.route, &request.model_identity)
+        .with_lane(&request.lane_ref)
+}
+
+trait ProviderRunLogEventExt {
+    fn with_attempt(self, attempt_index: u32) -> Self;
+    fn with_status(self, status: &str) -> Self;
+    fn with_failure(self, failure: &ProviderFailureV1) -> Self;
+    fn with_lane(self, lane_ref: &str) -> Self;
+}
+
+impl ProviderRunLogEventExt for ProviderRunLogEventV1 {
+    fn with_attempt(mut self, attempt_index: u32) -> Self {
+        self.attempt_index = Some(attempt_index);
+        self
+    }
+
+    fn with_status(mut self, status: &str) -> Self {
+        self.status = Some(status.to_string());
+        self
+    }
+
+    fn with_failure(mut self, failure: &ProviderFailureV1) -> Self {
+        self.failure_kind = Some(failure.kind.clone());
+        self.http_status_field(failure.http_status);
+        self
+    }
+
+    fn with_lane(mut self, lane_ref: &str) -> Self {
+        self.lane_ref = Some(lane_ref.to_string());
+        self
+    }
+}
+
+trait HttpStatusField {
+    fn http_status_field(&mut self, status: Option<u16>);
+}
+
+impl HttpStatusField for ProviderRunLogEventV1 {
+    fn http_status_field(&mut self, status: Option<u16>) {
+        if let Some(status) = status {
+            self.fields = Some(json!({"http_status": status}));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_identity::ModelIdentityStrengthV1;
+    use crate::provider_communication::{ProviderKindV1, ProviderRouteV1, RuntimeSurfaceV1};
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn temp_log(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "adl-provider-adapter-{name}-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&path);
+        path
+    }
+
+    fn request(
+        runtime_surface: RuntimeSurfaceV1,
+        endpoint_ref: String,
+    ) -> ProviderInvocationRequestV1 {
+        let route = ProviderRouteV1 {
+            provider_kind: if runtime_surface == RuntimeSurfaceV1::HostedApi {
+                ProviderKindV1::Hosted
+            } else {
+                ProviderKindV1::Local
+            },
+            provider: if runtime_surface == RuntimeSurfaceV1::HostedApi {
+                "openai".to_string()
+            } else {
+                "ollama".to_string()
+            },
+            runtime_surface: runtime_surface.clone(),
+            provider_model_id: "test-model".to_string(),
+            endpoint_ref: Some(endpoint_ref),
+            credential_ref: Some("env:ADL_PROVIDER_ADAPTER_TEST_KEY".to_string()),
+            source_registry: Some("test-registry".to_string()),
+        };
+        let model_identity = if runtime_surface == RuntimeSurfaceV1::HostedApi {
+            hosted_model_identity(
+                "openai",
+                "test-model",
+                "test-model",
+                Some("test".to_string()),
+            )
+        } else {
+            let mut identity =
+                ollama_model_identity("test-model", "test-model", None, Some("test".to_string()));
+            identity.identity_strength = ModelIdentityStrengthV1::TagOnly;
+            identity
+        };
+        ProviderInvocationRequestV1 {
+            route,
+            model_identity,
+            prompt_contract_ref: "test.prompt.v1".to_string(),
+            lane_ref: "regular".to_string(),
+            run_id: Some("run-test".to_string()),
+            request_id: Some("req-test".to_string()),
+            attempt_policy: ProviderAttemptPolicyV1 {
+                max_attempts: 1,
+                timeout_ms: 5_000,
+                retry_backoff_ms: Some(1),
+            },
+            input_text: Some("secret prompt should not enter logs".to_string()),
+            inference_parameter_fingerprint: None,
+            tool_surface: None,
+            governance_surface: None,
+            evaluator_ref: None,
+            benchmark_ref: None,
+        }
+    }
+
+    fn one_shot_server(body: &'static str, status: &'static str) -> String {
+        scripted_server(vec![(body, status)])
+    }
+
+    fn scripted_server(responses: Vec<(&'static str, &'static str)>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        thread::spawn(move || {
+            for (body, status) in responses {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let mut buffer = [0_u8; 8192];
+                let _ = stream.read(&mut buffer);
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn hosted_openai_adapter_returns_output_and_redacts_log() {
+        env::set_var("ADL_PROVIDER_ADAPTER_TEST_KEY", "test-key");
+        let endpoint = one_shot_server(r#"{"output_text":"adapter success"}"#, "200 OK");
+        let path = temp_log("hosted");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let result = execute_provider_invocation(
+            request(RuntimeSurfaceV1::HostedApi, endpoint),
+            &mut logger,
+        );
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("adapter success"));
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("adapter success"));
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_TEST_KEY");
+    }
+
+    #[test]
+    fn ollama_adapter_returns_output_and_redacts_log() {
+        let endpoint = scripted_server(vec![
+            (
+                r#"{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+                "200 OK",
+            ),
+            (r#"{"response":"ollama success"}"#, "200 OK"),
+        ]);
+        let path = temp_log("ollama");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let result = execute_provider_invocation(
+            request(RuntimeSurfaceV1::OllamaHttp, endpoint),
+            &mut logger,
+        );
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("ollama success"));
+        assert_eq!(
+            result.model_identity.identity_strength,
+            ModelIdentityStrengthV1::Pinned
+        );
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("ollama success"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn non_openai_hosted_route_is_rejected_not_misrouted() {
+        let endpoint = one_shot_server(r#"{"output_text":"should not happen"}"#, "200 OK");
+        let path = temp_log("non-openai");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "anthropic".to_string();
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderError)
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn missing_hosted_key_is_normalized_without_network_call() {
+        env::remove_var("ADL_PROVIDER_ADAPTER_TEST_KEY");
+        let (tx, rx) = mpsc::channel();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        thread::spawn(move || {
+            if listener.accept().is_ok() {
+                let _ = tx.send(());
+            }
+        });
+        let path = temp_log("missing-key");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut missing_request = request(RuntimeSurfaceV1::HostedApi, format!("http://{addr}"));
+        missing_request.route.credential_ref =
+            Some("env:ADL_PROVIDER_ADAPTER_MISSING_KEY".to_string());
+        let result = execute_provider_invocation(missing_request, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderAuthMissing)
+        );
+        assert!(rx.try_recv().is_err());
+        let _ = fs::remove_file(path);
+    }
+}

--- a/adl/src/provider_adapter_cli.rs
+++ b/adl/src/provider_adapter_cli.rs
@@ -1,5 +1,5 @@
-use adl::provider_adapter::execute_provider_invocation;
-use adl::provider_communication::{ProviderInvocationRequestV1, ProviderRunLoggerV1};
+use crate::provider_adapter::execute_provider_invocation;
+use crate::provider_communication::{ProviderInvocationRequestV1, ProviderRunLoggerV1};
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
@@ -8,22 +8,18 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[command(name = "adl-provider-adapter")]
 #[command(about = "Run one ADL provider invocation through the Rust provider adapter")]
-struct Args {
+pub struct ProviderAdapterCliArgs {
     #[arg(long)]
-    request: PathBuf,
+    pub request: PathBuf,
 
     #[arg(long)]
-    out: PathBuf,
+    pub out: PathBuf,
 
     #[arg(long)]
-    log: PathBuf,
+    pub log: PathBuf,
 }
 
-fn main() -> Result<()> {
-    run(Args::parse())
-}
-
-fn run(args: Args) -> Result<()> {
+pub fn run_provider_adapter_cli(args: ProviderAdapterCliArgs) -> Result<()> {
     let request_text = fs::read_to_string(&args.request)
         .with_context(|| format!("read request file {}", args.request.display()))?;
     let request: ProviderInvocationRequestV1 = serde_json::from_str(&request_text)
@@ -46,7 +42,6 @@ fn run(args: Args) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use adl::provider_communication::ProviderInvocationFinalStatusV1;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_path(name: &str) -> PathBuf {
@@ -96,7 +91,7 @@ mod tests {
         )
         .unwrap();
 
-        run(Args {
+        run_provider_adapter_cli(ProviderAdapterCliArgs {
             request: request.clone(),
             out: out.clone(),
             log: log.clone(),
@@ -124,6 +119,5 @@ mod tests {
         let _ = fs::remove_file(request);
         let _ = fs::remove_file(out);
         let _ = fs::remove_file(log);
-        let _ = ProviderInvocationFinalStatusV1::Failed;
     }
 }

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -54,12 +54,19 @@ pub struct ProviderAttemptPolicyV1 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ProviderInvocationRequestV1 {
     pub route: ProviderRouteV1,
     pub model_identity: ModelIdentityV1,
     pub prompt_contract_ref: String,
     pub lane_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
     pub attempt_policy: ProviderAttemptPolicyV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inference_parameter_fingerprint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -141,6 +148,8 @@ pub struct ProviderInvocationResultV1 {
     pub attempts: Vec<ProviderAttemptV1>,
     pub final_status: ProviderInvocationFinalStatusV1,
     pub duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_text_excerpt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -601,6 +610,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Ok,
             duration_ms: 10,
+            output_text: Some("{}".to_string()),
             output_text_excerpt: Some("{}".to_string()),
             failure: None,
             artifact_ref: None,
@@ -639,6 +649,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Failed,
             duration_ms: 10,
+            output_text: None,
             output_text_excerpt: None,
             failure: Some(failure),
             artifact_ref: None,
@@ -681,11 +692,14 @@ mod tests {
             model_identity: identity,
             prompt_contract_ref: "uts.v1".to_string(),
             lane_ref: "regular".to_string(),
+            run_id: Some("run-test".to_string()),
+            request_id: Some("req-test".to_string()),
             attempt_policy: ProviderAttemptPolicyV1 {
                 max_attempts: 1,
                 timeout_ms: 1000,
                 retry_backoff_ms: Some(100),
             },
+            input_text: Some("test prompt".to_string()),
             inference_parameter_fingerprint: None,
             tool_surface: None,
             governance_surface: None,

--- a/adl/tools/adl_provider_adapter.rs
+++ b/adl/tools/adl_provider_adapter.rs
@@ -1,0 +1,7 @@
+use adl::provider_adapter_cli::{run_provider_adapter_cli, ProviderAdapterCliArgs};
+use anyhow::Result;
+use clap::Parser;
+
+fn main() -> Result<()> {
+    run_provider_adapter_cli(ProviderAdapterCliArgs::parse())
+}

--- a/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
+++ b/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
@@ -1,0 +1,85 @@
+# Provider Adapter Runbook
+
+## Status
+
+`adl-provider-adapter` is the Rust execution boundary for one provider invocation. It consumes the shared provider communication substrate and writes both a structured result JSON file and a tail-friendly JSONL run log.
+
+## Command
+
+```bash
+cargo run --manifest-path adl/Cargo.toml --bin adl-provider-adapter -- \
+  --request /path/to/request.json \
+  --out /path/to/result.json \
+  --log /path/to/run.log.jsonl
+```
+
+The command prints:
+
+```text
+result=/path/to/result.json
+run_log=/path/to/run.log.jsonl
+watch=tail -f /path/to/run.log.jsonl
+```
+
+Provider failures are normalized into the result file. The process exits non-zero only for adapter I/O or request parsing failures.
+
+## Request Shape
+
+The request is `ProviderInvocationRequestV1`. The adapter requires `input_text` for execution while preserving existing `model_ref` / `provider_model_id` compatibility.
+
+Hosted OpenAI example. The current hosted adapter intentionally supports `provider: "openai"` only; other hosted providers must use a future provider-specific transport rather than being silently routed through OpenAI.
+
+```json
+{
+  "request_id": "req-001",
+  "run_id": "run-001",
+  "route": {
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "provider_model_id": "gpt-5.3-codex",
+    "runtime_surface": "hosted_api",
+    "credential_ref": "env:OPENAI_API_KEY"
+  },
+  "input_text": "Return exactly: ok",
+  "attempt_policy": {
+    "timeout_ms": 120000,
+    "max_attempts": 1,
+    "retry_backoff_ms": 1000
+  }
+}
+```
+
+Ollama HTTP example. The adapter calls `/api/show` before `/api/generate` and records a pinned model identity when Ollama returns a digest.
+
+```json
+{
+  "request_id": "req-ollama-001",
+  "run_id": "run-ollama-001",
+  "route": {
+    "provider_kind": "local",
+    "provider": "ollama",
+    "provider_model_id": "gemma3:27b",
+    "runtime_surface": "ollama_http",
+    "endpoint_ref": "http://127.0.0.1:11434"
+  },
+  "input_text": "Return exactly: ok",
+  "attempt_policy": {
+    "timeout_ms": 120000,
+    "max_attempts": 1,
+    "retry_backoff_ms": 1000
+  }
+}
+```
+
+## Outputs
+
+- `result.json`: one `ProviderInvocationResultV1`, including final status, normalized failure if any, attempts, model identity, and output text on success.
+- `run.log.jsonl`: one flushed JSON object per event for `tail -f` monitoring.
+
+Logs intentionally do not contain raw prompt text, credentials, or raw model output. Result files may contain successful model output because callers need the text for scoring; do not publish result artifacts without normal benchmark redaction.
+
+## Live Checks
+
+Live checks are opt-in. For hosted calls, set the credential env var named by `credential_ref`. For Ollama, make sure the model is already available and prefer a single local model at a time.
+
+This adapter does not start or stop Ollama models. Model lifecycle control belongs to the benchmark runner or operator script.

--- a/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
+++ b/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
@@ -49,7 +49,7 @@ Hosted OpenAI example. The current hosted adapter intentionally supports `provid
 }
 ```
 
-Ollama HTTP example. The adapter calls `/api/show` before `/api/generate` and records a pinned model identity when Ollama returns a digest.
+Ollama HTTP example. The adapter calls `/api/show`, then falls back to `/api/tags`, before `/api/generate` and records a pinned model identity when Ollama returns a digest.
 
 ```json
 {

--- a/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
+++ b/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
@@ -27,7 +27,15 @@ Provider failures are normalized into the result file. The process exits non-zer
 
 The request is `ProviderInvocationRequestV1`. The adapter requires `input_text` for execution while preserving existing `model_ref` / `provider_model_id` compatibility.
 
-Hosted OpenAI example. The current hosted adapter intentionally supports `provider: "openai"` only; other hosted providers must use a future provider-specific transport rather than being silently routed through OpenAI.
+Hosted providers use `runtime_surface: "hosted_api"` and dispatch by `route.provider`:
+
+- `openai` or `chatgpt`: OpenAI Responses API, default credential `OPENAI_API_KEY`.
+- `anthropic` or `claude`: Anthropic Messages API, default credential `ANTHROPIC_API_KEY`.
+- `google` or `gemini`: Gemini `generateContent` API, default credential `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
+
+Unsupported hosted providers are rejected instead of being silently routed through the wrong transport.
+
+OpenAI example:
 
 ```json
 {
@@ -40,6 +48,68 @@ Hosted OpenAI example. The current hosted adapter intentionally supports `provid
     "runtime_surface": "hosted_api",
     "credential_ref": "env:OPENAI_API_KEY"
   },
+  "input_text": "Return exactly: ok",
+  "attempt_policy": {
+    "timeout_ms": 120000,
+    "max_attempts": 1,
+    "retry_backoff_ms": 1000
+  }
+}
+```
+
+Claude example:
+
+```json
+{
+  "route": {
+    "provider_kind": "hosted",
+    "provider": "anthropic",
+    "provider_model_id": "claude-sonnet-4-5",
+    "runtime_surface": "hosted_api",
+    "credential_ref": "env:ANTHROPIC_API_KEY"
+  },
+  "model_identity": {
+    "provider_kind": "hosted",
+    "provider": "anthropic",
+    "model_ref": "claude-sonnet-4-5",
+    "provider_model_id": "claude-sonnet-4-5",
+    "runtime_surface": "hosted_api",
+    "identity_strength": "provider_asserted",
+    "observed_at": "unix:1"
+  },
+  "prompt_contract_ref": "provider_adapter.live_smoke.v1",
+  "lane_ref": "live_smoke",
+  "input_text": "Return exactly: ok",
+  "attempt_policy": {
+    "timeout_ms": 120000,
+    "max_attempts": 1,
+    "retry_backoff_ms": 1000
+  }
+}
+```
+
+Gemini example:
+
+```json
+{
+  "route": {
+    "provider_kind": "hosted",
+    "provider": "gemini",
+    "provider_model_id": "gemini-2.5-flash",
+    "runtime_surface": "hosted_api",
+    "credential_ref": "env:GEMINI_API_KEY"
+  },
+  "model_identity": {
+    "provider_kind": "hosted",
+    "provider": "gemini",
+    "model_ref": "gemini-2.5-flash",
+    "provider_model_id": "gemini-2.5-flash",
+    "runtime_surface": "hosted_api",
+    "identity_strength": "provider_asserted",
+    "observed_at": "unix:1"
+  },
+  "prompt_contract_ref": "provider_adapter.live_smoke.v1",
+  "lane_ref": "live_smoke",
   "input_text": "Return exactly: ok",
   "attempt_policy": {
     "timeout_ms": 120000,
@@ -81,5 +151,14 @@ Logs intentionally do not contain raw prompt text, credentials, or raw model out
 ## Live Checks
 
 Live checks are opt-in. For hosted calls, set the credential env var named by `credential_ref`. For Ollama, make sure the model is already available and prefer a single local model at a time.
+
+Live smoke results recorded during `#3486`:
+
+| Provider | Model | Result | Notes |
+| --- | --- | --- | --- |
+| OpenAI | `gpt-5.3-codex` | `ok`, HTTP 200, ~4.9s | Returned `adapter ok`; credential was supplied from a local env var only. |
+| Anthropic | `claude-sonnet-4-5` | `ok`, HTTP 200, ~1.6s | Returned `adapter ok`; credential was supplied from a local env var only. |
+| Gemini | `gemini-2.5-flash` | `ok`, HTTP 200, ~1.1s | Transport/extraction succeeded; model returned `hello world` despite the exact-output prompt. |
+| Ollama | `gemma:2b` | `ok`, HTTP 200, ~2.7s | Local identity pinned from `/api/tags`; model was stopped after the smoke. |
 
 This adapter does not start or stop Ollama models. Model lifecycle control belongs to the benchmark runner or operator script.


### PR DESCRIPTION
Closes #3486

## Summary
Implemented the Rust provider adapter execution boundary for one provider invocation at a time. The change adds a CLI, hosted OpenAI Responses transport, Ollama HTTP transport, normalized provider results, redacted tail-friendly JSONL logging, focused tests, and a runbook. Subagent review found five pre-publication defects; all were fixed before PR publication.

## Artifacts
- `adl/src/provider_adapter.rs`
- `adl/src/bin/adl_provider_adapter.rs`
- `adl/src/provider_communication.rs`
- `adl/src/lib.rs`
- `adl/Cargo.toml`
- `docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml provider_adapter --lib -- --nocapture`
    Verified adapter execution and failure behavior without live provider calls.
  - `cargo test --manifest-path adl/Cargo.toml provider_communication --lib -- --nocapture`
    Verified shared substrate compatibility after schema extension.
  - `cargo run --manifest-path adl/Cargo.toml --bin adl-provider-adapter -- --help`
    Verified CLI compile and user-facing command shape.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Summary\n\n- Adds the Rust adl-provider-adapter CLI for one provider invocation at a time.\n- Supports OpenAI Responses hosted calls and Ollama HTTP calls through the shared provider communication contract.\n- Writes ProviderInvocationResultV1 JSON and flushed JSONL logs suitable for tail -f monitoring.\n- Keeps logs redacted while preserving result output for scoring.\n- Rejects non-OpenAI hosted routes instead of silently misrouting them.\n- Attempts Ollama digest discovery through /api/show before generation.\n\nValidation\n\n- cargo fmt --manifest-path adl/Cargo.toml\n- cargo test --manifest-path adl/Cargo.toml provider_adapter --lib -- --nocapture\n- cargo test --manifest-path adl/Cargo.toml provider_communication --lib -- --nocapture\n- cargo run --manifest-path adl/Cargo.toml --bin adl-provider-adapter -- --help\n- git diff --check\n- bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.4/tasks/issue-3486__implement-rust-hosted-and-ollama-provider-adapter/sor.md\n- bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.4/tasks/issue-3486__implement-rust-hosted-and-ollama-provider-adapter/srp.md\n\nReview\n\n- Bounded subagent review found hosted misrouting, run-id/schema drift, Ollama digest, status, and local failure classification issues. All were fixed before publication.\n

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3486__implement-rust-hosted-and-ollama-provider-adapter/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3486__implement-rust-hosted-and-ollama-provider-adapter/sor.md
- Idempotency-Key: v0-91-4-provider-implement-rust-hosted-and-ollama-provider-adapter-adl-cargo-toml-adl-src-lib-rs-adl-src-provider-communication-rs-adl-src-provider-adapter-rs-adl-src-bin-adl-provider-adapter-rs-docs-milestones-v0-91-4-review-provider-communication-substrate-provider-adapter-runbook-md-adl-v0-91-4-tasks-issue-3486-implement-rust-hosted-and-ollama-provider-adapter-sip-md-adl-v0-91-4-tasks-issue-3486-implement-rust-hosted-and-ollama-provider-adapter-sor-md