### PR TITLE
[v0.91.5][WP-02][Sprint 1][tools] Externalize prompt-card schemas for markdown-rs validation

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "jsonschema",
+ "markdown",
  "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.28",
@@ -1024,6 +1025,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
 
 [[package]]
 name = "matchers"
@@ -2137,6 +2147,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -43,6 +43,7 @@ once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
+markdown = "1.0.0"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -92,7 +92,9 @@ adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
 adl tooling prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
 adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\
+adl tooling prompt-template validate-schemas [--repo-root <path>]\n\
 adl tooling prompt-template write-sample-values --out-dir <dir>\n\
+adl tooling prompt-template write-structure-schemas --out-dir <dir> [--repo-root <path>]\n\
 adl tooling validate-structured-prompt --type <sip|stp|spp|srp|sor> --input <path> [--phase <phase>]\n\
 adl tooling review-card-surface --input <input.md> --output <output.md>\n\
 adl tooling review-runtime-surface --review-root <dir>\n\

--- a/adl/src/cli/tooling_cmd/code_review_build.rs
+++ b/adl/src/cli/tooling_cmd/code_review_build.rs
@@ -85,7 +85,9 @@ pub(crate) fn changed_files(root: &Path, args: &CodeReviewArgs) -> anyhow::Resul
             .map(str::trim)
             .filter(|line| !line.is_empty())
         {
-            files.insert(validate_include_file(line)?);
+            if let Some(file) = validate_changed_file_from_git(line)? {
+                files.insert(file);
+            }
         }
     }
     if args.include_working_tree {
@@ -95,7 +97,9 @@ pub(crate) fn changed_files(root: &Path, args: &CodeReviewArgs) -> anyhow::Resul
             .map(str::trim)
             .filter(|line| !line.is_empty())
         {
-            files.insert(validate_include_file(line)?);
+            if let Some(file) = validate_changed_file_from_git(line)? {
+                files.insert(file);
+            }
         }
     }
     if !args.include_files.is_empty() {
@@ -108,6 +112,14 @@ pub(crate) fn changed_files(root: &Path, args: &CodeReviewArgs) -> anyhow::Resul
         return Ok(args.include_files.clone());
     }
     Ok(files.into_iter().collect())
+}
+
+fn validate_changed_file_from_git(raw: &str) -> anyhow::Result<Option<String>> {
+    let value = raw.trim();
+    if value.ends_with(".lock") {
+        return Ok(None);
+    }
+    validate_include_file(value).map(Some)
 }
 
 pub(crate) fn diff_hunks(

--- a/adl/src/cli/tooling_cmd/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/prompt_template.rs
@@ -1,7 +1,7 @@
 use adl::csdlc_prompt_editor::{
     render_all_cards_from_values_dir, render_card_from_values_file, repo_root_from_arg,
-    validate_rendered_card_structure_file, validate_values_file, write_all_sample_values,
-    PromptCardKind,
+    validate_rendered_card_structure_file, validate_structure_schema_files, validate_values_file,
+    write_all_sample_values, write_all_structure_schemas, PromptCardKind,
 };
 use anyhow::{bail, Result};
 use std::fs;
@@ -11,7 +11,7 @@ use super::tooling_usage;
 
 pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
-        bail!("prompt-template requires a subcommand: render | render-all | validate-values | validate-structure | write-sample-values");
+        bail!("prompt-template requires a subcommand: render | render-all | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas");
     };
 
     match subcommand {
@@ -19,13 +19,15 @@ pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
         "render-all" => render_all(&args[1..]),
         "validate-values" => validate_one(&args[1..]),
         "validate-structure" => validate_structure_one(&args[1..]),
+        "validate-schemas" => validate_schemas(&args[1..]),
         "write-sample-values" => write_samples(&args[1..]),
+        "write-structure-schemas" => write_structure_schemas(&args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", tooling_usage());
             Ok(())
         }
         other => bail!(
-            "unknown prompt-template subcommand '{other}' (expected render | render-all | validate-values | validate-structure | write-sample-values)"
+            "unknown prompt-template subcommand '{other}' (expected render | render-all | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
         ),
     }
 }
@@ -151,6 +153,35 @@ fn render_all(args: &[String]) -> Result<()> {
     Ok(())
 }
 
+fn validate_schemas(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+    let mut repo_root: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => bail!("unknown arg for tooling prompt-template validate-schemas: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = repo_root_from_arg(repo_root)?;
+    validate_structure_schema_files(&root)?;
+    println!("PASS: prompt-card structure schemas match active templates");
+    Ok(())
+}
+
 fn write_samples(args: &[String]) -> Result<()> {
     let mut out_dir: Option<PathBuf> = None;
 
@@ -174,6 +205,43 @@ fn write_samples(args: &[String]) -> Result<()> {
         out_dir.ok_or_else(|| anyhow::anyhow!("write-sample-values requires --out-dir"))?;
     write_all_sample_values(&out_dir)?;
     println!("PASS: wrote sample prompt values to {}", out_dir.display());
+    Ok(())
+}
+
+fn write_structure_schemas(args: &[String]) -> Result<()> {
+    let mut repo_root: Option<PathBuf> = None;
+    let mut out_dir: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--out-dir" => {
+                idx += 1;
+                out_dir = Some(PathBuf::from(value_arg(args, idx, "--out-dir")?));
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => {
+                bail!("unknown arg for tooling prompt-template write-structure-schemas: {other}")
+            }
+        }
+        idx += 1;
+    }
+
+    let out_dir =
+        out_dir.ok_or_else(|| anyhow::anyhow!("write-structure-schemas requires --out-dir"))?;
+    let root = repo_root_from_arg(repo_root)?;
+    write_all_structure_schemas(&root, &out_dir)?;
+    println!(
+        "PASS: wrote prompt-card structure schemas to {}",
+        out_dir.display()
+    );
     Ok(())
 }
 

--- a/adl/src/cli/tooling_cmd/tests/code_review.rs
+++ b/adl/src/cli/tooling_cmd/tests/code_review.rs
@@ -332,6 +332,40 @@ fn code_review_build_changed_files_accepts_file_filter_inside_changed_set() {
 }
 
 #[test]
+fn code_review_build_changed_files_skips_lockfiles_from_automatic_inventory() {
+    let root = init_temp_git_repo("changed-files-lockfile");
+    let source_path = root.join("src/sample.rs");
+    let lock_path = root.join("Cargo.lock");
+    std::fs::create_dir_all(source_path.parent().expect("source parent"))
+        .expect("create source parent");
+    std::fs::write(&source_path, "fn sample() { println!(\"v1\"); }\n")
+        .expect("write initial source");
+    std::fs::write(&lock_path, "# lock v1\n").expect("write initial lockfile");
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&root)
+        .output()
+        .expect("git add initial");
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&root)
+        .output()
+        .expect("git commit initial");
+    std::fs::write(&source_path, "fn sample() { println!(\"v2\"); }\n")
+        .expect("write changed source");
+    std::fs::write(&lock_path, "# lock v2\n").expect("write changed lockfile");
+
+    let mut args = test_args();
+    args.base_ref = "HEAD".to_string();
+    args.head_ref = "HEAD".to_string();
+    args.include_working_tree = true;
+
+    let files = changed_files(&root, &args).expect("changed file inventory should pass");
+    assert_eq!(files, vec!["src/sample.rs".to_string()]);
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn code_review_build_changed_files_rejects_file_filter_outside_changed_set() {
     let root = init_temp_git_repo_with_changed_file(
         "changed-files-reject",

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -72,6 +72,14 @@ fn prompt_template_cli_renders_and_validates_all_five_cards_from_values() {
         }
         real_tooling(&args).expect("rendered card should pass markdown validator");
     }
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-schemas".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+    ])
+    .expect("tracked structure schemas should match active templates");
 }
 
 #[test]
