### PR TITLE
[v0.91.5][WP-02][Sprint 1][tools] Adopt prompt-template schema tools across docs and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,15 @@ These rules are mandatory for ADL issue work.
    - The current prompt-template registry is `docs/templates/prompts/current.json`;
      use it rather than hard-coding a template version unless an issue
      explicitly requires a compatibility path.
+   - For new or fully re-rendered cards, prefer the deterministic
+     prompt-template values renderer over direct Markdown structure edits:
+     `adl tooling prompt-template validate-values`, `render`, `render-all`,
+     `validate-structure`, and `validate-schemas`.
+   - Treat the tracked structure schemas under
+     `docs/templates/prompts/<version>/schemas/` as the template-shape
+     authority. If a rendered card fails structure validation, fix the values or
+     intentionally version/regenerate the template schema; do not patch locked
+     template prose by hand.
 3. Always work in a bound worktree on a specific branch.
    - Never do tracked issue work on `main`.
    - Use the repo-native issue-mode `pr run` flow to bind execution context.
@@ -80,6 +89,10 @@ These rules are mandatory for ADL issue work.
 - Prefer the human prompt editor or card editor skills for filling and
   normalizing cards. Do not regenerate complete card prose when a template field
   update is sufficient.
+- When the issue context supports values-rendered prompt cards, update the
+  values object first, render through the Rust tooling, then run structure and
+  schema validation. Use editor skills for lifecycle truth and bounded repairs,
+  not as a reason to bypass the renderer/schema path.
 
 ## Where To Start
 
@@ -106,6 +119,10 @@ For a normal tracked issue:
 - Keep review records and output cards truthful about what was and was not run.
 - Docs-only and policy-only PVF work should prefer focused docs/path/contract/
   guardrail proof unless tracked runtime behavior changed.
+- Prompt-card generation or repair work should include the focused renderer
+  checks that apply to the touched surface: values validation, rendered
+  structure validation, schema parity validation, and the Python-readable schema
+  smoke check when schema artifacts are touched.
 
 ## Review And Publication Rules
 

--- a/adl/tools/skills/adl-milestone-creator/SKILL.md
+++ b/adl/tools/skills/adl-milestone-creator/SKILL.md
@@ -200,6 +200,12 @@ After merge or closure:
 
 - Do not create milestone docs on `main`.
 - Do not hand-roll cards from memory.
+- When prompt-template values rendering is available, create or regenerate
+  milestone issue cards through the values renderer and validate the rendered
+  Markdown with `validate-structure`. If template structure changes, also run
+  `validate-schemas` and `python3 adl/tools/test_prompt_template_structure_schemas.py`.
+- Use card editor skills for lifecycle-truth cleanup after generation; do not
+  use them to bypass locked template prose or schema validation.
 - Do not leave `SIP`, `STP`, or `SPP` generic when execution starts.
 - Do not leave feature docs missing for first-class work.
 - Do not let moved sidecar work disappear from closeout/checklist truth.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -114,6 +114,23 @@ The five card editor skills are helper skills:
 - `sip-editor` for truthful `sip.md` cleanup
 - `sor-editor` for truthful `sor.md` cleanup
 
+For new or fully re-rendered prompt cards, prefer the Rust-owned values
+renderer and structure-schema validator before editing Markdown directly:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind <kind> --values <kind>.values.yaml
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind <kind> --values <kind>.values.yaml --out <kind>.md
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind <kind> --input <kind>.md
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+python3 adl/tools/test_prompt_template_structure_schemas.py
+```
+
+The editor skills remain authoritative for lifecycle-truth normalization:
+branch/worktree truth, issue-specific readiness, review results, validation
+claims, integration state, and closeout truth. They should not be used as a
+reason to hand-write locked template prose or bypass schema validation when a
+values-rendered card path is available.
+
 `sprint-conductor` is a bounded orchestration helper rather than an editor skill. It sequences one sprint issue across ordered child issues using the existing lifecycle/editor stack, then assembles sprint review and sprint closeout evidence.
 It now includes a small deterministic sprint-state helper, supports a bounded review-subagent exception when policy enables it, and should be installed or synced into the active Codex skills directory before live use.
 

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -169,6 +169,21 @@ Ensure the repo's canonical bootstrap surfaces exist in the right places:
 
 Prefer the repo's existing templates and control-plane logic over hand-written file generation.
 
+When the active prompt-template values renderer is available for the target
+card kind, bootstrap or regeneration paths should prefer:
+
+1. resolve `docs/templates/prompts/current.json`;
+2. fill values YAML with locked fields under `system` and editable fields under
+   `values`;
+3. render Markdown through `adl tooling prompt-template render` or `render-all`;
+4. validate rendered shape with `validate-structure`;
+5. validate schema artifacts with `validate-schemas` when template structure is
+   touched.
+
+Do not hand-roll card Markdown from memory. If the generated card needs
+issue-local lifecycle truth repair after bootstrap, hand off to the matching
+card editor skill.
+
 Do not qualitatively rewrite STP or SIP content in this step beyond the mechanical bootstrap required by the repo's standard control-plane behavior.
 
 ### 4. Validate and Review the Bootstrap Result

--- a/adl/tools/skills/sip-editor/SKILL.md
+++ b/adl/tools/skills/sip-editor/SKILL.md
@@ -16,6 +16,22 @@ Its job is to:
 
 This is a helper skill, not a readiness or execution orchestrator.
 
+## Prompt-Template Tooling Boundary
+
+When creating a new SIP or fully re-rendering one, prefer the active
+prompt-template values renderer and structure/schema validators before using
+Markdown as lifecycle state:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sip --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sip --values <path> --out <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sip --input <path>
+```
+
+Use this skill for SIP truth repairs: issue-specific intent, branch/worktree
+truth, target surfaces, validation guidance, and placeholder cleanup. Do not use
+it to bypass locked template prose or schema validation.
+
 ## Required Inputs
 
 At minimum, gather:

