### PR TITLE
[v0.91.5][refactor] Fail closed on pr run ambiguity

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1646,6 +1646,73 @@ print_pr_run_summary() {
   echo "  proof_run_summary_json=$run_summary_json"
 }
 
+pr_run_flag_family() {
+  case "$1" in
+    --trace|--print-plan|--print-prompts|--print-prompt|--resume|--steer|--overlay|--out|--runs-root|--quiet|--no-step-output|--open|--allow-unsigned)
+      printf 'runtime\n'
+      ;;
+    --prefix|--slug|--title|--no-fetch-issue|--version|--allow-open-pr-wave)
+      printf 'issue\n'
+      ;;
+    *)
+      printf 'unknown\n'
+      ;;
+  esac
+}
+
+ensure_pr_run_issue_args_are_issue_only() {
+  local issue="$1"
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    local flag="$1"
+    local family
+    family="$(pr_run_flag_family "$flag")"
+    if [[ "$family" == "runtime" ]]; then
+      die "run: ambiguous operand '$issue': issue-mode run cannot accept runtime flag '$flag'. Use 'adl/tools/pr.sh run <adl.yaml> ...' for runtime workflows or 'adl/tools/pr.sh run <issue> ...' with issue flags only."
+    fi
+    case "$flag" in
+      --prefix|--slug|--title|--version)
+        [[ $# -ge 2 ]] || die_with_usage "run: $flag requires a value" usage_start
+        shift 2
+        ;;
+      --no-fetch-issue|--allow-open-pr-wave)
+        shift
+        ;;
+      *)
+        # Let the Rust start parser preserve the exact compatibility behavior
+        # for future issue-mode flags that are not classified here.
+        shift
+        ;;
+    esac
+  done
+}
+
+ensure_pr_run_runtime_args_are_runtime_only() {
+  local adl_path="$1"
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    local flag="$1"
+    local family
+    family="$(pr_run_flag_family "$flag")"
+    if [[ "$family" == "issue" ]]; then
+      die "run: ambiguous operand '$adl_path': runtime workflow run cannot accept issue flag '$flag'. Use 'adl/tools/pr.sh run <issue> ...' for C-SDLC issue execution or 'adl/tools/pr.sh run <adl.yaml> ...' with runtime flags only."
+    fi
+    case "$flag" in
+      --resume|--steer|--overlay|--out|--runs-root)
+        [[ $# -ge 2 ]] || die_with_usage "run: $flag requires a value" usage_run
+        shift 2
+        ;;
+      --print-plan|--print-prompts|--print-prompt|--trace|--quiet|--no-step-output|--open|--allow-unsigned|-h|--help)
+        shift
+        ;;
+      *)
+        # The normal runtime parser below owns unknown-runtime-flag diagnostics.
+        shift
+        ;;
+    esac
+  done
+}
+
 cmd_run() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     usage_run
