### PR TITLE
[v0.91.5][refactor] Migrate docs and skills to owner commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ These rules are mandatory for ADL issue work.
      explicitly requires a compatibility path.
    - For new or fully re-rendered cards, prefer the deterministic
      prompt-template values renderer over direct Markdown structure edits:
-     `adl tooling prompt-template validate-values`, `render`, `render-all`,
-     `validate-structure`, and `validate-schemas`.
+     `adl-csdlc tooling prompt-template validate-values`, `render`,
+     `render-all`, `validate-structure`, and `validate-schemas`.
    - Treat the tracked structure schemas under
      `docs/templates/prompts/<version>/schemas/` as the template-shape
      authority. If a rendered card fails structure validation, fix the values or

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -95,6 +95,8 @@ build_owner_bins() {
 }
 
 run_csdlc_lane() {
+  run_command "C-SDLC owner command guidance" \
+    bash adl/tools/test_cli_owner_command_guidance.sh
   run_command "C-SDLC wrapper migration contract" \
     bash adl/tools/test_cli_wrapper_migration_contract.sh
   run_command "C-SDLC run ambiguity policy" \

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -720,8 +720,6 @@ Structured schema:
 
 - `adl/tools/pr.sh create`
 - `adl/tools/pr.sh init`
-- `adl pr create`
-- `adl pr init`
 
 For `create_and_bootstrap`, the expected machine-safe path is:
 
@@ -850,11 +848,8 @@ Structured schema:
 Preferred diagnostic order:
 
 - `adl/tools/pr.sh doctor --json`
-- `adl pr doctor --json`
 - `adl/tools/pr.sh ready`
-- `adl pr ready`
 - `adl/tools/pr.sh preflight`
-- `adl pr preflight`
 
 Use direct inspection only when the repo-native doctor/readiness surfaces are
 unavailable or unusable.
@@ -965,13 +960,9 @@ Structured schema:
 Preferred execution order:
 
 - `adl/tools/pr.sh doctor --json`
-- `adl pr doctor --json`
 - `adl/tools/pr.sh run`
-- `adl pr run`
 - `adl/tools/pr.sh ready`
-- `adl pr ready`
 - `adl/tools/pr.sh preflight`
-- `adl pr preflight`
 
 ### Output And Stop Boundary
 

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -54,7 +54,6 @@ Useful additional inputs:
 2. Confirm the execution output record is present and truthful.
 3. Prefer repo-native finish commands:
    - `adl/tools/pr.sh finish`
-   - `adl pr finish`
 4. Validate the declared staged paths and PR metadata.
 5. Publish or update the draft PR surface.
 6. Emit a structured finish result and stop.

--- a/adl/tools/skills/pr-finish/adl-skill.yaml
+++ b/adl/tools/skills/pr-finish/adl-skill.yaml
@@ -40,7 +40,6 @@ execution:
   workflow_role: "finish"
   preferred_commands:
     - "adl/tools/pr.sh finish"
-    - "adl pr finish"
   preferred_path: "repo_native_finish_surface"
   invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
 boundaries:

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -23,15 +23,15 @@ Keep mechanical work separate from qualitative review.
 This skill should track the repository's canonical PR tooling planning docs.
 
 At the moment, the canonical repo docs are:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
 
 Within this skill bundle, the operational details live in:
 - `references/init-playbook.md`
 - `references/output-contract.md`
 
 The canonical caller-facing invocation template lives at:
-- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+- `<repo-root>/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
 If those docs move, prefer the moved tracked canonical copies over stale path references. Do not silently invent a new workflow model from memory when the repo docs have changed.
 
@@ -93,7 +93,7 @@ For deterministic ADL execution, also prefer an explicit issue-metadata policy:
 
 When the caller can provide structured input, prefer the tracked invocation
 template in:
-- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+- `<repo-root>/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
 When the caller provides an authored issue body, require it to follow the
 canonical authored issue body scaffold in that template before running create.
@@ -175,7 +175,7 @@ card kind, bootstrap or regeneration paths should prefer:
 1. resolve `docs/templates/prompts/current.json`;
 2. fill values YAML with locked fields under `system` and editable fields under
    `values`;
-3. render Markdown through `adl tooling prompt-template render` or `render-all`;
+3. render Markdown through `adl-csdlc tooling prompt-template render` or `render-all`;
 4. validate rendered shape with `validate-structure`;
 5. validate schema artifacts with `validate-schemas` when template structure is
    touched.
@@ -251,11 +251,9 @@ Recommended multi-issue pattern:
 Prefer repo-native control-plane commands such as:
 - `adl/tools/pr.sh create`
 - `adl/tools/pr.sh init`
-- `adl pr create`
-- `adl pr init`
 
 For caller payload shape, prefer the canonical tracked template:
-- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+- `<repo-root>/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
 Use existing templates, validation helpers, and path logic from the repository. Do not recreate bundle contents manually unless the repo-native path is unavailable and the user explicitly wants a fallback.
 
@@ -326,5 +324,5 @@ For stricter ADL execution, also use:
 
 - Playbook: `references/init-playbook.md`
 - Output contract: `references/output-contract.md`
-- PR tooling feature doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- PR tooling architecture doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- PR tooling feature doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- PR tooling architecture doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`

--- a/adl/tools/skills/pr-init/adl-skill.yaml
+++ b/adl/tools/skills/pr-init/adl-skill.yaml
@@ -79,8 +79,6 @@ execution:
   preferred_commands:
     - "adl/tools/pr.sh create"
     - "adl/tools/pr.sh init"
-    - "adl pr create"
-    - "adl pr init"
   preferred_path: "rust_owned_control_plane_when_available"
   invocation_pattern: "one_issue_per_invocation_parent_aggregates_multi_issue_results"
   validation_policy: "must_verify_issue_labels_source_prompt_root_bundle_and_no_branch_or_worktree_side_effects"

--- a/adl/tools/skills/pr-init/references/init-playbook.md
+++ b/adl/tools/skills/pr-init/references/init-playbook.md
@@ -3,8 +3,8 @@
 Use this file after the main skill triggers and you are ready to execute the `pr init` step.
 
 Planning basis:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
 - this skill bundle's `SKILL.md` and reference files
 
 If the repo relocates those docs, follow the relocated canonical copies instead of these exact paths.
@@ -95,8 +95,8 @@ Unsafe examples:
 The skill should prefer the Rust-owned control-plane path when available.
 
 Current command truth:
-- use `adl pr create` or `adl/tools/pr.sh create` when a new issue must be created
-- use `adl pr init` or `adl/tools/pr.sh init` when the issue already exists
+- use `adl/tools/pr.sh create` when a new issue must be created
+- use `adl/tools/pr.sh init` when the issue already exists
 - hand off to qualitative review after bootstrap
 - only after review does issue-mode `pr run` bind branch and worktree context
 

--- a/adl/tools/skills/pr-ready/SKILL.md
+++ b/adl/tools/skills/pr-ready/SKILL.md
@@ -21,9 +21,9 @@ This is a procedural execution skill.
 This skill should track the repository's canonical PR tooling docs.
 
 At the moment, the canonical repo docs are:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PREFLIGHT_CHECK_SKILL.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PREFLIGHT_CHECK_SKILL.md`
 
 Within this skill bundle, the operational details live in:
 - `references/ready-playbook.md`
@@ -93,12 +93,9 @@ If there is no concrete target, stop and report `blocked` with the missing targe
 1. Resolve the concrete target context.
 2. Prefer the canonical doctor path first:
    - `adl/tools/pr.sh doctor --json`
-   - `adl pr doctor --json`
 3. Use compatibility aliases only when the canonical doctor surface is unavailable:
    - `adl/tools/pr.sh ready`
-   - `adl pr ready`
    - `adl/tools/pr.sh preflight`
-   - `adl pr preflight`
 4. Use direct inspection only as a last resort.
 5. Inspect the relevant workflow surfaces:
    - issue/task identity
@@ -208,13 +205,10 @@ Unsafe parallel examples:
 
 Canonical machine surface:
 - `adl/tools/pr.sh doctor --json`
-- `adl pr doctor --json`
 
 Compatibility aliases:
 - `adl/tools/pr.sh ready`
 - `adl/tools/pr.sh preflight`
-- `adl pr ready`
-- `adl pr preflight`
 
 Command-order rule:
 - prefer `doctor --json` first when the surface exists
@@ -289,5 +283,5 @@ For stricter ADL execution, also use:
 
 - Playbook: `references/ready-playbook.md`
 - Output contract: `references/output-contract.md`
-- PR tooling feature doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- PR tooling architecture doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- PR tooling feature doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- PR tooling architecture doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`

--- a/adl/tools/skills/pr-ready/adl-skill.yaml
+++ b/adl/tools/skills/pr-ready/adl-skill.yaml
@@ -89,11 +89,8 @@ execution:
     - "pr_finish"
   preferred_commands:
     - "adl/tools/pr.sh doctor --json"
-    - "adl pr doctor --json"
     - "adl/tools/pr.sh ready"
     - "adl/tools/pr.sh preflight"
-    - "adl pr ready"
-    - "adl pr preflight"
   preferred_path: "doctor_json_first_then_compatibility_aliases_then_direct_inspection"
   repair_policy: "allow_only_small_bounded_mechanical_repairs_when_unambiguous"
   invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"

--- a/adl/tools/skills/pr-ready/references/ready-playbook.md
+++ b/adl/tools/skills/pr-ready/references/ready-playbook.md
@@ -3,9 +3,9 @@
 Use this file after the main skill triggers and you are ready to execute the doctor/readiness step.
 
 Planning basis:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PREFLIGHT_CHECK_SKILL.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PREFLIGHT_CHECK_SKILL.md`
 
 If the repo relocates those docs, follow the relocated canonical copies instead of these exact paths.
 
@@ -92,20 +92,15 @@ The skill should treat `ready` and `preflight` as compatibility inputs to the do
 
 When helpful:
 - use `adl/tools/pr.sh doctor --json` first for the canonical machine-readable diagnostic result
-- use `adl pr doctor --json` when that is the available canonical binary surface
 - use `adl/tools/pr.sh ready` first for worktree/execution-readiness when the shell surface exists
-- use `adl pr ready` when that is the available canonical binary surface
-- use `adl/tools/pr.sh preflight` or `adl pr preflight` for milestone/open-PR blocking state
+- use `adl/tools/pr.sh preflight` for milestone/open-PR blocking state
 - combine them into one structured ready result
 
 Fallback order:
 1. `adl/tools/pr.sh doctor --json`
-2. `adl pr doctor --json`
-3. `adl/tools/pr.sh ready`
-4. `adl pr ready`
-5. `adl/tools/pr.sh preflight`
-6. `adl pr preflight`
-7. direct inspection only if the repo-native surfaces are unavailable or unusable
+2. `adl/tools/pr.sh ready`
+3. `adl/tools/pr.sh preflight`
+4. direct inspection only if the repo-native surfaces are unavailable or unusable
 
 When `ready` and `preflight` disagree:
 - keep the main status tied to execution readiness

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -27,8 +27,8 @@ This is an execution skill. It is allowed to write code, docs, tests, and relate
 This skill should track the repository's canonical PR tooling docs.
 
 At the moment, the canonical repo docs are:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
 
 Within this skill bundle, the operational details live in:
 - `references/run-playbook.md`
@@ -276,17 +276,13 @@ Unsafe parallel examples:
 
 Canonical machine surface:
 - `adl/tools/pr.sh doctor --json`
-- `adl pr doctor --json`
 
 Execution surface:
 - `adl/tools/pr.sh run`
-- `adl pr run`
 
 Compatibility aliases:
 - `adl/tools/pr.sh ready`
 - `adl/tools/pr.sh preflight`
-- `adl pr ready`
-- `adl pr preflight`
 
 Use the repo's existing templates, validators, and path logic. Prefer the repository control plane over manual git branching when possible.
 
@@ -346,5 +342,5 @@ For stricter ADL execution, also use:
 
 - Playbook: `references/run-playbook.md`
 - Output contract: `references/output-contract.md`
-- PR tooling feature doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- PR tooling architecture doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- PR tooling feature doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- PR tooling architecture doc: `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`

--- a/adl/tools/skills/pr-run/adl-skill.yaml
+++ b/adl/tools/skills/pr-run/adl-skill.yaml
@@ -90,13 +90,9 @@ execution:
     - "closeout"
   preferred_commands:
     - "adl/tools/pr.sh doctor --json"
-    - "adl pr doctor --json"
     - "adl/tools/pr.sh run"
-    - "adl pr run"
     - "adl/tools/pr.sh ready"
     - "adl/tools/pr.sh preflight"
-    - "adl pr ready"
-    - "adl pr preflight"
   preferred_path: "consume_doctor_json_first_then_run_with_compatibility_fallbacks"
   repair_policy: "doctor_checks_must_precede_execution_and_issue_scope_must_remain_bounded"
   invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"

--- a/adl/tools/skills/pr-run/references/run-playbook.md
+++ b/adl/tools/skills/pr-run/references/run-playbook.md
@@ -3,8 +3,8 @@
 Use this file after the main skill triggers and you are ready to execute an issue.
 
 Planning basis:
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
-- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `<repo-root>/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
 
 If the repo relocates those docs, follow the relocated canonical copies instead of these exact paths.
 
@@ -53,11 +53,8 @@ Default stance:
 
 Preferred diagnostic order:
 1. `adl/tools/pr.sh doctor --json`
-2. `adl pr doctor --json`
-3. `adl/tools/pr.sh ready`
-4. `adl pr ready`
-5. `adl/tools/pr.sh preflight`
-6. `adl pr preflight`
+2. `adl/tools/pr.sh ready`
+3. `adl/tools/pr.sh preflight`
 
 ## Binding Checklist
 

--- a/adl/tools/skills/repo-code-review/references/output-contract.md
+++ b/adl/tools/skills/repo-code-review/references/output-contract.md
@@ -59,7 +59,7 @@ Fix Direction: <bounded repair direction>
 Repo-local validator:
 
 ```text
-adl tooling verify-repo-review-contract
+adl-review verify-repo-contract --review <review.md>
 ```
 
 Fixture test:

--- a/adl/tools/test_cli_owner_command_guidance.sh
+++ b/adl/tools/test_cli_owner_command_guidance.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+surfaces=(
+  "AGENTS.md"
+  "adl/tools/skills"
+  "docs/templates"
+  "docs/tooling/editor"
+)
+
+forbidden_patterns=(
+  "adl pr create"
+  "adl pr init"
+  "adl pr doctor"
+  "adl pr ready"
+  "adl pr preflight"
+  "adl pr run"
+  "adl pr finish"
+  "adl tooling prompt-template"
+  "adl tooling code-review"
+  "adl tooling review-card-surface"
+  "adl tooling review-runtime-surface"
+  "adl tooling verify-review-output-provenance"
+  "adl tooling verify-repo-review-contract"
+)
+
+for pattern in "${forbidden_patterns[@]}"; do
+  if rg -n --fixed-strings "$pattern" "${surfaces[@]}"; then
+    echo "FAIL: live command guidance still teaches deprecated command: $pattern" >&2
+    exit 1
+  fi
+done
+
+required_patterns=(
+  "adl/tools/pr.sh run <issue>"
+  "adl-csdlc tooling prompt-template"
+  "adl-review verify-repo-contract --review <review.md>"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! rg -n --fixed-strings "$pattern" "${surfaces[@]}" >/dev/null; then
+    echo "FAIL: live command guidance is missing required command: $pattern" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: live CLI owner command guidance is aligned with wrapper migration policy"

--- a/docs/milestones/v0.91.5/CLI_OWNER_COMMAND_GUIDANCE_AUDIT_3611.md
+++ b/docs/milestones/v0.91.5/CLI_OWNER_COMMAND_GUIDANCE_AUDIT_3611.md
@@ -1,0 +1,80 @@
+# CLI Owner Command Guidance Audit (#3611)
+
+Issue: #3611
+Status: implemented
+
+## Purpose
+
+Keep live ADL guidance aligned with the first CLI ownership split without
+creating a second workflow truth.
+
+The migration rule remains conservative:
+
+- `adl/tools/pr.sh` is still the canonical agent-facing issue-work wrapper.
+- `adl-csdlc` owns C-SDLC tooling and future wrapper internals where proven.
+- `adl-runtime` owns runtime workflow execution and runtime-facing command
+  families where proven.
+- `adl-review` owns review tooling where proven.
+
+## Surfaces Audited
+
+- Root agent guidance: `AGENTS.md`
+- Prompt-template docs: `docs/templates/prompts/README.md`
+- Invocation template docs: `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+- Live operational skills: `adl/tools/skills/`
+- Editor adapter docs: `docs/tooling/editor/`
+- Refactor truth docs:
+  - `docs/milestones/v0.91.5/CLI_COMMAND_INVENTORY_3594.md`
+  - `docs/milestones/v0.91.5/CLI_WRAPPER_MIGRATION_CONTRACT_3597.md`
+  - `docs/milestones/v0.91.5/CLI_RUNTIME_COMPATIBILITY_3598.md`
+  - `docs/milestones/v0.91.5/CLI_REVIEW_COMPATIBILITY_3599.md`
+
+Historical review packets and archived milestone evidence were intentionally
+not rewritten. Those files may preserve old commands as historical evidence.
+
+## Updates Made
+
+- Removed direct `adl pr ...` commands from live `pr-init`, `pr-ready`,
+  `pr-run`, and `pr-finish` skill guidance and machine-readable skill metadata.
+- Kept `adl/tools/pr.sh run <issue>` as the taught issue-binding command.
+- Updated prompt-template guidance to use
+  `adl-csdlc tooling prompt-template ...` where the owner binary is now proven.
+- Updated the repo-code-review output contract to use
+  `adl-review verify-repo-contract --review <review.md>`.
+- Added `adl/tools/test_cli_owner_command_guidance.sh` as a fast guardrail for
+  live guidance drift.
+
+## Command Policy
+
+| Surface | Taught command |
+| --- | --- |
+| Issue creation/bootstrap | `adl/tools/pr.sh create`, `adl/tools/pr.sh init` |
+| Issue readiness | `adl/tools/pr.sh doctor --json` |
+| Issue execution binding | `adl/tools/pr.sh run <issue>` |
+| Issue finish/publication | `adl/tools/pr.sh finish` |
+| Prompt-template rendering/validation | `adl-csdlc tooling prompt-template ...` |
+| Runtime workflow execution | `adl-runtime run <adl.yaml> ...` |
+| Review contract validation | `adl-review verify-repo-contract --review <review.md>` |
+
+## Deferred Routes
+
+- Do not teach `adl-csdlc issue run <issue>` as the primary agent-facing issue
+  command until the wrapper migration gate explicitly changes.
+- Do not rewrite downstream issue cards in this issue; that remains #3582.
+- Do not rewrite historical review evidence or old milestone packets.
+- Do not remove legacy `adl ...` compatibility shims in this issue; deprecation
+  and sunset policy remains #3615.
+
+## Validation
+
+- `bash adl/tools/test_cli_owner_command_guidance.sh`
+- `bash adl/tools/run_owner_validation_lane.sh csdlc`
+- `git diff --check`
+
+## Non-Claims
+
+- This does not complete the wrapper migration.
+- This does not remove compatibility shims.
+- This does not claim every historical command string in the repository was
+  rewritten.
+- This does not perform the downstream card rewrite owned by #3582.

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -69,7 +69,7 @@ Use the Rust tool to regenerate schemas only when template structure changes
 intentionally:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template \
   write-structure-schemas \
   --out-dir docs/templates/prompts/1.0.0/schemas
 ```
@@ -77,7 +77,7 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
 Then run both Rust and Python-readable schema checks:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-schemas
 python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
 
@@ -91,7 +91,7 @@ The local human editor for this template set lives at
 generated from Rust with:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling csdlc-prompt-editor \
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling csdlc-prompt-editor \
   --emit-model-js docs/tooling/csdlc-prompt-editor/editor_model.js
 ```
 


### PR DESCRIPTION
Closes #3611

## Summary
Aligned live docs and skill guidance with the first CLI owner-command split. Issue work still teaches `adl/tools/pr.sh`; prompt-template guidance now points at `adl-csdlc`; review contract validation now points at `adl-review`; and a fast C-SDLC owner-lane guard prevents live guidance from drifting back to deprecated command strings.

## Artifacts
- `AGENTS.md`
- `docs/templates/prompts/README.md`
- `docs/milestones/v0.91.5/CLI_OWNER_COMMAND_GUIDANCE_AUDIT_3611.md`
- `adl/tools/test_cli_owner_command_guidance.sh`
- `adl/tools/run_owner_validation_lane.sh`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/pr-init/SKILL.md`
- `adl/tools/skills/pr-init/adl-skill.yaml`
- `adl/tools/skills/pr-init/references/init-playbook.md`
- `adl/tools/skills/pr-ready/SKILL.md`
- `adl/tools/skills/pr-ready/adl-skill.yaml`
- `adl/tools/skills/pr-ready/references/ready-playbook.md`
- `adl/tools/skills/pr-run/SKILL.md`
- `adl/tools/skills/pr-run/adl-skill.yaml`
- `adl/tools/skills/pr-run/references/run-playbook.md`
- `adl/tools/skills/pr-finish/SKILL.md`
- `adl/tools/skills/pr-finish/adl-skill.yaml`
- `adl/tools/skills/repo-code-review/references/output-contract.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_cli_owner_command_guidance.sh`
    Verified live command guidance uses `pr.sh`, `adl-csdlc`, and `adl-review` according to the migration contract.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the C-SDLC owner lane including the new guidance guard.
  - `git diff --check`
    Verified diff hygiene.
  - `rg` command-guidance scan over live docs, templates, and skills
    Verified scoped live guidance does not teach deprecated command strings.
  - `rg` host-path scan over touched PR lifecycle skills
    Verified touched lifecycle skill docs use portable repo-root placeholders instead of the old host-local checkout path.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3611__v0-91-5-refactor-docs-migrate-docs-and-skills-to-proven-cli-owner-commands/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3611__v0-91-5-refactor-docs-migrate-docs-and-skills-to-proven-cli-owner-commands/sor.md
- Idempotency-Key: v0-91-5-refactor-migrate-docs-and-skills-to-owner-commands-agents-md-adl-tools-run-owner-validation-lane-sh-adl-tools-test-cli-owner-command-guidance-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-pr-finish-skill-md-adl-tools-skills-pr-finish-adl-skill-yaml-adl-tools-skills-pr-init-skill-md-adl-tools-skills-pr-init-adl-skill-yaml-adl-tools-skills-pr-init-references-init-playbook-md-adl-tools-skills-pr-ready-skill-md-adl-tools-skills-pr-ready-adl-skill-yaml-adl-tools-skills-pr-ready-references-ready-playbook-md-adl-tools-skills-pr-run-skill-md-adl-tools-skills-pr-run-adl-skill-yaml-adl-tools-skills-pr-run-references-run-playbook-md-adl-tools-skills-repo-code-review-references-output-contract-md-docs-templates-prompts-readme-md-docs-milestones-v0-91-5-cli-owner-command-guidance-audit-3611-md-adl-v0-91-5-tasks-issue-3611-v0-91-5-refactor-docs-migrate-docs-and-skills-to-proven-cli-owner-commands-sip-md-adl-v0-91-5-tasks-issue-3611-v0-91-5-refactor-docs-migrate-docs-and-skills-to-proven-cli-owner-commands-sor-md