### PR TITLE
[v0.91.5][Sprint 1][tools] Add Markdown AST template immutability validation

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -91,6 +91,7 @@ adl tooling lint-prompt-spec --input <path>\n\
 adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
 adl tooling prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
+adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template write-sample-values --out-dir <dir>\n\
 adl tooling validate-structured-prompt --type <sip|stp|spp|srp|sor> --input <path> [--phase <phase>]\n\
 adl tooling review-card-surface --input <input.md> --output <output.md>\n\

--- a/adl/src/cli/tooling_cmd/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/prompt_template.rs
@@ -1,6 +1,7 @@
 use adl::csdlc_prompt_editor::{
     render_all_cards_from_values_dir, render_card_from_values_file, repo_root_from_arg,
-    validate_values_file, write_all_sample_values, PromptCardKind,
+    validate_rendered_card_structure_file, validate_values_file, write_all_sample_values,
+    PromptCardKind,
 };
 use anyhow::{bail, Result};
 use std::fs;
@@ -10,20 +11,21 @@ use super::tooling_usage;
 
 pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
-        bail!("prompt-template requires a subcommand: render | render-all | validate-values | write-sample-values");
+        bail!("prompt-template requires a subcommand: render | render-all | validate-values | validate-structure | write-sample-values");
     };
 
     match subcommand {
         "render" => render_one(&args[1..]),
         "render-all" => render_all(&args[1..]),
         "validate-values" => validate_one(&args[1..]),
+        "validate-structure" => validate_structure_one(&args[1..]),
         "write-sample-values" => write_samples(&args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", tooling_usage());
             Ok(())
         }
         other => bail!(
-            "unknown prompt-template subcommand '{other}' (expected render | render-all | validate-values | write-sample-values)"
+            "unknown prompt-template subcommand '{other}' (expected render | render-all | validate-values | validate-structure | write-sample-values)"
         ),
     }
 }
