### PR TITLE
[v0.91.4][process] Add milestone creation skill and process guidance

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -59,6 +59,7 @@ run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_pa
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"
 run_step "records-hygiene contract check" bash "$ROOT/adl/tools/test_records_hygiene_skill_contracts.sh"
 run_step "pr-stack-manager contract check" bash "$ROOT/adl/tools/test_pr_stack_manager_skill_contracts.sh"
+run_step "adl-milestone-creator contract check" bash "$ROOT/adl/tools/test_adl_milestone_creator_skill_contracts.sh"
 run_step "CCC v0 instrumentation check" bash "$ROOT/adl/tools/test_ccc_v0_instrumentation.sh"
 run_step "skill documentation completeness check" bash "$ROOT/adl/tools/test_skill_documentation_completeness.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"

--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -60,6 +60,7 @@ run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_auth
 run_step "records-hygiene contract check" bash "$ROOT/adl/tools/test_records_hygiene_skill_contracts.sh"
 run_step "pr-stack-manager contract check" bash "$ROOT/adl/tools/test_pr_stack_manager_skill_contracts.sh"
 run_step "adl-milestone-creator contract check" bash "$ROOT/adl/tools/test_adl_milestone_creator_skill_contracts.sh"
+run_step "planning-doc-editor contract check" bash "$ROOT/adl/tools/test_planning_doc_editor_skill_contracts.sh"
 run_step "CCC v0 instrumentation check" bash "$ROOT/adl/tools/test_ccc_v0_instrumentation.sh"
 run_step "skill documentation completeness check" bash "$ROOT/adl/tools/test_skill_documentation_completeness.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"