--- a/adl/tools/skills/sor-editor/SKILL.md
+++ b/adl/tools/skills/sor-editor/SKILL.md
@@ -16,6 +16,23 @@ Its job is to:
 
 This is a helper skill, not a finish orchestrator.
 
+## Prompt-Template Tooling Boundary
+
+When creating a new SOR or fully re-rendering one, prefer the active
+prompt-template values renderer and structure/schema validators before using
+Markdown as lifecycle state:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sor --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sor --values <path> --out <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sor --input <path>
+```
+
+Use this skill for SOR truth repairs: execution result, changed paths,
+validation actually run, integration state, PR state, residual risks, and
+closeout truth. Do not use it to bypass locked template prose or schema
+validation.
+
 ## Required Inputs
 
 At minimum, gather:

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -22,6 +22,23 @@ Its job is to:
 
 This is a helper skill, not a lifecycle orchestrator.
 
+## Prompt-Template Tooling Boundary
+
+When creating a new SPP or fully re-rendering one, prefer the active
+prompt-template values renderer and structure/schema validators before using
+Markdown as lifecycle state:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind spp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind spp --values <path> --out <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind spp --input <path>
+```
+
+Use this skill for SPP truth repairs: issue-local plan readiness, `codex_plan`
+status normalization, assumptions, stop conditions, dependencies, and
+execution-handoff truth. Do not use it to bypass locked template prose or schema
+validation.
+
 ## Required Inputs
 
 At minimum, gather:

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -125,6 +125,9 @@ missing sprint-management issue first.
 3. When live execution is about to begin, run the installed-skill parity/readiness gate first.
 4. Run sprint-wide structured prompt review before issue execution begins.
 5. If any child issue cards are not ready, repair them through the editor skills first.
+   When the child issue needs new or fully re-rendered cards, prefer the
+   prompt-template values renderer and `validate-structure` before routing
+   issue-local lifecycle truth through the matching editor skill.
 6. Confirm the current issue is the earliest not-yet-closed issue in the list.
 7. Route that issue through `workflow-conductor`.
 8. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
@@ -149,6 +152,8 @@ This skill enforces:
   card-completion review for `SIP`, `STP`, `SPP`, and `SRP`
 - no issue `N+1` work before issue `N` is fully closed out
 - editor-skill routing when cards drift
+- prompt-template renderer/schema validation when cards need deterministic
+  regeneration rather than lifecycle-truth repair
 - immediate stop on true blocker
 - no silent creation of extra sprint-management issues
 - no missing sprint-management issue workaround outside the skill when sprint

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -16,6 +16,22 @@ Its job is to:
 
 This is a helper skill, not a lifecycle orchestrator.
 
+## Prompt-Template Tooling Boundary
+
+When creating a new SRP or fully re-rendering one, prefer the active
+prompt-template values renderer and structure/schema validators before using
+Markdown as lifecycle state:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind srp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind srp --values <path> --out <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind srp --input <path>
+```
+
+Use this skill for SRP truth repairs: review scope, review prompts, findings,
+dispositions, reviewer notes, residual risks, and recommended outcome. Do not
+use it to bypass locked template prose or schema validation.
+
 ## Required Inputs
 
 At minimum, gather:

--- a/adl/tools/skills/stp-editor/SKILL.md
+++ b/adl/tools/skills/stp-editor/SKILL.md
@@ -16,6 +16,22 @@ Its job is to:
 
 This is a helper skill, not a lifecycle orchestrator.
 
+## Prompt-Template Tooling Boundary
+
+When creating a new STP or fully re-rendering one, prefer the active
+prompt-template values renderer and structure/schema validators before using
+Markdown as lifecycle state:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind stp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind stp --values <path> --out <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind stp --input <path>
+```
+
+Use this skill for STP truth repairs: task intent, required outcome,
+acceptance criteria, bounded scope, validation plan, and placeholder cleanup. Do
+not use it to bypass locked template prose or schema validation.
+
 ## Required Inputs
 
 At minimum, gather:

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -130,6 +130,13 @@ Preferred next-skill mapping:
 - PR in flight with checks/conflicts/review blockers -> `pr-janitor`
 - PR merged or intentionally closed -> `pr-closeout`
 