@@ -286,6 +294,15 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     assert!(missing_out_dir
         .to_string()
         .contains("write-sample-values requires --out-dir"));
+
+    let missing_schema_out_dir = real_tooling(&[
+        "prompt-template".to_string(),
+        "write-structure-schemas".to_string(),
+    ])
+    .expect_err("write-structure-schemas requires out dir");
+    assert!(missing_schema_out_dir
+        .to_string()
+        .contains("write-structure-schemas requires --out-dir"));
 
     let missing_value = real_tooling(&[
         "prompt-template".to_string(),

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, ensure, Context, Result};
+use markdown::{mdast::Node, ParseOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -149,6 +150,7 @@ pub struct PromptCardForm {
     pub label: &'static str,
     pub output_file: &'static str,
     pub template_path: String,
+    pub structure_schema_path: String,
     pub fields: Vec<PromptField>,
     pub template: String,
 }
@@ -171,6 +173,7 @@ struct Registry {
 #[derive(Debug, Deserialize)]
 struct RegistryTemplate {
     path: String,
+    structure_schema_path: Option<String>,
 }
 
 pub fn load_editor_model(repo_root: &Path) -> Result<PromptEditorModel> {
@@ -195,6 +198,9 @@ pub fn load_editor_model(repo_root: &Path) -> Result<PromptEditorModel> {
             label: kind.label(),
             output_file: kind.output_file(),
             template_path: template.path.clone(),
+            structure_schema_path: template.structure_schema_path.clone().unwrap_or_else(|| {
+                default_structure_schema_path(&registry.csdlc_prompt_template_set, kind)
+            }),
             fields: form_fields(kind),
             template: template_text,
         });
@@ -219,7 +225,7 @@ pub fn render_sample_card(repo_root: &Path, kind: PromptCardKind) -> Result<Stri
     let values = sample_values();
     validate_values(card, &values)?;
     let rendered = render_template(&card.template, &values)?;
-    validate_rendered_card_structure(card, &rendered)?;
+    validate_rendered_card_structure_from_repo(repo_root, card, &rendered)?;
     Ok(rendered)
 }
 
@@ -233,7 +239,7 @@ pub fn render_card_from_values_file(
     let values = load_values_file(card, values_path, &model.template_set)?;
     validate_values(card, &values)?;
     let rendered = render_template(&card.template, &values)?;
-    validate_rendered_card_structure(card, &rendered)?;
+    validate_rendered_card_structure_from_repo(repo_root, card, &rendered)?;
     Ok(rendered)
 }
 
@@ -257,7 +263,37 @@ pub fn validate_rendered_card_structure_file(
     let card = card_model(&model, kind)?;
     let rendered = fs::read_to_string(rendered_path)
         .with_context(|| format!("failed to read rendered card {}", rendered_path.display()))?;
-    validate_rendered_card_structure(card, &rendered)
+    validate_rendered_card_structure_from_repo(repo_root, card, &rendered)
+}
+
+pub fn write_all_structure_schemas(repo_root: &Path, out_dir: &Path) -> Result<()> {
+    let model = load_editor_model(repo_root)?;
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    for card in &model.cards {
+        let schema = build_structure_schema(&model.template_set, card)?;
+        let text = serde_json::to_string_pretty(&schema)?;
+        fs::write(
+            out_dir.join(format!("{}.structure.json", card.key)),
+            format!("{text}\n"),
+        )
+        .with_context(|| format!("failed to write {} structure schema", card.key))?;
+    }
+    Ok(())
+}
+
+pub fn validate_structure_schema_files(repo_root: &Path) -> Result<()> {
+    let model = load_editor_model(repo_root)?;
+    for card in &model.cards {
+        let expected = build_structure_schema(&model.template_set, card)?;
+        let actual = load_structure_schema(repo_root, card)?;
+        ensure!(
+            actual == expected,
+            "{} structure schema does not match active template extraction",
+            card.key
+        );
+    }
+    Ok(())
 }
 
 pub fn render_all_cards_from_values_dir(
@@ -393,45 +429,90 @@ pub fn render_template(template: &str, values: &BTreeMap<String, String>) -> Res
     Ok(rendered)
 }
 
-pub fn validate_rendered_card_structure(card: &PromptCardForm, rendered: &str) -> Result<()> {
+pub fn validate_rendered_card_structure_from_repo(
+    repo_root: &Path,
+    card: &PromptCardForm,
+    rendered: &str,
+) -> Result<()> {
     ensure!(
         unresolved_placeholder_offset(rendered).is_none()
             && unresolved_curly_placeholder_offset(rendered).is_none(),
         "{} rendered card contains unresolved prompt-template placeholder",
         card.key
     );
-    let dynamic_sections = dynamic_markdown_sections(card);
-    let expected = PromptMarkdownStructure::from_text(card.key, &card.template, &dynamic_sections)?;
-    let actual = PromptMarkdownStructure::from_text(card.key, rendered, &dynamic_sections)?;
+    let schema = load_structure_schema(repo_root, card)?;
+    validate_rendered_card_structure_with_schema(card, rendered, &schema)
+}
+
+pub fn validate_rendered_card_structure(card: &PromptCardForm, rendered: &str) -> Result<()> {
+    let schema = build_structure_schema("inline", card)?;
+    validate_rendered_card_structure_with_schema(card, rendered, &schema)
+}
+
+fn validate_rendered_card_structure_with_schema(
+    card: &PromptCardForm,
+    rendered: &str,
+    schema: &PromptCardStructureSchema,
+) -> Result<()> {
     ensure!(
-        actual.frontmatter_keys == expected.frontmatter_keys,
+        schema.card_kind == card.key,
+        "{} structure schema card_kind mismatch: {}",
+        card.key,
+        schema.card_kind
+    );
+    ensure!(
+        schema.template_path == card.template_path,
+        "{} structure schema template_path mismatch: {}",
+        card.key,
+        schema.template_path
+    );
+    let actual = PromptMarkdownStructure::from_text(card.key, rendered, schema)?;
+    ensure!(
+        actual.frontmatter_keys == schema.frontmatter_keys,
         "{} frontmatter key inventory drifted: expected {:?}, got {:?}",
         card.key,
-        expected.frontmatter_keys,
+        schema.frontmatter_keys,
         actual.frontmatter_keys
     );
     ensure!(
-        headings_match(&expected.headings, &actual.headings),
+        headings_match(&schema.headings, &actual.headings),
         "{} Markdown heading structure drifted: expected {:?}, got {:?}",
         card.key,
-        expected.headings,
+        schema.headings,
         actual.headings
     );
     ensure!(
-        fenced_blocks_match(&expected.fenced_blocks, &actual.fenced_blocks),
+        fenced_blocks_match(&schema.fenced_blocks, &actual.fenced_blocks),
         "{} fenced block structure drifted: expected {:?}, got {:?}",
         card.key,
-        expected.fenced_blocks,
+        schema.fenced_blocks,
         actual.fenced_blocks
     );
-    if !locked_lines_match(&expected.locked_lines, &actual.locked_lines) {
+    if !locked_lines_match(&schema.locked_lines, &actual.locked_lines) {
         bail!(
             "{} locked template text drifted: {}",
             card.key,
-            locked_line_diff(&expected.locked_lines, &actual.locked_lines)
+            locked_line_diff(&schema.locked_lines, &actual.locked_lines)
         );
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct PromptCardStructureSchema {
+    schema: String,
+    template_set: String,
+    card_kind: String,
+    template_path: String,
+    parser: String,
+    editable_sections: Vec<String>,
+    scaffold_lines: Vec<String>,
+    scaffold_line_prefixes: Vec<String>,
+    rendered_value_line_prefixes: Vec<String>,
+    frontmatter_keys: Vec<String>,
+    headings: Vec<MarkdownHeading>,
+    fenced_blocks: Vec<FencedBlockShape>,
+    locked_lines: Vec<LockedLine>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -442,53 +523,38 @@ struct PromptMarkdownStructure {
     locked_lines: Vec<LockedLine>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct MarkdownHeading {
     level: usize,
     text: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct FencedBlockShape {
     ordinal: usize,
     info: String,
     heading_path: Vec<String>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct LockedLine {
     heading_path: Vec<String>,
     text: String,
 }
 
 impl PromptMarkdownStructure {
-    fn from_text(
-        kind: &str,
-        text: &str,
-        editable_sections: &BTreeSet<&'static str>,
-    ) -> Result<Self> {
+    fn from_text(kind: &str, text: &str, schema: &PromptCardStructureSchema) -> Result<Self> {
         let (frontmatter_keys, body) = split_optional_frontmatter_keys(text)?;
-        let mut headings = Vec::new();
-        let mut fenced_blocks = Vec::new();
+        let (headings, fenced_blocks) = markdown_ast_structure(kind, body)?;
         let mut locked_lines = Vec::new();
         let mut heading_stack: Vec<(usize, String)> = Vec::new();
         let mut in_fence = false;
-        let mut fence_ordinal = 0usize;
+        let editable_sections = schema.editable_sections.iter().collect::<BTreeSet<_>>();
 
         for raw_line in body.lines() {
             let trimmed_start = raw_line.trim_start();
             if trimmed_start.starts_with("```") {
-                if !in_fence {
-                    fenced_blocks.push(FencedBlockShape {
-                        ordinal: fence_ordinal,
-                        info: trimmed_start.trim_start_matches("```").trim().to_string(),
-                        heading_path: heading_path(&heading_stack),
-                    });
-                    fence_ordinal += 1;
-                    in_fence = true;
-                } else {
-                    in_fence = false;
-                }
+                in_fence = !in_fence;
                 continue;
             }
             if in_fence {
@@ -507,13 +573,12 @@ impl PromptMarkdownStructure {
                 } else {
                     heading_stack.push((heading.level, "<dynamic-heading>".to_string()));
                 }
-                headings.push(heading);
                 continue;
             }
 
             if heading_stack
                 .last()
-                .is_some_and(|(_, heading)| editable_sections.contains(heading.as_str()))
+                .is_some_and(|(_, heading)| editable_sections.contains(heading))
             {
                 continue;
             }
@@ -521,7 +586,8 @@ impl PromptMarkdownStructure {
             if trimmed.is_empty() || contains_prompt_placeholder(raw_line) {
                 continue;
             }
-            if is_template_scaffold_line(trimmed) || is_rendered_value_line(trimmed) {
+            if is_template_scaffold_line(trimmed, schema) || is_rendered_value_line(trimmed, schema)
+            {
                 continue;
             }
             locked_lines.push(LockedLine {
@@ -542,6 +608,79 @@ impl PromptMarkdownStructure {
             locked_lines,
         })
     }
+}
+
+fn build_structure_schema(
+    template_set: &str,
+    card: &PromptCardForm,
+) -> Result<PromptCardStructureSchema> {
+    let mut schema = PromptCardStructureSchema {
+        schema: "adl.csdlc.prompt_card_structure.v1".to_string(),
+        template_set: template_set.to_string(),
+        card_kind: card.key.to_string(),
+        template_path: card.template_path.clone(),
+        parser: "markdown-rs 1.0.0".to_string(),
+        editable_sections: dynamic_markdown_sections(card)
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        scaffold_lines: TEMPLATE_SCAFFOLD_LINES
+            .iter()
+            .map(|line| line.to_string())
+            .collect(),
+        scaffold_line_prefixes: TEMPLATE_SCAFFOLD_PREFIXES
+            .iter()
+            .map(|line| line.to_string())
+            .collect(),
+        rendered_value_line_prefixes: RENDERED_VALUE_LINE_PREFIXES
+            .iter()
+            .map(|line| line.to_string())
+            .collect(),
+        frontmatter_keys: Vec::new(),
+        headings: Vec::new(),
+        fenced_blocks: Vec::new(),
+        locked_lines: Vec::new(),
+    };
+    let structure = PromptMarkdownStructure::from_text(card.key, &card.template, &schema)?;
+    schema.frontmatter_keys = structure.frontmatter_keys;
+    schema.headings = structure.headings;
+    schema.fenced_blocks = structure.fenced_blocks;
+    schema.locked_lines = structure.locked_lines;
+    Ok(schema)
+}
+
+fn load_structure_schema(
+    repo_root: &Path,
+    card: &PromptCardForm,
+) -> Result<PromptCardStructureSchema> {
+    let path = repo_root.join(&card.structure_schema_path);
+    let raw = fs::read_to_string(&path).with_context(|| {
+        format!(
+            "failed to read prompt-card structure schema {}",
+            path.display()
+        )
+    })?;
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("json") => serde_json::from_str(&raw).with_context(|| {
+            format!(
+                "failed to parse prompt-card structure schema {}",
+                path.display()
+            )
+        }),
+        _ => serde_yaml::from_str(&raw).with_context(|| {
+            format!(
+                "failed to parse prompt-card structure schema {}",
+                path.display()
+            )
+        }),
+    }
+}
+
+fn default_structure_schema_path(template_set: &str, kind: PromptCardKind) -> String {
+    format!(
+        "docs/templates/prompts/{template_set}/schemas/{}.structure.json",
+        kind.key()
+    )
 }
 
 fn dynamic_markdown_sections(card: &PromptCardForm) -> BTreeSet<&'static str> {
@@ -673,6 +812,108 @@ fn heading_path(stack: &[(usize, String)]) -> Vec<String> {
     stack.iter().map(|(_, text)| text.clone()).collect()
 }
 
+fn markdown_ast_structure(
+    kind: &str,
+    body: &str,
+) -> Result<(Vec<MarkdownHeading>, Vec<FencedBlockShape>)> {
+    let ast = markdown::to_mdast(body, &ParseOptions::default())
+        .map_err(|err| anyhow!("{kind} markdown-rs AST parse failed: {err}"))?;
+    let mut headings = Vec::new();
+    let mut fenced_blocks = Vec::new();
+    let mut heading_stack: Vec<(usize, String)> = Vec::new();
+    let mut fence_ordinal = 0usize;
+    collect_markdown_ast_structure(
+        &ast,
+        &mut heading_stack,
+        &mut headings,
+        &mut fenced_blocks,
+        &mut fence_ordinal,
+    );
+    Ok((headings, fenced_blocks))
+}
+
+fn collect_markdown_ast_structure(
+    node: &Node,
+    heading_stack: &mut Vec<(usize, String)>,
+    headings: &mut Vec<MarkdownHeading>,
+    fenced_blocks: &mut Vec<FencedBlockShape>,
+    fence_ordinal: &mut usize,
+) {
+    match node {
+        Node::Root(root) => {
+            for child in &root.children {
+                collect_markdown_ast_structure(
+                    child,
+                    heading_stack,
+                    headings,
+                    fenced_blocks,
+                    fence_ordinal,
+                );
+            }
+        }
+        Node::Heading(heading) => {
+            let level = usize::from(heading.depth);
+            let text = children_plain_text(&heading.children);
+            while heading_stack
+                .last()
+                .is_some_and(|(stack_level, _)| *stack_level >= level)
+            {
+                heading_stack.pop();
+            }
+            let heading = MarkdownHeading {
+                level,
+                text: if text.trim().is_empty() || contains_prompt_placeholder(&text) {
+                    None
+                } else {
+                    Some(text.trim().to_string())
+                },
+            };
+            if let Some(text) = &heading.text {
+                heading_stack.push((heading.level, text.clone()));
+            } else {
+                heading_stack.push((heading.level, "<dynamic-heading>".to_string()));
+            }
+            headings.push(heading);
+        }
+        Node::Code(code) => {
+            fenced_blocks.push(FencedBlockShape {
+                ordinal: *fence_ordinal,
+                info: code.lang.clone().unwrap_or_default(),
+                heading_path: heading_path(heading_stack),
+            });
+            *fence_ordinal += 1;
+        }
+        _ => {
+            if let Some(children) = node.children() {
+                for child in children {
+                    collect_markdown_ast_structure(
+                        child,
+                        heading_stack,
+                        headings,
+                        fenced_blocks,
+                        fence_ordinal,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn children_plain_text(children: &[Node]) -> String {
+    children.iter().map(node_plain_text).collect::<String>()
+}
+
+fn node_plain_text(node: &Node) -> String {
+    match node {
+        Node::Text(text) => text.value.clone(),
+        Node::InlineCode(code) => code.value.clone(),
+        Node::InlineMath(math) => math.value.clone(),
+        _ => node.children().map_or_else(String::new, |children| {
+            children.iter().map(node_plain_text).collect::<String>()
+        }),
+    }
+}
+
 fn headings_match(expected: &[MarkdownHeading], actual: &[MarkdownHeading]) -> bool {
     expected.len() == actual.len()
         && expected.iter().zip(actual).all(|(expected, actual)| {
@@ -740,102 +981,114 @@ fn contains_prompt_placeholder(line: &str) -> bool {
         .any(|key| line.contains(&format!("<{key}>")) || line.contains(&format!("{{{{{key}}}}}")))
 }
 
-fn is_template_scaffold_line(trimmed: &str) -> bool {
-    matches!(
-        trimmed,
-        "---"
-            | "```yaml"
-            | "```"
-            | "labels:"
-            | "supersedes: []"
-            | "duplicates: []"
-            | "depends_on: []"
-            | "canonical_files: []"
-            | "demo_names: []"
-            | "pr_start:"
-            | "enabled: true"
-            | "source_refs:"
-            | "scope:"
-            | "files:"
-            | "components:"
-            | "out_of_scope:"
-            | "constraints:"
-            | "assumptions:"
-            | "proposed_steps:"
-            | "codex_plan:"
-            | "affected_areas:"
-            | "invariants_to_preserve:"
-            | "risks_and_edge_cases:"
-            | "test_strategy:"
-            | "required_permissions:"
-            | "stop_conditions:"
-            | "alternatives_considered:"
-            | "review_hooks:"
-            | "review_results:"
-    ) || trimmed.starts_with("- kind:")
-        || trimmed.starts_with("kind:")
-        || trimmed.starts_with("ref:")
-        || trimmed.starts_with("- id:")
-        || trimmed.starts_with("description:")
-        || trimmed.starts_with("expected_output:")
-        || trimmed.starts_with("allowed_mode:")
-        || trimmed.starts_with("- step:")
-        || trimmed.starts_with("status:")
-        || trimmed.starts_with("- description:")
-        || trimmed.starts_with("reason_not_chosen:")
+const TEMPLATE_SCAFFOLD_LINES: &[&str] = &[
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:",
+];
+
+const TEMPLATE_SCAFFOLD_PREFIXES: &[&str] = &[
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:",
+];
+
+const RENDERED_VALUE_LINE_PREFIXES: &[&str] = &[
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:",
+];
+
+fn is_template_scaffold_line(trimmed: &str, schema: &PromptCardStructureSchema) -> bool {
+    schema.scaffold_lines.iter().any(|line| line == trimmed)
+        || schema
+            .scaffold_line_prefixes
+            .iter()
+            .any(|prefix| trimmed.starts_with(prefix))
 }
 
-fn is_rendered_value_line(trimmed: &str) -> bool {
-    [
-        "Task ID:",
-        "Run ID:",
-        "Version:",
-        "Title:",
-        "Branch:",
-        "Card Status:",
-        "Status:",
-        "Generated:",
-        "- Actor:",
-        "- Model:",
-        "- Start Time:",
-        "- End Time:",
-        "- Issue:",
-        "- PR:",
-        "- Source Issue Prompt:",
-        "- Docs:",
-        "- Other:",
-        "- Agent:",
-        "- Provider:",
-        "- Tools allowed:",
-        "- Sandbox / approvals:",
-        "- Source issue-prompt slug:",
-        "- Required outcome type:",
-        "- Demo required:",
-        "- Local ignored output-card scaffold at",
-        "- `bash adl/tools/validate_structured_prompt.sh",
-        "Source issue-prompt slug:",
-        "Required outcome type:",
-        "Demo required:",
-        "Canonical Template Source:",
-        "Generated from",
-        "name:",
-        "issue:",
-        "task_id:",
-        "run_id:",
-        "version:",
-        "title:",
-        "branch:",
-        "generated_at:",
-        "card_status:",
-        "activation_state:",
-        "plan_revision:",
-        "confidence:",
-        "plan_summary:",
-        "execution_handoff:",
-        "notes:",
-    ]
-    .iter()
-    .any(|prefix| trimmed.starts_with(prefix))
+fn is_rendered_value_line(trimmed: &str, schema: &PromptCardStructureSchema) -> bool {
+    schema
+        .rendered_value_line_prefixes
+        .iter()
+        .any(|prefix| trimmed.starts_with(prefix))
 }
 
 fn load_values_file(

--- a/adl/tools/test_csdlc_prompt_editor.sh
+++ b/adl/tools/test_csdlc_prompt_editor.sh
@@ -16,6 +16,11 @@ cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" -- tooling csdlc-prompt
 
 cmp "$MODEL_TMP" "$TRACKED_MODEL"
 
+cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" -- tooling prompt-template \
+  validate-schemas \
+  --repo-root "$ROOT"
+python3 "$ROOT/adl/tools/test_prompt_template_structure_schemas.py"
+
 for kind in sip stp spp srp sor; do
   cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" -- tooling prompt-template \
     validate-structure \

--- a/adl/tools/test_prompt_template_structure_schemas.py
+++ b/adl/tools/test_prompt_template_structure_schemas.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Fast stdlib smoke test for versioned prompt-card structure schemas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = REPO_ROOT / "docs/templates/prompts/current.json"
+EXPECTED_KINDS = ["sip", "stp", "spp", "srp", "sor"]
+SCHEMA_ID = "adl.csdlc.prompt_card_structure.v1"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        fail(f"missing {path.relative_to(REPO_ROOT)}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path.relative_to(REPO_ROOT)}: {exc}")
+
+
+def require_list(schema: dict, key: str, kind: str) -> list:
+    value = schema.get(key)
+    if not isinstance(value, list):
+        fail(f"{kind} schema field {key!r} must be a list")
+    return value
+
+
+def main() -> None:
+    registry = load_json(REGISTRY_PATH)
+    template_set = registry.get("csdlc_prompt_template_set")
+    templates = registry.get("templates")
+    if not isinstance(template_set, str) or not template_set:
+        fail("registry must declare csdlc_prompt_template_set")
+    if not isinstance(templates, dict):
+        fail("registry templates must be an object")
+
+    missing = [kind for kind in EXPECTED_KINDS if kind not in templates]
+    if missing:
+        fail(f"registry missing template entries: {', '.join(missing)}")
+
+    for kind in EXPECTED_KINDS:
+        entry = templates[kind]
+        schema_rel = entry.get("structure_schema_path")
+        template_rel = entry.get("path")
+        if not isinstance(schema_rel, str) or not schema_rel.endswith(".json"):
+            fail(f"{kind} structure_schema_path must point at a JSON artifact")
+        if not isinstance(template_rel, str) or not template_rel:
+            fail(f"{kind} template path must be present")
+
+        schema = load_json(REPO_ROOT / schema_rel)
+        if schema.get("schema") != SCHEMA_ID:
+            fail(f"{kind} schema id mismatch")
+        if schema.get("template_set") != template_set:
+            fail(f"{kind} template_set mismatch")
+        if schema.get("card_kind") != kind:
+            fail(f"{kind} card_kind mismatch")
+        if schema.get("template_path") != template_rel:
+            fail(f"{kind} template_path mismatch")
+        if "markdown-rs" not in str(schema.get("parser", "")):
+            fail(f"{kind} parser must record markdown-rs extraction")
+
+        for key in [
+            "editable_sections",
+            "frontmatter_keys",
+            "headings",
+            "fenced_blocks",
+            "locked_lines",
+        ]:
+            require_list(schema, key, kind)
+
+        if not schema["headings"]:
+            fail(f"{kind} schema must record Markdown headings")
+
+    print("PASS: prompt-card structure schema artifacts are Python-readable")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/templates/prompts/1.0.0/schemas/sip.structure.json
+++ b/docs/templates/prompts/1.0.0/schemas/sip.structure.json
@@ -1,0 +1,554 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.0",
+  "card_kind": "sip",
+  "template_path": "docs/templates/prompts/1.0.0/sip.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [],
+  "headings": [
+    {
+      "level": 1,
+      "text": "ADL Input Card"
+    },
+    {
+      "level": 2,
+      "text": "Agent Execution Rules"
+    },
+    {
+      "level": 2,
+      "text": "Lifecycle Semantics"
+    },
+    {
+      "level": 2,
+      "text": "Prompt Spec"
+    },
+    {
+      "level": 2,
+      "text": "Execution"
+    },
+    {
+      "level": 2,
+      "text": "Goal"
+    },
+    {
+      "level": 2,
+      "text": "Required Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Acceptance Criteria"
+    },
+    {
+      "level": 2,
+      "text": "Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Target Files / Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Validation Plan"
+    },
+    {
+      "level": 2,
+      "text": "Demo / Proof Requirements"
+    },
+    {
+      "level": 2,
+      "text": "Constraints / Policies"
+    },
+    {
+      "level": 2,
+      "text": "System Invariants (must remain true)"
+    },
+    {
+      "level": 2,
+      "text": "Reviewer Checklist (machine-readable hints)"
+    },
+    {
+      "level": 2,
+      "text": "Card Automation Hooks (prompt generation)"
+    },
+    {
+      "level": 2,
+      "text": "Non-goals / Out of scope"
+    },
+    {
+      "level": 2,
+      "text": "Notes / Risks"
+    },
+    {
+      "level": 2,
+      "text": "Instructions to the Agent"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "ADL Input Card",
+        "Prompt Spec"
+      ]
+    },
+    {
+      "ordinal": 1,
+      "info": "yaml",
+      "heading_path": [
+        "ADL Input Card",
+        "Reviewer Checklist (machine-readable hints)"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "ADL Input Card"
+      ],
+      "text": "Semantic role: Structured Issue Prompt (`SIP`)."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card"
+      ],
+      "text": "Context:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- This issue is not started yet; do not assume a branch or worktree already exists."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not run `pr start`; use the current issue-mode `pr run` flow only if execution later becomes necessary."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not delete or recreate cards."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not switch branches unless explicitly instructed."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not work on `main`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Only modify files required for the issue."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Use repository-relative paths; avoid absolute host paths."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Write the output record to the paired local task bundle `sor.md` path."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- If repository state is unexpected, stop and ask before attempting repository repair."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Lifecycle stage: `SIP`"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Activation state: active after issue-intent review."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Next stage: `STP`, where the selected task or solution is made explicit."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Legacy compatibility: older references may call this an input card, but new"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "  issue work should treat it as the Structured Issue Prompt."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Follow `AGENTS.md`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Use workflow-conductor for lifecycle routing."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Edit cards only with editor skills."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Work only in the bound issue worktree after `pr run`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Keep validation focused on the touched surface."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Deterministic execution for identical inputs."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- No hidden state or undeclared side effects."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Artifacts remain replay-compatible with the replay runner."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Artifact schema changes are explicit and approved."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "- Prompt source fields:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Goal"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Required Outcome"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Acceptance Criteria"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Inputs"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Target Files / Surfaces"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Validation Plan"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Demo / Proof Requirements"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Constraints / Policies"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - System Invariants"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Reviewer Checklist"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "- Generation requirements:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Deterministic output for identical SIP content"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - No secrets, tokens, or absolute host paths in generated prompt text"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Preserve traceability back to the source issue prompt"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Preserve explicit required-outcome and demo/proof requirements"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Read this file."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Read the linked source issue prompt before starting work."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Do not create a branch or worktree from this card alone."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- When execution is approved, run the repo-native issue-mode `pr run` flow and then perform the work described above."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Write execution outcome truth to the paired `sor.md` file during execution."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.0/schemas/sor.structure.json
+++ b/docs/templates/prompts/1.0.0/schemas/sor.structure.json
@@ -1,0 +1,581 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.0",
+  "card_kind": "sor",
+  "template_path": "docs/templates/prompts/1.0.0/sor.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [],
+  "headings": [
+    {
+      "level": 1,
+      "text": null
+    },
+    {
+      "level": 2,
+      "text": "Summary"
+    },
+    {
+      "level": 2,
+      "text": "Artifacts produced"
+    },
+    {
+      "level": 2,
+      "text": "Actions taken"
+    },
+    {
+      "level": 2,
+      "text": "Main Repo Integration (REQUIRED)"
+    },
+    {
+      "level": 2,
+      "text": "Validation"
+    },
+    {
+      "level": 2,
+      "text": "Verification Summary"
+    },
+    {
+      "level": 2,
+      "text": "Determinism Evidence"
+    },
+    {
+      "level": 2,
+      "text": "Security / Privacy Checks"
+    },
+    {
+      "level": 2,
+      "text": "Replay Artifacts"
+    },
+    {
+      "level": 2,
+      "text": "Artifact Verification"
+    },
+    {
+      "level": 2,
+      "text": "Decisions / Deviations"
+    },
+    {
+      "level": 2,
+      "text": "Follow-ups / Deferred work"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "<dynamic-heading>",
+        "Verification Summary"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "Execution Record Requirements:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- The output card is a machine-auditable execution record."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- Every command listed must include both what was run and what it verified."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- If something is not applicable, include a one-line justification."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "Execution:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifacts produced"
+      ],
+      "text": "- Tracked implementation artifacts: not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Main-repo paths updated: none"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Worktree-only paths remaining: no tracked implementation artifacts exist yet; execution-time proof surfaces will be established during implementation and PR publication"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Integration state: worktree_only"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Verification scope: main_repo"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Integration method used: local ignored card-bundle scaffold write under the active checkout; tracked implementation artifacts do not exist yet"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Verification performed:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "    Verified bootstrap SOR contract compliance for the local pre-run scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Result: PASS"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "Rules:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Final artifacts must exist in the main repository, not only in a worktree."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Prefer git-aware transfer into the main repo (`git checkout BRANCH -- PATH` or commit + cherry-pick)."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- If artifacts exist only in the worktree, the task is NOT complete."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `Verification scope` describes where the verification commands were run."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `worktree_only` means at least one required path still exists only outside the main repository path."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Completed output records must not leave `Status` as `NOT_STARTED`."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure)."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Validation commands and their purpose:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "    Verified bootstrap SOR contract compliance for the local output scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Results:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "  - PASS"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "Validation command/path rules:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Prefer repository-relative paths in recorded commands and artifact references."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Do not record absolute host paths in output records unless they are explicitly required and justified."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Do not list commands without describing their effect."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Determinism tests executed: not_run; bootstrap scaffold creation has not been replay-verified for this issue yet."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Fixtures or scripts used: `adl/tools/pr.sh` issue-wave opening flow."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Replay verification (same inputs -> same artifacts/order): not yet verified for this specific issue record."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Ordering guarantees (sorting / tie-break rules used): not_applicable for a single-card bootstrap write."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Artifact stability notes: repository-relative paths only; execution-time proof artifacts are not expected yet."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Secret leakage scan performed: limited content review only; no secrets were intentionally recorded in the scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Prompt / tool argument redaction verified: not_applicable for bootstrap scaffold generation."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Absolute path leakage check: repository-relative paths only in the scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Sandbox / policy invariants preserved: yes; local ignored issue-record path only."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Trace bundle path(s): not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Run artifact root: not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Replay command used for verification: not_run"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Replay result: NOT_RUN"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Primary proof surface: this local pre-run SOR scaffold and its bootstrap validation result"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Required artifacts present: local output card scaffold only; tracked implementation artifacts are not expected yet"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Artifact schema/version checks: bootstrap SOR validator passed"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Hash/byte-stability checks: not_run"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Missing/optional artifacts and rationale: execution proofs, demos, and tracked outputs are intentionally absent before implementation begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Decisions / Deviations"
+      ],
+      "text": "- Issue-wave opening emits a truthful pre-run SOR scaffold instead of leaving raw template residue for later cleanup."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Decisions / Deviations"
+      ],
+      "text": "- Integration state remains `worktree_only` until execution creates tracked artifacts or opens a PR."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Follow-ups / Deferred work"
+      ],
+      "text": "- Update this record during execution with actual actions, validations, proof surfaces, and integration truth."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Follow-ups / Deferred work"
+      ],
+      "text": "- Normalize this record to `pr_open`, `merged`, or `closed_no_pr` during finish/closeout as appropriate."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.0/schemas/spp.structure.json
+++ b/docs/templates/prompts/1.0.0/schemas/spp.structure.json
@@ -1,0 +1,302 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.0",
+  "card_kind": "spp",
+  "template_path": "docs/templates/prompts/1.0.0/spp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [
+    "activation_state",
+    "affected_areas",
+    "alternatives_considered",
+    "artifact_type",
+    "assumptions",
+    "branch",
+    "card_status",
+    "codex_plan",
+    "confidence",
+    "constraints",
+    "execution_handoff",
+    "generated_at",
+    "invariants_to_preserve",
+    "issue",
+    "name",
+    "notes",
+    "plan_revision",
+    "plan_summary",
+    "proposed_steps",
+    "required_permissions",
+    "review_hooks",
+    "risks_and_edge_cases",
+    "run_id",
+    "schema_version",
+    "scope",
+    "scope.components",
+    "scope.files",
+    "scope.out_of_scope",
+    "source_refs",
+    "status",
+    "stop_conditions",
+    "task_id",
+    "test_strategy",
+    "title",
+    "version"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Plan Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Plan Summary"
+    },
+    {
+      "level": 2,
+      "text": "Codex Plan"
+    },
+    {
+      "level": 2,
+      "text": "Assumptions"
+    },
+    {
+      "level": 2,
+      "text": "Proposed Steps"
+    },
+    {
+      "level": 2,
+      "text": "Affected Areas"
+    },
+    {
+      "level": 2,
+      "text": "Invariants To Preserve"
+    },
+    {
+      "level": 2,
+      "text": "Risks And Edge Cases"
+    },
+    {
+      "level": 2,
+      "text": "Test Strategy"
+    },
+    {
+      "level": 2,
+      "text": "Execution Handoff"
+    },
+    {
+      "level": 2,
+      "text": "Stop Conditions"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    }
+  ],
+  "fenced_blocks": [],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "1. [pending] Confirm dependencies and starting state from the source issue prompt."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "2. [pending] Inspect repo inputs and target surfaces before editing."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "3. [pending] Implement the bounded deliverables only."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "4. [pending] Run focused validation and proof gates."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "5. [pending] Record issue-specific SRP findings and SOR outcome truth."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Assumptions"
+      ],
+      "text": "- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Invariants To Preserve"
+      ],
+      "text": "- Keep SPP issue-local; do not turn it into sprint orchestration."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Invariants To Preserve"
+      ],
+      "text": "- Keep SRP as review-result truth and SOR as output truth."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Execution Handoff"
+      ],
+      "text": "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and update SPP if touched files, proof gates, or validation commands change materially."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and route follow-on work if acceptance requires scope outside this issue."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.0/schemas/srp.structure.json
+++ b/docs/templates/prompts/1.0.0/schemas/srp.structure.json
@@ -1,0 +1,365 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.0",
+  "card_kind": "srp",
+  "template_path": "docs/templates/prompts/1.0.0/srp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [
+    "allowed_dispositions",
+    "artifact_type",
+    "branch",
+    "card_status",
+    "evidence_policy",
+    "follow_up_routing",
+    "generated_at",
+    "in_scope_surfaces",
+    "issue",
+    "name",
+    "non_claims",
+    "notes",
+    "policy_refs",
+    "refusal_policy",
+    "review_mode",
+    "review_results",
+    "review_results.findings_status",
+    "review_results.recommended_outcome",
+    "reviewer_constraints",
+    "schema_version",
+    "scope_basis",
+    "source_refs",
+    "status",
+    "task_id",
+    "timing",
+    "title",
+    "validation_inputs",
+    "version"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Review Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Review Summary"
+    },
+    {
+      "level": 2,
+      "text": "Scope Basis"
+    },
+    {
+      "level": 2,
+      "text": "In-Scope Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Evidence Rules"
+    },
+    {
+      "level": 2,
+      "text": "Validation Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Allowed Dispositions"
+    },
+    {
+      "level": 2,
+      "text": "Reviewer Constraints"
+    },
+    {
+      "level": 2,
+      "text": "Refusal Policy"
+    },
+    {
+      "level": 2,
+      "text": "Follow-up Routing"
+    },
+    {
+      "level": 2,
+      "text": "Non-Claims"
+    },
+    {
+      "level": 2,
+      "text": "Review Results"
+    },
+    {
+      "level": 3,
+      "text": "Findings"
+    },
+    {
+      "level": 3,
+      "text": "Dispositions"
+    },
+    {
+      "level": 3,
+      "text": "Recommended Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Summary"
+      ],
+      "text": "Use this prompt to govern the independent pre-PR review for this issue. Review results are intentionally absent before implementation exists and must be finalized before PR publication."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "In-Scope Surfaces"
+      ],
+      "text": "- tracked changes for this issue branch"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Evidence Rules"
+      ],
+      "text": "- Use repository evidence, targeted validation output, and linked issue-bundle artifacts only."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Validation Inputs"
+      ],
+      "text": "- Issue-local proofs recorded in the SOR."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- PASS"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- BLOCK"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- NEEDS_FOLLOWUP"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Reviewer Constraints"
+      ],
+      "text": "- Do not widen issue scope."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Reviewer Constraints"
+      ],
+      "text": "- Do not merge, publish, or close the issue."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Refusal Policy"
+      ],
+      "text": "- Refuse claims that are unsupported by repository evidence."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Refusal Policy"
+      ],
+      "text": "- Refuse approving behavior outside the recorded issue scope."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Follow-up Routing"
+      ],
+      "text": "- Route actionable defects back to the issue branch before PR publication."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Non-Claims"
+      ],
+      "text": "- This prompt does not claim review has already run."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Non-Claims"
+      ],
+      "text": "- This prompt does not guarantee review quality by itself."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results"
+      ],
+      "text": "When finalizing review, record the machine-readable review result in frontmatter:"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Findings"
+      ],
+      "text": "- Not run yet; implementation has not been bound."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Dispositions"
+      ],
+      "text": "- Not applicable until review runs."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Recommended Outcome"
+      ],
+      "text": "- Not run yet."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.0/schemas/stp.structure.json
+++ b/docs/templates/prompts/1.0.0/schemas/stp.structure.json
@@ -1,0 +1,217 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.0",
+  "card_kind": "stp",
+  "template_path": "docs/templates/prompts/1.0.0/stp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [
+    "action",
+    "canonical_files",
+    "card_status",
+    "demo_names",
+    "demo_required",
+    "depends_on",
+    "duplicates",
+    "generated_at",
+    "issue_card_schema",
+    "issue_graph_notes",
+    "issue_number",
+    "labels",
+    "milestone_sprint",
+    "pr_start",
+    "pr_start.enabled",
+    "pr_start.slug",
+    "repo_inputs",
+    "required_outcome_type",
+    "slug",
+    "status",
+    "supersedes",
+    "title",
+    "wp"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Task Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Summary"
+    },
+    {
+      "level": 2,
+      "text": "Goal"
+    },
+    {
+      "level": 2,
+      "text": "Required Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Deliverables"
+    },
+    {
+      "level": 2,
+      "text": "Acceptance Criteria"
+    },
+    {
+      "level": 2,
+      "text": "Repo Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Dependencies"
+    },
+    {
+      "level": 2,
+      "text": "Target Files / Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Validation Plan"
+    },
+    {
+      "level": 2,
+      "text": "Demo Expectations"
+    },
+    {
+      "level": 2,
+      "text": "Non-goals"
+    },
+    {
+      "level": 2,
+      "text": "Issue-Graph Notes"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    },
+    {
+      "level": 2,
+      "text": "Tooling Notes"
+    }
+  ],
+  "fenced_blocks": [],
+  "locked_lines": []
+}

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -4,6 +4,8 @@ This directory is the canonical tracked home for C-SDLC issue-card templates.
 
 The active template set is declared in [`current.json`](current.json). Each
 template file is a direct copy-and-fill card form, not an explanatory wrapper.
