### PR TITLE
[v0.91.4][provider][security] Harden provider identity and Gemini credential diagnostics

### DIFF
--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -310,10 +310,10 @@ fn execute_hosted_gemini(
     let url = gemini_generate_url(
         request.route.endpoint_ref.as_deref(),
         &request.route.provider_model_id,
-        &key,
     );
     let response = client(policy)?
         .post(url)
+        .header("x-goog-api-key", key)
         .json(&json!({
             "contents": [{
                 "role": "user",
@@ -405,27 +405,19 @@ fn resolve_credential(
     })
 }
 
-fn gemini_generate_url(endpoint_ref: Option<&str>, model: &str, key: &str) -> String {
+fn gemini_generate_url(endpoint_ref: Option<&str>, model: &str) -> String {
     let encoded_model = model.trim_start_matches("models/");
     let base = endpoint_ref
         .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
         .unwrap_or(DEFAULT_GEMINI_BASE_URL)
         .trim_end_matches('/');
     if base.contains(":generateContent") {
-        append_query_key(base, key)
+        base.to_string()
     } else if base.ends_with(&format!("models/{encoded_model}")) {
-        append_query_key(&format!("{base}:generateContent"), key)
+        format!("{base}:generateContent")
     } else {
-        append_query_key(
-            &format!("{base}/models/{encoded_model}:generateContent"),
-            key,
-        )
+        format!("{base}/models/{encoded_model}:generateContent")
     }
-}
-
-fn append_query_key(url: &str, key: &str) -> String {
-    let separator = if url.contains('?') { '&' } else { '?' };
-    format!("{url}{separator}key={key}")
 }
 
 fn ollama_generate_url(endpoint_ref: Option<&str>) -> String {
@@ -783,6 +775,80 @@ mod tests {
 
     fn one_shot_server(body: &'static str, status: &'static str) -> String {
         scripted_server(vec![(body, status)])
+    }
+
+    fn capture_one_request_server(
+        body: &'static str,
+        status: &'static str,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buffer = [0_u8; 8192];
+            let bytes_read = stream.read(&mut buffer).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let _ = tx.send(request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    #[test]
+    fn gemini_generate_url_does_not_embed_api_key() {
+        let url = gemini_generate_url(
+            Some("https://generativelanguage.googleapis.com/v1beta"),
+            "models/gemini-test",
+        );
+        assert_eq!(
+            url,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-test:generateContent"
+        );
+        assert!(!url.contains("key="));
+    }
+
+    #[test]
+    fn hosted_gemini_adapter_sends_api_key_header_without_url_key() {
+        env::set_var(
+            "ADL_PROVIDER_ADAPTER_GEMINI_TEST_KEY",
+            "synthetic-gemini-key",
+        );
+        let (endpoint, rx) = capture_one_request_server(
+            r#"{"candidates":[{"content":{"parts":[{"text":"gemini ok"}]}}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("gemini");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-gemini").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "gemini".to_string();
+        req.route.provider_model_id = "gemini-test".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_GEMINI_TEST_KEY".to_string());
+
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("gemini ok"));
+        let raw_request = rx.recv().expect("captured request");
+        assert!(raw_request
+            .to_ascii_lowercase()
+            .contains("x-goog-api-key: synthetic-gemini-key"));
+        assert!(!raw_request
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .contains("key="));
+        let raw_log = fs::read_to_string(&path).unwrap();
+        assert!(!raw_log.contains("synthetic-gemini-key"));
+        env::remove_var("ADL_PROVIDER_ADAPTER_GEMINI_TEST_KEY");
+        let _ = fs::remove_file(path);
     }
 
     fn scripted_server(responses: Vec<(&'static str, &'static str)>) -> String {

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -416,6 +416,8 @@ fn sanitize_provider_message(note: &str) -> String {
         "authorization",
         "bearer ",
         "x-api-key",
+        "key=",
+        "api_key=",
         "api key",
         ".key",
         "prompt:",
@@ -575,6 +577,20 @@ mod tests {
             classify_provider_failure("invalid API key provided", None),
             ProviderFailureKindV1::ProviderAuthError
         );
+    }
+
+    #[test]
+    fn url_query_api_keys_are_redacted_from_provider_failures() {
+        let failure = provider_failure_from_note(
+            "error sending request for url (https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent?key=synthetic-secret)",
+            None,
+        );
+        assert_eq!(failure.message, "redacted provider diagnostic");
+        assert!(!failure
+            .provider_error_excerpt
+            .as_deref()
+            .unwrap_or_default()
+            .contains("synthetic-secret"));
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -186,11 +186,12 @@ fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
     }
 }
 
-fn transport_surface_label(transport: &ProviderTransportV1) -> &'static str {
-    match transport {
-        ProviderTransportV1::Http => "hosted_http",
-        ProviderTransportV1::LocalCli => "local_cli",
-        ProviderTransportV1::InProcess => "in_process",
+fn transport_surface_label(vendor: &str, transport: &ProviderTransportV1) -> &'static str {
+    match (vendor, transport) {
+        ("ollama", ProviderTransportV1::Http) => "ollama_http",
+        (_, ProviderTransportV1::Http) => "hosted_http",
+        (_, ProviderTransportV1::LocalCli) => "local_cli",
+        (_, ProviderTransportV1::InProcess) => "in_process",
     }
 }
 
@@ -412,7 +413,7 @@ pub fn provider_invocation_target_v1(
         provider: provider_id.clone(),
         model_ref: model_ref.clone(),
         provider_model_id: provider_model_id.clone(),
-        runtime_surface: transport_surface_label(&transport).to_string(),
+        runtime_surface: transport_surface_label(&vendor, &transport).to_string(),
         identity_strength: model_identity_strength_for_target(&vendor, &transport),
         observed_at: observed_at_now_v1(),
         resolved_digest: None,
@@ -586,6 +587,14 @@ mod tests {
         assert_eq!(
             substrate.capabilities.structured_json.mode,
             CapabilityModeV1::PromptBased
+        );
+
+        let target = provider_invocation_target_v1("remote_ollama", &spec, None).expect("target");
+        assert_eq!(target.model_identity.provider_kind, "ollama");
+        assert_eq!(target.model_identity.runtime_surface, "ollama_http");
+        assert_eq!(
+            target.model_identity.identity_strength,
+            ModelIdentityStrengthV1::TagOnly
         );
     }
 


### PR DESCRIPTION
Closes #3544

## Summary
Hardened provider evidence and diagnostics by labeling remote Ollama HTTP identities as `ollama_http`, moving Gemini API-key transport out of the URL into `x-goog-api-key`, and extending provider diagnostic redaction for `key=` and `api_key=` query parameters.

## Artifacts
- Updated `adl/src/provider_adapter.rs`
- Updated `adl/src/provider_communication.rs`
- Updated `adl/src/provider_substrate.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Applied Rust formatting to changed files.
  - `cargo test --manifest-path adl/Cargo.toml hosted_gemini_adapter_sends_api_key_header_without_url_key --lib -- --nocapture`
    Verified Gemini credential transport and no synthetic key leakage in the provider run log.
  - `cargo test --manifest-path adl/Cargo.toml url_query_api_keys_are_redacted_from_provider_failures --lib -- --nocapture`
    Verified query-key diagnostic redaction.
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate_uses_http_transport_for_ollama_with_endpoint --lib -- --nocapture`
    Verified remote Ollama identity classification.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Focused validation passed: cargo fmt --manifest-path adl/Cargo.toml --all; cargo test --manifest-path adl/Cargo.toml hosted_gemini_adapter_sends_api_key_header_without_url_key --lib -- --nocapture; cargo test --manifest-path adl/Cargo.toml url_query_api_keys_are_redacted_from_provider_failures --lib -- --nocapture; cargo test --manifest-path adl/Cargo.toml provider_substrate_uses_http_transport_for_ollama_with_endpoint --lib -- --nocapture; git diff --check. Bounded pre-PR reviews completed and findings resolved.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3544__v0-91-4-provider-security-harden-provider-identity-and-gemini-credential-diagnostics/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3544__v0-91-4-provider-security-harden-provider-identity-and-gemini-credential-diagnostics/sor.md
- Idempotency-Key: v0-91-4-provider-security-harden-provider-identity-and-gemini-credential-diagnostics-adl-src-provider-adapter-rs-adl-src-provider-communication-rs-adl-src-provider-substrate-rs-adl-v0-91-4-tasks-issue-3544-v0-91-4-provider-security-harden-provider-identity-and-gemini-credential-diagnostics-sip-md-adl-v0-91-4-tasks-issue-3544-v0-91-4-provider-security-harden-provider-identity-and-gemini-credential-diagnostics-sor-md