### PR TITLE
[v0.91.5][portable-adl] Define portable ADL project contract and templates

### DIFF
--- a/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
+++ b/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
@@ -16,7 +16,7 @@ checks needed for truthful v0.91.5 closeout.
 
 - [x] v0.91.5 planning package exists.
 - [ ] WP-01 confirms planned issues, cards, sprint umbrellas, and initial sequencing are ready.
-- [x] Canonical milestone WP ordering standard is scheduled through `#3567`.
+- [x] Canonical milestone WP ordering standard is closed through `#3567`.
 - [x] Portable ADL project adapter planning is scheduled through `#3569`.
 - [x] Sprint umbrella issues `#3571` through `#3574` are seeded.
 - [x] Closeout-tail issues `#3575`, `#3579`, `#3576`, `#3580`,

--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -31,9 +31,8 @@ Setup truth:
   package, issue reallocation, v0.91.4 release-tail reconciliation, v0.92
   dependency reconciliation, and migration-truth review.
 - `#3568` is the closed WP-01 opening follow-up after v0.91.4 release.
-- `#3567` is scheduled to canonicalize the milestone WP ordering standard.
-- `#3569` is scheduled to define portable ADL project adapter contract and
-  templates.
+- `#3567` closed the reusable milestone WP ordering standard.
+- `#3569` defines the portable ADL project adapter contract and templates.
 - `#3582` is scheduled to rewrite/normalize downstream v0.91.5 card bundles
   after prompt templates v1.1 lands through `#3553`.
 - `#3571`-`#3574` are the seeded sprint umbrella issues.
@@ -160,9 +159,9 @@ Execution expectations:
 - WP-01 is the milestone planning/setup/issue-wave readiness gate. It closes
   only after planned issues, cards, sprint umbrellas, and initial sequencing are
   ready to begin or explicitly routed.
-- The canonical milestone structure is being captured by `#3567`.
-- Portable ADL adapter planning is scheduled through `#3569`; implementation
-  belongs in later issue execution, not WP-01 itself.
+- The canonical milestone structure is captured by closed issue `#3567`.
+- Portable ADL adapter planning and templates are routed through `#3569`;
+  external repository migrations live outside WP-01.
 - Public prompt, provider/model, multi-agent, demo, and activation work occupy
   the middle of the sequence.
 - Demo/proof, quality, docs/review convergence, v0.92 preflight, and release

--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -71,12 +71,12 @@ Make v0.92 openable without hidden operational debt.
 | Order | Item | Issue | Owner | Status |
 |---|---|---|---|---|
 | 1 | WP-01 milestone opening | `#3568`, consuming closed setup `#3506`-`#3511` | ADL maintainers | closed |
-| 2 | Canonical WP ordering standard | `#3567` | ADL maintainers | scheduled |
+| 2 | Canonical WP ordering standard | `#3567` | ADL maintainers | closed |
 | 3 | Sprint 1 umbrella: prompt/public records and portable ADL readiness | `#3571` | ADL maintainers | seeded |
 | 4 | Prompt-template values renderer | `#3553` | ADL maintainers | in progress |
 | 5 | Downstream card rewrite after prompt templates v1.1 | `#3582` | ADL maintainers | scheduled after `#3553` |
 | 6 | Public prompt records | `#3472`-`#3476` | ADL maintainers | moved |
-| 7 | Portable ADL adapter contract | `#3569` | ADL maintainers | scheduled |
+| 7 | Portable ADL adapter contract | `#3569` | ADL maintainers | in progress |
 | 8 | Sprint 2 umbrella: provider matrix and multi-agent proof | `#3572` | ADL maintainers | seeded |
 | 9 | Provider/model matrix | `#3501`, `#3505` | ADL maintainers | moved |
 | 10 | Multi-agent proof | `#3415`, `#3503`, `#3504` (`#3484` satisfied/closed evidence) | ADL maintainers | moved |

--- a/docs/milestones/v0.91.5/WBS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WBS_v0.91.5.md
@@ -73,9 +73,10 @@ to the reusable standard at
   coverage-quality gate, docs-review alignment, internal review, external /
   third-party review, review-findings remediation plus final preflight when
   applicable, next-milestone planning, and release ceremony.