@@ -1653,6 +1720,7 @@ cmd_run() {
   fi
 
   if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+    ensure_pr_run_issue_args_are_issue_only "$@"
     require_rust_pr_delegate
     note "Issue-mode run: binding execution context for issue $1"
     delegate_pr_command_to_rust start "$@"
@@ -1661,6 +1729,7 @@ cmd_run() {
 
   local adl_path="${1:-}"
   [[ -n "$adl_path" ]] || die_with_usage "run: missing <adl.yaml>" usage_run
+  ensure_pr_run_runtime_args_are_runtime_only "$@"
   shift || true
 
   local root adl_abs runs_root

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -24,6 +24,7 @@ run_check adl/tools/test_pr_init_skill_contracts.sh
 run_check adl/tools/test_card_editor_skill_contracts.sh
 run_check adl/tools/test_pr_closeout_skill_contracts.sh
 run_check adl/tools/test_pr_run.sh
+run_check adl/tools/test_pr_run_ambiguity_policy.sh
 run_check adl/tools/test_pr_run_materializes_worktree_cards.sh
 run_check adl/tools/test_pr_finish_default_stage_root.sh
 # Legacy shell-era rerun expectations in this harness currently diverge from the Rust-owned finish path.

--- a/adl/tools/test_pr_run_ambiguity_policy.sh
+++ b/adl/tools/test_pr_run_ambiguity_policy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASH_BIN="$(command -v bash)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+  local pattern="$1" text="$2" label="$3"
+  grep -Fq "$pattern" <<<"$text" || {
+    echo "assertion failed ($label): expected to find '$pattern'" >&2
+    echo "actual output:" >&2
+    echo "$text" >&2
+    exit 1
+  }
+}
+
+assert_status_nonzero() {
+  local status="$1" label="$2"
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed ($label): expected nonzero exit" >&2
+    exit 1
+  }
+}
+
+repo="$TMP_DIR/repo"
+mkdir -p "$repo/adl/tools"
+cp "$ROOT_DIR/adl/tools/pr.sh" "$repo/adl/tools/pr.sh"
+cp "$ROOT_DIR/adl/tools/card_paths.sh" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  touch README.md workflow.adl.yaml
+  git add README.md workflow.adl.yaml
+  git commit -q -m "init"
+)
+
+mock_bin="$TMP_DIR/mock-adl"
+cat >"$mock_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"$ADL_PR_RUN_CAPTURE"
+EOF
+chmod +x "$mock_bin"
+
+capture_file="$TMP_DIR/capture.txt"
+issue_output="$(
+  cd "$repo" &&
+    ADL_PR_RUST_BIN="$mock_bin" \
+    ADL_PR_RUN_CAPTURE="$capture_file" \
+    "$BASH_BIN" adl/tools/pr.sh run 1303 --slug example-slug --version v0.91.5
+)"
+
+assert_contains "Issue-mode run: binding execution context for issue 1303" "$issue_output" "issue-mode note"
+assert_contains "pr start 1303 --slug example-slug --version v0.91.5" "$(cat "$capture_file")" "issue delegation"
+
+set +e
+issue_with_runtime_flag="$(
+  cd "$repo" &&
+    ADL_PR_RUST_BIN="$mock_bin" \
+    ADL_PR_RUN_CAPTURE="$capture_file" \
+    "$BASH_BIN" adl/tools/pr.sh run 1303 --allow-unsigned 2>&1
+)"
+issue_with_runtime_flag_status=$?
+set -e
+assert_status_nonzero "$issue_with_runtime_flag_status" "issue operand with runtime flag"
+assert_contains "issue-mode run cannot accept runtime flag '--allow-unsigned'" "$issue_with_runtime_flag" "issue/runtime ambiguity diagnostic"
+
+set +e
+runtime_with_issue_flag="$(
+  cd "$repo" &&
+    "$BASH_BIN" adl/tools/pr.sh run workflow.adl.yaml --slug example-slug 2>&1
+)"
+runtime_with_issue_flag_status=$?
+set -e
+assert_status_nonzero "$runtime_with_issue_flag_status" "runtime operand with issue flag"
+assert_contains "runtime workflow run cannot accept issue flag '--slug'" "$runtime_with_issue_flag" "runtime/issue ambiguity diagnostic"
+
+set +e
+missing_runtime="$(
+  cd "$repo" &&
+    "$BASH_BIN" adl/tools/pr.sh run missing-workflow.adl.yaml 2>&1
+)"
+missing_runtime_status=$?
+set -e
+assert_status_nonzero "$missing_runtime_status" "missing runtime operand"
+assert_contains "run: ADL file not found: missing-workflow.adl.yaml" "$missing_runtime" "missing runtime diagnostic"
+
+if grep -R -E 'adl/tools/pr\.sh run [^`[:space:]]+\.adl\.ya?ml|adl pr run [^`[:space:]]+\.adl\.ya?ml' \
+  "$ROOT_DIR/docs/templates/prompts" \
+  "$ROOT_DIR/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md" >/dev/null 2>&1; then
+  echo "assertion failed: generated-card templates must not emit deprecated runtime-through-PR invocations" >&2
+  exit 1
+fi
+
+echo "PASS test_pr_run_ambiguity_policy"


### PR DESCRIPTION
Closes #3595

## Summary
Implemented fail-closed `pr.sh run` ambiguity policy and focused tests. Numeric
issue operands now reject runtime-only flags before delegation, runtime ADL path
operands reject issue-only flags before execution, missing runtime files keep a
clear diagnostic, and generated-card templates are checked for deprecated
runtime-through-PR invocations.

## Artifacts
- `adl/tools/pr.sh`
- `adl/tools/test_pr_run_ambiguity_policy.sh`
- `adl/tools/test_five_command_regression_suite.sh`
- Local ignored output-card record: `.adl/v0.91.5/tasks/issue-3595__v0-91-5-refactor-mini-sprint-3-8-implement-run-ambiguity-policy-and-tests/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_run_ambiguity_policy.sh`
    Verified issue/runtime ambiguity fail-closed behavior and generated-card template scan.
  - `bash adl/tools/test_pr_run_issue_mode.sh`
    Verified issue-mode delegation still works.
  - `bash adl/tools/test_pr_run.sh`
    Verified existing runtime wrapper success/failure behavior.
  - `bash -n adl/tools/pr.sh adl/tools/test_pr_run_ambiguity_policy.sh adl/tools/test_five_command_regression_suite.sh`
    Verified shell syntax.
  - `git diff --check`
    Verified patch hygiene.
  - `cargo run --manifest-path adl/Cargo.toml --quiet -- tooling prompt-template validate-schemas`
    Verified prompt-card structure schema parity.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3595__v0-91-5-refactor-mini-sprint-3-8-implement-run-ambiguity-policy-and-tests/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3595__v0-91-5-refactor-mini-sprint-3-8-implement-run-ambiguity-policy-and-tests/sor.md
- Idempotency-Key: v0-91-5-refactor-fail-closed-on-pr-run-ambiguity-adl-tools-pr-sh-adl-tools-test-pr-run-ambiguity-policy-sh-adl-tools-test-five-command-regression-suite-sh-adl-v0-91-5-tasks-issue-3595-v0-91-5-refactor-mini-sprint-3-8-implement-run-ambiguity-policy-and-tests-sip-md-adl-v0-91-5-tasks-issue-3595-v0-91-5-refactor-mini-sprint-3-8-implement-run-ambiguity-policy-and-tests-sor-md