+Prompt-template tooling route:
+- new or fully re-rendered prompt card -> active prompt-template values
+  renderer, then `validate-structure`
+- changed prompt-template schema artifact -> `validate-schemas`, then
+  `python3 adl/tools/test_prompt_template_structure_schemas.py`
+- lifecycle-truth drift in an existing card -> matching card editor skill
+
 Important rule:
 - treat partially completed early steps as normal state, not corruption
 - the conductor should resume from the next truthful step instead of restarting bootstrap by reflex
@@ -151,6 +158,9 @@ Important rule:
   planning sections, stale planning status claims, or generated-vs-reviewed
   truth drift should route to `planning-doc-editor`; do not send those defects
   to C-SDLC card editors unless the defect is actually in SIP/STP/SPP/SRP/SOR
+- when values-rendered prompt-card support exists for the target, do not route
+  broad card generation to direct Markdown edits; use the renderer/schema path
+  first, then card-editor skills only for issue-local lifecycle truth
 
 ## Policy Model
 

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -23,6 +23,8 @@ used by prompt-card structure validation.
 
 v0.91.5 adds the next authoring model described in
 [`PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md`](../../tooling/PROMPT_TEMPLATE_VALUES_RENDERER_PLAN_v0.91.5.md).
+The short operator checklist for using the renderer and structure schemas is
+[`PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md`](../../tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md).
 
 The intended direction is deterministic rendering:
 
@@ -35,6 +37,20 @@ editing surface can now be a values object with locked system fields, required
 values, enum validation, placeholder checks, and Rust-owned static validation.
 The browser editor exposes those values, but it must not become a separate
 template or validation authority.
+
+For new or fully re-rendered cards, prefer this path over direct Markdown
+structure edits:
+
+1. fill or export values YAML;
+2. run `validate-values`;
+3. render with `render` or `render-all`;
+4. run `validate-structure` on each rendered card;
+5. run `validate-schemas` and the Python schema smoke check when schema
+   artifacts are touched.
+
+Editor skills still own lifecycle-truth repairs. The renderer owns deterministic
+template filling and shape preservation; it does not invent execution, review,
+PR, merge, or closeout truth.
 
 ## Structure Schemas
 

--- a/docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md
+++ b/docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md
@@ -1,0 +1,82 @@
+# Prompt-Template Card Generation Checklist
+
+Use this checklist when an issue creates new C-SDLC prompt cards, fully
+re-renders existing cards, or changes prompt-template structure.
+
+The default path is:
+
+```text
+active prompt-template registry -> values YAML -> rendered Markdown card -> structure/schema validation
+```
+
+Rendered Markdown remains the reviewable lifecycle artifact. Values YAML is the
+safe editable surface for issue-local content; locked template prose and
+structure stay owned by the active template registry and schema artifacts.
+
+## Standard Commands
+
+Generate sample values when validating the tooling path:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  write-sample-values --out-dir /tmp/csdlc-prompt-values
+```
+
+Validate one values file before rendering:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  validate-values --kind sip --values /tmp/csdlc-prompt-values/sip.values.yaml
+```
+
+Render one card or all five cards:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  render --kind sip \
+  --values /tmp/csdlc-prompt-values/sip.values.yaml \
+  --out /tmp/csdlc-prompt-cards/sip.md
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  render-all \
+  --values-dir /tmp/csdlc-prompt-values \
+  --out-dir /tmp/csdlc-prompt-cards
+```
+
+Validate rendered card structure:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  validate-structure --kind sip --input /tmp/csdlc-prompt-cards/sip.md
+```
+
+Validate tracked schema artifacts and Python readability:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+python3 adl/tools/test_prompt_template_structure_schemas.py
+```
+
+## Required Review Questions
+
+- Did the card values come from the active registry in
+  `docs/templates/prompts/current.json`?
+- Did editable issue-local prose stay under `values` rather than `system`?
+- Did locked lifecycle, routing, branch, issue, path, enum, or derived template
+  fields stay under `system`?
+- Did `validate-values` pass before rendering?
+- Did `validate-structure` pass after rendering?
+- If template structure changed, were structure schemas regenerated and checked
+  by both Rust and Python?
+- Did any lifecycle-truth repair go through the matching editor skill instead of
+  direct Markdown edits?
+
+## Boundaries
+
+- Do not use this checklist to claim issue execution, review completion, PR
+  publication, merge, or closeout truth.
+- Do not rewrite historical cards only for style. Rewrite when the issue scope
+  requires deterministic regeneration or when a card is materially stale.
+- Do not patch rendered locked prose directly. Update values, use the matching
+  editor skill for lifecycle truth, or intentionally version/regenerate the
+  template schema.

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -83,6 +83,9 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
 python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
 
+For the concise operator checklist, see
+[`../PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md`](../PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md).
+
 Values files use:
 
 - `system` for locked lifecycle, routing, branch, issue, path, enum, and
@@ -149,6 +152,11 @@ still route through the card editor skills:
 - `sor-editor`
 
 The canonical template set remains `docs/templates/prompts/current.json`.
+For new or fully re-rendered cards, agents should prefer values YAML plus the
+Rust renderer and structure/schema validators before using rendered Markdown as
+the reviewable lifecycle artifact. Use editor skills for lifecycle-truth
+normalization and bounded repairs, not for hand-written template structure
+changes.
 
 Use the focused repair-example proof when validating the editor-skill boundary:
 


### PR DESCRIPTION
Closes #3588

## Summary
Updated the prompt-template adoption guidance so future C-SDLC card generation
uses the values renderer and structure/schema validators by default, while card
editor skills remain responsible for lifecycle-truth repairs. Added a concise
operator checklist and synced the installed ADL skill copies from the tracked
bundles after the tracked changes were made.

## Artifacts
- `AGENTS.md`
- `docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md`
- `docs/templates/prompts/README.md`
- `docs/tooling/csdlc-prompt-editor/README.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/pr-init/SKILL.md`
- `adl/tools/skills/adl-milestone-creator/SKILL.md`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/sip-editor/SKILL.md`
- `adl/tools/skills/stp-editor/SKILL.md`
- `adl/tools/skills/spp-editor/SKILL.md`
- `adl/tools/skills/srp-editor/SKILL.md`
- `adl/tools/skills/sor-editor/SKILL.md`

