### PR TITLE
[v0.91.5][WP-02][Sprint 1][tools] Add prompt-card values import and round-trip normalizer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ These rules are mandatory for ADL issue work.
      `adl-csdlc tooling prompt-template edit-values --kind <kind> --values <path> --set <field=value>`,
      then render and validate structure. Do not patch the rendered Markdown
      when a declared values-field edit is sufficient.
+   - When starting from an existing rendered card, test representability first
+     with `adl-csdlc tooling prompt-template import-values --kind <kind> --input <card.md> --out <values.yaml>`,
+     then validate the imported values and re-render before accepting a rewrite.
    - Treat the tracked structure schemas under
      `docs/templates/prompts/<version>/schemas/` as the template-shape
      authority. If a rendered card fails structure validation, fix the values or

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -91,6 +91,7 @@ adl tooling lint-prompt-spec --input <path>\n\
 adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
 adl tooling prompt-template edit-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> --set <field=value> [--set <field=value> ...] [--out <values.yaml>] [--repo-root <path>]\n\
+adl tooling prompt-template import-values --kind <sip|stp|spp|srp|sor> --input <card.md> --out <values.yaml> [--normalized-out <card.md>] [--repo-root <path>]\n\
 adl tooling prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
 adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template validate-schemas [--repo-root <path>]\n\

--- a/adl/src/cli/tooling_cmd/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/prompt_template.rs
@@ -1,7 +1,8 @@
 use adl::csdlc_prompt_editor::{
-    edit_values_file, render_all_cards_from_values_dir, render_card_from_values_file,
-    repo_root_from_arg, validate_rendered_card_structure_file, validate_structure_schema_files,
-    validate_values_file, write_all_sample_values, write_all_structure_schemas, PromptCardKind,
+    edit_values_file, import_values_from_rendered_card_file, render_all_cards_from_values_dir,
+    render_card_from_values_file, repo_root_from_arg, validate_rendered_card_structure_file,
+    validate_structure_schema_files, validate_values_file, write_all_sample_values,
+    write_all_structure_schemas, PromptCardKind,
 };
 use anyhow::{bail, ensure, Result};
 use std::fs;
@@ -11,13 +12,14 @@ use super::tooling_usage;
 
 pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
-        bail!("prompt-template requires a subcommand: render | render-all | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas");
+        bail!("prompt-template requires a subcommand: render | render-all | edit-values | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas");
     };
 
     match subcommand {
         "render" => render_one(&args[1..]),
         "render-all" => render_all(&args[1..]),
         "edit-values" => edit_values(&args[1..]),
+        "import-values" => import_values(&args[1..]),
         "validate-values" => validate_one(&args[1..]),
         "validate-structure" => validate_structure_one(&args[1..]),
         "validate-schemas" => validate_schemas(&args[1..]),
@@ -28,7 +30,7 @@ pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
             Ok(())
         }
         other => bail!(
-            "unknown prompt-template subcommand '{other}' (expected render | render-all | edit-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
+            "unknown prompt-template subcommand '{other}' (expected render | render-all | edit-values | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
         ),
     }
 }
