### PR TITLE
[v0.91.4][provider] Make direct provider API the canonical cross-substrate execution path

### DIFF
--- a/adl/tools/run_v0914_multi_agent_workcell_proof.sh
+++ b/adl/tools/run_v0914_multi_agent_workcell_proof.sh
@@ -7,7 +7,6 @@ TRACKED_REVIEW_ROOT_DEFAULT="$ROOT_DIR/docs/milestones/v0.91.4/review/multi_agen
 MANIFEST_DEFAULT="$TRACKED_REVIEW_ROOT_DEFAULT/workcell_proof_manifest.json"
 STATE_VALIDATOR="$ROOT_DIR/adl/tools/validate_multi_agent_workcell_state.py"
 PLANNER="$ROOT_DIR/adl/tools/plan_multi_agent_workcell.py"
-CODEX_BIN="${CODEX_BIN:-codex}"
 LOCAL_MODEL_A_DEFAULT="deepseek-r1:8b"
 LOCAL_MODEL_B_DEFAULT="gemma4:26b"
 LOCAL_MODEL_C_DEFAULT="Qwen3.5:35b-a3b"
@@ -22,7 +21,7 @@ MANIFEST_PATH="$MANIFEST_DEFAULT"
 LOCAL_MODEL_A="$LOCAL_MODEL_A_DEFAULT"
 LOCAL_MODEL_B="$LOCAL_MODEL_B_DEFAULT"
 SERIAL_MODEL_C="$LOCAL_MODEL_C_DEFAULT"
-HOSTED_REVIEW_MODEL="${HOSTED_REVIEW_MODEL:-codex_cli_default}"
+HOSTED_REVIEW_MODEL="${HOSTED_REVIEW_MODEL:-gpt-5.3-codex}"
 OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
 USE_SERIAL_MODEL_C=0
 DRY_RUN=0
@@ -40,7 +39,7 @@ Options:
   --local-model-b <name>         Second local Ollama worker model. Default: $LOCAL_MODEL_B_DEFAULT
   --serial-model-c <name>        Optional serialized local model note. Default: $LOCAL_MODEL_C_DEFAULT
   --use-serial-model-c           Record the optional serialized local model lane in the proof packet
-  --hosted-review-model <name>   Hosted reviewer model hint. Default: codex_cli_default
+  --hosted-review-model <name>   Hosted reviewer model hint. Default: gpt-5.3-codex
   --openai-key-file <path>       Hosted key file for OpenAI-backed Codex auth fallback
   --dry-run                      Prepare workcell repo, plan, and packet skeletons without invoking Codex
 USAGE
