### PR TITLE
[v0.91.5][tools] Strengthen recurring milestone gap-analysis skill/workflow

### DIFF
--- a/adl/tools/skills/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md
@@ -8,6 +8,10 @@ Compare an explicit expected baseline against observed implementation, docs,
 tests, review, PR, milestone, or closeout evidence and produce a bounded
 findings-first gap report.
 
+For milestone and release work, this schema should support repeatable truth
+maintenance: separating real blockers from routed work, stale release/readiness
+docs, durable proof gaps, and lower-risk quality concerns.
+
 ## Required Top-Level Fields
 
 - `skill_input_schema`: must be `gap_analysis.v1`.
@@ -23,20 +27,37 @@ findings-first gap report.
 ## Optional Fields
 
 - `artifact_root`: report destination.
-- `issue_ref`
-- `milestone_plan`
-- `spec_path`
-- `review_packet_path`
-- `report_path`
-- `closeout_record`
+- `milestone_version`
+- `quality_gate_target`
+- `gap_review_target`
+
+## Mode-Specific Nested Fields
+
+Place mode-specific source fields under `expected_baseline` and
+`observed_evidence`.
+
+- `compare_issue_to_implementation`
+  - `expected_baseline.issue_ref`
+  - `expected_baseline.acceptance_criteria_path`
+  - `observed_evidence.changed_paths`
+- `compare_milestone_to_evidence`
+  - `expected_baseline.milestone_plan`
+  - `observed_evidence.evidence_root`
+  - `observed_evidence.truth_sources`
+- `compare_spec_to_docs`
+  - `expected_baseline.spec_path`
+  - `observed_evidence.docs_paths`
+- `compare_review_to_closeout`
+  - `expected_baseline.review_artifact`
+  - `observed_evidence.closeout_record`
+- `compare_packet_to_report`
+  - `expected_baseline.review_packet_path`
+  - `observed_evidence.report_path`
 
 ## Policy Fields
 
-- `severity_floor`
-- `required_gap_types`
-- `uncertainty_policy`
-- `issue_creation_allowed`
-- `write_gap_artifact`
+- `quality_gate_update_allowed`
+- `separate_gap_review_allowed`
 - `stop_before_fix`
 - `stop_before_mutation`
 
@@ -44,28 +65,20 @@ findings-first gap report.
 
 ```yaml
 skill_input_schema: gap_analysis.v1
-mode: compare_issue_to_implementation
+mode: compare_milestone_to_evidence
 expected_baseline:
-  issue_ref: "#2044"
-  acceptance_criteria_path: .adl/v0.90/tasks/issue-2044__backlog-skills-add-gap-analysis-skill/stp.md
+  milestone_plan: docs/milestones/v0.91.4/SPRINT_v0.91.4.md
+  quality_gate_target: docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
 observed_evidence:
-  changed_paths:
-    - adl/tools/skills/gap-analysis/SKILL.md
-    - adl/tools/skills/gap-analysis/adl-skill.yaml
-    - adl/tools/test_gap_analysis_skill_contracts.sh
-  validation_commands:
-    - bash adl/tools/test_gap_analysis_skill_contracts.sh
+  truth_sources:
+    - .adl/docs/TBD/v0.91.4_gap_review.md
+    - docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md
+    - docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md
+    - docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md
+  evidence_root: .adl/reviews/gap-analysis/v0.91.4/
 policy:
-  severity_floor: P3
-  required_gap_types:
-    - missing_evidence
-    - implementation_gap
-    - docs_drift
-    - test_gap
-    - closeout_drift
-  uncertainty_policy: record_explicitly
-  issue_creation_allowed: false
-  write_gap_artifact: true
+  quality_gate_update_allowed: true
+  separate_gap_review_allowed: true
   stop_before_fix: true
   stop_before_mutation: true
 ```
@@ -90,6 +103,11 @@ Statuses:
 - `fail`: severe gap should block the requested closeout or release decision.
 - `not_run`: explicit baseline missing.
 - `blocked`: requested action violates stop boundary.