--- a/adl/tools/skills/adl-milestone-creator/SKILL.md
+++ b/adl/tools/skills/adl-milestone-creator/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: adl-milestone-creator
+description: Create, split, or reallocate ADL milestones with the full C-SDLC planning package, conductor-bound setup issue, version labels, issue migration truth, feature docs, validation, review, and PR publication. Use when the operator asks to create a new ADL milestone, bridge milestone, next-milestone package, milestone split, milestone setup wave, or to move open issues between ADL versions.
+---
+
+# ADL Milestone Creator
+
+Use this skill to create a complete ADL milestone package without relying on
+session memory. The goal is not only to make files; it is to establish truthful
+workflow state, issue routing, planning docs, proof surfaces, and downstream
+handoff contracts before the milestone starts.
+
+This skill is ADL-specific. It must respect the root `AGENTS.md` contract:
+route tracked repo work through `workflow-conductor`, never work on `main`, use
+versioned prompt templates for cards, and keep validation scoped to the touched
+surface.
+
+## Operating Rule
+
+Milestone creation is a first-class C-SDLC operation. Treat it as issue-backed
+work unless the operator explicitly asks only for an untracked local note.
+
+For ADL repo changes:
+- create or use one concrete setup issue
+- create all five cards from `docs/templates/prompts/current.json`
+- make `SIP`, `STP`, and `SPP` issue-specific and ready before execution
+- bind a worktree with the repo-native PR flow
+- use editor skills for card normalization
+- run a bounded pre-PR review before publication
+
+## Quick Workflow
+
+1. Read the current milestone docs, issue list, and operator decision.
+2. Route through `workflow-conductor` for issue setup or execution state.
+3. Create a setup issue if none exists.
+4. Confirm all five prompt cards exist from the active template registry.
+5. Bind execution to a worktree; stop if still on `main`.
+6. Create the complete milestone docs package.
+7. Reallocate or seed issues and labels.
+8. Update source and downstream milestone docs for routing truth.
+9. Validate docs, YAML, links, issue routing, and card truth.
+10. Run bounded review and fix actionable findings.
+11. Publish through the normal PR workflow and stop before merge unless told.
+
+## Setup Issue
+
+The setup issue should be titled like:
+
+```text
+[vX.Y.Z][planning] Create vA.B.C milestone planning package
+```
+
+If the work is a bridge or split, include the routing intent:
+
+```text
+[v0.91.4][planning] Create v0.91.5 bridge milestone and reallocate pre-v0.92 work
+```
+
+The issue body must state:
+- why the milestone exists
+- which milestone remains in scope
+- which work moves into the new milestone
+- what downstream milestone depends on it
+- exact non-goals
+- focused validation plan
+- that broad Rust/runtime tests are not required for docs-only setup unless
+  runtime/tooling behavior changes
+
+## Required Planning Package
+
+Do not create a skinny milestone package. Unless the operator explicitly narrows
+scope, create or refresh all of these surfaces:
+
+- `docs/milestones/<version>/README.md`
+- `docs/milestones/<version>/VISION_<version>.md`
+- `docs/milestones/<version>/DESIGN_<version>.md`
+- `docs/milestones/<version>/DECISIONS_<version>.md`
+- `docs/milestones/<version>/WBS_<version>.md`
+- `docs/milestones/<version>/SPRINT_<version>.md`
+- `docs/milestones/<version>/WP_ISSUE_WAVE_<version>.yaml`
+- `docs/milestones/<version>/DEMO_MATRIX_<version>.md`
+- `docs/milestones/<version>/MILESTONE_CHECKLIST_<version>.md`
+- `docs/milestones/<version>/RELEASE_PLAN_<version>.md`
+- `docs/milestones/<version>/RELEASE_NOTES_<version>.md`
+- `docs/milestones/<version>/QUALITY_GATE_<version>.md`
+- `docs/milestones/<version>/FEATURE_PROOF_COVERAGE_<version>.md`
+- `docs/milestones/<version>/WP_EXECUTION_READINESS_<version>.md`
+- `docs/milestones/<version>/ADR_PLAN_<version>.md`
+- `docs/milestones/<version>/NEXT_MILESTONE_HANDOFF_<version>.md`
+- `docs/milestones/<version>/features/README.md`
+- one feature doc per first-class milestone feature or work track
+
+If the new milestone prepares a later activation milestone, add an explicit
+activation/test map such as:
+
+```text
+docs/milestones/<version>/V<next>_ACTIVATION_TEST_MAP_<version>.md
+```
+
+## Feature And Work-Track Coverage
+
+For each milestone work track, ensure there is a visible home:
+- WBS work package or sidecar wave entry
+- issue-wave YAML entry with deliverables/proof specificity
+- feature doc when the work is product/process significant
+- demo matrix row if user-visible proof is expected
+- quality-gate or feature-proof line when release readiness depends on it
+- ADR plan row if the work creates or changes an architecture decision
+
+For bridge milestones, explicitly map:
+- what remains in the source milestone
+- what moves to the bridge milestone
+- what the bridge milestone must complete before the downstream milestone opens
+- which issues are final go/no-go gates
+
+## Issue Migration
+
+When moving live issues between versions:
+1. Add or confirm the target `version:<version>` label.
+2. Remove stale version labels when they would misroute the issue.
+3. Retitle issues if the title prefix names the old milestone.
+4. Comment with routing truth: source issue, target milestone, reason, and
+   whether the work is moved, deferred, or still a prerequisite.
+5. Update milestone docs so moved work is described as moved, not abandoned.
+6. Update downstream docs so they consume the new milestone rather than the old
+   direct handoff.
+7. Verify the issue list after edits; do not rely on memory.
+
+Do not open backlog-only items as GitHub issues unless the operator explicitly
+approves opening them.
+
+## Issue Wave Rules
+
+`WP_ISSUE_WAVE_<version>.yaml` must be machine-useful, not only human-readable.
+Include enough fields for issue seeding to preserve:
+- work package title and queue
+- dependencies
+- primary deliverables
+- proof or validation expectations
+- feature/proof surfaces
+- release-gate or sidecar routing when relevant
+
+The exact number of WPs is not a process invariant. The sequence is the
+invariant: setup, sprint execution, review/remediation, next-milestone planning,
+next-milestone review, ceremony/release closeout.
+
+## Docs Truth Rules
+
+Keep milestone docs in planned posture until execution evidence exists.
+
+Use language like:
+- `planned`
+- `must produce`
+- `will be validated by`
+- `not yet release-approved`
+
+Avoid language like:
+- `complete`
+- `proven`
+- `approved`
+- `landed`
+
+unless the repo, issue, PR, or review evidence exists and is cited.
+
+## Validation
+
+Use focused validation for docs-only milestone setup:
+
+- planning-template validation for canonical milestone docs
+- planning-template validation for feature docs
+- YAML parse for all touched issue-wave files
+- markdown relative-link resolver for touched milestone docs
+- placeholder scan scoped to the new or touched milestone
+- issue label/title/routing verification against GitHub when issues moved
+- `git diff --check`
+- repo-specific guardrails that are relevant to touched surfaces
+
+Do not run broad Rust/runtime tests for docs-only milestone creation unless a
+tracked runtime, tool, CI, or script behavior changed.
+
+If tooling changes are part of the issue, use the smallest proving queue and
+record PVF lane truth in the cards.
+
+## Review And Closeout
+
+Before PR publication:
+- run a bounded review subagent over the changed milestone package
+- fix actionable findings
+- update `SRP` with review findings and dispositions
+- update `SOR` with actual validation, integration state, touched paths, and
+  residual risks
+
+After merge or closure:
+- use `pr-closeout`
+- reconcile cards and GitHub truth
+- do not leave the setup issue claiming `ready` or `completed` before the PR
+  state supports it
+
+## Anti-Footguns
+
+- Do not create milestone docs on `main`.
+- Do not hand-roll cards from memory.
+- Do not leave `SIP`, `STP`, or `SPP` generic when execution starts.
+- Do not leave feature docs missing for first-class work.
+- Do not let moved sidecar work disappear from closeout/checklist truth.
+- Do not leave downstream docs pointing at an old direct handoff.
+- Do not silently expand scope beyond the milestone setup issue.
+- Do not delete `.adl` historical material during milestone setup; plan review,
+  archive, and ingestion separately.
+- Do not treat planning docs as release approval.
+- Do not run the full Rust test suite just because a docs-only PR exists.
+
+## Completion Criteria
+
+The milestone creation issue is ready for PR review when:
+- the full planning package exists
+- issue labels/titles/routing match the intended milestone
+- source and downstream milestone docs agree with the new route
+- feature docs and ADR plan cover first-class work
+- issue-wave YAML preserves deliverables and proof expectations
+- focused docs/YAML/link/guardrail validation passes
+- `SRP` and `SOR` record truthful review and validation evidence
+- the PR description states what moved, what stayed, and what remains gated

