### PR TITLE
[v0.91.4][WP-17][docs] Add third-party review handoff

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -21,7 +21,64 @@ The reviewer should not audit ADL against a frozen abstract standard alone. The 
 
 ## Current Review Entry Point
 
-For the most recently completed v0.90.5 governed-tools release package, start with:
+For the active v0.91.4 external / third-party review, start with:
+
+- `docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md`
+- `docs/milestones/v0.91.4/README.md`
+- `docs/milestones/v0.91.4/WBS_v0.91.4.md`
+- `docs/milestones/v0.91.4/SPRINT_v0.91.4.md`
+- `docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml`
+- `docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md`
+- `docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md`
+- `docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md`
+- `docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md`
+- `docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md`
+- `docs/milestones/v0.91.4/RELEASE_NOTES_v0.91.4.md`
+- `docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md`
+- `docs/milestones/v0.91.4/review/internal_review/`
+- `docs/milestones/v0.91.4/features/`
+- `docs/templates/prompts/`
+- `docs/cognitive-sdlc/`
+- `AGENTS.md`
+- `README.md`
+- `CHANGELOG.md`
+- `docs/README.md`
+- `adl/Cargo.toml`
+- `adl/Cargo.lock`
+
+The current review posture is v0.91.4 WP-17 external / third-party review.
+WP-15 and WP-16 are closed. WP-17 / `#3367` remains open until external review
+truth is recorded and any findings are fixed, routed to WP-18 / `#3368`, or
+explicitly accepted as residual risk. The third-party handoff is the
+controlling review entrypoint for this review pass.
+
+v0.91.4 should be reviewed as the Cognitive SDLC rollout-closeout milestone. It
+hardens the v0.91.3 C-SDLC vertical slice into default operational practice:
+conductor-first issue routing, `SIP -> STP -> SPP -> SRP -> SOR` cards,
+versioned prompt templates, editor skills, bound worktrees, pre-PR review,
+truthful SOR closeout, Parallel Validation Fabric classification, durable
+tracked evidence records, and release-tail review discipline.
+
+Important v0.91.4 non-claims:
+
+- v0.91.4 does not claim release approval or release ceremony completion.
+- v0.91.4 does not claim external review completion until WP-17 is closed.
+- v0.91.4 does not claim v0.91.5 bridge work is complete.
+- v0.91.4 does not claim v0.92 first-birthday readiness.
+- v0.91.4 does not claim multi-agent stabilization, provider/model matrix
+  breadth, public prompt-record transition, Unity Observatory, or
+  demo-readiness follow-ons are complete; those are routed to v0.91.5 or later.
+- CodeFriend and WildClawBench are bounded sidecars, not proof that C-SDLC core
+  operation is complete.
+
+The recovered WP-16 internal-review packet is tracked under
+`docs/milestones/v0.91.4/review/internal_review/` and was published through
+closed recovery issue `#3555`. Reviewers should treat those artifacts as part
+of the v0.91.4 review input, alongside the WP-16 closeout comments and
+remediation issue/PR wave.
+
+For historical context, the prior completed release-review entrypoint was
+v0.90.5:
 
 - `docs/milestones/v0.90.5/README.md`
 - `docs/milestones/v0.90.5/WBS_v0.90.5.md`
@@ -38,70 +95,6 @@ For the most recently completed v0.90.5 governed-tools release package, start wi
 - `docs/milestones/v0.90.5/END_OF_MILESTONE_REPORT_v0.90.5.md`
 - `docs/milestones/v0.90.5/WP_EXECUTION_READINESS_v0.90.5.md`
 - `docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml`
-- `docs/planning/ADL_FEATURE_LIST.md`
-- `CHANGELOG.md`
-- `adl/Cargo.toml`
-- `adl/Cargo.lock`
-
-The final v0.90.5 review posture is completed release copy. The wave ran as
-`#2566-#2591` and is now fully closed. Docs/review convergence, internal
-review, zero-finding third-party review, explicit no-remediation disposition,
-next-milestone handoff, and release ceremony are complete.
-
-v0.90.5 should produce Governed Tools v1.0 plus the landed first-level Comms /
-ACIP tranche: UTS public-compatible schema and conformance, ACC authority and
-visibility semantics, registry/compiler/normalization/policy/executor behavior,
-trace/replay/redaction evidence, dangerous negative tests, bounded
-model-proposal evaluation, the flagship governed-tools demo, and the bounded
-review/coding-agent communications substrate that was explicitly landed in this
-milestone.
-
-The crate version is `0.90.5` for the completed v0.90.5 release line.
-Reviewers should treat any conflicting older version reference as a stale
-release-truth defect.
-
-For the active next-milestone planning package, start with:
-
-- `docs/milestones/v0.91/README.md`
-- `docs/milestones/v0.91/WBS_v0.91.md`
-- `docs/milestones/v0.91/SPRINT_v0.91.md`
-- `docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md`
-- `docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml`
-- `docs/milestones/v0.91/features/README.md`
-
-The current active planning posture is `v0.91`. The reviewed candidate issue
-wave exists, but it is not opened yet.
-
-Important v0.90.5 non-claims:
-
-- v0.90.5 does not claim that UTS alone is an execution authority.
-- v0.90.5 does not claim arbitrary shell or network execution merely because a
-  model emitted valid JSON.
-- v0.90.5 does not claim payment rails, legal contracting, billing, or
-  inter-polis economics.
-- v0.90.5 does not claim full v0.91 moral/cognitive-being substrate or full
-  v0.91.1 identity/capability follow-on work.
-- v0.90.5 does not claim production secret-management or cloud-enclave
-  dependence.
-
-During execution, verify that every WP preserves the required outputs and
-validation from `WP_EXECUTION_READINESS_v0.90.5.md` rather than widening into
-generic implementation work.
-
-WP-21 tracker status to preserve during review:
-- `QUALITY_GATE_v0.90.5.md` is the canonical quality and coverage posture
-  record, including the explicit main-branch coverage exception still carried
-  into the review tail.
-- `RELEASE_READINESS_v0.90.5.md` is the reviewer entry surface for the active
-  milestone package.
-- docs/release-truth surfaces should consistently report v0.90.5 as the active
-  line, v0.90.4 as the most recently completed milestone, and `0.90.5` as the
-  active crate version.
-- root `README.md` cleanup is tracked separately under #2712 and should not be
-  treated as part of the bounded WP-21 reviewer-entry package until that issue
-  lands.
-- internal review has not happened yet; WP-21 prepares the package for WP-22
-  rather than pre-claiming that review outcome.
 
 For the most recently completed v0.90.2 release package, start with:
 

--- a/adl/tools/check_pr_closing_linkage.sh
+++ b/adl/tools/check_pr_closing_linkage.sh
@@ -20,6 +20,35 @@ raise SystemExit(1)
 ' "$issue"
 }
 
+body_has_non_closing_lifecycle_marker() {
+  local issue="$1"
+  python3 -c '
+import re
+import sys
+
+issue = sys.argv[1]
+body = sys.stdin.read()
+pattern = re.compile(
+    rf"^\s*Non-closing lifecycle PR:\s*issue\s+#?{re.escape(issue)}\s+remains\s+open\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+if pattern.search(body):
+    raise SystemExit(0)
+raise SystemExit(1)
+' "$issue"
+}
+
+issue_is_open() {
+  local repo="$1"
+  local issue="$2"
+  if [[ -z "$repo" ]] || ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  local state
+  state="$(gh issue view "$issue" -R "$repo" --json state --jq '.state' 2>/dev/null || true)"
+  [[ "$state" == "OPEN" ]]
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --event-name)
@@ -41,6 +70,11 @@ Usage:
 
 Enforces that pull requests from codex/<issue>-... branches contain a real GitHub
 closing keyword for that issue in the PR body so the source issue auto-closes on merge.
+
+Lifecycle handoff or evidence-prep PRs that must not close their issue may use
+this explicit marker while the issue is still open:
+
+  Non-closing lifecycle PR: issue <number> remains open
 EOF
       exit 0
       ;;
@@ -86,14 +120,8 @@ print(body)
 PY
 )"
 
