### PR TITLE
[v0.91.5][refactor] Add deterministic control-plane observability

### DIFF
--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -7,6 +7,7 @@ mod csm_cmd;
 mod demo_cmd;
 mod godel_cmd;
 mod identity_cmd;
+mod observability;
 mod open;
 mod pr_cmd;
 mod pr_cmd_args;
@@ -127,6 +128,16 @@ fn dispatch_args(args: &[String]) -> Result<()> {
         return Ok(());
     }
 
+    observability::emit_event(
+        "adl",
+        "dispatch",
+        "started",
+        &[(
+            "subcommand",
+            args.first().map(String::as_str).unwrap_or("workflow"),
+        )],
+    );
+
     match args.first().map(|s| s.as_str()) {
         Some("artifact") => real_artifact(&args[1..]),
         Some("agent") => real_agent(&args[1..]),
@@ -187,6 +198,13 @@ fn dispatch_runtime_args(args: &[String]) -> Result<()> {
         println!("{}", version_text());
         return Ok(());
     }
+
+    observability::emit_event(
+        "adl-runtime",
+        "dispatch",
+        "started",
+        &[("subcommand", args.first().map(String::as_str).unwrap_or(""))],
+    );
 
     match args.first().map(|s| s.as_str()) {
         Some("run") => real_runtime_run(&args[1..]),
@@ -265,6 +283,13 @@ fn dispatch_review_args(args: &[String]) -> Result<()> {
         println!("{}", version_text());
         return Ok(());
     }
+
+    observability::emit_event(
+        "adl-review",
+        "dispatch",
+        "started",
+        &[("subcommand", args.first().map(String::as_str).unwrap_or(""))],
+    );
 
     match args.first().map(|s| s.as_str()) {
         Some("code-review") => review_to_tooling_args("code-review", &args[1..])
@@ -348,6 +373,13 @@ fn dispatch_csdlc_args(args: &[String]) -> Result<()> {
         println!("{}", version_text());
         return Ok(());
     }
+
+    observability::emit_event(
+        "adl-csdlc",
+        "dispatch",
+        "started",
+        &[("subcommand", args.first().map(String::as_str).unwrap_or(""))],
+    );
 
     match args.first().map(|s| s.as_str()) {
         Some("pr") => {

--- a/adl/src/cli/observability.rs
+++ b/adl/src/cli/observability.rs
@@ -1,0 +1,103 @@
+use std::env;
+use std::path::Path;
+
+pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&str, &str)]) {
+    if env::var("ADL_OBSERVABILITY").ok().as_deref() == Some("0") {
+        return;
+    }
+
+    let mut line = format!(
+        "adl_event schema=adl.observability.event.v1 command={} stage={} result={}",
+        sanitize_value(command),
+        sanitize_value(stage),
+        sanitize_value(result)
+    );
+    for (key, value) in fields {
+        line.push(' ');
+        line.push_str(key);
+        line.push('=');
+        line.push_str(&sanitize_value(value));
+    }
+    eprintln!("{line}");
+}
+
+pub(crate) fn sanitize_value(value: &str) -> String {
+    let mut sanitized = value.replace(['\n', '\r'], " ").replace('"', "'");
+
+    if contains_secret_marker(&sanitized) {
+        return "<redacted>".to_string();
+    }
+
+    if let Ok(root) = env::var("ADL_OBSERVABILITY_REPO_ROOT") {
+        let root = root.trim_end_matches('/');
+        let prefix = format!("{root}/");
+        if sanitized.starts_with(&prefix) {
+            return format!("<repo>/{}", &sanitized[prefix.len()..]);
+        }
+    } else if let Ok(root) = env::current_dir() {
+        if let Some(root) = root.to_str() {
+            let root = root.trim_end_matches('/');
+            let prefix = format!("{root}/");
+            if sanitized.starts_with(&prefix) {
+                return format!("<repo>/{}", &sanitized[prefix.len()..]);
+            }
+        }
+    }
+
+    if let Ok(home) = env::var("HOME") {
+        let home = home.trim_end_matches('/');
+        let prefix = format!("{home}/");
+        if sanitized.starts_with(&prefix) {
+            return format!("<home>/{}", &sanitized[prefix.len()..]);
+        }
+    }
+
+    if sanitized.starts_with("/private/tmp/")
+        || sanitized.starts_with("/tmp/")
+        || sanitized.starts_with("/var/folders/")
+        || Path::new(&sanitized).is_absolute()
+    {
+        sanitized = "<path>".to_string();
+    }
+
+    sanitized
+}
+
+fn contains_secret_marker(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("token")
+        || lower.contains("secret")
+        || lower.contains("api_key")
+        || lower.contains("api-key")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_value;
+    use std::env;
+
+    #[test]
+    fn sanitize_value_redacts_secret_markers() {
+        assert_eq!(sanitize_value("api-token-value"), "<redacted>");
+        assert_eq!(sanitize_value("contains_secret_marker"), "<redacted>");
+    }
+
+    #[test]
+    fn sanitize_value_normalizes_repo_home_and_absolute_paths() {
+        env::set_var("ADL_OBSERVABILITY_REPO_ROOT", "/repo/adl");
+        env::set_var("HOME", "/home/operator");
+
+        assert_eq!(
+            sanitize_value("/repo/adl/docs/example.md"),
+            "<repo>/docs/example.md"
+        );
+        assert_eq!(
+            sanitize_value("/home/operator/.adl/state.json"),
+            "<home>/.adl/state.json"
+        );
+        assert_eq!(sanitize_value("/private/tmp/example"), "<path>");
+        assert_eq!(sanitize_value("/elsewhere/example"), "<path>");
+
+        env::remove_var("ADL_OBSERVABILITY_REPO_ROOT");
+    }
+}

--- a/adl/tools/attach_post_merge_closeout.sh
+++ b/adl/tools/attach_post_merge_closeout.sh
@@ -4,6 +4,14 @@ if [ -z "${BASH_VERSION:-}" ]; then
 fi
 set -euo pipefail
 
+OBSERVABILITY_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/observability.sh"
+if [[ -f "$OBSERVABILITY_LIB" ]]; then
+  # shellcheck disable=SC1090
+  source "$OBSERVABILITY_LIB"
+else
+  adl_obs_event() { :; }
+fi
+
 usage() {
   cat <<'EOF' >&2
 Usage:
@@ -45,6 +53,7 @@ poll_once() {
   local issue_state
   local issue_reason
 
+  adl_obs_event "attach_post_merge_closeout.sh" "github_fetch" "started" "issue" "$ISSUE" "operation" "pr_state"
   pr_json="$(gh pr view -R "$REPO" "$PR_URL" --json state,mergedAt,url 2>>"$run_log" || true)"
   if [[ -z "$pr_json" ]]; then
     return 1
@@ -59,6 +68,7 @@ poll_once() {
     return 1
   fi
 
+  adl_obs_event "attach_post_merge_closeout.sh" "github_fetch" "started" "issue" "$ISSUE" "operation" "issue_state"
   issue_json="$(gh issue view "$ISSUE" -R "$REPO" --json state,stateReason,url 2>>"$run_log" || true)"
   if [[ -z "$issue_json" ]]; then
     return 1
@@ -69,11 +79,14 @@ poll_once() {
     return 1
   fi
 
+  adl_obs_event "attach_post_merge_closeout.sh" "closeout" "started" "issue" "$ISSUE"
   if bash "$REPO_ROOT/adl/tools/pr.sh" closeout "$ISSUE" >>"$run_log" 2>&1; then
+    adl_obs_event "attach_post_merge_closeout.sh" "closeout" "ok" "issue" "$ISSUE"
     write_summary "$summary_file" "normalized" "Automatic post-merge closeout completed after PR merge and issue closure."
     return 0
   fi
 
+  adl_obs_event "attach_post_merge_closeout.sh" "closeout" "failed" "issue" "$ISSUE"
   write_summary "$summary_file" "failed_closeout" "PR merged and issue closed/completed, but automatic closeout failed. Inspect run.log for the bounded error."
   return 20
 }
@@ -143,6 +156,7 @@ RUN_LOG="${RUN_LOG:-$ARTIFACT_ROOT/run.log}"
 PID_FILE="$ARTIFACT_ROOT/pid"
 
 if [[ "$WATCH_MODE" == "1" ]]; then
+  adl_obs_event "attach_post_merge_closeout.sh" "watch_loop" "started" "issue" "$ISSUE" "branch" "$BRANCH"
   run_watch_loop "$ARTIFACT_ROOT" "$SUMMARY_FILE" "$RUN_LOG"
   exit 0
 fi
@@ -159,4 +173,5 @@ nohup bash "$0" \
 
 CLOSEOUT_PID=$!
 printf '%s\n' "$CLOSEOUT_PID" >"$PID_FILE"
+adl_obs_event "attach_post_merge_closeout.sh" "watcher_attached" "ok" "issue" "$ISSUE" "pid" "$CLOSEOUT_PID" "log" "$RUN_LOG" "summary" "$SUMMARY_FILE"
 printf 'ATTACHED issue=%s pr=%s pid=%s log=%s summary=%s\n' "$ISSUE" "$PR_URL" "$CLOSEOUT_PID" "$RUN_LOG" "$SUMMARY_FILE"

--- a/adl/tools/observability.sh
+++ b/adl/tools/observability.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Deterministic, redacted stage logging for ADL shell control-plane tools.
+# Source this file from bash scripts; it intentionally has no set -e side
+# effects so callers keep their own shell policy.
+
+adl_obs_enabled() {
+  [[ "${ADL_OBSERVABILITY:-1}" != "0" ]]
+}
+
+adl_obs_now_ms() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+adl_obs_repo_root() {
+  if [[ -n "${ADL_OBSERVABILITY_REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$ADL_OBSERVABILITY_REPO_ROOT"
+    return 0
+  fi
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+adl_obs_sanitize_value() {
+  local value="$1"
+  local root
+  root="$(adl_obs_repo_root)"
+
+  if [[ -n "$root" && "$value" == "$root/"* ]]; then
+    value="<repo>/${value#"$root/"}"
+  elif [[ "$value" == "$HOME/"* ]]; then
+    value="<home>/${value#"$HOME/"}"
+  elif [[ "$value" == /private/tmp/* || "$value" == /tmp/* || "$value" == /var/folders/* ]]; then
+    value="<tmp>"
+  fi
+
+  value="${value//$'\n'/ }"
+  value="${value//$'\r'/ }"
+  value="${value//\"/_}"
+
+  if [[ "$value" =~ [Tt][Oo][Kk][Ee][Nn] || "$value" =~ [Ss][Ee][Cc][Rr][Ee][Tt] || "$value" =~ [Aa][Pp][Ii][_-]?[Kk][Ee][Yy] ]]; then
+    value="<redacted>"
+  fi
+
+  printf '%s\n' "$value"
+}
+
+adl_obs_event() {
+  adl_obs_enabled || return 0
+  local command="$1"
+  local stage="$2"
+  local result="$3"
+  shift 3 || true
+
+  local line key value log_path
+  line="adl_event schema=adl.observability.event.v1 command=$(adl_obs_sanitize_value "$command") stage=$(adl_obs_sanitize_value "$stage") result=$(adl_obs_sanitize_value "$result")"
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    value="${2:-}"
+    shift 2 || true
+    [[ -n "$key" ]] || continue
+    line+=" ${key}=$(adl_obs_sanitize_value "$value")"
+  done
+
+  printf '%s\n' "$line" >&2
+  log_path="${ADL_OBSERVABILITY_LOG:-}"
+  if [[ -n "$log_path" ]]; then
+    mkdir -p "$(dirname "$log_path")"
+    printf '%s\n' "$line" >>"$log_path"
+  fi
+}
+
+adl_obs_stage_start() {
+  adl_obs_now_ms
+}
+
+adl_obs_stage_done() {
+  local command="$1"
+  local stage="$2"
+  local result="$3"
+  local started_ms="$4"
+  shift 4 || true
+  local now elapsed
+  now="$(adl_obs_now_ms)"
+  elapsed=$((now - started_ms))
+  adl_obs_event "$command" "$stage" "$result" "elapsed_ms" "$elapsed" "$@"
+}

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -44,6 +44,15 @@ set -euo pipefail
 CARD_PATHS_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/card_paths.sh"
 # shellcheck disable=SC1090
 source "$CARD_PATHS_LIB"
+OBSERVABILITY_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/observability.sh"
+if [[ -f "$OBSERVABILITY_LIB" ]]; then
+  # shellcheck disable=SC1090
+  source "$OBSERVABILITY_LIB"
+else
+  # Some compatibility tests copy pr.sh into a minimal fake repo. Observability
+  # must never make those compatibility surfaces fail before their assertions.
+  adl_obs_event() { :; }
+fi
 
 DEFAULT_VERSION="v0.86"
 DEFAULT_NEW_LABELS="track:roadmap,type:task,area:tools"
@@ -239,12 +248,15 @@ delegate_pr_command_to_rust() {
   # wrapper contract here is limited to exact delegation and exit-status
   # propagation into the Rust control plane.
   if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$ADL_PR_RUST_BIN"
     exec "${ADL_PR_RUST_BIN}" pr "$subcommand" "$@"
   fi
   cached_bin="$(rust_pr_delegate_cached_bin || true)"
   if [[ -n "$cached_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
     exec "$cached_bin" pr "$subcommand" "$@"
   fi
+  adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest"
   exec cargo run --quiet --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
 }
 
@@ -1718,10 +1730,12 @@ cmd_run() {
     usage_run
     return 0
   fi
+  adl_obs_event "pr.sh" "run_dispatch" "started" "arg0" "${1:-}"
 
   if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
     ensure_pr_run_issue_args_are_issue_only "$@"
     require_rust_pr_delegate
+    adl_obs_event "pr.sh" "issue_bind" "started" "issue" "$1"
     note "Issue-mode run: binding execution context for issue $1"
     delegate_pr_command_to_rust start "$@"
     return 0
@@ -2232,6 +2246,7 @@ cmd_start() {
     usage_start
     return 0
   fi
+  adl_obs_event "pr.sh" "issue_bind" "started" "issue" "${1:-}"
   require_rust_pr_delegate
   note "Deprecated compatibility path: prefer 'adl/tools/pr.sh run <issue> ...' for execution-context binding."
   delegate_pr_command_to_rust start "$@"
@@ -2243,6 +2258,7 @@ cmd_finish() {
     usage_finish
     return 0
   fi
+  adl_obs_event "pr.sh" "finish" "started" "issue" "${1:-}"
   require_rust_pr_delegate
   delegate_pr_command_to_rust finish "$@"
 }
@@ -2252,6 +2268,7 @@ cmd_closeout() {
     usage_closeout
     return 0
   fi
+  adl_obs_event "pr.sh" "closeout" "started" "issue" "${1:-}"
   require_rust_pr_delegate
   delegate_pr_command_to_rust closeout "$@"
 }
@@ -2287,6 +2304,7 @@ cmd_doctor() {
     usage_doctor
     return 0
   fi
+  adl_obs_event "pr.sh" "doctor" "started" "issue" "${1:-}"
   require_rust_pr_delegate
   delegate_pr_command_to_rust doctor "$@"
 }
@@ -2537,6 +2555,10 @@ main() {
     return 0
   fi
   local cmd="${1:-}"; shift || true
+  local first_arg="${1:-}"
+  if [[ -n "$cmd" && "$cmd" != "help" && "$cmd" != "-h" && "$cmd" != "--help" && "$first_arg" != "help" && "$first_arg" != "-h" && "$first_arg" != "--help" ]]; then
+    adl_obs_event "pr.sh" "command_start" "started" "subcommand" "$cmd"
+  fi
   case "$cmd" in
     help) usage ;;
     create) cmd_create "$@" ;;

--- a/adl/tools/test_control_plane_observability.sh
+++ b/adl/tools/test_control_plane_observability.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OBS="$ROOT_DIR/adl/tools/observability.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# shellcheck disable=SC1090
+source "$OBS"
+
+export ADL_OBSERVABILITY_REPO_ROOT="$ROOT_DIR"
+export ADL_OBSERVABILITY_LOG="$TMP_DIR/events.log"
+
+adl_obs_event "pr.sh" "doctor" "started" \
+  "path" "$ROOT_DIR/.adl/v0.91.5/tasks/example/sor.md" \
+  "token" "super-secret-token" \
+  "tmp" "/private/tmp/adl-secret"
+
+event="$(cat "$TMP_DIR/events.log")"
+case "$event" in
+  *"schema=adl.observability.event.v1"* ) ;;
+  *) echo "missing observability schema: $event" >&2; exit 1 ;;
+esac
+case "$event" in
+  *"command=pr.sh"*"stage=doctor"*"result=started"* ) ;;
+  *) echo "missing command/stage/result fields: $event" >&2; exit 1 ;;
+esac
+case "$event" in
+  *"<repo>/.adl/v0.91.5/tasks/example/sor.md"* ) ;;
+  *) echo "repo path was not normalized: $event" >&2; exit 1 ;;
+esac
+if grep -Fq "$ROOT_DIR" "$TMP_DIR/events.log"; then
+  echo "event leaked absolute repo path" >&2
+  exit 1
+fi
+if grep -Eiq 'super-secret-token|/private/tmp/adl-secret' "$TMP_DIR/events.log"; then
+  echo "event leaked secret-like or tmp path material" >&2
+  exit 1
+fi
+
+ADL_OBSERVABILITY=0 adl_obs_event "pr.sh" "disabled" "started"
+line_count="$(wc -l <"$TMP_DIR/events.log" | tr -d ' ')"
+[[ "$line_count" == "1" ]] || {
+  echo "disabled observability still wrote events" >&2
+  exit 1
+}
+
+echo "PASS test_control_plane_observability"

--- a/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
+++ b/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
@@ -1,0 +1,86 @@
+# Control-Plane Observability Contract (#3609)
+
+Issue: #3609
+Status: implementation contract
+
+## Purpose
+
+ADL control-plane commands must tell operators what they are doing before they
+block, mutate state, call GitHub, delegate to Rust, or fail. Silent waits are a
+workflow defect because agents cannot distinguish useful work from a wedge.
+
+## Event Shape
+
+Shell and Rust command-dispatch events use one line per stage:
+
+```text
+adl_event schema=adl.observability.event.v1 command=<command> stage=<stage> result=<result> key=value ...
+```
+
+Required fields:
+
+- `schema`: currently `adl.observability.event.v1`
+- `command`: command family such as `pr.sh`, `adl-runtime`, or
+  `attach_post_merge_closeout.sh`
+- `stage`: bounded stage name such as `dispatch`, `doctor`, `rust_delegate`,
+  `github_fetch`, `closeout`, or `watcher_attached`
+- `result`: `started`, `exec`, `ok`, `blocked`, `skipped`, or `failed`
+
+Optional fields may include `issue`, `subcommand`, `operation`, `branch`,
+`delegate`, `log`, `summary`, `elapsed_ms`, and other bounded diagnostic keys.
+
+## Redaction Rules
+
+Events must not expose:
+
+- raw credentials, secret markers, API keys, tokens, or private key material
+- raw prompts or private tool arguments
+- host-local absolute paths
+- unbounded command output
+
+Repo paths should be normalized to `<repo>/...`, home paths to `<home>/...`,
+and temp or unrelated absolute paths to `<tmp>` or `<path>`.
+
+## Terminal And Durable Logs
+
+By default, shell and Rust dispatch events are visible on stderr. If
+`ADL_OBSERVABILITY_LOG` is set, shell events are also appended to that durable
+log path.
+
+`ADL_OBSERVABILITY=0` disables event emission for compatibility tests that need
+a completely quiet stderr surface.
+
+## OTEL Mapping
+
+The event vocabulary is intentionally OTEL-ready:
+
+| ADL field | OTEL-style mapping |
+| --- | --- |
+| `command` | span name prefix or `service.operation` attribute |
+| `stage` | span name suffix or event name |
+| `result` | status/event result attribute |
+| `issue`, `branch`, `operation` | span attributes |
+| `elapsed_ms` | span/event duration field |
+
+This issue does not require a hosted collector. Exporter wiring belongs behind
+a later implementation gate after local deterministic logs are stable.
+
+## Implemented First Slice
+
+The first slice instruments:
+
+- `adl/tools/pr.sh` command dispatch and Rust delegation boundaries
+- high-pain `pr.sh` commands: `run`, `doctor`, `finish`, and `closeout`
+- `adl/tools/attach_post_merge_closeout.sh` watch, GitHub fetch, attach, and
+  closeout stages
+- Rust dispatch entrypoints for `adl`, `adl-csdlc`, `adl-runtime`, and
+  `adl-review`
+
+Runtime action-level logs remain owned by #3556. This contract keeps the
+vocabulary aligned so runtime and control-plane spans can converge later.
+
+## Non-Claims
+
+- This contract does not claim complete OpenTelemetry export.
+- This contract does not claim every Rust internal function is span-instrumented.
+- This contract does not change command semantics or exit-code policy.


### PR DESCRIPTION
Closes #3609

## Summary
Implemented the first deterministic C-SDLC control-plane observability slice for #3609. Shell control-plane scripts and Rust CLI dispatchers now emit one-line redacted `adl_event` records for high-pain stages while preserving existing command semantics and help-output compatibility.

## Artifacts
- `adl/tools/observability.sh`
- `adl/tools/test_control_plane_observability.sh`
- `adl/tools/pr.sh`
- `adl/tools/attach_post_merge_closeout.sh`
- `adl/src/cli/observability.rs`
- `adl/src/cli/mod.rs`
- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.5/tasks/issue-3609__v0-91-5-refactor-observability-add-deterministic-csdlc-control-plane-action-logs/sor.md`
    Verified bootstrap SOR contract compliance for the local output scaffold.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3609__v0-91-5-refactor-observability-add-deterministic-csdlc-control-plane-action-logs/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3609__v0-91-5-refactor-observability-add-deterministic-csdlc-control-plane-action-logs/sor.md
- Idempotency-Key: v0-91-5-refactor-add-deterministic-control-plane-observability-adl-tools-observability-sh-adl-tools-test-control-plane-observability-sh-adl-tools-pr-sh-adl-tools-attach-post-merge-closeout-sh-adl-src-cli-observability-rs-adl-src-cli-mod-rs-docs-milestones-v0-91-5-control-plane-observability-contract-3609-md-adl-v0-91-5-tasks-issue-3609-v0-91-5-refactor-observability-add-deterministic-csdlc-control-plane-action-logs-sip-md-adl-v0-91-5-tasks-issue-3609-v0-91-5-refactor-observability-add-deterministic-csdlc-control-plane-action-logs-sor-md