## Validation
- `git diff --check`
  Verified patch whitespace.
- `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template write-sample-values --out-dir TEMP_ROOT/csdlc-prompt-values-3588`
  Verified sample values generation.
- `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind KIND --values TEMP_ROOT/csdlc-prompt-values-3588/KIND.values.yaml`
  Verified values validation for `sip`, `stp`, `spp`, `srp`, and `sor`.
- `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render-all --values-dir TEMP_ROOT/csdlc-prompt-values-3588 --out-dir TEMP_ROOT/csdlc-prompt-cards-3588`
  Verified all five rendered cards are generated from values.
- `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind KIND --input TEMP_ROOT/csdlc-prompt-cards-3588/KIND.md`
  Verified rendered structure for `sip`, `stp`, `spp`, `srp`, and `sor`.
- `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas`
  Verified tracked schema artifacts match active templates.
- `python3 adl/tools/test_prompt_template_structure_schemas.py`
  Verified schema artifacts are Python-readable.
- `bash adl/tools/test_card_editor_skill_contracts.sh`
  Verified card-editor skill contracts and repair examples.
- `bash adl/tools/test_adl_milestone_creator_skill_contracts.sh`
  Verified milestone-creator skill contract.
- `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
  Verified workflow-conductor contract.
- `bash adl/tools/test_install_adl_operational_skills.sh`
  Verified operational skill install/parity behavior.
- Focused changed-doc Markdown link check.
  Verified local links added by this issue resolve.
- Focused overclaim grep audit.
  Verified the changes do not claim historical cards were migrated or `#3582`
  was completed.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3588__v0-91-5-tools-adopt-prompt-template-schema-tools-across-docs-and-skills/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3588__v0-91-5-tools-adopt-prompt-template-schema-tools-across-docs-and-skills/sor.md
- Idempotency-Key: v0-91-5-wp-02-sprint-1-tools-adopt-prompt-template-schema-tools-across-docs-and-skills-agents-md-docs-tooling-prompt-template-card-generation-checklist-md-docs-templates-prompts-readme-md-docs-tooling-csdlc-prompt-editor-readme-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-workflow-conductor-skill-md-adl-tools-skills-pr-init-skill-md-adl-tools-skills-adl-milestone-creator-skill-md-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sip-editor-skill-md-adl-tools-skills-stp-editor-skill-md-adl-tools-skills-spp-editor-skill-md-adl-tools-skills-srp-editor-skill-md-adl-tools-skills-sor-editor-skill-md-adl-v0-91-5-tasks-issue-3588-v0-91-5-tools-adopt-prompt-template-schema-tools-across-docs-and-skills-sip-md-adl-v0-91-5-tasks-issue-3588-v0-91-5-tools-adopt-prompt-template-schema-tools-across-docs-and-skills-sor-md