### PR TITLE
[v0.91.5][refactor] Add owner validation lanes for faster local proof

### DIFF
--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/adl/Cargo.toml"
+SURFACE=""
+BUILD=0
+PRINT_PLAN=0
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  adl/tools/run_owner_validation_lane.sh <csdlc|runtime|review|all> [--build] [--print-plan]
+
+Runs the focused validation lane for one CLI owner surface.
+
+Options:
+  --build       Build owner binaries once, then run compatibility scripts
+                through prebuilt binary overrides instead of repeated
+                `cargo run` startup.
+  --print-plan  Print the commands that would run without executing them.
+EOF
+}
+
+die() {
+  printf 'run_owner_validation_lane: %s\n' "$*" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    csdlc|runtime|review|all)
+      [[ -z "$SURFACE" ]] || die "surface already set to '$SURFACE'"
+      SURFACE="$1"
+      ;;
+    --build)
+      BUILD=1
+      ;;
+    --print-plan)
+      PRINT_PLAN=1
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unsupported argument '$1'"
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$SURFACE" ]] || {
+  usage
+  exit 2
+}
+
+package_version() {
+  cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])'
+}
+
+emit_command() {
+  printf '%s\n' "$*"
+}
+
+run_command() {
+  local label="$1"
+  shift
+  emit_command "==> $label"
+  if [[ "$PRINT_PLAN" == "1" ]]; then
+    emit_command "$*"
+    return
+  fi
+  (
+    cd "$ROOT_DIR"
+    "$@"
+  )
+}
+
+build_owner_bins() {
+  [[ "$BUILD" == "1" ]] || return 0
+  run_command "cargo build owner binaries" \
+    cargo build --quiet --manifest-path "$MANIFEST" \
+      --bin adl --bin adl-csdlc --bin adl-runtime --bin adl-review
+  if [[ "$PRINT_PLAN" == "1" ]]; then
+    return 0
+  fi
+  export ADL_BIN="$ROOT_DIR/adl/target/debug/adl"
+  export ADL_CSDLC_BIN="$ROOT_DIR/adl/target/debug/adl-csdlc"
+  export ADL_RUNTIME_BIN="$ROOT_DIR/adl/target/debug/adl-runtime"
+  export ADL_REVIEW_BIN="$ROOT_DIR/adl/target/debug/adl-review"
+  export ADL_PACKAGE_VERSION
+  ADL_PACKAGE_VERSION="$(package_version)"
+}
+
+run_csdlc_lane() {
+  run_command "C-SDLC wrapper migration contract" \
+    bash adl/tools/test_cli_wrapper_migration_contract.sh
+  run_command "C-SDLC run ambiguity policy" \
+    bash adl/tools/test_pr_run_ambiguity_policy.sh
+  run_command "C-SDLC control-plane observability contract" \
+    bash adl/tools/test_control_plane_observability.sh
+}
+
+run_runtime_lane() {
+  run_command "runtime compatibility boundary" \
+    bash adl/tools/test_adl_runtime_compatibility.sh
+}
+
+run_review_lane() {
+  run_command "review compatibility boundary" \
+    bash adl/tools/test_adl_review_compatibility.sh
+}
+
+build_owner_bins
+
+case "$SURFACE" in
+  csdlc)
+    run_csdlc_lane
+    ;;
+  runtime)
+    run_runtime_lane
+    ;;
+  review)
+    run_review_lane
+    ;;
+  all)
+    run_csdlc_lane
+    run_runtime_lane
+    run_review_lane
+    ;;
+esac
+
+emit_command "PASS run_owner_validation_lane surface=$SURFACE"

