### PR TITLE
[v0.91.4][release][docs] Reconcile release truth before external review

### DIFF
--- a/docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md
+++ b/docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md
@@ -13,8 +13,8 @@ Do not treat this scaffold as the final next-milestone decision.
 
 ## Purpose
 
-v0.91.4 completes the C-SDLC rollout. The next milestone should be planned from
-the evidence produced by that completion work, not from chat memory or local
+v0.91.4 is the C-SDLC rollout-closeout milestone. The next milestone should be planned from
+the evidence produced by completed release-tail work, not from chat memory or local
 drafts.
 
 By `WP-19`, this handoff should answer:
@@ -28,12 +28,13 @@ By `WP-19`, this handoff should answer:
 
 ## Current Planning Assumption
 
-The next milestone is now planned as v0.91.5, a bridge milestone for
+The current planning assumption is v0.91.5 as a bridge milestone for
 multi-agent stabilization, provider/model breadth, public prompt records,
 demo-readiness routing, and v0.92 activation preflight.
 
-The next milestone should therefore consume v0.91.4 outputs only after these
-conditions are true:
+WP-19 should confirm or revise that assumption from tracked evidence. The next
+milestone should therefore consume v0.91.4 outputs only after these conditions
+are true:
 
 - new ADL software-development issues default to `SIP -> STP -> SPP -> SRP -> SOR`
 - durable cards, sprint state, review, proof, trace, closeout, and release

--- a/docs/milestones/v0.91.4/README.md
+++ b/docs/milestones/v0.91.4/README.md
@@ -46,9 +46,10 @@ software-development path.
 
 ## Purpose
 
-v0.91.4 completes the Cognitive SDLC rollout.
+v0.91.4 is the Cognitive SDLC rollout-closeout milestone.
 
-Where v0.91.3 proves the crown jewel, v0.91.4 makes it operational:
+Where v0.91.3 proves the crown jewel, v0.91.4 is intended to make it
+operational through the release-tail gates:
 
 - stricter lifecycle validators
 - reliable conductor and editor routing
@@ -61,7 +62,7 @@ Where v0.91.3 proves the crown jewel, v0.91.4 makes it operational:
   blocking proof cycles
 - Parallel Validation Fabric planning so validation can be shardable,
   cache-aware, and truthful about pending/deferred/blocking proof
-- migration of future ADL software-development issues onto the C-SDLC default
+- migration of future ADL software-development issues toward the C-SDLC default
 - tracked durable workflow records for all C-SDLC truth
 - minimal signed trace proof for durable C-SDLC runs
 
@@ -82,7 +83,7 @@ preflight work so v0.91.4 can land cleanly.
 
 ## Milestone Role
 