+
+Milestone/release runs should also emit:
+
+- `gap_buckets`
+- `artifact_routing`
 
 ## Stop Boundary
 

--- a/adl/tools/skills/gap-analysis/SKILL.md
+++ b/adl/tools/skills/gap-analysis/SKILL.md
@@ -13,6 +13,11 @@ Use this skill before issue closeout, milestone closeout, third-party review,
 release readiness, or customer-facing report publication when a specific
 baseline must be reconciled against observed truth.
 
+For milestone and release work, this skill should make one extra distinction
+explicit: the goal is not just to list mismatches, but to separate release
+blockers from durable proof gaps, routed work, stale release/readiness docs,
+and lower-risk quality concerns.
+
 ## Quick Start
 
 1. Confirm the expected baseline:
@@ -33,7 +38,14 @@ baseline must be reconciled against observed truth.
    - `scripts/analyze_gaps.py <gap-root> --out <artifact-root>`
 4. Review the gap report for source-grounded findings, uncertainty, and follow-up
    recommendations.
-5. Stop before fixing gaps, creating issues, creating PRs, approving closeout, or
+5. For milestone/release use, classify the findings into the milestone truth
+   buckets:
+   - `release_blockers`
+   - `durable_proof_gaps`
+   - `routed_work`
+   - `stale_release_readiness_docs`
+   - `non_blocking_quality_concerns`
+6. Stop before fixing gaps, creating issues, creating PRs, approving closeout, or
    mutating repositories.
 
 ## Required Inputs
@@ -55,13 +67,13 @@ Supported modes:
 
 Useful policy fields:
 
-- `severity_floor`
-- `required_gap_types`
-- `uncertainty_policy`
-- `issue_creation_allowed`
-- `write_gap_artifact`
+ - `quality_gate_update_allowed`
+ - `separate_gap_review_allowed`
 - `stop_before_fix`
 - `stop_before_mutation`
+
+When the deterministic helper is used, these policy fields should be supplied in
+`gap_manifest.json`.
 
 If there is no explicit expected baseline, stop and report `not_run`. Do not
 infer intended outcomes from vibes or from the absence of evidence.
@@ -111,6 +123,12 @@ Required artifacts:
 - `gap_analysis_report.json`
 
 Use the detailed contract in `references/output-contract.md`.
+
+For milestone/release runs, the output should also answer:
+
+- should the result update an existing quality gate?
+- should the result emit a separate gap-review packet?
+- should both happen because blockers and narrative review drift both exist?
 
 ## Stop Boundary
 

--- a/adl/tools/skills/gap-analysis/adl-skill.yaml
+++ b/adl/tools/skills/gap-analysis/adl-skill.yaml
@@ -23,34 +23,32 @@ admission:
       - "compare_review_to_closeout"
       - "compare_packet_to_report"
     policy_fields:
-      - "severity_floor"
-      - "required_gap_types"
-      - "uncertainty_policy"
-      - "issue_creation_allowed"
-      - "write_gap_artifact"
+      - "quality_gate_update_allowed"
+      - "separate_gap_review_allowed"
       - "stop_before_fix"
       - "stop_before_mutation"
     mode_requirements:
       compare_issue_to_implementation:
         required_target_fields:
-          - "issue_ref"
-          - "changed_paths"
+          - "expected_baseline.issue_ref"
+          - "expected_baseline.acceptance_criteria_path"
+          - "observed_evidence.changed_paths"
       compare_milestone_to_evidence:
         required_target_fields:
-          - "milestone_plan"
-          - "evidence_root"
+          - "expected_baseline.milestone_plan"
+          - "observed_evidence.evidence_root"
       compare_spec_to_docs:
         required_target_fields:
-          - "spec_path"
-          - "docs_paths"
+          - "expected_baseline.spec_path"
+          - "observed_evidence.docs_paths"
       compare_review_to_closeout:
         required_target_fields:
-          - "review_artifact"
-          - "closeout_record"
+          - "expected_baseline.review_artifact"
+          - "observed_evidence.closeout_record"
       compare_packet_to_report:
         required_target_fields:
-          - "review_packet_path"
-          - "report_path"
+          - "expected_baseline.review_packet_path"
+          - "observed_evidence.report_path"
   intent:
     - "gap_analysis"
     - "expected_vs_observed_truth"
@@ -62,12 +60,9 @@ admission:
     - "policy"
   optional_inputs:
     - "artifact_root"
-    - "issue_ref"
-    - "milestone_plan"
-    - "spec_path"
-    - "review_packet_path"
-    - "report_path"
-    - "closeout_record"
+    - "milestone_version"
+    - "quality_gate_target"
+    - "gap_review_target"
   stop_if_missing:
     - "expected_baseline"
   prevalidation_rules:

--- a/adl/tools/skills/gap-analysis/references/output-contract.md
+++ b/adl/tools/skills/gap-analysis/references/output-contract.md
@@ -20,9 +20,11 @@ Required sections:
 - Expected Baseline
 - Observed Evidence
 - Findings
+- Gap Buckets
 - Missing Evidence
 - Uncertainty
 - Recommended Follow-up
+- Artifact Routing
 - Stop Boundary
 
 ### gap_analysis_report.json
@@ -36,10 +38,21 @@ Required top-level fields:
 - `expected_baseline`
 - `observed_evidence`
 - `findings`
+- `gap_buckets`
 - `missing_evidence`
 - `uncertainty`
 - `recommended_follow_up`
+- `artifact_routing`
 - `stop_boundary`
+
+Required `stop_boundary` fields:
+
+- `fixed_gaps`
+- `created_issues`
+- `created_prs`
+- `approved_closeout`
+- `approved_release`
+- `mutated_repository`
 
 ## Status Values
 
@@ -66,11 +79,18 @@ Each finding must include:
 - uncertainty
 - recommended follow-up
 - source artifact or path when available
+- milestone/release bucket when available
 
 ## Rules
 
 - Do not infer intended outcomes without an explicit baseline.
 - Distinguish missing evidence from proven failure.
+- Keep milestone/release truth buckets explicit:
+  - `release_blockers`
+  - `durable_proof_gaps`
+  - `routed_work`
+  - `stale_release_readiness_docs`
+  - `non_blocking_quality_concerns`
 - Use repo-relative, issue-relative, or packet-relative paths.
 - Do not write absolute host paths into report artifacts.
 - Do not claim approval, release-readiness, merge-readiness, compliance,

--- a/adl/tools/skills/gap-analysis/scripts/analyze_gaps.py
+++ b/adl/tools/skills/gap-analysis/scripts/analyze_gaps.py
@@ -20,6 +20,24 @@ GAP_TYPES = {
     "closeout_drift",
     "scope_ambiguity",
 }
+GAP_BUCKETS = {
+    "release_blockers",
+    "durable_proof_gaps",
+    "routed_work",
+    "stale_release_readiness_docs",
+    "non_blocking_quality_concerns",
+}
+BUCKET_ALIASES = {
+    "release_blocker": "release_blockers",
+    "release_blockers": "release_blockers",
+    "durable_proof_gap": "durable_proof_gaps",
+    "durable_proof_gaps": "durable_proof_gaps",
+    "routed_work": "routed_work",
+    "stale_release_docs": "stale_release_readiness_docs",
+    "stale_release_readiness_docs": "stale_release_readiness_docs",
+    "non_blocking_quality_concern": "non_blocking_quality_concerns",
+    "non_blocking_quality_concerns": "non_blocking_quality_concerns",
+}
 
 
 def now_utc() -> str:
@@ -81,7 +99,7 @@ def line_value(text: str, key: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-def metadata(root: Path) -> dict[str, str]:
+def metadata(root: Path) -> dict[str, Any]:
     manifest = load_json(root / "gap_manifest.json")
     if not isinstance(manifest, dict):
         manifest = {}
@@ -89,6 +107,7 @@ def metadata(root: Path) -> dict[str, str]:
         "run_id": str(manifest.get("run_id") or root.name),
         "scope": str(manifest.get("scope") or line_value(read_text(root / "expected_baseline.md"), "Scope") or root.name),
         "mode": str(manifest.get("mode") or "compare_issue_to_implementation"),
+        "policy": manifest.get("policy") if isinstance(manifest.get("policy"), dict) else {},
     }
 
 