--- a/adl/tools/test_adl_review_compatibility.sh
+++ b/adl/tools/test_adl_review_compatibility.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MANIFEST="$ROOT_DIR/adl/Cargo.toml"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+ADL_BIN="${ADL_BIN:-}"
+ADL_REVIEW_BIN="${ADL_REVIEW_BIN:-}"
+ADL_PACKAGE_VERSION="${ADL_PACKAGE_VERSION:-}"
 
 assert_contains() {
   local pattern="$1" text="$2" label="$3"
@@ -25,11 +28,27 @@ assert_status_nonzero() {
 }
 
 run_adl() {
+  if [[ -n "$ADL_BIN" ]]; then
+    "$ADL_BIN" "$@"
+    return
+  fi
   cargo run --quiet --manifest-path "$MANIFEST" --bin adl -- "$@"
 }
 
 run_review() {
+  if [[ -n "$ADL_REVIEW_BIN" ]]; then
+    "$ADL_REVIEW_BIN" "$@"
+    return
+  fi
   cargo run --quiet --manifest-path "$MANIFEST" --bin adl-review -- "$@"
+}
+
+package_version() {
+  if [[ -n "$ADL_PACKAGE_VERSION" ]]; then
+    printf '%s\n' "$ADL_PACKAGE_VERSION"
+    return
+  fi
+  cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])'
 }
 
 help_output="$(run_review --help)"
@@ -38,7 +57,7 @@ assert_contains "adl-review code-review --out <dir>" "$help_output" "review code
 assert_contains "C-SDLC issue work belongs to adl/tools/pr.sh run <issue>" "$help_output" "csdlc handoff help"
 
 version_output="$(run_review --version)"
-expected_version="$(cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+expected_version="$(package_version)"
 assert_contains "$expected_version" "$version_output" "review version"
 
 review_fixture="$TMP_DIR/review.md"

--- a/adl/tools/test_adl_runtime_compatibility.sh
+++ b/adl/tools/test_adl_runtime_compatibility.sh
@@ -6,6 +6,9 @@ MANIFEST="$ROOT_DIR/adl/Cargo.toml"
 FIXTURE="$ROOT_DIR/adl/examples/v0-3-concurrency-fork-join.adl.yaml"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+ADL_BIN="${ADL_BIN:-}"
+ADL_RUNTIME_BIN="${ADL_RUNTIME_BIN:-}"
+ADL_PACKAGE_VERSION="${ADL_PACKAGE_VERSION:-}"
 
 assert_contains() {
   local pattern="$1" text="$2" label="$3"
@@ -26,11 +29,27 @@ assert_status_nonzero() {
 }
 
 run_adl() {
+  if [[ -n "$ADL_BIN" ]]; then
+    "$ADL_BIN" "$@"
+    return
+  fi
   cargo run --quiet --manifest-path "$MANIFEST" --bin adl -- "$@"
 }
 
 run_runtime() {
+  if [[ -n "$ADL_RUNTIME_BIN" ]]; then
+    "$ADL_RUNTIME_BIN" "$@"
+    return
+  fi
   cargo run --quiet --manifest-path "$MANIFEST" --bin adl-runtime -- "$@"
+}
+
+package_version() {
+  if [[ -n "$ADL_PACKAGE_VERSION" ]]; then
+    printf '%s\n' "$ADL_PACKAGE_VERSION"
+    return
+  fi
+  cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])'
 }
 
 help_output="$(run_runtime --help)"
@@ -42,7 +61,7 @@ run_help_output="$(run_runtime run --help)"
 assert_contains "adl-runtime run <adl.yaml>" "$run_help_output" "runtime run subcommand help"
 
 version_output="$(run_runtime --version)"
-assert_contains "$(cargo metadata --quiet --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')" "$version_output" "runtime version"
+assert_contains "$(package_version)" "$version_output" "runtime version"
 
 legacy_plan="$TMP_DIR/legacy-plan.txt"
 runtime_plan="$TMP_DIR/runtime-plan.txt"

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -24,6 +24,7 @@ run_check adl/tools/test_pr_init_skill_contracts.sh
 run_check adl/tools/test_card_editor_skill_contracts.sh
 run_check adl/tools/test_pr_closeout_skill_contracts.sh
 run_check adl/tools/test_cli_wrapper_migration_contract.sh
+run_check adl/tools/test_owner_validation_lane.sh
 run_check adl/tools/test_adl_runtime_compatibility.sh
 run_check adl/tools/test_adl_review_compatibility.sh
 run_check adl/tools/test_pr_run.sh

