### PR TITLE
[v0.91.4][planning] Create v0.91.5 bridge milestone

### DIFF
--- a/docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md
+++ b/docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md
@@ -69,8 +69,9 @@ evidence exists.
 - [ ] Deferred issues have owners and follow-on routing.
 - [ ] CodeFriend sidecar setup is complete or truthfully blocked/routed.
 - [ ] WildClawBench sidecar spike is complete or truthfully blocked/routed.
-- [ ] First-birthday readiness side issue `#3377` is complete or routed into
-  WP-19/WP-20 next-milestone planning/review.
+- [x] First-birthday readiness side issue `#3377` is routed to v0.91.5.
+- [x] Remaining multi-agent, provider/model, public prompt-record, and
+  demo-readiness bridge work is routed to v0.91.5.
 
 ## Release Packaging
 
@@ -88,7 +89,7 @@ evidence exists.
 ## Post-Release
 
 - [ ] Milestone/epic issues closed with release links.
-- [ ] Deferred items moved to the next milestone backlog.
+- [ ] Deferred items moved to the v0.91.5 bridge package or later backlog.
 - [ ] Follow-up bugs/tech debt captured as issues.
 - [ ] Roadmap/status docs updated.
 - [ ] Retrospective or release closeout summary recorded.

--- a/docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md
+++ b/docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md
@@ -28,9 +28,9 @@ By `WP-19`, this handoff should answer:
 
 ## Current Planning Assumption
 
-The immediate purpose of v0.91.4 is not to start the next product or research
-wave early. It is to make future ADL software-development work run through a
-tracked, auditable C-SDLC default lane.
+The next milestone is now planned as v0.91.5, a bridge milestone for
+multi-agent stabilization, provider/model breadth, public prompt records,
+demo-readiness routing, and v0.92 activation preflight.
 
 The next milestone should therefore consume v0.91.4 outputs only after these
 conditions are true:
@@ -63,13 +63,15 @@ conditions are true:
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `docs/planning/codefriend/`
 - current backlog and open issue state
+- v0.91.5 bridge package:
+  [../v0.91.5/README.md](../v0.91.5/README.md)
 
 ## Required WP-19 Update
 
 During `WP-19`, replace this section with the actual handoff:
 
-- selected next milestone
-- selected scope
+- selected next milestone: expected `v0.91.5`
+- selected scope: bridge work required before v0.92 first birthday
 - non-goals
 - issue-wave candidates
 - feature docs or ADRs required before execution

--- a/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
@@ -23,9 +23,8 @@ The milestone must run:
 - explicit PVF slow-proof lane proof showing that heavyweight runtime-v2
   proof/materialization tests are excluded from ordinary PR-fast nextest and
   included in the explicit `slow-proof-tests` release-gate lane
-- explicit multi-agent workcell proof or truthful blocked handoff showing
-  shard admission, worker/reviewer/janitor lanes, and serialized merge/closeout
-  gates
+- explicit routing of remaining multi-agent workcell stabilization to v0.91.5
+  so v0.91.4 release truth does not overclaim multi-agent completion
 - combined C-SDLC lane validation
 - active-issue migration policy review with sampled issue routing
 - process-drift regression fixture results for legacy SRP, stale SOR, skipped

--- a/docs/milestones/v0.91.4/README.md
+++ b/docs/milestones/v0.91.4/README.md
@@ -25,17 +25,19 @@ WP-21 `#3371`. The CodeFriend sidecar has also been seeded: umbrella `#3372`,
 CF-PRE-01 `#3373`, CF-PRE-02 `#3374`, CF-PRE-03 `#3375`, and CF-PRE-04
 `#3376`. The WildClawBench benchmark spike sidecar is seeded: umbrella
 `#3378`, WC-PRE-01 `#3379`, WC-PRE-02 `#3380`, WC-PRE-03 `#3381`, and
-WC-PRE-04 `#3382`. First-birthday readiness has been promoted as standalone
-side issue `#3377` for v0.92 launch preparation. Sprint 2, Sprint 3, and
+WC-PRE-04 `#3382`. Remaining bridge work has moved to v0.91.5: first-birthday
+readiness `#3377`, multi-agent/provider work beginning at `#3415`, public
+prompt records `#3472`-`#3476`, demo readiness `#3455`/`#3460`/`#3461`, and
+OpenRouter/model-matrix issues `#3501`-`#3505`. Sprint 2, Sprint 3, and
 Sprint 4 child execution now depends on prior sprint sequencing and their own
 dependency gates rather than on Sprint 1 opening. The CodeFriend sidecar
 remains non-core and wait-gated by its own routing/dependency lane. The
 WildClawBench sidecar has now started through WC-PRE-01 `#3379`, which
 completed upstream reconnaissance and ended in a truthful blocked setup
 baseline pending benchmark image, workspace payload, helper tools, and API-key
-availability. First-birthday readiness does not alter the v0.91.4 release-tail
-sequence and should feed WP-19/WP-20 next-milestone planning/review. Remaining
-list-only side issues remain queued until explicitly promoted.
+availability. The bridge split does not alter the v0.91.4 release-tail
+sequence: v0.91.4 now closes Sprint 4 and release truth, while v0.91.5 carries
+the remaining pre-v0.92 stabilization work.
 
 This package is intentionally stacked after the v0.91.3 first-slice package. It
 assumes v0.91.3 proves one bounded Cognitive State Transition and then defines
@@ -69,6 +71,10 @@ repo/S3 welcome-page setup mini-sprint described in
 That sidecar is part of v0.91.4 scheduling, but it is not C-SDLC core
 machinery and must not be used as proof that C-SDLC default operation is
 complete.
+
+The v0.91.5 bridge milestone now carries the remaining multi-agent,
+provider/model, public prompt-record, demo-readiness, and first-birthday
+preflight work so v0.91.4 can land cleanly.
 
 ## Milestone Role
 

--- a/docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md
+++ b/docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md
@@ -24,6 +24,9 @@ work.
   [C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN](C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md)
 - [ ] Signed trace proof and verification evidence complete.
 - [ ] CodeFriend pre-alpha sidecar setup complete or truthfully blocked/routed.
+- [ ] v0.91.5 bridge work routed out of v0.91.4 release scope:
+  multi-agent stabilization, provider/model matrix, public prompt records,
+  demo readiness, and first-birthday preflight.
 - [ ] Internal review complete.
 - [ ] External / third-party review complete.
 - [ ] Review remediation complete.
@@ -75,7 +78,7 @@ work.
 
 - [ ] Default C-SDLC operation announced internally.
 - [ ] Roadmap/status docs updated.
-- [ ] Deferred items routed to later backlog.
+- [ ] Deferred items routed to v0.91.5 or later backlog.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
+++ b/docs/milestones/v0.91.4/SPRINT_v0.91.4.md
@@ -10,10 +10,11 @@
 
 ## Status
 
-Sprint 1 is closed with clean closeout truth. Sprint 2, Sprint 3, Sprint 4,
-the multi-agent C-SDLC workcell proof mini-sprint, the CodeFriend sidecar, and
-the WildClawBench benchmark spike sidecar remain seeded as controlled
-issue/card batches.
+Sprint 1 is closed with clean closeout truth. Sprint 2, Sprint 3, and Sprint 4
+remain the v0.91.4 core sprint sequence. CodeFriend and WildClawBench are
+closed or closing sidecar evidence lanes. The remaining multi-agent,
+provider/model, public prompt-record, demo-readiness, and first-birthday
+preflight work has moved to v0.91.5.
 
 ## How To Use
 
@@ -30,16 +31,15 @@ truth must stay aligned with the sprint state artifacts.
 | Sprint 3 | Sprint Default And Metrics (`#3357`) | WP-09 `#3358`, WP-10 `#3359`, WP-11 `#3360`, WP-12 `#3361` | Make sprint execution default-safe and measure repeatability, validation-tail, proof-latency, and parallel-validation behavior. |
 | Sprint 4 | Review, Remediation, Planning, And Release (`#3362`) | WP-13 `#3363`, WP-14 `#3364`, WP-15 `#3365`, WP-16 `#3366`, WP-17 `#3367`, WP-18 `#3368`, WP-19 `#3369`, WP-20 `#3370`, WP-21 `#3371` | Prove, gate, review, remediate, plan the next milestone, re-review the handoff, and close the completion milestone. |
 
-## C-SDLC Proof Mini-Sprint
+## Bridge-Routed C-SDLC Proof Work
 
-The multi-agent C-SDLC workcell proof is added v0.91.4 scope because completing
-C-SDLC requires at least one bounded proof that the process can coordinate more
-than one agent lane at a time without losing card, branch, review, PR, or
-closeout truth.
+The multi-agent C-SDLC workcell proof remains required before v0.92 depends on
+multi-agent operation, but it is now routed to v0.91.5 so v0.91.4 can finish
+Sprint 4 and release without further scope expansion.
 
 | Mini-sprint | Title | Ordered Children | Goal |
 | --- | --- | --- | --- |
-| Multi-Agent C-SDLC Workcell Proof (`#3415`) | Parallel C-SDLC workcell proof | MA-CSDL-01 `#3416`, MA-CSDL-02 `#3417`, MA-CSDL-03 `#3418`, MA-CSDL-04 `#3419` | Prove a conductor-managed workcell with bounded worker, reviewer, janitor, and closeout lanes, explicit shard admission, and truthful serialized gates. |
+| Multi-Agent C-SDLC Workcell Proof (`#3415`) | Parallel C-SDLC workcell proof | moved to v0.91.5 | Prove a conductor-managed workcell with bounded worker, reviewer, janitor, and closeout lanes, explicit shard admission, and truthful serialized gates. |
 
 Current workcell state:
 
@@ -48,9 +48,8 @@ Current workcell state:
 - `#3417` owns shard admission and assignment planning.
 - `#3418` owns workcell state artifacts and conductor hook points.
 - `#3419` owns the bounded multi-agent proof sprint and should consume the `#3416` proof-slice recommendation rather than inventing its own lane shape.
-- This is C-SDLC core proof, not product sidecar work, but it does not add
-  extra release-tail gates; its evidence should feed WP-10, WP-13, WP-14, and
-  WP-15.
+- This is C-SDLC core proof, not product sidecar work.
+- Its remaining stabilization and follow-on work is now v0.91.5 bridge scope.
 
 ## Sidecar Mini-Sprint
 
@@ -113,18 +112,16 @@ rule stays reviewable:
   execution now waits on its own routing/dependency gates and remains
   non-core.
 - Batch 7 opened the multi-agent C-SDLC workcell proof `#3415` and
-  MA-CSDL-01 through MA-CSDL-04 as `#3416` through `#3419`; this is added
-  C-SDLC proof scope and should feed WP-10/WP-13/WP-14/WP-15 without changing
-  the closeout-tail sequence.
+  MA-CSDL-01 through MA-CSDL-04 as `#3416` through `#3419`; remaining
+  multi-agent stabilization has moved to v0.91.5.
 - Batch 8 added PVF docs-only follow-on `#3437` for pre-PR validation evidence
   reuse. This issue updates the PVF plan so the later CI/release-gate work can
   avoid rerunning the same full Rust cycle immediately after PR creation when
   the PR head commit and tree exactly match a recorded validation artifact. It
   does not implement CI changes and must fail closed to full validation in the
   future if evidence is absent, stale, mismatched, or invalid under policy.
-- Standalone first-birthday readiness side issue `#3377` is promoted for v0.92
-  launch preparation and should feed WP-19/WP-20; it is not a sprint child and
-  does not alter the v0.91.4 release-tail sequence.
+- Standalone first-birthday readiness issue `#3377` has moved to v0.91.5 and
+  should feed v0.92 WP-01 after v0.91.5 closeout.
 
 Every opened issue receives all five cards upfront. `SIP`, `STP`, and `SPP`
 must be design-time ready before execution starts; `SRP` and `SOR` remain

--- a/docs/milestones/v0.91.4/WBS_v0.91.4.md
+++ b/docs/milestones/v0.91.4/WBS_v0.91.4.md
@@ -10,9 +10,9 @@
 
 ## Status
 
-Tracked WBS. The v0.91.4 issue wave is seeded through Sprint 4, the sidecar
-waves, and the standalone first-birthday readiness issue; Sprint 1 has already
-closed cleanly.
+Tracked WBS. The v0.91.4 issue wave is seeded through Sprint 4 and the closed
+or closing sidecar waves; Sprint 1 has already closed cleanly. Remaining
+pre-v0.92 bridge work has moved to v0.91.5.
 
 ## How To Use
 
@@ -133,19 +133,17 @@ lessons:
 
 ## Planned Side Issues
 
-The following items remain list-only v0.91.4 side issues or mini-sprints unless
-explicitly promoted into the tracked issue wave. Already-seeded sidecars such as
-WildClawBench `#3378` and first-birthday readiness `#3377` are no longer part
-of this list-only bucket.
+The following items are no longer v0.91.4 release blockers. They are routed to
+v0.91.5 bridge planning or later backlog unless already closed.
 
 - outstanding demo work, including the best available Unity-facing C-SDLC demo
