### PR TITLE
[v0.91.5][tools] Bump adl/Cargo.toml version to 0.91.5

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.91.4"
+version = "0.91.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.91.4"
+version = "0.91.5"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #3662

## Summary
Updated `adl/Cargo.toml` and the corresponding root package entry in `adl/Cargo.lock` from version `0.91.4` to `0.91.5`, then verified that the manifest still parses cleanly. This issue is a bounded package-version bump only and does not claim any broader runtime, API, or release-surface changes.

## Artifacts
- `adl/Cargo.toml`
- `adl/Cargo.lock`
- Local issue output record at `.adl/v0.91.5/tasks/issue-3662__v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo metadata --manifest-path adl/Cargo.toml --no-deps`
    Verified that the updated `adl/Cargo.toml` remains a valid Cargo manifest.
  - `git diff --check`
    Verified that the diff contains no whitespace or malformed-patch errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3662__v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3662__v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5/sor.md
- Idempotency-Key: v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5-adl-cargo-toml-adl-cargo-lock-adl-v0-91-5-tasks-issue-3662-v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5-sip-md-adl-v0-91-5-tasks-issue-3662-v0-91-5-tools-bump-adl-cargo-toml-version-to-0-91-5-sor-md