### PR TITLE
[v0.91.5][refactor] Introduce adl-csdlc compatibility binary

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -15,6 +15,10 @@ name = "adl"
 path = "src/main.rs"
 
 [[bin]]
+name = "adl-csdlc"
+path = "src/bin/adl_csdlc.rs"
+
+[[bin]]
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 

--- a/adl/src/bin/adl_csdlc.rs
+++ b/adl/src/bin/adl_csdlc.rs
@@ -1,0 +1,27 @@
+extern crate adl;
+
+#[allow(dead_code)]
+#[path = "../cli/mod.rs"]
+mod cli;
+
+#[cfg(not(test))]
+fn main() {
+    cli::run_csdlc_main();
+}
+
+#[cfg(test)]
+fn binary_help_probe() -> String {
+    cli::csdlc_usage().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn adl_csdlc_cli_binary_links_to_csdlc_dispatch_surface() {
+        let output = super::binary_help_probe();
+
+        assert!(output.contains("adl-csdlc - ADL C-SDLC compatibility binary"));
+        assert!(output.contains("adl-csdlc issue run <issue>"));
+        assert!(output.contains("adl/tools/pr.sh remains the canonical"));
+    }
+}

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -67,9 +67,25 @@ pub fn run_main() {
     }
 }
 
+#[allow(dead_code)]
+#[cfg(not(test))]
+pub fn run_csdlc_main() {
+    if let Err(err) = real_csdlc_main() {
+        print_error_chain(&err);
+        std::process::exit(1);
+    }
+}
+
 fn real_main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     dispatch_args(&args)