-if body_has_linkage "$ISSUE_NUMBER" <<<"$PR_BODY"; then
-  echo "closing linkage OK for issue #$ISSUE_NUMBER"
-  exit 0
-fi
-
-if command -v gh >/dev/null 2>&1; then
-  LIVE_REPO="$(
-    python3 - "$EVENT_PATH" <<'PY'
+LIVE_REPO="$(
+python3 - "$EVENT_PATH" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -102,7 +130,23 @@ data = json.loads(Path(sys.argv[1]).read_text())
 repo = data.get("repository", {}).get("full_name") or ""
 print(repo)
 PY
-  )"
+)"
+
+if body_has_linkage "$ISSUE_NUMBER" <<<"$PR_BODY"; then
+  echo "closing linkage OK for issue #$ISSUE_NUMBER"
+  exit 0
+fi
+
+if body_has_non_closing_lifecycle_marker "$ISSUE_NUMBER" <<<"$PR_BODY"; then
+  if issue_is_open "$LIVE_REPO" "$ISSUE_NUMBER"; then
+    echo "non-closing lifecycle PR OK for open issue #$ISSUE_NUMBER"
+    exit 0
+  fi
+  echo "ERROR: non-closing lifecycle marker is only allowed while issue #$ISSUE_NUMBER is open" >&2
+  exit 1
+fi
+
+if command -v gh >/dev/null 2>&1; then
   LIVE_PR="$(
     python3 - "$EVENT_PATH" <<'PY'
 import json
@@ -127,9 +171,19 @@ PY
       echo "closing linkage OK for issue #$ISSUE_NUMBER via live PR body"
       exit 0
     fi
+    if [[ -n "$LIVE_BODY" ]] && body_has_non_closing_lifecycle_marker "$ISSUE_NUMBER" <<<"$LIVE_BODY"; then
+      if issue_is_open "$LIVE_REPO" "$ISSUE_NUMBER"; then
+        echo "non-closing lifecycle PR OK for open issue #$ISSUE_NUMBER via live PR body"
+        exit 0
+      fi
+      echo "ERROR: non-closing lifecycle marker is only allowed while issue #$ISSUE_NUMBER is open" >&2
+      exit 1
+    fi
   fi
 fi
 
 echo "ERROR: PR body for branch '$HEAD_REF' is missing closing linkage for issue #$ISSUE_NUMBER" >&2
 echo "Add a real closing keyword such as 'Closes #$ISSUE_NUMBER' to the PR body." >&2
+echo "For lifecycle handoff PRs that intentionally keep the issue open, add:" >&2
+echo "Non-closing lifecycle PR: issue $ISSUE_NUMBER remains open" >&2
 exit 1

--- a/adl/tools/test_pr_closing_linkage.sh
+++ b/adl/tools/test_pr_closing_linkage.sh
@@ -21,6 +21,10 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
     exit 0
   fi
 fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  printf '%s\n' "${MOCK_GH_ISSUE_STATE:-OPEN}"
+  exit 0
+fi
 exit 1
 EOF
 chmod +x "$TMPDIR/bin/gh"
@@ -61,6 +65,20 @@ if bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref
   echo "expected failure for missing closing linkage" >&2
   exit 1
 fi
+
+event_non_closing="$TMPDIR/non-closing.json"
+make_event "$event_non_closing" "Non-closing lifecycle PR: issue 1414 remains open"
+export MOCK_GH_ISSUE_STATE="OPEN"
+bash "$SCRIPT" --event-name pull_request --event-path "$event_non_closing" --head-ref "codex/1414-remediation"
+
+event_non_closing_closed="$TMPDIR/non-closing-closed.json"
+make_event "$event_non_closing_closed" "Non-closing lifecycle PR: issue 1414 remains open"
+export MOCK_GH_ISSUE_STATE="CLOSED"
+if bash "$SCRIPT" --event-name pull_request --event-path "$event_non_closing_closed" --head-ref "codex/1414-remediation"; then
+  echo "expected failure for non-closing marker on closed issue" >&2
+  exit 1
+fi
+unset MOCK_GH_ISSUE_STATE
 
 event_stale="$TMPDIR/stale.json"
 make_event "$event_stale" "Refs #1414" "example/repo" "88"

--- a/docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md
+++ b/docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md
@@ -58,8 +58,8 @@ surface for its local preconditions and commands.
 | --- | --- | --- | --- | --- | --- |
 | D13 | Demo matrix and proof coverage refresh | WP-13 / `#3363` | closed | makes the release proof surface legible and scoped | this matrix, `FEATURE_PROOF_COVERAGE_v0.91.4.md`, and `review/demo_showcase/BEST_AVAILABLE_CSDLC_DEMO_SHOWCASE_v0.91.4.md` |
 | D14 | Coverage / quality gate | WP-14 / `#3364` | closed | proves lifecycle, tools, tests, traces, and blocker truth are gated before release | `QUALITY_GATE_v0.91.4.md` |
-| D15 | Docs + adoption review pass | WP-15 / `#3365` | pending | proves the default path is documented honestly enough for maintainers and reviewers | docs-review packet to be produced by WP-15 |
-| D16 | Internal review | WP-16 / `#3366` | pending | proves the code/docs/tests/process slice has internal reviewer scrutiny | internal review packet to be produced by WP-16 |
+| D15 | Docs + adoption review pass | WP-15 / `#3365` | closed | proves the default path is documented honestly enough for maintainers and reviewers | `review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md` |
+| D16 | Internal review | WP-16 / `#3366` | closed | proves the code/docs/tests/process slice has internal reviewer scrutiny | WP-16 closeout comment plus closed remediation issues `#3542` through `#3546` |
 | D17 | External / third-party review | WP-17 / `#3367` | pending | proves the release survives outside scrutiny | external review handoff and returned packet |
 | D18 | Review findings remediation | WP-18 / `#3368` | pending | proves findings are fixed, routed, or truthfully deferred | remediation packet and disposition record |
 | D19 | Next milestone planning refresh | WP-19 / `#3369` | pending | proves release closeout does not strand the next planning wave | `NEXT_MILESTONE_HANDOFF_v0.91.4.md` refresh |
@@ -133,7 +133,7 @@ command:
 - WP-13 refreshes demo/proof coverage.
 - WP-14 records quality-gate and validation posture.
 - WP-15 records docs/adoption readiness.
-- WP-16 and WP-17 provide internal and external review.
+- WP-16 has provided internal review; WP-17 provides external review.
 - WP-18 records remediation or truthful deferral.
 
 ## Determinism Evidence
@@ -150,7 +150,7 @@ Reviewers should sign off against:
 - `FEATURE_PROOF_COVERAGE_v0.91.4.md`
 - `QUALITY_GATE_v0.91.4.md`
 - `review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md`
-- internal and external review packets once WP-16 and WP-17 complete
+- WP-16 closeout evidence and the external review packet once WP-17 completes
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md
@@ -53,8 +53,8 @@ This claim is not the same as claiming every auxiliary experiment is complete. I
 | --- | --- | --- | --- |
 | WP-13 | `#3363` | closed | refreshed demo matrix, refreshed feature proof coverage, best-available showcase packet |
 | WP-14 | `#3364` | closed | `QUALITY_GATE_v0.91.4.md` with blocker dispositions |
