### PR TITLE
[v0.91.5][tools][octocrab] Harden fallback modes and review client migration

### DIFF
--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 const ADL_GITHUB_CLIENT_ENV: &str = "ADL_GITHUB_CLIENT";
+const ADL_GITHUB_DISABLE_GH_FALLBACK_ENV: &str = "ADL_GITHUB_DISABLE_GH_FALLBACK";
 const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
 const GH_TOKEN_ENV: &str = "GH_TOKEN";
 
@@ -79,6 +80,7 @@ pub(super) struct AdlGithubClientConfig {
     pub(super) backend: GithubClientBackend,
     pub(super) token_source: Option<GithubTokenSource>,
     pub(super) gh_fallback_allowed: bool,
+    pub(super) gh_fallback_disabled: bool,
 }
 
 #[derive(Clone)]
@@ -99,10 +101,13 @@ impl fmt::Debug for AdlGithubClient {
 
 impl AdlGithubClient {
     pub(super) fn from_env() -> Result<Self, AdlGithubClientError> {
-        Self::from_values(
+        Self::from_values_with_fallback_policy(
             std::env::var(ADL_GITHUB_CLIENT_ENV).ok().as_deref(),
             std::env::var(GITHUB_TOKEN_ENV).ok().as_deref(),
             std::env::var(GH_TOKEN_ENV).ok().as_deref(),
+            std::env::var(ADL_GITHUB_DISABLE_GH_FALLBACK_ENV)
+                .ok()
+                .as_deref(),
         )
     }
 
@@ -111,7 +116,17 @@ impl AdlGithubClient {
         github_token: Option<&str>,
         gh_token: Option<&str>,
     ) -> Result<Self, AdlGithubClientError> {
+        Self::from_values_with_fallback_policy(requested_mode, github_token, gh_token, None)
+    }
+
+    pub(super) fn from_values_with_fallback_policy(
+        requested_mode: Option<&str>,
+        github_token: Option<&str>,
+        gh_token: Option<&str>,
+        disable_gh_fallback: Option<&str>,
+    ) -> Result<Self, AdlGithubClientError> {
         let requested_mode = GithubClientMode::parse(requested_mode)?;
+        let gh_fallback_disabled = parse_disable_gh_fallback(disable_gh_fallback)?;
         let token_source = discover_token_source(github_token, gh_token);
         let backend = match (requested_mode, token_source) {
             (GithubClientMode::Gh, _) => GithubClientBackend::GhFallback,
@@ -128,12 +143,22 @@ impl AdlGithubClient {
                 ));
             }
         };
+        if gh_fallback_disabled && backend == GithubClientBackend::GhFallback {
+            return Err(AdlGithubClientError::new(
+                AdlGithubClientErrorKind::FallbackDisabled,
+                format!(
+                    "{ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}=1 disables gh fallback; set {GITHUB_TOKEN_ENV} or {GH_TOKEN_ENV} for octocrab-backed mode, or unset {ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}"
+                ),
+            ));
+        }
         Ok(Self {
             config: AdlGithubClientConfig {
                 requested_mode,
                 backend,
                 token_source,
-                gh_fallback_allowed: requested_mode != GithubClientMode::Octocrab,
+                gh_fallback_allowed: requested_mode != GithubClientMode::Octocrab
+                    && !gh_fallback_disabled,
+                gh_fallback_disabled,
             },
             _octocrab: PhantomData,
         })
@@ -157,10 +182,26 @@ fn discover_token_source(
     }
 }
 
+fn parse_disable_gh_fallback(raw: Option<&str>) -> Result<bool, AdlGithubClientError> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(false),
+        Some("1") | Some("true") | Some("yes") | Some("on") => Ok(true),
+        Some("0") | Some("false") | Some("no") | Some("off") => Ok(false),
+        Some(other) => Err(AdlGithubClientError::new(
+            AdlGithubClientErrorKind::InvalidMode,
+            format!(
+                "unsupported {ADL_GITHUB_DISABLE_GH_FALLBACK_ENV} value '{}'; expected 1, true, yes, on, 0, false, no, or off",
+                redact_for_diagnostics(other)
+            ),
+        )),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AdlGithubClientErrorKind {
     InvalidMode,
     MissingToken,
+    FallbackDisabled,
     Auth,
     RateLimit,
     NotFound,
@@ -189,6 +230,7 @@ impl AdlGithubClientError {
         match self.kind {
             AdlGithubClientErrorKind::InvalidMode => "github_client.invalid_mode",
             AdlGithubClientErrorKind::MissingToken => "github_client.missing_token",
+            AdlGithubClientErrorKind::FallbackDisabled => "github_client.fallback_disabled",
             AdlGithubClientErrorKind::Auth => "github_client.auth",
             AdlGithubClientErrorKind::RateLimit => "github_client.rate_limit",
             AdlGithubClientErrorKind::NotFound => "github_client.not_found",
@@ -428,11 +470,13 @@ mod tests {
             Some(GithubTokenSource::GithubToken)
         );
         assert!(client.config().gh_fallback_allowed);
+        assert!(!client.config().gh_fallback_disabled);
 
         let client = AdlGithubClient::from_values(Some("auto"), None, None).unwrap();
         assert_eq!(client.config().backend, GithubClientBackend::GhFallback);
         assert_eq!(client.config().token_source, None);
         assert!(client.config().gh_fallback_allowed);
+        assert!(!client.config().gh_fallback_disabled);
     }
 
     #[test]
@@ -472,6 +516,77 @@ mod tests {
     }
 
     #[test]
+    fn fallback_disable_fails_closed_for_shell_backed_modes() {
+        let err =
+            AdlGithubClient::from_values_with_fallback_policy(Some("auto"), None, None, Some("1"))
+                .unwrap_err();
+        assert_eq!(err.kind(), AdlGithubClientErrorKind::FallbackDisabled);
+        assert_eq!(err.stable_code(), "github_client.fallback_disabled");
+        assert!(err.to_string().contains("ADL_GITHUB_DISABLE_GH_FALLBACK=1"));
+
+        let err =
+            AdlGithubClient::from_values_with_fallback_policy(Some("gh"), None, None, Some("true"))
+                .unwrap_err();
+        assert_eq!(err.kind(), AdlGithubClientErrorKind::FallbackDisabled);
+    }
+
+    #[test]
+    fn fallback_disable_allows_token_backed_octocrab_modes_without_shell_fallback() {
+        let client = AdlGithubClient::from_values_with_fallback_policy(
+            Some("auto"),
+            Some("github"),
+            None,
+            Some("yes"),
+        )
+        .unwrap();
+        assert_eq!(client.config().backend, GithubClientBackend::Octocrab);
+        assert_eq!(
+            client.config().token_source,
+            Some(GithubTokenSource::GithubToken)
+        );
+        assert!(client.config().gh_fallback_disabled);
+        assert!(!client.config().gh_fallback_allowed);
+
+        let client = AdlGithubClient::from_values_with_fallback_policy(
+            Some("octocrab"),
+            Some("github"),
+            None,
+            Some("on"),
+        )
+        .unwrap();
+        assert_eq!(client.config().backend, GithubClientBackend::Octocrab);
+        assert!(client.config().gh_fallback_disabled);
+        assert!(!client.config().gh_fallback_allowed);
+    }
+
+    #[test]
+    fn fallback_disable_rejects_unsupported_values_without_leaking_tokens() {
+        let err = AdlGithubClient::from_values_with_fallback_policy(
+            Some("auto"),
+            Some("github"),
+            None,
+            Some("github_pat_secret"),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), AdlGithubClientErrorKind::InvalidMode);
+        assert!(!err.to_string().contains("github_pat_secret"));
+        assert!(err.to_string().contains("<redacted>"));
+    }
+
+    #[test]
+    fn migration_review_records_fallback_and_remaining_shell_boundaries() {
+        let doc = include_str!("../../../../docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md");
+
+        assert!(doc.contains("ADL_GITHUB_DISABLE_GH_FALLBACK"));
+        assert!(doc.contains("github_client.fallback_disabled"));
+        assert!(doc.contains("Remaining Shell-Backed Operations"));
+        assert!(
+            doc.contains("This packet does not claim all GitHub operations are octocrab-backed")
+        );
+        assert!(doc.contains("adl/tools/pr.sh"));
+    }
+
+    #[test]
     fn github_status_mapping_is_stable_and_redacted() {
         let auth = map_github_status(401, "Authorization: token=ghp_secret");
         assert_eq!(auth.kind(), AdlGithubClientErrorKind::Auth);
@@ -497,6 +612,7 @@ mod tests {
         let _guard = env_lock();
         unsafe {
             std::env::set_var(ADL_GITHUB_CLIENT_ENV, "auto");
+            std::env::set_var(ADL_GITHUB_DISABLE_GH_FALLBACK_ENV, "1");
             std::env::set_var(GITHUB_TOKEN_ENV, "github");
             std::env::set_var(GH_TOKEN_ENV, "gh");
         }
@@ -506,8 +622,11 @@ mod tests {
             client.config().token_source,
             Some(GithubTokenSource::GithubToken)
         );
+        assert!(client.config().gh_fallback_disabled);
+        assert!(!client.config().gh_fallback_allowed);
         unsafe {
             std::env::remove_var(ADL_GITHUB_CLIENT_ENV);
+            std::env::remove_var(ADL_GITHUB_DISABLE_GH_FALLBACK_ENV);
             std::env::remove_var(GITHUB_TOKEN_ENV);
             std::env::remove_var(GH_TOKEN_ENV);
         }

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -355,6 +355,7 @@ fn csdlc_github_client_boundary_doc_records_shared_ownership() {
     assert!(doc.contains("adl/src/cli/pr_cmd/github_client.rs"));
     assert!(doc.contains("adl/src/cli/pr_cmd/github.rs"));
     assert!(doc.contains("ADL_GITHUB_CLIENT"));
+    assert!(doc.contains("ADL_GITHUB_DISABLE_GH_FALLBACK"));
     assert!(doc.contains("Do not duplicate GitHub issue or PR metadata interpretation"));
 }
 

--- a/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
+++ b/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
@@ -24,6 +24,8 @@ The shared layer owns:
 - GitHub client mode selection through `ADL_GITHUB_CLIENT`.
 - Token-source selection using `GITHUB_TOKEN` before `GH_TOKEN`.
 - Fallback policy for `auto`, `octocrab`, and `gh` modes.
+- Fail-closed shell fallback disablement through
+  `ADL_GITHUB_DISABLE_GH_FALLBACK`.
 - Issue metadata parity planning.
 - PR wave filtering.
 - PR closing-linkage interpretation.
@@ -33,6 +35,8 @@ The shared layer owns:
 - Do not duplicate GitHub issue or PR metadata interpretation in `adl-csdlc`.
 - Do not bypass `adl/tools/pr.sh` as the taught operator entrypoint.
 - Do not remove `gh` fallback in this migration slice.
+- Do not silently use `gh` fallback when `ADL_GITHUB_DISABLE_GH_FALLBACK`
+  is enabled.
 - Do not introduce GitHub App authentication in this migration slice.
 - Do not rename public workflow commands in this migration slice.
 

--- a/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
+++ b/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
@@ -1,0 +1,72 @@
+# ADL Octocrab Migration Review
+
+This packet records the v0.91.5 octocrab mini-sprint state after the first
+typed GitHub client migration wave.
+
+## Scope
+
+The mini-sprint migrated GitHub issue and PR metadata interpretation toward a
+shared typed client layer while preserving `adl/tools/pr.sh` as the canonical
+agent-facing workflow entrypoint.
+
+This packet is a migration review surface, not a claim that every GitHub
+operation now uses live octocrab network calls.
+
+## Completed Slices
+
+- `#3637` added the typed GitHub client contract, mode selection, token-source
+  discovery, stable error codes, and diagnostic redaction.
+- `#3638` moved issue metadata parity interpretation onto typed helpers while
+  preserving existing shell-backed issue operations.
+- `#3639` moved PR wave filtering and closing-linkage interpretation onto typed
+  helpers while preserving existing shell-backed PR operations.
+- `#3640` documented the shared C-SDLC GitHub client boundary and proved that
+  `adl-csdlc` stays on the shared PR control-plane path.
+- `#3641` added fail-closed shell fallback disablement and this migration review
+  packet.
+
+## Mode Policy
+
+- `ADL_GITHUB_CLIENT=auto` uses an octocrab-backed configuration when
+  `GITHUB_TOKEN` or `GH_TOKEN` is present, otherwise it uses `gh` fallback.
+- `ADL_GITHUB_CLIENT=octocrab` requires `GITHUB_TOKEN` or `GH_TOKEN` and fails
+  closed without a token.
+- `ADL_GITHUB_CLIENT=gh` explicitly selects `gh` fallback.
+- `ADL_GITHUB_DISABLE_GH_FALLBACK=1` disables shell fallback and fails closed
+  for shell-backed modes.
+
+The stable failure code for disabled shell fallback is
+`github_client.fallback_disabled`.
+
+## Remaining Shell-Backed Operations
+
+The following operations still route through the existing `gh` command path:
+
+- issue creation and issue body updates
+- issue title and version-label updates
+- PR creation, body updates, readiness changes, and merge operations
+- live PR list/view calls used by workflow guardrails
+- live issue and PR linkage checks where the current code calls `gh`
+
+This is intentional for this migration wave. The typed helpers now own shared
+interpretation, but live network mutation was not migrated in this slice.
+
+## Follow-On Routes
+
+The next octocrab follow-ons should stay behavior-preserving and separately
+reviewable:
+
+- add a trait-backed live issue read/list path with `gh` parity tests
+- add a trait-backed live PR read/list path with `gh` parity tests
+- migrate issue create/edit operations after read/list parity is proven
+- migrate PR create/update operations after PR read/list parity is proven
+- add observability for fallback selection, slow GitHub calls, and command
+  timeouts
+- add an optional release-gate smoke check for token-backed octocrab auth
+
+## Non-Claims
+
+- This packet does not claim all GitHub operations are octocrab-backed.
+- This packet does not remove the canonical `adl/tools/pr.sh` workflow wrapper.
+- This packet does not introduce GitHub App authentication.
+- This packet does not change generated-card command policy.


### PR DESCRIPTION
Closes #3641

## Summary
Implemented fail-closed `gh` fallback disablement for the shared ADL GitHub client and added a migration review packet for the octocrab mini-sprint. The issue now records which GitHub paths are typed-client interpreted, which paths remain shell-backed, and which follow-ons remain for live octocrab network migration.

## Artifacts
- `adl/src/cli/pr_cmd/github_client.rs`
- `adl/src/cli/tests.rs`
- `docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md`
- `docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md`
- `.adl/v0.91.5/tasks/issue-3641__v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration/srp.md`
- `.adl/v0.91.5/tasks/issue-3641__v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting.
  - `CARGO_HOME=operator-local-cargo-home cargo test --manifest-path adl/Cargo.toml github_client -- --nocapture`
    Verified focused GitHub client fallback, redaction, metadata, PR, and migration-review tests.
  - `CARGO_HOME=operator-local-cargo-home cargo test --manifest-path adl/Cargo.toml csdlc_github_client_boundary_doc_records_shared_ownership -- --nocapture`
    Verified the boundary doc proof hook.
  - `CARGO_HOME=operator-local-cargo-home cargo clippy --manifest-path adl/Cargo.toml --bin adl-csdlc -- -D warnings`
    Verified C-SDLC binary clippy cleanliness.
  - `git diff --check`
    Verified whitespace hygiene.
  - `rg -n "host paths, private-key markers, and token-shaped examples" docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md adl/src/cli/pr_cmd/github_client.rs adl/src/cli/tests.rs`
    Verified docs hygiene and confirmed Rust matches are deliberate redaction fixtures.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3641__v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3641__v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration/sor.md
- Idempotency-Key: v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration-adl-src-cli-pr-cmd-github-client-rs-adl-src-cli-tests-rs-docs-tooling-adl-csdlc-github-client-boundary-md-docs-tooling-adl-octocrab-migration-review-md-adl-v0-91-5-tasks-issue-3641-v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration-sip-md-adl-v0-91-5-tasks-issue-3641-v0-91-5-tools-octocrab-harden-fallback-modes-and-review-client-migration-sor-md