--- a/adl/tools/test_owner_validation_lane.sh
+++ b/adl/tools/test_owner_validation_lane.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/adl/tools/run_owner_validation_lane.sh"
+
+plan_output="$(bash "$RUNNER" all --build --print-plan)"
+for expected in \
+  "cargo build owner binaries" \
+  "C-SDLC wrapper migration contract" \
+  "C-SDLC run ambiguity policy" \
+  "C-SDLC control-plane observability contract" \
+  "runtime compatibility boundary" \
+  "review compatibility boundary" \
+  "PASS run_owner_validation_lane surface=all"; do
+  grep -Fq "$expected" <<<"$plan_output" || {
+    echo "missing expected lane plan entry: $expected" >&2
+    echo "$plan_output" >&2
+    exit 1
+  }
+done
+
+bash "$RUNNER" csdlc
+
+set +e
+bad_output="$(bash "$RUNNER" unknown 2>&1)"
+bad_status=$?
+set -e
+[[ "$bad_status" -ne 0 ]] || {
+  echo "unsupported lane unexpectedly passed" >&2
+  exit 1
+}
+grep -Fq "unsupported argument 'unknown'" <<<"$bad_output" || {
+  echo "unsupported lane did not report a useful error" >&2
+  echo "$bad_output" >&2
+  exit 1
+}
+
+echo "PASS test_owner_validation_lane"

--- a/docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md
+++ b/docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md
@@ -1,0 +1,108 @@
+# Owner Validation Lane Split (#3610)
+
+Issue: #3610
+Status: implementation slice and split plan
+
+## Purpose
+
+The first CLI refactor mini-sprint proved owner binaries, but it did not make
+ordinary validation appreciably faster by itself. This issue adds a concrete
+owner-lane runner and records the next split boundary so C-SDLC, runtime, and
+review changes can use focused proof before broad integration proof.
+
+## Immediate Implementation
+
+The new focused runner is:
+
+```bash
+adl/tools/run_owner_validation_lane.sh <csdlc|runtime|review|all> [--build] [--print-plan]
+```
+
+Owner lanes:
+
+| Lane | Commands |
+| --- | --- |
+| `csdlc` | `test_cli_wrapper_migration_contract.sh`, `test_pr_run_ambiguity_policy.sh`, `test_control_plane_observability.sh` |
+| `runtime` | `test_adl_runtime_compatibility.sh` |
+| `review` | `test_adl_review_compatibility.sh` |
+| `all` | `csdlc`, then `runtime`, then `review` |
+
+`--build` builds `adl`, `adl-csdlc`, `adl-runtime`, and `adl-review` once and
+then runs compatibility scripts through prebuilt binary overrides. This avoids
+repeated `cargo run` startup costs inside the owner compatibility scripts.
+
+`--print-plan` prints the lane commands without executing them. It is intended
+for issue cards, docs review, and external adapter diagnostics.
+
+## Timing Evidence
+
+Measured from the #3610 worktree on 2026-06-03.
+
+| Command | Context | Result | Wall time |
+| --- | --- | --- | --- |
+| `bash adl/tools/test_cli_wrapper_migration_contract.sh` | shell-only focused C-SDLC check | PASS | `0.08s` |
+| `bash adl/tools/test_pr_run_ambiguity_policy.sh` | shell-only focused C-SDLC check | PASS | `0.14s` |
+| `bash adl/tools/test_adl_review_compatibility.sh` | fresh worktree before target warmup | PASS | `43.87s` |
+| `bash adl/tools/test_adl_runtime_compatibility.sh` | fresh worktree before target warmup | PASS | `44.44s` |
+| `bash adl/tools/test_adl_runtime_compatibility.sh` | warm target cache | PASS | `1.51s` |
+| `bash adl/tools/test_adl_review_compatibility.sh` | warm target cache | PASS | `0.87s` |
+| `bash adl/tools/run_owner_validation_lane.sh runtime --build` | warm target cache with prebuilt binary overrides | PASS | `3.44s` |
+| `bash adl/tools/run_owner_validation_lane.sh review --build` | warm target cache with prebuilt binary overrides | PASS | `3.28s` |
+| `bash adl/tools/run_owner_validation_lane.sh all --build` | warmed owner binaries after prior build | PASS | `0.68s` |
+
+Interpretation:
+
+- C-SDLC shell policy checks are already sub-second.
+- Runtime/review compatibility checks are fast once built, but fresh worktrees
+  still pay a large compilation/startup tax.
+- The owner-lane runner gives operators one deterministic command for focused
+  local proof now.
+- Real first-run speedup still requires a later Cargo/workspace or target-cache
+  split; this issue does not claim that larger extraction is complete.
+
+## Validation Policy
+
+Use the smallest proving lane for local work:
+
+| Touched surface | Local proof before PR | Broad proof |
+| --- | --- | --- |
+| C-SDLC wrapper, prompt-card policy, control-plane docs | `bash adl/tools/run_owner_validation_lane.sh csdlc` | CI integration lane |
+| Runtime command routing/provider/demo/agent behavior | `bash adl/tools/run_owner_validation_lane.sh runtime --build` plus focused Rust selector for touched module | CI integration lane |
+| Review command routing/review packets/contracts | `bash adl/tools/run_owner_validation_lane.sh review --build` plus focused Rust selector for touched module | CI integration lane |
+| Cross-owner command routing | `bash adl/tools/run_owner_validation_lane.sh all --build` | CI integration lane |
+| Cargo/workspace/package changes | owner lane plus `cargo check`/focused Rust tests for affected packages | CI integration lane |
+
+## Next Split Boundary
+
+The safe next decomposition should not be a blind file shuffle. It should start
+from these owner boundaries:
+
+1. Extract a C-SDLC/tooling library boundary around prompt-template,
+   structured-prompt, PR lifecycle, and issue-card validation internals.
+2. Keep the runtime centerpiece conservative: runtime workflow, providers,
+   demos, agents, signing, learning, identity, and Gödel remain together until
+   their own module-size/navigability review is complete.
+3. Keep review tooling as a thin owner boundary first, then extract review
+   packet/contract helpers only after docs and skills migrate.
+4. Preserve `adl/tools/pr.sh` as the canonical workflow spine until generated
+   cards, skills, portable adapter docs, and compatibility sunset policy move
+   together.
+
+## Routed Follow-Ons
+
+- #3607 owns local-preflight vs CI-integration proof policy.
+- #3611 owns docs/skills/generated-card migration to proven owner commands.
+- #3612 owns module navigability and consolidation review.
+- #3614 owns deferred helper-binary candidate review.
+- #3615 owns shim deprecation and compatibility sunset policy.
+
+If a true workspace/package extraction is still required after #3607 and #3612,
+open a dedicated extraction issue with a source-grounded module map, rollback
+plan, and timing target.
+
+## Non-Claims
+
+- This does not split the Rust workspace into multiple crates.
+- This does not remove the legacy `adl` binary.
+- This does not weaken runtime validation for runtime-owned changes.
+- This does not replace CI integration proof.


