### PR TITLE
[v0.91.5][WP-02][cards] Audit downstream prompt-card rewrite readiness

### DIFF
--- a/docs/milestones/v0.91.5/PROMPT_CARD_REWRITE_AUDIT_3582.md
+++ b/docs/milestones/v0.91.5/PROMPT_CARD_REWRITE_AUDIT_3582.md
@@ -1,0 +1,150 @@
+# v0.91.5 Prompt-Card Rewrite Audit
+
+Issue: `#3582`
+Date: 2026-06-04
+
+## Summary
+
+`#3582` reviewed the downstream v0.91.5 C-SDLC card surface after the
+prompt-template renderer, structure schemas, and field-level values editor
+landed.
+
+The audit found that the downstream local `.adl` card bundles do not need a
+mass Markdown rewrite before Sprint 1 continues. A phase-aware structured
+prompt validation pass covered all 62 v0.91.5 task bundles and all five card
+kinds per bundle:
+
+- Bundles checked: 62
+- Cards checked: 310
+- Phase-aware structured prompt result: 310 pass, 0 fail
+- Tracked Markdown card rewrites required by this issue: none
+
+The first naive validation pass reported branch failures for pre-run and
+retrospective no-PR cards. Those were validation-phase mismatches, not card
+truth defects:
+
+- pre-run `not bound yet` cards validate in bootstrap phase;
+- closed `closed_no_pr` cards with `retrospective-no-branch` validate in
+  completed phase.
+
+## Tooling Used
+
+The pass used the active C-SDLC prompt-template tooling and structured prompt
+validators:
+
+```sh
+cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template --help
+```
+
+```sh
+ADL_TOOLING_RUST_BIN=adl/target/debug/adl-csdlc \
+  adl/tools/validate_structured_prompt.sh --type <kind> --input <card>
+```
+
+Phase rules used by the audit:
+
+- `sip` / `sor` with `not bound yet` branch truth: `--phase bootstrap`
+- completed `sip` / `sor` terminal truth: `--phase completed`
+- all other cards: default validator phase
+
+## Disposition
+
+The safe Sprint 1 disposition is:
+
+- Preserve existing terminal card truth for closed/satisfied issues.
+- Preserve existing pre-run card truth for open issues that validate.
+- Do not regenerate rendered Markdown only for style.
+- Use `edit-values` for supported field-level updates on future values-rendered
+  cards.
+- Use card editor skills for lifecycle-truth repairs when doctor or review
+  finds an actual defect.
+- Keep `#3622` gated until this audit lands; then it may split
+  `csdlc_prompt_editor.rs` with the card surface stable.
+
+## Inventory
+
+| Issue | State | WP | Sprint | Disposition |
+| --- | --- | --- | --- | --- |
+| #3507 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3508 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3509 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3510 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3518 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3526 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3529 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3531 | closed | WP-14 | Sprint-4 | closed/satisfied; preserve terminal card truth |
+| #3534 | closed | WP-18 | Sprint-4 | closed/satisfied; preserve terminal card truth |
+| #3537 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3538 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3541 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3549 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3553 | closed | WP-02 | Sprint-1 | closed/satisfied; preserve terminal card truth |
+| #3556 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3562 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3567 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3568 | closed | WP-01 | - | closed/satisfied; preserve terminal card truth |
+| #3569 | open | Sprint-1 | Sprint-1 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3571 | open | Sprint-1 | Sprint-1 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3572 | open | Sprint-2 | Sprint-2 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3573 | open | Sprint-3 | Sprint-3 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3574 | open | Sprint-4 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3575 | open | WP-14 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3576 | open | WP-16 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3577 | open | WP-18 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3578 | open | WP-20 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3579 | open | WP-15 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3580 | open | WP-17 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3581 | open | WP-19 | Sprint-4 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3582 | open | WP-02 | Sprint-1 | active issue; records this audit and disposition pass |
+| #3585 | closed | Sprint-1 | Sprint-1 | closed/satisfied; preserve terminal card truth |
+| #3587 | closed | Sprint-1 | Sprint-1 | closed/satisfied; preserve terminal card truth |
+| #3588 | closed | WP-02 | Sprint-1 | closed/satisfied; preserve terminal card truth |
+| #3590 | open | Sprint-1 | Sprint-1 | open; card bundle validates and remains eligible for normal conductor execution |
+| #3592 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3593 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3594 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3595 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3596 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3597 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3598 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3599 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3600 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3607 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3609 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3610 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3611 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3612 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3614 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3615 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3621 | closed | WP-02 | Sprint-1 | closed/satisfied; preserve terminal card truth |
+| #3623 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3624 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3625 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3628 | closed | unassigned | - | closed/satisfied; preserve terminal card truth |
+| #3636 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3637 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3638 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3639 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3640 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+| #3641 | open | unassigned | - | open; card bundle validates and remains eligible for normal conductor execution |
+
+## Follow-On
+
+Follow-on issue: `#3643`
+
+This audit did not convert historical rendered cards into values YAML because
+the current prompt-template tooling is intentionally one-way:
+
+```text
+values YAML -> rendered Markdown -> structure/schema validation
+```
+
+A future tool should add a bounded import/round-trip path:
+
+```text
+existing card -> values YAML candidate -> render -> structure comparison
+```
+
+`#3643` tracks that importer/round-trip normalizer. It is useful, but it is not
+required to continue Sprint 1 because the current downstream cards validate and
+retain truthful lifecycle state.