@@ -123,6 +125,81 @@ fn edit_values(args: &[String]) -> Result<()> {
     let values = values.ok_or_else(|| anyhow::anyhow!("edit-values requires --values"))?;
     let target = edit_values_file(&root, kind, &values, &updates, out.as_deref())?;
     println!("PASS: edited {} values at {}", kind.key(), target.display());
+    Ok(())
+}
+
+fn import_values(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+    let mut repo_root: Option<PathBuf> = None;
+    let mut kind: Option<PromptCardKind> = None;
+    let mut input: Option<PathBuf> = None;
+    let mut out: Option<PathBuf> = None;
+    let mut normalized_out: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--kind" => {
+                idx += 1;
+                kind = Some(PromptCardKind::parse_key(value_arg(args, idx, "--kind")?)?);
+            }
+            "--input" => {
+                idx += 1;
+                input = Some(PathBuf::from(value_arg(args, idx, "--input")?));
+            }
+            "--out" => {
+                idx += 1;
+                out = Some(PathBuf::from(value_arg(args, idx, "--out")?));
+            }
+            "--normalized-out" => {
+                idx += 1;
+                normalized_out = Some(PathBuf::from(value_arg(args, idx, "--normalized-out")?));
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => bail!("unknown arg for tooling prompt-template import-values: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = repo_root_from_arg(repo_root)?;
+    let kind = kind.ok_or_else(|| anyhow::anyhow!("import-values requires --kind"))?;
+    let input = input.ok_or_else(|| anyhow::anyhow!("import-values requires --input"))?;
+    let out = out.ok_or_else(|| anyhow::anyhow!("import-values requires --out"))?;
+    let report = import_values_from_rendered_card_file(
+        &root,
+        kind,
+        &input,
+        &out,
+        normalized_out.as_deref(),
+    )?;
+    println!(
+        "PASS: imported {} card values to {} (round_trip={})",
+        kind.key(),
+        report.values_path.display(),
+        report.comparison.as_str()
+    );
+    if !report.unrepresented_required_fields.is_empty() {
+        println!(
+            "NOTE: populated unrepresented required fields: {}",
+            report.unrepresented_required_fields.join(", ")
+        );
+    }
+    if let Some(normalized_path) = report.normalized_path {
+        println!(
+            "PASS: wrote normalized rendered card to {}",
+            normalized_path.display()
+        );
+    }
     Ok(())
 }
 

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -223,6 +223,103 @@ fn prompt_template_cli_edits_declared_values_and_fails_closed() {
 }
 
 #[test]
+fn prompt_template_cli_imports_values_and_round_trips_rendered_card() {
+    let repo = TempRepo::new("prompt-template-import-values");
+    let values_dir = repo.path().join("values");
+    let rendered_dir = repo.path().join("rendered");
+    let imported_values = repo.path().join("imported-stp.values.yaml");
+    let normalized = repo.path().join("normalized-stp.md");
+    let rerendered = repo.path().join("rerendered-stp.md");
+    render_sample_cards_for_structure_test(&values_dir, &rendered_dir);
+    let source = rendered_dir.join("stp.md");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "import-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+        source.to_string_lossy().to_string(),
+        "--out".to_string(),
+        imported_values.to_string_lossy().to_string(),
+        "--normalized-out".to_string(),
+        normalized.to_string_lossy().to_string(),
+    ])
+    .expect("import-values should produce values YAML");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        imported_values.to_string_lossy().to_string(),
+    ])
+    .expect("imported values should validate");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "render".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--values".to_string(),
+        imported_values.to_string_lossy().to_string(),
+        "--out".to_string(),
+        rerendered.to_string_lossy().to_string(),
+    ])
+    .expect("imported values should render");
+
+    let source = fs::read_to_string(source).expect("source card");
+    assert_eq!(
+        fs::read_to_string(normalized).expect("normalized card"),
+        source
+    );
+    assert_eq!(
+        fs::read_to_string(rerendered).expect("rerendered card"),
+        source
+    );
+}
+
+#[test]
+fn prompt_template_cli_import_values_fails_closed_for_structure_drift() {
+    let repo = TempRepo::new("prompt-template-import-values-drift");
+    let values_dir = repo.path().join("values");
+    let rendered_dir = repo.path().join("rendered");
+    render_sample_cards_for_structure_test(&values_dir, &rendered_dir);
+    let source = rendered_dir.join("sip.md");
+    let drifted = repo.write_rel(
+        "drifted-sip.md",
+        &fs::read_to_string(source)
+            .expect("source card")
+            .replace("- Follow `AGENTS.md`.", "- Ignore `AGENTS.md`."),
+    );
+
+    let err = real_tooling(&[
+        "prompt-template".to_string(),
+        "import-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "sip".to_string(),
+        "--input".to_string(),
+        drifted.to_string_lossy().to_string(),
+        "--out".to_string(),
+        repo.path()
+            .join("drifted-sip.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+    ])
+    .expect_err("locked prose drift should fail");
+    assert!(err.to_string().contains("locked template text drifted"));
+}
+
+#[test]
 fn prompt_template_cli_rejects_markdown_structure_drift() {
     let repo = TempRepo::new("prompt-template-structure");
     let values_dir = repo.path().join("values");
@@ -333,6 +430,12 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
         "--help".to_string(),
     ])
     .expect("edit-values help should succeed");
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "import-values".to_string(),
+        "--help".to_string(),
+    ])
+    .expect("import-values help should succeed");
     real_tooling(&[
         "prompt-template".to_string(),
         "validate-structure".to_string(),

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -6,7 +6,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 mod values;
-use values::{load_values_document, load_values_file, sample_values_document};
+use values::{
+    load_values_document, load_values_file, sample_values_document, PromptValuesDocument,
+};
 
 const TEMPLATE_REGISTRY: &str = "docs/templates/prompts/current.json";
 const VALUES_SCHEMA: &str = "adl.csdlc.prompt_template_values.v1";
@@ -306,6 +308,290 @@ pub fn edit_values_file(
     fs::write(&target, doc.to_yaml(card))
         .with_context(|| format!("failed to write edited values file {}", target.display()))?;
     Ok(target)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptCardRoundTripComparison {
+    Exact,
+    Normalized,
+}
+
+impl PromptCardRoundTripComparison {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Normalized => "normalized",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PromptCardImportReport {
+    pub values_path: PathBuf,
+    pub normalized_path: Option<PathBuf>,
+    pub comparison: PromptCardRoundTripComparison,
+    pub unrepresented_required_fields: Vec<String>,
+}
+
+pub fn import_values_from_rendered_card_file(
+    repo_root: &Path,
+    kind: PromptCardKind,
+    input_path: &Path,
+    out_path: &Path,
+    normalized_out_path: Option<&Path>,
+) -> Result<PromptCardImportReport> {
+    let model = load_editor_model(repo_root)?;
+    let card = card_model(&model, kind)?;
+    let source = fs::read_to_string(input_path)
+        .with_context(|| format!("failed to read rendered card {}", input_path.display()))?;
+
+    validate_rendered_card_structure_from_repo(repo_root, card, &source)?;
+    let (doc, unrepresented_required_fields) =
+        import_values_document_from_rendered_card(card, &model.template_set, &source)?;
+    let values = doc.merged_values();
+    validate_values(card, &values)?;
+
+    let rendered = render_template(&card.template, &values)?;
+    validate_rendered_card_structure_from_repo(repo_root, card, &rendered)?;
+
+    let comparison = if rendered == source {
+        PromptCardRoundTripComparison::Exact
+    } else {
+        PromptCardRoundTripComparison::Normalized
+    };
+
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(out_path, doc.to_yaml(card)).with_context(|| {
+        format!(
+            "failed to write imported values file {}",
+            out_path.display()
+        )
+    })?;
+
+    if let Some(normalized_out_path) = normalized_out_path {
+        if let Some(parent) = normalized_out_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        fs::write(normalized_out_path, rendered).with_context(|| {
+            format!(
+                "failed to write normalized rendered card {}",
+                normalized_out_path.display()
+            )
+        })?;
+    }
+
+    Ok(PromptCardImportReport {
+        values_path: out_path.to_path_buf(),
+        normalized_path: normalized_out_path.map(Path::to_path_buf),
+        comparison,
+        unrepresented_required_fields,
+    })
+}
+
+fn import_values_document_from_rendered_card(
+    card: &PromptCardForm,
+    template_set: &str,
+    rendered: &str,
+) -> Result<(PromptValuesDocument, Vec<String>)> {
+    let mut extracted = extract_template_values(card, &card.template, rendered)?;
+    let unrepresented_required_fields =
+        populate_unrepresented_required_import_fields(card, &mut extracted)?;
+    let editable_keys = card
+        .fields
+        .iter()
+        .filter(|field| field.editable)
+        .map(|field| field.key)
+        .collect::<BTreeSet<_>>();
+
+    let mut system = BTreeMap::new();
+    let mut values = BTreeMap::new();
+    for (key, value) in extracted {
+        if editable_keys.contains(key.as_str()) {
+            values.insert(key, value);
+        } else {
+            system.insert(key, value);
+        }
+    }
+
+    Ok((
+        PromptValuesDocument {
+            schema: VALUES_SCHEMA.to_string(),
+            template_set: template_set.to_string(),
+            card_kind: Some(card.key.to_string()),
+            system,
+            values,
+        },
+        unrepresented_required_fields,
+    ))
+}
+
+fn populate_unrepresented_required_import_fields(
+    card: &PromptCardForm,
+    values: &mut BTreeMap<String, String>,
+) -> Result<Vec<String>> {
+    let issue = derive_import_issue(values).unwrap_or_else(|| "1".to_string());
+    let mut unrepresented = Vec::new();
+    for field in &card.fields {
+        if !field.required || values.contains_key(field.key) {
+            continue;
+        }
+        values.insert(
+            field.key.to_string(),
+            unrepresented_import_value(field.key, &issue),
+        );
+        unrepresented.push(field.key.to_string());
+    }
+    Ok(unrepresented)
+}
+
+fn derive_import_issue(values: &BTreeMap<String, String>) -> Option<String> {
+    for key in ["issue", "issue_padded"] {
+        if let Some(value) = values.get(key).map(|value| value.trim()) {
+            if value.parse::<u32>().is_ok() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    for key in ["task_id", "run_id", "issue_url", "source_issue_prompt"] {
+        if let Some(issue) = values
+            .get(key)
+            .and_then(|value| extract_issue_number(value))
+        {
+            return Some(issue);
+        }
+    }
+    None
+}
+
+fn extract_issue_number(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut idx = 0usize;
+    while idx < bytes.len() {
+        if bytes[idx].is_ascii_digit() {
+            let start = idx;
+            while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+                idx += 1;
+            }
+            return Some(value[start..idx].to_string());
+        }
+        idx += 1;
+    }
+    None
+}
+
+fn unrepresented_import_value(key: &str, issue: &str) -> String {
+    match key {
+        "issue" | "issue_padded" => issue.to_string(),
+        "task_id" | "run_id" => format!("issue-{issue}"),
+        "version" => "v0.0.0-imported".to_string(),
+        "slug" => "imported-rendered-prompt-card".to_string(),
+        "title" => "Imported rendered prompt card".to_string(),
+        "branch" => "not bound yet".to_string(),
+        "issue_url" => {
+            format!("https://github.com/danielbaustin/agent-design-language/issues/{issue}")
+        }
+        "source_issue_prompt" => {
+            format!(".adl/imported/issue-{issue}-source-issue-prompt.md")
+        }
+        "card_status" => "draft".to_string(),
+        _ => "UNREPRESENTED_IN_RENDERED_CARD".to_string(),
+    }
+}
+
+fn extract_template_values(
+    card: &PromptCardForm,
+    template: &str,
+    rendered: &str,
+) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    let mut template_pos = 0usize;
+    let mut rendered_pos = 0usize;
+
+    while let Some(token) = next_placeholder_token(template, template_pos) {
+        let literal = &template[template_pos..token.start];
+        ensure!(
+            rendered[rendered_pos..].starts_with(literal),
+            "{} rendered card cannot be represented by active template near byte {}",
+            card.key,
+            rendered_pos
+        );
+        rendered_pos += literal.len();
+
+        let next_template_pos = token.end;
+        let next_literal = next_placeholder_token(template, next_template_pos)
+            .map(|next| &template[next_template_pos..next.start])
+            .unwrap_or(&template[next_template_pos..]);
+        ensure!(
+            !next_literal.is_empty(),
+            "{} template has adjacent placeholders near byte {}; import would be ambiguous",
+            card.key,
+            token.start
+        );
+        let Some(next_literal_offset) = rendered[rendered_pos..].find(next_literal) else {
+            bail!(
+                "{} rendered card cannot find post-placeholder literal for {} near byte {}",
+                card.key,
+                token.key,
+                rendered_pos
+            );
+        };
+        let value = rendered[rendered_pos..rendered_pos + next_literal_offset].to_string();
+        if let Some(existing) = out.get(token.key) {
+            ensure!(
+                existing == &value,
+                "{} repeated placeholder {} resolved to different values",
+                card.key,
+                token.key
+            );
+        } else {
+            out.insert(token.key.to_string(), value);
+        }
+        rendered_pos += next_literal_offset;
+        template_pos = token.end;
+    }
+
+    let tail = &template[template_pos..];
+    ensure!(
+        rendered[rendered_pos..] == *tail,
+        "{} rendered card has trailing content that does not match active template",
+        card.key
+    );
+    Ok(out)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PlaceholderToken<'a> {
+    key: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn next_placeholder_token(text: &str, from: usize) -> Option<PlaceholderToken<'_>> {
+    let haystack = &text[from..];
+    PLACEHOLDERS
+        .iter()
+        .flat_map(|key| {
+            let legacy = format!("<{key}>");
+            let curly = format!("{{{{{key}}}}}");
+            [
+                haystack.find(&legacy).map(|offset| PlaceholderToken {
+                    key,
+                    start: from + offset,
+                    end: from + offset + legacy.len(),
+                }),
+                haystack.find(&curly).map(|offset| PlaceholderToken {
+                    key,
+                    start: from + offset,
+                    end: from + offset + curly.len(),
+                }),
+            ]
+        })
+        .flatten()
+        .min_by_key(|token| token.start)
 }
 
 pub fn validate_rendered_card_structure_file(
@@ -1865,6 +2151,85 @@ mod tests {
                 assert!(text.contains("# Structured Review Prompt"));
                 assert!(!text.contains("# Structured Review Policy"));
             }
+        }
+    }
+
+    #[test]
+    fn import_values_from_rendered_cards_round_trips_all_card_kinds() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-prompt-values-import-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).expect("tmp");
+
+        for kind in PromptCardKind::all() {
+            let rendered = render_sample_card(&repo_root(), kind).expect("sample render");
+            let input = tmp.join(format!("{}.md", kind.key()));
+            let values = tmp.join(format!("{}.imported.values.yaml", kind.key()));
+            let normalized = tmp.join(format!("{}.normalized.md", kind.key()));
+            fs::write(&input, &rendered).expect("rendered card");
+
+            let report = import_values_from_rendered_card_file(
+                &repo_root(),
+                kind,
+                &input,
+                &values,
+                Some(&normalized),
+            )
+            .expect("rendered card should import");
+            assert_eq!(report.comparison, PromptCardRoundTripComparison::Exact);
+
+            validate_values_file(&repo_root(), kind, &values).expect("imported values valid");
+            let rerendered = render_card_from_values_file(&repo_root(), kind, &values)
+                .expect("imported values render");
+            assert_eq!(
+                rerendered,
+                rendered,
+                "{} should round-trip exactly",
+                kind.key()
+            );
+            assert_eq!(
+                fs::read_to_string(&normalized).expect("normalized card"),
+                rendered
+            );
+        }
+    }
+
+    #[test]
+    fn import_values_fails_closed_for_locked_template_drift_on_all_card_kinds() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-prompt-values-import-drift-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).expect("tmp");
+
+        for kind in PromptCardKind::all() {
+            let rendered = render_sample_card(&repo_root(), kind).expect("sample render");
+            let drifted = rendered.replace(
+                "Canonical Template Source:",
+                "Canonical Template Source Drift:",
+            );
+            let input = tmp.join(format!("{}.drift.md", kind.key()));
+            let values = tmp.join(format!("{}.drift.values.yaml", kind.key()));
+            fs::write(&input, drifted).expect("drifted card");
+
+            let err =
+                import_values_from_rendered_card_file(&repo_root(), kind, &input, &values, None)
+                    .expect_err("locked template drift should fail");
+            assert!(
+                err.to_string().contains("locked template text drifted")
+                    || err
+                        .to_string()
+                        .contains("cannot be represented by active template"),
+                "{} should fail closed for locked prose drift: {err}",
+                kind.key()
+            );
         }
     }
 