--- a/adl/tools/skills/adl-milestone-creator/adl-skill.yaml
+++ b/adl/tools/skills/adl-milestone-creator/adl-skill.yaml
@@ -1,0 +1,129 @@
+version: "0.1"
+kind: "adl-skill"
+id: "adl-milestone-creator"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "adl_milestone_creator.v1"
+    reference_doc: "../docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "milestone"
+      - "policy"
+    mode_enum:
+      - "create_milestone_package"
+      - "create_bridge_milestone"
+      - "split_or_reallocate_milestone"
+      - "review_milestone_creation_plan"
+    policy_fields:
+      - "require_workflow_conductor"
+      - "require_versioned_prompt_templates"
+      - "require_bound_worktree"
+      - "require_full_planning_package"
+      - "require_issue_migration_truth"
+      - "require_focused_docs_validation"
+      - "allow_runtime_validation"
+      - "stop_before_merge"
+    mode_requirements:
+      create_milestone_package:
+        required_milestone_fields:
+          - "target_version"
+          - "purpose"
+      create_bridge_milestone:
+        required_milestone_fields:
+          - "source_version"
+          - "target_version"
+          - "downstream_version"
+          - "moved_issue_numbers"
+      split_or_reallocate_milestone:
+        required_milestone_fields:
+          - "source_version"
+          - "target_version"
+          - "moved_issue_numbers"
+      review_milestone_creation_plan:
+        required_milestone_fields:
+          - "target_version"
+          - "planning_package_paths"
+  intent:
+    - "milestone_creation"
+    - "milestone_split"
+    - "bridge_milestone"
+    - "issue_reallocation"
+    - "planning_package_creation"
+  required_inputs:
+    - "repo_root"
+    - "milestone.target_version"
+  optional_inputs:
+    - "milestone.source_version"
+    - "milestone.downstream_version"
+    - "milestone.purpose"
+    - "milestone.setup_issue_number"
+    - "milestone.moved_issue_numbers"
+    - "milestone.kept_issue_numbers"
+    - "milestone.planning_package_paths"
+    - "milestone.feature_tracks"
+    - "milestone.adr_candidates"
+    - "milestone.activation_map_required"
+  stop_if_missing:
+    - "repo_root"
+    - "milestone.target_version"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_adl_milestone_creator.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.require_workflow_conductor_must_be_true"
+    - "policy.require_versioned_prompt_templates_must_be_true"
+    - "policy.require_bound_worktree_must_be_true_for_repo_mutation"
+    - "policy.require_full_planning_package_must_be_true_unless_operator_explicitly_narrows_scope"
+    - "policy.require_issue_migration_truth_must_be_true_when_issues_move"
+    - "policy.require_focused_docs_validation_must_be_true"
+    - "policy.allow_runtime_validation_must_be_false_for_docs_only_setup"
+    - "policy.stop_before_merge_must_be_true"
+execution:
+  mode: "milestone_setup_process_guidance"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: true
+  workflow_role: "milestone_planning_operator"
+  preferred_commands:
+    - "workflow-conductor for issue routing"
+    - "pr-init/pr-ready/pr-run/pr-finish/pr-closeout for the setup issue lifecycle"
+    - "planning-doc-editor for milestone planning document cleanup"
+    - "card editor skills for SIP/STP/SPP/SRP/SOR normalization"
+    - "gh issue list/edit/comment for explicit issue migration truth"
+  preferred_path: "setup_issue_then_bound_worktree_then_full_planning_package_then_review"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - "docs/milestones/**"
+    - "adl/tools/skills/**"
+    - "issue labels/titles/comments explicitly named by the operator"
+    - ".adl/** local issue cards and closeout records"
+  must_not_write:
+    - "runtime source files unless explicitly scoped by a separate issue"
+    - "unrelated milestone packages"
+    - "historical .adl records scheduled for archive review"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  required_sections:
+    - "setup_issue"
+    - "target_milestone"
+    - "planning_package"
+    - "issue_routing"
+    - "validation"
+    - "review"
+    - "handoff"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+display_name: ADL Milestone Creator
+short_description: Create complete ADL milestone packages
+default_prompt: Create a complete ADL milestone package with issue routing, planning docs, validation, review, and handoff truth.

