### PR TITLE
[v0.91.5][WP-02][tools] Add field-level prompt-card values editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,12 @@ These rules are mandatory for ADL issue work.
      explicitly requires a compatibility path.
    - For new or fully re-rendered cards, prefer the deterministic
      prompt-template values renderer over direct Markdown structure edits:
-     `adl-csdlc tooling prompt-template validate-values`, `render`,
-     `render-all`, `validate-structure`, and `validate-schemas`.
+     `adl-csdlc tooling prompt-template validate-values`, `edit-values`,
+     `render`, `render-all`, `validate-structure`, and `validate-schemas`.
+   - For supported field-level card updates, edit the values object first with
+     `adl-csdlc tooling prompt-template edit-values --kind <kind> --values <path> --set <field=value>`,
+     then render and validate structure. Do not patch the rendered Markdown
+     when a declared values-field edit is sufficient.
    - Treat the tracked structure schemas under
      `docs/templates/prompts/<version>/schemas/` as the template-shape
      authority. If a rendered card fails structure validation, fix the values or

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -90,6 +90,7 @@ adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\
 adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
+adl tooling prompt-template edit-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> --set <field=value> [--set <field=value> ...] [--out <values.yaml>] [--repo-root <path>]\n\
 adl tooling prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
 adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template validate-schemas [--repo-root <path>]\n\

--- a/adl/src/cli/tooling_cmd/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/prompt_template.rs
@@ -1,9 +1,9 @@
 use adl::csdlc_prompt_editor::{
-    render_all_cards_from_values_dir, render_card_from_values_file, repo_root_from_arg,
-    validate_rendered_card_structure_file, validate_structure_schema_files, validate_values_file,
-    write_all_sample_values, write_all_structure_schemas, PromptCardKind,
+    edit_values_file, render_all_cards_from_values_dir, render_card_from_values_file,
+    repo_root_from_arg, validate_rendered_card_structure_file, validate_structure_schema_files,
+    validate_values_file, write_all_sample_values, write_all_structure_schemas, PromptCardKind,
 };
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use std::fs;
 use std::path::PathBuf;
 
@@ -17,6 +17,7 @@ pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
     match subcommand {
         "render" => render_one(&args[1..]),
         "render-all" => render_all(&args[1..]),
+        "edit-values" => edit_values(&args[1..]),
         "validate-values" => validate_one(&args[1..]),
         "validate-structure" => validate_structure_one(&args[1..]),
         "validate-schemas" => validate_schemas(&args[1..]),
@@ -27,7 +28,7 @@ pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
             Ok(())
         }
         other => bail!(
-            "unknown prompt-template subcommand '{other}' (expected render | render-all | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
+            "unknown prompt-template subcommand '{other}' (expected render | render-all | edit-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
         ),
     }
 }
@@ -71,6 +72,57 @@ fn validate_one(args: &[String]) -> Result<()> {
     let values = values.ok_or_else(|| anyhow::anyhow!("validate-values requires --values"))?;
     validate_values_file(&root, kind, &values)?;
     println!("PASS: values valid for {}", kind.key());
+    Ok(())
+}
+
+fn edit_values(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+    let mut repo_root: Option<PathBuf> = None;
+    let mut kind: Option<PromptCardKind> = None;
+    let mut values: Option<PathBuf> = None;
+    let mut out: Option<PathBuf> = None;
+    let mut updates: Vec<(String, String)> = Vec::new();
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--kind" => {
+                idx += 1;
+                kind = Some(PromptCardKind::parse_key(value_arg(args, idx, "--kind")?)?);
+            }
+            "--values" => {
+                idx += 1;
+                values = Some(PathBuf::from(value_arg(args, idx, "--values")?));
+            }
+            "--set" => {
+                idx += 1;
+                updates.push(parse_set_arg(value_arg(args, idx, "--set")?)?);
+            }
+            "--out" => {
+                idx += 1;
+                out = Some(PathBuf::from(value_arg(args, idx, "--out")?));
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => bail!("unknown arg for tooling prompt-template edit-values: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = repo_root_from_arg(repo_root)?;
+    let kind = kind.ok_or_else(|| anyhow::anyhow!("edit-values requires --kind"))?;
+    let values = values.ok_or_else(|| anyhow::anyhow!("edit-values requires --values"))?;
+    let target = edit_values_file(&root, kind, &values, &updates, out.as_deref())?;
+    println!("PASS: edited {} values at {}", kind.key(), target.display());
     Ok(())
 }
 
@@ -294,4 +346,13 @@ fn value_arg<'a>(args: &'a [String], idx: usize, flag: &str) -> Result<&'a str> 
 fn has_help_arg(args: &[String]) -> bool {
     args.iter()
         .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "help"))