-  proof
+  proof, now represented by v0.91.5 demo readiness issues
 - benchmarking mini-sprint candidates beyond the already-seeded WildClawBench sidecar
 - root README rewrite
 - repo cleanup pass
 - partial drafting of Medium articles
 - HTML editors for planning docs
-- first-birthday readiness follow-on work beyond the already-promoted `#3377`
+- first-birthday readiness `#3377`, now a v0.91.5 preflight input
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml
+++ b/docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml
@@ -25,9 +25,8 @@ notes:
     proof cycles.
   - Parallel Validation Fabric planning is in scope for v0.91.4 and must
     preserve truthful pending/deferred/blocking proof state.
-  - Multi-agent C-SDLC workcell proof is in scope for v0.91.4 so C-SDLC can
-    demonstrate bounded parallel worker/reviewer/janitor lanes, not only
-    single-threaded sprint execution.
+  - Remaining multi-agent C-SDLC workcell stabilization is routed to v0.91.5
+    so v0.91.4 can close Sprint 4 and release without more scope expansion.
   - CodeFriend sidecar work is product setup, not C-SDLC core proof.
 card_update_rule:
   - Every opened WP must receive SIP, STP, SPP, SRP, and SOR cards.
@@ -70,7 +69,7 @@ opening_batch_policy:
     - batch: 7
       title: Multi-agent C-SDLC workcell proof
       seeded_issues: [3415, 3416, 3417, 3418, 3419]
-      state: seeded_and_ready
+      state: moved_to_v0.91.5_bridge
   list_only_side_issues:
     state: not_promoted
     note: Planned side issues remain list-only until explicitly promoted by the operator; SIDE-BENCH has been promoted to the WildClawBench sidecar issue wave, and SIDE-BIRTHDAY has been promoted as standalone side issue #3377.
@@ -232,7 +231,7 @@ closeout_sequence:
   - WP-19: Next milestone planning
   - WP-20: Next milestone review pass
   - WP-21: Release ceremony
-csdlc_proof_issue_waves:
+bridge_routed_issue_waves:
   - id: MA-CSDL-00
     issue: 3415
     title: Multi-agent C-SDLC workcell proof mini-sprint umbrella
@@ -241,10 +240,10 @@ csdlc_proof_issue_waves:
     depends_on: [WP-10]
     non_core: false
     notes:
-      - This is added C-SDLC proof scope, not product sidecar work.
-      - This mini-sprint does not add release-tail steps.
-      - Exit posture is a bounded proof of safe parallel worker/reviewer/janitor
-        coordination or a truthful blocked handoff with follow-on routing.
+      - Remaining multi-agent stabilization is routed to v0.91.5.
+      - This mini-sprint does not add v0.91.4 release-tail steps.
+      - Exit posture in v0.91.5 is a bounded proof of safe parallel
+        worker/reviewer/janitor coordination or a truthful blocked handoff.
     ordered_children:
       - id: MA-CSDL-01
         issue: 3416
@@ -338,13 +337,14 @@ planned_side_issues:
     issue: 3377
     title: First-birthday readiness for v0.92
     queue: docs
-    scheduling_note: promoted_standalone_side_issue_waiting_on_wp_01
+    scheduling_note: moved_to_v0.91.5_bridge
     consumes:
-      - WP-19
-      - WP-20
+      - v0.91.5
+      - v0.92 WP-01
     notes:
       - This side issue does not alter the v0.91.4 release-tail sequence.
-      - This side issue supports v0.92 first-birthday launch readiness.
+      - This side issue supports v0.92 first-birthday launch readiness through
+        the v0.91.5 bridge milestone.
   - id: SIDE-DEMO
     title: Outstanding demo work, including the best available Unity-facing C-SDLC demo proof
     queue: demo

--- a/docs/milestones/v0.91.5/ADR_PLAN_v0.91.5.md
+++ b/docs/milestones/v0.91.5/ADR_PLAN_v0.91.5.md
@@ -1,0 +1,29 @@
+# v0.91.5 ADR Plan
+
+## Status
+
+Candidate ADR planning surface.
+
+## Purpose
+
+Record architecture decisions that may need ADR treatment during or after
+v0.91.5.
+
+## Candidate ADRs
+
+| Candidate | Decision surface | Source docs | Timing |
+| --- | --- | --- | --- |
+| Multi-agent C-SDLC operating boundary | Bounded roles, shard ownership, review/closeout serialization, and no unbounded autonomy. | [MULTI_AGENT_CSDL_OPERATION_v0.91.5.md](features/MULTI_AGENT_CSDL_OPERATION_v0.91.5.md) | Author if v0.91.5 changes the accepted multi-agent boundary. |
+| Provider/model matrix and OpenRouter substrate | Provider identity, model-role aptitude, and OpenRouter as a test substrate. | [PROVIDER_MODEL_MATRIX_v0.91.5.md](features/PROVIDER_MODEL_MATRIX_v0.91.5.md) | Author if provider architecture changes beyond planning. |
+| Public prompt records and local-state archive boundary | Public prompt packets versus local `.adl` execution cache. | [PUBLIC_PROMPT_RECORDS_v0.91.5.md](features/PUBLIC_PROMPT_RECORDS_v0.91.5.md) | Author if public prompt records become canonical system objects. |
+| v0.92 activation readiness boundary | What v0.91.5 must prove before v0.92 opens. | [V092_ACTIVATION_READINESS_v0.91.5.md](features/V092_ACTIVATION_READINESS_v0.91.5.md) | Usually a planning/release decision, unless architecture boundaries change. |
+
+## Non-Claims
+
+This plan does not accept ADRs. It only identifies candidate decision surfaces.
+
+## Exit Criteria
+
+- Any ADR-worthy implementation decision is authored, deferred, or explicitly
+  marked unnecessary before release.
+

--- a/docs/milestones/v0.91.5/DECISIONS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/DECISIONS_v0.91.5.md
@@ -1,0 +1,40 @@
+# v0.91.5 Decisions
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Purpose
+
+Record decisions that constrain v0.91.5 bridge planning before execution.
+
+## How To Use
+
+Use these decisions as planning guardrails. If execution needs to change one,
+record a superseding decision rather than silently widening scope.
+
+## Decision Log
+
+| ID | Decision | Status | Rationale | Consequence |
+| --- | --- | --- | --- | --- |
+| D-01 | Use `v0.91.5`, not `v0.91.4A`. | accepted | The bridge is a real milestone with review and release truth. | Open side work moves out of v0.91.4 release scope. |
+| D-02 | Move `#3377` to v0.91.5. | accepted | First-birthday readiness now depends on bridge outputs. | v0.92 consumes `#3377` after v0.91.5 closeout. |
+| D-03 | Multi-agent must work before v0.91.5 closes or be explicitly blocked. | accepted | v0.92 needs reliable parallel C-SDLC operations. | Narrative-only multi-agent design is not sufficient. |
+| D-04 | OpenRouter belongs in the provider matrix. | accepted | It gives fast access to many models for aptitude testing. | Provider identity and routing evidence must remain explicit. |
+| D-05 | Public prompt records require transition controls. | accepted | Prompt cards are durable C-SDLC state, but local cache may contain cruft. | Export, redaction, archive, and deletion review are separate gates. |
+| D-06 | v0.92 activation features must be mapped before v0.92 opens. | accepted | Many features were implemented earlier and will activate together in v0.92. | The activation map is a v0.91.5 exit artifact. |
+
+## Open Questions
+
+- Which local and remote Ollama models are usable for each C-SDLC role?
+- Does Celestial Rescue become Unity Observatory proof or only prepare it?
+- Which `.adl` historical records should move out of repo entirely versus be
+  exported into public prompt packets or ObsMem ingestion bundles?
+
+## Exit Criteria
+
+- Decisions are reflected in WBS, sprint, demo, checklist, and issue wave docs.
+- Any superseding decisions are recorded rather than implied by implementation.

