### PR TITLE
[v0.91.5][refactor] Introduce adl-runtime compatibility binary

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -19,6 +19,10 @@ name = "adl-csdlc"
 path = "src/bin/adl_csdlc.rs"
 
 [[bin]]
+name = "adl-runtime"
+path = "src/bin/adl_runtime.rs"
+
+[[bin]]
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 

--- a/adl/src/bin/adl_runtime.rs
+++ b/adl/src/bin/adl_runtime.rs
@@ -1,0 +1,9 @@
+#[cfg(not(test))]
+#[allow(dead_code)]
+#[path = "../cli/mod.rs"]
+mod cli;
+
+#[cfg(not(test))]
+fn main() {
+    cli::run_runtime_main();
+}

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -68,6 +68,14 @@ pub fn run_main() {
 }
 
 #[allow(dead_code)]
+pub fn run_runtime_main() {
+    if let Err(err) = real_runtime_main() {
+        print_error_chain(&err);
+        std::process::exit(1);
+    }
+}
+
+#[allow(dead_code)]
 #[cfg(not(test))]
 pub fn run_csdlc_main() {
     if let Err(err) = real_csdlc_main() {
@@ -79,6 +87,12 @@ pub fn run_csdlc_main() {
 fn real_main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     dispatch_args(&args)
+}
+
+#[allow(dead_code)]
+fn real_runtime_main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    dispatch_runtime_args(&args)
 }
 
 #[allow(dead_code)]
@@ -118,6 +132,99 @@ fn dispatch_args(args: &[String]) -> Result<()> {
         Some("resume") => real_resume(&args[1..]),
         _ => run_workflow(args),
     }
+}
+
+#[allow(dead_code)]
+pub(crate) fn runtime_usage() -> &'static str {
+    "adl-runtime - ADL runtime compatibility binary\n\n\
+Usage:\n\
+  adl-runtime run <adl.yaml> [--print-plan] [--print-prompts] [--trace] [--run] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--quiet] [--open]\n\
+  adl-runtime resume <run_id> --adl <path> [--steer <steering.json>]\n\
+  adl-runtime agent <tick|run|status|inspect|stop> ...\n\
+  adl-runtime artifact validate-control-path --root <dir>\n\
+  adl-runtime csm observatory --packet <visibility-packet.json> ...\n\
+  adl-runtime demo <name> ...\n\
+  adl-runtime godel <run|inspect|evaluate|affect-slice> ...\n\
+  adl-runtime identity <init|show|now|foundation|...> ...\n\
+  adl-runtime instrument <graph|replay|replay-bundle|diff-plan|diff-trace|trace-schema|validate-trace-v1|provider-substrate|provider-substrate-schema> ...\n\
+  adl-runtime learn export --format <jsonl|bundle-v1|trace-bundle-v2> ...\n\
+  adl-runtime provider setup <family> [--out <dir>] [--force]\n\
+  adl-runtime keygen --out-dir <dir>\n\
+  adl-runtime sign <adl.yaml> --key <private_key_path> [--key-id <id>] [--out <signed_file>]\n\
+  adl-runtime verify <adl.yaml> [--key <public_key_path>]\n\
+  adl-runtime --help\n\
+  adl-runtime --version\n\n\
+Notes:\n\
+  adl <adl.yaml> remains available as a compatibility shortcut during migration.\n\
+  C-SDLC issue work belongs to adl/tools/pr.sh run <issue>; adl-runtime run expects an ADL workflow YAML path."
+}
+
+#[allow(dead_code)]
+fn dispatch_runtime_args(args: &[String]) -> Result<()> {
+    if matches!(
+        args.first().map(|s| s.as_str()),
+        Some("--help" | "-h" | "help")
+    ) {
+        println!("{}", runtime_usage());
+        return Ok(());
+    }
+
+    if matches!(args.first().map(|s| s.as_str()), Some("--version" | "-V")) {
+        println!("{}", version_text());
+        return Ok(());
+    }
+
+    match args.first().map(|s| s.as_str()) {
+        Some("run") => real_runtime_run(&args[1..]),
+        Some("resume") => real_resume(&args[1..]),
+        Some("artifact") => real_artifact(&args[1..]),
+        Some("agent") => real_agent(&args[1..]),
+        Some("csm") => real_csm(&args[1..]),
+        Some("demo") => real_demo(&args[1..]),
+        Some("godel") => real_godel(&args[1..]),
+        Some("identity") => real_identity(&args[1..]),
+        Some("instrument") => real_instrument(&args[1..]),
+        Some("learn") => real_learn(&args[1..]),
+        Some("provider") => real_provider(&args[1..]),
+        Some("runtime-v2") => real_runtime_v2(&args[1..]),
+        Some("keygen") => real_keygen(&args[1..]),
+        Some("sign") => real_sign(&args[1..]),
+        Some("verify") => real_verify(&args[1..]),
+        Some("pr") | Some("tooling") => Err(anyhow::anyhow!(
+            "adl-runtime does not own C-SDLC workflow commands. Use adl/tools/pr.sh run <issue> for issue work or adl-csdlc for C-SDLC compatibility surfaces."
+        )),
+        Some(other) => Err(anyhow::anyhow!(
+            "unknown adl-runtime command '{other}'. Expected run, resume, agent, artifact, csm, demo, godel, identity, instrument, learn, provider, runtime-v2, keygen, sign, verify, help, or --version."
+        )),
+        None => Err(anyhow::anyhow!(
+            "adl-runtime requires a command. Run `adl-runtime --help` for usage."
+        )),
+    }
+}
+
+#[allow(dead_code)]
+fn real_runtime_run(args: &[String]) -> Result<()> {
+    if matches!(args.first().map(|s| s.as_str()), Some("--help" | "-h")) {
+        println!("{}", runtime_usage());
+        return Ok(());
+    }
+    let Some(operand) = args.first() else {
+        return Err(anyhow::anyhow!(
+            "adl-runtime run requires an ADL workflow YAML path."
+        ));
+    };
+    if looks_like_issue_ref(operand) {
+        return Err(anyhow::anyhow!(
+            "adl-runtime run expects an ADL workflow YAML path, got issue id '{operand}'. C-SDLC issue work belongs to adl/tools/pr.sh run <issue>."
+        ));
+    }
+    run_workflow(args)
+}
+
+#[allow(dead_code)]
+fn looks_like_issue_ref(value: &str) -> bool {
+    let issue = value.strip_prefix('#').unwrap_or(value);
+    !issue.is_empty() && issue.chars().all(|ch| ch.is_ascii_digit())
 }
 
 #[allow(dead_code)]

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -20,9 +20,9 @@ use super::run_artifacts::{
     AEE_DECISION_VERSION, PAUSE_STATE_SCHEMA_VERSION,
 };
 use super::{
-    csdlc_issue_to_pr_args, csdlc_usage, dispatch_args, dispatch_csdlc_args,
-    looks_like_adl_workflow_path, real_instrument, real_keygen, real_learn, real_sign, real_verify,
-    reject_csdlc_runtime_run, usage, version_text,
+    csdlc_issue_to_pr_args, csdlc_usage, dispatch_args, dispatch_csdlc_args, dispatch_runtime_args,
+    looks_like_adl_workflow_path, looks_like_issue_ref, real_instrument, real_keygen, real_learn,
+    real_sign, real_verify, reject_csdlc_runtime_run, runtime_usage, usage, version_text,
 };
 use ::adl::godel::cross_workflow::{
     DownstreamWorkflowDecision, PersistedCrossWorkflowArtifact, CROSS_WORKFLOW_ARTIFACT_VERSION,
@@ -148,6 +148,55 @@ fn csdlc_dispatch_exposes_help_and_version_without_runtime_dispatch() {
     assert!(usage.contains("adl-csdlc issue run <issue>"));
     assert!(usage.contains("adl/tools/pr.sh remains the canonical agent-facing issue wrapper"));
     assert!(usage.contains("adl-runtime run <adl.yaml>"));
+}
+
+#[test]
+fn runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch() {
+    dispatch_runtime_args(&["--help".to_string()]).expect("runtime help should succeed");
+    dispatch_runtime_args(&["-h".to_string()]).expect("runtime short help should succeed");
+    dispatch_runtime_args(&["help".to_string()]).expect("runtime help alias should succeed");
+    dispatch_runtime_args(&["--version".to_string()]).expect("runtime version should succeed");
+    dispatch_runtime_args(&["-V".to_string()]).expect("runtime short version should succeed");
+
+    let usage = runtime_usage();
+    assert!(usage.contains("adl-runtime run <adl.yaml>"));
+    assert!(usage.contains("adl <adl.yaml> remains available as a compatibility shortcut"));
+    assert!(usage.contains("C-SDLC issue work belongs to adl/tools/pr.sh run <issue>"));
+}
+
+#[test]
+fn runtime_dispatch_rejects_csdlc_and_issue_run_inputs() {
+    dispatch_runtime_args(&["run".to_string(), "--help".to_string()])
+        .expect("runtime run help should succeed");
+
+    let issue_err = dispatch_runtime_args(&["run".to_string(), "3598".to_string()])
+        .expect_err("runtime run must reject numeric issue ids");
+    assert!(issue_err
+        .to_string()
+        .contains("adl/tools/pr.sh run <issue>"));
+
+    let hash_issue_err = dispatch_runtime_args(&["run".to_string(), "#3598".to_string()])
+        .expect_err("runtime run must reject hash-prefixed issue ids");
+    assert!(hash_issue_err
+        .to_string()
+        .contains("adl/tools/pr.sh run <issue>"));
+    assert!(looks_like_issue_ref("3598"));
+    assert!(looks_like_issue_ref("#3598"));
+    assert!(!looks_like_issue_ref("workflow.adl.yaml"));
+    assert!(!looks_like_issue_ref("#not-an-issue"));
+
+    let pr_err = dispatch_runtime_args(&["pr".to_string(), "run".to_string(), "3598".to_string()])
+        .expect_err("runtime must not own pr commands");
+    assert!(pr_err
+        .to_string()
+        .contains("does not own C-SDLC workflow commands"));
+
+    let tooling_err =
+        dispatch_runtime_args(&["tooling".to_string(), "prompt-template".to_string()])
+            .expect_err("runtime must not own tooling commands");
+    assert!(tooling_err
+        .to_string()
+        .contains("does not own C-SDLC workflow commands"));
 }
 
 #[test]

--- a/adl/tests/cli_smoke.rs
+++ b/adl/tests/cli_smoke.rs
@@ -38,6 +38,22 @@ fn run_adl_csdlc(args: &[&str]) -> std::process::Output {
         .expect("run adl-csdlc binary")
 }
 
+fn run_adl_runtime(args: &[&str]) -> std::process::Output {
+    Command::new(resolve_adl_runtime_exe())
+        .args(args)
+        .output()
+        .expect("run adl-runtime binary")
+}
+
+fn run_adl_runtime_with_env(args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(resolve_adl_runtime_exe());
+    cmd.args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run adl-runtime binary")
+}
+
 fn run_adl_with_env(args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
     let mut cmd = Command::new(resolve_adl_exe());
     cmd.args(args);
@@ -61,6 +77,17 @@ fn resolve_adl_exe() -> PathBuf {
 fn resolve_adl_csdlc_exe() -> PathBuf {
     let raw = std::env::var("CARGO_BIN_EXE_adl-csdlc")
         .unwrap_or_else(|_| env!("CARGO_BIN_EXE_adl-csdlc").to_string());
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+    }
+}
+
+fn resolve_adl_runtime_exe() -> PathBuf {
+    let raw = std::env::var("CARGO_BIN_EXE_adl-runtime")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_adl-runtime").to_string());
     let path = PathBuf::from(raw);
     if path.is_absolute() {
         path
@@ -103,6 +130,106 @@ fn adl_csdlc_cli_binary_help_and_version_smoke() {
     assert_eq!(
         String::from_utf8_lossy(&version.stdout).trim(),
         env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn adl_runtime_cli_binary_help_and_version_smoke() {
+    let help = run_adl_runtime(&["--help"]);
+    assert!(
+        help.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&help.stdout),
+        String::from_utf8_lossy(&help.stderr)
+    );
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(help_stdout.contains("adl-runtime - ADL runtime compatibility binary"));
+    assert!(help_stdout.contains("adl-runtime run <adl.yaml>"));
+    assert!(help_stdout.contains("adl-runtime resume <run_id>"));
+
+    let run_help = run_adl_runtime(&["run", "--help"]);
+    assert!(
+        run_help.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run_help.stdout),
+        String::from_utf8_lossy(&run_help.stderr)
+    );
+    assert!(String::from_utf8_lossy(&run_help.stdout).contains("adl-runtime run <adl.yaml>"));
+
+    let version = run_adl_runtime(&["--version"]);
+    assert!(
+        version.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&version.stdout),
+        String::from_utf8_lossy(&version.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn adl_runtime_run_matches_adl_yaml_shortcut_for_print_plan() {
+    let path = fixture_path("examples/v0-3-concurrency-fork-join.adl.yaml");
+    let legacy = run_adl(&[path.to_str().unwrap(), "--print-plan"]);
+    let runtime = run_adl_runtime(&["run", path.to_str().unwrap(), "--print-plan"]);
+
+    assert!(
+        legacy.status.success() && runtime.status.success(),
+        "legacy stderr:\n{}\nruntime stderr:\n{}",
+        String::from_utf8_lossy(&legacy.stderr),
+        String::from_utf8_lossy(&runtime.stderr)
+    );
+    assert_eq!(
+        legacy.stdout, runtime.stdout,
+        "adl-runtime run should preserve legacy YAML shortcut semantics"
+    );
+}
+
+#[test]
+fn adl_runtime_run_executes_fixture_with_mock_provider_and_writes_outputs() {
+    let out_dir = unique_test_temp_dir("adl-runtime-run-mock").join("out");
+    let runs_root = unique_test_temp_dir("adl-runtime-run-mock-runs");
+    let fixture = fixture_path("examples/v0-6-hitl-no-pause.adl.yaml");
+    let mock = fixture_path("tools/mock_ollama_v0_4.sh");
+    let out = run_adl_runtime_with_env(
+        &[
+            "run",
+            fixture.to_str().unwrap(),
+            "--run",
+            "--allow-unsigned",
+            "--out",
+            out_dir.to_str().unwrap(),
+        ],
+        &[
+            ("ADL_OLLAMA_BIN", mock.to_str().unwrap()),
+            ("ADL_RUNS_ROOT", runs_root.to_str().unwrap()),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out_dir.join("s1.txt").is_file(), "missing s1.txt");
+    assert!(out_dir.join("s2.txt").is_file(), "missing s2.txt");
+    assert!(out_dir.join("s3.txt").is_file(), "missing s3.txt");
+}
+
+#[test]
+fn adl_runtime_run_fails_closed_for_issue_ids() {
+    let out = run_adl_runtime(&["run", "3598"]);
+    assert_failure_contains(
+        &out,
+        "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>",
+    );
+
+    let hash_out = run_adl_runtime(&["run", "#3598"]);
+    assert_failure_contains(
+        &hash_out,
+        "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>",
     );
 }
 

--- a/adl/tools/test_adl_runtime_compatibility.sh
+++ b/adl/tools/test_adl_runtime_compatibility.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/adl/Cargo.toml"
+FIXTURE="$ROOT_DIR/adl/examples/v0-3-concurrency-fork-join.adl.yaml"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+  local pattern="$1" text="$2" label="$3"
+  grep -Fq "$pattern" <<<"$text" || {
+    echo "assertion failed ($label): expected to find '$pattern'" >&2
+    echo "actual output:" >&2
+    echo "$text" >&2
+    exit 1
+  }
+}
+
+assert_status_nonzero() {
+  local status="$1" label="$2"
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed ($label): expected nonzero exit" >&2
+    exit 1
+  }
+}
+
+run_adl() {
+  cargo run --quiet --manifest-path "$MANIFEST" --bin adl -- "$@"
+}
+
+run_runtime() {
+  cargo run --quiet --manifest-path "$MANIFEST" --bin adl-runtime -- "$@"
+}
+
+help_output="$(run_runtime --help)"
+assert_contains "adl-runtime - ADL runtime compatibility binary" "$help_output" "runtime help title"
+assert_contains "adl-runtime run <adl.yaml>" "$help_output" "runtime run help"
+assert_contains "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>" "$help_output" "csdlc handoff help"
+
+run_help_output="$(run_runtime run --help)"
+assert_contains "adl-runtime run <adl.yaml>" "$run_help_output" "runtime run subcommand help"
+
+version_output="$(run_runtime --version)"
+assert_contains "$(cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')" "$version_output" "runtime version"
+
+legacy_plan="$TMP_DIR/legacy-plan.txt"
+runtime_plan="$TMP_DIR/runtime-plan.txt"
+run_adl "$FIXTURE" --print-plan >"$legacy_plan"
+run_runtime run "$FIXTURE" --print-plan >"$runtime_plan"
+cmp "$legacy_plan" "$runtime_plan" || {
+  echo "assertion failed: adl-runtime run output drifted from adl <yaml> compatibility shortcut" >&2
+  exit 1
+}
+
+set +e
+issue_output="$(run_runtime run 3598 2>&1)"
+issue_status=$?
+set -e
+assert_status_nonzero "$issue_status" "runtime run issue id"
+assert_contains "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>" "$issue_output" "runtime issue handoff"
+
+set +e
+hash_issue_output="$(run_runtime run '#3598' 2>&1)"
+hash_issue_status=$?
+set -e
+assert_status_nonzero "$hash_issue_status" "runtime run hash-prefixed issue id"
+assert_contains "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>" "$hash_issue_output" "runtime hash issue handoff"
+
+set +e
+pr_output="$(run_runtime pr run 3598 2>&1)"
+pr_status=$?
+set -e
+assert_status_nonzero "$pr_status" "runtime pr ownership"
+assert_contains "adl-runtime does not own C-SDLC workflow commands" "$pr_output" "runtime pr rejection"
+
+set +e
+tooling_output="$(run_runtime tooling prompt-template 2>&1)"
+tooling_status=$?
+set -e
+assert_status_nonzero "$tooling_status" "runtime tooling ownership"
+assert_contains "adl-runtime does not own C-SDLC workflow commands" "$tooling_output" "runtime tooling rejection"
+
+echo "PASS test_adl_runtime_compatibility"

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -24,6 +24,7 @@ run_check adl/tools/test_pr_init_skill_contracts.sh
 run_check adl/tools/test_card_editor_skill_contracts.sh
 run_check adl/tools/test_pr_closeout_skill_contracts.sh
 run_check adl/tools/test_cli_wrapper_migration_contract.sh
+run_check adl/tools/test_adl_runtime_compatibility.sh
 run_check adl/tools/test_pr_run.sh
 run_check adl/tools/test_pr_run_ambiguity_policy.sh
 run_check adl/tools/test_pr_run_materializes_worktree_cards.sh

--- a/docs/milestones/v0.91.5/CLI_RUNTIME_COMPATIBILITY_3598.md
+++ b/docs/milestones/v0.91.5/CLI_RUNTIME_COMPATIBILITY_3598.md
@@ -1,0 +1,92 @@
+# CLI Runtime Compatibility Boundary (#3598)
+
+## Summary
+
+Issue `#3598` introduces `adl-runtime` as the runtime compatibility binary for
+the first v0.91.5 CLI ownership split. This is a behavior-preserving boundary:
+runtime command ownership becomes explicit, but the existing `adl <adl.yaml>`
+shortcut and runtime command semantics remain intact.
+
+## Ownership Contract
+
+`adl-runtime` owns runtime-facing command families during this split:
+
+- `adl-runtime run <adl.yaml> ...`
+- `adl-runtime resume <run_id> --adl <path> ...`
+- `adl-runtime agent ...`
+- `adl-runtime artifact ...`
+- `adl-runtime csm observatory ...`
+- `adl-runtime demo ...`
+- `adl-runtime godel ...`
+- `adl-runtime identity ...`
+- `adl-runtime instrument ...`
+- `adl-runtime learn export ...`
+- `adl-runtime provider setup ...`
+- `adl-runtime runtime-v2 ...`
+- `adl-runtime keygen`, `adl-runtime sign`, and `adl-runtime verify`
+
+The compatibility binary does not move implementation modules yet. It routes to
+the existing runtime functions so command behavior can be proven equivalent
+before deeper module or crate decomposition begins.
+
+## Compatibility Rules
+
+- `adl <adl.yaml>` remains a compatibility shortcut.
+- `adl-runtime run <adl.yaml>` must preserve the legacy YAML shortcut behavior.
+- `adl-runtime run <issue>` and `adl-runtime run #<issue>` must fail closed and direct issue work to
+  `adl/tools/pr.sh run <issue>`.
+- `adl-runtime pr ...` and `adl-runtime tooling ...` must fail closed because
+  C-SDLC issue and tooling commands remain under the C-SDLC wrapper/migration
+  spine.
+- `adl/tools/pr.sh` remains the canonical agent-facing issue-work entrypoint
+  under the wrapper migration contract from `#3597`.
+
+## Runtime Design Notes
+
+The runtime binary is intentionally conservative:
+
+- no runtime execution semantics are changed;
+- no provider, agent, demo, identity, Gödel, signing, learning, or
+  instrumentation module is moved;
+- no new runtime configuration state is introduced;
+- no external-repo adapter command truth is changed;
+- help text names the runtime boundary and the C-SDLC handoff explicitly.
+
+This keeps the centerpiece runtime stable while still giving future issues a
+clear binary boundary to test against.
+
+## Validation Surface
+
+Focused validation should prove:
+
+- `adl-runtime --help` and `adl-runtime --version` work;
+- `adl-runtime run <adl.yaml> --print-plan` matches
+  `adl <adl.yaml> --print-plan`;
+- `adl-runtime run <adl.yaml> --run` executes the existing runtime path with a
+  mock provider and writes expected output artifacts;
+- `adl-runtime run <issue>` and `adl-runtime run #<issue>` reject issue IDs
+  with a C-SDLC handoff;
+- `adl-runtime pr ...` and `adl-runtime tooling ...` reject C-SDLC ownership
+  drift;
+- the old `adl <adl.yaml>` shortcut remains available.
+
+The fast shell proof is:
+
+```bash
+bash adl/tools/test_adl_runtime_compatibility.sh
+```
+
+The focused Rust proof is:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml runtime_dispatch -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke adl_runtime -- --nocapture
+```
+
+## Non-Claims
+
+- This does not split the Rust workspace into multiple crates.
+- This does not remove or deprecate the `adl` binary.
+- This does not change generated-card issue-work commands.
+- This does not make `adl-runtime` the C-SDLC issue executor.
+- This does not complete later observability or OpenTelemetry work.


### PR DESCRIPTION
Closes #3598

## Summary
Implemented the `adl-runtime` compatibility binary as the runtime ownership boundary for issue #3598 without moving runtime modules or changing runtime behavior. The new binary routes runtime-owned command families through the existing implementation, preserves the legacy `adl` plus ADL workflow YAML shortcut, fails closed for C-SDLC issue inputs, and records a tracked runtime compatibility contract.

## Artifacts
- `adl/src/bin/adl_runtime.rs`
- `docs/milestones/v0.91.5/CLI_RUNTIME_COMPATIBILITY_3598.md`
- `adl/tools/test_adl_runtime_compatibility.sh`
- Updated runtime dispatch and tests in `adl/src/cli/mod.rs`, `adl/src/cli/tests.rs`, and `adl/tests/cli_smoke.rs`
- Updated authoring regression suite registration in `adl/tools/test_five_command_regression_suite.sh`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting for the touched crate.
  - `git diff --check`
    Verified whitespace hygiene for the pending diff.
  - `bash adl/tools/test_adl_runtime_compatibility.sh`
    Verified fast shell-level runtime compatibility and fail-closed behavior.
  - `cargo test --manifest-path adl/Cargo.toml runtime_dispatch -- --nocapture`
    Verified runtime dispatcher behavior in Rust unit coverage.
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke adl_runtime -- --nocapture`
    Verified real binary smoke, print-plan parity, mocked execution artifact output, and issue-id rejection.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-runtime -- --nocapture`
    Verified the split runtime binary test target compiles without importing the full legacy CLI unit-test tree.
  - `cargo test --manifest-path adl/Cargo.toml --test provider_tests -- --nocapture`
    Verified provider/runtime integration tests still pass.
  - `cargo check --manifest-path adl/Cargo.toml --bin adl --bin adl-runtime --bin adl-csdlc`
    Verified compile health for the legacy and split owner binaries.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- cli`
    Generated focused coverage evidence for changed runtime/CLI source surfaces.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight passed for changed Rust source files.
  - `cargo run --manifest-path adl/Cargo.toml --quiet -- tooling prompt-template validate-schemas`
    Verified prompt-template schema parity after card updates.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.5/tasks/issue-3598__v0-91-5-refactor-mini-sprint-6-8-introduce-adl-runtime-compatibility-binary/spp.md`
    Verified SPP structural validity after plan-truth repair.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3598__v0-91-5-refactor-mini-sprint-6-8-introduce-adl-runtime-compatibility-binary/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3598__v0-91-5-refactor-mini-sprint-6-8-introduce-adl-runtime-compatibility-binary/sor.md
- Idempotency-Key: v0-91-5-refactor-introduce-adl-runtime-compatibility-binary-adl-cargo-toml-adl-src-bin-adl-runtime-rs-adl-src-cli-mod-rs-adl-src-cli-tests-rs-adl-tests-cli-smoke-rs-adl-tools-test-adl-runtime-compatibility-sh-adl-tools-test-five-command-regression-suite-sh-docs-milestones-v0-91-5-cli-runtime-compatibility-3598-md-adl-v0-91-5-tasks-issue-3598-v0-91-5-refactor-mini-sprint-6-8-introduce-adl-runtime-compatibility-binary-sip-md-adl-v0-91-5-tasks-issue-3598-v0-91-5-refactor-mini-sprint-6-8-introduce-adl-runtime-compatibility-binary-sor-md