+}
+
+fn parse_set_arg(value: &str) -> Result<(String, String)> {
+    let Some((key, value)) = value.split_once('=') else {
+        bail!("--set must use field=value syntax");
+    };
+    let key = key.trim();
+    ensure!(!key.is_empty(), "--set field name must not be empty");
+    Ok((key.to_string(), value.to_string()))
 }

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -135,6 +135,94 @@ fn prompt_template_cli_renders_one_card_and_rejects_locked_value_edits() {
 }
 
 #[test]
+fn prompt_template_cli_edits_declared_values_and_fails_closed() {
+    let repo = TempRepo::new("prompt-template-edit-values");
+    let values_dir = repo.path().join("values");
+    let edited_values = repo.path().join("edited-stp.values.yaml");
+    let rendered = repo.path().join("edited-stp.md");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("stp.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "summary=Edited through the deterministic field editor.".to_string(),
+        "--out".to_string(),
+        edited_values.to_string_lossy().to_string(),
+    ])
+    .expect("edit-values should update editable field");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "render".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        edited_values.to_string_lossy().to_string(),
+        "--out".to_string(),
+        rendered.to_string_lossy().to_string(),
+    ])
+    .expect("edited values should render");
+    assert!(fs::read_to_string(&rendered)
+        .expect("rendered edited card")
+        .contains("Edited through the deterministic field editor."));
+
+    let locked = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("stp.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "issue=9999".to_string(),
+    ])
+    .expect_err("locked field should fail");
+    assert!(locked.to_string().contains("stp.issue is locked"));
+
+    let missing_set = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("stp.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+    ])
+    .expect_err("missing --set should fail");
+    assert!(missing_set
+        .to_string()
+        .contains("edit-values requires at least one --set"));
+}
+
+#[test]
 fn prompt_template_cli_rejects_markdown_structure_drift() {
     let repo = TempRepo::new("prompt-template-structure");
     let values_dir = repo.path().join("values");
@@ -239,6 +327,12 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
         "--help".to_string(),
     ])
     .expect("validate-values help should succeed");
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--help".to_string(),
+    ])
+    .expect("edit-values help should succeed");
     real_tooling(&[
         "prompt-template".to_string(),
         "validate-structure".to_string(),

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -254,6 +254,57 @@ pub fn validate_values_file(
     validate_values(card, &values)
 }
 
+pub fn edit_values_file(
+    repo_root: &Path,
+    kind: PromptCardKind,
+    values_path: &Path,
+    updates: &[(String, String)],
+    out_path: Option<&Path>,
+) -> Result<PathBuf> {
+    ensure!(
+        !updates.is_empty(),
+        "edit-values requires at least one --set field=value update"
+    );
+    let model = load_editor_model(repo_root)?;
+    let card = card_model(&model, kind)?;
+    let mut doc = load_values_document(card, values_path, &model.template_set)?;
+
+    for (key, value) in updates {
+        let field = card
+            .fields
+            .iter()
+            .find(|field| field.key == key.as_str())
+            .ok_or_else(|| {
+                anyhow!(
+                    "{}.{} is not a declared prompt-template field",
+                    card.key,
+                    key
+                )
+            })?;
+        ensure!(
+            field.editable,
+            "{}.{} is locked; edit only declared values fields",
+            card.key,
+            key
+        );
+        doc.values.insert(key.clone(), value.clone());
+    }
+
+    let values = doc.merged_values();
+    validate_values(card, &values)?;
+    let rendered = render_template(&card.template, &values)?;
+    validate_rendered_card_structure_from_repo(repo_root, card, &rendered)?;
+
+    let target = out_path.unwrap_or(values_path).to_path_buf();
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&target, doc.to_yaml(card))
+        .with_context(|| format!("failed to write edited values file {}", target.display()))?;
+    Ok(target)
+}
+
 pub fn validate_rendered_card_structure_file(
     repo_root: &Path,
     kind: PromptCardKind,
@@ -1091,11 +1142,54 @@ fn is_rendered_value_line(trimmed: &str, schema: &PromptCardStructureSchema) -> 
         .any(|prefix| trimmed.starts_with(prefix))
 }
 
+#[derive(Debug, Clone)]
+struct PromptValuesDocument {
+    schema: String,
+    template_set: String,
+    card_kind: Option<String>,
+    system: BTreeMap<String, String>,
+    values: BTreeMap<String, String>,
+}
+
+impl PromptValuesDocument {
+    fn merged_values(&self) -> BTreeMap<String, String> {
+        let mut merged = self.system.clone();
+        merged.extend(self.values.clone());
+        merged
+    }
+
+    fn to_yaml(&self, card: &PromptCardForm) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("schema: {}\n", yaml_scalar(&self.schema)));
+        out.push_str(&format!(
+            "template_set: {}\n",
+            yaml_scalar(&self.template_set)
+        ));
+        out.push_str(&format!(
+            "card_kind: {}\n",
+            yaml_scalar(self.card_kind.as_deref().unwrap_or(card.key))
+        ));
+        out.push_str("system:\n");
+        write_yaml_mapping(&mut out, &self.system);
+        out.push_str("values:\n");
+        write_yaml_mapping(&mut out, &self.values);
+        out
+    }
+}
+
 fn load_values_file(
     card: &PromptCardForm,
     path: &Path,
     expected_template_set: &str,
 ) -> Result<BTreeMap<String, String>> {
+    Ok(load_values_document(card, path, expected_template_set)?.merged_values())
+}
+
+fn load_values_document(
+    card: &PromptCardForm,
+    path: &Path,
+    expected_template_set: &str,
+) -> Result<PromptValuesDocument> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read values file {}", path.display()))?;
     let doc: serde_yaml::Value = serde_yaml::from_str(&raw)