-- `#3567` owns the reusable template/standard for this milestone structure.
+- Closed issue `#3567` owns the reusable template/standard for this milestone
+  structure.
 - `#3569` owns the portable ADL project adapter contract and templates; WP-01
-  schedules it, but adapter implementation does not become WP-01 work.
+  schedules it, but external repository migration does not become WP-01 work.
 - `#3582` owns the downstream card rewrite/normalization pass after prompt
   templates, structure schemas, and field-level values editing land. Its audit
   records phase-aware validation and avoids polishing every downstream card

--- a/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
+++ b/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
@@ -13,7 +13,7 @@ notes:
   - v0.91.5 is the bridge milestone between v0.91.4 C-SDLC hardening and v0.92 first birthday.
   - v0.91.5 opened after the v0.91.4 release ceremony, tag, and GitHub Release publication.
   - WP-01 is the planning and setup gate; it seeds/schedules issues, cards, sprint umbrellas, and ordering before execution sprints begin.
-  - Canonical milestone WP ordering is scheduled through #3567; portable ADL project adapter planning is scheduled through #3569.
+  - Canonical milestone WP ordering was closed through #3567; portable ADL project adapter planning and templates are routed through #3569.
   - Downstream v0.91.5 card rewrite/normalization waits for prompt templates v1.1 and is tracked through #3582 instead of blocking WP-01.
   - Sprint umbrella issues are seeded as #3571 through #3574; closeout-tail issues are seeded as #3575, #3579, #3576, #3580, #3577, #3581, and #3578.
   - Multi-agent C-SDLC execution must work by milestone closeout or be truthfully blocked before v0.92 depends on it.
@@ -80,7 +80,7 @@ work_packages:
     queue: docs
     depends_on: [v0.91.4 release closeout complete]
     primary_deliverable: active v0.91.5 planning package, issue/card/sprint readiness, canonical WP ordering scheduling, and portable ADL adapter planning route
-    proof_surface: planning docs, issue labels, setup child issues #3507-#3511, scheduled issues #3567/#3553/#3582/#3569, sprint umbrellas #3571-#3574, closeout-tail issues #3575/#3579/#3576/#3580/#3577/#3581/#3578, and focused docs validation
+    proof_surface: planning docs, issue labels, setup child issues #3507-#3511, closed #3567, scheduled issues #3553/#3582/#3569, sprint umbrellas #3571-#3574, closeout-tail issues #3575/#3579/#3576/#3580/#3577/#3581/#3578, and focused docs validation
   - wp: WP-02
     issue: 3553
     title: Deterministic prompt-template values renderer

--- a/docs/templates/portable-adl/1.0.0/AGENTS.md
+++ b/docs/templates/portable-adl/1.0.0/AGENTS.md
@@ -1,0 +1,40 @@
+# <project_name> Agent Guidelines
+
+This repository follows ADL C-SDLC workflow discipline.
+
+Before doing tracked issue work, read `adl_project.json` at the repository root.
+That file declares the project profile, ADL tooling discovery rules, issue
+authority, card/worktree policy, validation profile, and artifact boundaries.
+
+## Required Workflow
+
+- Do not do tracked issue work on `main`.
+- Do not hand-roll lifecycle cards.
+- Use the resolved ADL checkout from `adl_project.json`.
+- Route issue execution through ADL conductor-style workflow.
+- Preserve the canonical lifecycle: `SIP -> STP -> SPP -> SRP -> SOR`.
+- Keep public artifacts free of host-local absolute paths, credentials, private
+  notes, and scratch state.
+- Record what validation did and did not run.
+
+## Tooling Discovery
+
+Resolve ADL tooling in this order:
+
+1. `ADL_HOME`, if set.
+2. The repo-relative path declared in `adl_project.json`, if present.
+3. The sibling checkout declared in `adl_project.json`, if present.
+4. Fail closed with setup instructions.
+
+Do not search the whole filesystem or use vendored ADL tooling.
+
+## Project-Specific Notes
+
+- Project profile: `<profile>`
+- Issue authority: `<issue_authority>`
+- Card location: `<cards_location>`
+- Worktree location: `<worktree_location>`
+- Validation profile: `<validation_profile>`
+
+Use repo-specific validation commands only when they are declared in
+`adl_project.json` or in a tracked issue card.

