### PR TITLE
[v0.91.4][tools] Stabilize browser automation for demo proof

### DIFF
--- a/adl/tools/diagnose_browser_routes.py
+++ b/adl/tools/diagnose_browser_routes.py
@@ -24,7 +24,13 @@ from pathlib import Path
 from typing import Any
 
 APP_NAMES = ["chromium", "Chromium", "Google Chrome", "Safari"]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRIMARY_REPO_ROOT = REPO_ROOT.parent.parent if REPO_ROOT.parent.name == ".worktrees" else REPO_ROOT
+PLAYWRIGHT_CHROMIUM_REL = Path(".adl/.cache/diagram-renderers/playwright/chromium-1134/chrome-mac/Chromium.app/Contents/MacOS/Chromium")
+
 EXECUTABLE_CANDIDATES = [
+    str(PRIMARY_REPO_ROOT / PLAYWRIGHT_CHROMIUM_REL),
+    str(REPO_ROOT / PLAYWRIGHT_CHROMIUM_REL),
     "/Applications/Chromium.app/Contents/MacOS/Chromium",
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/Applications/Google Chrome copy.app/Contents/MacOS/Google Chrome",
@@ -32,8 +38,8 @@ EXECUTABLE_CANDIDATES = [
 ]
 PATH_COMMANDS = ["chromium", "chromium-browser", "google-chrome", "chrome"]
 PROFILE_CANDIDATES = [
-    "/Users/daniel/Library/Application Support/Chromium",
-    "/Users/daniel/Library/Caches/Chromium",
+    str(Path.home() / "Library/Application Support/Chromium"),
+    str(Path.home() / "Library/Caches/Chromium"),
 ]
 
 
@@ -64,6 +70,15 @@ def app_route(name: str) -> dict[str, Any]:
 def executable_route(path: str) -> dict[str, Any]:
     p = Path(path)
     return {"path": path, "exists": p.exists(), "is_file": p.is_file(), "executable": os.access(path, os.X_OK) if p.exists() else False}
+
+
+def version_smoke(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists() or not os.access(path, os.X_OK):
+        return {"attempted": False, "reason": "executable_missing_or_not_executable"}
+    if "Chrome" not in path and "Chromium" not in path:
+        return {"attempted": False, "reason": "not_a_chrome_family_executable"}
+    return run_command([path, "--version"], timeout=5)
 
 
 def headless_smoke(path: str) -> dict[str, Any]:
@@ -120,11 +135,12 @@ def main() -> int:
         "recommended_canonical_route": "codex_in_app_browser_for_agent_proof",
         "proof_boundaries": {
             "http_reachability": "curl/urllib can prove a URL responds, but not browser rendering or interaction.",
-            "browser_interaction": "Use the Codex in-app browser CUA/evaluate route or an explicit operator browser session.",
+            "browser_interaction": "Use the Codex in-app browser CUA/evaluate route, or an explicit operator browser session.",
+            "direct_shell_browser": "A Chrome/Chromium executable version check proves only executable identity. Direct shell proof also requires a passing headless smoke.",
         },
         "app_routes": [app_route(name) for name in APP_NAMES],
         "known_executable_routes": [
-            {**executable_route(path), **({"headless_smoke": headless_smoke(path)} if args.headless_smoke else {})}
+            {**executable_route(path), "version_smoke": version_smoke(path), **({"headless_smoke": headless_smoke(path)} if args.headless_smoke else {})}
             for path in EXECUTABLE_CANDIDATES
         ],
         "path_routes": [path_route(command) for command in PATH_COMMANDS],

--- a/adl/tools/diagnose_browser_routes.py
+++ b/adl/tools/diagnose_browser_routes.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Diagnose browser routes for ADL demo and web proof work.
+
+This script is intentionally small and dependency-free. It separates:
+- shell/app-launch visibility from the Codex process
+- known executable paths
+- HTTP reachability through curl/urllib
+- real browser interaction proof, which must be performed by the Codex in-app
+  browser or an explicit operator browser session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+APP_NAMES = ["chromium", "Chromium", "Google Chrome", "Safari"]
+EXECUTABLE_CANDIDATES = [
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Google Chrome copy.app/Contents/MacOS/Google Chrome",
+    "/Applications/Safari.app/Contents/MacOS/Safari",
+]
+PATH_COMMANDS = ["chromium", "chromium-browser", "google-chrome", "chrome"]
+PROFILE_CANDIDATES = [
+    "/Users/daniel/Library/Application Support/Chromium",
+    "/Users/daniel/Library/Caches/Chromium",
+]
+
+
+def run_command(command: list[str], timeout: int = 5) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+        return {
+            "command": command,
+            "ok": completed.returncode == 0,
+            "returncode": completed.returncode,
+            "stdout": completed.stdout.strip()[:500],
+            "stderr": completed.stderr.strip()[:500],
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"command": command, "ok": False, "error": str(exc)[:500]}
+
+
+def app_route(name: str) -> dict[str, Any]:
+    result = run_command(["open", "-Ra", name])
+    return {
+        "app": name,
+        "visible_to_codex_process": bool(result.get("ok")),
+        "check": result,
+        "operator_note": "If this fails here but `open -a {}` works in the operator shell, treat that as a process/app-lookup boundary, not proof the app is absent.".format(name),
+    }
+
+
+def executable_route(path: str) -> dict[str, Any]:
+    p = Path(path)
+    return {"path": path, "exists": p.exists(), "is_file": p.is_file(), "executable": os.access(path, os.X_OK) if p.exists() else False}
+
+
+def headless_smoke(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists() or not os.access(path, os.X_OK):
+        return {"attempted": False, "reason": "executable_missing_or_not_executable"}
+    if "Chrome" not in path and "Chromium" not in path:
+        return {"attempted": False, "reason": "no_headless_mode_for_this_route"}
+    with tempfile.TemporaryDirectory(prefix="adl-browser-smoke-") as profile:
+        return run_command([
+            path,
+            "--headless=new",
+            "--disable-gpu",
+            "--no-first-run",
+            "--no-default-browser-check",
+            f"--user-data-dir={profile}",
+            "--dump-dom",
+            "data:text/html,<html><body>adl-browser-smoke</body></html>",
+        ], timeout=10)
+
+
+def profile_route(path: str) -> dict[str, Any]:
+    p = Path(path)
+    return {"path": path, "exists": p.exists(), "is_dir": p.is_dir(), "note": "profile/cache presence is evidence of browser use, not an executable route"}
+
+
+def path_route(command: str) -> dict[str, Any]:
+    resolved = shutil.which(command)
+    return {"command": command, "resolved": resolved, "available": resolved is not None}
+
+
+def http_check(url: str | None) -> dict[str, Any] | None:
+    if not url:
+        return None
+    try:
+        request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310 - operator-supplied diagnostic URL
+            return {"url": url, "reachable": True, "status": response.status, "content_type": response.headers.get("content-type")}
+    except urllib.error.HTTPError as exc:
+        return {"url": url, "reachable": False, "status": exc.code, "error": str(exc)[:500]}
+    except Exception as exc:  # noqa: BLE001
+        return {"url": url, "reachable": False, "error": str(exc)[:500]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diagnose ADL browser proof routes.")
+    parser.add_argument("--url", help="optional URL for HTTP reachability only; this is not browser interaction proof")
+    parser.add_argument("--headless-smoke", action="store_true", help="try direct Chrome/Chromium headless smoke for known executable paths")
+    parser.add_argument("--json", action="store_true", help="emit JSON only")
+    args = parser.parse_args()
+
+    report: dict[str, Any] = {
+        "schema_version": "adl.browser_routes_diagnostic.v1",
+        "recommended_canonical_route": "codex_in_app_browser_for_agent_proof",
+        "proof_boundaries": {
+            "http_reachability": "curl/urllib can prove a URL responds, but not browser rendering or interaction.",
+            "browser_interaction": "Use the Codex in-app browser CUA/evaluate route or an explicit operator browser session.",
+        },
+        "app_routes": [app_route(name) for name in APP_NAMES],
+        "known_executable_routes": [
+            {**executable_route(path), **({"headless_smoke": headless_smoke(path)} if args.headless_smoke else {})}
+            for path in EXECUTABLE_CANDIDATES
+        ],
+        "path_routes": [path_route(command) for command in PATH_COMMANDS],
+        "profile_routes": [profile_route(path) for path in PROFILE_CANDIDATES],
+        "http_check": http_check(args.url),
+        "codex_in_app_browser_route": {
+            "status": "documented_not_shell_diagnosed",
+            "why": "The in-app browser is exposed through the Codex Browser skill, not through this shell process.",
+            "known_working_pattern": "browser tab + tab.cua.click({x,y}) + tab.cua.keypress({keys:['Space']}) + DOM evaluate",
+        },
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print("ADL browser route diagnostic")
+        print(f"recommended: {report['recommended_canonical_route']}")
+        if report["http_check"]:
+            print(f"http: {report['http_check']}")
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
@@ -10,7 +10,7 @@ ADL agents need a boring, repeatable browser proof path for demos, localhost che
 
 ## Canonical Recommendation
 
-For ADL agent proof, use the Codex in-app browser first.
+For ADL agent proof, use the Codex in-app browser first. The repo-cached Playwright Chromium executable should be diagnosed and recorded when present, but direct shell-driven headless Chromium is not the default proof route unless its smoke test passes in the current environment.
 
 Why:
 
@@ -18,8 +18,10 @@ Why:
 - it supports screenshot/DOM proof
 - it supports real browser-side CUA input such as clicks and keypresses
 - it avoids relying on macOS LaunchServices app-name lookup from the sandboxed shell
+- the primary-checkout or worktree Playwright Chromium cache path can be diagnosed directly without relying on `open -a`
+- a cached Chromium version check can prove which executable exists, while a headless smoke check proves whether direct shell execution is usable
 
-Use installed Chromium/Safari/Chrome as operator-visible fallback paths, not as the primary automated agent path.
+Use operator-installed Chromium/Safari/Chrome as operator-visible fallback paths, not as the primary automated agent path. Use direct cached Chromium headless only after the diagnostic smoke says it works. In the current environment, the cached Chromium executable can report its version, but direct shell headless launch fails under crashpad permission constraints.
 
 ## Route Types
 
@@ -29,6 +31,7 @@ Use installed Chromium/Safari/Chrome as operator-visible fallback paths, not as 
 | Codex in-app browser | page load, rendering, screenshot, DOM state, CUA input | operator's external browser app state | canonical for agent proof |
 | `open -a chromium ...` from operator shell | operator can open a URL in local Chromium | Codex shell can resolve the same app name | valid manual/operator route |
 | `open -Ra <app>` from Codex shell | whether LaunchServices resolves an app for the Codex process | whether the operator can open it from another shell | diagnostic only |
+| repo-cached Playwright Chromium executable | shell-visible Chromium executable under `.adl/.cache/diagram-renderers/playwright/...`; version check | app-name lookup or successful headless execution | diagnostic route; direct proof only if smoke passes |
 | direct Chrome/Chromium executable headless | possible headless proof if stable | may abort under macOS/sandbox constraints | optional fallback |
 
 ## Why Chromium Can Be Up But Not Usable From Codex Shell
@@ -91,6 +94,8 @@ The diagnostic separates:
 
 - `app_routes`: app lookup visible to the Codex shell
 - `known_executable_routes`: known macOS executable paths
+- `version_smoke`: direct executable identity check for Chrome/Chromium-family routes
+- `headless_smoke`: optional direct shell headless execution check
 - `path_routes`: PATH-resolved browser commands
 - `http_check`: HTTP reachability only
 - `codex_in_app_browser_route`: documented canonical route that must be exercised through the Browser skill, not the shell
@@ -133,8 +138,10 @@ Observed in the Codex shell during `#3497`:
 - `/Applications/Safari.app/Contents/MacOS/Safari`: exists and is executable.
 - `~/Library/Application Support/Chromium` and `~/Library/Caches/Chromium`: exist as Chromium profile/cache directories; this is evidence of browser use, not an executable route.
 - `/Applications/Google Chrome copy.app/Contents/MacOS/Google Chrome`: exists in this environment and should be diagnosed separately from the primary Chrome app when needed.
+- primary-checkout Playwright Chromium executable: discovered at `.adl/.cache/diagram-renderers/playwright/chromium-1134/chrome-mac/Chromium.app/Contents/MacOS/Chromium` and reports `Chromium 129.0.6668.29`; issue worktrees may not have their own `.adl/.cache` copy.
+- direct primary-checkout Playwright Chromium headless smoke from the Codex shell: attempted and failed with crashpad permission/handshake errors; do not use direct cached Chromium headless as the proof route unless a fresh smoke passes.
 - direct Google Chrome headless smoke from the Codex shell: attempted and failed with signal-style return code `-6`; do not use direct Chrome headless as the default proof route here.
 - Chromium operator route: operator reports `open -a chromium ...` works from their shell, but Codex shell cannot resolve `chromium`; preserve that distinction.
 - Codex in-app browser route: worked during Starharvest proof and remains the canonical agent route.
 
-Conclusion: the issue is not simply “no browser is installed.” It is a boundary between shell app lookup, direct macOS app execution, and the Codex in-app browser automation surface. ADL agents should use the in-app browser for automated proof, prefer operator `open -a chromium ...` for human-visible manual playback when available, and avoid direct Chrome headless unless a fresh diagnostic proves it works.
+Conclusion: the issue is not simply “no browser is installed.” It is a boundary between shell app lookup, direct macOS app execution, and the Codex in-app browser automation surface. ADL agents should use the in-app browser for automated proof, record the repo-cached Playwright Chromium executable as a diagnostic route, prefer operator `open -a chromium ...` for human-visible manual playback when available, and avoid direct cached Chromium or Chrome headless unless a fresh diagnostic proves it works.

--- a/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
@@ -1,0 +1,140 @@
+# Browser Automation Runbook v0.91.4
+
+## Status
+
+`canonical_agent_route_defined`
+
+## Purpose
+
+ADL agents need a boring, repeatable browser proof path for demos, localhost checks, and web-facing review work. Browser proof should not be rediscovered during every demo issue.
+
+## Canonical Recommendation
+
+For ADL agent proof, use the Codex in-app browser first.
+
+Why:
+
+- it can load `localhost` and `127.0.0.1` pages from the Codex app context
+- it supports screenshot/DOM proof
+- it supports real browser-side CUA input such as clicks and keypresses
+- it avoids relying on macOS LaunchServices app-name lookup from the sandboxed shell
+
+Use installed Chromium/Safari/Chrome as operator-visible fallback paths, not as the primary automated agent path.
+
+## Route Types
+
+| Route | What it proves | What it does not prove | Status |
+| --- | --- | --- | --- |
+| `curl` / HTTP HEAD | URL reachability and HTTP status | rendering, script execution, keyboard/mouse interaction | useful but insufficient |
+| Codex in-app browser | page load, rendering, screenshot, DOM state, CUA input | operator's external browser app state | canonical for agent proof |
+| `open -a chromium ...` from operator shell | operator can open a URL in local Chromium | Codex shell can resolve the same app name | valid manual/operator route |
+| `open -Ra <app>` from Codex shell | whether LaunchServices resolves an app for the Codex process | whether the operator can open it from another shell | diagnostic only |
+| direct Chrome/Chromium executable headless | possible headless proof if stable | may abort under macOS/sandbox constraints | optional fallback |
+
+## Why Chromium Can Be Up But Not Usable From Codex Shell
+
+The operator shell and Codex tool process do not necessarily share the same app lookup behavior. During `#3458`, the operator reported:
+
+```bash
+open -a chromium http://www.google.com
+```
+
+worked locally. In the Codex shell, app lookup for `chromium` failed even though browser proof was still possible through the Codex in-app browser. Treat this as an environment boundary:
+
+- operator shell app lookup: useful manual route
+- Codex shell app lookup: diagnostic route only
+- Codex in-app browser: canonical automated proof route
+
+Do not conclude that a browser is unavailable merely because one route fails.
+
+## In-App Browser Proof Pattern
+
+Use the Browser skill and the in-app browser. For interaction proof, prefer CUA input for keys/clicks, then inspect DOM state.
+
+Known working Starharvest pattern:
+
+```js
+await tab.goto('http://127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html');
+await tab.playwright.waitForLoadState({ state: 'load', timeoutMs: 10000 });
+await tab.cua.click({ x: 500, y: 400 });
+await tab.cua.keypress({ keys: ['Space'] });
+const afterSpace = await tab.playwright.evaluate(() => ({
+  score: document.querySelector('#hud-score')?.textContent,
+  seeds: document.querySelector('#hud-seeds')?.textContent,
+  status: document.querySelector('#status-banner')?.textContent,
+}));
+await tab.cua.keypress({ keys: ['r'] });
+const afterRestart = await tab.playwright.evaluate(() => ({
+  score: document.querySelector('#hud-score')?.textContent,
+  seeds: document.querySelector('#hud-seeds')?.textContent,
+  status: document.querySelector('#status-banner')?.textContent,
+}));
+```
+
+Important: do not rely on constructing `KeyboardEvent` inside the evaluated page context unless you have verified that event constructors exist there. During `#3458`, CUA keypress was the reliable route.
+
+## Diagnostic Script
+
+Use the browser route diagnostic to record what the current environment exposes:
+
+```bash
+python3 adl/tools/diagnose_browser_routes.py --json
+```
+
+With a local URL reachability check:
+
+```bash
+python3 adl/tools/diagnose_browser_routes.py --url http://127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html --json
+```
+
+The diagnostic separates:
+
+- `app_routes`: app lookup visible to the Codex shell
+- `known_executable_routes`: known macOS executable paths
+- `path_routes`: PATH-resolved browser commands
+- `http_check`: HTTP reachability only
+- `codex_in_app_browser_route`: documented canonical route that must be exercised through the Browser skill, not the shell
+
+## Demo Issue Rules
+
+- Record browser proof as `passed` only when a browser route loads the page and verifies the required DOM or interaction behavior.
+- Record `curl` as reachability proof only.
+- If operator Chromium works but Codex shell app lookup fails, record both facts.
+- Prefer representative proof paths for demo readiness and route exhaustive coverage as separate follow-on work.
+- Do not bury browser setup discoveries inside chat; update this runbook or the issue proof record.
+
+## Starharvest Reference Result
+
+The Starharvest proof route that worked in `#3458` was:
+
+- local server on `127.0.0.1:43191`
+- Codex in-app browser opened the demo URL
+- CUA click focused the page
+- CUA `Space` changed seeds from `4` to `3`
+- CUA `r` restarted the game and reset seeds to `4`
+
+This is the model for future lightweight demo browser proof.
+
+## Current Diagnostic Result
+
+Focused diagnostic command:
+
+```bash
+python3 adl/tools/diagnose_browser_routes.py --headless-smoke --json
+```
+
+Observed in the Codex shell during `#3497`:
+
+- `open -Ra chromium`: failed with `Unable to find application named 'chromium'`.
+- `open -Ra Chromium`: failed with `Unable to find application named 'Chromium'`.
+- `open -Ra Google Chrome`: failed with `Unable to find application named 'Google Chrome'`.
+- `open -Ra Safari`: failed with `Unable to find application named 'Safari'`.
+- `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`: exists and is executable.
+- `/Applications/Safari.app/Contents/MacOS/Safari`: exists and is executable.
+- `~/Library/Application Support/Chromium` and `~/Library/Caches/Chromium`: exist as Chromium profile/cache directories; this is evidence of browser use, not an executable route.
+- `/Applications/Google Chrome copy.app/Contents/MacOS/Google Chrome`: exists in this environment and should be diagnosed separately from the primary Chrome app when needed.
+- direct Google Chrome headless smoke from the Codex shell: attempted and failed with signal-style return code `-6`; do not use direct Chrome headless as the default proof route here.
+- Chromium operator route: operator reports `open -a chromium ...` works from their shell, but Codex shell cannot resolve `chromium`; preserve that distinction.
+- Codex in-app browser route: worked during Starharvest proof and remains the canonical agent route.
+
+Conclusion: the issue is not simply “no browser is installed.” It is a boundary between shell app lookup, direct macOS app execution, and the Codex in-app browser automation surface. ADL agents should use the in-app browser for automated proof, prefer operator `open -a chromium ...` for human-visible manual playback when available, and avoid direct Chrome headless unless a fresh diagnostic proves it works.

--- a/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
@@ -29,10 +29,13 @@ Use operator-installed Chromium/Safari/Chrome as operator-visible fallback paths
 | --- | --- | --- | --- |
 | `curl` / HTTP HEAD | URL reachability and HTTP status | rendering, script execution, keyboard/mouse interaction | useful but insufficient |
 | Codex in-app browser | page load, rendering, screenshot, DOM state, CUA input | operator's external browser app state | canonical for agent proof |
+| Codex Browser MCP route | local HTTP page load, Playwright-backed DOM inspection, click/type/key proof through the in-app browser | direct control of the operator's visible Chromium app | canonical automation substrate inside Codex |
+| Computer Use visible Chromium route | control of the real visible Chromium app, address-bar navigation, accessibility-tree proof, screenshots of what the operator sees | Playwright DOM APIs or headless automation | canonical for human-visible Chromium demos |
 | `open -a chromium ...` from operator shell | operator can open a URL in local Chromium | Codex shell can resolve the same app name | valid manual/operator route |
 | `open -Ra <app>` from Codex shell | whether LaunchServices resolves an app for the Codex process | whether the operator can open it from another shell | diagnostic only |
 | repo-cached Playwright Chromium executable | shell-visible Chromium executable under `.adl/.cache/diagram-renderers/playwright/...`; version check | app-name lookup or successful headless execution | diagnostic route; direct proof only if smoke passes |
 | direct Chrome/Chromium executable headless | possible headless proof if stable | may abort under macOS/sandbox constraints | optional fallback |
+| standalone Playwright install outside repo | package/runtime availability and browser-cache metadata | successful browser launch from the Codex shell | diagnostic only unless launch smoke passes |
 
 ## Why Chromium Can Be Up But Not Usable From Codex Shell
 
@@ -47,12 +50,46 @@ worked locally. In the Codex shell, app lookup for `chromium` failed even though
 - operator shell app lookup: useful manual route
 - Codex shell app lookup: diagnostic route only
 - Codex in-app browser: canonical automated proof route
+- Computer Use app control: canonical route when the requirement is the visible Chromium window
 
 Do not conclude that a browser is unavailable merely because one route fails.
 
+## Visible Chromium Proof Pattern
+
+When the requirement is specifically "open it in Chromium" or "show the demo in the real browser window," use Computer Use against the running Chromium app instead of shell `open -a` or direct headless Playwright.
+
+Known working route from `#3497`:
+
+- Computer Use resolved the running Chromium app:
+  - app bundle: `.adl/.cache/diagram-renderers/playwright/chromium-1134/chrome-mac/Chromium.app/`
+  - bundle ID: `org.chromium.Chromium`
+- Computer Use set the Chromium address bar to:
+  - `http://127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html`
+- Chromium loaded the Starharvest page.
+- The accessibility tree verified:
+  - window title: `Starharvest / Five-Minute Sprint Demo`
+  - URL: `127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html`
+  - heading: `Starharvest`
+  - timer, stardust, seeds, hull, objective, asteroid field, selected asteroid, and restart button were present.
+
+Use this route for human-visible demo playback. Use the Browser MCP route for automated DOM/gameplay proof where Playwright selectors are more precise.
+
 ## In-App Browser Proof Pattern
 
-Use the Browser skill and the in-app browser. For interaction proof, prefer CUA input for keys/clicks, then inspect DOM state.
+Use the Browser skill and the in-app browser. For interaction proof, prefer Playwright-backed DOM inspection for stable selectors, CUA input for game keys/clicks when needed, then inspect DOM state.
+
+Minimal local HTTP smoke pattern:
+
+```js
+await tab.goto('http://127.0.0.1:43219/');
+await tab.playwright.waitForLoadState({ state: 'load', timeoutMs: 10000 });
+await tab.playwright.locator('#btn').click();
+const result = await tab.playwright.evaluate(() => ({
+  title: document.title,
+  heading: document.querySelector('#ok')?.textContent,
+  clicked: document.body.dataset.clicked || null,
+}));
+```
 
 Known working Starharvest pattern:
 
@@ -130,6 +167,9 @@ python3 adl/tools/diagnose_browser_routes.py --headless-smoke --json
 
 Observed in the Codex shell during `#3497`:
 
+- Browser MCP / Codex in-app browser route: passed a local HTTP proof against `127.0.0.1`, including page load, selector click, and DOM mutation inspection.
+- Computer Use visible Chromium route: passed against the actual Chromium window. It loaded Starharvest, verified the visible URL/title, and exposed the game state through the accessibility tree.
+- Standalone Playwright installed outside the repo at `~/tools/playwright-browser` reports Playwright `1.60.0` and browser cache metadata, but `chromium.launch({ headless: true })` fails from the Codex shell with a macOS MachPort permission error. Treat this as proof that the package is installed, not proof that direct shell browser launch is usable.
 - `open -Ra chromium`: failed with `Unable to find application named 'chromium'`.
 - `open -Ra Chromium`: failed with `Unable to find application named 'Chromium'`.
 - `open -Ra Google Chrome`: failed with `Unable to find application named 'Google Chrome'`.
@@ -142,6 +182,6 @@ Observed in the Codex shell during `#3497`:
 - direct primary-checkout Playwright Chromium headless smoke from the Codex shell: attempted and failed with crashpad permission/handshake errors; do not use direct cached Chromium headless as the proof route unless a fresh smoke passes.
 - direct Google Chrome headless smoke from the Codex shell: attempted and failed with signal-style return code `-6`; do not use direct Chrome headless as the default proof route here.
 - Chromium operator route: operator reports `open -a chromium ...` works from their shell, but Codex shell cannot resolve `chromium`; preserve that distinction.
-- Codex in-app browser route: worked during Starharvest proof and remains the canonical agent route.
+- Codex in-app browser route: worked during Starharvest proof, worked during local HTTP smoke, and remains the canonical agent route.
 
-Conclusion: the issue is not simply “no browser is installed.” It is a boundary between shell app lookup, direct macOS app execution, and the Codex in-app browser automation surface. ADL agents should use the in-app browser for automated proof, record the repo-cached Playwright Chromium executable as a diagnostic route, prefer operator `open -a chromium ...` for human-visible manual playback when available, and avoid direct cached Chromium or Chrome headless unless a fresh diagnostic proves it works.
+Conclusion: the issue is not simply “no browser is installed.” It is a boundary between shell app lookup, direct macOS app execution, standalone Playwright shell launch, visible-app control, and the Codex in-app browser automation surface. ADL agents should use the in-app browser / Browser MCP route for automated proof, use Computer Use for visible Chromium demos, record Playwright and Chromium executable paths as diagnostic routes, preserve operator `open -a chromium ...` as a manual fallback, and avoid direct cached Chromium, Chrome, or standalone Playwright headless launch unless a fresh diagnostic proves it works.

--- a/docs/milestones/v0.91.4/review/demo_showcase/BROWSER_PROOF_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/demo_showcase/BROWSER_PROOF_RUNBOOK_v0.91.4.md
@@ -56,3 +56,12 @@ A real browser/gameplay proof should verify at least:
 ## Current v0.91.4 Finding
 
 During `#3458`, `curl` confirmed the Starharvest page returned HTTP 200 from the local server. The operator confirmed `open -a chromium http://www.google.com` works from their shell, while the Codex sandbox could not resolve `open -a chromium`. Future proof tooling should preserve both routes instead of treating one failed launcher as evidence that browsers are unavailable.
+
+## Canonical Browser Automation Reference
+
+The broader ADL browser automation contract is tracked in:
+
+- `docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md`
+- `adl/tools/diagnose_browser_routes.py`
+
+Use that runbook before adding new browser-backed demo proof. This demo-showcase note remains the local Starharvest-specific quick path.

--- a/docs/milestones/v0.91.4/review/demo_showcase/BROWSER_PROOF_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/demo_showcase/BROWSER_PROOF_RUNBOOK_v0.91.4.md
@@ -12,14 +12,21 @@ This runbook records the preferred browser-proof order for v0.91.4 demo work.
    - It can load `localhost` and `127.0.0.1` pages.
    - It has a Playwright-backed evaluation surface.
    - Use it for proof capture when the demo needs DOM/gameplay assertions.
-2. Use the installed Chromium app from an operator terminal when the in-app browser is unavailable.
+2. Use Computer Use to control the visible Chromium app when the demo must be shown in Chromium.
+   - This is the preferred human-visible Chromium route.
+   - It can set the address bar, read the accessibility tree, and capture the visible app state.
+   - Known working target:
+     ```text
+     http://127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html
+     ```
+3. Use the installed Chromium app from an operator terminal when automated visible-app control is unavailable.
    - Known operator command:
      ```bash
      open -a chromium http://127.0.0.1:43191/demos/v0.91.3/starharvest_five_minute_sprint_demo.html
      ```
    - This may work in the operator shell even if `open -a chromium` does not resolve from a sandboxed Codex process.
-3. Use Safari as a manual fallback only when automation is not required.
-4. Use `curl` only for HTTP reachability, not for gameplay proof.
+4. Use Safari as a manual fallback only when automation is not required.
+5. Use `curl` only for HTTP reachability, not for gameplay proof.
 
 ## Starharvest Local Server
 
@@ -56,6 +63,8 @@ A real browser/gameplay proof should verify at least:
 ## Current v0.91.4 Finding
 
 During `#3458`, `curl` confirmed the Starharvest page returned HTTP 200 from the local server. The operator confirmed `open -a chromium http://www.google.com` works from their shell, while the Codex sandbox could not resolve `open -a chromium`. Future proof tooling should preserve both routes instead of treating one failed launcher as evidence that browsers are unavailable.
+
+During `#3497`, Computer Use successfully controlled the visible Chromium app and loaded Starharvest in that real Chromium window. The accessibility tree verified the Starharvest title, URL, heading, timer, stardust, seeds, hull, asteroid field, selected asteroid, and restart button. This is the correct route when a demo must be shown in Chromium.
 
 ## Canonical Browser Automation Reference
 


### PR DESCRIPTION
Closes #3497

## Summary
Created a canonical ADL browser automation runbook and a focused browser-route diagnostic script. The work records the important distinction between Codex in-app browser automation, operator Chromium manual playback, Codex shell app lookup, direct Chrome executable/headless behavior, and HTTP reachability.

## Artifacts
- `adl/tools/diagnose_browser_routes.py`
- `docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md`
- `docs/milestones/v0.91.4/review/demo_showcase/BROWSER_PROOF_RUNBOOK_v0.91.4.md`
- Local ignored output-card record at `.adl/v0.91.4/tasks/issue-3497__v0-91-4-tools-stabilize-browser-automation-for-demo-and-web-proof/sor.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/diagnose_browser_routes.py`
    Verified Python syntax.
  - `python3 adl/tools/diagnose_browser_routes.py --json > browser_routes.json`
    Verified basic diagnostic execution.
  - `python3 -m json.tool browser_routes.json >/dev/null`
    Verified basic diagnostic JSON validity.
  - `python3 adl/tools/diagnose_browser_routes.py --headless-smoke --json > browser_routes_headless.json`
    Verified optional headless-smoke diagnostic execution.
  - `python3 -m json.tool browser_routes_headless.json >/dev/null`
    Verified headless-smoke diagnostic JSON validity.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3497__v0-91-4-tools-stabilize-browser-automation-for-demo-and-web-proof/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3497__v0-91-4-tools-stabilize-browser-automation-for-demo-and-web-proof/sor.md
- Idempotency-Key: v0-91-4-tools-stabilize-browser-automation-for-demo-proof-adl-tools-diagnose-browser-routes-py-docs-milestones-v0-91-4-review-browser-automation-docs-milestones-v0-91-4-review-demo-showcase-browser-proof-runbook-v0-91-4-md-adl-v0-91-4-tasks-issue-3497-v0-91-4-tools-stabilize-browser-automation-for-demo-and-web-proof-sip-md-adl-v0-91-4-tasks-issue-3497-v0-91-4-tools-stabilize-browser-automation-for-demo-and-web-proof-sor-md