### PR TITLE
[v0.91.5][tools] Map prompt-editor child modules to PR-fast lane

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -205,6 +205,10 @@ filter_token_for_path() {
       printf 'cli'
       return 0
       ;;
+    adl/src/csdlc_prompt_editor.rs|adl/src/csdlc_prompt_editor/*.rs)
+      printf 'csdlc_prompt_editor'
+      return 0
+      ;;
     adl/src/cli/identity_cmd/*.rs|adl/src/cli/identity_cmd/tests.rs|adl/src/cli/identity_cmd/tests/*.rs)
       printf 'identity_cmd'
       return 0

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -106,6 +106,13 @@ assert_has "$cli_family_output" "mode=focused"
 assert_has "$cli_family_output" "filter_tokens=cli"
 assert_has "$cli_family_output" "filter_expression=test(cli)"
 
+csdlc_prompt_editor_child="$TMP/csdlc_prompt_editor_child.txt"
+printf 'M\tadl/src/csdlc_prompt_editor/values.rs\n' >"$csdlc_prompt_editor_child"
+csdlc_prompt_editor_child_output="$(bash "$SCRIPT" --changed-files "$csdlc_prompt_editor_child" --print-plan)"
+assert_has "$csdlc_prompt_editor_child_output" "mode=focused"
+assert_has "$csdlc_prompt_editor_child_output" "filter_tokens=csdlc_prompt_editor"
+assert_has "$csdlc_prompt_editor_child_output" "filter_expression=test(csdlc_prompt_editor)"
+
 run_artifacts_runtime="$TMP/run_artifacts_runtime.txt"
 printf 'M\tadl/src/cli/run_artifacts/runtime/trace_validation.rs\n' >"$run_artifacts_runtime"
 run_artifacts_runtime_output="$(bash "$SCRIPT" --changed-files "$run_artifacts_runtime" --print-plan)"


### PR DESCRIPTION
Closes #3646

## Summary
Mapped prompt-template editor child modules under `adl/src/csdlc_prompt_editor/` to the existing `csdlc_prompt_editor` focused PR-fast test lane. Added a regression proving a change to `adl/src/csdlc_prompt_editor/values.rs` selects focused nextest instead of the full default lane.

## Artifacts
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/test_run_pr_fast_test_lane.sh`
- Local output card update at `.adl/v0.91.5/tasks/issue-3646__v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified the full shell contract suite for PR-fast lane selection.
  - `tmp=$(mktemp); printf 'M\tadl/src/csdlc_prompt_editor.rs\nM\tadl/src/csdlc_prompt_editor/values.rs\n' > "$tmp"; bash adl/tools/run_pr_fast_test_lane.sh --changed-files "$tmp" --print-plan; rm -f "$tmp"`
    Verified the exact prompt-editor root-plus-child diff class that caused #3622 to fall back to full nextest now stays focused.
  - `bash -n adl/tools/run_pr_fast_test_lane.sh adl/tools/test_run_pr_fast_test_lane.sh`
    Verified syntax for both changed shell scripts.
  - `git diff --check`
    Verified no whitespace errors in the issue worktree diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
## Summary
- Maps csdlc_prompt_editor child modules to the csdlc_prompt_editor focused PR-fast lane.
- Adds a regression for adl/src/csdlc_prompt_editor/values.rs.
- Proves the representative #3622-style diff now selects focused nextest instead of full nextest.

## Validation
- bash adl/tools/test_run_pr_fast_test_lane.sh
- tmp=$(mktemp); printf 'M\\tadl/src/csdlc_prompt_editor.rs\\nM\\tadl/src/csdlc_prompt_editor/values.rs\\n' > "$tmp"; bash adl/tools/run_pr_fast_test_lane.sh --changed-files "$tmp" --print-plan; rm -f "$tmp"\n- bash -n adl/tools/run_pr_fast_test_lane.sh adl/tools/test_run_pr_fast_test_lane.sh\n- git diff --check

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3646__v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3646__v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane/sor.md
- Idempotency-Key: v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-5-tasks-issue-3646-v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane-sip-md-adl-v0-91-5-tasks-issue-3646-v0-91-5-tools-map-prompt-editor-child-modules-to-pr-fast-lane-sor-md