### PR DESCRIPTION
Closes #3610

## Summary
Implemented the #3610 owner-validation lane slice. The work adds a deterministic `csdlc`, `runtime`, `review`, and `all` validation runner, lets runtime/review compatibility scripts use prebuilt binaries, records timing evidence, and preserves the larger workspace/package extraction as routed follow-on work rather than forcing risky crate surgery into this issue.

## Artifacts
- `adl/tools/run_owner_validation_lane.sh`
- `adl/tools/test_owner_validation_lane.sh`
- `adl/tools/test_adl_runtime_compatibility.sh`
- `adl/tools/test_adl_review_compatibility.sh`
- `adl/tools/test_five_command_regression_suite.sh`
- `docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.5/tasks/issue-3610__v0-91-5-refactor-speed-split-workspace-and-test-lanes-for-real-validation-speedup/sor.md`
    Verified bootstrap SOR contract compliance for the local output scaffold.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3610__v0-91-5-refactor-speed-split-workspace-and-test-lanes-for-real-validation-speedup/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3610__v0-91-5-refactor-speed-split-workspace-and-test-lanes-for-real-validation-speedup/sor.md
- Idempotency-Key: v0-91-5-refactor-add-owner-validation-lanes-for-faster-local-proof-adl-tools-run-owner-validation-lane-sh-adl-tools-test-owner-validation-lane-sh-adl-tools-test-adl-runtime-compatibility-sh-adl-tools-test-adl-review-compatibility-sh-adl-tools-test-five-command-regression-suite-sh-docs-milestones-v0-91-5-validation-lane-split-3610-md-adl-v0-91-5-tasks-issue-3610-v0-91-5-refactor-speed-split-workspace-and-test-lanes-for-real-validation-speedup-sip-md-adl-v0-91-5-tasks-issue-3610-v0-91-5-refactor-speed-split-workspace-and-test-lanes-for-real-validation-speedup-sor-md