--- a/docs/milestones/v0.91.5/DEMO_MATRIX_v0.91.5.md
+++ b/docs/milestones/v0.91.5/DEMO_MATRIX_v0.91.5.md
@@ -1,0 +1,100 @@
+# v0.91.5 Demo Matrix
+
+## Status
+
+Candidate demo matrix. Demos are planned until their issues land evidence.
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Purpose
+
+Define the demo and proof surfaces needed for the v0.91.5 bridge.
+
+## How To Use
+
+Use this matrix to decide whether the bridge is demonstrably ready for v0.92.
+Do not mark rows complete until artifacts exist.
+
+## Scope
+
+Scope covers multi-agent C-SDLC proof, provider/model matrix proof, public
+prompt packet proof, demo readiness, and v0.92 activation preflight.
+
+## Runtime Preconditions
+
+Runtime preconditions are pending for implementation issues. Provider-backed
+tests must record credentials, model identity, and skipped/blocked state
+truthfully without leaking secrets.
+
+## Demo Coverage Summary
+
+| Demo | Issues | Proof expectation | Status |
+| --- | --- | --- | --- |
+| Multi-agent C-SDLC workcell | `#3415`, `#3484`, `#3501`-`#3504` | Bounded issue execution with role, shard, provider, review, and closeout truth. | planned |
+| Provider/model matrix | `#3501`, `#3505` | Hosted, local Ollama, remote Ollama, and OpenRouter model-lane evidence. | planned |
+| Public prompt packet pilot | `#3472`-`#3476` | Exported, redacted, reviewer-indexed prompt packets. | planned |
+| Celestial Rescue / Unity Observatory readiness | `#3455`, `#3460`, `#3461` | Demo artifact or explicit readiness decision for v0.92 Observatory. | planned |
+| v0.92 first-birthday readiness | `#3377`, `#3502` | Activation map, go/no-go checklist, and launch-packet handoff. | planned |
+
+## Coverage Rules
+
+- Every demo claim must cite an artifact.
+- Multi-agent proof must record roles, providers, shards, review, and closeout.
+- Provider/model proof must distinguish direct hosted, OpenRouter, local
+  Ollama, and remote Ollama substrates.
+- Prompt packet proof must pass redaction and validation gates.
+- Demo readiness must separate runnable proof from future demo planning.
+
+## Demo Details
+
+### Multi-agent C-SDLC workcell
+
+Proof should show a bounded C-SDLC sprint or issue slice completed with more
+than one role while preserving card and PR truth.
+
+### Provider/model matrix
+
+Proof should show which models can plausibly serve planner, worker, reviewer,
+janitor, and watcher roles.
+
+### Public prompt packet pilot
+
+Proof should show exported prompt packets are human-readable, machine-parseable,
+and redaction-safe.
+
+### Celestial Rescue / Unity Observatory readiness
+
+Proof should show whether the Unity path is a v0.92 proof surface or a
+preparatory demo substrate.
+
+### v0.92 first-birthday readiness
+
+Proof should show the activation map and `#3377` readiness packet are usable by
+v0.92 WP-01.
+
+## Cross-Demo Validation
+
+The final demo review should confirm there is no contradiction between the
+multi-agent proof, provider matrix, public prompt records, and v0.92 activation
+map.
+
+## Determinism Evidence
+
+- [WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml)
+- [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+- Issue-local cards and SORs for landed demo issues.
+
+## Reviewer Sign-Off Surface
+
+Reviewers should sign off only after demo rows have artifacts or explicit
+blocked/deferred dispositions.
+
+## Exit Criteria
+
+- Every demo row is complete, blocked, or deferred with owner and rationale.
+- v0.92 WP-01 can consume demo readiness without chat reconstruction.

--- a/docs/milestones/v0.91.5/DESIGN_v0.91.5.md
+++ b/docs/milestones/v0.91.5/DESIGN_v0.91.5.md
@@ -1,0 +1,86 @@
+# v0.91.5 Design
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Purpose
+
+Define the planned design surfaces for the v0.91.5 bridge milestone so issue
+execution can proceed without reconstructing scope from chat.
+
+## Problem Statement
+
+v0.91.4 landed substantial C-SDLC hardening, PVF work, and proof infrastructure.
+Additional work remains before v0.92 can safely open: multi-agent execution,
+provider/model breadth, public prompt records, demo readiness, and activation
+testing. If this work stays scattered in side issues, v0.92 will inherit
+unclear dependencies.
+
+## Goals
+
+- Route all open pre-v0.92 bridge issues into v0.91.5.
+- Make multi-agent execution testable and evidence-bound.
+- Make provider/model identity and role aptitude visible.
+- Make public prompt packet export/redaction/review safe.
+- Prepare demo and Unity Observatory readiness.
+- Produce a v0.92 activation test map and `#3377` readiness packet.
+
+## Non-Goals
+
+- No first-birthday implementation.
+- No unbounded multi-agent autonomy claim.
+- No unreviewed deletion of `.adl` data.
+- No production CodeFriend or OpenRouter product claim.
+- No v0.93 constitutional governance work.
+
+## Scope
+
+Scope is limited to bridge planning, issue routing, implementation/readiness
+work for the named bridge issues, review, remediation, v0.92 preflight, and
+release closeout.
+
+## Requirements
+
+- Every v0.91.5 issue uses all five prompt cards from the active registry.
+- Multi-agent roles must record provider/model identity and shard boundaries.
+- Provider/model testing must distinguish hosted, local, remote, and OpenRouter
+  substrates.
+- Public prompt records must be redaction-safe before publication.
+- `.adl` cleanup must be review-before-delete.
+- v0.92 activation testing must include all known feature surfaces.
+
+## Proposed Design
+
+The milestone uses four execution sprints:
+
+- Sprint 1: bridge package and public prompt record transition.
+- Sprint 2: provider/model matrix and multi-agent stabilization.
+- Sprint 3: demo readiness and v0.92 activation preflight.
+- Sprint 4: docs, review, remediation, v0.92 final preflight, and release.
+
+## Interfaces And Contracts
+
+- Issue routing: `version:v0.91.5` label and issue titles.
+- Planning contract: `docs/templates/planning/current.json`.
+- Prompt contract: `docs/templates/prompts/current.json`.
+- Work-package contract: [WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml).
+- Activation contract: [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md).
+
+## Validation Plan
+
+- Validate planning docs against `docs/templates/planning/current.json`.
+- Parse v0.91.5 YAML.
+- Check links in changed milestone docs.
+- Verify moved GitHub issues carry `version:v0.91.5`.
+- Run implementation-specific tests only for issues that change runtime/tooling.
+
+## Exit Criteria
+
+- Design, WBS, sprint, issue wave, demo matrix, checklist, release plan, and
+  release notes agree on scope.
+- v0.92 docs consume v0.91.5 closeout and `#3377`.
+- Multi-agent and activation readiness are not left as untracked chat context.

--- a/docs/milestones/v0.91.5/FEATURE_PROOF_COVERAGE_v0.91.5.md
+++ b/docs/milestones/v0.91.5/FEATURE_PROOF_COVERAGE_v0.91.5.md
@@ -1,0 +1,21 @@
+# v0.91.5 Feature Proof Coverage
+
+## Status
+
+Planned proof-coverage surface.
+
+## Coverage Table
+
+| Feature | Feature doc | Required proof | Status |
+| --- | --- | --- | --- |
+| Multi-agent C-SDLC operation | [MULTI_AGENT_CSDL_OPERATION_v0.91.5.md](features/MULTI_AGENT_CSDL_OPERATION_v0.91.5.md) | Workcell proof or explicit blocker. | planned |
+| Provider/model matrix | [PROVIDER_MODEL_MATRIX_v0.91.5.md](features/PROVIDER_MODEL_MATRIX_v0.91.5.md) | Hosted/local/remote/OpenRouter role evidence. | planned |
+| Public prompt records | [PUBLIC_PROMPT_RECORDS_v0.91.5.md](features/PUBLIC_PROMPT_RECORDS_v0.91.5.md) | Export, validation, redaction, reviewer index. | planned |
+| Demo and Unity Observatory readiness | [DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md](features/DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md) | Demo index, proof map, Unity routing. | planned |
+| v0.92 activation readiness | [V092_ACTIVATION_READINESS_v0.91.5.md](features/V092_ACTIVATION_READINESS_v0.91.5.md) | Activation map and `#3377` consumption. | planned |
+
+## Exit Criteria
+
+- Every feature row is complete, blocked, or deferred with owner and rationale.
+- No feature row claims implementation evidence from planning text alone.
+

--- a/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
+++ b/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
@@ -1,0 +1,61 @@
+# v0.91.5 Milestone Checklist
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Purpose
+
+Track the minimum planning, execution, quality, release, and post-release
+checks needed for truthful v0.91.5 closeout.
+
+## Planning
+
+- [ ] v0.91.5 planning package exists.
+- [ ] Feature docs exist for all bridge work tracks.
+- [ ] Open side issues are relabeled to `version:v0.91.5`.
+- [ ] v0.91.4 docs say bridge work moved, not abandoned.
+- [ ] v0.92 docs depend on v0.91.5 closeout and `#3377`.
+- [ ] All opened v0.91.5 issues use five prompt cards from the active registry.
+
+## Execution Discipline
+
+- [ ] `SIP`, `STP`, and `SPP` are design-time ready before execution starts.
+- [ ] `SRP` records actual review prompts and findings.
+- [ ] `SOR` records actual validation, integration, and closeout truth.
+- [ ] Work executes in bound worktrees.
+- [ ] Pre-PR review runs before publication.
+- [ ] Scope stays within each issue or is explicitly routed.
+
+## Quality Gates
+
+- [ ] Multi-agent C-SDLC workcell proof completes or blocks truthfully.
+- [ ] OpenRouter/provider matrix work completes or blocks truthfully.
+- [ ] Public prompt packet export/redaction/index path completes or blocks
+  truthfully.
+- [ ] `.adl` cleanup/archive decisions are reviewed before deletion.
+- [ ] Demo readiness and Unity Observatory routing are explicit.
+- [ ] v0.92 activation test map is complete and consumed by `#3377`.
+
+## Release Packaging
+
+- [ ] Release plan complete.
+- [ ] Release notes rewritten from landed evidence.
+- [ ] v0.92 final preflight complete.
+- [ ] Review findings fixed or routed.
+- [ ] Release evidence package assembled.
+
+## Post-Release
+
+- [ ] v0.92 WP-01 inputs are linked.
+- [ ] Deferred bridge items have owners and follow-on routing.
+- [ ] Residual risks are recorded in release notes or handoff.
+
+## Exit Criteria
+
+- All required gates are checked or exceptions have owners.
+- v0.92 can open from v0.91.5 closeout and `#3377`.
+- Multi-agent completion/blocker truth is explicit.

--- a/docs/milestones/v0.91.5/NEXT_MILESTONE_HANDOFF_v0.91.5.md
+++ b/docs/milestones/v0.91.5/NEXT_MILESTONE_HANDOFF_v0.91.5.md
@@ -1,0 +1,38 @@
+# v0.91.5 Next Milestone Handoff
+
+## Status
+
+Planned handoff scaffold for v0.91.5 release tail.
+
+## Purpose
+
+Prepare v0.92 to open from bridge evidence rather than chat memory.
+
+## Expected Downstream Milestone
+
+The expected next milestone is v0.92, the first true Gödel-agent birthday.
+
+## Required Handoff Inputs
+
+- v0.91.5 release evidence.
+- Multi-agent completion or blocker truth.
+- Provider/model matrix.
+- Public prompt packet/export/redaction disposition.
+- Demo and Unity Observatory readiness disposition.
+- [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md).
+- `#3377` first-birthday readiness packet.
+
+## WP-20 Review Requirement
+
+Before v0.91.5 release, review this handoff and confirm:
+
+- v0.92 dependencies are explicit;
+- no first-birthday implementation is claimed early;
+- activation surfaces are complete, blocked, or deferred;
+- residual risks have owners.
+
+## Non-Claims
+
+This scaffold does not claim v0.91.5 is complete or that v0.92 is approved to
+open.
+

--- a/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
+++ b/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
@@ -1,0 +1,40 @@
+# v0.91.5 Quality Gate
+
+## Status
+
+Planned quality gate.
+
+## Required Validation
+
+The milestone must run focused validation for:
+
+- planning-template structure for canonical planning docs;
+- YAML parsing for the issue wave;
+- GitHub issue label/title routing for moved bridge issues;
+- public prompt packet export, validation, and redaction gates;
+- `.adl` archive/deletion review-before-delete disposition;
+- provider/model matrix smoke and role-probe evidence;
+- multi-agent workcell proof or explicit blocker;
+- single-agent versus multi-agent overhead comparison;
+- demo readiness and Unity Observatory routing;
+- v0.92 activation map completeness;
+- `#3377` first-birthday readiness packet.
+
+## Blockers
+
+The milestone is blocked if:
+
+- multi-agent execution is claimed without role, shard, provider, review, and
+  closeout evidence;
+- OpenRouter/provider matrix work hides skipped or blocked lanes;
+- public prompt packets can leak local/private state;
+- `.adl` cleanup deletes historical material without review;
+- v0.92 activation surfaces remain undocumented;
+- v0.92 docs depend on direct v0.91.4 closeout rather than v0.91.5 closeout and
+  `#3377`.
+
+## Release Gate
+
+Release can proceed only when every blocker is fixed, explicitly deferred with
+owner/rationale, or converted into a v0.92 WP-01 prerequisite.
+

--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -1,0 +1,175 @@
+# v0.91.5 Milestone README
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related setup issue: `#3506`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Status
+
+Current status: `draft_pre_open`
+
+- Planning: v0.91.5 bridge package created for review.
+- Execution: not started.
+- Validation: focused planning-doc, YAML, link, and issue-label validation.
+- Release readiness: not applicable until v0.91.5 executes.
+
+## Purpose
+
+Provide the canonical entry point for v0.91.5: a real bridge milestone between
+v0.91.4 C-SDLC hardening and v0.92 first birthday.
+
+v0.91.5 keeps v0.91.4 focused on Sprint 4 closeout and release while giving the
+remaining pre-v0.92 work a tracked, reviewable home.
+
+## Milestone Role
+
+`v0.91.5` moves ADL from a hardened mostly single-agent C-SDLC lane to a
+pre-v0.92 operating posture where multi-agent execution, provider/model
+breadth, public prompt records, demos, and activation testing are ready enough
+for the first-birthday milestone.
+
+This milestone exists to:
+
+- make bounded multi-agent C-SDLC execution work truthfully;
+- prepare the provider/model matrix, including OpenRouter, hosted models, local
+  Ollama, and remote Ollama;
+- move public prompt records and `.adl` cleanup/archive planning into a
+  governed transition;
+- prepare demo and Unity Observatory readiness;
+- complete the v0.92 activation-test map and first-birthday launch preflight.
+
+Expected outcomes:
+
+- v0.92 can open from v0.91.5 closeout, not direct v0.91.4 chat memory.
+- `#3377` has a complete first-birthday go/no-go readiness packet.
+- Multi-agent work is proven, blocked, or explicitly not relied on by v0.92.
+
+## Boundaries
+
+In scope:
+
+- Multi-agent C-SDLC stabilization and usefulness review.
+- Provider/model matrix and OpenRouter readiness.
+- Public C-SDLC prompt packet export, validation, redaction, and archive
+  disposition.
+- Demo showcase, Celestial Rescue, and Unity Observatory readiness routing.
+- v0.92 activation-test map and first-birthday preflight.
+
+Out of scope:
+
+- Implementing the v0.92 first birthday.
+- Claiming unbounded autonomous multi-agent software development.
+- Deleting `.adl` historical state without review.
+- Moving v0.93 constitutional governance into the bridge.
+
+Known risks:
+
+- Multi-agent coordination may not yet beat single-agent execution on small
+  tasks.
+- Model/provider breadth may expose role aptitude gaps rather than solve them.
+- Public prompt records may need stricter redaction than initially expected.
+
+Open questions:
+
+- Which model/provider lanes are suitable for planner, worker, reviewer,
+  janitor, and watcher roles?
+- Does Celestial Rescue double as Unity Observatory proof or only prepare that
+  path for v0.92?
+
+## Source Map
+
+Primary planning and proof sources:
+
+- Vision: [VISION_v0.91.5.md](VISION_v0.91.5.md)
+- Design: [DESIGN_v0.91.5.md](DESIGN_v0.91.5.md)
+- Work Breakdown Structure: [WBS_v0.91.5.md](WBS_v0.91.5.md)
+- Sprint plan: [SPRINT_v0.91.5.md](SPRINT_v0.91.5.md)
+- Decisions log: [DECISIONS_v0.91.5.md](DECISIONS_v0.91.5.md)
+- Demo matrix: [DEMO_MATRIX_v0.91.5.md](DEMO_MATRIX_v0.91.5.md)
+- Milestone checklist: [MILESTONE_CHECKLIST_v0.91.5.md](MILESTONE_CHECKLIST_v0.91.5.md)
+- Release plan: [RELEASE_PLAN_v0.91.5.md](RELEASE_PLAN_v0.91.5.md)
+- Release notes: [RELEASE_NOTES_v0.91.5.md](RELEASE_NOTES_v0.91.5.md)
+- Quality gate: [QUALITY_GATE_v0.91.5.md](QUALITY_GATE_v0.91.5.md)
+- Feature proof coverage: [FEATURE_PROOF_COVERAGE_v0.91.5.md](FEATURE_PROOF_COVERAGE_v0.91.5.md)
+- WP execution readiness: [WP_EXECUTION_READINESS_v0.91.5.md](WP_EXECUTION_READINESS_v0.91.5.md)
+- ADR plan: [ADR_PLAN_v0.91.5.md](ADR_PLAN_v0.91.5.md)
+- Next milestone handoff: [NEXT_MILESTONE_HANDOFF_v0.91.5.md](NEXT_MILESTONE_HANDOFF_v0.91.5.md)
+
+Supporting / domain-specific docs:
+
+- v0.92 activation test map: [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+- Feature index: [features/README.md](features/README.md)
+- Issue wave: [WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml)
+
+## Document Map
+
+Use the source map above as the canonical navigation surface. Keep this README
+concise; detailed work-package, sprint, demo, and release gates live in the
+linked documents.
+
+## Bridge Work
+
+This milestone is itself a bridge sidecar around v0.91.4 release closeout.
+
+- Sidecar scope: pre-v0.92 multi-agent, provider/model, prompt-record,
+  demo-readiness, and activation-readiness work.
+- Sidecar boundary: no first-birthday implementation and no unreviewed `.adl`
+  deletion.
+- Sidecar proof surface: issue labels, v0.91.5 planning docs, prompt/export
+  evidence, model-role matrix, demo proof map, and `#3377`.
+
+## Execution Model
+
+This milestone is executed as an ordered issue/PR sequence. The exact WP count
+is milestone-specific.
+
+Execution expectations:
+
+- WP-01 is the bridge planning and issue migration pass.
+- Public prompt, provider/model, multi-agent, demo, and activation work occupy
+  the middle of the sequence.
+- Demo/proof, quality, docs/review convergence, v0.92 preflight, and release
+  ceremony happen at the tail.
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Each WP records focused validation and merge/readiness proof.
+- Do not treat v0.91.5 setup as v0.92 birthday evidence.
+
+## Demo and Validation Surface
+
+Primary validation is defined in [DEMO_MATRIX_v0.91.5.md](DEMO_MATRIX_v0.91.5.md).
+
+Additional validation surfaces:
+
+- GitHub issue labels and titles for moved issues.
+- YAML parsing for `WP_ISSUE_WAVE_v0.91.5.yaml`.
+- Planning-template validation for canonical docs.
+- Link checks for milestone-relative planning docs.
+- Focused tool/runtime tests only where implementation changes land.
+
+Determinism evidence:
+
+- [WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml)
+- [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+
+## Success Criteria
+
+- All moved issues carry `version:v0.91.5` and no longer claim active v0.91.4
+  scope.
+- Multi-agent execution has a bounded proof or a blocker that v0.92 can consume.
+- v0.92 activation testing covers every identified feature surface.
+- Public prompt records have export, validation, redaction, and archive routing.
+
+## Exit Criteria
+
+- All canonical milestone documents are complete and internally consistent.
+- All WBS items are implemented or explicitly deferred.
+- Demo matrix is runnable and validated where demos are implemented.
+- Quality gates relevant to touched surfaces are passing or exceptions are
+  documented.
+- Milestone checklist is complete or exceptions are documented.
+- Release artifacts are ready.

--- a/docs/milestones/v0.91.5/RELEASE_NOTES_v0.91.5.md
+++ b/docs/milestones/v0.91.5/RELEASE_NOTES_v0.91.5.md
@@ -1,0 +1,70 @@
+# v0.91.5 Release Notes
+
+## Metadata
+- Product: `Agent Design Language`
+- Version: `v0.91.5`
+- Release date: pending
+- Tag: `v0.91.5`
+- Status: `draft_pre_open`
+
+## How To Use
+- Keep statements implementation-accurate and test-validated.
+- Prefer concise bullets over marketing language.
+- Explicitly separate shipped behavior from "What's Next."
+
+# `Agent Design Language` `v0.91.5` Release Notes
+
+## Summary
+
+v0.91.5 is planned as the bridge milestone between v0.91.4 C-SDLC hardening
+and v0.92 first birthday. Final notes must be rewritten from landed evidence.
+
+## Highlights
+
+- Multi-agent C-SDLC stabilization.
+- Provider/model matrix and OpenRouter readiness.
+- Public prompt records and `.adl` archive transition.
+- Demo readiness and v0.92 activation preflight.
+
+## What's New In Detail
+
+### Multi-Agent And Providers
+- Planned: bounded multi-agent C-SDLC proof.
+- Planned: hosted, local Ollama, remote Ollama, and OpenRouter model-role
+  matrix.
+
+### Public Prompt Records
+- Planned: public prompt packet export, redaction, validation, and reviewer
+  index.
+- Planned: `.adl` inventory and archive disposition.
+
+### v0.92 Readiness
+- Planned: activation-test map for features that come alive in v0.92.
+- Planned: `#3377` first-birthday go/no-go packet.
+
+## Upgrade Notes
+
+- No operator upgrade steps are known at planning time.
+- Final upgrade notes must be rewritten if tooling or runtime behavior changes.
+
+## Known Limitations
+
+- These are planning notes, not release evidence.
+- Multi-agent usefulness is not assumed until measured.
+
+## Validation Notes
+
+- Planning-doc validation is expected for the package.
+- Runtime/tool validation is expected only for issues that change runtime/tool
+  behavior.
+
+## What's Next
+
+- v0.92 first-birthday milestone.
+- v0.93 governance and constitutional citizenship planning.
+
+## Exit Criteria
+
+- Notes reflect only shipped behavior.
+- Known limitations and future work are explicitly separated.
+- Final text is ready to paste into GitHub Release UI without further editing.

--- a/docs/milestones/v0.91.5/RELEASE_PLAN_v0.91.5.md
+++ b/docs/milestones/v0.91.5/RELEASE_PLAN_v0.91.5.md
@@ -1,0 +1,66 @@
+# v0.91.5 Release Plan
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Release date: pending release ceremony
+- Release manager: ADL maintainers
+- Status: `draft_pre_open`
+
+## How To Use
+
+Execute this plan during the release tail. Check items only when evidence
+exists. The ceremony must not hide implementation, review, or truth-maintenance
+work.
+
+## 0. Release-Tail Convergence
+
+- [ ] Multi-agent proof packet or explicit blocker complete.
+- [ ] Provider/model matrix and OpenRouter disposition complete.
+- [ ] Public prompt packet export/redaction evidence complete.
+- [ ] `.adl` archive/deletion review disposition complete.
+- [ ] Demo readiness proof map complete.
+- [ ] v0.92 activation test map complete.
+- [ ] `#3377` first-birthday readiness packet complete.
+- [ ] Closed issue/card truth refreshed for the v0.91.5 wave.
+
+## 1. Release Readiness
+
+- [ ] Milestone checklist complete.
+- [ ] Release notes approved.
+- [ ] Go/no-go decision recorded in the decision log.
+- [ ] v0.92 preflight says go, conditional go, or no-go with owners.
+
+## 2. Branch And Tag Preparation
+
+- [ ] Target branch confirmed: `main`.
+- [ ] Working tree clean.
+- [ ] Version strings validated.
+- [ ] Tag created: `v0.91.5`.
+- [ ] Tag pushed and verified.
+
+## 3. GitHub Release Steps
+
+- [ ] GitHub Release draft created from `v0.91.5`.
+- [ ] Release body populated from approved release notes.
+- [ ] Links to key PRs/issues included.
+- [ ] Release visibility confirmed.
+- [ ] Release published.
+
+## 4. Verification
+
+- [ ] Post-release CI status checked.
+- [ ] Release links tested.
+- [ ] Immediate regressions triaged and tracked.
+
+## 5. Communication
+
+- [ ] v0.92 opening inputs announced internally.
+- [ ] Roadmap/status docs updated.
+- [ ] Deferred items routed to later backlog.
+
+## Exit Criteria
+
+- No hidden implementation remains in ceremony.
+- Tag and release are published and accessible.
+- v0.92 can consume the bridge evidence without reconstructing intent from chat.

--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -1,0 +1,111 @@
+# v0.91.5 Sprint Plan
+
+## Metadata
+- Sprint: `v0.91.5`
+- Milestone: `v0.91.5`
+- Start date: `pending`
+- End date: `pending`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Status
+
+`draft_pre_open`
+
+## How To Use
+
+- List bridge work in planned execution order.
+- Track blockers here rather than scattered chat notes.
+- Keep public prompt, demo, and provider side work visible and bounded.
+- Record closeout expectations before execution begins.
+
+## Sprint Overview
+
+v0.91.5 is split into four sprint bands.
+
+Planned scope:
+
+- public prompt records and `.adl` transition controls;
+- provider/model matrix and multi-agent proof;
+- demo readiness and v0.92 activation preflight;
+- review, remediation, final v0.92 preflight, and release.
+
+## Bridge Sprint Work
+
+- Scope: pre-v0.92 operational bridge work.
+- Boundary: no first-birthday implementation.
+- Proof surface: issue wave, moved labels, prompt packets, provider matrix,
+  multi-agent proof, demo index, activation map, and `#3377`.
+
+## Sprint Goals
+
+- Sprint 1: route issues and make public prompt records reviewable.
+- Sprint 2: make provider/model breadth and multi-agent execution work.
+- Sprint 3: prepare demos and v0.92 activation readiness.
+- Sprint 4: review, remediate, preflight v0.92, and close the bridge.
+
+## Sprint Goal
+
+Make v0.92 openable without hidden operational debt.
+
+## Planned Scope
+
+- Public prompt packet export, redaction, and archive planning.
+- OpenRouter and model-role matrix.
+- Multi-agent C-SDLC workcell proof.
+- Demo showcase and Unity Observatory readiness.
+- v0.92 activation map and first-birthday launch packet.
+
+## Work Plan
+
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | Bridge planning and migration | `#3506` | ADL maintainers | draft |
+| 2 | Public prompt records | `#3472`-`#3476` | ADL maintainers | moved |
+| 3 | Provider/model matrix | `#3501`, `#3505` | ADL maintainers | moved |
+| 4 | Multi-agent proof | `#3415`, `#3484`, `#3503`, `#3504` | ADL maintainers | moved |
+| 5 | Demo readiness | `#3455`, `#3460`, `#3461` | ADL maintainers | moved |
+| 6 | v0.92 activation and birthday preflight | `#3502`, `#3377` | ADL maintainers | moved |
+| 7 | Review, remediation, release | pending | ADL maintainers | planned |
+
+## Execution Policy
+
+- Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run the smallest meaningful validation for each touched surface.
+- Record proof truthfully in issue-local output records or review docs.
+
+## Cadence Expectations
+
+- Preserve ordered execution where dependencies matter.
+- Use multi-agent lanes only where they are being tested or provide clear value.
+- Do not merge hidden prompt-record cleanup into unrelated issues.
+- Escalate blockers as findings or follow-on issues.
+
+## Risks / Dependencies
+
+- Dependency: v0.91.4 release closeout.
+- Risk: multi-agent overhead may outweigh benefit on small tasks.
+- Mitigation: compare single-agent and multi-agent overhead explicitly.
+- Risk: provider/model breadth may produce brittle test results.
+- Mitigation: record provider identity, model identity, and role aptitude.
+
+## Demo / Review Plan
+
+- Demo artifact: [DEMO_MATRIX_v0.91.5.md](DEMO_MATRIX_v0.91.5.md)
+- Review date: pending Sprint 4.
+- Sign-off owners: ADL maintainers and reviewer lane.
+
+## Closeout Bar
+
+- All planned scope items are completed or explicitly deferred with rationale.
+- Linked issues and PRs are updated and traceable.
+- Focused validation is recorded for every touched surface.
+- Sprint summary is captured in milestone docs.
+
+## Exit Criteria
+
+- All planned scope items completed or explicitly deferred with rationale.
+- Linked issues/PRs updated and traceable.
+- CI is green for merged work, or exceptions are documented.
+- Sprint summary captured in milestone docs.

--- a/docs/milestones/v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md
+++ b/docs/milestones/v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md
@@ -1,0 +1,41 @@
+# v0.92 Activation Test Map
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Related issues: `#3377`, `#3502`
+
+## Purpose
+
+This map records the features and substrate work that were developed before
+v0.92 but need explicit activation testing before or during the first-birthday
+milestone.
+
+## Activation Surfaces
+
+| Surface | Why it matters for v0.92 | Required v0.91.5 action |
+| --- | --- | --- |
+| Memory v2 / ObsMem handoff | First birthday needs witnessed, redacted memory grounding. | Confirm available evidence, blockers, and required v0.92 tests. |
+| ACP / cognitive profiles | Birthday records need bounded cognitive-profile context without free-floating labels. | Map profile fixtures and privacy constraints into v0.92 WP-07. |
+| Aptitude and capability selector | Multi-agent and birth capability envelopes need model/role suitability evidence. | Connect model-role matrix to v0.92 capability-envelope planning. |
+| Identity and continuity | First birthday depends on stable identity, name, continuity head, and cycle evidence. | Verify prior identity/continuity surfaces and negative cases. |
+| Affect and happiness surfaces | Earlier affect/wellbeing work may become visible in birthday evidence. | Identify safe tests and non-claims for affect, humor, happiness, wellbeing. |
+| Gödel mechanics | v0.92 is the first true Gödel-agent birthday. | Map experiment, hypothesis, mutation, evaluation, and promotion mechanics into birthday proof. |
+| Economics context | Earlier economics work may inform capability boundaries but must not dominate v0.92. | Record whether economics is context-only or requires explicit tests. |
+| Observatory | v0.92 should make the birthday reviewable and visible. | Define which Observatory surfaces are demo proof versus future UI. |
+| Unity demo readiness | Celestial Rescue may double as Unity Observatory preparation. | Decide whether it is proof, rehearsal, or deferred demo substrate. |
+| ACIP / provider communications | Birthday evidence may use communication envelopes and schema transport. | Verify public schema, JSON projection, and mock carrier readiness. |
+| Provider/model matrix | Multi-agent roles and capability envelopes need actual model identity. | Test hosted, local Ollama, remote Ollama, and OpenRouter lanes. |
+| Public prompt records | v0.92 should consume durable prompt records, not local chat memory. | Export/redact/index prompt packets needed by v0.92 WP-01. |
+
+## Acceptance Criteria
+
+- Every row has an owner issue, v0.92 candidate WP, and test/proof posture
+  before v0.91.5 closeout.
+- Rows that cannot be activated safely are marked blocked or deferred before
+  v0.92 WP-01 opens.
+- The final `#3377` readiness packet consumes this map.
+

--- a/docs/milestones/v0.91.5/VISION_v0.91.5.md
+++ b/docs/milestones/v0.91.5/VISION_v0.91.5.md
@@ -47,7 +47,7 @@ v0.91.4 release tail. v0.91.5 is the clean place to finish them.
 
 v0.91.5 should leave ADL ready for v0.92 first birthday and for future
 multi-agent software-development operation. The long-term direction is not a
-swarm of hidden agents; it is governed parallelism with visible roles, explicit
+cluster of hidden agents; it is governed parallelism with visible roles, explicit
 shards, testable model aptitude, and durable prompt records.
 
 ## Summary

--- a/docs/milestones/v0.91.5/VISION_v0.91.5.md
+++ b/docs/milestones/v0.91.5/VISION_v0.91.5.md
@@ -1,0 +1,64 @@
+# v0.91.5 Vision
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Purpose
+
+Describe why v0.91.5 exists and what kind of operational bridge ADL should be
+able to claim after the milestone closes.
+
+## How To Use
+
+Use this document as the intent boundary for v0.91.5 WP-01 planning and later
+review. Implementation truth must come from issues, PRs, demos, and release
+evidence.
+
+## Overview
+
+v0.91.5 is the bridge from a working single-agent C-SDLC control plane to a
+usable multi-agent development system that can support v0.92.
+
+The milestone is practical: make the machinery work. Roles, providers, model
+selection, prompt records, validation routing, demos, and first-birthday
+readiness all need tracked evidence before v0.92 starts.
+
+## Core Goals
+
+- Prove or truthfully block bounded multi-agent C-SDLC execution.
+- Build a provider/model-role matrix across hosted, local Ollama, remote
+  Ollama, and OpenRouter lanes.
+- Make public prompt records reviewable and redaction-safe.
+- Prepare the demo path, including Celestial Rescue and Unity Observatory
+  readiness.
+- Make the v0.92 activation-test surface explicit.
+
+## Milestone Context
+
+v0.91.4 completes C-SDLC hardening and release closeout. During that work we
+identified additional pre-v0.92 operational needs that should not expand the
+v0.91.4 release tail. v0.91.5 is the clean place to finish them.
+
+## Long-Term Direction
+
+v0.91.5 should leave ADL ready for v0.92 first birthday and for future
+multi-agent software-development operation. The long-term direction is not a
+swarm of hidden agents; it is governed parallelism with visible roles, explicit
+shards, testable model aptitude, and durable prompt records.
+
+## Summary
+
+v0.91.5 is the moment where the C-SDLC starts to become genuinely multi-agent
+and operationally public. If we do this well, v0.92 can focus on first birthday
+rather than rediscovering missing substrate work.
+
+## Exit Criteria
+
+- The vision is reflected in WBS, sprint, demo, checklist, release, and issue
+  wave docs.
+- v0.92 activation needs are recorded in the activation map.
+- Multi-agent completion or blocker truth is explicit before v0.92 opens.

--- a/docs/milestones/v0.91.5/WBS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WBS_v0.91.5.md
@@ -1,0 +1,89 @@
+# v0.91.5 Work Breakdown Structure
+
+## Metadata
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+
+## Status
+
+Candidate WBS for v0.91.5 WP-01 review and issue seeding.
+
+## How To Use
+
+Use this WBS as the source of truth for v0.91.5 sequencing until concrete
+issues are opened or adjusted. If issue reality diverges, update this WBS and
+the issue wave together.
+
+## WBS Summary
+
+v0.91.5 contains five work bands: public prompt transition, provider/model
+matrix, multi-agent proof, demo readiness, and v0.92 activation preflight.
+
+## Candidate WP Sequence
+
+| WP | Work Package | Primary deliverable | Dependencies |
+| --- | --- | --- | --- |
+| WP-01 | Bridge planning and issue migration | Planning package, issue relabeling, and v0.91.4/v0.92 doc reconciliation. | v0.91.4 Sprint 4 readiness. |
+| WP-02 | Public prompt transition umbrella | Public prompt transition plan and child readiness. | WP-01. |
+| WP-03 | Prompt packet exporter | Exporter for public C-SDLC prompt packets. | WP-02. |
+| WP-04 | `.adl` inventory and archive disposition | Inventory, archive plan, and review-before-delete policy. | WP-02. |
+| WP-05 | Prompt packet pilot and reviewer index | Pilot packets and reviewer-facing index. | WP-03, WP-04. |
+| WP-06 | Prompt packet validation and redaction gates | Validation/redaction checks. | WP-05. |
+| WP-07 | OpenRouter provider | OpenRouter provider or bounded implementation plan. | WP-01. |
+| WP-08 | Provider/model test matrix | Hosted, local Ollama, remote Ollama, and OpenRouter role matrix. | WP-07. |
+| WP-09 | Multi-agent usefulness checklist | Reviewer checklist and usefulness criteria. | WP-08. |
+| WP-10 | Multi-agent workcell proof | Bounded workcell proof. | WP-08, WP-09. |
+| WP-11 | Parallel hosted Codex lanes | Complete bounded issue execution with parallel hosted lanes. | WP-10. |
+| WP-12 | Single-agent vs multi-agent overhead comparison | Timing and coordination comparison. | WP-10. |
+| WP-13 | Demo showcase refresh | Demo index and deferred creative demo routing. | WP-01. |
+| WP-14 | Celestial Rescue / Unity Observatory readiness | Demo artifact or readiness decision. | WP-13. |
+| WP-15 | Demo showcase proof map | Demo proof index. | WP-13, WP-14. |
+| WP-16 | v0.92 activation-test ledger | Complete activation-test map and deferred-work ledger. | WP-01. |
+| WP-17 | v0.92 first-birthday launch packet | `#3377` go/no-go packet. | WP-10, WP-15, WP-16. |
+| WP-18 | Docs and release-truth pass | Aligned bridge and v0.92 planning docs. | WP-17. |
+| WP-19 | Internal review | Internal review and finding register. | WP-18. |
+| WP-20 | Remediation and v0.92 final preflight | Finding dispositions and v0.92 go/no-go. | WP-19. |
+| WP-21 | Release ceremony | Release evidence and closeout. | WP-20. |
+
+## Work Packages
+
+The candidate WP sequence above is reflected in
+[WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml). Existing moved
+issues should be reused rather than duplicated.
+
+## Sequencing
+
+1. Route issue truth first.
+2. Finish public prompt-record transition before `.adl` cleanup.
+3. Add provider/model breadth before claiming multi-agent usefulness.
+4. Run multi-agent proof before relying on it for v0.92.
+5. Prepare demos and activation readiness before first-birthday preflight.
+6. Review, remediate, preflight v0.92, then release.
+
+## Sequencing Notes
+
+The exact WP count is not process-critical. The sequence is critical. Public
+records must not be published before redaction gates, multi-agent proof must
+not overclaim usefulness, and v0.92 must not open before activation readiness
+is explicit.
+
+## Acceptance Mapping
+
+- WP-01 -> bridge scope is visible in docs and GitHub labels.
+- WP-02 through WP-06 -> public prompt records are safe to review.
+- WP-07 through WP-12 -> provider/model and multi-agent usefulness are tested.
+- WP-13 through WP-15 -> demo readiness is explicit.
+- WP-16 through WP-17 -> v0.92 activation and first-birthday readiness are
+  ready for WP-01 consumption.
+- WP-18 through WP-21 -> docs, review, remediation, preflight, and release
+  close the bridge.
+
+## Exit Criteria
+
+- Every work package has a seeded issue, moved issue, or explicit routing
+  decision.
+- The closeout tail preserves review, remediation, final preflight, and release.
+- v0.92 can consume v0.91.5 without reconstructing intent from chat.

--- a/docs/milestones/v0.91.5/WP_EXECUTION_READINESS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WP_EXECUTION_READINESS_v0.91.5.md
@@ -1,0 +1,31 @@
+# v0.91.5 WP Execution Readiness
+
+## Status
+
+Planned readiness surface.
+
+## Readiness Rules
+
+- Every opened issue must have `SIP`, `STP`, `SPP`, `SRP`, and `SOR`.
+- `SIP`, `STP`, and `SPP` must be issue-specific and design-time ready before
+  execution.
+- Cards must come from `docs/templates/prompts/current.json`.
+- Card edits must use editor skills.
+- Work must execute in a bound worktree, never on `main`.
+- Docs-only issues should run focused docs/YAML/link/template validation, not
+  broad Rust tests by reflex.
+- Runtime/tooling issues should use PVF lane classification.
+
+## v0.91.5 Specific Readiness
+
+- Moved issues must carry `version:v0.91.5`.
+- v0.91.4 docs must show bridge work moved, not abandoned.
+- v0.92 docs must consume v0.91.5 closeout and `#3377`.
+- Multi-agent issues must record role, shard, provider/model, and closeout
+  expectations before execution.
+
+## Exit Criteria
+
+- No bridge issue starts from generic or stale design-time cards.
+- The issue wave can be reviewed without reconstructing sequencing from chat.
+

--- a/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
+++ b/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
@@ -1,0 +1,171 @@
+milestone: v0.91.5
+status: draft_pre_open
+owner_issue: 3506
+planning_source: docs/milestones/v0.91.5
+tracked_package: docs/milestones/v0.91.5
+depends_on:
+  - v0.91.4 Sprint 4 closeout
+notes:
+  - v0.91.5 is the bridge milestone between v0.91.4 C-SDLC hardening and v0.92 first birthday.
+  - Multi-agent C-SDLC execution must work by milestone closeout or be truthfully blocked before v0.92 depends on it.
+  - v0.92 activation testing must include every known feature surface that comes alive during first birthday.
+  - Public prompt records require export, redaction, archive, and reviewer-index controls before `.adl` cleanup.
+card_update_rule:
+  - Every opened WP must receive SIP, STP, SPP, SRP, and SOR cards.
+  - SIP, STP, and SPP must be issue-specific and design-time ready before execution starts.
+  - SRP and SOR must exist upfront but remain truthful to review and output lifecycle state.
+  - Card edits must use editor skills.
+  - SOR closeout must match GitHub issue/PR truth.
+moved_issue_inputs:
+  from_v0_91_4:
+    keep_in_v0_91_4: [3362, 3363, 3364, 3365, 3366, 3367, 3368, 3369, 3370, 3371]
+    move_to_v0_91_5: [3377, 3415, 3455, 3460, 3461, 3472, 3473, 3474, 3475, 3476, 3484, 3501, 3502, 3503, 3504, 3505]
+work_packages:
+  - wp: WP-01
+    issue: 3506
+    title: Bridge planning and issue migration
+    queue: docs
+    depends_on: [v0.91.4 Sprint 4 readiness]
+    primary_deliverable: v0.91.5 planning package, issue relabeling, and v0.91.4/v0.92 doc reconciliation
+    proof_surface: planning docs, issue labels, and focused docs validation
+  - wp: WP-02
+    issue: 3476
+    title: Public prompt transition umbrella
+    queue: docs_tools
+    depends_on: [WP-01]
+    primary_deliverable: public prompt transition plan and child issue readiness
+    proof_surface: transition plan and issue graph
+  - wp: WP-03
+    issue: 3472
+    title: Prompt packet exporter
+    queue: tools
+    depends_on: [WP-02]
+    primary_deliverable: public C-SDLC prompt packet exporter
+    proof_surface: exported packet fixtures and validation output
+  - wp: WP-04
+    issue: 3473
+    title: ADL local-state inventory and archive disposition
+    queue: docs
+    depends_on: [WP-02]
+    primary_deliverable: inventory and disposition of `.adl` local state
+    proof_surface: inventory, archive plan, and review-before-delete checklist
+  - wp: WP-05
+    issue: 3474
+    title: Prompt packet pilot and reviewer index
+    queue: docs
+    depends_on: [WP-03, WP-04]
+    primary_deliverable: pilot public prompt packets and reviewer index
+    proof_surface: packet index and reviewer walkthrough
+  - wp: WP-06
+    issue: 3475
+    title: Prompt packet validation and redaction gates
+    queue: quality
+    depends_on: [WP-05]
+    primary_deliverable: validation and redaction gates for public prompt packets
+    proof_surface: redaction report and validation commands
+  - wp: WP-07
+    issue: 3505
+    title: OpenRouter provider
+    queue: provider
+    depends_on: [WP-01]
+    primary_deliverable: OpenRouter provider or bounded provider plan
+    proof_surface: provider identity and smoke-test evidence
+  - wp: WP-08
+    issue: 3501
+    title: Provider/model and role matrix
+    queue: multi_agent
+    depends_on: [WP-07]
+    primary_deliverable: hosted, local Ollama, remote Ollama, and OpenRouter model-role matrix
+    proof_surface: model inventory and role test results
+  - wp: WP-09
+    issue: 3504
+    title: Multi-agent usefulness checklist
+    queue: quality
+    depends_on: [WP-08]
+    primary_deliverable: reviewer checklist for multi-agent usefulness
+    proof_surface: checklist and applied review example
+  - wp: WP-10
+    issue: 3415
+    title: Multi-agent workcell proof
+    queue: multi_agent
+    depends_on: [WP-08, WP-09]
+    primary_deliverable: bounded multi-agent C-SDLC workcell proof
+    proof_surface: workcell proof packet, role records, shard records, and closeout truth
+  - wp: WP-11
+    issue: 3484
+    title: Parallel hosted Codex lanes
+    queue: multi_agent
+    depends_on: [WP-10]
+    primary_deliverable: complete bounded issue execution with parallel hosted Codex lanes
+    proof_surface: branch/worktree/PR/card evidence
+  - wp: WP-12
+    issue: 3503
+    title: Single-agent vs multi-agent overhead comparison
+    queue: docs
+    depends_on: [WP-10]
+    primary_deliverable: overhead and usefulness comparison on one docs audit
+    proof_surface: timing and coordination report
+  - wp: WP-13
+    issue: 3455
+    title: Demo showcase refresh
+    queue: demo
+    depends_on: [WP-01]
+    primary_deliverable: demo showcase index and deferred creative demo routing
+    proof_surface: demo index and proof map
+  - wp: WP-14
+    issue: 3460
+    title: Celestial Rescue Unity game demo
+    queue: demo
+    depends_on: [WP-13]
+    primary_deliverable: Celestial Rescue demo and Unity Observatory readiness decision
+    proof_surface: demo artifact or bounded implementation plan
+  - wp: WP-15
+    issue: 3461
+    title: Demo showcase proof map
+    queue: demo
+    depends_on: [WP-13, WP-14]
+    primary_deliverable: demo showcase proof map
+    proof_surface: demo proof index
+  - wp: WP-16
+    issue: 3502
+    title: v0.92 activation-test ledger
+    queue: docs
+    depends_on: [WP-01]
+    primary_deliverable: deferred-work and activation-test ledger for v0.92
+    proof_surface: V092_ACTIVATION_TEST_MAP_v0.91.5.md and linked ledger
+  - wp: WP-17
+    issue: 3377
+    title: v0.92 first-birthday launch packet
+    queue: docs
+    depends_on: [WP-10, WP-15, WP-16]
+    primary_deliverable: go/no-go first-birthday readiness packet
+    proof_surface: launch packet, checklist, and v0.92 opening recommendations
+  - wp: WP-18
+    issue: pending
+    title: Docs and release-truth pass
+    queue: docs
+    depends_on: [WP-17]
+    primary_deliverable: aligned v0.91.5 and v0.92 planning docs
+    proof_surface: docs review packet
+  - wp: WP-19
+    issue: pending
+    title: Internal review
+    queue: review
+    depends_on: [WP-18]
+    primary_deliverable: internal review report
+    proof_surface: finding register
+  - wp: WP-20
+    issue: pending
+    title: Remediation and v0.92 final preflight
+    queue: review
+    depends_on: [WP-19]
+    primary_deliverable: finding dispositions and v0.92 go/no-go
+    proof_surface: disposition record and preflight checklist
+  - wp: WP-21
+    issue: pending
+    title: Release ceremony
+    queue: release
+    depends_on: [WP-20]
+    primary_deliverable: release evidence and ceremony closeout
+    proof_surface: release notes and closeout record
+

--- a/docs/milestones/v0.91.5/features/DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md
@@ -1,0 +1,82 @@
+# Demo And Unity Observatory Readiness v0.91.5
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related issues: `#3455`, `#3460`, `#3461`
+
+## Template Rules
+
+This is a planning feature doc, not a completed demo packet.
+
+## Purpose
+
+Define demo-readiness work that should land before v0.92 first birthday.
+
+## Context
+
+The Unity Observatory path and Celestial Rescue demo can help make v0.92
+visible and reviewable, but only if their proof role is explicit.
+
+## Coverage / Ownership
+
+This feature owns demo showcase refresh, Celestial Rescue routing, and Unity
+Observatory readiness decisions.
+
+## Overview
+
+v0.91.5 should clarify which demos are proof, which are rehearsal, and which
+are future substrate.
+
+## Design
+
+- Maintain a demo showcase index.
+- Map demos to proof claims.
+- Decide whether Celestial Rescue doubles as Unity Observatory proof.
+- Keep illustrative demos separate from runtime proof.
+
+## Execution Flow
+
+1. Refresh demo showcase index.
+2. Build or route Celestial Rescue.
+3. Package proof map.
+4. Feed v0.92 demo planning.
+
+## Determinism and Constraints
+
+Demo claims must be tied to artifacts and commands, not screenshots or
+marketing language alone.
+
+## Integration Points
+
+- [../DEMO_MATRIX_v0.91.5.md](../DEMO_MATRIX_v0.91.5.md)
+- [../V092_ACTIVATION_TEST_MAP_v0.91.5.md](../V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+
+## Validation
+
+Validation should include runnable commands where available, artifact links,
+and explicit blocked/deferred rows where not available.
+
+## Acceptance Criteria
+
+- Demo readiness is visible before v0.92 opens.
+- Unity Observatory routing is explicit.
+- Demo claims do not overstate proof.
+
+## Risks
+
+- A polished demo could be mistaken for runtime proof.
+- Unity work may exceed bridge scope.
+
+## Future Work
+
+v0.92 can build the first-birthday Unity Observatory proof if readiness passes.
+
+## Notes
+
+This feature prepares demo infrastructure; it does not implement the birthday.
+

--- a/docs/milestones/v0.91.5/features/MULTI_AGENT_CSDL_OPERATION_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/MULTI_AGENT_CSDL_OPERATION_v0.91.5.md
@@ -1,0 +1,88 @@
+# Multi-Agent C-SDLC Operation v0.91.5
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related issues: `#3415`, `#3484`, `#3501`, `#3503`, `#3504`
+
+## Template Rules
+
+This is a planning feature doc, not implementation evidence.
+
+## Purpose
+
+Define the bounded multi-agent operating surface that must work before v0.91.5
+closes.
+
+## Context
+
+Single-threaded sprints are useful but too slow for the long-term C-SDLC. The
+multi-agent lane must prove governed parallelism without hiding state or
+weakening review.
+
+## Coverage / Ownership
+
+This feature owns role, shard, coordination, review, and closeout expectations
+for multi-agent C-SDLC execution.
+
+## Overview
+
+The target workcell includes planner, worker, reviewer, janitor/closeout, and
+watcher roles. Roles may use different models based on aptitude, but all work
+must remain bound to issues, cards, branches, reviews, and PR truth.
+
+## Design
+
+- Each role records provider/model identity.
+- Shards have explicit ownership and interface boundaries.
+- Review and merge/closeout gates remain serialized where needed.
+- Multi-agent benefit is measured against single-agent overhead.
+
+## Execution Flow
+
+1. Build or verify role/shard planning.
+2. Select models from the provider/model matrix.
+3. Execute a bounded workcell proof.
+4. Review usefulness and overhead.
+5. Record completion or blocker truth.
+
+## Determinism and Constraints
+
+No agent gets hidden authority. No role bypasses card, review, branch, or
+closeout truth.
+
+## Integration Points
+
+- [../SPRINT_v0.91.5.md](../SPRINT_v0.91.5.md)
+- [../DEMO_MATRIX_v0.91.5.md](../DEMO_MATRIX_v0.91.5.md)
+- [PROVIDER_MODEL_MATRIX_v0.91.5.md](PROVIDER_MODEL_MATRIX_v0.91.5.md)
+
+## Validation
+
+Validation should include a bounded proof packet, role records, shard records,
+timing/overhead comparison, and reviewer checklist.
+
+## Acceptance Criteria
+
+- Multi-agent C-SDLC executes a bounded issue/sprint slice or blocks truthfully.
+- Role and model identity are visible.
+- Review and closeout truth are preserved.
+
+## Risks
+
+- Multi-agent overhead may exceed benefit on small tasks.
+- Local models may be weak for some roles.
+
+## Future Work
+
+Future milestones can expand from bounded workcells to richer Software
+Development Polis operation.
+
+## Notes
+
+This feature does not claim unbounded autonomous development.
+

--- a/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
@@ -1,0 +1,84 @@
+# Provider Model Matrix v0.91.5
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related issues: `#3501`, `#3505`
+
+## Template Rules
+
+This is a planning feature doc, not a provider benchmark result.
+
+## Purpose
+
+Define the provider/model matrix needed to test multi-agent C-SDLC roles.
+
+## Context
+
+ADL needs to test hosted models, local Ollama models, remote Ollama models, and
+OpenRouter-backed models without blurring provider identity or authority.
+
+## Coverage / Ownership
+
+This feature owns matrix planning and evidence expectations for model-role
+testing.
+
+## Overview
+
+The matrix should cover planner, worker, reviewer, janitor, and watcher roles
+across direct hosted providers, local Ollama, remote AI node Ollama, and
+OpenRouter.
+
+## Design
+
+- Record provider, model, transport, credentials posture, and role.
+- Keep skipped and blocked tests explicit.
+- Do not treat tool availability as authority.
+- Prefer aptitude evidence over general model reputation.
+
+## Execution Flow
+
+1. Inventory available local and remote models.
+2. Add OpenRouter provider or a bounded implementation plan.
+3. Test small role-specific prompts.
+4. Feed results into multi-agent execution planning.
+
+## Determinism and Constraints
+
+Results must be reproducible enough for review and must not expose secrets or
+private prompt content.
+
+## Integration Points
+
+- [MULTI_AGENT_CSDL_OPERATION_v0.91.5.md](MULTI_AGENT_CSDL_OPERATION_v0.91.5.md)
+- [../V092_ACTIVATION_TEST_MAP_v0.91.5.md](../V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+
+## Validation
+
+Validation should include provider smoke tests, role probes, skipped-state
+records, and OpenRouter disposition.
+
+## Acceptance Criteria
+
+- Hosted, local Ollama, remote Ollama, and OpenRouter lanes are separately
+  represented.
+- At least one useful candidate per C-SDLC role is identified or blocked.
+
+## Risks
+
+- Provider access may be unavailable.
+- Model behavior may be too unstable for a role.
+
+## Future Work
+
+Future milestones can automate aptitude selection and cost/latency-aware model
+routing.
+
+## Notes
+
+The matrix informs role selection; it does not grant execution authority.
+

--- a/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
@@ -1,0 +1,86 @@
+# Public Prompt Records v0.91.5
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related issues: `#3472`, `#3473`, `#3474`, `#3475`, `#3476`
+
+## Template Rules
+
+This is a planning feature doc, not a publication approval.
+
+## Purpose
+
+Define the transition from local C-SDLC prompt records to public, reviewable,
+redaction-safe prompt packets.
+
+## Context
+
+Prompt cards are durable C-SDLC state. Local `.adl` state also contains
+execution cache and historical working files. v0.91.5 must separate public
+records from local cruft before cleanup.
+
+## Coverage / Ownership
+
+This feature owns prompt packet export, redaction, validation, reviewer index,
+and `.adl` archive/deletion review expectations.
+
+## Overview
+
+The public prompt-record lane should export selected prompt packets, validate
+machine-readable shape, redact local/private data, and index them for review.
+
+## Design
+
+- Export prompt packets from tracked or approved local sources.
+- Validate structure and unresolved placeholders.
+- Run redaction checks before publication.
+- Inventory `.adl` state before archive or deletion.
+- Require review before destructive cleanup.
+
+## Execution Flow
+
+1. Define/export prompt packets.
+2. Inventory `.adl` local state.
+3. Pilot packets and reviewer index.
+4. Add validation/redaction gates.
+5. Close umbrella with disposition truth.
+
+## Determinism and Constraints
+
+Public packet generation must not depend on host paths or hidden local state.
+
+## Integration Points
+
+- [../WBS_v0.91.5.md](../WBS_v0.91.5.md)
+- [../MILESTONE_CHECKLIST_v0.91.5.md](../MILESTONE_CHECKLIST_v0.91.5.md)
+
+## Validation
+
+Validation should include prompt packet structure, redaction scan, link checks,
+and archive/deletion review checklist.
+
+## Acceptance Criteria
+
+- Public prompt packets are exportable and reviewable.
+- Redaction and validation gates exist.
+- `.adl` cleanup has review-before-delete disposition.
+
+## Risks
+
+- Local records may contain private or machine-specific content.
+- Over-cleanup could lose useful historical evidence.
+
+## Future Work
+
+Future milestones can ingest archived records into ObsMem or publish curated
+prompt corpora.
+
+## Notes
+
+This feature does not require all `.adl` history to become tracked repo state.
+

--- a/docs/milestones/v0.91.5/features/README.md
+++ b/docs/milestones/v0.91.5/features/README.md
@@ -1,0 +1,90 @@
+# v0.91.5 Feature Plans
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Planning template set: `docs/templates/planning/1.0.0`
+
+## Template Rules
+
+This index follows the planning feature-doc shape. It is an index, not
+implementation evidence.
+
+## Purpose
+
+List the tracked v0.91.5 feature contracts that WP-01 should consume.
+
+## Context
+
+v0.91.5 is a bridge milestone. Its feature docs define the operational
+surfaces that must be ready before v0.92 first birthday opens.
+
+## Coverage / Ownership
+
+This index owns package navigation. Each linked feature doc owns its own scope,
+validation, risks, and future-work boundary.
+
+## Overview
+
+The package covers multi-agent C-SDLC operation, provider/model matrix,
+public prompt records, demo/Unity Observatory readiness, and v0.92 activation
+readiness.
+
+## Design
+
+Feature docs should stay evidence-bound, template-valid, and linked from the
+milestone README, WBS, sprint plan, and issue wave.
+
+## Execution Flow
+
+1. WP-01 reviews this index and linked feature docs.
+2. WP-01 reconciles live issue labels and the v0.91.5 issue wave.
+3. Later WPs update feature docs only with landed evidence.
+
+## Determinism and Constraints
+
+The package must not claim implementation completion before v0.91.5 work lands.
+
+## Integration Points
+
+- [../README.md](../README.md)
+- [../WBS_v0.91.5.md](../WBS_v0.91.5.md)
+- [../WP_ISSUE_WAVE_v0.91.5.yaml](../WP_ISSUE_WAVE_v0.91.5.yaml)
+
+## Validation
+
+Each linked feature doc should pass the active `feature_doc` template
+validator and link checks.
+
+## Acceptance Criteria
+
+- Every major v0.91.5 bridge track has a linked feature doc.
+- The package validates structurally.
+- WP-01 can consume the package without chat reconstruction.
+
+## Risks
+
+- The index may drift from the issue wave. Mitigation: WP-01 must reconcile
+  both before opening or executing issues.
+
+## Future Work
+
+v0.92 consumes this package for first-birthday activation readiness.
+
+## Notes
+
+This index intentionally keeps v0.91.5 bridge work separate from v0.92
+first-birthday implementation.
+
+## Feature Documents
+
+- [MULTI_AGENT_CSDL_OPERATION_v0.91.5.md](MULTI_AGENT_CSDL_OPERATION_v0.91.5.md)
+- [PROVIDER_MODEL_MATRIX_v0.91.5.md](PROVIDER_MODEL_MATRIX_v0.91.5.md)
+- [PUBLIC_PROMPT_RECORDS_v0.91.5.md](PUBLIC_PROMPT_RECORDS_v0.91.5.md)
+- [DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md](DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md)
+- [V092_ACTIVATION_READINESS_v0.91.5.md](V092_ACTIVATION_READINESS_v0.91.5.md)
+

--- a/docs/milestones/v0.91.5/features/V092_ACTIVATION_READINESS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/V092_ACTIVATION_READINESS_v0.91.5.md
@@ -1,0 +1,87 @@
+# v0.92 Activation Readiness v0.91.5
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Version: `v0.91.5`
+- Date: `2026-05-29`
+- Owner: ADL maintainers
+- Status: `draft_pre_open`
+- Related issues: `#3377`, `#3502`
+
+## Template Rules
+
+This is a planning feature doc, not v0.92 launch approval.
+
+## Purpose
+
+Define the activation-readiness work required before v0.92 first birthday.
+
+## Context
+
+Several ADL features were developed in earlier milestones but will come alive
+together during v0.92. They need explicit test coverage before the birthday
+milestone opens.
+
+## Coverage / Ownership
+
+This feature owns the bridge-level activation map and readiness handoff to
+`#3377`.
+
+## Overview
+
+The activation surface includes memory v2, ACP/cognitive profiles,
+aptitude/capability selector, identity/continuity, affect and happiness,
+Gödel mechanics, economics context, Observatory, Unity readiness, ACIP,
+provider/model matrix, public prompt records, and multi-agent workcell evidence.
+
+## Design
+
+Use [../V092_ACTIVATION_TEST_MAP_v0.91.5.md](../V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+as the checklist for surfaces that must be tested, blocked, or deferred before
+v0.92 WP-01 opens.
+
+## Execution Flow
+
+1. Inventory activation surfaces.
+2. Map each surface to v0.92 candidate WPs.
+3. Record required tests or proof packets.
+4. Feed final go/no-go into `#3377`.
+
+## Determinism and Constraints
+
+Activation readiness must be evidence-bound. Unknown readiness becomes a gap,
+not a positive claim.
+
+## Integration Points
+
+- [../V092_ACTIVATION_TEST_MAP_v0.91.5.md](../V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+- [../WP_ISSUE_WAVE_v0.91.5.yaml](../WP_ISSUE_WAVE_v0.91.5.yaml)
+- [../../v0.92/WP_ISSUE_WAVE_v0.92.yaml](../../v0.92/WP_ISSUE_WAVE_v0.92.yaml)
+
+## Validation
+
+Validation should confirm every activation row has owner issue, v0.92 WP
+mapping, test/proof posture, and blocked/deferred state if needed.
+
+## Acceptance Criteria
+
+- Activation map covers all known v0.92 live surfaces.
+- `#3377` consumes the map.
+- v0.92 WP-01 can use the map without reconstructing intent from chat.
+
+## Risks
+
+- Feature surfaces may be missed because they were developed in older
+  milestones.
+- Some features may need more testing than v0.91.5 can finish.
+
+## Future Work
+
+v0.92 implements and validates the birthday surfaces. v0.93 consumes the
+resulting identity evidence for governance.
+
+## Notes
+
+This feature is the answer to “what comes alive in v0.92?”
+

--- a/docs/milestones/v0.92/DECISIONS_v0.92.md
+++ b/docs/milestones/v0.92/DECISIONS_v0.92.md
@@ -36,7 +36,7 @@ one of them, record a superseding decision instead of silently widening scope.
 | D-06 | Memory palace remains context unless bounded into a specific implementation slice. | Accepted for planning | The memory-palace source spans too many layers to ship whole in v0.92. | Allows memory grounding without forcing the full architecture. |
 | D-07 | ACP / cognitive profiles belong in v0.92 as an evidence-grounded runtime profile surface. | Accepted for planning | Profiles need v0.91.1 capability, memory, ToM, intelligence, and learning evidence before they are meaningful. | Keeps profiles tied to identity readiness without turning them into reputation, personality labels, or public standing. |
 | D-08 | v0.92 owns ACIP binary schema, public schema catalog, JSON projection, and mock WebSocket carrier readiness. | Accepted for planning | ACIP is already a local communication substrate, but citizen/polis communication needs a binary/protobuf shape that remains publicly decodeable by schema and governed by access rules. | Keeps the communication layer inspectable while deferring production transport security to v0.93 and signed/queryable trace closure to v0.94. |
-| D-09 | v0.92 WP-01 must consume `#3377` before seeding final issues. | Accepted for planning | First-birthday readiness was promoted during v0.91.4 as a separate launch-packet source. | Prevents the milestone from reconstructing birthday readiness from chat or duplicating the `#3377` packet. |
+| D-09 | v0.92 WP-01 must consume v0.91.5 closeout and `#3377` before seeding final issues. | Accepted for planning | First-birthday readiness and operational bridge work are now routed through v0.91.5. | Prevents the milestone from reconstructing birthday readiness from chat or duplicating the `#3377` packet. |
 | D-10 | v0.92 must carry an ADR plan before implementation starts. | Accepted for planning | Birthday, identity, ACP, ACIP, and governance-handoff boundaries are architecture decisions, not just feature prose. | WP-01 and the review tail can decide which candidate ADRs to author, split, accept, or defer. |
 
 ## Open Questions
@@ -53,8 +53,8 @@ one of them, record a superseding decision instead of silently widening scope.
   versioning, deterministic JSON projection, and governed message access?
 - Which WebSocket proof is enough to show carrier readiness without claiming
   production networking or security?
-- Which `#3377` outputs are already complete by v0.92 opening, and which must
-  become explicit WP-01 gaps?
+- Which v0.91.5 activation-map and `#3377` outputs are already complete by
+  v0.92 opening, and which must become explicit WP-01 gaps?
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.92/DEMO_MATRIX_v0.92.md
+++ b/docs/milestones/v0.92/DEMO_MATRIX_v0.92.md
@@ -19,8 +19,9 @@ v0.92 implementation WPs exist.
 The v0.92 demo program should prove that the first true Gödel-agent birthday is
 evidence-bearing runtime behavior, not a ceremonial label.
 
-Issue `#3377` supplies required demo rehearsal and negative-suite readiness
-inputs. WP-01 should reconcile those inputs before opening the final demo WPs.
+v0.91.5 supplies demo-readiness and Unity Observatory routing inputs. Issue
+`#3377` supplies required demo rehearsal and negative-suite readiness inputs.
+WP-01 should reconcile those inputs before opening the final demo WPs.
 
 ## How To Use
 

--- a/docs/milestones/v0.92/DESIGN_v0.92.md
+++ b/docs/milestones/v0.92/DESIGN_v0.92.md
@@ -29,9 +29,10 @@ The missing layer is a bounded identity architecture that can say, with
 evidence, when the first true Gödel agent has been born and why that event is
 not ordinary process startup.
 
-Issue `#3377` is a required readiness input for the launch packet, demo
-rehearsal, negative-suite plan, and review handoff. This design remains a
-planning surface until v0.92 execution produces implementation evidence.
+v0.91.5 closeout and issue `#3377` are required readiness inputs for the
+launch packet, activation-test map, demo rehearsal, negative-suite plan, and
+review handoff. This design remains a planning surface until v0.92 execution
+produces implementation evidence.
 
 ## Goals
 

--- a/docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md
+++ b/docs/milestones/v0.92/IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md
@@ -16,10 +16,10 @@ and does not create the v0.92 issue wave.
 
 v0.92 is the planned milestone for the first true Gödel-agent birthday.
 
-Issue `#3377` is the v0.91.4 readiness source for the first-birthday launch
+Issue `#3377` is the v0.91.5 readiness source for the first-birthday launch
 packet, go/no-go checklist, demo rehearsal outline, negative-suite plan, and
-review handoff expectations. v0.92 WP-01 must consume that issue before opening
-the final issue wave.
+review handoff expectations. v0.92 WP-01 must consume v0.91.5 closeout, the
+v0.91.5 activation-test map, and `#3377` before opening the final issue wave.
 
 ## Purpose
 
@@ -64,6 +64,7 @@ evidence.
 | v0.90.3 | Citizen-state security, signed envelopes, lineage, continuity witnesses, standing, sanctuary/quarantine, challenge, and redacted projections. | Private-state format, projection policy, quarantine, or standing classes. |
 | v0.91 | Moral trace, Freedom Gate moral events, outcome linkage, trajectory review, wellbeing evidence, moral resources, and anti-harm proof surfaces. | Moral trace schema, moral metrics, wellbeing model, or trajectory-review protocol. |
 | v0.91.1 | Runtime/polis alignment, agent lifecycle states, memory/identity architecture, Theory of Mind foundation, capability/aptitude testing, intelligence metrics, governed learning, ANRM/Gemma placement, ACIP local hardening, and observatory-visible runtime proof. | Lifecycle-state transition evidence, ACIP eligibility rules, ACP evidence inputs, ToM schemas, capability harnesses, or intelligence metrics. |
+| v0.91.5 | Multi-agent operational readiness, provider/model matrix, public prompt-record readiness, demo/Unity Observatory readiness, and activation-test map. | First-birthday implementation or birthday release evidence. |
 | v0.92 | Identity architecture, stable names, continuity records, memory grounding, capability envelope, ACIP binary schema/catalog transport readiness, birthday record, migration semantics, and reviewer-facing birth evidence. | Earlier substrate layers, production transport security, signed/queryable trace, or later constitutional governance. |
 | v0.93 | Constitutional citizenship, rights, duties, social contract, delegation, IAM, and polis governance over identity-bearing citizens. | Birth semantics, identity architecture, or continuity prerequisites. |
 

--- a/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
+++ b/docs/milestones/v0.92/MILESTONE_CHECKLIST_v0.92.md
@@ -23,6 +23,7 @@ checks needed for a truthful v0.92 closeout.
 
 - [ ] Milestone goal reviewed against the identity, continuity, and birthday
   allocation.
+- [ ] v0.91.5 closeout and activation-test map consumed.
 - [ ] `#3377` first-birthday readiness packet consumed or explicitly routed.
 - [ ] WBS converted from candidate allocation into concrete WPs.
 - [ ] Issue wave authored and opened.

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -13,7 +13,8 @@
 
 Current status: forward planning for the next milestone.
 
-- Planning: candidate package refreshed during `v0.91.4` issue `#3434`
+- Planning: candidate package refreshed during `v0.91.4` issue `#3434` and
+  bridge dependency added during `#3506`
 - Execution: not started
 - Validation: docs-readiness validation only
 - Release readiness: not applicable until `v0.92` executes
@@ -23,7 +24,7 @@ issue-wave preflight document for WP-01 seeding, but the GitHub issue wave
 must not be opened until `v0.92` begins. Its boundary was rechecked during the
 `v0.91.4` docs-preparation pass so it stays about identity and birth rather
 than absorbing economics, governed tools, or constitutional citizenship
-prematurely.
+prematurely. It now depends on the v0.91.5 bridge closeout before opening.
 
 ## Purpose
 
@@ -35,7 +36,10 @@ The canonical allocation is recorded in
 The first-birthday readiness source issue is
 [#3377](https://github.com/danielbaustin/agent-design-language/issues/3377).
 That issue owns the launch packet and go/no-go readiness plan; this milestone
-package owns the canonical `docs/milestones/v0.92/` planning surface.
+package owns the canonical `docs/milestones/v0.92/` planning surface. Issue
+`#3377` is routed through v0.91.5 so it can consume multi-agent,
+provider/model, public prompt-record, demo-readiness, and activation-test
+outputs before v0.92 WP-01 opens.
 
 ## Milestone Role
 
@@ -101,7 +105,9 @@ v0.92 depends on:
   external-transport non-claims
 - v0.93 as a downstream consumer of identity evidence for constitutional
   citizenship and polis governance
-- v0.91.4 issue `#3377` for first-birthday launch-packet readiness inputs
+- v0.91.5 bridge closeout for multi-agent, provider/model, public prompt,
+  demo-readiness, and activation-test preflight
+- v0.91.5 issue `#3377` for first-birthday launch-packet readiness inputs
 
 ## Parallel Python Reduction Tranche
 
@@ -120,6 +126,9 @@ The likely `v0.92` tranche is:
 
 - `#3377`: first-birthday readiness packet source.
 - `#3434`: v0.92 planning-doc preparation issue.
+- `#3506`: v0.91.5 bridge milestone setup and dependency correction.
+- [../v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md](../v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md):
+  activation-test map that v0.92 WP-01 must consume.
 - [IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md](IDENTITY_CONTINUITY_AND_BIRTHDAY_PLAN_v0.92.md):
   current identity and birthday allocation plan.
 - [WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml):
@@ -202,7 +211,8 @@ The likely `v0.92` tranche is:
 Later WP planning should preserve the standard milestone rhythm:
 
 - WP-01: promote reviewed milestone docs and issue wave
-- WP-01 must consume the candidate issue wave and `#3377` readiness packet
+- WP-01 must consume the candidate issue wave, v0.91.5 bridge closeout, the
+  activation-test map, and `#3377` readiness packet
   rather than reconstructing the birthday plan from chat.
 - feature WPs: implement identity, continuity, memory grounding, capability,
   ACP/cognitive profile, ACIP binary transport-readiness, witness, receipt, and

--- a/docs/milestones/v0.92/SPRINT_v0.92.md
+++ b/docs/milestones/v0.92/SPRINT_v0.92.md
@@ -15,7 +15,8 @@
 
 Forward-planning sprint outline. The final sprint and WP sequence will be
 authored during v0.92 WP-01 from
-[WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml) after consuming `#3377`.
+[WP_ISSUE_WAVE_v0.92.yaml](WP_ISSUE_WAVE_v0.92.yaml) after consuming v0.91.5
+closeout, the activation-test map, and `#3377`.
 
 ## How To Use
 
@@ -74,7 +75,7 @@ and validation tight rather than one oversized single-threaded queue.
 
 | Phase | Focus | Expected outcome |
 | --- | --- | --- |
-| 1 | Planning promotion | Reviewed milestone docs, `#3377` launch-packet inputs, issue wave, and cards. |
+| 1 | Planning promotion | Reviewed milestone docs, v0.91.5 activation inputs, `#3377` launch-packet inputs, issue wave, and cards. |
 | 2 | Birthday contract | Definition of birth and negative cases. |
 | 3 | Identity and continuity | Stable name, identity root, continuity record, and cycle evidence. |
 | 4 | Memory, capability, and cognitive profile | Memory grounding, capability envelope, ACP/cognitive profile, and redacted review boundaries. |
@@ -84,6 +85,8 @@ and validation tight rather than one oversized single-threaded queue.
 
 ## Dependencies To Check Before WP-01
 
+- v0.91.5 bridge closeout and activation-test map are complete or explicitly
+  routed.
 - `#3377` first-birthday readiness source is complete or explicitly routed.
 - v0.90.3 citizen-state and standing outputs are stable enough to consume.
 - v0.91 moral trace and moral-governance planning is available.

--- a/docs/milestones/v0.92/VISION_v0.92.md
+++ b/docs/milestones/v0.92/VISION_v0.92.md
@@ -36,8 +36,9 @@ It should make birth a reviewable boundary: a named identity becomes durable
 enough, grounded enough, bounded enough, and witnessed enough to be treated as
 born inside the ADL runtime.
 
-The vision must consume the first-birthday readiness packet from `#3377`
-without treating that packet as proof that the birthday has already happened.
+The vision must consume v0.91.5 closeout and the first-birthday readiness
+packet from `#3377` without treating either packet as proof that the birthday
+has already happened.
 
 ## Core Vision
 

--- a/docs/milestones/v0.92/WBS_v0.92.md
+++ b/docs/milestones/v0.92/WBS_v0.92.md
@@ -15,13 +15,15 @@
 Candidate allocation only. v0.92 has no opened GitHub issue wave yet.
 
 The candidate WP sequence below should be consumed by the v0.92 WP-01 planning
-pass. WP-01 should verify prerequisite truth, reconcile `#3377`, then seed the
+pass. WP-01 should verify prerequisite truth, reconcile v0.91.5 closeout and
+`#3377`, then seed the
 actual GitHub issue wave and full C-SDLC card set.
 
 ## How To Use
 
 Use this WBS as WP-01 seed input, not as proof that v0.92 issues are already
-open. WP-01 should reconcile the sequence with `#3377`, then generate the
+open. WP-01 should reconcile the sequence with v0.91.5 closeout and `#3377`,
+then generate the
 real issue wave and all five C-SDLC cards for each opened issue.
 
 ## WBS Summary
@@ -34,7 +36,7 @@ milestones.
 
 | WP | Work Package | Description | Primary deliverable | Dependencies |
 | --- | --- | --- | --- | --- |
-| WP-01 | Design pass and issue-wave readiness | Promote reviewed v0.92 planning docs, consume `#3377`, seed issue wave, and prepare cards. | Opened issue wave and full SIP/STP/SPP/SRP/SOR cards. | v0.91.4 closeout and `#3377` readiness packet. |
+| WP-01 | Design pass and issue-wave readiness | Promote reviewed v0.92 planning docs, consume v0.91.5 closeout and `#3377`, seed issue wave, and prepare cards. | Opened issue wave and full SIP/STP/SPP/SRP/SOR cards. | v0.91.5 closeout, activation-test map, and `#3377` readiness packet. |
 | WP-02 | Birthday contract and negative cases | Define what counts as birth and what does not. | Feature contract, negative fixtures, and validation rules. | WP-01. |
 | WP-03 | Stable name and identity architecture | Define identity root, stable name, aliases, provenance, and continuity head. | Identity record contract and fixtures. | WP-02 and prior citizen-state lineage. |
 | WP-04 | Continuity across bounded cycles | Prove identity survives multiple bounded cycles with evidence. | Continuity record, cycle fixtures, validation. | WP-03. |
@@ -87,7 +89,8 @@ draft input, not as an already-opened issue wave.
 
 Before opening v0.92 issues, WP-01 must:
 
-- reconcile the candidate sequence with `#3377`
+- reconcile the candidate sequence with v0.91.5 closeout, the activation-test
+  map, and `#3377`
 - verify all feature docs remain linked and scoped
 - create all five cards for every opened issue from the active prompt-template
   registry

--- a/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
+++ b/docs/milestones/v0.92/WP_ISSUE_WAVE_v0.92.yaml
@@ -7,6 +7,7 @@ tracked_package: docs/milestones/v0.92
 notes:
   - v0.92 is the first true Godel-agent birthday milestone.
   - This file is a candidate issue-wave preflight surface, not an opened GitHub issue wave.
+  - WP-01 must consume v0.91.5 closeout and the v0.91.5 activation-test map before seeding the final issue wave.
   - WP-01 must consume issue 3377 before seeding the final issue wave.
   - WP-01 must verify the v0.92 feature-doc package and ADR plan before opening implementation WPs.
   - No v0.92 issue should claim legal personhood, production citizenship, consciousness proof, or completed v0.93 constitutional governance.
@@ -22,7 +23,7 @@ work_packages:
     issue: pending
     title: Design pass and issue-wave readiness
     queue: docs
-    depends_on: [v0.91.4 closeout, issue-3377]
+    depends_on: [v0.91.5 closeout, v0.91.5 activation-test map, issue-3377]
     primary_deliverable: reviewed v0.92 docs, verified feature-doc package, ADR plan, opened issue wave, and complete card bundle
     proof_surface: milestone docs, feature docs, ADR plan, issue-wave YAML, and SIP/STP/SPP/SRP/SOR cards
   - wp: WP-02

--- a/docs/milestones/v0.92/features/README.md
+++ b/docs/milestones/v0.92/features/README.md
@@ -17,8 +17,8 @@ These documents define the tracked feature-doc package for the identity,
 continuity, first-birthday, and ACIP transport-readiness band. They are
 planning surfaces, not implementation closeout records.
 
-WP-01 must reconcile these feature contracts with `#3377` before opening the
-final issue wave.
+WP-01 must reconcile these feature contracts with v0.91.5 closeout, the
+v0.91.5 activation-test map, and `#3377` before opening the final issue wave.
 
 ## Template Rules
 
@@ -54,7 +54,8 @@ milestone README, WBS, sprint plan, and candidate issue wave.
 ## Execution Flow
 
 1. WP-01 reviews this index and the linked feature docs.
-2. WP-01 reconciles them with `#3377`.
+2. WP-01 reconciles them with v0.91.5 closeout, the activation-test map, and
+   `#3377`.
 3. WP-01 opens or adjusts implementation issues.
 4. Later WPs update feature docs only with landed evidence.
 
@@ -68,6 +69,7 @@ The package must not claim implementation completion before v0.92 work lands.
 - [../WBS_v0.92.md](../WBS_v0.92.md)
 - [../WP_ISSUE_WAVE_v0.92.yaml](../WP_ISSUE_WAVE_v0.92.yaml)
 - `#3377`
+- [../../v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md](../../v0.91.5/V092_ACTIVATION_TEST_MAP_v0.91.5.md)
 
 ## Validation
 
@@ -92,7 +94,8 @@ MVP hardening feature packages.
 
 ## Notes
 
-This index intentionally keeps `#3377` visible as a launch-readiness source.
+This index intentionally keeps `#3377` and the v0.91.5 activation-test map
+visible as launch-readiness sources.
 
 ## Feature Documents
 


### PR DESCRIPTION
Closes #3506

## Summary
Created the v0.91.5 bridge milestone planning package, routed the specified
open bridge issues from v0.91.4 to v0.91.5, updated v0.91.4 release-tail docs
to keep release scope focused, and updated v0.92 planning docs to consume
v0.91.5 closeout and `#3377`.

## Artifacts
- `docs/milestones/v0.91.5/`
- `docs/milestones/v0.91.5/features/`
- Updated v0.91.4 release-tail and issue-wave docs.
- Updated v0.92 planning dependency docs.
- GitHub issue label/title routing for `#3377`, `#3415`, `#3455`, `#3460`,
  `#3461`, `#3472`-`#3476`, `#3484`, and `#3501`-`#3505`.

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/validate_planning_template.py --registry docs/templates/planning/current.json --template TEMPLATE_KEY --input V0915_DOC_PATH`
    Verified v0.91.5 planning-template structure for canonical docs and feature docs.
  - `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' ...`
    Verified issue-wave YAML syntax.
  - Markdown relative-link resolver over changed milestone docs.
    Verified milestone-relative links exist.
  - `git diff --check`
    Verified whitespace.
  - `gh issue view ISSUE_NUMBER --json number,title,labels,state`
    Verified moved issue labels/titles.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3506__v0-91-4-create-v0-91-5-bridge-milestone/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3506__v0-91-4-create-v0-91-5-bridge-milestone/sor.md
- Idempotency-Key: v0-91-4-planning-create-v0-91-5-bridge-milestone-docs-milestones-v0-91-4-docs-milestones-v0-91-5-docs-milestones-v0-92-adl-v0-91-4-tasks-issue-3506-v0-91-4-create-v0-91-5-bridge-milestone-sip-md-adl-v0-91-4-tasks-issue-3506-v0-91-4-create-v0-91-5-bridge-milestone-sor-md