--- a/adl/tools/skills/adl-milestone-creator/agents/openai.yaml
+++ b/adl/tools/skills/adl-milestone-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADL Milestone Creator"
+  short_description: "Create complete ADL milestone packages"
+  default_prompt: "Use $adl-milestone-creator to create a complete ADL milestone package."

--- a/adl/tools/skills/adl-milestone-creator/references/output-contract.md
+++ b/adl/tools/skills/adl-milestone-creator/references/output-contract.md
@@ -1,0 +1,53 @@
+# ADL Milestone Creator Output Contract
+
+Milestone creation outputs must be reviewable, bounded, and explicit about what
+was planned, moved, validated, and left gated.
+
+## Required Markdown Sections
+
+- `Milestone Creation Summary`
+- `Setup Issue`
+- `Target Milestone`
+- `Planning Package`
+- `Issue Routing`
+- `Feature And Proof Coverage`
+- `Downstream Handoff`
+- `Validation Commands`
+- `Review Results`
+- `Non-Claims`
+- `Residual Risks`
+
+## Required JSON Shape
+
+Schema id: `adl.milestone_creation_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `source_version`
+- `target_version`
+- `downstream_version`
+- `setup_issue`
+- `planning_package`
+- `issue_routing`
+- `feature_tracks`
+- `validation_commands`
+- `review_results`
+- `non_claims`
+- `residual_risks`
+
+## Safety Flags
+
+Every report must state:
+
+- `release_approved: false`
+- `milestone_released: false`
+- `created_tags: false`
+- `merged_prs: false`
+- `deleted_history: false`
+- `runtime_behavior_changed: false`
+
+The skill may report that a milestone package is ready for review. It must not
+claim release approval, milestone completion, or downstream readiness without
+explicit review and closeout evidence.

--- a/adl/tools/skills/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,49 @@
+# ADL Milestone Creator Skill Input Schema
+
+```yaml
+skill_input_schema: adl_milestone_creator.v1
+mode: create_milestone_package | create_bridge_milestone | split_or_reallocate_milestone | review_milestone_creation_plan
+repo_root: /absolute/path
+milestone:
+  source_version: v0.91.4 | null
+  target_version: v0.91.5
+  downstream_version: v0.92 | null
+  purpose: <bounded milestone purpose>
+  setup_issue_number: <u32 or null>
+  moved_issue_numbers:
+    - <u32>
+  kept_issue_numbers:
+    - <u32>
+  planning_package_paths:
+    - docs/milestones/<version>/README.md
+  feature_tracks:
+    - id: <track-id>
+      title: <track title>
+      feature_doc: docs/milestones/<version>/features/<feature>.md
+      proof_surface: <bounded proof or validation surface>
+  adr_candidates:
+    - docs/architecture/adr/<candidate>.md
+  activation_map_required: true | false
+policy:
+  require_workflow_conductor: true
+  require_versioned_prompt_templates: true
+  require_bound_worktree: true
+  require_full_planning_package: true
+  require_issue_migration_truth: true | false
+  require_focused_docs_validation: true
+  allow_runtime_validation: false
+  stop_before_merge: true
+```
+
+## Required Behavior
+
+- Use `workflow-conductor` as the mandatory front door for tracked issue setup
+  and execution routing.
+- Use prompt cards from `docs/templates/prompts/current.json`.
+- Make `SIP`, `STP`, and `SPP` design-time ready before execution begins.
+- Create the full milestone planning package unless the operator explicitly
+  narrows scope.
+- Keep moved work visible as moved, not abandoned.
+- Keep downstream docs aligned with the new milestone handoff.
+- Use focused docs/YAML/link/metadata validation for docs-only milestone setup.
+- Stop before merge or release approval.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -14,6 +14,7 @@ scratch.
 
 The tracked skill set is:
 
+- `adl-milestone-creator`
 - `adr-curator`
 - `architecture-diagram-reviewer`
 - `architecture-fitness-function-author`
@@ -87,6 +88,7 @@ The normal workflow is:
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 `sprint-conductor` is a slow-path sprint orchestrator that sequences issues through the existing lifecycle and editor skills, then finishes with sprint review and closeout.
+`adl-milestone-creator` is a bounded milestone setup helper for creating full milestone packages, bridge milestones, issue-routing truth, feature/proof coverage, and downstream handoff docs without relying on session memory.
 `issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
 `issue-splitter` is a bounded issue-scope helper for deciding whether one issue should stay intact, split now, defer splitting, or stop for operator review.
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
@@ -241,6 +243,13 @@ The conductor should be especially useful when:
 - initial workflow steps are only partially complete
 - the operator wants one bounded entrypoint
 - skill/subagent policy should be applied explicitly instead of by memory