@@ -99,6 +98,18 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+resolve_path() {
+  python3 - "$1" <<'__PY__'
+from pathlib import Path
+import sys
+print(Path(sys.argv[1]).resolve())
+__PY__
+}
+
+ARTIFACT_ROOT="$(resolve_path "$ARTIFACT_ROOT")"
+TRACKED_REVIEW_ROOT="$(resolve_path "$TRACKED_REVIEW_ROOT")"
+MANIFEST_PATH="$(resolve_path "$MANIFEST_PATH")"
 
 load_key() {
   local env_name="$1"
@@ -230,6 +241,117 @@ Path(parsed_path).write_text(json.dumps(parsed, indent=2) + "\n", encoding="utf-
 __PY__
 }
 
+run_hosted_openai_reviewer() {
+  local model="$1"
+  local prompt_file="$2"
+  local message_file="$3"
+  local log_file="$4"
+
+  python3 - "$model" "$prompt_file" "$message_file" "$log_file" <<'__PY__'
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+
+def extract_openai_text(payload: dict) -> str:
+    output_text = payload.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text.strip()
+    chunks = []
+    for item in payload.get("output", []):
+        if not isinstance(item, dict):
+            continue
+        for content in item.get("content", []):
+            if not isinstance(content, dict):
+                continue
+            text = content.get("text")
+            if isinstance(text, str) and text.strip():
+                chunks.append(text)
+    return "\n".join(chunks).strip()
+
+model, prompt_path, message_path, log_path = sys.argv[1:]
+api_key = os.environ["OPENAI_API_KEY"]
+prompt = Path(prompt_path).read_text(encoding="utf-8")
+payload = {
+    "model": model,
+    "input": prompt,
+}
+request = urllib.request.Request(
+    OPENAI_RESPONSES_URL,
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+started = time.time()
+try:
+    with urllib.request.urlopen(request, timeout=300) as response:
+        body = response.read().decode("utf-8")
+        status = response.status
+        request_id = (
+            response.headers.get("x-request-id")
+            or response.headers.get("request-id")
+            or response.headers.get("x-openai-request-id")
+        )
+except urllib.error.HTTPError as exc:
+    detail = exc.read().decode("utf-8", errors="replace")
+    Path(log_path).write_text(
+        json.dumps(
+            {
+                "status": exc.code,
+                "request_id_present": bool(exc.headers.get("x-request-id") or exc.headers.get("request-id")),
+                "latency_ms": int((time.time() - started) * 1000),
+                "error": detail[:400],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    raise
+payload = json.loads(body)
+text = extract_openai_text(payload)
+if not text:
+    Path(log_path).write_text(
+        json.dumps(
+            {
+                "status": status,
+                "request_id_present": bool(request_id),
+                "latency_ms": int((time.time() - started) * 1000),
+                "error": "empty text output",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    raise SystemExit("hosted reviewer response did not contain text output")
+Path(message_path).write_text(text.rstrip() + "\n", encoding="utf-8")
+Path(log_path).write_text(
+    json.dumps(
+        {
+            "status": status,
+            "request_id_present": bool(request_id),
+            "latency_ms": int((time.time() - started) * 1000),
+            "output_chars": len(text),
+            "provider": "openai",
+            "model": model,
+        },
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+__PY__
+}
+
 sanitize_text_file() {
   local path="$1"
   python3 - "$path" "$ROOT_DIR" "$ARTIFACT_ROOT" "$OPENAI_KEY_FILE" <<'__PY__'
@@ -286,9 +408,9 @@ TRACKED_PLAN_JSON="$TRACKED_REVIEW_ROOT/workcell_proof_plan_${PROOF_DATE}.json"
 TRACKED_STATE_JSON="$TRACKED_REVIEW_ROOT/workcell_proof_state_${PROOF_DATE}.json"
 TRACKED_PACKET_MD="$TRACKED_REVIEW_ROOT/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_${PROOF_DATE}.md"
 REVIEWER_MESSAGE="$REPORT_ROOT/reviewer_last_message.md"
-REVIEWER_LOG="$LOG_ROOT/reviewer_codex.log"
-WORKER_A_LOG="$LOG_ROOT/worker_a_codex.log"
-WORKER_B_LOG="$LOG_ROOT/worker_b_codex.log"
+REVIEWER_LOG="$LOG_ROOT/reviewer_openai.json"
+WORKER_A_LOG="$LOG_ROOT/worker_a_ollama.log"
+WORKER_B_LOG="$LOG_ROOT/worker_b_ollama.log"
 WORKER_A_LAST="$REPORT_ROOT/worker_a_last_message.md"
 WORKER_B_LAST="$REPORT_ROOT/worker_b_last_message.md"
 PLAN_TEXT="$REPORT_ROOT/workcell_plan.txt"
@@ -508,7 +630,11 @@ __REVIEW_PROMPT__
   } > "$REPORT_ROOT/reviewer_prompt.md"
   (
     cd "$REPORT_ROOT"
-    OPENAI_API_KEY="$OPENAI_API_KEY" "$CODEX_BIN" exec -s read-only - < "$REPORT_ROOT/reviewer_prompt.md" > "$REVIEWER_MESSAGE" 2> "$REVIEWER_LOG"
+    OPENAI_API_KEY="$OPENAI_API_KEY" run_hosted_openai_reviewer \
+      "$HOSTED_REVIEW_MODEL" \
+      "$REPORT_ROOT/reviewer_prompt.md" \
+      "$REVIEWER_MESSAGE" \
+      "$REVIEWER_LOG"
   )
   reviewer_end="$(record_epoch)"
 else
@@ -679,7 +805,7 @@ Tracked bounded proof packet for issue \`#3419\`.
 This proof executed a bounded multi-agent C-SDLC workcell with:
 
 - two parallel local worker lanes via the Ollama local provider API
-- one independent hosted Codex reviewer lane after serialized publication normalization
+- one independent hosted OpenAI/Codex reviewer lane after serialized publication normalization
 - serialized conductor admission, publication normalization, review publication, and closeout/janitor decisions
 
 This packet proves bounded parallel coordination. It does not claim production-grade autonomous merge or closeout authority.
@@ -688,7 +814,7 @@ This packet proves bounded parallel coordination. It does not claim production-g
 
 - worker A: \`local_ollama\` / \`$LOCAL_MODEL_A\`
 - worker B: \`local_ollama\` / \`$LOCAL_MODEL_B\`
-- reviewer: \`hosted_codex\` / \`$HOSTED_REVIEW_MODEL\`
+- reviewer: \`hosted_openai_responses\` / \`$HOSTED_REVIEW_MODEL\`
 - optional serialized local model observed for future work: \`$SERIAL_MODEL_C\`
 
 ## Planned / Serialized Gates
@@ -745,7 +871,7 @@ Timing evidence is recorded in:
 ## Residual Risk
 
 - This proof uses a demo-local repository rather than live GitHub PR creation for shard publication.
-- Hosted reviewer execution depends on the local Codex CLI authentication surface remaining healthy.
+- Hosted reviewer execution depends on direct OpenAI Responses API credential availability and network reachability.
 - The proof demonstrates bounded coordination, not general autonomous multi-agent delivery.
 
 ## Validation

--- a/docs/milestones/v0.91.4/review/multi_agent_workcell/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_2026-05-28.md
+++ b/docs/milestones/v0.91.4/review/multi_agent_workcell/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_2026-05-28.md
@@ -2,23 +2,23 @@
 
 ## Status
 
-Tracked bounded proof packet for issue `#3419` showing local worker proposal generation, serialized publication normalization, and hosted independent review.
+Tracked bounded proof packet for issue `#3419`.
 
 ## Summary
 
 This proof executed a bounded multi-agent C-SDLC workcell with:
 
 - two parallel local worker lanes via the Ollama local provider API
-- one independent hosted Codex reviewer lane after serialized publication normalization
+- one independent hosted OpenAI/Codex reviewer lane after serialized publication normalization
 - serialized conductor admission, publication normalization, review publication, and closeout/janitor decisions
 
-This packet provides useful bounded proof evidence. It does not claim raw local worker publication correctness, production-grade autonomous merge, or closeout authority.
+This packet proves bounded parallel coordination. It does not claim production-grade autonomous merge or closeout authority.
 
 ## Lane Assignment
 
 - worker A: `local_ollama` / `deepseek-r1:8b`
 - worker B: `local_ollama` / `gemma4:26b`
-- reviewer: `hosted_codex` / `codex_cli_default`
+- reviewer: `hosted_openai_responses` / `gpt-5.3-codex`
 - optional serialized local model observed for future work: `Qwen3.5:35b-a3b`
 
 ## Planned / Serialized Gates
@@ -32,10 +32,9 @@ This packet provides useful bounded proof evidence. It does not claim raw local 
 ## Assignment And State Evidence
 
 - planner manifest: `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_manifest.json`
-- planner report: `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_plan_2026-05-28.json` (pre-execution admission plan, not post-publication truth)
-- validated workcell state packet: `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_state_2026-05-28.json` (admitted-workcell contract state, not closeout truth)
+- planner report: `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_plan_2026-05-28.json`
+- validated workcell state packet: `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_state_2026-05-28.json`
 - raw local worker proposals remain archived under `artifacts/v0914/multi_agent_workcell/v0-91-4-multi-agent-proof-20260528/reports/`
-- follow-on Codex-only parallel slice: `docs/milestones/v0.91.4/review/multi_agent_workcell/CODEX_ONLY_PARALLEL_WORKER_SLICE_2026-05-29.md`
 
 ## Actual Branch / Worktree Boundaries
 
@@ -43,9 +42,7 @@ This packet provides useful bounded proof evidence. It does not claim raw local 
 - `codex/proof-worker-b` -> `artifacts/v0914/multi_agent_workcell/v0-91-4-multi-agent-proof-20260528/worktrees/worker_b`
 - `codex/proof-reviewer` -> `artifacts/v0914/multi_agent_workcell/v0-91-4-multi-agent-proof-20260528/worktrees/reviewer`
 
-## Normalized Publication Surfaces
-
-The raw local-model proposals remain archived under `artifacts/v0914/multi_agent_workcell/v0-91-4-multi-agent-proof-20260528/reports/`. The surfaces below are the serialized normalized publication surfaces that were sent to the hosted reviewer lane.
+## Worker Outputs
 
 ### Worker A
 
@@ -61,29 +58,39 @@ The raw local-model proposals remain archived under `artifacts/v0914/multi_agent
 
 ## Reviewer Output
 
-## Findings
+## 1. Findings
 
 No material findings.
 
-The two patches preserve separated write ownership: Worker A touched only its summary plus its own SOR, and Worker B touched only its contract plus its own SOR. The content also keeps reviewer, janitor, publication, and closeout decisions outside the worker lanes.
+Both patches are narrowly scoped, consistent with bounded lane ownership, and do not show cross-lane or shared-surface modification.
+- **Worker A** edits only:
+  - `.adl/v0.91.4/tasks/issue-5001__demo-worker-a/sor.md`
+  - `docs/worker_a_summary.md`
+- **Worker B** edits only:
+  - `.adl/v0.91.4/tasks/issue-5002__demo-worker-b/sor.md`
+  - `docs/worker_b_contract.md`
 
-## Non-findings
+The SOR summaries align with the described worker-local normalization actions.
 
-Worker A’s summary accurately describes bounded parallel coordination and serialized downstream gates.
+## 2. Non-findings
 
-Worker B’s contract states path ownership limits and avoids claiming authority over Worker A or shared proof packet surfaces.
+- No evidence of unauthorized file-path overlap between Worker A and Worker B.
+- No executable/config/security-sensitive code changes.
+- No indication of hidden behavior in the provided diffs.
+- No contradiction between claimed bounded behavior and actual file edits shown.
 
-Both SOR updates are consistent with the narrow file-local changes shown.
+## 3. Residual risk
 
-## Residual risk
+Low residual risk, limited to process/attestation integrity rather than code impact:
+- The proof still depends on truthful lane attribution and correct serialization of downstream decisions.
+- Markdown content is declarative; risk is mainly misstatement risk, not runtime/system risk.
 
-The embedded diffs do not show validation output, reviewer execution logs, or proof packet aggregation state. That is acceptable for this lane, but those claims should not be inferred from the worker patches alone.
+## 4. Serialized gates that still remain outside the proof
 
-The SOR records are very terse, so they prove completion only at a minimal summary level.
-
-## Serialized gates that still remain outside the proof
-
-Independent reviewer disposition, janitor/publication decisions, PR/base or stack verification, merge/closure, and final closeout remain serialized outside the parallel worker proof.
+Per the worker text and patch scope, these remain outside worker-lane proof and must be serialized elsewhere:
+- **Reviewer decision/publication**
+- **Janitor/cleanup actions**
+- **Closeout/finalization decision**
 
 ## Timing
 
@@ -95,8 +102,6 @@ Timing evidence is recorded in:
 
 - No blocking coordination failure occurred in the bounded two-worker plus reviewer slice.
 - Janitor and closeout remained explicit serialized gates instead of being smuggled into worker autonomy.
-- The current proof demonstrates that local worker proposals still benefit from a serialized publication-normalization step before independent review.
-- A separate ad hoc Codex-only slice showed that two hosted Codex worker lanes could complete disjoint shard edits in parallel and pass hosted Codex review without material findings.
 
 ## Non-findings
 
@@ -106,8 +111,7 @@ Timing evidence is recorded in:
 ## Residual Risk
 
 - This proof uses a demo-local repository rather than live GitHub PR creation for shard publication.
-- Hosted reviewer execution depends on the local Codex CLI authentication surface remaining healthy.
-- The tracked planner artifact is a pre-execution admission plan and should not be read as post-publication dependency truth.
+- Hosted reviewer execution depends on direct OpenAI Responses API credential availability and network reachability.
 - The proof demonstrates bounded coordination, not general autonomous multi-agent delivery.
 
 ## Validation

--- a/docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_plan_2026-05-28.json
+++ b/docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_plan_2026-05-28.json
@@ -53,20 +53,6 @@
     {
       "classification": "blocked",
       "execution_backend": null,
-      "issue_number": 5003,
-      "model_hint": null,
-      "reasons": [
-        "review lane awaits serialized normalized worker publication"
-      ],
-      "role": "reviewer",
-      "shard_id": "hosted-reviewer",
-      "write_paths": [
-        "docs/milestones/v0.91.4/review/multi_agent_workcell/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_2026-05-28.md"
-      ]
-    },
-    {
-      "classification": "blocked",
-      "execution_backend": null,
       "issue_number": 5005,
       "model_hint": null,
       "reasons": [
@@ -75,6 +61,20 @@
       "role": "closeout",
       "shard_id": "closeout-lane",
       "write_paths": []
+    },
+    {
+      "classification": "blocked",
+      "execution_backend": null,
+      "issue_number": 5003,
+      "model_hint": null,
+      "reasons": [
+        "review lane missing reviewable input"
+      ],
+      "role": "reviewer",
+      "shard_id": "hosted-reviewer",
+      "write_paths": [
+        "docs/milestones/v0.91.4/review/multi_agent_workcell/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_2026-05-28.md"
+      ]
     },
     {
       "classification": "blocked",

--- a/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
+++ b/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-`adl-provider-adapter` is the Rust execution boundary for one provider invocation. It consumes the shared provider communication substrate and writes both a structured result JSON file and a tail-friendly JSONL run log.
+`adl-provider-adapter` is an optional Rust wrapper around the canonical provider execution surface for one provider invocation. The canonical ADL execution claim is the direct provider API/library path; the CLI remains useful for debug, operator inspection, and compatibility-only workflows. When used, it consumes the shared provider communication substrate and writes both a structured result JSON file and a tail-friendly JSONL run log.
+
+## Canonical Integration Boundary
+
+ADL callers should prefer the direct provider invocation API over the CLI wrapper:
+
+- internal runtime and proof surfaces should call the provider execution surface directly
+- cross-substrate behavior should be owned by the shared request/result/log contract
+- the CLI should remain a thin optional shell, not the primary architectural boundary
+
+This distinction matters for cross-platform and cross-substrate execution: model calls should not require shelling out to the CLI wrapper in order to reach hosted or local providers.
 
 ## Command
 


### PR DESCRIPTION
Closes #3489

## Summary
Made the direct API path canonical for the bounded multi-agent proof surface by removing hosted model CLI use from the reviewer lane, rerunning the proof with API-only model calls, and updating the provider adapter runbook and proof packet to reflect the API-first boundary.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.4/tasks/issue-3489__v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path/sor.md`
- Tracked implementation artifacts:
  - `adl/tools/run_v0914_multi_agent_workcell_proof.sh`
  - `docs/milestones/v0.91.4/review/multi_agent_workcell/MULTI_AGENT_CSDLC_WORKCELL_PROOF_PACKET_2026-05-28.md`
  - `docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_plan_2026-05-28.json`
  - `docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/run_v0914_multi_agent_workcell_proof.sh`
    Verified the updated proof runner shell script parses after the direct API and path-resolution changes.
  - `bash adl/tools/run_v0914_multi_agent_workcell_proof.sh --artifact-root artifacts/v0914/multi_agent_workcell --tracked-review-root docs/milestones/v0.91.4/review/multi_agent_workcell --hosted-review-model gpt-5.3-codex --openai-key-file [runtime credential file]`
    Verified the bounded workcell proof reruns successfully with Ollama workers and a hosted OpenAI/Codex reviewer through APIs only.
  - `python3 adl/tools/validate_multi_agent_workcell_state.py docs/milestones/v0.91.4/review/multi_agent_workcell/workcell_proof_state_2026-05-28.json`
    Verified the retained workcell state packet still matches the validator contract after the proof rerun.
  - `git diff --check`
    Verified whitespace hygiene for the tracked changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3489__v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3489__v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path/sor.md
- Idempotency-Key: v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path-adl-tools-run-v0914-multi-agent-workcell-proof-sh-docs-milestones-v0-91-4-review-multi-agent-workcell-multi-agent-csdlc-workcell-proof-packet-2026-05-28-md-docs-milestones-v0-91-4-review-multi-agent-workcell-workcell-proof-plan-2026-05-28-json-docs-milestones-v0-91-4-review-provider-communication-substrate-provider-adapter-runbook-md-adl-v0-91-4-tasks-issue-3489-v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path-sip-md-adl-v0-91-4-tasks-issue-3489-v0-91-4-provider-make-direct-provider-api-the-canonical-cross-substrate-execution-path-sor-md