--- a/docs/templates/portable-adl/1.0.0/adl_project.json
+++ b/docs/templates/portable-adl/1.0.0/adl_project.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "adl.project.v1",
+  "project_id": "<project_id>",
+  "profile": "<paper|spec|demo|runtime|library>",
+  "tooling_ref": "agent-design-language@v0.91.5",
+  "min_adl_version": "0.91.5",
+  "prompt_template_registry": "docs/templates/prompts/current.json",
+  "issue_tracker": {
+    "provider": "github",
+    "repo": "<owner>/<repo>"
+  },
+  "tooling_discovery": {
+    "env": "ADL_HOME",
+    "repo_relative": null,
+    "sibling_repo": "../agent-design-language",
+    "failure_mode": "fail_with_setup_instructions"
+  },
+  "state_policy": {
+    "issue_authority": "external_repo",
+    "cards_location": "repo_local_ignored_adl",
+    "worktree_location": "external_repo_worktrees",
+    "tracked_public_evidence": true,
+    "local_adl_state_ignored": true
+  },
+  "validation_profile": "<paper|spec|demo|runtime|library>",
+  "artifact_policy": {
+    "forbid_absolute_host_paths": true,
+    "public_outputs": [],
+    "private_outputs": []
+  }
+}

--- a/docs/templates/portable-adl/1.0.0/examples/cognitive-sdlc-paper.adl_project.json
+++ b/docs/templates/portable-adl/1.0.0/examples/cognitive-sdlc-paper.adl_project.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "adl.project.v1",
+  "project_id": "cognitive-sdlc-paper",
+  "profile": "paper",
+  "tooling_ref": "agent-design-language@v0.91.5",
+  "min_adl_version": "0.91.5",
+  "prompt_template_registry": "docs/templates/prompts/current.json",
+  "issue_tracker": {
+    "provider": "github",
+    "repo": "danielbaustin/cognitive-sdlc-paper"
+  },
+  "tooling_discovery": {
+    "env": "ADL_HOME",
+    "repo_relative": null,
+    "sibling_repo": "../agent-design-language",
+    "failure_mode": "fail_with_setup_instructions"
+  },
+  "state_policy": {
+    "issue_authority": "external_repo",
+    "cards_location": "repo_local_ignored_adl",
+    "worktree_location": "external_repo_worktrees",
+    "tracked_public_evidence": true,
+    "local_adl_state_ignored": true
+  },
+  "validation_profile": "paper",
+  "artifact_policy": {
+    "forbid_absolute_host_paths": true,
+    "public_outputs": [
+      "review_packet",
+      "approved_pdf"
+    ],
+    "private_outputs": [
+      "draft_notes",
+      "local_build",
+      "reviewer_scratch"
+    ]
+  }
+}

--- a/docs/templates/portable-adl/1.0.0/examples/general-intelligence-paper.adl_project.json
+++ b/docs/templates/portable-adl/1.0.0/examples/general-intelligence-paper.adl_project.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "adl.project.v1",
+  "project_id": "general-intelligence-paper",
+  "profile": "paper",
+  "tooling_ref": "agent-design-language@v0.91.5",
+  "min_adl_version": "0.91.5",
+  "prompt_template_registry": "docs/templates/prompts/current.json",
+  "issue_tracker": {
+    "provider": "github",
+    "repo": "danielbaustin/general-intelligence-paper"
+  },
+  "tooling_discovery": {
+    "env": "ADL_HOME",
+    "repo_relative": null,
+    "sibling_repo": "../agent-design-language",
+    "failure_mode": "fail_with_setup_instructions"
+  },
+  "state_policy": {
+    "issue_authority": "external_repo",
+    "cards_location": "repo_local_ignored_adl",
+    "worktree_location": "external_repo_worktrees",
+    "tracked_public_evidence": true,
+    "local_adl_state_ignored": true
+  },
+  "validation_profile": "paper",
+  "artifact_policy": {
+    "forbid_absolute_host_paths": true,
+    "public_outputs": [
+      "review_packet",
+      "approved_pdf"
+    ],
+    "private_outputs": [
+      "draft_notes",
+      "local_build",
+      "reviewer_scratch"
+    ]
+  }
+}