-| WP-15 | `#3365` | pending | docs/adoption review packet |
-| WP-16 | `#3366` | pending | internal review packet |
+| WP-15 | `#3365` | closed | docs/adoption review packet |
+| WP-16 | `#3366` | closed | internal review closeout and remediation routing |
 | WP-17 | `#3367` | pending | external review handoff and returned packet |
 | WP-18 | `#3368` | pending | remediation packet and finding dispositions |
 | WP-19 | `#3369` | pending | next-milestone handoff refresh |

--- a/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
+++ b/docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md
@@ -39,7 +39,8 @@ Non-core sidecar work that is not required as Sprint 4 release proof:
 - `docs/milestones/v0.91.4/WP_EXECUTION_READINESS_v0.91.4.md`
 - `docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md`
 - `docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md`
-- GitHub issue truth for Sprint 4 closeout-tail issues `#3365` through `#3371`, checked at `2026-05-30T19:58:36Z`
+- GitHub issue truth for Sprint 4 closeout-tail issues `#3365` through `#3371`,
+  refreshed for WP-17 entry after WP-16 closed at `2026-06-01T01:36:50Z`
 
 ## Gap-Analysis Role
 
@@ -119,8 +120,6 @@ The milestone remains blocked for the reasons below.
 
 The following required release-tail issues remain open:
 
-- `#3365` Docs + adoption review pass
-- `#3366` Internal review
 - `#3367` External / 3rd-party review
 - `#3368` Review findings remediation
 - `#3369` Next milestone planning
@@ -134,12 +133,12 @@ Sprint 4 lane. At the current snapshot, that includes:
 - `#3526` `[v0.91.4][docs] Audit ADL feature completion dates and AEE closure`
   with draft PR `#3528`
 
-State snapshot recorded at `2026-05-30T19:58:36Z`:
+State snapshot refreshed at `2026-06-01T01:36:50Z` after WP-16 closeout:
 
 | Issue | State |
 | --- | --- |
-| `#3365` | `OPEN` |
-| `#3366` | `OPEN` |
+| `#3365` | `CLOSED` |
+| `#3366` | `CLOSED` |
 | `#3367` | `OPEN` |
 | `#3368` | `OPEN` |
 | `#3369` | `OPEN` |
@@ -222,11 +221,9 @@ Manual checks performed on 2026-05-30:
 3. `Internal review plan existence/readiness`
    - source:
      `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_PLAN_2026-05-30.md`
-   - result: present, scoped, and reviewer-facing; status remains
-     `planned_not_started`
-   - interpretation: the internal review surface exists and is structurally
-     ready, but WP-16 is still a real open blocker because execution has not
-     started
+   - result: present, scoped, and reviewer-facing; WP-16 is now closed
+   - interpretation: the internal review gate has completed; later external
+     review findings belong to WP-18 rather than reopening WP-16
 4. `Test coverage gap analysis`
    - artifact:
      `docs/milestones/v0.91.4/review/quality_gate/V0914_TEST_COVERAGE_GAP_ANALYSIS_2026-05-30.md`
@@ -244,15 +241,15 @@ Manual checks performed on 2026-05-30:
      truthfully enough that broad runtime proof is not being forced into this
      PR path; PVF remains usable as a release input rather than a fresh blocker
 6. `Changed-file risk review`
-   - current open Sprint 4 PRs: only `#3527`
+   - WP-14 snapshot open Sprint 4 PRs: only `#3527`
    - current tracked WP-14 delta:
      - `docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md`
      - `docs/milestones/v0.91.4/review/quality_gate/V0914_TEST_COVERAGE_GAP_ANALYSIS_2026-05-30.md`
      - `docs/milestones/v0.91.4/review/quality_gate/V0914_TEST_RUNTIME_REGRESSION_CHECK_2026-05-30.md`
      - `docs/milestones/v0.91.4/review/quality_gate/V0914_REDACTION_AUDIT_2026-05-30.md`
-   - interpretation: current open release-tail delta is low-risk and docs-only;
-     no additional runtime/provider/workflow-control code is presently in flight
-     in the Sprint 4 release-tail lane
+   - interpretation at WP-14: the open release-tail delta was low-risk and
+     docs-only; later release-tail updates should be reviewed in their own WP
+     records
 7. `Test runtime regression check`
    - artifact:
      `docs/milestones/v0.91.4/review/quality_gate/V0914_TEST_RUNTIME_REGRESSION_CHECK_2026-05-30.md`
@@ -268,8 +265,8 @@ Manual checks performed on 2026-05-30:
      the current blocker is release-tail sequencing/execution, not missing card
      scaffolding
 9. `PR stack/base hygiene`
-   - current open release-tail PRs: only `#3527`
-   - result: base `main`, merge state `CLEAN`, checks green, draft still open
+   - WP-14 snapshot open release-tail PRs: only `#3527`
+   - result at WP-14: base `main`, merge state `CLEAN`, checks green, draft still open
      at `2026-05-30T20:48:53Z`
    - interpretation: current stack/base hygiene looks clean; no hidden conflict
      or stale-base problem is visible in the active release-tail PR snapshot
@@ -346,14 +343,15 @@ Available as landed proof input. Current posture: `pass_as_release_input`, not a
 
 Available as landed evidence from the repeatability/PVF work. Current posture: `pass_as_release_input`, with the reminder that slow or deferred proof must remain explicit rather than being hidden behind aggregate green summaries.
 
-## Required Remediation Before Internal Review
+## Required Remediation Before External Review
 
-Before WP-16 internal review can be considered ready, the milestone should at minimum have:
+Before WP-17 external review can be considered ready, the milestone should at minimum have:
 
 1. docs/adoption review package completed under WP-15
-2. release-readiness surfaces aligned to the Sprint 4-only scope boundary
-3. durable workflow-state migration proof made explicit enough to review
-4. signed-trace / release-evidence expectation made concrete for the remaining tail
+2. WP-16 internal review closed with accepted findings fixed or routed
+3. release-readiness surfaces aligned to the Sprint 4-only scope boundary
+4. durable workflow-state migration proof made explicit enough to review
+5. signed-trace / release-evidence expectation made concrete for the remaining tail
 
 ## Follow-on Routing
 

--- a/docs/milestones/v0.91.4/README.md
+++ b/docs/milestones/v0.91.4/README.md
@@ -20,7 +20,7 @@ Sprint 3 is complete and closed as the sprint-default and metrics batch:
 Sprint 3 `#3357`, WP-09 `#3358`, WP-10 `#3359`, WP-11 `#3360`, and WP-12
 `#3361`. Sprint 4 is the active review/remediation/planning/release batch:
 Sprint 4 `#3362`, closed WP-13 `#3363`, closed WP-14 `#3364`, closed WP-15
-`#3365`, open WP-16 `#3366`, open WP-17 `#3367`, and later release-tail WPs
+`#3365`, closed WP-16 `#3366`, open WP-17 `#3367`, and later release-tail WPs
 `#3368` through `#3371`.
 
 The CodeFriend sidecar is complete and closed: umbrella `#3372`, CF-PRE-01

--- a/docs/milestones/v0.91.4/README.md
+++ b/docs/milestones/v0.91.4/README.md
@@ -14,30 +14,29 @@ Sprint 1 is complete and closed: WP-01 `#3346`, WP-02 `#3348`, WP-03 `#3349`,
 and WP-04 `#3350` all merged, and umbrella `#3347` is closed with clean sprint
 truth.
 