+Each active template entry also points at a generated structure schema artifact
+used by prompt-card structure validation.
 
 ## Current Set
 
@@ -11,10 +13,11 @@ template file is a direct copy-and-fill card form, not an explanatory wrapper.
 - Lifecycle: `SIP -> STP -> SPP -> SRP -> SOR`
 - Template root: `docs/templates/prompts/1.0.0/`
 - Registry: `docs/templates/prompts/current.json`
+- Structure schemas: `docs/templates/prompts/1.0.0/schemas/*.structure.json`
 - Implementation owner: Rust tooling owns the canonical template registry,
-  field model, and validation path. Python sprint helpers may fill templates or
-  call the Rust-backed validators, but they should not become a separate
-  template authority.
+  field model, schema extraction, and validation path. Python sprint helpers may
+  load schema artifacts, fill templates, or call the Rust-backed validators, but
+  they should not become a separate template authority.
 
 ## Values Renderer
 
@@ -32,6 +35,35 @@ editing surface can now be a values object with locked system fields, required
 values, enum validation, placeholder checks, and Rust-owned static validation.
 The browser editor exposes those values, but it must not become a separate
 template or validation authority.
+
+## Structure Schemas
+
+The `*.structure.json` files under the active template set are generated from
+the Markdown templates and consumed by the Rust validator. They record:
+
+- the template set and card kind;
+- the source template path;
+- the parser used for Markdown extraction;
+- frontmatter key inventory;
+- Markdown heading order;
+- fenced code block shape;
+- locked template prose.
+
+Use the Rust tool to regenerate schemas only when template structure changes
+intentionally:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  write-structure-schemas \
+  --out-dir docs/templates/prompts/1.0.0/schemas
+```
+
+Then run both Rust and Python-readable schema checks:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+python3 adl/tools/test_prompt_template_structure_schemas.py
+```
 
 `current.json` should not move to a new active template set until all five card
 kinds have renderer fixtures, values validation, and compatibility notes.