--- a/docs/templates/portable-adl/1.0.0/examples/universal-tool-schema.adl_project.json
+++ b/docs/templates/portable-adl/1.0.0/examples/universal-tool-schema.adl_project.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "adl.project.v1",
+  "project_id": "universal-tool-schema",
+  "profile": "spec",
+  "tooling_ref": "agent-design-language@v0.91.5",
+  "min_adl_version": "0.91.5",
+  "prompt_template_registry": "docs/templates/prompts/current.json",
+  "issue_tracker": {
+    "provider": "github",
+    "repo": "danielbaustin/universal-tool-schema"
+  },
+  "tooling_discovery": {
+    "env": "ADL_HOME",
+    "repo_relative": null,
+    "sibling_repo": "../agent-design-language",
+    "failure_mode": "fail_with_setup_instructions"
+  },
+  "state_policy": {
+    "issue_authority": "external_repo",
+    "cards_location": "repo_local_ignored_adl",
+    "worktree_location": "external_repo_worktrees",
+    "tracked_public_evidence": true,
+    "local_adl_state_ignored": true
+  },
+  "validation_profile": "spec",
+  "artifact_policy": {
+    "forbid_absolute_host_paths": true,
+    "public_outputs": [
+      "spec_docs",
+      "examples",
+      "conformance_notes"
+    ],
+    "private_outputs": [
+      "scratch_runs",
+      "credentials",
+      "non_public_reviewer_notes"
+    ]
+  }
+}

--- a/docs/templates/portable-adl/README.md
+++ b/docs/templates/portable-adl/README.md
@@ -1,0 +1,34 @@
+# Portable ADL Project Templates
+
+This directory contains reusable templates for ADL-governed external
+repositories.
+
+The initial template set is:
+
+- version: `1.0.0`
+- contract issue: `#3569`
+- contract doc:
+  `docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_CONTRACT_v0.91.5.md`
+
+## Templates
+
+| Template | Purpose |
+|---|---|
+| `1.0.0/AGENTS.md` | Compact repo-local operating instructions for an external ADL-governed repo. |
+| `1.0.0/adl_project.json` | Machine-readable project adapter contract. |
+
+## Examples
+
+Example `adl_project.json` files live under `1.0.0/examples/`.
+
+They are examples only. Do not copy one into a real repository without checking
+issue authority, repository name, validation profile, artifact policy, and ADL
+tooling compatibility.
+
+## Portability Rules
+
+- Template paths must stay repo-relative.
+- Templates must not embed operator-local absolute paths.
+- External repositories must resolve ADL tooling through `ADL_HOME`, an explicit
+  repo-relative path, or a declared sibling checkout.
+- The canonical card lifecycle remains `SIP -> STP -> SPP -> SRP -> SOR`.