-Sprint 2 is seeded as the transition-operation batch: Sprint 2 `#3352`,
-WP-05 `#3353`, WP-06 `#3354`, WP-07 `#3355`, and WP-08 `#3356`.
-Sprint 3 is seeded as the sprint-default and metrics batch: Sprint 3 `#3357`,
-WP-09 `#3358`, WP-10 `#3359`, WP-11 `#3360`, and WP-12 `#3361`.
-Sprint 4 is seeded as the review/remediation/planning/release batch:
-Sprint 4 `#3362`, WP-13 `#3363`, WP-14 `#3364`, WP-15 `#3365`, WP-16
-`#3366`, WP-17 `#3367`, WP-18 `#3368`, WP-19 `#3369`, WP-20 `#3370`, and
-WP-21 `#3371`. The CodeFriend sidecar has also been seeded: umbrella `#3372`,
-CF-PRE-01 `#3373`, CF-PRE-02 `#3374`, CF-PRE-03 `#3375`, and CF-PRE-04
-`#3376`. The WildClawBench benchmark spike sidecar is seeded: umbrella
+Sprint 2 is complete and closed as the transition-operation batch: Sprint 2
+`#3352`, WP-05 `#3353`, WP-06 `#3354`, WP-07 `#3355`, and WP-08 `#3356`.
+Sprint 3 is complete and closed as the sprint-default and metrics batch:
+Sprint 3 `#3357`, WP-09 `#3358`, WP-10 `#3359`, WP-11 `#3360`, and WP-12
+`#3361`. Sprint 4 is the active review/remediation/planning/release batch:
+Sprint 4 `#3362`, closed WP-13 `#3363`, closed WP-14 `#3364`, closed WP-15
+`#3365`, open WP-16 `#3366`, open WP-17 `#3367`, and later release-tail WPs
+`#3368` through `#3371`.
+
+The CodeFriend sidecar is complete and closed: umbrella `#3372`, CF-PRE-01
+`#3373`, CF-PRE-02 `#3374`, CF-PRE-03 `#3375`, and CF-PRE-04 `#3376`. The
+WildClawBench benchmark spike sidecar is also complete and closed: umbrella
 `#3378`, WC-PRE-01 `#3379`, WC-PRE-02 `#3380`, WC-PRE-03 `#3381`, and
-WC-PRE-04 `#3382`. Remaining bridge work has moved to v0.91.5: first-birthday
-readiness `#3377`, multi-agent/provider work beginning at `#3415`, public
-prompt records `#3472`-`#3476`, demo readiness `#3455`/`#3460`/`#3461`, and
-OpenRouter/model-matrix issues `#3501`-`#3505`. Sprint 2, Sprint 3, and
-Sprint 4 child execution now depends on prior sprint sequencing and their own
-dependency gates rather than on Sprint 1 opening. The CodeFriend sidecar
-remains non-core and wait-gated by its own routing/dependency lane. The
-WildClawBench sidecar has now started through WC-PRE-01 `#3379`, which
-completed upstream reconnaissance and ended in a truthful blocked setup
-baseline pending benchmark image, workspace payload, helper tools, and API-key
-availability. The bridge split does not alter the v0.91.4 release-tail
-sequence: v0.91.4 now closes Sprint 4 and release truth, while v0.91.5 carries
-the remaining pre-v0.92 stabilization work.
+WC-PRE-04 `#3382`. Both sidecars remain non-core evidence lanes rather than
+C-SDLC default-operation proof or release-tail gates.
+
+Remaining bridge work has moved to v0.91.5: first-birthday readiness `#3377`,
+multi-agent/provider work beginning at `#3415`, public prompt records
+`#3472`-`#3476`, demo readiness `#3455`/`#3460`/`#3461`, and
+OpenRouter/model-matrix issues `#3501`-`#3505`. The bridge split does not
+alter the v0.91.4 release-tail sequence: v0.91.4 now closes Sprint 4 and
+release truth, while v0.91.5 carries the remaining pre-v0.92 stabilization
+work.
 
 This package is intentionally stacked after the v0.91.3 first-slice package. It
 assumes v0.91.3 proves one bounded Cognitive State Transition and then defines
@@ -162,6 +161,8 @@ are the branch-verifiable C-SDLC planning surfaces for review.
 - Quality gate: [QUALITY_GATE_v0.91.4.md](QUALITY_GATE_v0.91.4.md)
 - Docs/adoption review:
   [review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md](review/docs_adoption/WP15_DOCS_ADOPTION_REVIEW_2026-05-31.md)
+- Third-party review handoff:
+  [review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md](review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md)
 - Release plan: [RELEASE_PLAN_v0.91.4.md](RELEASE_PLAN_v0.91.4.md)
 - Release notes: [RELEASE_NOTES_v0.91.4.md](RELEASE_NOTES_v0.91.4.md)
 - Milestone checklist:

--- a/docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md
+++ b/docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md
@@ -28,7 +28,7 @@ work.
 - [ ] v0.91.5 bridge work routed out of v0.91.4 release scope:
   multi-agent stabilization, provider/model matrix, public prompt records,
   demo readiness, and first-birthday preflight.
-- [ ] Internal review complete.
+- [x] Internal review complete.
 - [ ] External / third-party review complete.
 - [ ] Review remediation complete.
 - [ ] Next milestone planning complete.