--- a/docs/tooling/PROMPT_CARD_VALUES_IMPORT_ROUND_TRIP_v0.91.5.md
+++ b/docs/tooling/PROMPT_CARD_VALUES_IMPORT_ROUND_TRIP_v0.91.5.md
@@ -1,0 +1,68 @@
+# Prompt Card Values Import And Round-Trip Normalization
+
+Status: v0.91.5 Sprint 1 tooling contract
+
+Issue: #3643
+
+## Purpose
+
+Prompt cards should move toward values-driven generation without treating rendered Markdown as the editable source of truth. The import path exists for one bounded job:
+
+```text
+existing rendered card -> values YAML candidate -> render -> structure validation -> round-trip comparison
+```
+
+It lets an agent test whether a current `sip.md`, `stp.md`, `spp.md`, `srp.md`, or `sor.md` can be represented by the active prompt-template values model.
+
+## Command
+
+```sh
+adl-csdlc tooling prompt-template import-values \
+  --kind <sip|stp|spp|srp|sor> \
+  --input <card.md> \
+  --out <values.yaml> \
+  [--normalized-out <card.md>] \
+  [--repo-root <path>]
+```
+
+The command:
+
+- validates the source card against the tracked structure schema for the active template;
+- extracts values from active template placeholders only;
+- populates any required fields that are not represented in the rendered template with deterministic import scaffolding and reports those fields on stdout;
+- writes locked fields under `system` and editable fields under `values`;
+- validates the imported values with `validate-values`;
+- re-renders through the active template registry;
+- validates the rendered structure; and
+- reports whether the round trip is `exact` or `normalized`.
+
+## Workflow Guidance
+
+Use `import-values` when starting from an existing rendered card and you need to know whether it can be migrated to values YAML safely.
+
+Use `edit-values` when a values YAML file already exists and the change is a declared editable field update.
+
+Use SIP/STP/SPP/SRP/SOR editor skills when lifecycle truth needs human or agent judgment. The importer proves template representability; it does not decide whether issue truth is correct.
+
+Some required fields are values-schema metadata rather than rendered card text for every card kind. When the importer cannot recover those fields from Markdown, it writes deterministic scaffolding values only so the candidate file remains schema-valid and round-trip testable. Treat any stdout `NOTE: populated unrepresented required fields` line as a review marker before reusing the values file as lifecycle truth.
+
+## Fail-Closed Rules
+
+The importer must fail rather than infer when:
+
+- locked template prose has changed;
+- headings, fenced blocks, or frontmatter structure drift from the active schema;
+- the card cannot be matched against the active template literals;
+- repeated placeholders resolve to inconsistent values; or
+- imported values fail the values schema or enum checks.
+
+Unsupported historical cards should be routed to an editor skill or a dedicated migration issue, not silently coerced.
+
+## Validation
+
+Focused proof for this contract should include:
+
+- helper tests for all five card kinds;
+- CLI tests for import, values validation, render, and fail-closed drift;
+- `validate-schemas` when tracked prompt-template schemas change; and
+- `git diff --check`.