@@ -101,16 +120,28 @@ def expected_items(text: str) -> list[dict[str, str]]:
     )
     items = []
     for index, bullet in enumerate(bullets, start=1):
-        gap_type = infer_gap_type(bullet)
+        bucket, cleaned = split_bucket_tag(bullet)
+        gap_type = infer_gap_type(cleaned)
+        severity = infer_severity(cleaned, gap_type)
         items.append(
             {
                 "id": f"E-{index:03d}",
-                "expected": bullet,
+                "expected": cleaned,
                 "gap_type": gap_type,
-                "severity": infer_severity(bullet, gap_type),
+                "severity": severity,
+                "bucket": bucket or infer_bucket(cleaned, gap_type, severity),
             }
         )
     return items
+
+
+def split_bucket_tag(text: str) -> tuple[str | None, str]:
+    match = re.match(r"^\[(?P<tag>[a-z0-9_ -]+)\]\s*(?P<body>.+)$", text.strip(), re.IGNORECASE)
+    if not match:
+        return None, text.strip()
+    tag = normalize(match.group("tag")).replace(" ", "_")
+    bucket = BUCKET_ALIASES.get(tag)
+    return bucket, match.group("body").strip()
 
 
 def infer_gap_type(text: str) -> str:
@@ -133,6 +164,52 @@ def infer_severity(text: str, gap_type: str) -> str:
     if gap_type in {"closeout_drift", "test_gap"}:
         return "P2"
     return "P3"
+
+
+def infer_bucket(text: str, gap_type: str, severity: str) -> str:
+    lowered = text.lower()
+    if any(
+        phrase in lowered
+        for phrase in [
+            "route to",
+            "routed",
+            "follow-on",
+            "bridge work",
+            "sidecar",
+            "move to v0.91.5",
+            "v0.91.5",
+            "deferred",
+        ]
+    ):
+        return "routed_work"
+    if gap_type == "docs_drift" and any(
+        phrase in lowered
+        for phrase in [
+            "release",
+            "readiness",
+            "quality gate",
+            "feature proof coverage",
+            "demo matrix",
+            "milestone checklist",
+            "release plan",
+            "wording",
+        ]
+    ):
+        return "stale_release_readiness_docs"
+    if severity in {"P0", "P1"}:
+        return "release_blockers"
+    if gap_type in {"missing_evidence", "test_gap", "closeout_drift"} or any(
+        phrase in lowered
+        for phrase in [
+            "closeout truth",
+            "sor truth",
+            "proof gap",
+            "missing proof",
+            "validation gap",
+        ]
+    ):
+        return "durable_proof_gaps"
+    return "non_blocking_quality_concerns"
 
 
 def observed_text(root: Path, explicit_observed: Path | None) -> tuple[str, list[str]]:
@@ -160,30 +237,77 @@ def explicit_gaps(root: Path) -> list[dict[str, str]]:
     bullets = extract_bullets_after(text, "Gaps") or [line.strip()[2:] for line in text.splitlines() if line.strip().startswith("- ")]
     findings = []
     for index, bullet in enumerate(bullets, start=1):
-        gap_type = infer_gap_type(bullet)
+        bucket, cleaned = split_bucket_tag(bullet)
+        gap_type = infer_gap_type(cleaned)
+        severity = infer_severity(cleaned, gap_type)
         findings.append(
             {
                 "id": f"G-{index:03d}",
                 "gap_type": gap_type,
-                "severity": infer_severity(bullet, gap_type),
-                "title": bullet[:96],
+                "severity": severity,
+                "title": cleaned[:96],
                 "expected": "Recorded baseline expectation or review finding.",
-                "observed": bullet,
+                "observed": cleaned,
                 "evidence": "known_gaps.md",
                 "uncertainty": "low",
                 "recommended_follow_up": recommended_follow_up(gap_type),
                 "source_artifact": "known_gaps.md",
+                "bucket": bucket or infer_bucket(cleaned, gap_type, severity),
             }
         )
     return findings