--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -103,9 +103,10 @@ Make v0.92 openable without hidden operational debt.
 - Preserve ordered execution where dependencies matter.
 - Do not close WP-01 until planned issues, cards, sprint umbrellas, and initial
   sequencing are ready to begin or explicitly routed.
-- Downstream card rewrite is explicitly routed through `#3582` and waits until
-  `#3553` lands; WP-01 does not need to rewrite every scaffold-era downstream
-  card before opening Sprint 1.
+- Downstream card rewrite is explicitly routed through `#3582` after the
+  prompt-template renderer, schema guard, and field-level editor land. Its
+  audit records that all downstream v0.91.5 cards validate phase-aware, so
+  Sprint 1 can proceed without mass Markdown rewrites.
 - Sprint umbrellas `#3571` through `#3574` own sprint-level coordination and
   closeout truth; they do not replace child issue execution.
 - Use multi-agent lanes only where they are being tested or provide clear value.

--- a/docs/milestones/v0.91.5/WBS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WBS_v0.91.5.md
@@ -77,8 +77,9 @@ to the reusable standard at
 - `#3569` owns the portable ADL project adapter contract and templates; WP-01
   schedules it, but adapter implementation does not become WP-01 work.
 - `#3582` owns the downstream card rewrite/normalization pass after prompt
-  templates v1.1 lands. WP-01 records that route instead of blocking on
-  polishing every downstream card before the new templates exist.
+  templates, structure schemas, and field-level values editing land. Its audit
+  records phase-aware validation and avoids polishing every downstream card
+  when no lifecycle-truth defect exists.
 
 ## Sprint Umbrella Issues
 
@@ -112,9 +113,9 @@ is explicit.
   issues/cards/sprint umbrellas are ready to begin or explicitly routed.
   Sprint umbrellas are `#3571` through `#3574`; closeout-tail issues are
   `#3575`, `#3579`, `#3576`, `#3580`, `#3577`, `#3581`, and `#3578`.
-- WP-01 explicitly routes downstream card rewriting through `#3582` after
-  `#3553` lands, so old card scaffolds are not treated as final execution
-  truth and do not block opening the milestone.
+- WP-01 explicitly routes downstream card rewriting through `#3582`, so old
+  card scaffolds are validated or dispositioned before later sprint work
+  consumes them.
 - WP-02 through WP-07 -> prompt-template and public prompt records are safe to review.
 - WP-08 through WP-12 -> provider/model and multi-agent usefulness are tested.
 - WP-13 -> demo matrix and showcase readiness are explicit.

--- a/docs/milestones/v0.91.5/WP_EXECUTION_READINESS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WP_EXECUTION_READINESS_v0.91.5.md
@@ -26,9 +26,10 @@ Planned readiness surface.
 - Sprint umbrella issues `#3571` through `#3574` must receive qualitative
   card review before they are used for sprint execution/closeout.
 - Downstream issue-card rewrite/normalization is intentionally routed through
