### PR TITLE
[v0.91.5][provider] Add native DeepSeek API provider

### DIFF
--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -167,15 +167,15 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
         },
         "deepseek" => &ProviderSetupTemplate {
             family: "deepseek",
-            profile: Some("http:deepseek-chat"),
-            kind: None,
+            profile: None,
+            kind: Some("deepseek"),
             env_var: "DEEPSEEK_API_KEY",
             provider_id: "deepseek_primary",
             agent_id: "deepseek_agent",
             model_ref: "reasoning/default",
             provider_model_id: "deepseek-chat",
-            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
-            notes: "Use this with an ADL-compatible HTTP endpoint that fronts DeepSeek-compatible models.",
+            endpoint_hint: None,
+            notes: "Use this for the Rust-native DeepSeek provider path. The default endpoint is DeepSeek's chat completions API; override config.endpoint only for tests or a trusted compatible endpoint.",
         },
         "http" | "generic-http" => &ProviderSetupTemplate {
             family: "http",
@@ -208,11 +208,17 @@ fn render_provider_yaml(template: &ProviderSetupTemplate) -> String {
         .endpoint_hint
         .map(|endpoint| format!("      endpoint: \"{endpoint}\"\n"))
         .unwrap_or_default();
+    let headers_line = if template.kind.is_some() {
+        String::new()
+    } else {
+        "      headers:\n        X-Client: \"adl-provider-setup\"\n".to_string()
+    };
     format!(
-        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    {provider_identity}\n    config:\n{endpoint_line}      auth:\n        type: bearer\n        env: {env_var}\n      headers:\n        X-Client: \"adl-provider-setup\"\n      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n",
+        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    {provider_identity}\n    config:\n{endpoint_line}      auth:\n        type: bearer\n        env: {env_var}\n{headers_line}      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n",
         provider_id = template.provider_id,
         provider_identity = provider_identity,
         endpoint_line = endpoint_line,
+        headers_line = headers_line,
         env_var = template.env_var,
         model_ref = template.model_ref,
         provider_model_id = template.provider_model_id,
@@ -493,11 +499,7 @@ mod tests {
                 "profile: \"http:gemini-2.0-flash\"",
                 "GEMINI_API_KEY",
             ),
-            (
-                "deepseek",
-                "profile: \"http:deepseek-chat\"",
-                "DEEPSEEK_API_KEY",
-            ),
+            ("deepseek", "type: \"deepseek\"", "DEEPSEEK_API_KEY"),
             (
                 "generic-http",
                 "profile: \"http:gpt-4.1-mini\"",

--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -1,6 +1,6 @@
 //! HTTP-based provider implementations and request transport helpers.
 //!
-//! Supports OpenAI, Anthropic, generic HTTP, and Ollama-HTTP style backends.
+//! Supports OpenAI, Anthropic, DeepSeek, generic HTTP, and Ollama-HTTP style backends.
 use super::*;
 use std::thread;
 use std::time::Duration;
@@ -243,6 +243,21 @@ fn extract_anthropic_output_text(json: &Value) -> Option<String> {
     (!joined.is_empty()).then_some(joined)
 }
 
+fn extract_deepseek_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    for choice in json.get("choices")?.as_array()? {
+        if let Some(text) = choice
+            .get("message")
+            .and_then(|v| v.get("content"))
+            .and_then(|v| v.as_str())
+        {
+            chunks.push(text);
+        }
+    }
+    let joined = chunks.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
+}
+
 #[derive(Debug, Clone)]
 /// OpenAI-compatible provider backed by HTTP/requests API.
 pub struct OpenAiProvider {
@@ -381,6 +396,80 @@ impl Provider for AnthropicProvider {
             runtime_error_non_retryable("anthropic", "response missing text output")
         })?;
         write_native_invocation_record("anthropic", &self.model, prompt, &output, http_status)?;
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone)]
+/// DeepSeek native provider using the chat completions API format.
+pub struct DeepSeekProvider {
+    endpoint: String,
+    auth_env: String,
+    model: String,
+    max_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl DeepSeekProvider {
+    /// Build a DeepSeek provider from normalized invocation target.
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        let endpoint =
+            vendor_endpoint(spec, target, DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT, "deepseek")?;
+        let auth_env = auth_env_for(spec, "DEEPSEEK_API_KEY")?;
+        validate_vendor_credential_endpoint(
+            spec,
+            "deepseek",
+            &endpoint,
+            &auth_env,
+            "DEEPSEEK_API_KEY",
+            &["api.deepseek.com"],
+        )?;
+        Ok(Self {
+            endpoint,
+            auth_env,
+            model: target.provider_model_id.clone(),
+            max_tokens: cfg_u64(&spec.config, "max_tokens")
+                .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
+                .unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for DeepSeekProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let token = env::var(&self.auth_env).map_err(|_| {
+            invalid_config(
+                "deepseek",
+                format!("missing required auth env var '{}'", self.auth_env),
+            )
+        })?;
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build DeepSeek client")
+            .map_err(|err| runtime_error("deepseek", err.to_string()))?;
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": self.max_tokens,
+                "stream": false,
+            }));
+        let (json, http_status) = provider_http_json("deepseek", req)?;
+        let output = extract_deepseek_output_text(&json).ok_or_else(|| {
+            runtime_error_non_retryable("deepseek", "response missing message content")
+        })?;
+        write_native_invocation_record("deepseek", &self.model, prompt, &output, http_status)?;
         Ok(output)
     }
 }

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -447,6 +447,126 @@ fn anthropic_provider_complete_records_output_and_version_header() {
 }
 
 #[test]