--- a/docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_CONTRACT_v0.91.5.md
+++ b/docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_CONTRACT_v0.91.5.md
@@ -1,0 +1,267 @@
+# Portable ADL Project Adapter Contract
+
+Status: v0.91.5 Sprint 1 contract
+
+Issue: #3569
+
+## Purpose
+
+The portable ADL project adapter makes external repositories self-describing for
+C-SDLC work. An agent starting inside a paper repo, UTS repo, demo repo, runtime
+repo, or library repo should be able to determine the applicable ADL workflow,
+tooling checkout, issue authority, card policy, worktree policy, validation
+profile, and artifact boundaries without relying on session memory.
+
+This contract does not migrate any external repository. It defines the tracked
+public surface those repositories should carry when migration is approved.
+
+## Required Repo Surface
+
+An ADL-governed external repository should carry two tracked files at its root:
+
+- `AGENTS.md`
+- `adl_project.json`
+
+`AGENTS.md` is the human and agent instruction surface. It points readers to
+`adl_project.json`, states that ADL workflow discipline applies, and preserves
+the core prohibitions: no tracked issue work on `main`, no hand-rolled cards,
+and no hidden local state in public artifacts.
+
+`adl_project.json` is the machine-readable adapter contract. It records project
+identity, ADL tooling discovery, version compatibility, issue/card/worktree
+ownership, validation profile, and artifact policy.
+
+## Centralized Tooling Rule
+
+External repositories must not vendor or fork the ADL workflow toolchain.
+
+They should reference a canonical ADL checkout for:
+
+- `adl/tools/pr.sh`
+- `adl-csdlc` prompt-card and workflow tooling
+- prompt-template registries under `docs/templates/prompts/`
+- editor skills and lifecycle expectations
+- review, validation, and closeout helpers
+
+Thin repo-local wrappers are allowed only when documented in
+`adl_project.json`. A wrapper must delegate to the resolved ADL checkout and must
+not redefine lifecycle semantics.
+
+## Deterministic Tooling Discovery
+
+Portable repos resolve ADL tooling in this order:
+
+1. `ADL_HOME`, if set.
+2. `tooling_discovery.repo_relative`, if configured.
+3. `tooling_discovery.sibling_repo`, if configured.
+4. Fail closed with setup instructions.
+
+The resolver must not search the whole filesystem, guess silently, or fall back
+to stale vendored tooling.
+
+## Valid ADL Checkout
+
+A resolved ADL checkout is valid only if all required checks pass:
+
+- path exists;
+- `adl/tools/pr.sh` exists and is executable;
+- `docs/templates/prompts/current.json` exists;
+- the checkout satisfies `min_adl_version`;
+- the checkout matches `tooling_ref`, or emits an explicit compatibility
+  warning before continuing;
+- required templates, skills, and lifecycle helpers for the configured profile
+  are present.
+
+If a required check fails, the future project doctor must fail closed before
+issue work starts.
+
+## Required `adl_project.json` Fields
+
+| Field | Required | Description |
+|---|---:|---|
+| `schema_version` | yes | Adapter schema version. Initial value: `adl.project.v1`. |
+| `project_id` | yes | Stable lowercase project identifier. |
+| `profile` | yes | One of `paper`, `spec`, `demo`, `runtime`, or `library`. |
+| `tooling_ref` | yes | Expected ADL toolchain identity, such as `agent-design-language@v0.91.5`. |
+| `min_adl_version` | yes | Minimum compatible ADL version. |
+| `prompt_template_registry` | yes | Registry path relative to the ADL checkout. |
+| `issue_tracker` | yes | Issue provider and repository authority. |
+| `tooling_discovery` | yes | Deterministic ADL checkout resolver settings. |
+| `state_policy` | yes | Issue, card, worktree, local state, and public evidence policy. |
+| `validation_profile` | yes | Validation lane profile. Usually matches `profile`. |
+| `artifact_policy` | yes | Public/private artifact rules and leakage controls. |
+
+Optional future field:
+
+- `prompt_template_version_lock`: pins prompt cards to a specific template set
+  during compatibility migrations.
+
+## Allowed Enum Values
+
+Allowed `profile` and `validation_profile` values:
+
+- `paper`
+- `spec`
+- `demo`
+- `runtime`
+- `library`
+
+Allowed `state_policy.issue_authority` values:
+
+- `external_repo`: issues and PRs live in the external project repo.
+- `adl_repo`: issues and PRs live in the ADL repo.
+- `split_explicit`: authority is split and must be declared per issue family.
+
+Allowed `state_policy.cards_location` values:
+
+- `repo_local_ignored_adl`: lifecycle cards live under an ignored repo-local
+  `.adl/` tree.
+- `tracked_public_adl_subset`: only declared public review/evidence cards may
+  be tracked.
+- `external_adl_state_root`: lifecycle state lives in a declared non-default
+  state root.
+
+Allowed `state_policy.worktree_location` values:
+
+- `external_repo_worktrees`: worktrees are managed in the external repo.
+- `adl_managed_worktrees`: worktrees are managed by ADL tooling in a declared
+  location.
+- `disabled`: no worktrees are used for this project type.
+
+Allowed `tooling_discovery.failure_mode` value:
+
+- `fail_with_setup_instructions`
+
+## State Ownership Defaults
+
+The default external-repo policy is:
+
+- GitHub issues live in the external repository.
+- Pull requests live in the external repository.
+- Worktrees live under the external repository's normal worktree area.
+- Repo-local `.adl/` lifecycle cards are ignored unless a repo explicitly
+  chooses a tracked public subset.
+- Public review/evidence packets are tracked only when they are intended review
+  surfaces.
+- Private notes, build outputs, credentials, temp files, and scratch state stay
+  ignored.
+
+This prevents agents from accidentally creating issue truth in ADL when the
+work belongs to UTS, a paper repo, or a demo repo.
+
+## Project Profiles
+
+Profiles guide validation and artifact policy without changing the canonical
+`SIP -> STP -> SPP -> SRP -> SOR` lifecycle.
+
+### `paper`
+
+Default validation lanes:
+
+- citation key scan;
+- duplicate bibliography key scan;
+- LaTeX build when local dependencies are available;
+- PDF freshness check;
+- forbidden-claim scan.
+
+Public artifacts:
+
+- review packet;
+- final or private-review PDF when explicitly intended;
+- source package only when publication is approved.
+
+Private artifacts:
+
+- local build directories;
+- draft notes;
+- reviewer scratch comments.
+
+### `spec`
+
+Default validation lanes:
+
+- schema parse checks;
+- example parse checks;
+- conformance example checks;
+- docs link checks where available;
+- evidence packet path hygiene.
+
+### `demo`
+
+Default validation lanes:
+
+- demo build or smoke check;
+- screenshot or transcript freshness check when relevant;
+- operator runbook validation;
+- public artifact path hygiene.
+
+### `runtime`
+
+Default validation lanes:
+
+- focused unit/integration tests for touched runtime surfaces;
+- provider credential boundary checks;
+- benchmark evidence hygiene;
+- PVF lane classification when tests are added.
+
+### `library`
+
+Default validation lanes:
+
+- package tests;
+- API docs;
+- examples;
+- release notes or changelog checks.
+
+## External Repo `AGENTS.md` Template
+
+The reusable template lives at:
+
+```text
+docs/templates/portable-adl/1.0.0/AGENTS.md
+```
+
+It intentionally stays compact. External repos should fill the declared values
+and avoid copying the full ADL root `AGENTS.md`.
+
+## External Repo `adl_project.json` Template
+
+The reusable template lives at:
+
+```text
+docs/templates/portable-adl/1.0.0/adl_project.json
+```
+
+Example configs live under:
+
+```text
+docs/templates/portable-adl/1.0.0/examples/
+```
+
+## Fail-Closed Rules
+
+Portable ADL startup must fail before issue work if:
+
+- no valid ADL checkout can be resolved;
+- the configured ADL checkout is older than `min_adl_version`;
+- the prompt-template registry is missing;
+- issue/card/worktree authority is ambiguous;
+- `adl_project.json` contains unsupported enum values;
+- public artifacts would include host-local absolute paths;
+- private `.adl` state, credentials, build output, or scratch state are marked
+  for public tracking without explicit policy.
+
+## Non-Claims
+
+This contract does not claim:
+
+- external repos are migrated;
+- the read-only project doctor is implemented;
+- all profile-specific validations exist;
+- local paper/demo/UTS repos are ready for public review;
+- ADL tooling can run without a valid canonical ADL checkout.
+
+## Follow-On Routing
+
+Tracked follow-on candidates are recorded in
+`docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_FOLLOW_ONS_v0.91.5.md`.