--- a/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -1,0 +1,267 @@
+# Third-Party Review Handoff - v0.91.4
+
+## Metadata
+
+- Milestone: `v0.91.4`
+- Version: `v0.91.4`
+- Review lane: `WP-17` external / third-party review, following `WP-16`
+  internal review
+- Prepared during: `v0.91.4` release tail
+- Prepared for issue: `#3367`
+- Parent sprint: `#3362`
+- Current packet status: `draft_pre_send`
+- Date: `2026-05-31`
+- Publication attempted: false
+- Release approval claimed: false
+- External review approval claimed: false
+
+## Send Gate
+
+This handoff is the tracked third-party review packet surface for `WP-17`, but
+it is not ready to send while `WP-16` / `#3366` is still open.
+
+Before sending this packet to an external reviewer, confirm:
+
+- `#3366` is closed with tracked internal-review outputs.
+- The internal review directory contains the expected findings register,
+  synthesis report, and internal-review handoff.
+- Accepted internal-review findings are fixed, routed to `WP-18`, or explicitly
+  deferred with owner and rationale.
+- `README.md`, `CHANGELOG.md`, `adl/Cargo.toml`, `adl/Cargo.lock`,
+  `docs/README.md`, and `docs/milestones/v0.91.4/` agree on v0.91.4 release
+  truth.
+- No tracked review packet depends on hidden `.adl/` notes, private scratch
+  paths, workstation-local paths, or unredacted secrets.
+- GitHub issue and PR state agree with the milestone release-tail docs.
+- v0.91.5 bridge work is represented as routed follow-on work, not as an
+  unclosed v0.91.4 release blocker.
+
+## Purpose
+
+This handoff gives a third-party reviewer a bounded review packet for
+`v0.91.4`, the Cognitive SDLC rollout-closeout milestone.
+
+Review `v0.91.4` as the milestone that hardens the v0.91.3 C-SDLC vertical
+slice into default operational practice. The review should focus on whether ADL
+now has an evidence-bound, repeatable development control plane:
+
+- `SIP -> STP -> SPP -> SRP -> SOR` card lifecycle
+- conductor, doctor, editor, worktree, PR, review, and closeout discipline
+- Software Development Polis role and shard-ownership boundaries
+- durable tracked C-SDLC evidence records
+- merge-readiness, review, and release-tail truth
+- Parallel Validation Fabric classification and test-lane policy
+- signed-trace, evidence-bundle, review-synthesis, and memory-handoff proof
+- demo/proof surfaces that support the actual v0.91.4 claims
+
+The reviewer should produce evidence-backed findings with severity, location,
+impact, and recommended remediation. The reviewer should not rewrite docs,
+perform remediation, create release tags, merge PRs, close issues, or run the
+release ceremony.
+
+## Current Milestone Truth
+
+At packet preparation time:
+
+- `WP-15` / `#3365` is closed.
+- `WP-16` / `#3366` is open and remains the controlling internal-review gate.
+- `WP-17` / `#3367` is open and should not close until external review truth is
+  recorded.
+- Sprint 4 remains the controlling release-tail lane for v0.91.4 closeout.
+- CodeFriend and WildClawBench are bounded sidecars, not proof that C-SDLC core
+  operation is complete.
+- Remaining multi-agent, provider/model, public-prompt-record, demo-readiness,
+  and first-birthday preflight work has moved to the v0.91.5 bridge milestone.
+
+This handoff does not claim that v0.91.4 is release-ready. It prepares the
+review packet that should be used after internal review completes.
+
+## Controlling Internal Review Packet
+
+The controlling internal-review owner is:
+
+- `#3366` `[v0.91.4][WP-16][review] Internal review`
+
+The internal-review plan is tracked at:
+
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_PLAN_2026-05-30.md`
+
+Before external review starts, the following expected internal-review outputs
+should also exist in the same directory:
+
+- `V0914_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-05-30.md`
+- `V0914_INTERNAL_REVIEW_SYNTHESIS_2026-05-30.md`
+- `V0914_INTERNAL_REVIEW_HANDOFF_2026-05-30.md`
+
+If those outputs are absent, treat this handoff as a draft and stop before
+sending it to a third-party reviewer.
+
+## Required Review Scope
+
+Review these top-level repository surfaces first:
+
+- `README.md`
+- `CHANGELOG.md`
+- `docs/README.md`
+- `AGENTS.md`
+- `adl/README.md`
+- `adl/Cargo.toml`
+- `adl/Cargo.lock`
+
+Review the v0.91.4 milestone package:
+
+- `docs/milestones/v0.91.4/README.md`
+- `docs/milestones/v0.91.4/VISION_v0.91.4.md`
+- `docs/milestones/v0.91.4/DESIGN_v0.91.4.md`
+- `docs/milestones/v0.91.4/DECISIONS_v0.91.4.md`
+- `docs/milestones/v0.91.4/WBS_v0.91.4.md`
+- `docs/milestones/v0.91.4/SPRINT_v0.91.4.md`
+- `docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml`
+- `docs/milestones/v0.91.4/WP_EXECUTION_READINESS_v0.91.4.md`
+- `docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md`
+- `docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md`
+- `docs/milestones/v0.91.4/QUALITY_GATE_v0.91.4.md`
+- `docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md`
+- `docs/milestones/v0.91.4/RELEASE_PLAN_v0.91.4.md`
+- `docs/milestones/v0.91.4/RELEASE_NOTES_v0.91.4.md`
+- `docs/milestones/v0.91.4/NEXT_MILESTONE_HANDOFF_v0.91.4.md`
+
+Review the C-SDLC and prompt-template surfaces:
+
+- `docs/cognitive-sdlc/`
+- `docs/templates/prompts/`
+- `docs/tooling/card-lifecycle.md`
+- `docs/tooling/structured-prompt-contracts.md`
+- `docs/tooling/csdlc-prompt-editor/`
+- `adl/tools/skills/`
+
+Review the v0.91.4 feature and proof packet:
+
+- `docs/milestones/v0.91.4/features/`
+- `docs/milestones/v0.91.4/review/evidence/csdlc/`
+- `docs/milestones/v0.91.4/review/merge_readiness/`
+- `docs/milestones/v0.91.4/review/obsmem_transition_memory/`
+- `docs/milestones/v0.91.4/review/software_development_polis/`
+- `docs/milestones/v0.91.4/review/multi_agent_workcell/`
+- `docs/milestones/v0.91.4/review/provider_substrate_reconciliation/`
+- `docs/milestones/v0.91.4/review/provider_communication_substrate/`
+- `docs/milestones/v0.91.4/review/browser_automation/`
+- `docs/milestones/v0.91.4/review/demo_showcase/`
+- `docs/milestones/v0.91.4/review/quality_gate/`
+- `docs/milestones/v0.91.4/review/docs_adoption/`
+- `docs/milestones/v0.91.4/review/internal_review/`
+
+Use v0.91.5 docs only for bridge-routing truth:
+
+- `docs/milestones/v0.91.5/`
+
+Do not review v0.91.5 as completed implementation evidence for v0.91.4.
+
+## Review Questions
+
+Ask these questions first:
+
+- Do milestone docs accurately separate completed v0.91.4 work from v0.91.5
+  bridge work?
+- Can a normal ADL issue now move through conductor, cards, worktree, PR,
+  review, and closeout without hand-rolled process?
+- Are `SIP`, `STP`, and `SPP` design-time truth surfaces rather than generic
+  placeholders?
+- Do `SRP` and `SOR` record review and output truth without overstating
+  completion?
+- Are public/tracked C-SDLC records sufficient for reviewers, or do important
+  claims still depend on ignored `.adl/` state?
+- Do PVF lane records distinguish fast PR proof, slow proof, release-gate
+  proof, deferred proof, and docs-only proof?
+- Do demo rows and proof packets state what they prove and what they do not
+  prove?
+- Are CodeFriend and WildClawBench consistently treated as sidecars?
+- Are provider, model, multi-agent, public prompt, Unity, and first-birthday
+  claims routed to v0.91.5 when they are not complete in v0.91.4?
+- Are issue, PR, release-plan, release-notes, checklist, and handoff states
+  mutually consistent?
+
+## Sidecar Boundaries
+
+CodeFriend sidecar work should be reviewed as bounded product setup evidence.
+It must not be treated as proof that C-SDLC core machinery is complete.
+
+WildClawBench sidecar work should be reviewed as benchmark-spike and
+failure-taxonomy evidence. It must not be treated as a benchmark-win claim, a
+release gate, or proof that all model/provider evaluation is complete.
+
+## v0.91.5 Bridge Boundary
+
+The following work is intentionally outside v0.91.4 completion and is routed to
+v0.91.5 or later:
+
+- multi-agent stabilization and five-minute sprint proof
+- provider/model matrix expansion
+- OpenRouter and DeepSeek provider work
+- public C-SDLC prompt-record transition
+- `.adl` archive and cleanup after review
+- demo readiness beyond the best available v0.91.4 proof packet
+- Unity Observatory work
+- first-birthday readiness `#3377`
+- feature activation testing for v0.92
+- AEE completion tranche planning
+- enterprise-security separation planning
+
+The reviewer should report any v0.91.4 doc that still treats those items as
+complete v0.91.4 release proof.
+
+## Expected Reviewer Output
+
+The expected third-party review output is:
+
+- severity-ranked findings: `P0`, `P1`, `P2`, `P3`
+- file and line evidence for each finding
+- impact and recommended remediation
+- explicit statement when no blocking findings are found
+- residual risks and testing gaps
+- recommendation for whether v0.91.4 may proceed to `WP-18` remediation
+
+If there are no findings, the reviewer should say so explicitly and identify
+the residual risks they did not exhaustively validate.
+
+## Non-Claims
+
+This handoff does not claim:
+
+- release approval
+- release ceremony completion
+- external review completion
+- v0.91.5 completion
+- v0.92 first-birthday readiness
+- production multi-agent execution readiness
+- Unity Observatory readiness
+- OpenRouter or DeepSeek provider completion
+- benchmark superiority
+- CodeFriend product launch success
+- WildClawBench benchmark validity beyond the recorded spike evidence
+- legal personhood, consciousness proof, or constitutional citizenship
+
+## Suggested Validation Before Sending
+
+Run focused review-packet validation rather than broad Rust tests:
+
+```bash
+git diff --check
+ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml")'
+python3 adl/tools/validate_planning_template.py --template readme --input docs/milestones/v0.91.4/README.md
+python3 adl/tools/validate_planning_template.py --template wbs --input docs/milestones/v0.91.4/WBS_v0.91.4.md
+python3 adl/tools/validate_planning_template.py --template sprint --input docs/milestones/v0.91.4/SPRINT_v0.91.4.md
+python3 adl/tools/validate_planning_template.py --template milestone_checklist --input docs/milestones/v0.91.4/MILESTONE_CHECKLIST_v0.91.4.md
+```
+
+Also check:
+
+- all referenced review packet paths exist
+- relative Markdown links under `docs/milestones/v0.91.4/` resolve
+- no tracked review docs contain `/Users/`, `/private/tmp`, credentials, or
+  private key material
+- GitHub issue state for `#3362` through `#3371` matches the release-tail docs
+
+Broad Rust, slow-proof, or release-gate validation should only be run when the
+internal review or release gate requires it. This handoff is a docs/review
+packet and should not by itself trigger a full runtime test cycle.