+}
+
+#[allow(dead_code)]
+#[cfg(not(test))]
+fn real_csdlc_main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    dispatch_csdlc_args(&args)
 }
 
 fn dispatch_args(args: &[String]) -> Result<()> {
@@ -102,4 +118,107 @@ fn dispatch_args(args: &[String]) -> Result<()> {
         Some("resume") => real_resume(&args[1..]),
         _ => run_workflow(args),
     }
+}
+
+#[allow(dead_code)]
+pub(crate) fn csdlc_usage() -> &'static str {
+    "adl-csdlc - ADL C-SDLC compatibility binary\n\n\
+Usage:\n\
+  adl-csdlc pr <create|init|start|doctor|ready|preflight|finish|closeout> ...\n\
+  adl-csdlc issue <create|init|run|doctor|finish|closeout> ...\n\
+  adl-csdlc issue run <issue> [--slug <slug>] [--version <v>]\n\
+  adl-csdlc tooling <card-prompt|csdlc-prompt-editor|generate-wp-issue-wave|lint-prompt-spec|prompt-template|validate-structured-prompt|...> ...\n\
+  adl-csdlc --help\n\
+  adl-csdlc --version\n\n\
+Notes:\n\
+  adl/tools/pr.sh remains the canonical agent-facing issue wrapper during migration.\n\
+  adl-csdlc issue run expects a numeric issue id. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
+}
+
+#[allow(dead_code)]
+fn dispatch_csdlc_args(args: &[String]) -> Result<()> {
+    if matches!(
+        args.first().map(|s| s.as_str()),
+        Some("--help" | "-h" | "help")
+    ) {
+        println!("{}", csdlc_usage());
+        return Ok(());
+    }
+
+    if matches!(args.first().map(|s| s.as_str()), Some("--version" | "-V")) {
+        println!("{}", version_text());
+        return Ok(());
+    }
+
+    match args.first().map(|s| s.as_str()) {
+        Some("pr") => {
+            reject_csdlc_runtime_run("adl-csdlc pr", &args[1..])?;
+            real_pr(&args[1..])
+        }
+        Some("issue") => real_csdlc_issue(&args[1..]),
+        Some("tooling") => real_tooling(&args[1..]),
+        Some("run") => Err(anyhow::anyhow!(
+            "adl-csdlc does not run ADL workflow YAML. Use adl-runtime run <adl.yaml> for runtime workflows or adl-csdlc issue run <issue> for C-SDLC issue execution."
+        )),
+        Some(other) => Err(anyhow::anyhow!(
+            "unknown adl-csdlc command '{other}'. Expected pr, issue, tooling, help, or --version."
+        )),
+        None => Err(anyhow::anyhow!(
+            "adl-csdlc requires a command. Run `adl-csdlc --help` for usage."
+        )),
+    }
+}
+
+#[allow(dead_code)]
+fn real_csdlc_issue(args: &[String]) -> Result<()> {
+    let pr_args = csdlc_issue_to_pr_args(args)?;
+    real_pr(&pr_args)
+}
+
+#[allow(dead_code)]
+fn csdlc_issue_to_pr_args(args: &[String]) -> Result<Vec<String>> {
+    reject_csdlc_runtime_run("adl-csdlc issue", args)?;
+    let Some(subcommand) = args.first().map(|s| s.as_str()) else {
+        return Err(anyhow::anyhow!(
+            "adl-csdlc issue requires a pr-compatible subcommand such as run, doctor, finish, or closeout."
+        ));
+    };
+    if subcommand == "run" {
+        let Some(issue) = args.get(1) else {
+            return Err(anyhow::anyhow!(
+                "adl-csdlc issue run requires a numeric issue id."
+            ));
+        };
+        if !issue.chars().all(|ch| ch.is_ascii_digit()) {
+            return Err(anyhow::anyhow!(
+                "adl-csdlc issue run expects a numeric issue id, got '{issue}'. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
+            ));
+        }
+        let mut mapped = Vec::with_capacity(args.len());
+        mapped.push("start".to_string());
+        mapped.extend(args[1..].iter().cloned());
+        return Ok(mapped);
+    }
+    Ok(args.to_vec())
+}
+
+#[allow(dead_code)]
+fn reject_csdlc_runtime_run(context: &str, args: &[String]) -> Result<()> {
+    if args.first().map(|s| s.as_str()) != Some("run") {
+        return Ok(());
+    }
+    let Some(operand) = args.get(1) else {
+        return Ok(());
+    };
+    if looks_like_adl_workflow_path(operand) {
+        return Err(anyhow::anyhow!(
+            "{context} run cannot execute ADL workflow YAML '{operand}'. Use adl-runtime run <adl.yaml> for runtime workflows."
+        ));
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn looks_like_adl_workflow_path(value: &str) -> bool {
+    value.ends_with(".adl.yaml") || value.ends_with(".adl.yml")
 }

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -20,8 +20,9 @@ use super::run_artifacts::{
     AEE_DECISION_VERSION, PAUSE_STATE_SCHEMA_VERSION,
 };
 use super::{
-    dispatch_args, real_instrument, real_keygen, real_learn, real_sign, real_verify, usage,
-    version_text,
+    csdlc_issue_to_pr_args, csdlc_usage, dispatch_args, dispatch_csdlc_args,
+    looks_like_adl_workflow_path, real_instrument, real_keygen, real_learn, real_sign, real_verify,
+    reject_csdlc_runtime_run, usage, version_text,
 };
 use ::adl::godel::cross_workflow::{
     DownstreamWorkflowDecision, PersistedCrossWorkflowArtifact, CROSS_WORKFLOW_ARTIFACT_VERSION,
@@ -133,6 +134,127 @@ fn top_level_version_flag_is_handled_before_workflow_dispatch() {
     dispatch_args(&["--version".to_string()]).expect("version flag should succeed");
     dispatch_args(&["-V".to_string()]).expect("short version flag should succeed");
     assert_eq!(version_text(), env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn csdlc_dispatch_exposes_help_and_version_without_runtime_dispatch() {
+    dispatch_csdlc_args(&["--help".to_string()]).expect("csdlc help should succeed");
+    dispatch_csdlc_args(&["-h".to_string()]).expect("csdlc short help should succeed");
+    dispatch_csdlc_args(&["help".to_string()]).expect("csdlc help alias should succeed");
+    dispatch_csdlc_args(&["--version".to_string()]).expect("csdlc version should succeed");
+    dispatch_csdlc_args(&["-V".to_string()]).expect("csdlc short version should succeed");
+
+    let usage = csdlc_usage();
+    assert!(usage.contains("adl-csdlc issue run <issue>"));
+    assert!(usage.contains("adl/tools/pr.sh remains the canonical agent-facing issue wrapper"));
+    assert!(usage.contains("adl-runtime run <adl.yaml>"));
+}
+
+#[test]
+fn csdlc_dispatch_routes_tooling_and_pr_errors_to_existing_surfaces() {
+    dispatch_csdlc_args(&["tooling".to_string(), "help".to_string()])
+        .expect("tooling help should route through existing tooling");
+    let missing_command = dispatch_csdlc_args(&[]).expect_err("missing command should fail closed");
+    assert!(missing_command
+        .to_string()
+        .contains("adl-csdlc requires a command"));
+    let unknown_command =
+        dispatch_csdlc_args(&["frobnicate".to_string()]).expect_err("unknown command should fail");
+    assert!(unknown_command
+        .to_string()
+        .contains("unknown adl-csdlc command"));
+    let pr_err = dispatch_csdlc_args(&["pr".to_string()])
+        .expect_err("empty pr command should route to existing pr validation");
+    assert!(pr_err.to_string().contains("pr requires a subcommand"));
+    let issue_err = dispatch_csdlc_args(&["issue".to_string()])
+        .expect_err("empty issue alias should fail before behavior changes");
+    assert!(issue_err
+        .to_string()
+        .contains("adl-csdlc issue requires a pr-compatible subcommand"));
+}
+
+#[test]
+fn csdlc_issue_run_rejects_runtime_yaml_and_non_numeric_operands() {
+    let missing_issue_err = dispatch_csdlc_args(&["issue".to_string(), "run".to_string()])
+        .expect_err("issue run should require an issue id");
+    assert!(missing_issue_err
+        .to_string()
+        .contains("requires a numeric issue id"));
+
+    let yaml_err = dispatch_csdlc_args(&[
+        "issue".to_string(),
+        "run".to_string(),
+        "workflow.adl.yaml".to_string(),
+    ])
+    .expect_err("runtime YAML must not route through adl-csdlc issue run");
+    assert!(yaml_err
+        .to_string()
+        .contains("Use adl-runtime run <adl.yaml>"));
+
+    let non_numeric_err = dispatch_csdlc_args(&[
+        "issue".to_string(),
+        "run".to_string(),
+        "not-an-issue".to_string(),
+    ])
+    .expect_err("issue run should require numeric issue ids");
+    assert!(non_numeric_err
+        .to_string()
+        .contains("expects a numeric issue id"));
+
+    assert!(looks_like_adl_workflow_path("workflow.adl.yaml"));
+    assert!(looks_like_adl_workflow_path("workflow.adl.yml"));
+    assert!(!looks_like_adl_workflow_path("3596"));
+    reject_csdlc_runtime_run("adl-csdlc issue", &["run".to_string()])
+        .expect("run without operand is left to downstream issue validation");
+    reject_csdlc_runtime_run(
+        "adl-csdlc issue",
+        &["doctor".to_string(), "3596".to_string()],
+    )
+    .expect("non-run issue subcommands should not be rejected");
+}
+
+#[test]
+fn csdlc_issue_run_maps_to_existing_pr_start_command() {
+    let mapped = csdlc_issue_to_pr_args(&[
+        "run".to_string(),
+        "3596".to_string(),
+        "--slug".to_string(),
+        "example".to_string(),
+    ])
+    .expect("numeric issue run should map to existing pr start command");
+    assert_eq!(
+        mapped,
+        vec![
+            "start".to_string(),
+            "3596".to_string(),
+            "--slug".to_string(),
+            "example".to_string()
+        ]
+    );
+
+    let doctor = csdlc_issue_to_pr_args(&["doctor".to_string(), "3596".to_string()])
+        .expect("non-run issue subcommands should preserve pr args");
+    assert_eq!(doctor, vec!["doctor".to_string(), "3596".to_string()]);
+}
+
+#[test]
+fn csdlc_pr_and_top_level_run_reject_runtime_workflow_execution() {
+    let pr_yaml_err = dispatch_csdlc_args(&[
+        "pr".to_string(),
+        "run".to_string(),
+        "workflow.adl.yml".to_string(),
+    ])
+    .expect_err("runtime YAML must not route through adl-csdlc pr run");
+    assert!(pr_yaml_err
+        .to_string()
+        .contains("cannot execute ADL workflow YAML"));
+
+    let top_level_run_err =
+        dispatch_csdlc_args(&["run".to_string(), "workflow.adl.yaml".to_string()])
+            .expect_err("top-level csdlc run is ambiguous");
+    assert!(top_level_run_err
+        .to_string()
+        .contains("does not run ADL workflow YAML"));
 }
 
 #[test]

--- a/adl/tests/cli_smoke.rs
+++ b/adl/tests/cli_smoke.rs
@@ -31,6 +31,13 @@ fn run_adl(args: &[&str]) -> std::process::Output {
         .expect("run adl binary")
 }
 
+fn run_adl_csdlc(args: &[&str]) -> std::process::Output {
+    Command::new(resolve_adl_csdlc_exe())
+        .args(args)
+        .output()
+        .expect("run adl-csdlc binary")
+}
+
 fn run_adl_with_env(args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
     let mut cmd = Command::new(resolve_adl_exe());
     cmd.args(args);
@@ -51,6 +58,17 @@ fn resolve_adl_exe() -> PathBuf {
     }
 }
 
+fn resolve_adl_csdlc_exe() -> PathBuf {
+    let raw = std::env::var("CARGO_BIN_EXE_adl-csdlc")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_adl-csdlc").to_string());
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+    }
+}
+
 fn assert_failure_contains(out: &std::process::Output, needle: &str) {
     assert!(
         !out.status.success(),
@@ -60,6 +78,32 @@ fn assert_failure_contains(out: &std::process::Output, needle: &str) {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains(needle), "stderr:\n{stderr}");
+}
+
+#[test]
+fn adl_csdlc_cli_binary_help_and_version_smoke() {
+    let help = run_adl_csdlc(&["--help"]);
+    assert!(
+        help.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&help.stdout),
+        String::from_utf8_lossy(&help.stderr)
+    );
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(help_stdout.contains("adl-csdlc - ADL C-SDLC compatibility binary"));
+    assert!(help_stdout.contains("adl-csdlc issue run <issue>"));
+
+    let version = run_adl_csdlc(&["--version"]);
+    assert!(
+        version.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&version.stdout),
+        String::from_utf8_lossy(&version.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        env!("CARGO_PKG_VERSION")
+    );
 }
 
 #[path = "cli_smoke/agent.rs"]


### PR DESCRIPTION
Closes #3596

## Summary
Implemented the first C-SDLC CLI ownership boundary by adding an `adl-csdlc` Rust binary. The binary reuses the existing CLI module as a compatibility entrypoint, routes C-SDLC surfaces through existing PR/tooling implementations, provides explicit help/version output, and fails closed when runtime workflow YAML is sent through the C-SDLC owner.

## Artifacts
- `adl/src/bin/adl_csdlc.rs`
- `adl/Cargo.toml`
- `adl/src/cli/mod.rs`
- `adl/src/cli/tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting for the changed crate.
  - `cargo test --manifest-path adl/Cargo.toml csdlc -- --nocapture`
    Verified focused C-SDLC tests and new dispatcher tests.
  - `cargo run --manifest-path adl/Cargo.toml --quiet --bin adl-csdlc -- --help`
    Verified the new binary help text.
  - `cargo run --manifest-path adl/Cargo.toml --quiet --bin adl-csdlc -- --version`
    Verified the new binary version output.
  - `cargo run --manifest-path adl/Cargo.toml --quiet --bin adl-csdlc -- issue run workflow.adl.yaml`
    Verified fail-closed runtime YAML rejection; command exits non-zero by design.
  - `cargo check --manifest-path adl/Cargo.toml --bin adl --bin adl-csdlc`
    Verified binary compile coverage for old and new owners.
  - `bash adl/tools/test_pr_run_ambiguity_policy.sh`
    Verified previous ambiguity policy remained intact.
  - `cargo run --manifest-path adl/Cargo.toml --quiet -- tooling prompt-template validate-schemas`
    Verified prompt-template schema parity.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3596__v0-91-5-refactor-mini-sprint-4-8-introduce-adl-csdlc-compatibility-binary/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3596__v0-91-5-refactor-mini-sprint-4-8-introduce-adl-csdlc-compatibility-binary/sor.md
- Idempotency-Key: v0-91-5-refactor-introduce-adl-csdlc-compatibility-binary-adl-cargo-toml-adl-src-bin-adl-csdlc-rs-adl-src-cli-mod-rs-adl-src-cli-tests-rs-adl-tests-cli-smoke-rs-adl-v0-91-5-tasks-issue-3596-v0-91-5-refactor-mini-sprint-4-8-introduce-adl-csdlc-compatibility-binary-sip-md-adl-v0-91-5-tasks-issue-3596-v0-91-5-refactor-mini-sprint-4-8-introduce-adl-csdlc-compatibility-binary-sor-md