### PR TITLE
Disable nightly coverage issue automation

### DIFF
--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -1,14 +1,10 @@
 name: nightly-coverage-ratchet
 
 on:
-  schedule:
-    # 11:00 UTC is 03:00 PST / 04:00 PDT.
-    - cron: "0 11 * * *"
   workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   nightly-coverage-ratchet:
@@ -180,23 +176,6 @@ jobs:
             adl/coverage-summary.json
             ${{ steps.report.outputs.report_path }}
           if-no-files-found: error
-
-      - name: Open or update daily blocker issue
-        if: always() && (steps.report.outputs.has_below_threshold == 'true' || steps.checks.outcome != 'success')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          day="$(TZ=America/Los_Angeles date '+%Y-%m-%d')"
-          title="Daily coverage blockers: $day"
-          body_file="${{ steps.report.outputs.report_path }}"
-
-          existing="$(gh issue list --state open --search "$title in:title" --json number,title --jq '.[] | select(.title == "'"$title"'") | .number' | head -n 1 || true)"
-          if [ -n "${existing:-}" ]; then
-            gh issue edit "$existing" --body-file "$body_file"
-          else
-            gh issue create --title "$title" --body-file "$body_file"
-          fi
 
       - name: Fail when blockers exist or checks fail
         if: always() && (steps.report.outputs.has_below_threshold == 'true' || steps.checks.outcome != 'success')


### PR DESCRIPTION
## Summary
- remove the scheduled trigger from the nightly coverage ratchet workflow
- remove issue-writing permission and the daily blocker issue creation step
- keep the workflow available for manual runs without bot-opening GitHub issues

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-coverage-ratchet.yaml"); puts "yaml-ok"'
- git diff --check
