### PR TITLE
[v0.91.5][refactor] Separate local preflight from CI proof policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,11 @@ For a normal tracked issue:
 - Run the smallest proving validation that matches the issue's outcome type.
 - Do not skip required proof just because the change is small.
 - Do not run broad validation reflexively when focused proof is enough.
+- Separate local preflight proof from CI integration proof. Local records must
+  say what ran locally, what is deferred to GitHub CI, and why that deferral is
+  safe for the touched surface.
+- For owner-binary surfaces, prefer the focused lane runner when it matches the
+  change: `bash adl/tools/run_owner_validation_lane.sh csdlc|runtime|review|all`.
 - Keep review records and output cards truthful about what was and was not run.
 - Docs-only and policy-only PVF work should prefer focused docs/path/contract/
   guardrail proof unless tracked runtime behavior changed.

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -455,6 +455,37 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         {
             commands.push("bash adl/tools/test_ci_path_policy.sh".to_string());
         }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_owner_lane_contract_validation(path))
+        {
+            commands.push("bash adl/tools/test_owner_validation_lane.sh".to_string());
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_csdlc_owner_lane_validation(path))
+        {
+            commands.push("bash adl/tools/run_owner_validation_lane.sh csdlc".to_string());
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_runtime_owner_lane_validation(path))
+        {
+            commands
+                .push("bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string());
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_review_owner_lane_validation(path))
+        {
+            commands.push("bash adl/tools/run_owner_validation_lane.sh review --build".to_string());
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_all_owner_lane_validation(path))
+        {
+            commands.push("bash adl/tools/run_owner_validation_lane.sh all --build".to_string());
+        }
         return Ok(FinishValidationPlan {
             mode: FinishValidationMode::FocusedLocalCiGated,
             commands,
@@ -522,6 +553,15 @@ fn finish_path_is_focused_local_ci_gated(path: &str) -> bool {
             | "adl/tools/test_check_coverage_impact.sh"
             | "adl/tools/ci_path_policy.sh"
             | "adl/tools/test_ci_path_policy.sh"
+            | "adl/tools/run_owner_validation_lane.sh"
+            | "adl/tools/test_owner_validation_lane.sh"
+            | "adl/tools/test_cli_wrapper_migration_contract.sh"
+            | "adl/tools/test_pr_run_ambiguity_policy.sh"
+            | "adl/tools/test_control_plane_observability.sh"
+            | "adl/tools/test_adl_runtime_compatibility.sh"
+            | "adl/tools/test_adl_review_compatibility.sh"
+            | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
+            | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
             | "adl/src/cli/pr_cmd/finish_support.rs"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("docs/milestones/v0.91.4/review/merge_readiness/")
@@ -553,6 +593,46 @@ fn finish_path_needs_ci_policy_focused_validation(path: &str) -> bool {
             | "adl/tools/ci_path_policy.sh"
             | "adl/tools/test_ci_path_policy.sh"
     )
+}
+
+fn finish_path_needs_owner_lane_contract_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/run_owner_validation_lane.sh"
+            | "adl/tools/test_owner_validation_lane.sh"
+            | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
+            | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
+    )
+}
+
+fn finish_path_needs_csdlc_owner_lane_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/run_owner_validation_lane.sh"
+            | "adl/tools/test_owner_validation_lane.sh"
+            | "adl/tools/test_cli_wrapper_migration_contract.sh"
+            | "adl/tools/test_pr_run_ambiguity_policy.sh"
+            | "adl/tools/test_control_plane_observability.sh"
+            | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
+            | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
+    )
+}
+
+fn finish_path_needs_runtime_owner_lane_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(trimmed, "adl/tools/test_adl_runtime_compatibility.sh")
+}
+
+fn finish_path_needs_review_owner_lane_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(trimmed, "adl/tools/test_adl_review_compatibility.sh")
+}
+
+fn finish_path_needs_all_owner_lane_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(trimmed, "adl/tools/run_owner_validation_lane.sh")
 }
 
 pub(super) fn run_finish_validation_rust(
@@ -602,6 +682,26 @@ pub(super) fn run_finish_validation_rust(
                 "bash adl/tools/test_ci_path_policy.sh" => {
                     let script = repo_root.join("adl/tools/test_ci_path_policy.sh");
                     run_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_owner_validation_lane.sh" => {
+                    let script = repo_root.join("adl/tools/test_owner_validation_lane.sh");
+                    run_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/run_owner_validation_lane.sh csdlc" => {
+                    let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
+                    run_status("bash", &[path_str(&script)?, "csdlc"])?;
+                }
+                "bash adl/tools/run_owner_validation_lane.sh runtime --build" => {
+                    let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
+                    run_status("bash", &[path_str(&script)?, "runtime", "--build"])?;
+                }
+                "bash adl/tools/run_owner_validation_lane.sh review --build" => {
+                    let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
+                    run_status("bash", &[path_str(&script)?, "review", "--build"])?;
+                }
+                "bash adl/tools/run_owner_validation_lane.sh all --build" => {
+                    let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
+                    run_status("bash", &[path_str(&script)?, "all", "--build"])?;
                 }
                 other => bail!("finish: unsupported focused validation command '{other}'"),
             }
@@ -743,11 +843,31 @@ fn ensure_existing_pr_base_matches(repo: &str, pr_url: &str, expected_base: &str
 }
 
 pub(super) fn render_default_finish_validation(plan: &FinishValidationPlan) -> String {
-    plan.commands
+    let mut lines = plan
+        .commands
         .iter()
         .map(|command| format!("- {command}"))
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect::<Vec<_>>();
+    match plan.mode {
+        FinishValidationMode::DocsOnly => {
+            lines.push(
+                "- CI integration proof: deferred to GitHub checks for merge-context validation."
+                    .to_string(),
+            );
+        }
+        FinishValidationMode::FocusedLocalCiGated => {
+            lines.push(
+                "- Local preflight profile: focused owner/policy proof only; this is not full local Rust validation."
+                    .to_string(),
+            );
+            lines.push(
+                "- CI integration proof: deferred to GitHub checks for merge-context validation."
+                    .to_string(),
+            );
+        }
+        FinishValidationMode::FullRust => {}
+    }
+    lines.join("\n")
 }
 
 pub(super) fn ensure_issue_surfaces_are_local_only(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -436,6 +436,54 @@ fn finish_validation_plan_supports_focused_local_ci_gated_mode() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_owner_validation_lanes() {
+    let csdlc_plan = select_finish_validation_plan(
+        "adl/tools/run_owner_validation_lane.sh,docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md",
+    )
+    .expect("owner lane plan");
+    assert_eq!(csdlc_plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(csdlc_plan
+        .commands
+        .contains(&"bash adl/tools/test_owner_validation_lane.sh".to_string()));
+    assert!(csdlc_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
+    assert!(csdlc_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh all --build".to_string()));
+    assert!(!csdlc_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    let csdlc_rendered_validation = render_default_finish_validation(&csdlc_plan);
+    assert!(!csdlc_rendered_validation.contains("cargo nextest run"));
+    assert!(csdlc_rendered_validation.contains("focused owner/policy proof only"));
+    assert!(csdlc_rendered_validation.contains("CI integration proof"));
+
+    let runtime_plan = select_finish_validation_plan("adl/tools/test_adl_runtime_compatibility.sh")
+        .expect("runtime owner lane plan");
+    assert_eq!(runtime_plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(runtime_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string()));
+    assert!(!runtime_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+
+    let review_plan = select_finish_validation_plan("adl/tools/test_adl_review_compatibility.sh")
+        .expect("review owner lane plan");
+    assert_eq!(review_plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(review_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh review --build".to_string()));
+    assert!(!review_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
 fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request() {
     let docs_plan = select_finish_validation_plan_for_finish(
         ".",

--- a/docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md
+++ b/docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md
@@ -1,0 +1,64 @@
+# Local Preflight And CI Integration Validation Policy (#3607)
+
+Issue: #3607
+Status: implementation policy
+
+## Purpose
+
+ADL issue work should run the right proof at the right layer. Local preflight
+proves the touched surface is coherent before PR publication. CI integration
+proves merge-context behavior, coverage, and release-gate posture. Deferring
+broad proof to CI is valid only when the local record says so truthfully and the
+change is not in a surface that requires broad local proof before publication.
+
+## Responsibility Model
+
+| Change surface | Local preflight proof | CI integration proof | Broad local proof before PR |
+| --- | --- | --- | --- |
+| Docs-only milestone/review/policy docs | `git diff --check`, link/path/YAML or template checks that match the touched docs | CI docs/path policy and repository integration checks | Not required unless docs change executable policy or release gates |
+| Prompt-card generation/repair | Renderer values/structure/schema checks for touched cards plus card validators | CI integration checks | Not required unless schema/tooling code changed |
+| C-SDLC control-plane/tooling policy | `bash adl/tools/run_owner_validation_lane.sh csdlc` plus touched focused Rust tests when applicable | CI integration and coverage | Required only when the change affects Rust behavior outside focused owner lanes |
+| Runtime/provider/demo/agent behavior | `bash adl/tools/run_owner_validation_lane.sh runtime --build` plus focused Rust selector for touched behavior | CI integration, coverage, and release/nightly proof where applicable | Required for risky runtime semantics, provider execution, signing/security, or release-gate behavior |
+| Review tooling/review packet contracts | `bash adl/tools/run_owner_validation_lane.sh review --build` plus focused Rust selector for touched behavior | CI integration and coverage | Required for broad review-runtime coupling or schema changes |
+| Cross-owner command routing | `bash adl/tools/run_owner_validation_lane.sh all --build` | CI integration and coverage | Required for Cargo/workspace/package topology changes |
+| Release/nightly/PVF/slow-proof policy | Focused policy tests for the touched runner/manifest | Authoritative release, nightly, slow-proof, and coverage gates | Required when local policy code changes can hide or bypass release proof |
+
+## Proof Wording Rules
+
+SOR and PR validation sections must distinguish:
+
+- `Local preflight run`: commands actually run before PR publication.
+- `CI integration proof`: checks expected to run in GitHub after PR creation.
+- `Release-gate proof`: slow-proof, coverage, or nightly/release validation that
+  is intentionally not run locally for ordinary PRs.
+- `Validation not run locally`: explicit statement that a broad or release proof
+  was deferred to CI/release gate, with the reason.
+
+Never write “full validation passed” when only a focused owner lane ran. Use
+language such as:
+
+```text
+Local preflight: PASS (`bash adl/tools/run_owner_validation_lane.sh csdlc`).
+CI integration: deferred to GitHub `adl-ci` / `adl-coverage`.
+Release-gate proof: not required for this docs/tooling-local change.
+```
+
+## Finish Validation Profiles
+
+The Rust `pr finish` validation selector owns the default local profile:
+
+- docs-only paths select docs-only local proof;
+- known focused control-plane and owner-lane surfaces select
+  `FocusedLocalCiGated`;
+- broad or unknown source changes select full Rust validation.
+
+The selector must prefer actual changed tracked paths over a broad `--paths .`
+request so the PR body does not overclaim local proof.
+
+## Non-Claims
+
+- This policy does not remove CI gates.
+- This policy does not make CI the only proof source for risky runtime changes.
+- This policy does not replace release/nightly/PVF slow-proof evidence.
+- This policy does not claim every future path is classified; unclassified
+  source paths should remain full-local-validation by default.


### PR DESCRIPTION
Closes #3607

## Summary
Implemented the local-preflight versus CI-integration validation policy for #3607. The change makes owner-lane validation explicit in repo guidance, adds a tracked policy document, and teaches `pr finish` to classify owner-lane surfaces as focused local preflight instead of broad local Rust proof.

## Artifacts
- `AGENTS.md`
- `docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the C-SDLC owner validation lane for the touched control-plane policy surface.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_plan_classifies_owner_validation_lanes -- --nocapture`
    Verified owner-lane finish classification, focused commands, and local-preflight/CI-proof PR wording.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request -- --nocapture`
    Verified finish validation uses actual changed tracked paths for profile selection.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3607__v0-91-5-refactor-validation-separate-local-preflight-and-ci-integration-proof-policy/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3607__v0-91-5-refactor-validation-separate-local-preflight-and-ci-integration-proof-policy/sor.md
- Idempotency-Key: v0-91-5-refactor-separate-local-preflight-from-ci-proof-policy-agents-md-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-milestones-v0-91-5-local-vs-ci-validation-policy-3607-md-adl-v0-91-5-tasks-issue-3607-v0-91-5-refactor-validation-separate-local-preflight-and-ci-integration-proof-policy-sip-md-adl-v0-91-5-tasks-issue-3607-v0-91-5-refactor-validation-separate-local-preflight-and-ci-integration-proof-policy-sor-md