+fn deepseek_provider_complete_records_chat_completion_request() {
+    let _guard = env_lock();
+    let Some((endpoint, captured, handle)) = spawn_json_server(
+        200,
+        r#"{"choices":[{"message":{"role":"assistant","content":"deepseek ok"}}]}"#,
+    ) else {
+        return;
+    };
+
+    let artifact = std::env::temp_dir().join(format!(
+        "adl-provider-invocations-{}-deepseek.json",
+        std::process::id()
+    ));
+    let artifact_display = artifact.to_string_lossy().to_string();
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    let prev_key = env::var_os("DEEPSEEK_API_KEY");
+    env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", &artifact_display);
+    env::set_var("DEEPSEEK_API_KEY", "test-deepseek-token");
+
+    let spec = provider_spec(
+        "deepseek",
+        &format!("{endpoint}/chat/completions"),
+        Some("DEEPSEEK_API_KEY"),
+        &[],
+    );
+    let target = provider_target(
+        "deepseek",
+        format!("{endpoint}/chat/completions"),
+        "deepseek-chat",
+    );
+    let provider = DeepSeekProvider::from_target(&spec, &target).expect("provider");
+
+    let output = provider.complete("hello deepseek").expect("completion");
+    assert_eq!(output, "deepseek ok");
+
+    let captured = captured.lock().expect("capture").clone().expect("request");
+    assert_eq!(captured.url, "/chat/completions");
+    assert!(captured.body.contains(r#""model":"deepseek-chat""#));
+    assert!(captured.body.contains(r#""content":"hello deepseek""#));
+    assert!(captured.body.contains(r#""stream":false"#));
+    assert!(
+        captured
+            .headers
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("authorization")
+                && v == "Bearer test-deepseek-token")
+    );
+
+    let payload = std::fs::read_to_string(&artifact).expect("artifact");
+    let json: serde_json::Value = serde_json::from_str(&payload).expect("json artifact");
+    assert_eq!(json["invocations"][0]["family"], "deepseek");
+    assert_eq!(json["invocations"][0]["model"], "deepseek-chat");
+    assert_eq!(json["invocations"][0]["output_chars"], 11);
+
+    match prev_artifact {
+        Some(v) => env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", v),
+        None => env::remove_var("ADL_PROVIDER_INVOCATIONS_PATH"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("DEEPSEEK_API_KEY", v),
+        None => env::remove_var("DEEPSEEK_API_KEY"),
+    }
+
+    let _ = handle.join();
+}
+
+#[test]
+fn deepseek_provider_rejects_missing_credentials_and_bad_response_shape() {
+    let _guard = env_lock();
+    let prev_key = env::var_os("DEEPSEEK_API_KEY");
+    env::remove_var("DEEPSEEK_API_KEY");
+
+    let spec = provider_spec(
+        "deepseek",
+        DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT,
+        Some("DEEPSEEK_API_KEY"),
+        &[],
+    );
+    let target = provider_target(
+        "deepseek",
+        DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT.to_string(),
+        "deepseek-chat",
+    );
+    let provider = DeepSeekProvider::from_target(&spec, &target).expect("provider");
+    let missing_key = provider
+        .complete("hello")
+        .expect_err("missing credential should fail");
+    assert!(missing_key
+        .to_string()
+        .contains("missing required auth env var 'DEEPSEEK_API_KEY'"));
+
+    env::set_var("DEEPSEEK_API_KEY", "test-deepseek-token");
+    let Some((endpoint, _captured, handle)) = spawn_json_server(200, r#"{"choices":[]}"#) else {
+        restore_env_var("DEEPSEEK_API_KEY", prev_key);
+        return;
+    };
+    let bad_spec = provider_spec(
+        "deepseek",
+        &format!("{endpoint}/chat/completions"),
+        Some("DEEPSEEK_API_KEY"),
+        &[],
+    );
+    let bad_target = provider_target(
+        "deepseek",
+        format!("{endpoint}/chat/completions"),
+        "deepseek-chat",
+    );
+    let bad_provider = DeepSeekProvider::from_target(&bad_spec, &bad_target).expect("provider");
+    let bad_shape = bad_provider
+        .complete("hello")
+        .expect_err("missing message content should fail");
+    assert!(bad_shape
+        .to_string()
+        .contains("response missing message content"));
+
+    restore_env_var("DEEPSEEK_API_KEY", prev_key);
+    let _ = handle.join();
+}
+
+#[test]
 fn http_provider_complete_and_helper_errors_cover_status_and_validation() {
     let _guard = env_lock();
     let Some((endpoint, captured, handle)) = spawn_json_server(200, r#"{"output":"http ok"}"#)
@@ -588,6 +708,25 @@ fn http_provider_complete_and_helper_errors_cover_status_and_validation() {
         .to_string()
         .contains("config.trust_custom_endpoint"));
 
+    let untrusted_deepseek_spec = provider_spec(
+        "deepseek",
+        "https://proxy.example.com/chat/completions",
+        Some("DEEPSEEK_API_KEY"),
+        &[],
+    );
+    let untrusted_deepseek_err = DeepSeekProvider::from_target(
+        &untrusted_deepseek_spec,
+        &provider_target(
+            "deepseek",
+            "https://proxy.example.com/chat/completions".to_string(),
+            "deepseek-chat",
+        ),
+    )
+    .expect_err("default DeepSeek credentials should not go to untrusted remote endpoints");
+    assert!(untrusted_deepseek_err
+        .to_string()
+        .contains("config.trust_custom_endpoint"));
+
     assert_eq!(
         extract_openai_output_text(&json!({"output_text": "  openai inline  "})),
         Some("openai inline".to_string())
@@ -609,6 +748,16 @@ fn http_provider_complete_and_helper_errors_cover_status_and_validation() {
         extract_anthropic_output_text(&json!({
             "content": [{"type": "tool_use", "text": "ignored"}]
         })),
+        None
+    );
+    assert_eq!(
+        extract_deepseek_output_text(&json!({
+            "choices": [{"message": {"content": "  deepseek inline  "}}]
+        })),
+        Some("deepseek inline".to_string())
+    );
+    assert_eq!(
+        extract_deepseek_output_text(&json!({"choices": [{"message": {"role": "assistant"}}]})),
         None
     );
 

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_error_helpers_and_classification_are_stable() {
+    fn provider_mod_error_helpers_and_classification_are_stable() {
         let retryable = runtime_error("mock", "retryable");
         assert!(is_retryable_error(&retryable));
         assert_eq!(stable_failure_kind(&retryable), Some("provider_error"));
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_complete_stream_default_buffers_mock_output() {
+    fn provider_mod_complete_stream_default_buffers_mock_output() {
         let spec = provider_spec("mock", Some("mock-model"));
         let provider = build_provider_for_id("mock_primary", &spec, None).expect("mock provider");
         let mut chunks = Vec::new();
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn build_provider_dispatches_supported_native_and_compatibility_kinds() {
+    fn provider_mod_build_provider_dispatches_supported_native_and_compatibility_kinds() {
         let mock = provider_spec("mock", Some("mock-model"));
         build_provider_for_id("mock_primary", &mock, None).expect("mock provider");
 
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn build_provider_rejects_unknown_kind_and_invalid_native_endpoint() {
+    fn provider_mod_build_provider_rejects_unknown_kind_and_invalid_native_endpoint() {
         let unknown = provider_spec("not-a-provider", Some("model"));
         let unknown_err = match build_provider_for_id("unknown_primary", &unknown, None) {
             Ok(_) => panic!("unknown kind should fail"),
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_retry_classification_distinguishes_deterministic_failures() {
+    fn provider_mod_remote_retry_classification_distinguishes_deterministic_failures() {
         let schema = anyhow::Error::new(crate::remote_exec::RemoteExecuteClientError::new(
             crate::remote_exec::RemoteExecuteClientErrorKind::SchemaViolation,
             "REMOTE_SCHEMA_VIOLATION",
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_endpoint_validation_rejects_placeholder_and_invalid_hosts() {
+    fn provider_mod_profile_endpoint_validation_rejects_placeholder_and_invalid_hosts() {
         let empty =
             validate_profile_endpoint("p1", "http:gpt-4o-mini", " ").expect_err("empty endpoint");
         assert!(empty
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_endpoint_validation_rejects_plain_http() {
+    fn provider_mod_profile_endpoint_validation_rejects_plain_http() {
         let err = validate_profile_endpoint(
             "p1",
             "http:gpt-4o-mini",
@@ -441,13 +441,13 @@ mod tests {
     }
 
     #[test]
-    fn profile_endpoint_validation_allows_loopback_http_for_local_harnesses() {
+    fn provider_mod_profile_endpoint_validation_allows_loopback_http_for_local_harnesses() {
         validate_profile_endpoint("p1", "http:gpt-4o-mini", "http://127.0.0.1:8787/complete")
             .expect("loopback http should remain allowed");
     }
 
     #[test]
-    fn provider_profile_registry_includes_first_class_claude_profiles() {
+    fn provider_mod_provider_profile_registry_includes_first_class_claude_profiles() {
         let names = provider_profile_names();
         assert!(names.contains(&"claude:claude-3-7-sonnet".to_string()));
         assert!(names.contains(&"claude:claude-3-5-haiku".to_string()));
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn cfg_numeric_helpers_cover_all_supported_and_rejected_types() {
+    fn provider_mod_cfg_numeric_helpers_cover_all_supported_and_rejected_types() {
         let mut cfg = HashMap::new();
         cfg.insert("f64".to_string(), serde_json::json!(0.5));
         cfg.insert("i64".to_string(), serde_json::json!(2));
@@ -487,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    fn timeout_secs_rejects_zero_and_uses_default_without_env() {
+    fn provider_mod_timeout_secs_rejects_zero_and_uses_default_without_env() {
         let prev_adl = env::var_os("ADL_TIMEOUT_SECS");
 
         env::set_var("ADL_TIMEOUT_SECS", "0");

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -23,13 +23,14 @@ mod http_family;
 mod local;
 mod profiles;
 
+pub use http_family::DeepSeekProvider;
 pub use http_family::{AnthropicProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider};
 pub use local::{MockProvider, OllamaProvider};
 pub use profiles::{expand_provider_profiles, provider_profile_names};
 
 pub(crate) use profiles::{
     is_allowed_ollama_endpoint, is_allowed_remote_endpoint, ANTHROPIC_MESSAGES_ENDPOINT,
-    ANTHROPIC_VERSION, OPENAI_RESPONSES_ENDPOINT,
+    ANTHROPIC_VERSION, DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT, OPENAI_RESPONSES_ENDPOINT,
 };
 
 /// A minimal blocking provider abstraction used by runtime execution paths.
@@ -69,8 +70,8 @@ impl ProviderError {
             kind: ProviderErrorKind::UnknownKind,
             provider: None,
             message: format!(
-                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic). \
-Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic. The remote provider surfaces are HTTPS-only."
+                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek). \
+Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek. The remote provider surfaces are HTTPS-only."
             ),
         }
     }
@@ -234,7 +235,8 @@ pub fn build_provider_for_id(
     model_override: Option<&str>,
 ) -> Result<Box<dyn Provider>> {
     match spec.kind.trim() {
-        "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic" => {}
+        "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic"
+        | "deepseek" => {}
         other => return Err(unknown_kind(other)),
     }
 
@@ -247,6 +249,7 @@ pub fn build_provider_for_id(
             "ollama" => Ok(Box::new(OllamaHttpProvider::from_target(spec, &target)?)),
             "openai" => Ok(Box::new(OpenAiProvider::from_target(spec, &target)?)),
             "anthropic" => Ok(Box::new(AnthropicProvider::from_target(spec, &target)?)),
+            "deepseek" => Ok(Box::new(DeepSeekProvider::from_target(spec, &target)?)),
             other => Err(unknown_kind(other)),
         },
         provider_substrate::ProviderTransportV1::LocalCli

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -270,6 +270,17 @@ mod tests {
     use super::*;
     use std::env;
 
+    fn provider_spec(kind: &str, default_model: Option<&str>) -> adl::ProviderSpec {
+        adl::ProviderSpec {
+            id: Some(format!("{kind}_primary")),
+            profile: None,
+            kind: kind.to_string(),
+            base_url: None,
+            default_model: default_model.map(ToString::to_string),
+            config: HashMap::new(),
+        }
+    }
+
     #[test]
     fn provider_error_helpers_and_classification_are_stable() {
         let retryable = runtime_error("mock", "retryable");
@@ -288,6 +299,85 @@ mod tests {
         assert!(!is_retryable_error(&panic));
         assert_eq!(stable_failure_kind(&panic), Some("panic"));
         assert!(format!("{panic:#}").contains("provider mock panic: panic"));
+
+        let config = invalid_config("mock", "bad config");
+        assert!(!is_retryable_error(&config));
+        assert_eq!(stable_failure_kind(&config), Some("schema_error"));
+        assert!(format!("{config:#}").contains("provider mock invalid config: bad config"));
+
+        let unknown = unknown_kind("mystery");
+        assert!(!is_retryable_error(&unknown));
+        assert_eq!(stable_failure_kind(&unknown), Some("schema_error"));
+        assert!(format!("{unknown:#}").contains("provider kind 'mystery' is not supported"));
+    }
+
+    #[test]
+    fn provider_complete_stream_default_buffers_mock_output() {
+        let spec = provider_spec("mock", Some("mock-model"));
+        let provider = build_provider_for_id("mock_primary", &spec, None).expect("mock provider");
+        let mut chunks = Vec::new();
+        let output = provider
+            .complete_stream("hello mock", &mut |chunk| chunks.push(chunk.to_string()))
+            .expect("mock stream completion");
+
+        assert_eq!(output, "hello mock");
+        assert_eq!(chunks, vec!["hello mock".to_string()]);
+    }
+
+    #[test]
+    fn build_provider_dispatches_supported_native_and_compatibility_kinds() {
+        let mock = provider_spec("mock", Some("mock-model"));
+        build_provider_for_id("mock_primary", &mock, None).expect("mock provider");
+
+        let local_ollama = provider_spec("ollama", Some("phi4-mini"));
+        build_provider_for_id("ollama_primary", &local_ollama, Some("phi4-mini"))
+            .expect("local ollama provider");
+
+        let mut http_ollama = provider_spec("ollama", Some("phi4-mini"));
+        http_ollama.base_url = Some("http://127.0.0.1:11434".to_string());
+        build_provider_for_id("ollama_http_primary", &http_ollama, None)
+            .expect("ollama http provider");
+
+        let mut generic_http = provider_spec("http", Some("http-model"));
+        generic_http.config.insert(
+            "endpoint".to_string(),
+            serde_json::json!("https://api.example.com/v1/complete"),
+        );
+        build_provider_for_id("http_primary", &generic_http, None).expect("generic http provider");
+
+        let openai = provider_spec("openai", Some("gpt-test"));
+        build_provider_for_id("openai_primary", &openai, None).expect("openai provider");
+
+        let anthropic = provider_spec("anthropic", Some("claude-test"));
+        build_provider_for_id("anthropic_primary", &anthropic, None).expect("anthropic provider");
+
+        let deepseek = provider_spec("deepseek", Some("deepseek-chat"));
+        build_provider_for_id("deepseek_primary", &deepseek, None).expect("deepseek provider");
+    }
+
+    #[test]
+    fn build_provider_rejects_unknown_kind_and_invalid_native_endpoint() {
+        let unknown = provider_spec("not-a-provider", Some("model"));
+        let unknown_err = match build_provider_for_id("unknown_primary", &unknown, None) {
+            Ok(_) => panic!("unknown kind should fail"),
+            Err(err) => err,
+        };
+        assert!(unknown_err
+            .to_string()
+            .contains("provider kind 'not-a-provider' is not supported"));
+
+        let mut unsafe_openai = provider_spec("openai", Some("gpt-test"));
+        unsafe_openai.config.insert(
+            "endpoint".to_string(),
+            serde_json::json!("http://api.openai.com/v1/responses"),
+        );
+        let endpoint_err = match build_provider_for_id("openai_primary", &unsafe_openai, None) {
+            Ok(_) => panic!("plain http hosted endpoint should fail"),
+            Err(err) => err,
+        };
+        assert!(endpoint_err
+            .to_string()
+            .contains("endpoint must use https://"));
     }
 
     #[test]

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -55,6 +55,8 @@ pub(crate) fn is_allowed_ollama_endpoint(endpoint: &str) -> bool {
 
 pub(crate) const OPENAI_RESPONSES_ENDPOINT: &str = "https://api.openai.com/v1/responses";
 pub(crate) const ANTHROPIC_MESSAGES_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+pub(crate) const DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT: &str =
+    "https://api.deepseek.com/chat/completions";
 /// Canonical Anthropic API version used by the HTTP adapter.
 pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";
 

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -268,6 +268,23 @@ fn infer_capability_defaults(
         };
     }
 
+    if matches!(transport, ProviderTransportV1::Http) && vendor == "deepseek" {
+        return ProviderCapabilitiesV1 {
+            tool_calling: CapabilitySupportV1 {
+                supported: false,
+                mode: CapabilityModeV1::None,
+            },
+            structured_json: CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::PromptBased,
+            },
+            semantic_tool_fallback: CapabilitySupportV1 {
+                supported: false,
+                mode: CapabilityModeV1::None,
+            },
+        };
+    }
+
     let native_tool_calling = match transport {
         ProviderTransportV1::Http | ProviderTransportV1::InProcess => CapabilitySupportV1 {
             supported: true,
@@ -546,6 +563,15 @@ mod tests {
         assert_eq!(deepseek_substrate.vendor, "deepseek");
         assert_eq!(deepseek_substrate.transport, ProviderTransportV1::Http);
         assert_eq!(deepseek_substrate.provider_kind, "deepseek");
+        assert!(!deepseek_substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            deepseek_substrate.capabilities.tool_calling.mode,
+            CapabilityModeV1::None
+        );
+        assert_eq!(
+            deepseek_substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -125,7 +125,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
                 "mock" => return "mock".to_string(),
                 "chatgpt" => return "openai".to_string(),
                 "claude" => return "anthropic".to_string(),
-                "http" => {}
+                "http" => return "generic_http".to_string(),
                 _ => {}
             }
         }
@@ -162,6 +162,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         "mock" => "mock".to_string(),
         "openai" => "openai".to_string(),
         "anthropic" => "anthropic".to_string(),
+        "deepseek" => "deepseek".to_string(),
         "http" | "http_remote" => "generic_http".to_string(),
         other if !other.is_empty() => other.to_lowercase(),
         _ => "unknown".to_string(),
@@ -177,7 +178,9 @@ fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
                 Ok(ProviderTransportV1::LocalCli)
             }
         }
-        "http" | "http_remote" | "openai" | "anthropic" => Ok(ProviderTransportV1::Http),
+        "http" | "http_remote" | "openai" | "anthropic" | "deepseek" => {
+            Ok(ProviderTransportV1::Http)
+        }
         "local_ollama" => Ok(ProviderTransportV1::LocalCli),
         "mock" => Ok(ProviderTransportV1::InProcess),
         other => Err(anyhow!(
@@ -519,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_substrate_accepts_native_openai_and_anthropic_kinds() {
+    fn provider_substrate_accepts_native_openai_anthropic_and_deepseek_kinds() {
         let mut openai = provider_spec("openai");
         openai.default_model = Some("gpt-test".to_string());
         let openai_substrate =
@@ -535,6 +538,14 @@ mod tests {
         assert_eq!(anthropic_substrate.vendor, "anthropic");
         assert_eq!(anthropic_substrate.transport, ProviderTransportV1::Http);
         assert_eq!(anthropic_substrate.provider_kind, "anthropic");
+
+        let mut deepseek = provider_spec("deepseek");
+        deepseek.default_model = Some("deepseek-chat".to_string());
+        let deepseek_substrate =
+            provider_substrate_v1("deepseek_primary", &deepseek).expect("deepseek substrate");
+        assert_eq!(deepseek_substrate.vendor, "deepseek");
+        assert_eq!(deepseek_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(deepseek_substrate.provider_kind, "deepseek");
     }
 
     #[test]
@@ -724,6 +735,29 @@ mod tests {
         assert_eq!(
             substrate.capabilities.structured_json.mode,
             CapabilityModeV1::Native
+        );
+    }
+
+    #[test]
+    fn provider_substrate_keeps_http_deepseek_profile_as_compatibility_lane() {
+        let mut spec = provider_spec("http");
+        spec.profile = Some("http:deepseek-chat".to_string());
+        spec.default_model = Some("reasoning/default".to_string());
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("https://proxy.deepseek.example.com/v1/complete"),
+        );
+        spec.config
+            .insert("provider_model_id".to_string(), json!("deepseek-chat"));
+
+        let substrate = provider_substrate_v1("deepseek_compat", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "generic_http");
+        assert_eq!(substrate.provider_kind, "http");
+        assert_eq!(substrate.transport, ProviderTransportV1::Http);
+        assert!(!substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
         );
     }
 

--- a/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
@@ -33,6 +33,18 @@ The matrix should cover planner, worker, reviewer, janitor, and watcher roles
 across direct hosted providers, local Ollama, remote AI node Ollama, and
 OpenRouter.
 
+## Native Provider Status
+
+| Provider family | Native ADL type | Credential env | Default endpoint | Status |
+| --- | --- | --- | --- | --- |
+| OpenAI | `openai` | `OPENAI_API_KEY` | `https://api.openai.com/v1/responses` | implemented |
+| Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | `https://api.anthropic.com/v1/messages` | implemented |
+| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/chat/completions` | implemented in `#3549` |
+| Gemini | none yet | `GEMINI_API_KEY` | n/a | compatibility/profile lane only |
+
+Compatibility profiles such as `http:deepseek-chat` remain useful for gateway
+tests, but they must not be confused with the native `deepseek` provider path.
+
 ## Design
 
 - Record provider, model, transport, credentials posture, and role.

--- a/docs/milestones/v0.91.5/review/native_deepseek_provider/DEEPSEEK_NATIVE_PROVIDER_PROOF_3549.md
+++ b/docs/milestones/v0.91.5/review/native_deepseek_provider/DEEPSEEK_NATIVE_PROVIDER_PROOF_3549.md
@@ -1,0 +1,145 @@
+# Native DeepSeek Provider Proof Packet `#3549`
+
+## Metadata
+
+- Issue: `#3549`
+- Milestone: `v0.91.5`
+- Surface: native hosted-provider adapter
+- Provider family: `deepseek`
+- Credential policy: operator environment only; no secret material recorded
+- Live run status: `passed_operator_provided_key`
+
+## Change Summary
+
+`#3549` adds a first-class Rust-native DeepSeek provider path:
+
+- `type: "deepseek"` is accepted by provider construction and provider
+  substrate normalization.
+- The native adapter targets DeepSeek's chat completions API by default:
+  `https://api.deepseek.com/chat/completions`.
+- The native adapter reads `DEEPSEEK_API_KEY` from the environment by default.
+- `adl provider setup deepseek` now emits `type: "deepseek"` instead of the
+  older `http:deepseek-chat` compatibility profile.
+- `http:deepseek-chat` remains available only as a compatibility/profile lane
+  for ADL-style completion gateways.
+- Compatibility `http:*` profiles remain classified as `generic_http` in the
+  provider substrate even when their endpoint names contain vendor-family
+  strings.
+
+## Contract Boundaries
+
+- No credential values are written to tracked files.
+- No native tool-calling claim is made for DeepSeek.
+- No OpenRouter path is treated as native DeepSeek.
+- Local/Ollama DeepSeek support is unchanged and remains a separate local model
+  lane.
+- Live provider proof requires the operator to provide `DEEPSEEK_API_KEY`.
+
+## Focused Test Surfaces Added
+
+The implementation adds focused Rust tests for:
+
+- DeepSeek request construction against a local loopback JSON server.
+- Bearer authentication header behavior without storing credential material.
+- DeepSeek chat-completion response parsing.
+- Missing `DEEPSEEK_API_KEY` failure classification.
+- Missing message-content failure classification.
+- Custom endpoint credential-safety rejection.
+- Provider setup output using native `type: "deepseek"`.
+- Provider substrate recognition of native `deepseek` as hosted HTTP.
+- Provider substrate preservation of `http:deepseek-chat` as a compatibility
+  lane rather than native DeepSeek.
+
+## Validation Results
+
+Focused Rust validation passed:
+
+```bash
+DEEPSEEK_API_KEY="$(tr -d '\n\r' < "$HOME/keys/deepseek.key")" \
+  cargo test --manifest-path adl/Cargo.toml deepseek --lib
+```
+
+Result:
+
+- `5` tests passed
+- `0` failed
+- Covered native DeepSeek request construction, missing credentials, bad
+  response shape, native substrate routing, and compatibility-lane preservation
+
+Focused provider setup validation passed:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families
+```
+
+Result:
+
+- `cli::provider_cmd::tests::provider_setup_supports_all_declared_families`
+  passed in both `src/main.rs` and `src/bin/adl_csdlc.rs` test targets
+- `0` failures
+
+Focused compatibility-lane validation passed:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml \
+  provider_substrate_keeps_http_deepseek_profile_as_compatibility_lane --lib
+```
+
+Result:
+
+- `1` test passed
+- `0` failed
+
+Focused coverage-impact evidence passed:
+
+```bash
+cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features \
+  --json --summary-only --output-path target/coverage-impact-summary.json -- provider
+```
+
+Result:
+
+- provider-focused coverage slice passed across provider setup, provider
+  profiles, provider substrate, native adapters, provider integration, and
+  related provider proof surfaces
+- `0` failures
+- Summary artifact written to `adl/target/coverage-impact-summary.json`
+
+## Live Run Disposition
+
+Live DeepSeek API execution was run once with the operator-provided key from
+`$HOME/keys/deepseek.key`. The key was loaded into process environment only and
+was not printed or written to tracked files.
+
+Command shape:
+
+```bash
+key="$(tr -d '\n\r' < "$HOME/keys/deepseek.key")"
+curl -sS --fail-with-body https://api.deepseek.com/chat/completions \
+  -H "Authorization: Bearer ${key}" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-chat","messages":[{"role":"user","content":"Return exactly: ADL_DEEPSEEK_OK"}],"max_tokens":16,"stream":false}'
+```
+
+Observed non-secret result:
+
+- Response text: `ADL_DEEPSEEK_OK`
+- Reported served model: `deepseek-v4-flash`
+
+Required live proof command shape, after operator credential setup:
+
+```bash
+export DEEPSEEK_API_KEY=...
+adl provider setup deepseek --force
+```
+
+A stronger future proof can add a bounded demo wrapper that invokes the native
+provider with a small prompt and records only status, model, HTTP status,
+timestamp, prompt length, and output length.
+
+## Non-Claims
+
+- This packet does not claim DeepSeek tool-calling support.
+- This packet does not claim benchmark quality or role aptitude.
+- This packet does not claim the compatibility `http:deepseek-chat` profile is
+  equivalent to the native DeepSeek API.

--- a/docs/milestones/v0.91.5/review/native_deepseek_provider/DEEPSEEK_NATIVE_PROVIDER_PROOF_3549.md
+++ b/docs/milestones/v0.91.5/review/native_deepseek_provider/DEEPSEEK_NATIVE_PROVIDER_PROOF_3549.md
@@ -7,7 +7,8 @@
 - Surface: native hosted-provider adapter
 - Provider family: `deepseek`
 - Credential policy: operator environment only; no secret material recorded
-- Live run status: `passed_operator_provided_key`
+- Live API reachability status: `passed_operator_provided_key`
+- Native adapter live status: `not_run`
 
 ## Change Summary
 
@@ -25,6 +26,9 @@
 - Compatibility `http:*` profiles remain classified as `generic_http` in the
   provider substrate even when their endpoint names contain vendor-family
   strings.
+- Native DeepSeek substrate capability defaults intentionally do not advertise
+  native tool-calling. This issue proves text completion request/response
+  behavior only.
 
 ## Contract Boundaries
 
@@ -47,6 +51,8 @@ The implementation adds focused Rust tests for:
 - Custom endpoint credential-safety rejection.
 - Provider setup output using native `type: "deepseek"`.
 - Provider substrate recognition of native `deepseek` as hosted HTTP.
+- Provider substrate capability truth for native DeepSeek: no native
+  tool-calling claim, prompt-based structured JSON only.
 - Provider substrate preservation of `http:deepseek-chat` as a compatibility
   lane rather than native DeepSeek.
 
@@ -105,11 +111,17 @@ Result:
 - `0` failures
 - Summary artifact written to `adl/target/coverage-impact-summary.json`
 
-## Live Run Disposition
+## Live API Reachability Disposition
 
-Live DeepSeek API execution was run once with the operator-provided key from
-`$HOME/keys/deepseek.key`. The key was loaded into process environment only and
-was not printed or written to tracked files.
+Live DeepSeek API reachability was checked once with the operator-provided key
+from `$HOME/keys/deepseek.key`. The key was loaded into process environment only
+and was not printed or written to tracked files.
+
+This live check used raw `curl`. It did not invoke `DeepSeekProvider::complete`
+and is not claimed as end-to-end live proof of the Rust adapter. The Rust
+adapter path is covered by deterministic loopback tests that exercise request
+construction, bearer auth, DeepSeek response parsing, and invocation-record
+writing without exposing a real credential.
 
 Command shape:
 
@@ -126,20 +138,22 @@ Observed non-secret result:
 - Response text: `ADL_DEEPSEEK_OK`
 - Reported served model: `deepseek-v4-flash`
 
-Required live proof command shape, after operator credential setup:
+Setup command shape, after operator credential setup:
 
 ```bash
 export DEEPSEEK_API_KEY=...
 adl provider setup deepseek --force
 ```
 
-A stronger future proof can add a bounded demo wrapper that invokes the native
-provider with a small prompt and records only status, model, HTTP status,
-timestamp, prompt length, and output length.
+The setup command generates provider configuration only; it does not invoke the
+provider. A stronger future proof can add a bounded demo wrapper or provider
+invoke command that calls the native adapter with a small prompt and records
+only status, model, HTTP status, timestamp, prompt length, and output length.
 
 ## Non-Claims
 
 - This packet does not claim DeepSeek tool-calling support.
 - This packet does not claim benchmark quality or role aptitude.
+- This packet does not claim an end-to-end live ADL native-adapter invocation.
 - This packet does not claim the compatibility `http:deepseek-chat` profile is
   equivalent to the native DeepSeek API.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -30,15 +30,16 @@ The generated bundle is intentionally local-only:
 - users are expected to copy/fill a local env file and source it before running ADL
 
 Important transport note:
-- `openai` and `anthropic` now use Rust-native provider adapters by default:
+- `openai`, `anthropic`, and `deepseek` now use Rust-native provider adapters by default:
   - `type: "openai"` targets the OpenAI Responses API unless `config.endpoint` is explicitly overridden
   - `type: "anthropic"` targets the Anthropic Messages API unless `config.endpoint` is explicitly overridden
+  - `type: "deepseek"` targets the DeepSeek chat completions API unless `config.endpoint` is explicitly overridden
 - ADL's bounded HTTP provider expects a completion-style contract:
   - request JSON with `{"prompt": "..."}`
   - response JSON with `{"output": "..."}`
 - raw vendor-native endpoints may need an adapter or compatibility gateway if
   they do not expose that exact contract directly; this applies to HTTP/profile
-  families such as `chatgpt`, `claude`, `gemini`, `deepseek`, and `http`
+  families such as `chatgpt`, `claude`, `gemini`, and `http`
 - provider-family demos should keep setup instructions here and keep family-specific
   runtime proof steps in their own wrapper surfaces
 
@@ -48,7 +49,12 @@ Example:
 adl provider setup chatgpt
 adl provider setup claude
 adl provider setup openai --out ./.adl/provider-setup/openai
+adl provider setup deepseek
 ```
+
+DeepSeek native note:
+- `adl provider setup deepseek` emits `type: "deepseek"`, reads `DEEPSEEK_API_KEY`, and uses `https://api.deepseek.com/chat/completions` by default
+- the older `http:deepseek-chat` profile remains a compatibility surface for ADL-style completion gateways; it is not the native DeepSeek API path
 
 Loopback demo note:
 - the `v0.87.1` bounded HTTP family demo uses `http://127.0.0.1:8787/complete` with a dummy bearer token as a local proof path for the ADL completion contract


### PR DESCRIPTION
Closes #3549

## Summary
Implemented a native Rust DeepSeek hosted-provider path for `#3549`, including
provider construction, provider substrate recognition, setup generation,
focused tests, documentation, and a bounded live API smoke with the
operator-provided key.

## Artifacts
- `adl/src/provider/http_family.rs`
- `adl/src/provider/http_family/tests.rs`
- `adl/src/provider/mod.rs`
- `adl/src/provider/profiles.rs`
- `adl/src/provider_substrate.rs`
- `adl/src/cli/provider_cmd.rs`
- `docs/tooling/PROVIDER_SETUP.md`
- `docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md`
- `docs/milestones/v0.91.5/review/native_deepseek_provider/DEEPSEEK_NATIVE_PROVIDER_PROOF_3549.md`

## Validation
- Validation commands and their purpose:
  - `DEEPSEEK_API_KEY="$(tr -d '\n\r' < "$HOME/keys/deepseek.key")" cargo test --manifest-path adl/Cargo.toml deepseek --lib`
    Verified the native DeepSeek provider and related DeepSeek substrate tests.
  - `cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families`
    Verified provider setup generation for all declared families, including native DeepSeek.
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate_keeps_http_deepseek_profile_as_compatibility_lane --lib`
    Verified compatibility DeepSeek profile classification.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- provider`
    Verified focused coverage evidence for the changed Rust provider surfaces.
  - Live DeepSeek smoke using `$HOME/keys/deepseek.key`
    Verified reachable hosted DeepSeek API path without recording credential material.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3549__v0-91-5-provider-native-deepseek-api/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3549__v0-91-5-provider-native-deepseek-api/sor.md
- Idempotency-Key: v0-91-5-provider-add-native-deepseek-api-provider-adl-v0-91-5-tasks-issue-3549-v0-91-5-provider-native-deepseek-api-sip-md-adl-v0-91-5-tasks-issue-3549-v0-91-5-provider-native-deepseek-api-sor-md