@@ -67,6 +69,47 @@ fn validate_one(args: &[String]) -> Result<()> {
     let values = values.ok_or_else(|| anyhow::anyhow!("validate-values requires --values"))?;
     validate_values_file(&root, kind, &values)?;
     println!("PASS: values valid for {}", kind.key());
+    Ok(())
+}
+
+fn validate_structure_one(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+    let mut repo_root: Option<PathBuf> = None;
+    let mut kind: Option<PromptCardKind> = None;
+    let mut input: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--kind" => {
+                idx += 1;
+                kind = Some(PromptCardKind::parse_key(value_arg(args, idx, "--kind")?)?);
+            }
+            "--input" => {
+                idx += 1;
+                input = Some(PathBuf::from(value_arg(args, idx, "--input")?));
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => bail!("unknown arg for tooling prompt-template validate-structure: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = repo_root_from_arg(repo_root)?;
+    let kind = kind.ok_or_else(|| anyhow::anyhow!("validate-structure requires --kind"))?;
+    let input = input.ok_or_else(|| anyhow::anyhow!("validate-structure requires --input"))?;
+    validate_rendered_card_structure_file(&root, kind, &input)?;
+    println!("PASS: rendered structure valid for {}", kind.key());
     Ok(())
 }
 

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -162,6 +162,18 @@ fn prompt_template_cli_rejects_markdown_structure_drift() {
     let err = validate_structure_err("sip", &locked_mutation);
     assert!(err.to_string().contains("locked template text drifted"));
 
+    let sor = rendered_dir.join("sor.md");
+    let valid_sor = fs::read_to_string(&sor).expect("sor");
+    let sor_locked_mutation = repo.write_rel(
+        "sor-locked-mutation.md",
+        &valid_sor.replace(
+            "If artifacts exist only in the worktree, the task is NOT complete.",
+            "If artifacts exist only in the worktree, the task can still be complete.",
+        ),
+    );
+    let err = validate_structure_err("sor", &sor_locked_mutation);
+    assert!(err.to_string().contains("locked template text drifted"));
+
     let inserted_frontmatter = repo.write_rel(
         "frontmatter-insertion.md",
         &valid_stp.replace(

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -47,6 +47,17 @@ fn prompt_template_cli_renders_and_validates_all_five_cards_from_values() {
             values.to_string_lossy().to_string(),
         ])
         .expect("values should validate");
+        real_tooling(&[
+            "prompt-template".to_string(),
+            "validate-structure".to_string(),
+            "--repo-root".to_string(),
+            repo_root_for_tests().to_string_lossy().to_string(),
+            "--kind".to_string(),
+            kind.to_string(),
+            "--input".to_string(),
+            card.to_string_lossy().to_string(),
+        ])
+        .expect("rendered structure should validate");
 
         let mut args = vec![
             "validate-structured-prompt".to_string(),
@@ -116,6 +127,71 @@ fn prompt_template_cli_renders_one_card_and_rejects_locked_value_edits() {
 }
 
 #[test]
+fn prompt_template_cli_rejects_markdown_structure_drift() {
+    let repo = TempRepo::new("prompt-template-structure");
+    let values_dir = repo.path().join("values");
+    let rendered_dir = repo.path().join("rendered");
+    render_sample_cards_for_structure_test(&values_dir, &rendered_dir);
+
+    let stp = rendered_dir.join("stp.md");
+    let valid_stp = fs::read_to_string(&stp).expect("stp");
+
+    let missing_heading = repo.write_rel(
+        "missing-heading.md",
+        &valid_stp.replace("\n## Goal\n", "\n"),
+    );
+    let err = validate_structure_err("stp", &missing_heading);
+    assert!(err.to_string().contains("heading structure drifted"));
+
+    let reordered = repo.write_rel(
+        "reordered-heading.md",
+        &valid_stp
+            .replace("## Summary", "## TEMP_HEADING")
+            .replace("## Required Outcome", "## Summary")
+            .replace("## TEMP_HEADING", "## Required Outcome"),
+    );
+    let err = validate_structure_err("stp", &reordered);
+    assert!(err.to_string().contains("heading structure drifted"));
+
+    let sip = rendered_dir.join("sip.md");
+    let valid_sip = fs::read_to_string(&sip).expect("sip");
+    let locked_mutation = repo.write_rel(
+        "locked-mutation.md",
+        &valid_sip.replace("- Follow `AGENTS.md`.", "- Ignore `AGENTS.md`."),
+    );
+    let err = validate_structure_err("sip", &locked_mutation);
+    assert!(err.to_string().contains("locked template text drifted"));
+
+    let inserted_frontmatter = repo.write_rel(
+        "frontmatter-insertion.md",
+        &valid_stp.replace(
+            "issue_card_schema: adl.issue.v1\n",
+            "issue_card_schema: adl.issue.v1\nsurprise_field: true\n",
+        ),
+    );
+    let err = validate_structure_err("stp", &inserted_frontmatter);
+    assert!(err
+        .to_string()
+        .contains("frontmatter key inventory drifted"));
+
+    let fence_drift = repo.write_rel(
+        "fence-drift.md",
+        &valid_sip.replace("```yaml\nprompt_schema", "```\nprompt_schema"),
+    );
+    let err = validate_structure_err("sip", &fence_drift);
+    assert!(err.to_string().contains("fenced block structure drifted"));
+
+    let unresolved = repo.write_rel(
+        "unresolved-placeholder.md",
+        &valid_stp.replace("Sample C-SDLC prompt editor card.", "{{summary}}"),
+    );
+    let err = validate_structure_err("stp", &unresolved);
+    assert!(err
+        .to_string()
+        .contains("unresolved prompt-template placeholder"));
+}
+
+#[test]
 fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     let repo = TempRepo::new("prompt-template-errors");
     let values = repo.write_rel(
@@ -143,6 +219,12 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
         "--help".to_string(),
     ])
     .expect("validate-values help should succeed");
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--help".to_string(),
+    ])
+    .expect("validate-structure help should succeed");
 
     let missing = real_tooling(&["prompt-template".to_string()])
         .expect_err("missing prompt-template subcommand should fail");
@@ -202,4 +284,56 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     assert!(missing_value
         .to_string()
         .contains("missing value for --values-dir"));
+
+    let missing_input = real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "sip".to_string(),
+    ])
+    .expect_err("validate-structure requires input");
+    assert!(missing_input
+        .to_string()
+        .contains("validate-structure requires --input"));
+}
+
+fn render_sample_cards_for_structure_test(
+    values_dir: &std::path::Path,
+    rendered_dir: &std::path::Path,
+) {
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "render-all".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--values-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+        "--out-dir".to_string(),
+        rendered_dir.to_string_lossy().to_string(),
+    ])
+    .expect("render sample cards");
+}
+
+fn validate_structure_err(kind: &str, input: &std::path::Path) -> anyhow::Error {
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        kind.to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+    ])
+    .expect_err("structure drift should fail")
 }

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -517,10 +517,6 @@ impl PromptMarkdownStructure {
             {
                 continue;
             }
-            if kind == "sor" {
-                continue;
-            }
-
             let trimmed = raw_line.trim();
             if trimmed.is_empty() || contains_prompt_placeholder(raw_line) {
                 continue;
@@ -816,6 +812,7 @@ fn is_rendered_value_line(trimmed: &str) -> bool {
         "- Required outcome type:",
         "- Demo required:",
         "- Local ignored output-card scaffold at",
+        "- `bash adl/tools/validate_structured_prompt.sh",
         "Source issue-prompt slug:",
         "Required outcome type:",
         "Demo required:",

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -218,7 +218,9 @@ pub fn render_sample_card(repo_root: &Path, kind: PromptCardKind) -> Result<Stri
         .ok_or_else(|| anyhow!("missing card model for {}", kind.key()))?;
     let values = sample_values();
     validate_values(card, &values)?;
-    render_template(&card.template, &values)
+    let rendered = render_template(&card.template, &values)?;
+    validate_rendered_card_structure(card, &rendered)?;
+    Ok(rendered)
 }
 
 pub fn render_card_from_values_file(
@@ -230,7 +232,9 @@ pub fn render_card_from_values_file(
     let card = card_model(&model, kind)?;
     let values = load_values_file(card, values_path, &model.template_set)?;
     validate_values(card, &values)?;
-    render_template(&card.template, &values)
+    let rendered = render_template(&card.template, &values)?;
+    validate_rendered_card_structure(card, &rendered)?;
+    Ok(rendered)
 }
 
 pub fn validate_values_file(
@@ -242,6 +246,18 @@ pub fn validate_values_file(
     let card = card_model(&model, kind)?;
     let values = load_values_file(card, values_path, &model.template_set)?;
     validate_values(card, &values)
+}
+
+pub fn validate_rendered_card_structure_file(
+    repo_root: &Path,
+    kind: PromptCardKind,
+    rendered_path: &Path,
+) -> Result<()> {
+    let model = load_editor_model(repo_root)?;
+    let card = card_model(&model, kind)?;
+    let rendered = fs::read_to_string(rendered_path)
+        .with_context(|| format!("failed to read rendered card {}", rendered_path.display()))?;
+    validate_rendered_card_structure(card, &rendered)
 }
 
 pub fn render_all_cards_from_values_dir(
@@ -375,6 +391,454 @@ pub fn render_template(template: &str, values: &BTreeMap<String, String>) -> Res
         bail!("rendered card contains unresolved prompt-template placeholder near byte {idx}");
     }
     Ok(rendered)
+}
+
+pub fn validate_rendered_card_structure(card: &PromptCardForm, rendered: &str) -> Result<()> {
+    ensure!(
+        unresolved_placeholder_offset(rendered).is_none()
+            && unresolved_curly_placeholder_offset(rendered).is_none(),
+        "{} rendered card contains unresolved prompt-template placeholder",
+        card.key
+    );
+    let dynamic_sections = dynamic_markdown_sections(card);
+    let expected = PromptMarkdownStructure::from_text(card.key, &card.template, &dynamic_sections)?;
+    let actual = PromptMarkdownStructure::from_text(card.key, rendered, &dynamic_sections)?;
+    ensure!(
+        actual.frontmatter_keys == expected.frontmatter_keys,
+        "{} frontmatter key inventory drifted: expected {:?}, got {:?}",
+        card.key,
+        expected.frontmatter_keys,
+        actual.frontmatter_keys
+    );
+    ensure!(
+        headings_match(&expected.headings, &actual.headings),
+        "{} Markdown heading structure drifted: expected {:?}, got {:?}",
+        card.key,
+        expected.headings,
+        actual.headings
+    );
+    ensure!(
+        fenced_blocks_match(&expected.fenced_blocks, &actual.fenced_blocks),
+        "{} fenced block structure drifted: expected {:?}, got {:?}",
+        card.key,
+        expected.fenced_blocks,
+        actual.fenced_blocks
+    );
+    if !locked_lines_match(&expected.locked_lines, &actual.locked_lines) {
+        bail!(
+            "{} locked template text drifted: {}",
+            card.key,
+            locked_line_diff(&expected.locked_lines, &actual.locked_lines)
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PromptMarkdownStructure {
+    frontmatter_keys: Vec<String>,
+    headings: Vec<MarkdownHeading>,
+    fenced_blocks: Vec<FencedBlockShape>,
+    locked_lines: Vec<LockedLine>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MarkdownHeading {
+    level: usize,
+    text: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct FencedBlockShape {
+    ordinal: usize,
+    info: String,
+    heading_path: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct LockedLine {
+    heading_path: Vec<String>,
+    text: String,
+}
+
+impl PromptMarkdownStructure {
+    fn from_text(
+        kind: &str,
+        text: &str,
+        editable_sections: &BTreeSet<&'static str>,
+    ) -> Result<Self> {
+        let (frontmatter_keys, body) = split_optional_frontmatter_keys(text)?;
+        let mut headings = Vec::new();
+        let mut fenced_blocks = Vec::new();
+        let mut locked_lines = Vec::new();
+        let mut heading_stack: Vec<(usize, String)> = Vec::new();
+        let mut in_fence = false;
+        let mut fence_ordinal = 0usize;
+
+        for raw_line in body.lines() {
+            let trimmed_start = raw_line.trim_start();
+            if trimmed_start.starts_with("```") {
+                if !in_fence {
+                    fenced_blocks.push(FencedBlockShape {
+                        ordinal: fence_ordinal,
+                        info: trimmed_start.trim_start_matches("```").trim().to_string(),
+                        heading_path: heading_path(&heading_stack),
+                    });
+                    fence_ordinal += 1;
+                    in_fence = true;
+                } else {
+                    in_fence = false;
+                }
+                continue;
+            }
+            if in_fence {
+                continue;
+            }
+
+            if let Some(heading) = parse_markdown_heading(raw_line) {
+                while heading_stack
+                    .last()
+                    .is_some_and(|(level, _)| *level >= heading.level)
+                {
+                    heading_stack.pop();
+                }
+                if let Some(text) = &heading.text {
+                    heading_stack.push((heading.level, text.clone()));
+                } else {
+                    heading_stack.push((heading.level, "<dynamic-heading>".to_string()));
+                }
+                headings.push(heading);
+                continue;
+            }
+
+            if heading_stack
+                .last()
+                .is_some_and(|(_, heading)| editable_sections.contains(heading.as_str()))
+            {
+                continue;
+            }
+            if kind == "sor" {
+                continue;
+            }
+
+            let trimmed = raw_line.trim();
+            if trimmed.is_empty() || contains_prompt_placeholder(raw_line) {
+                continue;
+            }
+            if is_template_scaffold_line(trimmed) || is_rendered_value_line(trimmed) {
+                continue;
+            }
+            locked_lines.push(LockedLine {
+                heading_path: heading_path(&heading_stack),
+                text: raw_line.trim_end().to_string(),
+            });
+        }
+
+        ensure!(
+            !in_fence,
+            "{kind} rendered card has an unclosed fenced code block"
+        );
+
+        Ok(Self {
+            frontmatter_keys,
+            headings,
+            fenced_blocks,
+            locked_lines,
+        })
+    }
+}
+
+fn dynamic_markdown_sections(card: &PromptCardForm) -> BTreeSet<&'static str> {
+    let mut sections = PLACEHOLDERS
+        .iter()
+        .flat_map(|key| dynamic_field_sections(key))
+        .collect::<BTreeSet<_>>();
+    if card.kind == PromptCardKind::Stp {
+        sections.insert("Demo Expectations");
+        sections.insert("Notes");
+    }
+    sections
+}
+
+fn dynamic_field_sections(key: &str) -> Vec<&'static str> {
+    match key {
+        "summary" => vec!["Summary"],
+        "goal" => vec!["Goal"],
+        "required_outcome" => vec!["Required Outcome"],
+        "deliverables" => vec!["Deliverables"],
+        "acceptance_criteria" => vec!["Acceptance Criteria"],
+        "inputs" => vec!["Inputs"],
+        "repo_inputs" => vec!["Repo Inputs"],
+        "dependencies" => vec!["Dependencies"],
+        "target_files_surfaces" => vec!["Target Files / Surfaces"],
+        "validation_plan" => vec!["Validation Plan"],
+        "demo_proof_requirements" => vec!["Demo / Proof Requirements", "Demo Expectations"],
+        "constraints_policies" => vec!["Constraints / Policies"],
+        "system_invariants" => vec!["System Invariants (must remain true)"],
+        "reviewer_checklist" => vec!["Reviewer Checklist (machine-readable hints)"],
+        "non_goals" => vec!["Non-goals", "Non-goals / Out of scope"],
+        "issue_graph_notes" => vec!["Issue-Graph Notes"],
+        "notes_risks" => vec!["Notes / Risks", "Notes"],
+        "tooling_notes" => vec!["Tooling Notes"],
+        "plan_summary" => vec!["Plan Summary"],
+        "dependencies_inline" => vec!["Proposed Steps"],
+        "repo_inputs_inline" => vec!["Proposed Steps"],
+        "deliverables_inline" => vec!["Proposed Steps"],
+        "acceptance_criteria_inline" => vec!["Proposed Steps"],
+        "risks_inline" => vec!["Risks And Edge Cases"],
+        "validation_plan_inline" => vec!["Test Strategy"],
+        "notes_risks_inline" => vec!["Notes"],
+        "slug" => vec!["Affected Areas"],
+        "stp_card" | "sip_card" | "spp_card" | "srp_card" | "sor_card" => {
+            vec!["Scope Basis", "Policy Refs"]
+        }
+        "output_card" => vec!["Outputs"],
+        "branch_action" => vec!["Actions taken"],
+        _ => Vec::new(),
+    }
+}
+
+fn split_optional_frontmatter_keys(text: &str) -> Result<(Vec<String>, &str)> {
+    let mut lines = text.lines().collect::<Vec<_>>();
+    if lines.first().is_none_or(|line| line.trim() != "---") {
+        return Ok((Vec::new(), text));
+    }
+    let close = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim() == "---")
+        .map(|(idx, _)| idx)
+        .ok_or_else(|| anyhow!("missing YAML frontmatter closer"))?;
+    let frontmatter = lines[1..close].join("\n");
+    let keys = frontmatter_key_inventory(&frontmatter)?;
+    let body_start = text
+        .match_indices('\n')
+        .nth(close)
+        .map(|(idx, _)| idx + 1)
+        .unwrap_or(text.len());
+    lines.clear();
+    Ok((keys, &text[body_start..]))
+}
+
+fn frontmatter_key_inventory(frontmatter: &str) -> Result<Vec<String>> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(frontmatter)
+        .with_context(|| "failed to parse prompt card frontmatter")?;
+    let mut keys = Vec::new();
+    collect_yaml_key_paths(&doc, "", &mut keys)?;
+    keys.sort();
+    Ok(keys)
+}
+
+fn collect_yaml_key_paths(
+    value: &serde_yaml::Value,
+    prefix: &str,
+    out: &mut Vec<String>,
+) -> Result<()> {
+    let Some(mapping) = value.as_mapping() else {
+        return Ok(());
+    };
+    for (key, value) in mapping {
+        let key = key
+            .as_str()
+            .ok_or_else(|| anyhow!("frontmatter keys must be strings"))?;
+        let path = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        out.push(path.clone());
+        collect_yaml_key_paths(value, &path, out)?;
+    }
+    Ok(())
+}
+
+fn parse_markdown_heading(line: &str) -> Option<MarkdownHeading> {
+    let trimmed = line.trim_start();
+    let marker_len = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if !(1..=6).contains(&marker_len) {
+        return None;
+    }
+    let rest = &trimmed[marker_len..];
+    if !rest.starts_with(' ') {
+        return None;
+    }
+    Some(MarkdownHeading {
+        level: marker_len,
+        text: if contains_prompt_placeholder(rest) {
+            None
+        } else {
+            Some(rest.trim().to_string())
+        },
+    })
+}
+
+fn heading_path(stack: &[(usize, String)]) -> Vec<String> {
+    stack.iter().map(|(_, text)| text.clone()).collect()
+}
+
+fn headings_match(expected: &[MarkdownHeading], actual: &[MarkdownHeading]) -> bool {
+    expected.len() == actual.len()
+        && expected.iter().zip(actual).all(|(expected, actual)| {
+            expected.level == actual.level
+                && expected
+                    .text
+                    .as_ref()
+                    .is_none_or(|expected_text| actual.text.as_ref() == Some(expected_text))
+        })
+}
+
+fn fenced_blocks_match(expected: &[FencedBlockShape], actual: &[FencedBlockShape]) -> bool {
+    expected.len() == actual.len()
+        && expected.iter().zip(actual).all(|(expected, actual)| {
+            expected.ordinal == actual.ordinal
+                && expected.info == actual.info
+                && heading_paths_match(&expected.heading_path, &actual.heading_path)
+        })
+}
+
+fn heading_paths_match(expected: &[String], actual: &[String]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(expected, actual)| expected == "<dynamic-heading>" || expected == actual)
+}
+
+fn locked_lines_match(expected: &[LockedLine], actual: &[LockedLine]) -> bool {
+    expected.len() == actual.len()
+        && expected.iter().zip(actual).all(|(expected, actual)| {
+            expected.text == actual.text
+                && heading_paths_match(&expected.heading_path, &actual.heading_path)
+        })
+}
+
+fn locked_line_diff(expected: &[LockedLine], actual: &[LockedLine]) -> String {
+    let max = expected.len().max(actual.len());
+    for idx in 0..max {
+        match (expected.get(idx), actual.get(idx)) {
+            (Some(expected), Some(actual))
+                if expected.text != actual.text
+                    || !heading_paths_match(&expected.heading_path, &actual.heading_path) =>
+            {
+                return format!(
+                    "first drift at locked line {idx}: expected {:?}, got {:?}",
+                    expected, actual
+                );
+            }
+            (Some(expected), None) => {
+                return format!("missing locked line {idx}: expected {:?}", expected);
+            }
+            (None, Some(actual)) => {
+                return format!("unexpected locked line {idx}: got {:?}", actual);
+            }
+            _ => {}
+        }
+    }
+    "locked line inventory differs".to_string()
+}
+
+fn contains_prompt_placeholder(line: &str) -> bool {
+    PLACEHOLDERS
+        .iter()
+        .any(|key| line.contains(&format!("<{key}>")) || line.contains(&format!("{{{{{key}}}}}")))
+}
+
+fn is_template_scaffold_line(trimmed: &str) -> bool {
+    matches!(
+        trimmed,
+        "---"
+            | "```yaml"
+            | "```"
+            | "labels:"
+            | "supersedes: []"
+            | "duplicates: []"
+            | "depends_on: []"
+            | "canonical_files: []"
+            | "demo_names: []"
+            | "pr_start:"
+            | "enabled: true"
+            | "source_refs:"
+            | "scope:"
+            | "files:"
+            | "components:"
+            | "out_of_scope:"
+            | "constraints:"
+            | "assumptions:"
+            | "proposed_steps:"
+            | "codex_plan:"
+            | "affected_areas:"
+            | "invariants_to_preserve:"
+            | "risks_and_edge_cases:"
+            | "test_strategy:"
+            | "required_permissions:"
+            | "stop_conditions:"
+            | "alternatives_considered:"
+            | "review_hooks:"
+            | "review_results:"
+    ) || trimmed.starts_with("- kind:")
+        || trimmed.starts_with("kind:")
+        || trimmed.starts_with("ref:")
+        || trimmed.starts_with("- id:")
+        || trimmed.starts_with("description:")
+        || trimmed.starts_with("expected_output:")
+        || trimmed.starts_with("allowed_mode:")
+        || trimmed.starts_with("- step:")
+        || trimmed.starts_with("status:")
+        || trimmed.starts_with("- description:")
+        || trimmed.starts_with("reason_not_chosen:")
+}
+
+fn is_rendered_value_line(trimmed: &str) -> bool {
+    [
+        "Task ID:",
+        "Run ID:",
+        "Version:",
+        "Title:",
+        "Branch:",
+        "Card Status:",
+        "Status:",
+        "Generated:",
+        "- Actor:",
+        "- Model:",
+        "- Start Time:",
+        "- End Time:",
+        "- Issue:",
+        "- PR:",
+        "- Source Issue Prompt:",
+        "- Docs:",
+        "- Other:",
+        "- Agent:",
+        "- Provider:",
+        "- Tools allowed:",
+        "- Sandbox / approvals:",
+        "- Source issue-prompt slug:",
+        "- Required outcome type:",
+        "- Demo required:",
+        "- Local ignored output-card scaffold at",
+        "Source issue-prompt slug:",
+        "Required outcome type:",
+        "Demo required:",
+        "Canonical Template Source:",
+        "Generated from",
+        "name:",
+        "issue:",
+        "task_id:",
+        "run_id:",
+        "version:",
+        "title:",
+        "branch:",
+        "generated_at:",
+        "card_status:",
+        "activation_state:",
+        "plan_revision:",
+        "confidence:",
+        "plan_summary:",
+        "execution_handoff:",
+        "notes:",
+    ]
+    .iter()
+    .any(|prefix| trimmed.starts_with(prefix))
 }
 
 fn load_values_file(

--- a/adl/tools/test_csdlc_prompt_editor.sh
+++ b/adl/tools/test_csdlc_prompt_editor.sh
@@ -17,6 +17,11 @@ cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" -- tooling csdlc-prompt
 cmp "$MODEL_TMP" "$TRACKED_MODEL"
 
 for kind in sip stp spp srp sor; do
+  cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" -- tooling prompt-template \
+    validate-structure \
+    --repo-root "$ROOT" \
+    --kind "$kind" \
+    --input "$SAMPLES_DIR/$kind.md"
   bash "$ROOT/adl/tools/validate_structured_prompt.sh" \
     --type "$kind" \
     --phase bootstrap \

--- a/docs/tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md
+++ b/docs/tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md
@@ -131,17 +131,22 @@ The v0.91.5 values validator implemented by `#3553` rejects:
 - invalid issue, version, slug, and card-status values;
 - locked/system field supplied through ordinary `values`.
 
-The following validation surfaces are intentionally routed to follow-on guard
-work instead of being claimed by the `#3553` renderer:
+The following validation surfaces were intentionally routed out of `#3553`
+instead of being claimed by the values validator:
 
-- rendered Markdown structure drift;
 - host-local absolute paths or secret markers in public card output;
 - richer typed list/item schema validation beyond the current values model.
 
-Markdown structure immutability is tracked by `#3585`, which must land before
-the downstream card rewrite in `#3582`. Public artifact hygiene and redaction
-checks remain separate review/validation surfaces unless a later issue binds
-them directly to the renderer.
+Markdown structure immutability is implemented by `#3585` as a deterministic
+structure guard over frontmatter key inventory, Markdown heading order, fenced
+block shape, unresolved placeholders, and locked template prose where the card
+kind has stable prose. It deliberately uses the existing Rust-owned template
+model and lightweight Markdown structure scanner for v0.91.5 instead of adding
+a new parser dependency. `markdown-rs` or a richer LST-style parser remains a
+future option if later work needs trivia-preserving structure checks.
+
+Public artifact hygiene and redaction checks remain separate review/validation
+surfaces unless a later issue binds them directly to the renderer.
 
 Validation should fail fast with short, deterministic messages. These docs are
 small; failures should be effectively immediate.
@@ -174,6 +179,10 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template write-sample
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render-all \
   --values-dir /tmp/csdlc-prompt-values \
   --out-dir /tmp/csdlc-prompt-cards
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure \
+  --kind stp \
+  --input /tmp/csdlc-prompt-cards/stp.md
 ```
 
 The existing Markdown validator remains in use:
@@ -207,15 +216,15 @@ Compatibility rules:
 - existing `1.0.0` Markdown cards can be validated as Markdown;
 - new values-rendered cards should carry enough metadata to identify the
   template set and card kind;
-- downstream card rewrite after the renderer and AST structure guard is tracked
+- downstream card rewrite after the renderer and structure guard is tracked
   through `#3582`;
 - historical cards are not migrated in `#3553`;
 - cards with truthful lifecycle state should not be rewritten merely for style.
 
 ## Follow-On Routing
 
-This issue implements the renderer and values validator. The remaining bounded
-follow-ons are Markdown AST template immutability validation (`#3585`) and then
+This issue implements the renderer and values validator. Markdown structure
+immutability is implemented by `#3585`; the remaining bounded follow-on is
 downstream card rewrite/normalization after both guards land (`#3582`).
 
 ## Acceptance Bar For Follow-Ons
@@ -227,7 +236,7 @@ Renderer implementation is complete when:
 - values validation rejects the implemented failure modes above;
 - rendered Markdown passes existing structured prompt validation;
 - editor model is Rust-owned and can render/preview the values contract;
-- `#3585` can add structure immutability proof without redesigning the renderer;
+- `#3585` adds structure immutability proof without redesigning the renderer;
 - `#3582` can rewrite downstream v0.91.5 cards without hand-editing structure
   after the renderer and AST guard are available.
 
@@ -237,7 +246,6 @@ Renderer implementation is complete when:
 - This plan does not migrate historical cards.
 - This plan does not change C-SDLC lifecycle semantics.
 - This plan does not make browser/editor validation authoritative.
-- This plan does not claim rendered Markdown structure immutability, redaction,
-  or host-path scanning is implemented by `#3553`.
-- This plan does not close `#3585`.
+- This plan does not claim redaction or host-path scanning is implemented by
+  `#3553` or `#3585`.
 - This plan does not close `#3582`.

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -73,6 +73,9 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
 
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
   validate-values --kind sip --values /tmp/csdlc-prompt-values/sip.values.yaml
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  validate-structure --kind sip --input /tmp/csdlc-prompt-cards/sip.md
 ```
 
 Values files use:
@@ -84,6 +87,14 @@ Values files use:
 The renderer rejects unknown fields, locked fields under `values`, editable
 fields under `system`, unresolved placeholders, enum drift, and malformed
 issue/version/card-status values.
+
+The structure validator protects rendered cards from template-shape drift. It
+checks frontmatter key inventory, Markdown heading order, fenced-block shape,
+unresolved placeholders, and locked template prose where the card kind has
+stable prose. It intentionally does not add a new Markdown parser dependency in
+v0.91.5; the current guard uses the Rust-owned template model and lightweight
+Markdown structure scanner. A richer `markdown-rs` or LST-style parser remains a
+future option if later work needs whitespace/trivia-preserving validation.
 
 ## Proof Command
 


### PR DESCRIPTION
Closes #3585

## Summary
Implemented deterministic rendered-card structure validation for the v0.91.5 prompt-template values renderer. The guard validates rendered SIP, STP, SPP, SRP, and SOR cards against their Rust-owned template structure before publication or downstream card rewrite.

## Artifacts
- `adl/src/csdlc_prompt_editor.rs`: added rendered-card structure extraction and validation.
- `adl/src/cli/tooling_cmd/prompt_template.rs`: added `prompt-template validate-structure`.
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`: added positive coverage and drift-rejection tests.
- `adl/src/cli/tooling_cmd.rs`: documented the new CLI command in tooling usage.
- `adl/tools/test_csdlc_prompt_editor.sh`: added structure validation for all rendered sample cards.
- `docs/tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md`: updated scope, non-claims, and follow-on routing after `#3585`.
- `docs/tooling/csdlc-prompt-editor/README.md`: documented the new structure validator and parser boundary.

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml`
- `git diff --check`
- `cargo test --manifest-path adl/Cargo.toml cli::tooling_cmd::tests::prompt_template -- --nocapture`
- `bash adl/tools/test_csdlc_prompt_editor.sh`
- `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path adl/Cargo.toml csdlc_prompt_editor::tests -- --nocapture`
- `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- tooling_cmd`
- `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
- `adl/tools/pr.sh finish 3585 ...` publication validation ran default nextest and doc tests:
  - `cargo nextest` default profile: 2192 passed, 2 skipped, 5 slow, 0 failed
  - doc tests: 0 run, pass

## Review
Focused repo-code-review and repo-review-tests posture found no actionable findings before publication. Review boundary: no live provider calls or slow-proof lane were run for this tooling change.

## Local Artifacts
- Input card: `.adl/v0.91.5/tasks/issue-3585__v0-91-5-tools-markdown-ast-template-immutability-validation/sip.md`
- Output card: `.adl/v0.91.5/tasks/issue-3585__v0-91-5-tools-markdown-ast-template-immutability-validation/sor.md`