--- a/docs/templates/prompts/current.json
+++ b/docs/templates/prompts/current.json
@@ -8,23 +8,28 @@
   "templates": {
     "sip": {
       "semantic_role": "Structured Issue Prompt",
-      "path": "docs/templates/prompts/1.0.0/sip.md"
+      "path": "docs/templates/prompts/1.0.0/sip.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/sip.structure.json"
     },
     "stp": {
       "semantic_role": "Structured Task Prompt",
-      "path": "docs/templates/prompts/1.0.0/stp.md"
+      "path": "docs/templates/prompts/1.0.0/stp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/stp.structure.json"
     },
     "spp": {
       "semantic_role": "Structured Plan Prompt",
-      "path": "docs/templates/prompts/1.0.0/spp.md"
+      "path": "docs/templates/prompts/1.0.0/spp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/spp.structure.json"
     },
     "srp": {
       "semantic_role": "Structured Review Prompt",
-      "path": "docs/templates/prompts/1.0.0/srp.md"
+      "path": "docs/templates/prompts/1.0.0/srp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/srp.structure.json"
     },
     "sor": {
       "semantic_role": "Structured Outcome Record",
-      "path": "docs/templates/prompts/1.0.0/sor.md"
+      "path": "docs/templates/prompts/1.0.0/sor.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/sor.structure.json"
     }
   },
   "compatibility_fallbacks": {

--- a/docs/tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md
+++ b/docs/tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md
@@ -137,13 +137,14 @@ instead of being claimed by the values validator:
 - host-local absolute paths or secret markers in public card output;
 - richer typed list/item schema validation beyond the current values model.
 
-Markdown structure immutability is implemented by `#3585` as a deterministic
+Markdown structure immutability was introduced by `#3585` as a deterministic
 structure guard over frontmatter key inventory, Markdown heading order, fenced
 block shape, unresolved placeholders, and locked template prose where the card
-kind has stable prose. It deliberately uses the existing Rust-owned template
-model and lightweight Markdown structure scanner for v0.91.5 instead of adding
-a new parser dependency. `markdown-rs` or a richer LST-style parser remains a
-future option if later work needs trivia-preserving structure checks.
+kind has stable prose. `#3587` promotes that guard to consume versioned
+structure schema artifacts from `docs/templates/prompts/current.json` and uses
+`markdown-rs` AST extraction for headings and fenced blocks. The tracked schema
+artifacts are JSON so a dependency-free Python smoke test can verify registry
+coverage and schema readability outside the Rust implementation.
 
 Public artifact hygiene and redaction checks remain separate review/validation
 surfaces unless a later issue binds them directly to the renderer.
@@ -183,6 +184,10 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render-all \
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure \
   --kind stp \
   --input /tmp/csdlc-prompt-cards/stp.md
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+
+python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
 
 The existing Markdown validator remains in use:

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -76,6 +76,11 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
 
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
   validate-structure --kind sip --input /tmp/csdlc-prompt-cards/sip.md
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  validate-schemas
+
+python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
 
 Values files use:
@@ -91,10 +96,23 @@ issue/version/card-status values.
 The structure validator protects rendered cards from template-shape drift. It
 checks frontmatter key inventory, Markdown heading order, fenced-block shape,
 unresolved placeholders, and locked template prose where the card kind has
-stable prose. It intentionally does not add a new Markdown parser dependency in
-v0.91.5; the current guard uses the Rust-owned template model and lightweight
-Markdown structure scanner. A richer `markdown-rs` or LST-style parser remains a
-future option if later work needs whitespace/trivia-preserving validation.
+stable prose. The active registry points each card kind at a tracked JSON
+structure schema under `docs/templates/prompts/1.0.0/schemas/`. Rust validates
+rendered cards against those schema files, and
+`adl/tools/test_prompt_template_structure_schemas.py` proves the same artifacts
+are easy to load with Python stdlib tooling.
+
+When template structure changes intentionally, regenerate and validate the
+schema artifacts:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  write-structure-schemas \
+  --out-dir docs/templates/prompts/1.0.0/schemas
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  validate-schemas
+```
 
 ## Proof Command
 

--- a/docs/tooling/csdlc-prompt-editor/editor_model.js
+++ b/docs/tooling/csdlc-prompt-editor/editor_model.js
@@ -19,6 +19,7 @@ window.CSDLC_PROMPT_EDITOR_MODEL = {
       "label": "Structured Issue Prompt",
       "output_file": "sip.md",
       "template_path": "docs/templates/prompts/1.0.0/sip.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/sip.structure.json",
       "fields": [
         {
           "key": "issue",
@@ -209,6 +210,7 @@ window.CSDLC_PROMPT_EDITOR_MODEL = {
       "label": "Structured Task Prompt",
       "output_file": "stp.md",
       "template_path": "docs/templates/prompts/1.0.0/stp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/stp.structure.json",
       "fields": [
         {
           "key": "issue",
@@ -444,6 +446,7 @@ window.CSDLC_PROMPT_EDITOR_MODEL = {
       "label": "Structured Plan Prompt",
       "output_file": "spp.md",
       "template_path": "docs/templates/prompts/1.0.0/spp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/spp.structure.json",
       "fields": [
         {
           "key": "issue",
@@ -625,6 +628,7 @@ window.CSDLC_PROMPT_EDITOR_MODEL = {
       "label": "Structured Review Prompt",
       "output_file": "srp.md",
       "template_path": "docs/templates/prompts/1.0.0/srp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/srp.structure.json",
       "fields": [
         {
           "key": "issue",
@@ -770,6 +774,7 @@ window.CSDLC_PROMPT_EDITOR_MODEL = {
       "label": "Structured Outcome Record",
       "output_file": "sor.md",
       "template_path": "docs/templates/prompts/1.0.0/sor.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.0/schemas/sor.structure.json",
       "fields": [
         {
           "key": "issue",


### PR DESCRIPTION
Closes #3587

## Summary
Implemented the `#3587` prompt-card schema extraction substrate. The active prompt-template registry now points each C-SDLC card kind at a tracked JSON structure schema, rendered-card structure validation consumes those schema artifacts, Markdown heading and fenced-block extraction uses `markdown-rs`, and a dependency-free Python smoke test proves the schema files can be loaded outside Rust.

## Artifacts
- `docs/templates/prompts/1.0.0/schemas/sip.structure.json`
- `docs/templates/prompts/1.0.0/schemas/stp.structure.json`
- `docs/templates/prompts/1.0.0/schemas/spp.structure.json`
- `docs/templates/prompts/1.0.0/schemas/srp.structure.json`
- `docs/templates/prompts/1.0.0/schemas/sor.structure.json`
- `adl/tools/test_prompt_template_structure_schemas.py`
- Updated prompt-template CLI commands: `validate-schemas` and `write-structure-schemas`
- Updated `docs/templates/prompts/current.json` with `structure_schema_path` entries
- Updated prompt-template/editor documentation and regenerated `docs/tooling/csdlc-prompt-editor/editor_model.js`
- Follow-on adoption issue `#3588` created for `AGENTS.md`, docs, and skill updates after `#3587` lands

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_csdlc_prompt_editor.sh`
    Proved the complete prompt editor / renderer / schema validation surface, including schema parity and Python-readable schema smoke.
  - `python3 adl/tools/test_prompt_template_structure_schemas.py`
    Proved tracked schema artifacts are dependency-free Python-readable JSON and match the registry shape.
  - `CARGO_HOME=[temp-cargo-home] cargo run --quiet --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas --repo-root .`
    Proved the tracked structure schemas match Rust extraction from the active templates.
  - `CARGO_HOME=[temp-cargo-home] cargo test --manifest-path adl/Cargo.toml cli::tooling_cmd::tests::prompt_template -- --nocapture`
    Proved prompt-template CLI rendering, validation, structure-drift detection, schema validation, and error paths.
  - `CARGO_HOME=[temp-cargo-home] cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Proved Rust lint cleanliness after adding `markdown-rs` and schema CLI paths.
  - `CARGO_HOME=[temp-cargo-home] CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- prompt_template`
    Proved focused coverage for prompt-template CLI/schema/renderer tests.
  - `CARGO_HOME=[temp-cargo-home] CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- tooling_cmd`
    Proved focused coverage for tooling dispatcher changes.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Proved coverage-impact preflight passed.
  - `git diff --check`
    Proved diff whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3587__v0-91-5-tools-externalize-prompt-card-schemas-for-markdown-rs-validation/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3587__v0-91-5-tools-externalize-prompt-card-schemas-for-markdown-rs-validation/sor.md
- Idempotency-Key: v0-91-5-wp-02-sprint-1-tools-externalize-prompt-card-schemas-for-markdown-rs-validation-adl-v0-91-5-tasks-issue-3587-v0-91-5-tools-externalize-prompt-card-schemas-for-markdown-rs-validation-sip-md-adl-v0-91-5-tasks-issue-3587-v0-91-5-tools-externalize-prompt-card-schemas-for-markdown-rs-validation-sor-md