+
+
+def empty_gap_buckets() -> dict[str, list[str]]:
+    return {bucket: [] for bucket in sorted(GAP_BUCKETS)}
+
+
+def summarize_buckets(findings: list[dict[str, str]]) -> dict[str, list[str]]:
+    buckets = empty_gap_buckets()
+    for finding in findings:
+        bucket = str(finding.get("bucket") or "")
+        if bucket in buckets:
+            buckets[bucket].append(str(finding["id"]))
+    return buckets
+
+
+def artifact_routing(mode: str, gap_buckets: dict[str, list[str]], has_findings: bool, policy: dict[str, Any]) -> dict[str, object]:
+    quality_gate_candidate = bool(
+        gap_buckets["release_blockers"]
+        or gap_buckets["durable_proof_gaps"]
+        or gap_buckets["stale_release_readiness_docs"]
+    )
+    separate_gap_candidate = has_findings and (mode == "compare_milestone_to_evidence" or bool(gap_buckets["routed_work"]))
+    quality_gate_update = quality_gate_candidate and policy.get("quality_gate_update_allowed", True) is not False
+    separate_gap_review = separate_gap_candidate and policy.get("separate_gap_review_allowed", True) is not False
+    if quality_gate_update and separate_gap_review:
+        recommendation = "both"
+        rationale = "Blocker-grade or release-doc gaps exist and a standalone gap-review packet is still useful."
+    elif quality_gate_update:
+        recommendation = "quality_gate_only"
+        rationale = "The findings should update the milestone quality gate."
+    elif separate_gap_review:
+        recommendation = "separate_gap_review_only"
+        rationale = "The findings are useful for milestone review but do not require gate mutation."
+    else:
+        recommendation = "none"
+        rationale = "No milestone artifact routing is required from this comparison."
+    return {
+        "update_quality_gate": quality_gate_update,
+        "emit_separate_gap_review": separate_gap_review,
+        "recommended_surface": recommendation,
+        "rationale": rationale,
+    }
 
 
 def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[str, object]:
     baseline_path = baseline if baseline else root / "expected_baseline.md"
     baseline_text = read_text(baseline_path)
     meta = metadata(root)
+    policy = meta["policy"] if isinstance(meta.get("policy"), dict) else {}
     observed_blob, observed_sources = observed_text(root, observed)
     if not baseline_text:
+        gap_buckets = empty_gap_buckets()
         return {
             "schema": SCHEMA,
             "created_at": now_utc(),
@@ -193,9 +317,11 @@ def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[st
             "expected_baseline": {"path": rel(root, baseline_path), "items": []},
             "observed_evidence": {"sources": observed_sources},
             "findings": [],
+            "gap_buckets": gap_buckets,
             "missing_evidence": ["Expected baseline missing or unreadable."],
             "uncertainty": ["No baseline was available; no gap claims were made."],
             "recommended_follow_up": ["Provide an explicit expected baseline."],
+            "artifact_routing": artifact_routing(meta["mode"], gap_buckets, False, policy),
             "stop_boundary": stop_boundary(),
         }
     items = expected_items(baseline_text)
@@ -216,6 +342,7 @@ def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[st
             "uncertainty": "medium" if observed_blob else "high",
             "recommended_follow_up": recommended_follow_up(item["gap_type"]),
             "source_artifact": rel(root, baseline_path),
+            "bucket": item["bucket"],
         }
         findings.append(finding)
         missing.append(item["expected"])
@@ -225,6 +352,7 @@ def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[st
     status = "pass" if not findings and items else "partial"
     if any(item["severity"] in {"P0", "P1"} for item in findings):
         status = "fail"
+    gap_buckets = summarize_buckets(findings)
     return {
         "schema": SCHEMA,
         "created_at": now_utc(),
@@ -234,9 +362,11 @@ def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[st
         "expected_baseline": {"path": rel(root, baseline_path), "items": items},
         "observed_evidence": {"sources": observed_sources},
         "findings": findings,
+        "gap_buckets": gap_buckets,
         "missing_evidence": missing,
         "uncertainty": uncertainty or ["Uncertainty is limited to the supplied evidence bundle."],
         "recommended_follow_up": dedupe([str(item["recommended_follow_up"]) for item in findings]) or ["No follow-up required from this comparison."],
+        "artifact_routing": artifact_routing(meta["mode"], gap_buckets, bool(findings), policy),
         "stop_boundary": stop_boundary(),
     }
 
@@ -286,6 +416,7 @@ def finding_lines(findings: list[dict[str, str]]) -> str:
             f"""### {finding['id']}: [{finding['severity']}] {finding['title']}
 
 - Gap type: {finding['gap_type']}
+- Milestone bucket: {finding.get('bucket', 'not_classified')}
 - Expected: {finding['expected']}
 - Observed: {finding['observed']}
 - Evidence: {finding['evidence']}
@@ -297,8 +428,32 @@ def finding_lines(findings: list[dict[str, str]]) -> str:
     return "\n".join(parts)
 
 
+def bucket_lines(report: dict[str, object]) -> str:
+    buckets = report["gap_buckets"]
+    labels = {
+        "release_blockers": "Release blockers",
+        "durable_proof_gaps": "Durable proof gaps",
+        "routed_work": "Routed work",
+        "stale_release_readiness_docs": "Stale release/readiness docs",
+        "non_blocking_quality_concerns": "Non-blocking quality concerns",
+    }
+    parts = []
+    for key in [
+        "release_blockers",
+        "durable_proof_gaps",
+        "routed_work",
+        "stale_release_readiness_docs",
+        "non_blocking_quality_concerns",
+    ]:
+        values = buckets.get(key, [])
+        rendered = ", ".join(values) if values else "None."
+        parts.append(f"- {labels[key]}: {rendered}")
+    return "\n".join(parts)
+
+
 def write_markdown(path: Path, report: dict[str, object]) -> None:
     boundary = report["stop_boundary"]
+    routing = report["artifact_routing"]
     content = f"""# Gap Analysis Report: {report['scope']}
 
 ## Gap Analysis Summary
@@ -324,6 +479,10 @@ def write_markdown(path: Path, report: dict[str, object]) -> None:
 
 {finding_lines(report['findings'])}
 
+## Gap Buckets
+
+{bucket_lines(report)}
+
 ## Missing Evidence
 
 {bullet_lines(report['missing_evidence'])}
@@ -335,6 +494,13 @@ def write_markdown(path: Path, report: dict[str, object]) -> None:
 ## Recommended Follow-up
 
 {bullet_lines(report['recommended_follow_up'])}
+
+## Artifact Routing
+
+- Update quality gate: {str(routing['update_quality_gate']).lower()}.
+- Emit separate gap review: {str(routing['emit_separate_gap_review']).lower()}.
+- Recommended surface: {routing['recommended_surface']}.
+- Rationale: {routing['rationale']}
 
 ## Stop Boundary
 

--- a/adl/tools/test_gap_analysis_skill_contracts.sh
+++ b/adl/tools/test_gap_analysis_skill_contracts.sh
@@ -18,9 +18,13 @@ grep -Fq 'id: "gap-analysis"' "${skills_root}/gap-analysis/adl-skill.yaml"
 grep -Fq 'id: "gap_analysis.v1"' "${skills_root}/gap-analysis/adl-skill.yaml"
 grep -Fq 'reference_doc: "../docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"' "${skills_root}/gap-analysis/adl-skill.yaml"
 grep -Fq "expected_baseline_must_be_explicit" "${skills_root}/gap-analysis/adl-skill.yaml"
+grep -Fq "expected_baseline.milestone_plan" "${skills_root}/gap-analysis/adl-skill.yaml"
 grep -Fq "Compare an explicit expected baseline" "${skills_root}/gap-analysis/SKILL.md"
 grep -Fq "Distinguish missing evidence from proven failure." "${skills_root}/gap-analysis/references/output-contract.md"
 grep -Fq "Schema id: \`gap_analysis.v1\`" "${skills_root}/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"
+grep -Fq "release_blockers" "${skills_root}/gap-analysis/references/output-contract.md"
+grep -Fq "quality_gate_update_allowed" "${skills_root}/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"
+grep -Fq "Mode-Specific Nested Fields" "${skills_root}/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"
 
 gap_root="${tmpdir}/gap"
 report_root="${tmpdir}/gap-report"
@@ -28,8 +32,14 @@ mkdir -p "${gap_root}"
 cat >"${gap_root}/gap_manifest.json" <<'JSON'
 {
   "run_id": "gap-analysis-contract-test",
-  "scope": "issue-2044",
-  "mode": "compare_issue_to_implementation"
+  "scope": "v0.91.4",
+  "mode": "compare_milestone_to_evidence",
+  "policy": {
+    "quality_gate_update_allowed": false,
+    "separate_gap_review_allowed": true,
+    "stop_before_fix": true,
+    "stop_before_mutation": true
+  }
 }
 JSON
 cat >"${gap_root}/expected_baseline.md" <<'MD'
@@ -39,7 +49,7 @@ cat >"${gap_root}/expected_baseline.md" <<'MD'
 
 - Create gap-analysis skill bundle with SKILL metadata and bounded stop boundary.
 - Add validation contract tests for findings format and evidence guardrails.
-- Document input schema for explicit expected baseline and observed evidence.
+- [stale_release_docs] Document milestone/release routing for explicit expected baseline and observed evidence.
 - Record closeout truth in output cards.
 MD
 cat >"${gap_root}/observed_evidence.md" <<'MD'
@@ -53,7 +63,7 @@ cat >"${gap_root}/known_gaps.md" <<'MD'
 
 ## Gaps
 
-- Validation contract tests for findings format and evidence guardrails are missing.
+- [release_blocker] Validation contract tests for findings format and evidence guardrails are missing.
 MD
 
 python3 "${skills_root}/gap-analysis/scripts/analyze_gaps.py" \
@@ -63,10 +73,17 @@ python3 "${skills_root}/gap-analysis/scripts/analyze_gaps.py" \
 grep -Fq '"schema": "adl.gap_analysis_report.v1"' "${report_root}/gap_analysis_report.json"
 grep -Fq '"run_id": "gap-analysis-contract-test"' "${report_root}/gap_analysis_report.json"
 grep -Fq '"gap_type": "test_gap"' "${report_root}/gap_analysis_report.json"
+grep -Fq '"gap_buckets"' "${report_root}/gap_analysis_report.json"
+grep -Fq '"release_blockers": [' "${report_root}/gap_analysis_report.json"
+grep -Fq '"artifact_routing": {' "${report_root}/gap_analysis_report.json"
+grep -Fq '"update_quality_gate": false' "${report_root}/gap_analysis_report.json"
+grep -Fq '"emit_separate_gap_review": true' "${report_root}/gap_analysis_report.json"
 grep -Fq '"created_issues": false' "${report_root}/gap_analysis_report.json"
 grep -Fq '"mutated_repository": false' "${report_root}/gap_analysis_report.json"
 grep -Fq "## Gap Analysis Summary" "${report_root}/gap_analysis_report.md"
 grep -Fq "## Findings" "${report_root}/gap_analysis_report.md"
+grep -Fq "## Gap Buckets" "${report_root}/gap_analysis_report.md"
+grep -Fq "## Artifact Routing" "${report_root}/gap_analysis_report.md"
 grep -Fq "Created issues: false." "${report_root}/gap_analysis_report.md"
 grep -Fq "Mutated repository: false." "${report_root}/gap_analysis_report.md"
 


### PR DESCRIPTION
## Summary
- strengthen the tracked gap-analysis skill for recurring milestone and release review use
- add milestone truth buckets and artifact-routing guidance to the helper output contract
- align the tracked schema, manifest, helper, and contract test around the supported markdown-bundle workflow

## Validation
- `bash adl/tools/test_gap_analysis_skill_contracts.sh`
- `git diff --check`

## Review
- bounded subagent review found and resolved contract drift around nested mode fields, supported policy knobs, and stop-boundary documentation
- final re-review returned no actionable findings

Closes #3529