-  `#3582` after prompt templates v1.1 lands via `#3553`; WP-01 does not block
-  on rewriting every downstream scaffold-era card before that template contract
-  exists.
+  `#3582` after the prompt-template renderer, structure schemas, and
+  field-level values editor land. The `#3582` audit validates all downstream
+  v0.91.5 cards phase-aware and records the disposition in
+  `PROMPT_CARD_REWRITE_AUDIT_3582.md`.
 - Closeout-tail issues `#3575`, `#3579`, `#3576`, `#3580`, `#3577`,
   `#3581`, and `#3578` must remain ordered and must not start before their
   dependency WPs are truthfully complete or blocked.
@@ -36,7 +37,8 @@ Planned readiness surface.
 ## Exit Criteria
 
 - No bridge issue execution starts from generic or stale design-time cards;
-  downstream scaffold-era card rewrites are explicitly routed through `#3582`.
+  downstream card truth is validated or repaired through `#3582` before later
+  Sprint 1 work consumes it.
 - The issue wave can be reviewed without reconstructing sequencing from chat.
 - Sprint and release-tail issue routes are visible from tracked docs and
   GitHub issue state.


### PR DESCRIPTION
Closes #3582

## Summary
Audited the downstream v0.91.5 C-SDLC card bundles after the prompt-template
renderer, structure schemas, and field-level values editor landed. The
phase-aware validation pass covered 63 local v0.91.5 task bundles including the
new follow-on `#3643`, for 315 total cards. All 315 cards passed.

No mass Markdown rewrite was needed: the existing downstream cards validate and
retain truthful lifecycle state. The tracked output is an audit/disposition
report plus minimal milestone-doc routing updates.

## Artifacts
- `docs/milestones/v0.91.5/PROMPT_CARD_REWRITE_AUDIT_3582.md`
- Updated `docs/milestones/v0.91.5/WP_EXECUTION_READINESS_v0.91.5.md`
- Updated `docs/milestones/v0.91.5/SPRINT_v0.91.5.md`
- Updated `docs/milestones/v0.91.5/WBS_v0.91.5.md`
- Follow-on issue `#3643`: prompt-card values import and round-trip normalizer
- Local generated `#3643` issue bundle under `.adl/v0.91.5/tasks/`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified tracked Markdown/doc changes have no whitespace errors.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-schemas`
    Verified prompt-card structure schema artifacts match active templates.
  - `python3 adl/tools/test_prompt_template_structure_schemas.py`
    Verified prompt-card structure schemas load through Python stdlib tooling.
  - phase-aware `adl/tools/validate_structured_prompt.sh` loop over
    `.adl/v0.91.5/tasks/issue-*`
    Verified SIP/STP/SPP/SRP/SOR cards across all 63 local v0.91.5 bundles.
  - phase-aware `adl/tools/validate_structured_prompt.sh` loop over the new
    `#3643` bundle
    Verified the follow-on issue bundle created by this issue.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Records the downstream v0.91.5 prompt-card rewrite audit after renderer/schema/field-editor tooling landed, validates all local card bundles phase-aware, and routes the values import follow-on as #3643.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3582__v0-91-5-sprint-1-cards-rewrite-downstream-issue-cards-after-prompt-templates-v1-1/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3582__v0-91-5-sprint-1-cards-rewrite-downstream-issue-cards-after-prompt-templates-v1-1/sor.md
- Idempotency-Key: v0-91-5-wp-02-cards-audit-downstream-prompt-card-rewrite-readiness-docs-milestones-v0-91-5-prompt-card-rewrite-audit-3582-md-docs-milestones-v0-91-5-wp-execution-readiness-v0-91-5-md-docs-milestones-v0-91-5-sprint-v0-91-5-md-docs-milestones-v0-91-5-wbs-v0-91-5-md-adl-v0-91-5-tasks-issue-3582-v0-91-5-sprint-1-cards-rewrite-downstream-issue-cards-after-prompt-templates-v1-1-sip-md-adl-v0-91-5-tasks-issue-3582-v0-91-5-sprint-1-cards-rewrite-downstream-issue-cards-after-prompt-templates-v1-1-sor-md