@@ -1127,31 +1221,42 @@ fn load_values_file(
         );
     }
 
-    let mut values = BTreeMap::new();
-    if let Some(system) = mapping.get(serde_yaml::Value::String("system".to_string())) {
-        collect_values_section(card, system, false, &mut values, "system")?;
-    }
-    if let Some(editable) = mapping.get(serde_yaml::Value::String("values".to_string())) {
-        collect_values_section(card, editable, true, &mut values, "values")?;
-    }
+    let system = if let Some(system) = mapping.get(serde_yaml::Value::String("system".to_string()))
+    {
+        collect_values_section(card, system, false, "system")?
+    } else {
+        BTreeMap::new()
+    };
+    let values =
+        if let Some(editable) = mapping.get(serde_yaml::Value::String("values".to_string())) {
+            collect_values_section(card, editable, true, "values")?
+        } else {
+            BTreeMap::new()
+        };
 
     ensure!(
-        !values.is_empty(),
+        !system.is_empty() || !values.is_empty(),
         "values file must contain system and/or values mappings"
     );
-    Ok(values)
+    Ok(PromptValuesDocument {
+        schema,
+        template_set,
+        card_kind: mapping_string_value(mapping, "card_kind")?,
+        system,
+        values,
+    })
 }
 
 fn collect_values_section(
     card: &PromptCardForm,
     section: &serde_yaml::Value,
     ordinary_values: bool,
-    out: &mut BTreeMap<String, String>,
     section_name: &str,
-) -> Result<()> {
+) -> Result<BTreeMap<String, String>> {
     let mapping = section
         .as_mapping()
         .ok_or_else(|| anyhow!("{section_name} must be a mapping"))?;
+    let mut out = BTreeMap::new();
     for (key, value) in mapping {
         let key = key
             .as_str()
@@ -1182,7 +1287,7 @@ fn collect_values_section(
             .ok_or_else(|| anyhow!("{}.{} must be a scalar value", section_name, key))?;
         out.insert(key.to_string(), value);
     }
-    Ok(())
+    Ok(out)
 }
 
 fn scalar_to_string(value: &serde_yaml::Value) -> Option<String> {
@@ -1203,6 +1308,34 @@ fn mapping_string_value(mapping: &serde_yaml::Mapping, key: &str) -> Result<Opti
         .as_str()
         .ok_or_else(|| anyhow!("{key} must be a string"))?;
     Ok(Some(value.to_string()))
+}
+
+fn write_yaml_mapping(out: &mut String, values: &BTreeMap<String, String>) {
+    if values.is_empty() {
+        out.push_str("  {}\n");
+        return;
+    }
+    for (key, value) in values {
+        if value.contains('\n') {
+            let (indicator, body) = if let Some(stripped) = value.strip_suffix('\n') {
+                ("|", stripped)
+            } else {
+                ("|-", value.as_str())
+            };
+            out.push_str(&format!("  {key}: {indicator}\n"));
+            for line in body.split('\n') {
+                out.push_str("    ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        } else {
+            out.push_str(&format!("  {key}: {}\n", yaml_scalar(value)));
+        }
+    }
+}
+
+fn yaml_scalar(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 fn sample_values_document(kind: PromptCardKind) -> String {
@@ -2051,5 +2184,130 @@ system:
         assert!(err
             .to_string()
             .contains("template_set must match active template set"));
+    }
+
+    #[test]
+    fn edit_values_file_updates_declared_editable_fields_for_all_card_kinds() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-prompt-values-edit-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).expect("tmp");
+
+        for (kind, field, value) in [
+            (
+                PromptCardKind::Sip,
+                "goal",
+                "Exercise the field-level editor for SIP.",
+            ),
+            (
+                PromptCardKind::Stp,
+                "summary",
+                "Exercise the field-level editor for STP.",
+            ),
+            (
+                PromptCardKind::Spp,
+                "plan_summary",
+                "Exercise the field-level editor for SPP.",
+            ),
+            (
+                PromptCardKind::Srp,
+                "notes_risks",
+                "Exercise the field-level editor for SRP.",
+            ),
+            (PromptCardKind::Sor, "status", "DONE"),
+        ] {
+            let input = tmp.join(format!("{}.values.yaml", kind.key()));
+            let output = tmp.join(format!("{}.edited.values.yaml", kind.key()));
+            fs::write(&input, sample_values_document(kind)).expect("sample values");
+
+            edit_values_file(
+                &repo_root(),
+                kind,
+                &input,
+                &[(field.to_string(), value.to_string())],
+                Some(&output),
+            )
+            .expect("editable field should update");
+
+            let model = load_editor_model(&repo_root()).expect("model");
+            let card = card_model(&model, kind).expect("card");
+            let edited = load_values_file(card, &output, &model.template_set)
+                .expect("edited values should load");
+            assert_eq!(edited.get(field).map(String::as_str), Some(value));
+            render_card_from_values_file(&repo_root(), kind, &output)
+                .expect("edited values should render and validate structure");
+        }
+
+        let input = tmp.join("stp-multiline.values.yaml");
+        let output = tmp.join("stp-multiline.edited.values.yaml");
+        let multiline = "First line.\nSecond line.";
+        fs::write(&input, sample_values_document(PromptCardKind::Stp)).expect("sample values");
+        edit_values_file(
+            &repo_root(),
+            PromptCardKind::Stp,
+            &input,
+            &[("summary".to_string(), multiline.to_string())],
+            Some(&output),
+        )
+        .expect("multiline editable value should update");
+        let model = load_editor_model(&repo_root()).expect("model");
+        let stp = card_model(&model, PromptCardKind::Stp).expect("stp");
+        let edited =
+            load_values_file(stp, &output, &model.template_set).expect("load multiline values");
+        assert_eq!(edited.get("summary").map(String::as_str), Some(multiline));
+    }
+
+    #[test]
+    fn edit_values_file_fails_closed_for_locked_unknown_and_invalid_fields() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-prompt-values-edit-fail-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).expect("tmp");
+        let sip = tmp.join("sip.values.yaml");
+        fs::write(&sip, sample_values_document(PromptCardKind::Sip)).expect("sip values");
+
+        let locked = edit_values_file(
+            &repo_root(),
+            PromptCardKind::Sip,
+            &sip,
+            &[("issue".to_string(), "9999".to_string())],
+            Some(&tmp.join("locked.values.yaml")),
+        )
+        .expect_err("locked field edit should fail");
+        assert!(locked.to_string().contains("sip.issue is locked"));
+
+        let unknown = edit_values_file(
+            &repo_root(),
+            PromptCardKind::Sip,
+            &sip,
+            &[("unknown_field".to_string(), "nope".to_string())],
+            Some(&tmp.join("unknown.values.yaml")),
+        )
+        .expect_err("unknown field edit should fail");
+        assert!(unknown
+            .to_string()
+            .contains("sip.unknown_field is not a declared prompt-template field"));
+
+        let sor = tmp.join("sor.values.yaml");
+        fs::write(&sor, sample_values_document(PromptCardKind::Sor)).expect("sor values");
+        let invalid_enum = edit_values_file(
+            &repo_root(),
+            PromptCardKind::Sor,
+            &sor,
+            &[("status".to_string(), "ALMOST_DONE".to_string())],
+            Some(&tmp.join("invalid-enum.values.yaml")),
+        )
+        .expect_err("invalid enum edit should fail");
+        assert!(invalid_enum
+            .to_string()
+            .contains("sor.status must be one of"));
     }
 }