-v0.91.4 should leave ADL with one default issue execution model:
+v0.91.4 should leave ADL ready to rely on one default issue execution model:
 
 ```text
 SIP -> STP -> SPP -> SRP -> SOR
@@ -169,7 +170,7 @@ are the branch-verifiable C-SDLC planning surfaces for review.
   [NEXT_MILESTONE_HANDOFF_v0.91.4.md](NEXT_MILESTONE_HANDOFF_v0.91.4.md)
 - Tracked workflow-state migration plan:
   [C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md](C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md)
-- Public C-SDLC prompt records transition:
+- Public C-SDLC prompt records transition plan:
   [PUBLIC_CSDLC_PROMPT_RECORDS_TRANSITION_PLAN.md](PUBLIC_CSDLC_PROMPT_RECORDS_TRANSITION_PLAN.md)
 - C-SDLC canonical docs:
   [../../cognitive-sdlc/README.md](../../cognitive-sdlc/README.md)
@@ -230,7 +231,7 @@ tracked evidence.
 
 v0.91.4 is ready to close when:
 
-- new ADL software-development issues default to the C-SDLC lifecycle
+- new ADL software-development issues can truthfully use the C-SDLC lifecycle as the default path
 - durable `SPP` records are tracked, issue-local, and operative before they are
   used to guide execution
 - conductor/editor/doctor/validator tooling agrees on lifecycle state

--- a/docs/milestones/v0.91.4/RELEASE_NOTES_v0.91.4.md
+++ b/docs/milestones/v0.91.4/RELEASE_NOTES_v0.91.4.md
@@ -17,17 +17,19 @@ shipped behavior.
 
 ## Summary
 
-`v0.91.4` completes the C-SDLC rollout by hardening the first slice into a
-repeatable default development lane for future ADL software work.
+`v0.91.4` is planned to close the C-SDLC rollout by hardening the first slice
+into a repeatable development lane for future ADL software work. Final release
+notes must confirm this only after the release-tail gates land.
 
 ## Highlights
 
-- Makes C-SDLC the default path for future ADL software-development issues.
-- Hardens validators, doctor, conductor, and editor routing around lifecycle
-  truth.
+- Prepares C-SDLC to become the default path for future ADL
+  software-development issues, subject to final release-tail proof.
+- Should harden validators, doctor, conductor, and editor routing around lifecycle
+  truth, pending final release-tail proof.
 - Adds Software Development Polis actor-standing and shard-ownership support
   needed for repeated execution.
-- Tracks durable workflow records in Git.
+- Should track durable workflow records in Git.
 - Adds signed trace proof and verification evidence.
 - Integrates SRP/SOR outcome truth with ObsMem handoff.
 - Measures repeatable five-minute-sprint behavior, including validation-tail
@@ -62,7 +64,8 @@ repeatable default development lane for future ADL software work.
 
 ## Upgrade Notes
 
-- Future ADL software-development issues should use the C-SDLC default lane.
+- Future ADL software-development issues should use the C-SDLC lane once the
+  release-tail proof has landed.
 - Durable workflow records must be tracked; local `.adl` state is not enough.
 - Active issues should follow the migration policy rather than ad hoc rewrites.
 

--- a/docs/milestones/v0.91.4/review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md
+++ b/docs/milestones/v0.91.4/review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md
@@ -7,7 +7,7 @@
 - Issue: `#3365`
 - Date: `2026-05-31`
 - Review type: docs/adoption readiness before internal and external review
-- Status: `draft_for_pr_review`
+- Status: `merged_review_record`
 
 ## Scope
 


### PR DESCRIPTION
Closes #3543

## Summary
Reconciled v0.91.4 release-facing docs so they describe rollout-closeout and release-tail proof truth instead of prematurely claiming completed shipped behavior.

## Artifacts
- Updated `docs/milestones/v0.91.4/README.md`
- Updated `docs/milestones/v0.91.4/RELEASE_NOTES_v0.91.4.md`
- Updated `docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md`
- Updated `docs/milestones/v0.91.4/review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md`

## Validation
- Validation commands and their purpose:
  - `rg -n "v0\\.91\\.4 completes|is now planned as v0.91.5|draft_for_pr_review" ...`
    Checked the targeted stale strings.
  - `git diff --check`
    Checked diff hygiene.
  - bounded pre-PR docs review
    Checked release-truth language and handoff consistency.
- Results:
  - PASS

## Notes
Docs-only validation passed: focused stale-language search, git diff --check, and bounded pre-PR docs review with findings resolved.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3543__v0-91-4-release-docs-reconcile-release-truth-before-external-review/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3543__v0-91-4-release-docs-reconcile-release-truth-before-external-review/sor.md
- Idempotency-Key: v0-91-4-release-docs-reconcile-release-truth-before-external-review-docs-milestones-v0-91-4-readme-md-docs-milestones-v0-91-4-release-notes-v0-91-4-md-docs-milestones-v0-91-4-next-milestone-handoff-v0-91-4-md-docs-milestones-v0-91-4-review-docs-adoption-wp15-docs-adoption-review-2026-05-31-md-adl-v0-91-4-tasks-issue-3543-v0-91-4-release-docs-reconcile-release-truth-before-external-review-sip-md-adl-v0-91-4-tasks-issue-3543-v0-91-4-release-docs-reconcile-release-truth-before-external-review-sor-md