--- a/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -9,24 +9,24 @@
 - Prepared during: `v0.91.4` release tail
 - Prepared for issue: `#3367`
 - Parent sprint: `#3362`
-- Current packet status: `draft_pre_send`
-- Date: `2026-05-31`
+- Current packet status: `ready_for_external_review`
+- Date: `2026-06-01`
 - Publication attempted: false
 - Release approval claimed: false
 - External review approval claimed: false
 
 ## Send Gate
 
-This handoff is the tracked third-party review packet surface for `WP-17`, but
-it is not ready to send while `WP-16` / `#3366` is still open.
+This handoff is the tracked third-party review packet surface for `WP-17`.
+`WP-16` / `#3366` is closed, and the WP-16-originated remediation wave is
+closed through merged PRs.
 
-Before sending this packet to an external reviewer, confirm:
+Before sending this packet to an external reviewer, confirm again:
 
-- `#3366` is closed with tracked internal-review outputs.
-- The internal review directory contains the expected findings register,
-  synthesis report, and internal-review handoff.
-- Accepted internal-review findings are fixed, routed to `WP-18`, or explicitly
-  deferred with owner and rationale.
+- `#3366` remains closed.
+- The WP-16 closeout comment remains the controlling internal-review closeout
+  evidence.
+- Accepted WP-16 findings remain fixed through merged PRs or explicitly routed.
 - `README.md`, `CHANGELOG.md`, `adl/Cargo.toml`, `adl/Cargo.lock`,
   `docs/README.md`, and `docs/milestones/v0.91.4/` agree on v0.91.4 release
   truth.
@@ -64,17 +64,18 @@ release ceremony.
 At packet preparation time:
 
 - `WP-15` / `#3365` is closed.
-- `WP-16` / `#3366` is open and remains the controlling internal-review gate.
+- `WP-16` / `#3366` is closed.
 - `WP-17` / `#3367` is open and should not close until external review truth is
   recorded.
-- Sprint 4 remains the controlling release-tail lane for v0.91.4 closeout.
+- Sprint 4 remains open as the controlling release-tail lane for v0.91.4
+  closeout.
 - CodeFriend and WildClawBench are bounded sidecars, not proof that C-SDLC core
   operation is complete.
 - Remaining multi-agent, provider/model, public-prompt-record, demo-readiness,
   and first-birthday preflight work has moved to the v0.91.5 bridge milestone.
 
-This handoff does not claim that v0.91.4 is release-ready. It prepares the
-review packet that should be used after internal review completes.
+This handoff does not claim that v0.91.4 is release-ready. It records that the
+internal review gate has closed and prepares the packet for external review.
 
 ## Controlling Internal Review Packet
 
@@ -86,15 +87,39 @@ The internal-review plan is tracked at:
 
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_PLAN_2026-05-30.md`
 
-Before external review starts, the following expected internal-review outputs
-should also exist in the same directory:
+The WP-16 closeout evidence is recorded in the issue closeout comments:
 
-- `V0914_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-05-30.md`
-- `V0914_INTERNAL_REVIEW_SYNTHESIS_2026-05-30.md`
-- `V0914_INTERNAL_REVIEW_HANDOFF_2026-05-30.md`
+- `https://github.com/danielbaustin/agent-design-language/issues/3366#issuecomment-4588929069`
+- `https://github.com/danielbaustin/agent-design-language/issues/3366#issuecomment-4588929132`
 
-If those outputs are absent, treat this handoff as a draft and stop before
-sending it to a third-party reviewer.
+The closeout comment names the intended internal-review artifacts:
+
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_SPECIALIST_FINDINGS_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_FINDINGS_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_SYNTHESIS_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_REMEDIATION_ISSUES_2026-05-31.md`
+
+Those named files are not present on current `origin/main` as tracked files at
+the time this handoff was refreshed. For WP-17 entry, the controlling evidence
+is therefore the WP-16 closeout comment plus the closed remediation issue/PR
+wave below. The external reviewer should treat the missing tracked files as a
+reviewable evidence-shape caveat, not as release approval.
+
+## WP-16 Finding Disposition
+
+WP-16 routed accepted findings through five remediation issues. All five are
+closed through merged PRs:
+
+| Finding route | Issue state | PR state | Disposition |
+| --- | --- | --- | --- |
+| PVF release-policy test execution and CI coverage | `#3542` closed | `#3547` merged | fixed |
+| Release-doc truth before external review | `#3543` closed | `#3550` merged | fixed |
+| Provider identity and Gemini credential diagnostics | `#3544` closed | `#3548` merged | fixed |
+| Review evidence path and redaction cleanup | `#3545` closed | `#3552` merged | fixed |
+| WildClawBench replayability-boundary cleanup | `#3546` closed | `#3554` merged | fixed |
+
+No accepted WP-16 finding remains open at the time this handoff was refreshed.
+Future findings from the external review belong to `WP-18` / `#3368`.
 
 ## Required Review Scope
 

--- a/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -9,7 +9,7 @@
 - Prepared during: `v0.91.4` release tail
 - Prepared for issue: `#3367`
 - Parent sprint: `#3362`
-- Current packet status: `ready_for_external_review`
+- Current packet status: `external_review_recorded`
 - Date: `2026-06-01`
 - Publication attempted: false
 - Release approval claimed: false
@@ -79,6 +79,26 @@ At packet preparation time:
 
 This handoff does not claim that v0.91.4 is release-ready. It records that the
 internal review gate has closed and prepares the packet for external review.
+
+## External Review Result
+
+The external review result is now tracked at:
+
+- `docs/milestones/v0.91.4/review/third_party_review/V0914_EXTERNAL_REVIEW_FINDINGS_2026-06-01.md`
+
+The review found no `P0` or `P1` findings in the reviewed surfaces, but it did
+record four actionable findings:
+
+| Finding | Severity | Required route |
+| --- | --- | --- |
+| `R1` PVF policy test retains the F001 bug class on the release lane | `P2` | fix before `WP-18` close |
+| `R2` WildClawBench host path persists after replayability-boundary cleanup | `P3` | fix or explicitly retain as sidecar caveat |
+| `R3` PVF CI wiring is path-policy gated | `P3` | add a path-policy assertion or documented guard |
+| `R4` F003 provider identity closure is not verifiable from tracked state | `P2` | record fixed-by-PR evidence or explicit v0.91.5 route |
+
+Those findings are routed to `WP-18` / `#3368`. `WP-17` should not be closed
+until this tracked review result is published and the `WP-18` remediation path
+has clear issue-level ownership.
 
 ## Controlling Internal Review Packet
 