--- a/docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_FOLLOW_ONS_v0.91.5.md
+++ b/docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_FOLLOW_ONS_v0.91.5.md
@@ -1,0 +1,38 @@
+# Portable ADL Project Adapter Follow-Ons
+
+Status: v0.91.5 Sprint 1 follow-on register
+
+Issue: #3569
+
+## Purpose
+
+This register keeps the portable ADL adapter work from disappearing after the
+contract issue lands. It records the follow-on issues that should be opened or
+scheduled before external repositories depend on this adapter.
+
+## Follow-On Issue Candidates
+
+| Order | Candidate Title | Purpose | Suggested Timing |
+|---:|---|---|---|
+| 1 | `[v0.91.5][portable-adl] Implement read-only portable project doctor` | Add `adl-csdlc project doctor` with deterministic config/tooling validation. | v0.91.5 after contract review |
+| 2 | `[v0.91.5][portable-adl] Pilot adapter in cognitive-sdlc-paper` | Add repo-local `AGENTS.md` and `adl_project.json`; prove paper profile startup. | after doctor or with explicit manual review |
+| 3 | `[v0.91.5][portable-adl] Pilot adapter in general-intelligence-paper` | Add repo-local adapter files and paper-profile validation notes. | after first paper pilot |
+| 4 | `[v0.91.5][portable-adl] Pilot adapter in universal-tool-schema` | Prove runtime/spec profile boundaries without making UTS depend on ADL at runtime. | after doctor and paper pilots |
+| 5 | `[v0.91.5][portable-adl] Add portable adapter docs to C-SDLC skills` | Update workflow-conductor, pr lifecycle, and editor skill guidance to discover external project contracts. | after first pilot evidence |
+| 6 | `[v0.91.5][portable-adl] Add CI smoke fixture for adapter templates` | Validate template JSON examples and fail on host-local absolute paths. | after template review |
+
+## Dependency Notes
+
+- The doctor should remain read-only.
+- Repo pilots should not copy the full ADL toolchain.
+- Public `AGENTS.md` surfaces should stay compact and point to
+  `adl_project.json`.
+- UTS must remain independent at runtime; ADL workflow guidance must not become
+  a runtime dependency.
+- Skill updates should wait until the adapter contract survives at least one
+  pilot or explicit review.
+
+## Non-Goals
+
+This register does not create the issues by itself and does not migrate any
+external repository.