--- a/adl/tools/skills/sip-editor/SKILL.md
+++ b/adl/tools/skills/sip-editor/SKILL.md
@@ -24,13 +24,16 @@ Markdown as lifecycle state:
 
 ```sh
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sip --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind sip --values <path> --set <field=value> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sip --values <path> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sip --input <path>
 ```
 
 Use this skill for SIP truth repairs: issue-specific intent, branch/worktree
 truth, target surfaces, validation guidance, and placeholder cleanup. Do not use
-it to bypass locked template prose or schema validation.
+it to bypass locked template prose or schema validation. When a supported
+declared values field is the only change needed, prefer `edit-values` before
+rendering instead of patching rendered Markdown.
 
 ## Required Inputs
 

--- a/adl/tools/skills/sor-editor/SKILL.md
+++ b/adl/tools/skills/sor-editor/SKILL.md
@@ -24,6 +24,7 @@ Markdown as lifecycle state:
 
 ```sh
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sor --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind sor --values <path> --set <field=value> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sor --values <path> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sor --input <path>
 ```
@@ -31,7 +32,8 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-str
 Use this skill for SOR truth repairs: execution result, changed paths,
 validation actually run, integration state, PR state, residual risks, and
 closeout truth. Do not use it to bypass locked template prose or schema