+
+Use `adl-milestone-creator` when the operator asks to create a milestone,
+bridge milestone, next-milestone package, milestone split, setup wave, or issue
+reallocation package. It should create or consume one setup issue, require
+versioned prompt cards, bind work to a worktree, produce the full milestone
+planning package, preserve moved-vs-abandoned issue truth, run focused
+docs/YAML/link validation, and stop before merge or release approval.
 
 ## Compression-Era Execution Policy
 

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -28,6 +28,7 @@ The tracked skill set is:
 - `issue-splitter`
 - `issue-watcher`
 - `medium-article-writer`
+- `planning-doc-editor`
 - `portable-contract-normalizer`
 - `pr-closeout`
 - `pr-finish`
@@ -95,6 +96,7 @@ The normal workflow is:
 `pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
 `review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
 `review-readiness-cleanup` is a bounded review-cycle preflight helper for classifying safe cleanup, blockers, skipped surfaces, and follow-on needs before formal review starts.
+`planning-doc-editor` is a bounded planning-document editor for milestone/project docs that need placeholder cleanup, required-section repair, status-truth normalization, template-contract alignment, or portable-path cleanup without editing lifecycle cards.
 `portable-contract-normalizer` is a bounded portability helper for detecting machine-local assumptions and applying only explicitly approved safe mechanical normalization.
 
 The PR lifecycle skills share the CI runtime interpretation policy in

--- a/adl/tools/skills/docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,37 @@
+# Planning Doc Editor Skill Input Schema
+
+```yaml
+skill_input_schema: planning_doc_editor.v1
+mode: placeholder_cleanup | required_section_repair | status_truth_normalization | planning_packet_review_cleanup | template_contract_alignment | portable_path_cleanup
+repo_root: /absolute/path
+target:
+  target_path: docs/milestones/<version>/<doc>.md
+  target_paths:
+    - docs/milestones/<version>/<doc>.md
+  planning_doc_type: README | WBS | SPRINT | VISION | FEATURE_DOC | DESIGN | DECISIONS | DEMO_MATRIX | MILESTONE_CHECKLIST | RELEASE_PLAN | RELEASE_NOTES | HANDOFF | planning_doc_unknown
+  template_version: <version or null>
+  template_registry_path: docs/templates/planning/current.json | null
+  issue_number: <u32 or null>
+  milestone: <version or null>
+  source_issue_prompt: <repo-relative path or null>
+  review_findings: <bounded finding summary or null>
+  status_truth: generated | draft | reviewed | approved | historical | unknown
+  validation_command: <focused command or null>
+policy:
+  bounded_target_required: true
+  source_evidence_required: true
+  no_card_edits: true
+  no_release_approval: true
+  stop_before_publication: true
+```
+
+## Required Behavior
+
+- Edit only the bounded planning document target or target packet.
+- Preserve the difference between generated, reviewed, and approved docs.
+- Demote unsupported release, PR, review, or closeout claims.
+- Route lifecycle-card defects to the appropriate card editor skill instead of
+  editing `SIP`, `STP`, `SPP`, `SRP`, or `SOR`.
+- Run the smallest focused validation that proves the planning-doc edit.
+- Stop before PR publication, issue closeout, release approval, or broad
+  repo-wide rewrite.