--- a/docs/tooling/PORTABLE_ADL_PROJECT_DOCTOR_PLAN_v0.91.5.md
+++ b/docs/tooling/PORTABLE_ADL_PROJECT_DOCTOR_PLAN_v0.91.5.md
@@ -1,0 +1,121 @@
+# Portable ADL Project Doctor Plan
+
+Status: v0.91.5 Sprint 1 planning surface
+
+Issue: #3569
+
+## Purpose
+
+The portable project doctor is a future read-only command that checks whether
+the current repository is ready to run ADL-governed C-SDLC work. It should make
+startup failures visible, deterministic, and fast.
+
+This issue defines the doctor contract only. It does not implement the doctor.
+
+## Proposed Command Shape
+
+Preferred future command:
+
+```sh
+adl-csdlc project doctor --project-config adl_project.json
+```
+
+Compatibility wrapper shape:
+
+```sh
+$ADL_HOME/adl/tools/pr.sh project-doctor --project-config adl_project.json
+```
+
+The wrapper shape is optional and must not create a second workflow truth.
+
+## Inputs
+
+Required input:
+
+- `adl_project.json`
+
+Optional inputs:
+
+- explicit repo root;
+- explicit ADL checkout path;
+- JSON output mode;
+- profile-specific validation selector.
+
+## Checks
+
+The doctor should check:
+
+- root `AGENTS.md` exists;
+- root `adl_project.json` exists and parses;
+- `schema_version` is supported;
+- all required fields are present;
+- enum values are supported;
+- ADL tooling discovery resolves exactly one checkout;
+- resolved checkout satisfies the valid-checkout contract;
+- `prompt_template_registry` exists relative to the ADL checkout;
+- issue tracker authority is explicit;
+- card and worktree state ownership is explicit;
+- local `.adl/`, worktrees, build output, scratch state, and private keys are
+  ignored or explicitly declared;
+- public artifact policy forbids host-local absolute paths;
+- profile validation expectations are listed.
+
+## Output Contract
+
+The doctor should emit:
+
+- `PASS`, `WARN`, or `FAIL`;
+- resolved ADL checkout source;
+- ADL tooling compatibility status;
+- issue/card/worktree ownership summary;
+- profile and validation summary;
+- public/private artifact policy summary;
+- actionable setup instructions for every failure.
+
+JSON output should be machine-readable and stable enough for CI.
+
+## Read-Only Rule
+
+The doctor must not:
+
+- create files;
+- modify `.gitignore`;
+- create issues;
+- create cards;
+- bind worktrees;
+- run broad tests;
+- install tooling;
+- migrate repo state.
+
+All mutations should happen in separate, explicitly tracked issues after the
+doctor reports readiness gaps.
+
+## Logging Expectations
+
+The doctor should use the standard ADL observability event style so a hang is
+visible immediately:
+
+```text
+adl_event schema=adl.observability.event.v1 command=adl-csdlc stage=project_doctor result=started
+```
+
+Long-running checks should emit stage events before and after each major
+operation, including tooling discovery, config parse, checkout validation, and
+profile validation.
+
+## Follow-On Implementation Issue Candidate
+
+Title:
+
+```text
+[v0.91.5][portable-adl] Implement read-only portable project doctor
+```
+
+Scope:
+
+- implement `adl-csdlc project doctor`;
+- validate `adl_project.json` shape and enum values;
+- validate deterministic ADL checkout discovery;
+- emit text and JSON output;
+- add focused tests;
+- do not migrate external repositories.

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -28,6 +28,16 @@ These docs describe the structured prompt surfaces used to shape issues, issue-c
 - [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings)
 - [Issue Prompt Templates](issue-prompts/README.md)
 