-validation.
+validation. When a supported declared values field is the only change needed,
+prefer `edit-values` before rendering instead of patching rendered Markdown.
 
 ## Required Inputs
 

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -30,6 +30,7 @@ Markdown as lifecycle state:
 
 ```sh
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind spp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind spp --values <path> --set <field=value> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind spp --values <path> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind spp --input <path>
 ```
@@ -37,7 +38,8 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-str
 Use this skill for SPP truth repairs: issue-local plan readiness, `codex_plan`
 status normalization, assumptions, stop conditions, dependencies, and
 execution-handoff truth. Do not use it to bypass locked template prose or schema
-validation.
+validation. When a supported declared values field is the only change needed,
+prefer `edit-values` before rendering instead of patching rendered Markdown.
 
 ## Required Inputs
 

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -24,13 +24,16 @@ Markdown as lifecycle state:
 
 ```sh
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind srp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind srp --values <path> --set <field=value> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind srp --values <path> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind srp --input <path>
 ```
 
 Use this skill for SRP truth repairs: review scope, review prompts, findings,
 dispositions, reviewer notes, residual risks, and recommended outcome. Do not
-use it to bypass locked template prose or schema validation.
+use it to bypass locked template prose or schema validation. When a supported
+declared values field is the only change needed, prefer `edit-values` before
+rendering instead of patching rendered Markdown.
 
 ## Required Inputs
 

--- a/adl/tools/skills/stp-editor/SKILL.md
+++ b/adl/tools/skills/stp-editor/SKILL.md
@@ -24,13 +24,16 @@ Markdown as lifecycle state:
 
 ```sh
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind stp --values <path>
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind stp --values <path> --set <field=value> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind stp --values <path> --out <path>
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind stp --input <path>
 ```
 
 Use this skill for STP truth repairs: task intent, required outcome,
 acceptance criteria, bounded scope, validation plan, and placeholder cleanup. Do
-not use it to bypass locked template prose or schema validation.
+not use it to bypass locked template prose or schema validation. When a
+supported declared values field is the only change needed, prefer `edit-values`
+before rendering instead of patching rendered Markdown.
 
 ## Required Inputs
 