--- a/adl/tools/skills/planning-doc-editor/adl-skill.yaml
+++ b/adl/tools/skills/planning-doc-editor/adl-skill.yaml
@@ -1,0 +1,118 @@
+version: "0.1"
+kind: "adl-skill"
+id: "planning-doc-editor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "planning_doc_editor.v1"
+    reference_doc: "../docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "placeholder_cleanup"
+      - "required_section_repair"
+      - "status_truth_normalization"
+      - "planning_packet_review_cleanup"
+      - "template_contract_alignment"
+      - "portable_path_cleanup"
+    policy_fields:
+      - "bounded_target_required"
+      - "source_evidence_required"
+      - "no_card_edits"
+      - "no_release_approval"
+      - "stop_before_publication"
+    mode_requirements:
+      placeholder_cleanup:
+        required_target_fields:
+          - "target_path"
+      required_section_repair:
+        required_target_fields:
+          - "target_path"
+          - "planning_doc_type"
+      status_truth_normalization:
+        required_target_fields:
+          - "target_path"
+          - "status_truth"
+      planning_packet_review_cleanup:
+        required_target_fields:
+          - "target_paths"
+      template_contract_alignment:
+        required_target_fields:
+          - "target_path"
+          - "template_registry_path"
+      portable_path_cleanup:
+        required_target_fields:
+          - "target_path"
+  intent:
+    - "planning_doc_editing"
+    - "milestone_planning_cleanup"
+    - "template_contract_alignment"
+    - "planning_truth_normalization"
+  required_inputs:
+    - "repo_root"
+    - "target.target_path"
+  optional_inputs:
+    - "target.target_paths"
+    - "target.planning_doc_type"
+    - "target.template_version"
+    - "target.template_registry_path"
+    - "target.issue_number"
+    - "target.milestone"
+    - "target.source_issue_prompt"
+    - "target.review_findings"
+    - "target.status_truth"
+    - "target.validation_command"
+  stop_if_missing:
+    - "repo_root"
+    - "target.target_path"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_planning_doc_editor.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.bounded_target_required_must_be_true"
+    - "policy.source_evidence_required_must_be_true"
+    - "policy.no_card_edits_must_be_true"
+    - "policy.no_release_approval_must_be_true"
+    - "policy.stop_before_publication_must_be_true"
+execution:
+  mode: "bounded_planning_doc_editing"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  workflow_role: "planning_doc_editor"
+  preferred_path: "bounded_target_then_source_evidence_then_focused_edit_then_validation_report"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - "bounded planning-document targets explicitly named by the caller"
+  must_not_write:
+    - "SIP/STP/SPP/SRP/SOR lifecycle cards"
+    - "runtime source files"
+    - "unrelated milestone packages"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  required_sections:
+    - "target"
+    - "planning_document_type"
+    - "editing_mode"
+    - "defects_corrected"
+    - "claims_demoted_or_qualified"
+    - "validation"
+    - "residual_risks"
+    - "recommended_handoff"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+display_name: Planning Doc Editor
+short_description: Normalize ADL milestone and project planning docs without editing issue cards
+default_prompt: Normalize this ADL planning document against the planning-template contract while preserving generated, reviewed, and approved truth.

