### PR TITLE
[v0.91.4][WildClawBench][docs] Pin replayability boundary

### DIFF
--- a/docs/milestones/v0.91.4/WILDCLAW_RESULTS.md
+++ b/docs/milestones/v0.91.4/WILDCLAW_RESULTS.md
@@ -16,6 +16,30 @@ This document closes the bounded WildClawBench spike by recording:
 - how to interpret the `UTS`/`ACC` framing
 - what the next responsible step should be
 
+
+## Replayability Boundary
+
+The Safety Alignment result packet is a bounded sidecar evidence record, not a
+self-contained replay bundle.
+
+External reviewers should treat the tracked docs as replayable for:
+
+- result interpretation
+- command shape
+- claim boundaries
+- known caveats and failure taxonomy
+
+External reviewers should not treat the tracked docs as sufficient for:
+
+- byte-for-byte rerun of the original task outputs
+- reconstruction of local Docker image state
+- reconstruction of local benchmark workspace payloads
+- verification of raw per-task logs unless those logs are separately supplied
+
+The corrected replayability boundary lives in:
+
+- `docs/milestones/v0.91.4/WILDCLAW_SAFETY_ALIGNMENT_RESULTS_2026-05-27.md`
+
 ## Mini-sprint scope
 
 The bounded WildClawBench sidecar consisted of:

--- a/docs/milestones/v0.91.4/WILDCLAW_SAFETY_ALIGNMENT_RESULTS_2026-05-27.md
+++ b/docs/milestones/v0.91.4/WILDCLAW_SAFETY_ALIGNMENT_RESULTS_2026-05-27.md
@@ -55,6 +55,47 @@ The stable benchmark copy used for the authoritative Safety Alignment slice was:
 
 That corrected host path matters when interpreting the final results.
 
+
+## Replayability Boundary
+
+This evidence is **reviewable from tracked repository docs**, but it is not fully
+replayable from tracked repository artifacts alone.
+
+Replayable from this repository:
+
+- the result table and interpretation in this document
+- the documented command shape and output-path pattern
+- the claim boundary that these are Codex-harness results, not ADL-native agent
+  benchmark results
+- the recorded distinction between environment failures, grader-boundary caveats,
+  and visible model behavior
+
+Not replayable from this repository alone:
+
+- the local WildClawBench checkout contents under the operator-local benchmark
+  copy
+- downloaded `workspace/06_Safety_Alignment/**` task payloads
+- Docker image tarballs and local Docker image state
+- local credential environment used by the Codex harness
+- raw per-task output directories, unless separately preserved outside this repo
+
+Local-only state used for the run:
+
+- benchmark checkout: summarized as an operator-local stable checkout under the
+  `$HOME/temp/wildclawbench-3380` pattern
+- Docker image: summarized as `wildclawbench-codex-ubuntu:v0.0`
+- task payloads: summarized as the locally downloaded `06_Safety_Alignment`
+  workspace subtree
+- raw logs: summarized by task outcome and caveat in this document
+
+Therefore the replay claim for this note is limited to:
+
+- **document replay**: yes, from tracked docs
+- **command-shape replay**: yes, if an operator recreates the benchmark setup
+- **byte-for-byte run replay**: no, not from tracked artifacts alone
+- **scientific-result reuse**: provisional sidecar evidence only, with the local
+  setup and fairness caveats preserved
+
 ## Re-entry Setup Notes
 
 This section is here so we can come back to the benchmark after launch without
@@ -294,7 +335,7 @@ worth keeping with the evidence:
 
 The main thing we proved in this lane is modest but useful:
 
-- we can run WildClawBench locally in a stable, reproducible-enough way
+- we can run WildClawBench locally in a stable way when the local setup is recreated
 - we can diagnose the difference between environment failures and model misses
 - we can preserve truthful evidence for later ADL-native benchmark work
 

--- a/docs/milestones/v0.91.4/WILDCLAW_SPIKE_CLOSEOUT_v0.91.4.md
+++ b/docs/milestones/v0.91.4/WILDCLAW_SPIKE_CLOSEOUT_v0.91.4.md
@@ -38,6 +38,9 @@ what remains in flight, and what it deferred.
 
 - WildClawBench can be run locally in a stable way when the benchmark copy
   lives on a trustworthy host path under `$HOME/temp`.
+- The tracked result docs now preserve the replayability boundary: document and
+  command-shape replay are available, but byte-for-byte rerun requires
+  recreating local-only benchmark state.
 - The first ten `06_Safety_Alignment` tasks can serve as a bounded baseline
   slice for later follow-up.
 - ADL is useful as an investigation and evidence-recording control plane even


### PR DESCRIPTION
Closes #3546

## Summary
Completed docs-only replayability-boundary cleanup for WildClawBench sidecar evidence. The tracked docs now distinguish document replay, operator-recreated reruns, and local-only state that is not replayable from tracked artifacts alone.

## Artifacts
- `docs/milestones/v0.91.4/WILDCLAW_SAFETY_ALIGNMENT_RESULTS_2026-05-27.md`
- `docs/milestones/v0.91.4/WILDCLAW_RESULTS.md`
- `docs/milestones/v0.91.4/WILDCLAW_SPIKE_CLOSEOUT_v0.91.4.md`

## Validation
- Focused search for replayability and overclaim language: PASS.
- `git diff --check`: PASS.
- Bounded pre-PR subagent review: PASS, no findings.
- Structured SOR validation: PASS.

## Local Artifacts
- Input card:  .adl/v0.91.4/tasks/issue-3546__v0-91-4-wildclawbench-quality-pin-replayability-boundary-for-benchmark-evidence/sip.md
- Output card: .adl/v0.91.4/tasks/issue-3546__v0-91-4-wildclawbench-quality-pin-replayability-boundary-for-benchmark-evidence/sor.md
- Idempotency-Key: v0-91-4-wildclawbench-docs-pin-replayability-boundary-docs-milestones-v0-91-4-wildclaw-safety-alignment-results-2026-05-27-md-docs-milestones-v0-91-4-wildclaw-results-md-docs-milestones-v0-91-4-wildclaw-spike-closeout-v0-91-4-md-adl-v0-91-4-tasks-issue-3546-v0-91-4-wildclawbench-quality-pin-replayability-boundary-for-benchmark-evidence-sip-md-adl-v0-91-4-tasks-issue-3546-v0-91-4-wildclawbench-quality-pin-replayability-boundary-for-benchmark-evidence-sor-md