--- a/docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md
+++ b/docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md
@@ -29,6 +29,16 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
   validate-values --kind sip --values /tmp/csdlc-prompt-values/sip.values.yaml
 ```
 
+Apply a supported field-level update to values YAML:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  edit-values --kind sip \
+  --values /tmp/csdlc-prompt-values/sip.values.yaml \
+  --set goal="Tighten the issue goal." \
+  --out /tmp/csdlc-prompt-values/sip.edited.values.yaml
+```
+
 Render one card or all five cards:
 
 ```sh
@@ -62,6 +72,8 @@ python3 adl/tools/test_prompt_template_structure_schemas.py
 - Did the card values come from the active registry in
   `docs/templates/prompts/current.json`?
 - Did editable issue-local prose stay under `values` rather than `system`?
+- If only declared field values changed, did the edit use `edit-values` rather
+  than direct Markdown patching?
 - Did locked lifecycle, routing, branch, issue, path, enum, or derived template
   fields stay under `system`?
 - Did `validate-values` pass before rendering?

--- a/docs/tooling/PROMPT_TEMPLATE_FIELD_EDITOR_CONTRACT_3621.md
+++ b/docs/tooling/PROMPT_TEMPLATE_FIELD_EDITOR_CONTRACT_3621.md
@@ -1,0 +1,69 @@
+# Prompt-Template Field Editor Contract
+
+Issue: `#3621`
+Milestone: `v0.91.5`
+
+## Purpose
+
+The field editor gives Sprint 1 a deterministic way to update prompt-card
+values without editing locked rendered Markdown. It is intentionally narrower
+than a full Markdown editor: the editable surface is the values YAML consumed by
+the active prompt-template renderer.
+
+## Command
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  edit-values \
+  --kind <sip|stp|spp|srp|sor> \
+  --values <values.yaml> \
+  --set <field=value> \
+  [--set <field=value> ...] \
+  [--out <values.yaml>] \
+  [--repo-root <path>]
+```
+
+The command is also available through the owner binary path:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template edit-values ...
+```
+
+## First-Slice Editable Fields
+
+The supported fields are the declared editable fields in the Rust prompt editor
+model for each card kind. The first slice proves at least one high-value update
+path for every active card:
+
+| Card | Example editable field | Typical use |
+|---|---|---|
+| `sip` | `goal` | Tighten issue intent without touching branch, issue, or routing fields. |
+| `stp` | `summary` | Tighten task summary or acceptance-facing prose. |
+| `spp` | `plan_summary` | Tighten the operative plan before execution binds. |
+| `srp` | `notes_risks` | Record review scope notes before or after review. |
+| `sor` | `status` | Move execution status through the declared enum when evidence supports it. |
+
+## Validation Contract
+
+`edit-values` fails closed before writing output when:
+
+- `--set` is omitted or malformed;
+- the card kind is unsupported;
+- the values file schema, template set, or card kind does not match the active
+  registry;
+- the target field is unknown;
+- the target field is locked/system-owned;
+- enum or required-field validation fails;
+- rendering leaves unresolved placeholders; or
+- rendered Markdown structure fails the tracked schema validation.
+
+After applying updates in memory, the tool runs the same validation path as
+`validate-values` plus an in-memory `render` and `validate-structure` pass
+against `docs/templates/prompts/<version>/schemas/*.structure.json`.
+
+## Boundary
+
+Use this tool for supported field edits. Use the card editor skills for
+lifecycle-truth judgment, review dispositions, execution evidence, or repairs
+that require semantic reasoning. Do not patch rendered locked prose by hand
+when a declared values-field update is sufficient.

--- a/docs/tooling/csdlc-prompt-editor/README.md
+++ b/docs/tooling/csdlc-prompt-editor/README.md
@@ -75,6 +75,12 @@ cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
   validate-values --kind sip --values /tmp/csdlc-prompt-values/sip.values.yaml
 
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
+  edit-values --kind sip \
+  --values /tmp/csdlc-prompt-values/sip.values.yaml \
+  --set goal="Tighten the issue goal." \
+  --out /tmp/csdlc-prompt-values/sip.edited.values.yaml
+
+cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
   validate-structure --kind sip --input /tmp/csdlc-prompt-cards/sip.md
 
 cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template \
@@ -95,6 +101,14 @@ Values files use:
 The renderer rejects unknown fields, locked fields under `values`, editable
 fields under `system`, unresolved placeholders, enum drift, and malformed
 issue/version/card-status values.
