### PR TITLE
[v0.91.5][docs] Fix closed setup wave wording

### DIFF
--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -7,7 +7,7 @@
 - Owner: ADL maintainers
 - Status: `draft_pre_open`
 - Related setup umbrella: `#3506` (closed)
-- Active setup children: `#3507`, `#3508`, `#3509`, `#3510`, `#3511`
+- Closed setup children: `#3507`, `#3508`, `#3509`, `#3510`, `#3511`
 - Planning template set: `docs/templates/planning/1.0.0`
 
 ## Status
@@ -23,7 +23,7 @@ Setup truth:
 
 - `#3506` is the closed v0.91.4-origin setup umbrella that created the bridge
   package and child setup wave.
-- `#3507`-`#3511` are the active v0.91.5 setup child issues for planning
+- `#3507`-`#3511` are the closed v0.91.5 setup child issues for planning
   package, issue reallocation, v0.91.4 release-tail reconciliation, v0.92
   dependency reconciliation, and migration-truth review.
 

--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -60,7 +60,7 @@ Make v0.92 openable without hidden operational debt.
 
 | Order | Item | Issue | Owner | Status |
 |---|---|---|---|---|
-| 1 | Bridge planning and migration | `#3507`-`#3511` (`#3506` closed umbrella) | ADL maintainers | active setup |
+| 1 | Bridge planning and migration | `#3507`-`#3511` (`#3506` closed umbrella) | ADL maintainers | satisfied setup wave |
 | 2 | Public prompt records | `#3472`-`#3476` | ADL maintainers | moved |
 | 3 | Provider/model matrix | `#3501`, `#3505` | ADL maintainers | moved |
 | 4 | Multi-agent proof | `#3415`, `#3503`, `#3504` (`#3484` satisfied/closed evidence) | ADL maintainers | moved |


### PR DESCRIPTION
Closes #3518

## Summary
Fixed stale v0.91.5 setup-status wording after `#3507`-`#3511` closed.

## Artifacts
- Updated `docs/milestones/v0.91.5/README.md`
- Updated `docs/milestones/v0.91.5/SPRINT_v0.91.5.md`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/validate_planning_template.py --template readme --input docs/milestones/v0.91.5/README.md`
    Verified README planning-template structure.
  - `python3 adl/tools/validate_planning_template.py --template sprint --input docs/milestones/v0.91.5/SPRINT_v0.91.5.md`
    Verified sprint planning-template structure.
  - targeted `rg` stale-wording check
    Verified no stale `active setup` wording remains in the touched docs and the replacement wording is present.
  - `git diff --check`
    Verified whitespace.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3518__v0-91-5-docs-fix-closed-setup-wave-wording/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3518__v0-91-5-docs-fix-closed-setup-wave-wording/sor.md
- Idempotency-Key: v0-91-5-docs-fix-closed-setup-wave-wording-docs-milestones-v0-91-5-readme-md-docs-milestones-v0-91-5-sprint-v0-91-5-md-adl-v0-91-5-tasks-issue-3518-v0-91-5-docs-fix-closed-setup-wave-wording-sip-md-adl-v0-91-5-tasks-issue-3518-v0-91-5-docs-fix-closed-setup-wave-wording-sor-md