+### Portable ADL Project Surfaces
+
+These docs and templates describe how external repositories can declare ADL
+C-SDLC workflow policy without copying the full ADL toolchain.
+
+- [Portable ADL Project Adapter Contract](PORTABLE_ADL_PROJECT_ADAPTER_CONTRACT_v0.91.5.md)
+- [Portable ADL Project Doctor Plan](PORTABLE_ADL_PROJECT_DOCTOR_PLAN_v0.91.5.md)
+- [Portable ADL Adapter Follow-Ons](PORTABLE_ADL_PROJECT_ADAPTER_FOLLOW_ONS_v0.91.5.md)
+- [Portable ADL Templates](../templates/portable-adl/README.md)
+
 ### Reviewer and Validation Surfaces
 
 These docs describe bounded reviewer behavior, deterministic output formats, and provenance/review validation surfaces.


### PR DESCRIPTION
Closes #3569

## Summary
Defined the portable ADL project adapter contract, reusable external-repo
templates, example adapter configs, read-only project-doctor plan, and follow-on
register for `#3569`.

## Artifacts
- `docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_CONTRACT_v0.91.5.md`
- `docs/tooling/PORTABLE_ADL_PROJECT_DOCTOR_PLAN_v0.91.5.md`
- `docs/tooling/PORTABLE_ADL_PROJECT_ADAPTER_FOLLOW_ONS_v0.91.5.md`
- `docs/templates/portable-adl/README.md`
- `docs/templates/portable-adl/1.0.0/AGENTS.md`
- `docs/templates/portable-adl/1.0.0/adl_project.json`
- `docs/templates/portable-adl/1.0.0/examples/cognitive-sdlc-paper.adl_project.json`
- `docs/templates/portable-adl/1.0.0/examples/general-intelligence-paper.adl_project.json`
- `docs/templates/portable-adl/1.0.0/examples/universal-tool-schema.adl_project.json`
- v0.91.5 milestone status/link updates for `#3567` and `#3569`.

## Validation
- Validation commands and their purpose:
  - `find docs/templates/portable-adl -name '*.json' -print0 | xargs -0 -n1 python3 -m json.tool >/dev/null`
    Verified portable adapter template and examples parse as JSON.
  - `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml"); puts "PASS yaml"'`
    Verified touched issue-wave YAML parses.
  - Repo-relative Markdown link resolver over touched docs.
    Verified 48 touched Markdown links resolve inside the repository.
  - Example enum validator over `docs/templates/portable-adl/1.0.0/examples/*.json`.
    Verified example adapter configs use allowed profile, issue-authority,
    card-location, and worktree-location values.
  - Focused host-path and secret-marker scan over the new adapter docs/templates.
    Verified no host-local absolute paths or obvious secret markers in new
    adapter docs/templates.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3569__v0-91-5-portable-adl-project-contract-and-templates/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3569__v0-91-5-portable-adl-project-contract-and-templates/sor.md
- Idempotency-Key: v0-91-5-portable-adl-define-portable-adl-project-contract-and-templates-docs-tooling-docs-templates-portable-adl-docs-milestones-v0-91-5-adl-v0-91-5-tasks-issue-3569-v0-91-5-portable-adl-project-contract-and-templates-sip-md-adl-v0-91-5-tasks-issue-3569-v0-91-5-portable-adl-project-contract-and-templates-sor-md