--- a/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -9,7 +9,7 @@
 - Prepared during: `v0.91.4` release tail
 - Prepared for issue: `#3367`
 - Parent sprint: `#3362`
-- Current packet status: `blocked_pending_internal_review_artifact_recovery`
+- Current packet status: `ready_for_external_review`
 - Date: `2026-06-01`
 - Publication attempted: false
 - Release approval claimed: false
@@ -18,9 +18,9 @@
 ## Send Gate
 
 This handoff is the tracked third-party review packet surface for `WP-17`.
-`WP-16` / `#3366` is closed, and the WP-16-originated remediation wave is
-closed through merged PRs. This packet is not ready to send until the recovered
-WP-16 internal-review artifacts are published through `#3555`.
+`WP-16` / `#3366` is closed, the WP-16-originated remediation wave is closed
+through merged PRs, and the recovered WP-16 internal-review artifacts are now
+tracked through closed recovery issue `#3555`.
 
 Before sending this packet to an external reviewer, confirm again:
 
@@ -95,23 +95,20 @@ The WP-16 closeout evidence is recorded in the issue closeout comments:
 - `https://github.com/danielbaustin/agent-design-language/issues/3366#issuecomment-4588929069`
 - `https://github.com/danielbaustin/agent-design-language/issues/3366#issuecomment-4588929132`
 
-The closeout comment names the intended internal-review artifacts:
+The internal-review artifacts are tracked at:
 
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_PLAN_2026-05-30.md`
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_SPECIALIST_FINDINGS_2026-05-31.md`
-- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_FINDINGS_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-05-31.md`
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_SYNTHESIS_2026-05-31.md`
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_REMEDIATION_ISSUES_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_HANDOFF_2026-05-31.md`
+- `docs/milestones/v0.91.4/review/internal_review/repo_packet_2026-05-31/`
 
-Those named files were recovered from the WP-16 worktree after this handoff
-was refreshed, but they are not yet present on current `origin/main` as tracked
-files. The recovery is tracked by `#3555`
-`[v0.91.4][WP-16][review] Publish recovered internal review artifacts`.
-
-Do not send this packet to an external reviewer until `#3555` is closed and
-the recovered artifacts are present under the tracked internal-review path.
-Until then, the controlling evidence is the WP-16 closeout comment plus the
-closed remediation issue/PR wave below, and the absent tracked files remain a
-blocking evidence-shape gap.
+Those artifacts were recovered from the WP-16 worktree and published through
+`#3555` `[v0.91.4][WP-16][review] Publish recovered internal review artifacts`,
+which is now closed. The controlling evidence is therefore the tracked
+internal-review packet plus the closed remediation issue/PR wave below.
 
 ## WP-16 Finding Disposition
 

--- a/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -9,7 +9,7 @@
 - Prepared during: `v0.91.4` release tail
 - Prepared for issue: `#3367`
 - Parent sprint: `#3362`
-- Current packet status: `ready_for_external_review`
+- Current packet status: `blocked_pending_internal_review_artifact_recovery`
 - Date: `2026-06-01`
 - Publication attempted: false
 - Release approval claimed: false
@@ -19,11 +19,14 @@
 
 This handoff is the tracked third-party review packet surface for `WP-17`.
 `WP-16` / `#3366` is closed, and the WP-16-originated remediation wave is
-closed through merged PRs.
+closed through merged PRs. This packet is not ready to send until the recovered
+WP-16 internal-review artifacts are published through `#3555`.
 
 Before sending this packet to an external reviewer, confirm again:
 
 - `#3366` remains closed.
+- `#3555` is closed and the recovered WP-16 internal-review artifacts are
+  present under `docs/milestones/v0.91.4/review/internal_review/`.
 - The WP-16 closeout comment remains the controlling internal-review closeout
   evidence.
 - Accepted WP-16 findings remain fixed through merged PRs or explicitly routed.
@@ -99,11 +102,16 @@ The closeout comment names the intended internal-review artifacts:
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_SYNTHESIS_2026-05-31.md`
 - `docs/milestones/v0.91.4/review/internal_review/V0914_INTERNAL_REVIEW_REMEDIATION_ISSUES_2026-05-31.md`
 
-Those named files are not present on current `origin/main` as tracked files at
-the time this handoff was refreshed. For WP-17 entry, the controlling evidence
-is therefore the WP-16 closeout comment plus the closed remediation issue/PR
-wave below. The external reviewer should treat the missing tracked files as a
-reviewable evidence-shape caveat, not as release approval.
+Those named files were recovered from the WP-16 worktree after this handoff
+was refreshed, but they are not yet present on current `origin/main` as tracked
+files. The recovery is tracked by `#3555`
+`[v0.91.4][WP-16][review] Publish recovered internal review artifacts`.
+
+Do not send this packet to an external reviewer until `#3555` is closed and
+the recovered artifacts are present under the tracked internal-review path.
+Until then, the controlling evidence is the WP-16 closeout comment plus the
+closed remediation issue/PR wave below, and the absent tracked files remain a
+blocking evidence-shape gap.
 
 ## WP-16 Finding Disposition
 