--- a/adl/tools/skills/planning-doc-editor/references/output-contract.md
+++ b/adl/tools/skills/planning-doc-editor/references/output-contract.md
@@ -1,0 +1,47 @@
+# Planning Doc Editor Output Contract
+
+Planning doc editor outputs must be bounded, evidence-backed, and explicit
+about what planning truth was changed.
+
+## Required Markdown Sections
+
+- `Target`
+- `Planning Document Type`
+- `Editing Mode`
+- `Defects Corrected`
+- `Claims Demoted Or Qualified`
+- `Validation`
+- `Validation Not Run`
+- `Residual Risks`
+- `Recommended Handoff`
+
+## Required JSON Shape
+
+Schema id: `adl.planning_doc_editor_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `target_path`
+- `planning_doc_type`
+- `editing_mode`
+- `defects_corrected`
+- `claims_demoted_or_qualified`
+- `validation_run`
+- `validation_not_run`
+- `residual_risks`
+- `recommended_handoff`
+
+## Safety Flags
+
+Every report must state:
+
+- `edited_lifecycle_cards: false`
+- `claimed_release_approval: false`
+- `claimed_pr_publication: false`
+- `claimed_issue_closeout: false`
+- `widened_scope: false`
+
+The skill may report that a planning document is cleaner or ready for review.
+It must not claim release approval, PR publication, issue closeout, or lifecycle
+card truth.

--- a/adl/tools/test_adl_milestone_creator_skill_contracts.sh
+++ b/adl/tools/test_adl_milestone_creator_skill_contracts.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/adl-milestone-creator/SKILL.md" ]]
+[[ -f "${skills_root}/adl-milestone-creator/adl-skill.yaml" ]]
+[[ -f "${skills_root}/adl-milestone-creator/agents/openai.yaml" ]]
+[[ -f "${skills_root}/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'name: adl-milestone-creator' "${skills_root}/adl-milestone-creator/SKILL.md"
+grep -Fq 'id: "adl-milestone-creator"' "${skills_root}/adl-milestone-creator/adl-skill.yaml"
+grep -Fq 'id: "adl_milestone_creator.v1"' "${skills_root}/adl-milestone-creator/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/adl-milestone-creator/adl-skill.yaml"
+grep -Fq "require_full_planning_package" "${skills_root}/adl-milestone-creator/adl-skill.yaml"
+grep -Fq "Do not create a skinny milestone package" "${skills_root}/adl-milestone-creator/SKILL.md"
+grep -Fq "docs/templates/prompts/current.json" "${skills_root}/adl-milestone-creator/SKILL.md"
+grep -Fq 'Schema id: `adl_milestone_creator.v1`' "${skills_root}/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md" || \
+  grep -Fq 'skill_input_schema: adl_milestone_creator.v1' "${skills_root}/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "adl-milestone-creator" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+python3 - <<'PY' "${skills_root}/adl-milestone-creator/SKILL.md" "${skills_root}/adl-milestone-creator/adl-skill.yaml" "${skills_root}/adl-milestone-creator/agents/openai.yaml"
+from pathlib import Path
+import sys
+
+for raw in sys.argv[1:]:
+    text = Path(raw).read_text()
+    todo_marker = "[" + "TODO"
+    if todo_marker in text:
+        raise SystemExit(f"TODO residue in {raw}")
+    host_markers = ["/" + "Users/", "/" + "private/tmp"]
+    if any(marker in text for marker in host_markers):
+        raise SystemExit(f"host path leakage in {raw}")
+
+skill = Path(sys.argv[1]).read_text()
+if len(skill.splitlines()) > 500:
+    raise SystemExit("SKILL.md exceeds compact skill size budget")
+PY
+
+printf '%s\n' "OK: adl-milestone-creator skill contract"

--- a/adl/tools/test_planning_doc_editor_skill_contracts.sh
+++ b/adl/tools/test_planning_doc_editor_skill_contracts.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/planning-doc-editor/SKILL.md" ]]
+[[ -f "${skills_root}/planning-doc-editor/adl-skill.yaml" ]]
+[[ -f "${skills_root}/planning-doc-editor/agents/openai.yaml" ]]
+[[ -f "${skills_root}/planning-doc-editor/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'name: planning-doc-editor' "${skills_root}/planning-doc-editor/SKILL.md"
+grep -Fq 'id: "planning-doc-editor"' "${skills_root}/planning-doc-editor/adl-skill.yaml"
+grep -Fq 'id: "planning_doc_editor.v1"' "${skills_root}/planning-doc-editor/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/planning-doc-editor/adl-skill.yaml"
+grep -Fq "policy.no_card_edits_must_be_true" "${skills_root}/planning-doc-editor/adl-skill.yaml"
+grep -Fq "Planning Doc Editor Output Contract" "${skills_root}/planning-doc-editor/references/output-contract.md"
+grep -Fq "skill_input_schema: planning_doc_editor.v1" "${skills_root}/docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "planning-doc-editor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+python3 - <<'PY' "${skills_root}/planning-doc-editor/SKILL.md" "${skills_root}/planning-doc-editor/adl-skill.yaml" "${skills_root}/planning-doc-editor/agents/openai.yaml" "${skills_root}/planning-doc-editor/references/output-contract.md"
+from pathlib import Path
+import sys
+
+todo_marker = "[" + "TODO"
+host_markers = ["/" + "Users/", "/" + "private/tmp"]
+for raw in sys.argv[1:]:
+    text = Path(raw).read_text()
+    if todo_marker in text:
+        raise SystemExit(f"TODO residue in {raw}")
+    if any(marker in text for marker in host_markers):
+        raise SystemExit(f"host path leakage in {raw}")
+PY
+
+printf '%s\n' "OK: planning-doc-editor skill contract"


### PR DESCRIPTION
Closes #3513

## Summary
Added a tracked `adl-milestone-creator` operational skill for deterministic ADL milestone setup, bridge milestone planning, issue reallocation truth, validation, review, and handoff. The work is docs/process-only and does not change runtime behavior.

## Artifacts
- `adl/tools/skills/adl-milestone-creator/SKILL.md`
- `adl/tools/skills/adl-milestone-creator/adl-skill.yaml`
- `adl/tools/skills/adl-milestone-creator/agents/openai.yaml`
- `adl/tools/skills/adl-milestone-creator/references/output-contract.md`
- `adl/tools/skills/docs/ADL_MILESTONE_CREATOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/test_adl_milestone_creator_skill_contracts.sh`
- `adl/tools/batched_checks.sh`
- `adl/tools/skills/planning-doc-editor/adl-skill.yaml`
- `adl/tools/skills/planning-doc-editor/references/output-contract.md`
- `adl/tools/skills/docs/PLANNING_DOC_EDITOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_planning_doc_editor_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_adl_milestone_creator_skill_contracts.sh`
    Verified the issue-local skill contract.
  - `bash adl/tools/test_planning_doc_editor_skill_contracts.sh`
    Verified the planning editor skill contract added after operator-directed scope expansion.
  - `bash adl/tools/test_skill_documentation_completeness.sh`
    Rechecked the reviewer-reported completeness surface after the planning editor fix; the command now passes.
  - `bash -n adl/tools/test_adl_milestone_creator_skill_contracts.sh && bash -n adl/tools/batched_checks.sh`
    Verified shell syntax for touched scripts.
  - `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "OK #{p}" }' adl/tools/skills/adl-milestone-creator/adl-skill.yaml adl/tools/skills/adl-milestone-creator/agents/openai.yaml`
    Verified YAML metadata parseability.
  - `git diff --check`
    Verified whitespace safety.
  - `tmp_home="$(mktemp -d)" && ADL_OPERATIONAL_SKILLS_INSTALL_MODE=copy CODEX_HOME="$tmp_home" bash adl/tools/install_adl_operational_skills.sh >/dev/null && test -f "$tmp_home/skills/adl-milestone-creator/SKILL.md" && diff -q adl/tools/skills/adl-milestone-creator/SKILL.md "$tmp_home/skills/adl-milestone-creator/SKILL.md"`
    Verified the operational skill installer picks up the new skill.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified existing operational skill install behavior.
- Results:
  - PASS for issue-local checks, planning-editor completeness checks, and installer checks.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3513__v0-91-4-process-add-milestone-creation-skill-and-process-guidance/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3513__v0-91-4-process-add-milestone-creation-skill-and-process-guidance/sor.md
- Idempotency-Key: v0-91-4-process-add-milestone-creation-skill-and-process-guidance-adl-tools-skills-adl-milestone-creator-adl-tools-skills-planning-doc-editor-adl-tools-skills-docs-adl-milestone-creator-skill-input-schema-md-adl-tools-skills-docs-planning-doc-editor-skill-input-schema-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-adl-milestone-creator-skill-contracts-sh-adl-tools-test-planning-doc-editor-skill-contracts-sh-adl-tools-batched-checks-sh-adl-v0-91-4-tasks-issue-3513-v0-91-4-process-add-milestone-creation-skill-and-process-guidance-sip-md-adl-v0-91-4-tasks-issue-3513-v0-91-4-process-add-milestone-creation-skill-and-process-guidance-sor-md