### PR TITLE
[v0.91.4][evidence][docs] Normalize review evidence paths

### DIFF
--- a/docs/cognitive-sdlc/c_sdlc_paper_handoff.md
+++ b/docs/cognitive-sdlc/c_sdlc_paper_handoff.md
@@ -15,7 +15,7 @@ https://github.com/danielbaustin/cognitive-sdlc-paper
 Local checkout:
 
 ```text
-/Users/daniel/git/cognitive-sdlc-paper
+<operator-local-csdlc-paper-checkout>
 ```
 
 ## Canonical Draft

--- a/docs/cognitive-sdlc/c_sdlc_private_paper_repo_plan.md
+++ b/docs/cognitive-sdlc/c_sdlc_private_paper_repo_plan.md
@@ -26,7 +26,7 @@ Use the same staged workflow as the private SSC/general-intelligence paper repo:
 
 Reference local pattern:
 
-- `/Users/daniel/git/general-intelligence-paper/GENERAL_INTELLIGENCE_PAPER_WORKFLOW.md`
+- `<operator-local-papers-workspace>/general-intelligence-paper/GENERAL_INTELLIGENCE_PAPER_WORKFLOW.md`
 
 ## Proposed Private Repo
 
@@ -39,7 +39,7 @@ cognitive-sdlc-paper
 Suggested local path:
 
 ```text
-/Users/daniel/git/cognitive-sdlc-paper
+<operator-local-csdlc-paper-checkout>
 ```
 
 GitHub repository:
@@ -276,7 +276,7 @@ manuscript once the private repo exists.
 Completed:
 
 - private GitHub repository created
-- local checkout initialized at `/Users/daniel/git/cognitive-sdlc-paper`
+- local checkout initialized at `<operator-local-csdlc-paper-checkout>`
 - initial paper workflow added
 - current Markdown draft migrated into the private repo
 - claim/citation packet scaffold added

--- a/docs/milestones/v0.91.4/CODEFRIEND_AWS_PUBLICATION.md
+++ b/docs/milestones/v0.91.4/CODEFRIEND_AWS_PUBLICATION.md
@@ -18,7 +18,7 @@ published the coming-soon page live over HTTPS.
 
 - `https://codefriend.ai`
 - `https://www.codefriend.ai`
-- CloudFront distribution domain: `https://dgqj4hit346az.cloudfront.net`
+- CloudFront distribution domain: retained in private infrastructure records
 
 ## What changed
 

--- a/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
+++ b/docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md
@@ -169,15 +169,15 @@ Observed in the Codex shell during `#3497`:
 
 - Browser MCP / Codex in-app browser route: passed a local HTTP proof against `127.0.0.1`, including page load, selector click, and DOM mutation inspection.
 - Computer Use visible Chromium route: passed against the actual Chromium window. It loaded Starharvest, verified the visible URL/title, and exposed the game state through the accessibility tree.
-- Standalone Playwright installed outside the repo at `~/tools/playwright-browser` reports Playwright `1.60.0` and browser cache metadata, but `chromium.launch({ headless: true })` fails from the Codex shell with a macOS MachPort permission error. Treat this as proof that the package is installed, not proof that direct shell browser launch is usable.
+- Standalone Playwright installed outside the repo at `<operator-local-playwright-tools>` reports Playwright `1.60.0` and browser cache metadata, but `chromium.launch({ headless: true })` fails from the Codex shell with a macOS MachPort permission error. Treat this as proof that the package is installed, not proof that direct shell browser launch is usable.
 - `open -Ra chromium`: failed with `Unable to find application named 'chromium'`.
 - `open -Ra Chromium`: failed with `Unable to find application named 'Chromium'`.
 - `open -Ra Google Chrome`: failed with `Unable to find application named 'Google Chrome'`.
 - `open -Ra Safari`: failed with `Unable to find application named 'Safari'`.
-- `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`: exists and is executable.
-- `/Applications/Safari.app/Contents/MacOS/Safari`: exists and is executable.
-- `~/Library/Application Support/Chromium` and `~/Library/Caches/Chromium`: exist as Chromium profile/cache directories; this is evidence of browser use, not an executable route.
-- `/Applications/Google Chrome copy.app/Contents/MacOS/Google Chrome`: exists in this environment and should be diagnosed separately from the primary Chrome app when needed.
+- macOS Chrome binary pattern, `<macos-app-bundle>/Contents/MacOS/Google Chrome`: exists in the reviewed environment and is executable.
+- macOS Safari binary pattern, `<macos-app-bundle>/Contents/MacOS/Safari`: exists in the reviewed environment and is executable.
+- `<operator-local-chromium-profile>` and `<operator-local-chromium-cache>`: exist as Chromium profile/cache directories; this is evidence of browser use, not an executable route.
+- Alternate Chrome bundle pattern, `<alternate-macos-app-bundle>/Contents/MacOS/Google Chrome`: exists in this environment and should be diagnosed separately from the primary Chrome app when needed.
 - primary-checkout Playwright Chromium executable: discovered at `.adl/.cache/diagram-renderers/playwright/chromium-1134/chrome-mac/Chromium.app/Contents/MacOS/Chromium` and reports `Chromium 129.0.6668.29`; issue worktrees may not have their own `.adl/.cache` copy.
 - direct primary-checkout Playwright Chromium headless smoke from the Codex shell: attempted and failed with crashpad permission/handshake errors; do not use direct cached Chromium headless as the proof route unless a fresh smoke passes.
 - direct Google Chrome headless smoke from the Codex shell: attempted and failed with signal-style return code `-6`; do not use direct Chrome headless as the default proof route here.


### PR DESCRIPTION
Closes #3545

## Summary
Completed the docs-only redaction cleanup for issue `#3545`. Reviewer-facing docs now replace unnecessary machine-local values with portable wording while preserving useful setup and troubleshooting detail.

## Artifacts
- `docs/cognitive-sdlc/c_sdlc_private_paper_repo_plan.md`
- `docs/cognitive-sdlc/c_sdlc_paper_handoff.md`
- `docs/milestones/v0.91.4/CODEFRIEND_AWS_PUBLICATION.md`
- `docs/milestones/v0.91.4/review/browser_automation/BROWSER_AUTOMATION_RUNBOOK_v0.91.4.md`

## Validation
- Focused stale-path search over the changed docs: PASS.
- `git diff --check`: PASS.
- Structured SOR validation: PASS.
- Structured SPP validation: PASS.
- Structured SRP validation: PASS.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3545__v0-91-4-evidence-docs-normalize-review-evidence-paths-and-redaction-surfaces/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3545__v0-91-4-evidence-docs-normalize-review-evidence-paths-and-redaction-surfaces/sor.md
- Idempotency-Key: v0-91-4-evidence-docs-normalize-review-evidence-paths-docs-cognitive-sdlc-c-sdlc-private-paper-repo-plan-md-docs-cognitive-sdlc-c-sdlc-paper-handoff-md-docs-milestones-v0-91-4-codefriend-aws-publication-md-docs-milestones-v0-91-4-review-browser-automation-browser-automation-runbook-v0-91-4-md-adl-v0-91-4-tasks-issue-3545-v0-91-4-evidence-docs-normalize-review-evidence-paths-and-redaction-surfaces-sip-md-adl-v0-91-4-tasks-issue-3545-v0-91-4-evidence-docs-normalize-review-evidence-paths-and-redaction-surfaces-sor-md