### PR TITLE
[v0.91.5][tools][octocrab] Port PR inspection and closing-linkage path

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::cli::pr_cmd::github_client::{
-    issue_labels_from_csv, issue_labels_from_csv_in_order, issue_metadata_drift,
-    plan_issue_metadata_parity, IssueMetadataSnapshot,
+    body_contains_closing_linkage, issue_labels_from_csv, issue_labels_from_csv_in_order,
+    issue_metadata_drift, linked_issue_numbers_from_lines, linked_issue_numbers_include,
+    plan_issue_metadata_parity, pr_matches_main_version_wave, IssueMetadataSnapshot,
+    PullRequestMetadataSnapshot,
 };
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use ::adl::control_plane::resolve_primary_checkout_root;
@@ -66,19 +68,23 @@ pub(super) fn unresolved_milestone_pr_wave(
     .unwrap_or_else(|| "[]".to_string());
     let prs: Vec<OpenPullRequest> =
         serde_json::from_str(&out).with_context(|| "failed to parse gh pr list json")?;
-    let version_tag = format!("[{version}]");
     Ok(prs
         .into_iter()
-        .filter(|pr| pr.base_ref_name == "main")
-        .filter(|pr| pr.title.contains(&version_tag))
+        .filter(|pr| {
+            pr_matches_main_version_wave(
+                &PullRequestMetadataSnapshot::new(
+                    &pr.title,
+                    &pr.head_ref_name,
+                    &pr.base_ref_name,
+                    pr.is_draft,
+                ),
+                version,
+                exclude_branch,
+            )
+        })
         .map(|mut pr| {
             pr.queue = infer_workflow_queue(&pr.title, "", None).map(str::to_string);
             pr
-        })
-        .filter(|pr| {
-            exclude_branch
-                .map(|branch| pr.head_ref_name != branch)
-                .unwrap_or(true)
         })
         .filter(|pr| {
             pr.queue
@@ -121,12 +127,9 @@ pub(super) fn pr_has_closing_linkage(repo: &str, pr_ref: &str, issue: u32) -> Re
             ".closingIssuesReferences[]?.number",
         ],
     )?;
-    if linked
-        .as_deref()
-        .unwrap_or_default()
-        .lines()
-        .any(|line| line.trim() == issue.to_string())
-    {
+    let linked_issue_numbers =
+        linked_issue_numbers_from_lines(linked.as_deref().unwrap_or_default());
+    if linked_issue_numbers_include(&linked_issue_numbers, issue) {
         return Ok(true);
     }
     let body = run_capture_allow_failure(
@@ -136,7 +139,7 @@ pub(super) fn pr_has_closing_linkage(repo: &str, pr_ref: &str, issue: u32) -> Re
         ],
     )?
     .unwrap_or_default();
-    Ok(body.contains(&format!("Closes #{issue}")))
+    Ok(body_contains_closing_linkage(&body, issue))
 }
 
 pub(super) fn ensure_pr_closing_linkage(

--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -331,6 +331,60 @@ pub(super) fn issue_metadata_drift(
     problems
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PullRequestMetadataSnapshot {
+    pub(super) title: String,
+    pub(super) head_ref_name: String,
+    pub(super) base_ref_name: String,
+    pub(super) is_draft: bool,
+}
+
+impl PullRequestMetadataSnapshot {
+    pub(super) fn new(
+        title: impl Into<String>,
+        head_ref_name: impl Into<String>,
+        base_ref_name: impl Into<String>,
+        is_draft: bool,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            head_ref_name: head_ref_name.into(),
+            base_ref_name: base_ref_name.into(),
+            is_draft,
+        }
+    }
+}
+
+pub(super) fn pr_matches_main_version_wave(
+    pr: &PullRequestMetadataSnapshot,
+    version: &str,
+    exclude_branch: Option<&str>,
+) -> bool {
+    pr.base_ref_name == "main"
+        && pr.title.contains(&format!("[{version}]"))
+        && exclude_branch
+            .map(|branch| pr.head_ref_name != branch)
+            .unwrap_or(true)
+}
+
+pub(super) fn linked_issue_numbers_from_lines(lines: &str) -> BTreeSet<u32> {
+    lines
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .collect()
+}
+
+pub(super) fn linked_issue_numbers_include(
+    linked_issue_numbers: &BTreeSet<u32>,
+    issue: u32,
+) -> bool {
+    linked_issue_numbers.contains(&issue)
+}
+
+pub(super) fn body_contains_closing_linkage(body: &str, issue: u32) -> bool {
+    body.contains(&format!("Closes #{issue}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -533,5 +587,50 @@ mod tests {
         assert!(
             issue_metadata_drift("[v0.91.5][tools] new title", &expected, &final_actual).is_empty()
         );
+    }
+
+    #[test]
+    fn pr_wave_matching_preserves_main_version_and_branch_filters() {
+        let pr = PullRequestMetadataSnapshot::new(
+            "[v0.91.5][tools] Example",
+            "codex/example",
+            "main",
+            false,
+        );
+        assert!(pr_matches_main_version_wave(&pr, "v0.91.5", None));
+        assert!(!pr_matches_main_version_wave(
+            &pr,
+            "v0.91.5",
+            Some("codex/example")
+        ));
+        assert!(!pr_matches_main_version_wave(&pr, "v0.91.4", None));
+
+        let non_main = PullRequestMetadataSnapshot::new(
+            "[v0.91.5][tools] Example",
+            "codex/example",
+            "release",
+            true,
+        );
+        assert!(!pr_matches_main_version_wave(&non_main, "v0.91.5", None));
+        assert!(non_main.is_draft);
+    }
+
+    #[test]
+    fn closing_linkage_helpers_preserve_api_and_body_semantics() {
+        let linked = linked_issue_numbers_from_lines("1153\nnot-a-number\n1160\n");
+        assert!(linked_issue_numbers_include(&linked, 1153));
+        assert!(!linked_issue_numbers_include(&linked, 9999));
+        assert!(body_contains_closing_linkage(
+            "Summary\n\nCloses #1153\n",
+            1153
+        ));
+        assert!(!body_contains_closing_linkage(
+            "Summary\n\ncloses #1153\n",
+            1153
+        ));
+        assert!(!body_contains_closing_linkage(
+            "Summary\n\nRefs #1153\n",
+            1153
+        ));
     }
 }


### PR DESCRIPTION
Closes #3639

## Summary
Ported the deterministic PR inspection and closing-linkage read semantics into the typed GitHub client contract while preserving the existing shell-backed behavior. This issue adds typed helper surfaces for PR wave filtering and closing-linkage interpretation, then routes the existing `gh` command output through those helpers without introducing live octocrab network calls yet.

## Artifacts
- `adl/src/cli/pr_cmd/github_client.rs`
  Added typed PR metadata and closing-linkage helper functions with focused unit tests.
- `adl/src/cli/pr_cmd/github.rs`
  Routed existing PR wave and closing-linkage logic through the typed helper contract while preserving current shell fallback behavior.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified formatting for the modified Rust sources.
  - `CARGO_HOME=operator-local-cargo-home cargo test --manifest-path adl/Cargo.toml closing_linkage -- --nocapture`
    Verified the closing-linkage helpers preserve API-linked issue parsing and exact `Closes #N` body fallback behavior.
  - `CARGO_HOME=operator-local-cargo-home cargo test --manifest-path adl/Cargo.toml pr_wave -- --nocapture`
    Verified the PR wave helper preserves `main` base filtering, version title filtering, and excluded-branch behavior.
  - `CARGO_HOME=operator-local-cargo-home cargo clippy --manifest-path adl/Cargo.toml --bin adl-csdlc -- -D warnings`
    Verified the touched C-SDLC CLI path remains warning-clean.
  - `git diff --check`
    Verified patch whitespace hygiene.
  - `ADL_TOOLING_RUST_BIN=adl/target/debug/adl bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.5/tasks/issue-3639__v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path/sor.md`
    Verified final SOR structure after execution record normalization.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3639__v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3639__v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path/sor.md
- Idempotency-Key: v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-client-rs-adl-v0-91-5-tasks-issue-3639-v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path-sip-md-adl-v0-91-5-tasks-issue-3639-v0-91-5-tools-octocrab-port-pr-inspection-and-closing-linkage-path-sor-md