### PR DESCRIPTION
Closes #3643

## Summary
Implemented a deterministic `prompt-template import-values` path that imports existing rendered SIP/STP/SPP/SRP/SOR cards into values YAML candidates, validates the source and rendered structures against tracked schemas, re-renders through the active template registry, and reports exact versus normalized round-trip status. The importer fails closed on locked template/structure drift and visibly reports required fields that are schema-required but not represented in a rendered card.

## Artifacts
- `adl/src/csdlc_prompt_editor.rs`: added rendered-card value import, exact/normalized round-trip reporting, invisible-required-field scaffolding, and focused all-card helper tests.
- `adl/src/cli/tooling_cmd.rs`: added `import-values` to prompt-template usage.
- `adl/src/cli/tooling_cmd/prompt_template.rs`: added CLI dispatch, argument parsing, output reporting, and visible unrepresented-field notes.
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`: added CLI import/round-trip and fail-closed drift tests.
- `docs/tooling/PROMPT_CARD_VALUES_IMPORT_ROUND_TRIP_v0.91.5.md`: documented the importer contract, command, workflow guidance, fail-closed rules, and validation expectations.
- `AGENTS.md`: added guidance to test existing rendered cards with `import-values` before accepting values-driven rewrites.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified formatting for the touched Rust sources.
  - `cargo test --manifest-path adl/Cargo.toml csdlc_prompt_editor::tests -- --nocapture`
    Verified library-level importer behavior, all-card round trips, and fail-closed locked-template drift.
  - `cargo test --manifest-path adl/Cargo.toml cli::tooling_cmd::tests::prompt_template -- --nocapture`
    Verified the prompt-template CLI contract, including `import-values`.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-schemas`
    Verified schema parity with active templates.
  - `python3 adl/tools/test_prompt_template_structure_schemas.py`
    Verified schema portability to Python-readable tooling.
  - `git diff --check`
    Verified whitespace hygiene.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- prompt` from `adl/`
    Generated focused coverage evidence for changed Rust source files.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified local coverage-impact preflight.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Implements prompt-template import-values for rendered prompt cards, with values YAML import, structure/schema validation, exact round-trip checks, visible unrepresented-field notes, docs, AGENTS guidance, focused tests, and coverage-impact evidence.\n\nCloses #3643.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3643__v0-91-5-tools-add-prompt-card-values-import-round-trip-normalizer/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3643__v0-91-5-tools-add-prompt-card-values-import-round-trip-normalizer/sor.md
- Idempotency-Key: v0-91-5-wp-02-sprint-1-tools-add-prompt-card-values-import-and-round-trip-normalizer-agents-md-adl-src-csdlc-prompt-editor-rs-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-prompt-template-rs-adl-src-cli-tooling-cmd-tests-prompt-template-rs-docs-tooling-prompt-card-values-import-round-trip-v0-91-5-md-adl-v0-91-5-tasks-issue-3643-v0-91-5-tools-add-prompt-card-values-import-round-trip-normalizer-sip-md-adl-v0-91-5-tasks-issue-3643-v0-91-5-tools-add-prompt-card-values-import-round-trip-normalizer-sor-md