+
+`edit-values` is the deterministic field-level edit path for supported
+declared values fields. It updates the values YAML, rejects locked or unknown
+fields, validates enum and required-field constraints, renders the card in
+memory, and checks the rendered Markdown against the tracked structure schema
+before writing the updated values file. Use it when a bounded field change is
+sufficient; use the editor skills for lifecycle-truth judgment or unsupported
+repairs.
 
 The structure validator protects rendered cards from template-shape drift. It
 checks frontmatter key inventory, Markdown heading order, fenced-block shape,


### PR DESCRIPTION
Closes #3621

## Summary
Implemented the first-slice field-level prompt-card values editor for #3621.
The new `prompt-template edit-values` command updates declared editable values
fields only, rejects locked or unknown fields, reruns values validation, renders
the card in memory, and validates rendered Markdown against the tracked
markdown-rs structure schema before writing output.

## Artifacts
- Rust implementation:
  - `adl/src/csdlc_prompt_editor.rs`
  - `adl/src/cli/tooling_cmd/prompt_template.rs`
  - `adl/src/cli/tooling_cmd.rs`
- Focused tests:
  - `adl/src/csdlc_prompt_editor.rs`
  - `adl/src/cli/tooling_cmd/tests/prompt_template.rs`
- Operator and skill guidance:
  - `AGENTS.md`
  - `docs/tooling/PROMPT_TEMPLATE_CARD_GENERATION_CHECKLIST.md`
  - `docs/tooling/PROMPT_TEMPLATE_FIELD_EDITOR_CONTRACT_3621.md`
  - `docs/tooling/csdlc-prompt-editor/README.md`
  - `adl/tools/skills/sip-editor/SKILL.md`
  - `adl/tools/skills/stp-editor/SKILL.md`
  - `adl/tools/skills/spp-editor/SKILL.md`
  - `adl/tools/skills/srp-editor/SKILL.md`
  - `adl/tools/skills/sor-editor/SKILL.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml csdlc_prompt_editor::tests -- --nocapture`
    Verified the complete prompt editor unit-test group.
  - `cargo test --manifest-path adl/Cargo.toml cli::tooling_cmd::tests::prompt_template -- --nocapture`
    Verified the CLI command route and prompt-template dispatch behavior.
  - `bash adl/tools/test_csdlc_prompt_editor.sh`
    Verified renderer, schema, Python readability, and browser sample proof.
  - `bash adl/tools/test_card_editor_repair_examples.sh`
    Verified tracked editor-skill repair examples.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template write-sample-values --out-dir TMPDIR/values`
    Verified owner-binary sample values generation.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template edit-values --kind sip --values TMPDIR/values/sip.values.yaml --set 'goal=Smoke test edit-values through adl-csdlc.' --out TMPDIR/values/sip.edited.values.yaml`
    Verified owner-binary field edit.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template render --kind sip --values TMPDIR/values/sip.edited.values.yaml --out TMPDIR/sip.md`
    Verified owner-binary render from edited values.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-structure --kind sip --input TMPDIR/sip.md`
    Verified owner-binary structure validation after edit.
  - `git diff --check`
    Verified patch whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Adds a deterministic prompt-template edit-values command for declared editable card fields, with schema-backed render/structure validation and tracked editor guidance.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3621__v0-91-5-tools-add-field-level-prompt-card-editor-backed-by-markdown-rs-schemas/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3621__v0-91-5-tools-add-field-level-prompt-card-editor-backed-by-markdown-rs-schemas/sor.md
- Idempotency-Key: v0-91-5-wp-02-tools-add-field-level-prompt-card-values-editor-agents-md-adl-src-csdlc-prompt-editor-rs-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-prompt-template-rs-adl-src-cli-tooling-cmd-tests-prompt-template-rs-adl-tools-skills-sip-editor-skill-md-adl-tools-skills-stp-editor-skill-md-adl-tools-skills-spp-editor-skill-md-adl-tools-skills-srp-editor-skill-md-adl-tools-skills-sor-editor-skill-md-docs-tooling-prompt-template-card-generation-checklist-md-docs-tooling-prompt-template-field-editor-contract-3621-md-docs-tooling-csdlc-prompt-editor-readme-md-adl-v0-91-5-tasks-issue-3621-v0-91-5-tools-add-field-level-prompt-card-editor-backed-by-markdown-rs-schemas-sip-md-adl-v0-91-5-tasks-issue-3621-v0-91-5-tools-add-field-level-prompt-card-editor-backed-by-markdown-rs-schemas-sor-md