--- a/docs/milestones/v0.91.4/review/third_party_review/V0914_EXTERNAL_REVIEW_FINDINGS_2026-06-01.md
+++ b/docs/milestones/v0.91.4/review/third_party_review/V0914_EXTERNAL_REVIEW_FINDINGS_2026-06-01.md
@@ -1,0 +1,123 @@
+# ADL v0.91.4 — Whole-Milestone Third-Party Review (WP-17)
+
+- Reviewer: Independent technical review (Claude)
+- Date: 2026-06-01
+- Lane: WP-17 external review, per `ADL_v0.91.4_THIRD_PARTY_REVIEW_HANDOFF.md`
+
+## Method and honesty boundary
+
+This is a real review of tracked repo state. I read source and docs directly and
+report what is actually there. What I did **not** do, and therefore do not
+assert: I did not compile the Rust, run the test suite, run the PVF lanes, or
+make live provider calls in this environment. Runtime-dependent conclusions are
+marked "read, not executed." A numeric per-category score is deliberately **not**
+given, because scoring categories I did not exercise (full test execution, broad
+security, performance) would not be evidence-backed. The earlier rounds of these
+reviews did exactly that and it was wrong.
+
+### Coverage map (so the gaps are visible)
+
+- **Deep-read (line-level):** `signing.rs` (+ its tests), `provider_adapter.rs`,
+  `model_identity.rs`, `.github/workflows/ci.yaml`,
+  `tools/test_pvf_ci_release_policy.sh`, signed-trace fixtures,
+  `MILESTONE_CHECKLIST`, `QUALITY_GATE`, `NEXT_MILESTONE_HANDOFF`, the WP-16
+  internal-review findings register + synthesis, and the C-SDLC paper docs.
+- **Targeted-read (consistency/claims):** README/RELEASE_NOTES/handoff release
+  truth; v0.91.4↔v0.91.5 boundary; WildClaw safety-results doc.
+- **Sampled (not line-audited):** the remaining ~70 milestone docs, the feature
+  docs, the JSON fixtures, CodeFriend/WildClaw sidecar docs, browser runbook.
+- **Not opened:** the bulk of the 1.36 MB Rust tree outside the files above
+  (e.g. `long_lived_agent.rs`, `obsmem_*`, `csm_observatory.rs`, runtime_v2/*,
+  the multi-agent planner source). I make no claims about those.
+
+## Verified positives (checked in code, not taken on faith)
+
+1. **Signed trace is real cryptography (read, not executed).** `signing.rs`
+   signs a canonical `{header, document}` envelope with ed25519-dalek, strips
+   only the top-level typed `signature` field (no recursive over-strip), sorts
+   keys deterministically, and verifies the body — not just a thin header. Good
+   typed failure classes, embedded/explicit key sourcing, ed25519-only policy,
+   and a substantial in-file test suite (round-trip, malformed sig/key, policy
+   enforcement). My initial worry that the signature covered only a near-empty
+   header was wrong.
+   - Honest note (not a finding): the signed header binds `adl_version` and
+     `workflow_id` only — no timestamp/expiry — so signatures are non-expiring
+     by design. Normal for content-integrity signing; the doc comments are
+     accurate about scope.
+2. **F010 (Gemini credential-in-URL) — verified fixed.** Key is sent via
+   `x-goog-api-key` header; `gemini_generate_url` builds the URL from model name
+   only; error paths don't interpolate the URL into persisted diagnostics.
+3. **F004 (PVF tests not in CI) — verified fixed.** `ci.yaml` runs the PVF
+   release-policy contract and exercises the validation lane (path-policy gated).
+4. **F008 (`/Users/` absolute paths in paper docs) — verified fixed** at all
+   cited locations; now placeholder tokens.
+5. **F002 (release docs overclaim) — verified fixed and honest.** QUALITY_GATE
+   outcome is `blocked`; MILESTONE_CHECKLIST leaves ship-gates unchecked rather
+   than pre-ticked; handoff disclaims release-readiness. Cross-document release
+   truth is mutually consistent — a genuine positive.
+6. **WP-16 internal review quality is high** — specific, file-and-line evidence,
+   correct severity instincts, explicit non-claims. The "five routes merged"
+   claim is substantially true.
+
+## Findings (this review)
+
+### R1 (P2) — PVF policy test retains the F001 bug class on the release lane
+`tools/test_pvf_ci_release_policy.sh` (~line 38). The F001 fix wrapped the
+docs- and runtime-lane runner calls in `set +e`/capture, but the third
+(release-mode) call runs bare under `set -e`. If that runner ever exits
+non-zero, the script dies before its Python assertions and `grep` checks — the
+exact failure mode F001 described, on the one path the fix didn't cover. Read,
+not executed: it may exit 0 today, so this is fragility, not a proven failure.
+Fix before WP-18 closes, because PVF is a headline proof surface and a test that
+can die before asserting yields false green. Route: WP-18.
+
+### R2 (P3) — WildClawBench host path persists (F007/F009 partial close)
+`WILDCLAW_SAFETY_ALIGNMENT_RESULTS_2026-05-27.md:~54` still names
+`$HOME/temp/wildclawbench-3380` as the stable benchmark copy. Remediation did
+real work (replayability-boundary framing, `/private/tmp` now historical,
+ADL-superiority disclaimed) and `$HOME` is not a username leak, so this is no
+longer P2. But "an external reviewer cannot reconstruct this checkout" is still
+literally true. De-risked, not fully closed. Acceptable to keep as explicit
+sidecar caveat if you decide that deliberately.
+
+### R3 (P3, informational) — F004 CI wiring is path-policy gated
+The PVF contract step is conditioned on `ci_contracts_required == 'true'`. A PR
+touching only the PVF runner under a docs-classified path could skip it. Add a
+one-line path-policy assertion so the PVF surface always forces the contract.
+
+### R4 (P2, traceability) — F003 closure is not verifiable from tracked state
+The WP-16 synthesis routed F003 (remote Ollama misclassified as `hosted_http`)
+as "fix before release **or** route to v0.91.5," and the handoff's disposition
+table does not list F003 among the five merged remediation routes — only F001,
+F002, F003-adjacent provider identity (#3544), F007-area, and F009 appear, with
+#3544 framed as "provider identity and Gemini credential diagnostics." From the
+code I can confirm `model_identity.rs` *knows* the local-vs-hosted distinction
+(its tests use both `hosted_http` and `local_http`), but `provider_adapter.rs`
+uses a different surface vocabulary (`hosted_api`/`ollama_http`) and I could not
+trace, from tracked artifacts alone, whether remote-Ollama specifically now
+classifies correctly. This is not a claim that the code is wrong — it's that the
+finding's disposition is ambiguous in tracked state. Before WP-18 closes, record
+F003's actual disposition (fixed-by-PR with a pointer, or explicitly routed to
+v0.91.5) so an external reviewer doesn't have to guess.
+
+### Acknowledged-and-correctly-deferred (not new findings)
+- **F011** (next-milestone handoff scaffold tension about v0.91.5 selection) is
+  real but explicitly routed to WP-19/WP-20 at P3; the doc's own text both
+  assumes v0.91.5 and instructs WP-19 to confirm/revise. Acceptable as deferred.
+- **F012 / F013** (browser-runbook machine paths; CodeFriend infra fingerprint)
+  — sampled, consistent with their P3 routing; not re-verified line-by-line.
+
+## Verdict
+
+On every surface I actually opened, the engineering is real and the WP-16
+remediation claims hold up, with the exceptions logged above. The release-tail
+honesty (blocked gate, unchecked ship boxes, consistent cross-doc truth) is a
+real strength and the opposite of overclaiming.
+
+Recommendation: **proceed to WP-18 remediation**, with R1 and R4 as
+fix-before-close items (R1 because it can produce false-green on a headline
+proof; R4 because closure must be auditable, not inferred), and R2/R3 as
+cleanup. No release-blocking P0/P1 found in the reviewed surfaces — but note the
+explicit coverage gaps above: this is not a clean bill of health for the ~70%
+of the Rust tree I did not open, and a full pass should either be run with the
+test suite executing or scoped across more of the runtime source.


### PR DESCRIPTION
## Summary

Adds the v0.91.4 WP-17 third-party review handoff packet and links it from the v0.91.4 milestone README.

Current handoff state: ready for external review. The recovered WP-16 internal-review artifacts are now tracked through closed issue 3555 and are included as controlling review inputs.

## Scope

- Adds the third-party review handoff document for v0.91.4.
- Links the handoff from the milestone README.
- Refreshes WP-15/WP-16 release-tail truth in v0.91.4 planning docs.
- Records the WP-16 remediation issue/PR dispositions.
- Points the handoff at the recovered tracked WP-16 internal-review packet from issue 3555.
- Allows explicit non-closing lifecycle PRs to pass the issue-linkage guardrail while the source issue remains open.

## Validation

- `git diff --check`
- `bash adl/tools/test_pr_closing_linkage.sh`
- YAML parse for `docs/milestones/v0.91.4/WP_ISSUE_WAVE_v0.91.4.yaml`
- Focused planning-template checks for touched planning docs
- Focused Markdown/path check for the third-party handoff and recovered WP-16 artifact references
- Focused redaction scan for touched/recovered review docs; hits are review-findings language about prior host-path/secret-boundary checks, not exposed credentials

## Issue Routing

Non-closing lifecycle PR: issue 3367 remains open

Related issue: issue 3367.

Issue 3367 must remain open until the external review result is recorded. This PR intentionally does not auto-close that issue.

Issue 3555 published the recovered WP-16 internal-review artifacts and is closed.
