### PR TITLE
[v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -14,6 +14,8 @@ mod markdown;
 mod portable_project_doctor;
 #[path = "tooling_cmd/prompt_template.rs"]
 mod prompt_template;
+#[path = "tooling_cmd/public_prompt_packet.rs"]
+mod public_prompt_packet;
 #[path = "tooling_cmd/review_contract.rs"]
 mod review_contract;
 #[path = "tooling_cmd/review_surface.rs"]
@@ -28,6 +30,7 @@ use code_review::real_code_review;
 use csdlc_prompt_editor::real_csdlc_prompt_editor;
 use portable_project_doctor::real_portable_project_doctor;
 use prompt_template::real_prompt_template;
+use public_prompt_packet::real_public_prompt_packet;
 use review_contract::{real_verify_repo_review_contract, real_verify_review_output_provenance};
 use review_surface::{real_review_card_surface, real_review_runtime_surface};
 use structured_prompt::{real_lint_prompt_spec, real_validate_structured_prompt};
@@ -57,7 +60,7 @@ use structured_prompt::{
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "tooling requires a subcommand: card-prompt | code-review | csdlc-prompt-editor | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
+            "tooling requires a subcommand: card-prompt | code-review | csdlc-prompt-editor | lint-prompt-spec | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
         ));
     };
 
@@ -69,6 +72,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
         "lint-prompt-spec" => real_lint_prompt_spec(&args[1..]),
         "portable-project-doctor" => real_portable_project_doctor(&args[1..]),
         "prompt-template" => real_prompt_template(&args[1..]),
+        "public-prompt-packet" => real_public_prompt_packet(&args[1..]),
         "validate-structured-prompt" => real_validate_structured_prompt(&args[1..]),
         "review-card-surface" => real_review_card_surface(&args[1..]),
         "review-runtime-surface" => real_review_runtime_surface(&args[1..]),
@@ -79,7 +83,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | csdlc-prompt-editor | generate-wp-issue-wave | lint-prompt-spec | portable-project-doctor | prompt-template | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
+            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | csdlc-prompt-editor | generate-wp-issue-wave | lint-prompt-spec | portable-project-doctor | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
         )),
     }
 }
@@ -102,6 +106,7 @@ adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --in
 adl tooling prompt-template validate-schemas [--repo-root <path>]\n\
 adl tooling prompt-template write-sample-values --out-dir <dir>\n\
 adl tooling prompt-template write-structure-schemas --out-dir <dir> [--repo-root <path>]\n\
+adl tooling public-prompt-packet export --issue <number> --slug <slug> --version <version> [--source <dir>] [--out-root <dir>] [--tracker-url <url>] [--repo-root <path>]\n\
 adl tooling validate-structured-prompt --type <sip|stp|spp|srp|sor> --input <path> [--phase <phase>]\n\
 adl tooling review-card-surface --input <input.md> --output <output.md>\n\
 adl tooling review-runtime-surface --review-root <dir>\n\

--- a/adl/src/cli/tooling_cmd/public_prompt_packet.rs
+++ b/adl/src/cli/tooling_cmd/public_prompt_packet.rs
@@ -1,0 +1,352 @@
+use anyhow::{bail, ensure, Result};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::common::{
+    contains_absolute_host_path_in_text, contains_secret_like_token, is_normalized_slug,
+    repo_relative_display, repo_root, valid_github_issue_url, valid_version,
+};
+use super::structured_prompt::{
+    validate_sip_text, validate_sor_text, validate_spp_text, validate_srp_text, validate_stp_text,
+};
+use super::tooling_usage;
+
+const CARD_KINDS: [&str; 5] = ["sip", "stp", "spp", "srp", "sor"];
+
+pub(crate) fn real_public_prompt_packet(args: &[String]) -> Result<()> {
+    let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
+        bail!("public-prompt-packet requires a subcommand: export");
+    };
+
+    match subcommand {
+        "export" => export_public_prompt_packet(&args[1..]),
+        "--help" | "-h" | "help" => {
+            println!("{}", tooling_usage());
+            Ok(())
+        }
+        other => bail!("unknown public-prompt-packet subcommand '{other}' (expected export)"),
+    }
+}
+
+fn export_public_prompt_packet(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+
+    let mut issue: Option<u32> = None;
+    let mut slug: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut source: Option<PathBuf> = None;
+    let mut out_root: Option<PathBuf> = None;
+    let mut tracker_url: Option<String> = None;
+    let mut root_override: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--issue" => {
+                idx += 1;
+                issue = Some(value_arg(args, idx, "--issue")?.parse()?);
+            }
+            "--slug" => {
+                idx += 1;
+                slug = Some(value_arg(args, idx, "--slug")?.to_string());
+            }
+            "--version" => {
+                idx += 1;
+                version = Some(value_arg(args, idx, "--version")?.to_string());
+            }
+            "--source" => {
+                idx += 1;
+                source = Some(PathBuf::from(value_arg(args, idx, "--source")?));
+            }
+            "--out-root" => {
+                idx += 1;
+                out_root = Some(PathBuf::from(value_arg(args, idx, "--out-root")?));
+            }
+            "--tracker-url" => {
+                idx += 1;
+                tracker_url = Some(value_arg(args, idx, "--tracker-url")?.to_string());
+            }
+            "--repo-root" => {
+                idx += 1;
+                root_override = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            other => bail!("unknown arg for tooling public-prompt-packet export: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = root_override.unwrap_or(repo_root()?);
+    let issue = issue.ok_or_else(|| anyhow::anyhow!("export requires --issue"))?;
+    let slug = slug.ok_or_else(|| anyhow::anyhow!("export requires --slug"))?;
+    let version = version.ok_or_else(|| anyhow::anyhow!("export requires --version"))?;
+    ensure!(issue > 0, "--issue must be positive");
+    ensure!(
+        is_normalized_slug(&slug),
+        "--slug must be lowercase kebab-case with no leading/trailing hyphen"
+    );
+    ensure!(
+        valid_version(&version),
+        "--version must use milestone form like v0.91.5"
+    );
+    if let Some(url) = tracker_url.as_deref() {
+        ensure!(
+            valid_github_issue_url(url),
+            "--tracker-url must be a GitHub issue URL when provided"
+        );
+    }
+
+    let source = source
+        .map(|path| absolutize_against(&root, &path))
+        .unwrap_or_else(|| {
+            root.join(".adl")
+                .join(&version)
+                .join("tasks")
+                .join(format!("issue-{issue}__{slug}"))
+        });
+    ensure!(
+        source.is_dir(),
+        "source card bundle not found: {}",
+        source.display()
+    );
+
+    let out_root = out_root
+        .map(|path| absolutize_against(&root, &path))
+        .unwrap_or_else(|| {
+            root.join("docs")
+                .join("milestones")
+                .join(&version)
+                .join("review")
+                .join("evidence")
+                .join("csdlc")
+                .join("issues")
+        });
+    let packet_dir = out_root.join(format!("issue-{issue}-{slug}"));
+    let mut source_cards = Vec::new();
+    for kind in CARD_KINDS {
+        let source_path = source.join(format!("{kind}.md"));
+        ensure!(
+            source_path.is_file(),
+            "missing required {kind} card: {}",
+            source_path.display()
+        );
+        let text = fs::read_to_string(&source_path)?;
+        validate_public_card_text(kind, &source_path, &text)?;
+        source_cards.push((kind, source_path, text));
+    }
+
+    if packet_dir.exists() {
+        ensure!(
+            packet_dir.is_dir(),
+            "public packet output path exists but is not a directory: {}",
+            packet_dir.display()
+        );
+        fs::remove_dir_all(&packet_dir)?;
+    }
+    let cards_dir = packet_dir.join("cards");
+    fs::create_dir_all(&cards_dir)?;
+
+    let mut cards = Vec::new();
+    let mut checks = Vec::new();
+    for (kind, source_path, text) in source_cards {
+        let public_path = cards_dir.join(format!("{kind}.md"));
+        fs::write(&public_path, text.as_bytes())?;
+
+        cards.push(json!({
+            "kind": kind,
+            "source_rel_path": repo_relative_display(&root, &source_path)?,
+            "public_rel_path": repo_relative_display(&root, &public_path)?,
+            "template_version": extract_template_version(&text),
+            "card_status": extract_card_status(&text),
+            "validation_state": "source_present_export_hygiene_passed"
+        }));
+        checks.push(format!("{kind}: no host paths, secret-like tokens, private key markers, or local scratch paths"));
+    }
+
+    let source_rel = repo_relative_display(&root, &source)?;
+    let packet_rel = repo_relative_display(&root, &packet_dir)?;
+    let manifest = json!({
+        "schema": "adl.public_prompt_packet.v1",
+        "version": &version,
+        "issue_number": issue,
+        "slug": &slug,
+        "template_registry": "docs/templates/prompts/current.json",
+        "source_bundle": &source_rel,
+        "output_dir": &packet_rel,
+        "tracker": {
+            "provider": "github",
+            "url": tracker_url.as_deref(),
+            "issue_number": issue
+        },
+        "work_item": {
+            "kind": "issue",
+            "id": format!("issue-{issue}"),
+            "slug": &slug
+        },
+        "cards": cards,
+        "redaction": {
+            "status": "passed",
+            "mode": "refuse_not_rewrite",
+            "checks": checks
+        },
+        "generated_by": "adl tooling public-prompt-packet export",
+        "non_claims": [
+            "This packet does not make local .adl state canonical public truth.",
+            "This packet does not claim runtime validation was executed.",
+            "This packet preserves source card text after export hygiene checks."
+        ]
+    });
+    fs::write(
+        packet_dir.join("manifest.json"),
+        serde_json::to_string_pretty(&manifest)? + "\n",
+    )?;
+    fs::write(
+        packet_dir.join("README.md"),
+        packet_readme(
+            issue,
+            &version,
+            &slug,
+            &source_rel,
+            &packet_rel,
+            tracker_url.as_deref(),
+        ),
+    )?;
+
+    println!("PASS: public prompt packet exported to {packet_rel}");
+    Ok(())
+}
+
+fn validate_public_card_text(kind: &str, source_path: &Path, text: &str) -> Result<()> {
+    if contains_absolute_host_path_in_text(text)
+        || contains_secret_like_token(text)
+        || contains_private_key_marker(text)
+        || contains_local_scratch_marker(text)
+    {
+        bail!("{kind} card contains disallowed public-packet content");
+    }
+    ensure!(
+        !text.contains("{{") && !text.contains("}}"),
+        "{kind} card contains unresolved template markers"
+    );
+    match kind {
+        "sip" => validate_sip_text(text, source_path, Some("bootstrap"))?,
+        "stp" => validate_stp_text(text)?,
+        "spp" => validate_spp_text(text)?,
+        "srp" => validate_srp_text(text)?,
+        "sor" => validate_sor_text(text, Some("bootstrap"))?,
+        _ => bail!("unsupported public prompt card kind: {kind}"),
+    }
+    Ok(())
+}
+
+fn contains_private_key_marker(text: &str) -> bool {
+    [
+        "BEGIN OPENSSH PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+        "BEGIN EC PRIVATE KEY",
+        "id_rsa",
+        "id_ed25519",
+        ".ssh/",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+fn contains_local_scratch_marker(text: &str) -> bool {
+    [
+        "$HOME/temp/",
+        "$HOME/tmp/",
+        "/private/tmp/",
+        ".worktrees/",
+        ".codex/attachments/",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+fn extract_template_version(text: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let (_, rest) = line.split_once("docs/templates/prompts/")?;
+        let version = rest.split('/').next()?;
+        if valid_version_like_template(version) {
+            Some(version.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn valid_version_like_template(value: &str) -> bool {
+    value
+        .split('.')
+        .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+}
+
+fn extract_card_status(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        for prefix in ["card_status:", "Card Status:"] {
+            if let Some(value) = trimmed.strip_prefix(prefix) {
+                return Some(value.trim().trim_matches('"').trim_matches('`').to_string());
+            }
+        }
+    }
+    None
+}
+
+fn packet_readme(
+    issue: u32,
+    version: &str,
+    slug: &str,
+    source_rel: &str,
+    packet_rel: &str,
+    tracker_url: Option<&str>,
+) -> String {
+    let tracker = tracker_url.unwrap_or("not provided");
+    format!(
+        "# Public C-SDLC Prompt Packet: issue-{issue}\n\n\
+## Summary\n\n\
+This packet exports the public prompt-card record for `{slug}` in `{version}`.\n\n\
+## Source\n\n\
+- Source bundle: `{source_rel}`\n\
+- Output packet: `{packet_rel}`\n\
+- Tracker URL: `{tracker}`\n\n\
+## Contents\n\n\
+- `cards/sip.md`\n\
+- `cards/stp.md`\n\
+- `cards/spp.md`\n\
+- `cards/srp.md`\n\
+- `cards/sor.md`\n\
+- `manifest.json`\n\n\
+## Safety Boundary\n\n\
+The exporter refuses obvious host-local paths, secret-like tokens, private key \
+markers, local scratch paths, and unresolved template markers. It does not \
+rewrite card content during export.\n\n\
+## Non-Claims\n\n\
+- This packet does not make local `.adl` state canonical public truth.\n\
+- This packet does not claim runtime validation was executed.\n\
+- This packet is a reviewable prompt-record surface only.\n"
+    )
+}
+
+fn absolutize_against(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn value_arg<'a>(args: &'a [String], idx: usize, flag: &str) -> Result<&'a str> {
+    args.get(idx)
+        .map(String::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing value for {flag}"))
+}
+
+fn has_help_arg(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "help"))
+}

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -12,6 +12,7 @@ mod card_prompt;
 mod common_helpers;
 mod prompt_spec;
 mod prompt_template;
+mod public_prompt_packet;
 mod review_surfaces;
 mod structured_prompt;
 mod support;

--- a/adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs
+++ b/adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs
@@ -1,0 +1,154 @@
+use super::support::*;
+use super::*;
+
+#[test]
+fn public_prompt_packet_export_writes_manifest_readme_and_cards() {
+    let repo = TempRepo::new("public-prompt-packet");
+    let source = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3472__public-card-export");
+    render_sample_cards(&repo, &source);
+
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3472".to_string(),
+        "--slug".to_string(),
+        "public-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+        "--tracker-url".to_string(),
+        "https://github.com/danielbaustin/agent-design-language/issues/3472".to_string(),
+    ])
+    .expect("export public prompt packet");
+
+    let packet = repo
+        .path()
+        .join("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-public-card-export");
+    assert!(packet.join("README.md").is_file());
+    assert!(packet.join("cards/sip.md").is_file());
+    assert!(packet.join("cards/stp.md").is_file());
+    assert!(packet.join("cards/spp.md").is_file());
+    assert!(packet.join("cards/srp.md").is_file());
+    assert!(packet.join("cards/sor.md").is_file());
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(packet.join("manifest.json")).unwrap()).unwrap();
+    assert_eq!(manifest["schema"], "adl.public_prompt_packet.v1");
+    assert_eq!(manifest["version"], "v0.91.5");
+    assert_eq!(manifest["tracker"]["provider"], "github");
+    assert_eq!(manifest["tracker"]["issue_number"], 3472);
+    assert_eq!(manifest["work_item"]["id"], "issue-3472");
+    assert_eq!(manifest["work_item"]["slug"], "public-card-export");
+    assert_eq!(manifest["cards"].as_array().unwrap().len(), 5);
+    assert_eq!(manifest["cards"][0]["template_version"], "1.0.0");
+    assert_eq!(manifest["cards"][0]["card_status"], "ready");
+    assert_eq!(manifest["redaction"]["status"], "passed");
+
+    for card in manifest["cards"].as_array().unwrap() {
+        let public = card["public_rel_path"].as_str().unwrap();
+        let source = card["source_rel_path"].as_str().unwrap();
+        assert!(!public.starts_with('/'));
+        assert!(!source.starts_with('/'));
+        assert!(!public.contains(".adl/"));
+    }
+
+    fs::write(packet.join("stale.txt"), "stale output should be removed").unwrap();
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3472".to_string(),
+        "--slug".to_string(),
+        "public-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect("repeat export should replace packet directory");
+    assert!(!packet.join("stale.txt").exists());
+}
+
+#[test]
+fn public_prompt_packet_export_refuses_host_paths_and_secret_markers() {
+    let repo = TempRepo::new("public-prompt-packet-refuse");
+    let source = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3472__unsafe-card-export");
+    render_sample_cards(&repo, &source);
+    append_to_card(&source, "sip", "Leaked path: /Users/example/private\n");
+
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3472".to_string(),
+        "--slug".to_string(),
+        "unsafe-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect_err("host path should fail closed");
+    assert!(err
+        .to_string()
+        .contains("contains disallowed public-packet content"));
+
+    let source = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3473__secret-card-export");
+    render_sample_cards(&repo, &source);
+    append_to_card(&source, "sip", "Leaked token: ghp_exampletoken\n");
+
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3473".to_string(),
+        "--slug".to_string(),
+        "secret-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect_err("secret marker should fail closed");
+    assert!(err
+        .to_string()
+        .contains("contains disallowed public-packet content"));
+}
+
+fn render_sample_cards(repo: &TempRepo, source: &Path) {
+    let values_dir = repo.path().join("values");
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "render-all".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--values-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+        "--out-dir".to_string(),
+        source.to_string_lossy().to_string(),
+    ])
+    .expect("render public packet source cards");
+}
+
+fn append_to_card(source: &Path, kind: &str, text: &str) {
+    let path = source.join(format!("{kind}.md"));
+    let mut existing = fs::read_to_string(&path).expect("read card");
+    existing.push_str(text);
+    fs::write(path, existing).expect("append card text");
+}

--- a/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
@@ -42,6 +42,36 @@ machine-readable shape, redact local/private data, and index them for review.
 - Inventory `.adl` state before archive or deletion.
 - Require review before destructive cleanup.
 
+## Export Command
+
+Initial packet export is handled by the repository tooling command:
+
+```bash
+adl tooling public-prompt-packet export \
+  --issue <number> \
+  --slug <normalized-slug> \
+  --version <milestone-version> \
+  [--source <card-bundle-dir>] \
+  [--out-root <public-packet-root>] \
+  [--tracker-url <github-issue-url>] \
+  [--repo-root <repo-root>]
+```
+
+By default, the exporter reads from
+`.adl/<version>/tasks/issue-<number>__<slug>/` and writes to
+`docs/milestones/<version>/review/evidence/csdlc/issues/issue-<number>-<slug>/`.
+
+The command copies `sip.md`, `stp.md`, `spp.md`, `srp.md`, and `sor.md` into a
+public `cards/` directory, writes a machine-readable `manifest.json`, and writes
+a packet `README.md`. The manifest separates tracker identity from
+tracker-agnostic work-item identity so future Jira or other adapters do not have
+to reinterpret GitHub issue fields as the only source of work identity.
+
+The exporter refuses, rather than rewrites, source cards containing obvious
+host-local absolute paths, secret-like tokens, private key markers, local scratch
+paths, or unresolved template markers. Later redaction gates may add richer
+review, but this first exporter must not silently sanitize away lifecycle truth.
+
 ## Execution Flow
 
 1. Define/export prompt packets.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md
@@ -1,0 +1,30 @@
+# Public C-SDLC Prompt Packet: issue-3472
+
+## Summary
+
+This packet exports the public prompt-card record for `v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter` in `v0.91.5`.
+
+## Source
+
+- Source bundle: `.adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`
+- Output packet: `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`
+- Tracker URL: `https://github.com/danielbaustin/agent-design-language/issues/3472`
+
+## Contents
+
+- `cards/sip.md`
+- `cards/stp.md`
+- `cards/spp.md`
+- `cards/srp.md`
+- `cards/sor.md`
+- `manifest.json`
+
+## Safety Boundary
+
+The exporter refuses obvious host-local paths, secret-like tokens, private key markers, local scratch paths, and unresolved template markers. It does not rewrite card content during export.
+
+## Non-Claims
+
+- This packet does not make local `.adl` state canonical public truth.
+- This packet does not claim runtime validation was executed.
+- This packet is a reviewable prompt-record surface only.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md
@@ -1,0 +1,176 @@
+# ADL Input Card
+
+Semantic role: Structured Issue Prompt (`SIP`).
+Canonical Template Source: `docs/templates/prompts/1.0.0/sip.md`
+
+Task ID: issue-3472
+Run ID: issue-3472
+Version: v0.91.5
+Title: [v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter
+Branch: codex/3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter
+Card Status: ready
+Generated: 2026-06-04T19:39:09Z
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/3472
+- PR:
+- Source Issue Prompt: .adl/v0.91.5/bodies/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- This issue is not started yet; do not assume a branch or worktree already exists.
+- Do not run `pr start`; use the current issue-mode `pr run` flow only if execution later becomes necessary.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Lifecycle Semantics
+- Lifecycle stage: `SIP`
+- Activation state: active after issue-intent review.
+- Next stage: `STP`, where the selected task or solution is made explicit.
+- Legacy compatibility: older references may call this an input card, but new
+  issue work should treat it as the Structured Issue Prompt.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+## Execution
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug: v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter
+- Required outcome type: combination
+- Demo required: false
+
+## Goal
+
+Execute the linked issue prompt in the bound issue worktree.
+
+## Required Outcome
+
+Ship the required outcome described by the linked source issue prompt.
+
+## Acceptance Criteria
+
+Satisfy the acceptance criteria in the linked source issue prompt and record focused proof in SOR.
+
+## Inputs
+
+Linked source issue prompt; root task bundle cards; current repository state.
+
+## Target Files / Surfaces
+
+Files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt.
+
+## Validation Plan
+
+Run the smallest proving validation for the touched surface and record exact commands in SOR.
+
+## Demo / Proof Requirements
+
+Follow demo and proof requirements from the linked source issue prompt.
+
+## Constraints / Policies
+
+- Follow `AGENTS.md`.
+- Use workflow-conductor for lifecycle routing.
+- Edit cards only with editor skills.
+- Work only in the bound issue worktree after `pr run`.
+- Keep validation focused on the touched surface.
+
+## System Invariants (must remain true)
+
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical SIP content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+Do not widen scope beyond the linked source issue prompt.
+
+## Notes / Risks
+
+Refine this card if the linked source issue prompt changes materially before execution begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do not create a branch or worktree from this card alone.
+- When execution is approved, run the repo-native issue-mode `pr run` flow and then perform the work described above.
+- Write execution outcome truth to the paired `sor.md` file during execution.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md
@@ -1,0 +1,200 @@
+# v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/sor.md`
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-3472
+Run ID: issue-3472
+Version: v0.91.5
+Title: [v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter
+Branch: codex/3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter
+Card Status: ready
+Status: DONE
+Generated: 2026-06-04T19:39:09Z
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-06-04T19:39:09Z
+- End Time: 2026-06-04T20:47:31Z
+
+## Summary
+
+Implemented a version-aware public C-SDLC prompt packet exporter under
+`adl tooling public-prompt-packet export`. The command copies the five lifecycle
+cards into a tracked public packet, writes `manifest.json` and `README.md`,
+preserves template/status metadata, separates GitHub tracker identity from
+tracker-agnostic work-item identity, and refuses obvious publication-unsafe
+source card content.
+
+## Artifacts produced
+- `adl/src/cli/tooling_cmd/public_prompt_packet.rs`
+- `adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs`
+- `docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md`
+- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md`
+
+## Actions taken
+- Added the `public-prompt-packet export` tooling subcommand and dispatcher/help wiring.
+- Added deterministic defaults for milestone-scoped `.adl` issue bundles and milestone-scoped public packet output under `docs/milestones/v0.91.5/review/evidence/csdlc/issues/`.
+- Added export hygiene checks for host-local paths, secret-like tokens, private key markers, local scratch paths, and unresolved template markers.
+- Added contract tests for packet creation, manifest shape, repo-relative paths, tracker/work-item split, and fail-closed unsafe content handling.
+- Added in-export structured-prompt validation for all five cards using the existing SIP/STP/SPP/SRP/SOR validators before any public packet directory is replaced.
+- Updated exporter tests to render real sample prompt cards through `prompt-template render-all` instead of relying on toy Markdown fixtures.
+- Exported the real `#3472` card bundle into the v0.91.5 public evidence tree.
+- Updated the public prompt records feature doc with the command contract and safety boundary.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; tracked artifacts are present in the issue worktree and require PR publication.
+- Worktree-only paths remaining: implementation code, tests, feature doc update, and exported packet paths listed above
+- Integration state: worktree_only
+- Verification scope: main_repo
+- Integration method used: issue worktree edits on branch `codex/3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`; PR publication pending
+- Verification performed:
+  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo fmt --manifest-path adl/Cargo.toml`
+    Formatted Rust changes.
+  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo test --manifest-path adl/Cargo.toml public_prompt_packet -- --nocapture`
+    Verified exporter creation/refusal tests in the focused selector, including real rendered prompt cards and in-export structured-prompt validation.
+  - `./adl/target/debug/adl tooling public-prompt-packet export --issue 3472 --slug v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter --version v0.91.5 --tracker-url https://github.com/danielbaustin/agent-design-language/issues/3472`
+    Verified real `#3472` public packet generation.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind sip --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md`
+    Verified exported SIP structure.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind stp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md`
+    Verified exported STP structure.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind spp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md`
+    Verified exported SPP structure.
+  - `./adl/target/debug/adl tooling validate-structured-prompt --type srp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md`
+    Verified exported SRP structured-prompt contract.
+  - `./adl/target/debug/adl tooling validate-structured-prompt --type sor --phase bootstrap --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md`
+    Verified exported SOR execution-record contract.
+  - `git diff --check`
+    Verified no whitespace errors.
+  - `ruby -rjson -e 'JSON.parse(File.read("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json")); puts "manifest json ok"'`
+    Verified exported manifest JSON parses.
+  - `rg -n PUBLIC_PACKET_REDACTION_SCAN docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`
+    Verified no matches for the focused public packet redaction scan.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout BRANCH -- PATH` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo fmt --manifest-path adl/Cargo.toml`
+    Formatted Rust changes.
+  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo test --manifest-path adl/Cargo.toml public_prompt_packet -- --nocapture`
+    Verified the new exporter contract tests; 2 tests passed in `src/main.rs` and 2 tests passed in `src/bin/adl_csdlc.rs`. The tests now render real prompt cards and prove the exporter runs structured-prompt validation before publication.
+  - `./adl/target/debug/adl tooling public-prompt-packet export --issue 3472 --slug v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter --version v0.91.5 --tracker-url https://github.com/danielbaustin/agent-design-language/issues/3472`
+    Verified real packet generation from the `#3472` card bundle.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind sip --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md`
+    Verified exported SIP structure.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind stp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md`
+    Verified exported STP structure.
+  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind spp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md`
+    Verified exported SPP structure.
+  - `./adl/target/debug/adl tooling validate-structured-prompt --type srp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md`
+    Verified exported SRP structured-prompt contract.
+  - `./adl/target/debug/adl tooling validate-structured-prompt --type sor --phase bootstrap --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md`
+    Verified exported SOR execution-record contract.
+  - `git diff --check`
+    Verified whitespace hygiene.
+  - `ruby -rjson -e 'JSON.parse(File.read("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json")); puts "manifest json ok"'`
+    Verified exported manifest JSON parses.
+  - `rg -n PUBLIC_PACKET_REDACTION_SCAN docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`
+    Verified the exported packet has no matches for the focused redaction scan.
+- Results:
+  - PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo fmt --manifest-path adl/Cargo.toml"
+      - "CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo test --manifest-path adl/Cargo.toml public_prompt_packet -- --nocapture"
+      - "./adl/target/debug/adl tooling public-prompt-packet export --issue 3472 --slug v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter --version v0.91.5 --tracker-url https://github.com/danielbaustin/agent-design-language/issues/3472"
+      - "./adl/target/debug/adl tooling prompt-template validate-structure --kind sip --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md"
+      - "./adl/target/debug/adl tooling prompt-template validate-structure --kind stp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md"
+      - "./adl/target/debug/adl tooling prompt-template validate-structure --kind spp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md"
+      - "./adl/target/debug/adl tooling validate-structured-prompt --type srp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md"
+      - "./adl/target/debug/adl tooling validate-structured-prompt --type sor --phase bootstrap --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md"
+      - "git diff --check"
+      - "ruby -rjson -e 'JSON.parse(File.read(\"docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json\")); puts \"manifest json ok\"'"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PARTIAL
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: focused exporter tests and real packet export.
+- Fixtures or scripts used: test-created temporary card bundles and the real `#3472` card bundle.
+- Replay verification (same inputs -> same artifacts/order): exporter contract tests verify deterministic packet paths and manifest/card shape.
+- Ordering guarantees (sorting / tie-break rules used): fixed lifecycle card order `sip`, `stp`, `spp`, `srp`, `sor`.
+- Artifact stability notes: exported public paths are repository-relative; the exporter refuses rather than rewrites unsafe source card text.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: focused redaction scan over the exported packet; no matches.
+- Prompt / tool argument redaction verified: exporter refuses obvious secret-like tokens and private key markers in source cards.
+- Absolute path leakage check: exporter tests and real packet scan cover host-local absolute paths.
+- Sandbox / policy invariants preserved: yes; local `.adl` source records remain source inputs only and are not added as tracked artifacts.
+
+## Replay Artifacts
+- Trace bundle path(s): not_applicable for this tooling/docs issue
+- Run artifact root: `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/`
+- Replay command used for verification: `./adl/target/debug/adl tooling public-prompt-packet export --issue 3472 --slug v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter --version v0.91.5 --tracker-url https://github.com/danielbaustin/agent-design-language/issues/3472`
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: exporter tests plus exported `#3472` public prompt packet manifest/cards.
+- Required artifacts present: yes, in the issue worktree; PR publication pending.
+- Artifact schema/version checks: manifest JSON parse passed; exported SIP/STP/SPP prompt-card structure validation passed; exported SRP and SOR structured-prompt contracts passed; exporter tests prove in-export structured-prompt validation for all five source cards.
+- Hash/byte-stability checks: not_run; focused deterministic shape/path tests were run instead.
+- Missing/optional artifacts and rationale: no runtime trace bundle is required for this tooling/docs issue.
+
+## Decisions / Deviations
+- Implemented the exporter in the existing `adl tooling` command family to avoid adding a new loose script before the CLI decomposition work settles.
+- Exporter refuses unsafe source cards rather than redacting or rewriting them; richer redaction gates remain owned by later public-card validation work.
+- Integration state remains `worktree_only` until the issue is finished and published as a PR.
+
+## Follow-ups / Deferred work
+- Run bounded pre-PR review and fix actionable findings before publication.
+- Normalize this record to `pr_open`, `merged`, or `closed_no_pr` during finish/closeout as appropriate.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md
@@ -1,0 +1,156 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+name: "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-execution-plan"
+issue: 3472
+task_id: "issue-3472"
+run_id: "issue-3472"
+version: "v0.91.5"
+title: "[v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter"
+branch: "codex/3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+generated_at: "2026-06-04T19:39:09Z"
+card_status: "ready"
+status: "reviewed"
+activation_state: "ready"
+plan_revision: 1
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/danielbaustin/agent-design-language/issues/3472"
+  - kind: "source_issue_prompt"
+    ref: ".adl/v0.91.5/bodies/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter.md"
+  - kind: "stp"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md"
+  - kind: "sip"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md"
+scope:
+  files:
+    - "`#3471`; `docs/milestones/v0.91.4/C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md`; `docs/planning/C_SDLC_PROMPT_TEMPLATE_EDITOR_TRANSITION_PLAN.md`; `docs/templates/prompts/current.json`; `adl/tools/pr.sh`; `adl/src/cli/pr_cmd*`; local `.adl/v0.91.4/tasks/` card bundles as source inputs only"
+  components:
+    - "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+  out_of_scope:
+    - "Do not bulk-export all historical cards.; Do not ingest into ObsMem directly.; Do not support every external tracker adapter in this issue.; Do not rewrite card content beyond safe redaction/sanitization required for public records."
+constraints:
+  - "design_time_plan_must_be_reviewed_before_execution"
+  - "runtime_execution_must_update_spp_if_plan_changes"
+  - "no_hidden_scope_expansion"
+confidence: "medium"
+plan_summary: "Ready issue-local execution plan for [v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter."
+assumptions:
+  - "The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+  - "The original issue body references v0.91.4 because it predates the v0.91.5 bridge split; implement the exporter as version-aware and use v0.91.5 for this milestone's immediate public-card wave."
+proposed_steps:
+  - id: "step-1"
+    description: "Confirm dependency readiness and starting state: Depends on `#3471` for final packet contract, but can proceed with the draft namespace and manifest shape if explicitly recorded."
+    expected_output: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-2"
+    description: "Review repo inputs and scoped surfaces before editing: `#3471`; `docs/milestones/v0.91.4/C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md`; `docs/planning/C_SDLC_PROMPT_TEMPLATE_EDITOR_TRANSITION_PLAN.md`; `docs/templates/prompts/current.json`; `adl/tools/pr.sh`; `adl/src/cli/pr_cmd*`; local `.adl/v0.91.4/tasks/` card bundles as source inputs only"
+    expected_output: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-3"
+    description: "Implement only the bounded deliverables: Exporter command or helper design for public prompt packets.; Initial implementation if small enough; otherwise an exact implementation follow-on with command shape and contract tests.; Public packet manifest fields for issue number, slug, template set, source refs, lifecycle state, validation state, redaction status, and tracker URL.; Rules for copying/sanitizing local cards into tracked packet records without treating `.adl` as canonical public truth.; Closeout integration notes for `pr finish` / `pr closeout`."
+    expected_output: "tracked issue work product"
+    allowed_mode: "execution_after_approval"
+  - id: "step-4"
+    description: "Run focused proof gates for acceptance: Export output uses repo-relative paths only.; Export does not add `.adl/` to Git.; Export refuses obvious secret markers, absolute host paths, private key filenames, and local scratch paths.; Export preserves template version and card lifecycle status.; Export distinguishes GitHub tracker identity from tracker-agnostic work-item identity so Jira or other adapters remain possible.; Focused tests or documented test plan prove the exporter contract."
+    expected_output: "validation evidence recorded in SOR"
+    allowed_mode: "execution_after_approval"
+  - id: "step-5"
+    description: "Record issue-specific review findings in SRP, issue outcome truth in SOR, and refresh this SPP if execution diverges."
+    expected_output: "reviewed SRP and truthful SOR"
+    allowed_mode: "execution_after_approval"
+codex_plan:
+  - step: "Confirm dependencies and starting state from the source issue prompt."
+    status: "pending"
+  - step: "Inspect repo inputs and target surfaces before editing."
+    status: "pending"
+  - step: "Implement the bounded deliverables only."
+    status: "pending"
+  - step: "Run focused validation and proof gates."
+    status: "pending"
+  - step: "Record issue-specific SRP findings and SOR outcome truth."
+    status: "pending"
+affected_areas:
+  - "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+invariants_to_preserve:
+  - "Keep SPP issue-local; do not turn it into sprint orchestration."
+  - "Keep SRP as review-result truth and SOR as output truth."
+risks_and_edge_cases:
+  - "Generated card may need editor tightening if the source issue prompt is underspecified."
+test_strategy:
+  - "Use `workflow-conductor` and the normal issue lifecycle.; Use focused tooling tests only unless Rust source changes require broader proof."
+execution_handoff: "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
+required_permissions:
+  - "workspace-write after execution approval"
+stop_conditions:
+  - "Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+  - "Stop and update SPP if touched files, proof gates, or validation commands change materially."
+  - "Stop and route follow-on work if acceptance requires scope outside this issue."
+alternatives_considered:
+  - description: "Rely only on transient chat planning."
+    reason_not_chosen: "Chat-only planning is not durable or reviewable enough for this workflow surface."
+review_hooks:
+  - "Check dependency truth, scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
+notes: "Generated from 1.0.0 template; update before continuing if execution diverges."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/spp.md`
+
+# Structured Plan Prompt
+
+## Plan Summary
+
+Design-time operative plan for `[v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter`.
+
+Issue-local execution plan for [v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter.
+
+## Codex Plan
+
+1. [pending] Confirm dependencies and starting state from the source issue prompt.
+2. [pending] Inspect repo inputs and target surfaces before editing.
+3. [pending] Implement the bounded deliverables only.
+4. [pending] Run focused validation and proof gates.
+5. [pending] Record issue-specific SRP findings and SOR outcome truth.
+
+## Assumptions
+
+- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs.
+
+## Proposed Steps
+
+1. Confirm dependency readiness and starting state: Depends on `#3471` for final packet contract, but can proceed with the draft namespace and manifest shape if explicitly recorded.
+2. Review repo inputs and scoped surfaces before editing: `#3471`; `docs/milestones/v0.91.4/C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md`; `docs/planning/C_SDLC_PROMPT_TEMPLATE_EDITOR_TRANSITION_PLAN.md`; `docs/templates/prompts/current.json`; `adl/tools/pr.sh`; `adl/src/cli/pr_cmd*`; local `.adl/v0.91.4/tasks/` card bundles as source inputs only
+3. Implement only the bounded deliverables: Exporter command or helper design for public prompt packets.; Initial implementation if small enough; otherwise an exact implementation follow-on with command shape and contract tests.; Public packet manifest fields for issue number, slug, template set, source refs, lifecycle state, validation state, redaction status, and tracker URL.; Rules for copying/sanitizing local cards into tracked packet records without treating `.adl` as canonical public truth.; Closeout integration notes for `pr finish` / `pr closeout`.
+4. Run focused proof gates for acceptance: Export output uses repo-relative paths only.; Export does not add `.adl/` to Git.; Export refuses obvious secret markers, absolute host paths, private key filenames, and local scratch paths.; Export preserves template version and card lifecycle status.; Export distinguishes GitHub tracker identity from tracker-agnostic work-item identity so Jira or other adapters remain possible.; Focused tests or documented test plan prove the exporter contract.
+5. Record issue-specific review findings in SRP, issue outcome truth in SOR, and refresh this SPP if execution diverges.
+
+## Affected Areas
+
+- v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter
+
+## Invariants To Preserve
+
+- Keep SPP issue-local; do not turn it into sprint orchestration.
+- Keep SRP as review-result truth and SOR as output truth.
+
+## Risks And Edge Cases
+
+- Generated card may need editor tightening if the source issue prompt is underspecified.
+
+## Test Strategy
+
+- Use `workflow-conductor` and the normal issue lifecycle.; Use focused tooling tests only unless Rust source changes require broader proof.
+
+## Execution Handoff
+
+Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes.
+
+## Stop Conditions
+
+- Stop and re-plan if dependencies are unmet or materially different from this design-time plan.
+- Stop and update SPP if touched files, proof gates, or validation commands change materially.
+- Stop and route follow-on work if acceptance requires scope outside this issue.
+
+## Notes
+
+Generated from 1.0.0 template; update before continuing if execution diverges.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md
@@ -1,0 +1,134 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-review-prompt"
+issue: 3472
+task_id: "issue-3472"
+version: "v0.91.5"
+title: "[v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter"
+branch: "codex/3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+generated_at: "2026-06-04T19:39:09Z"
+card_status: "approved"
+status: "approved"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/danielbaustin/agent-design-language/issues/3472"
+  - kind: "stp"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md"
+  - kind: "sip"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md"
+  - kind: "spp"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/spp.md"
+  - kind: "sor"
+    ref: ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sor.md"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md"
+  - ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md"
+in_scope_surfaces:
+  - "tracked changes for this issue branch"
+evidence_policy:
+  - "Use repository evidence, targeted validation output, and linked issue-bundle artifacts only."
+validation_inputs:
+  - "Issue-local proofs recorded in the SOR."
+allowed_dispositions:
+  - "PASS"
+  - "BLOCK"
+  - "NEEDS_FOLLOWUP"
+reviewer_constraints:
+  - "Do not widen issue scope."
+  - "Do not merge, publish, or close the issue."
+refusal_policy:
+  - "Refuse claims that are unsupported by repository evidence."
+  - "Refuse approving behavior outside the recorded issue scope."
+follow_up_routing:
+  - "Route actionable defects back to the issue branch before PR publication."
+non_claims:
+  - "This prompt does not claim review has already run."
+  - "This prompt does not guarantee review quality by itself."
+policy_refs:
+  - ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md"
+  - ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md"
+review_results:
+  findings_status: "no_open_findings"
+  recommended_outcome: "pass"
+notes: "Pre-PR review was run over the exporter, tests, docs, and generated packet. One review observation about stale packet replacement was fixed before publication."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/srp.md`
+
+# Structured Review Prompt
+
+## Review Summary
+
+Use this prompt to govern the independent pre-PR review for this issue. Review ran after implementation and before PR publication.
+
+## Scope Basis
+
+- .adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md
+- .adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md
+
+## In-Scope Surfaces
+
+- tracked changes for this issue branch
+
+## Evidence Rules
+
+- Use repository evidence, targeted validation output, and linked issue-bundle artifacts only.
+
+## Validation Inputs
+
+- Issue-local proofs recorded in the SOR.
+
+## Allowed Dispositions
+
+- PASS
+- BLOCK
+- NEEDS_FOLLOWUP
+
+## Reviewer Constraints
+
+- Do not widen issue scope.
+- Do not merge, publish, or close the issue.
+
+## Refusal Policy
+
+- Refuse claims that are unsupported by repository evidence.
+- Refuse approving behavior outside the recorded issue scope.
+
+## Follow-up Routing
+
+- Route actionable defects back to the issue branch before PR publication.
+
+## Non-Claims
+
+- This prompt does not claim review has already run.
+- This prompt does not guarantee review quality by itself.
+
+## Review Results
+
+Machine-readable review result is recorded in frontmatter:
+
+```yaml
+review_results:
+  findings_status: "no_open_findings"
+  recommended_outcome: "pass"
+```
+
+### Findings
+
+- No open findings remain.
+- Review observation fixed during review: the exporter now validates all source cards before replacing the packet directory, removes stale packet output on repeat export, and has a regression assertion for stale-file removal.
+
+### Dispositions
+
+- Stale-output replacement observation: fixed in `adl/src/cli/tooling_cmd/public_prompt_packet.rs` and covered by `public_prompt_packet_export_writes_manifest_readme_and_cards`.
+
+### Recommended Outcome
+
+- PASS. Proceed to `pr finish` / PR publication after final focused validation.
+
+## Notes
+
+Pre-PR review completed with no open findings. Residual risk: the first exporter performs refuse-not-rewrite hygiene checks; richer redaction policy remains owned by later public prompt validation work.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md
@@ -1,0 +1,96 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "WP-04"
+slug: "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+title: "[v0.91.5][WP-04][tools] Add public C-SDLC prompt packet exporter"
+labels:
+  - "track:roadmap"
+  - "area:docs"
+  - "area:tools"
+  - "type:task"
+  - "wp:WP-04"
+  - "wp:Sprint-1"
+  - "version:v0.91.5"
+issue_number: 3472
+generated_at: "2026-06-04T19:52:54Z"
+card_status: "ready"
+status: "draft"
+action: "edit"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "v0.91.5"
+required_outcome_type:
+  - "docs"
+repo_inputs:
+  - ".adl/v0.91.5/bodies/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter.md"
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Versioned C-SDLC prompt template applied; source issue prompt remains the design-time intent source."
+pr_start:
+  enabled: true
+  slug: "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.0/stp.md`
+Generated: 2026-06-04T19:52:54Z
+
+# Structured Task Prompt
+
+## Summary
+
+Add the tooling path that exports safe public C-SDLC prompt packets from local issue-card state into the tracked milestone evidence namespace.
+
+## Goal
+
+Make public prompt packet creation deterministic enough that future issue closeout can promote durable prompt truth without manually copying `.adl` files or tracking local scratch state.
+
+## Required Outcome
+
+ADL has a bounded exporter design and first implementation path for writing public prompt packets under `docs/milestones/v0.91.4/review/evidence/csdlc/issues/<issue-number>-&lt;slug&gt;/` with a manifest and sanitized `SIP`, `STP`, `SPP`, `SRP`, and `SOR` records.
+
+## Deliverables
+
+Exporter command or helper design for public prompt packets.; Initial implementation if small enough; otherwise an exact implementation follow-on with command shape and contract tests.; Public packet manifest fields for issue number, slug, template set, source refs, lifecycle state, validation state, redaction status, and tracker URL.; Rules for copying/sanitizing local cards into tracked packet records without treating `.adl` as canonical public truth.; Closeout integration notes for `pr finish` / `pr closeout`.
+
+## Acceptance Criteria
+
+Export output uses repo-relative paths only.; Export does not add `.adl/` to Git.; Export refuses obvious secret markers, absolute host paths, private key filenames, and local scratch paths.; Export preserves template version and card lifecycle status.; Export distinguishes GitHub tracker identity from tracker-agnostic work-item identity so Jira or other adapters remain possible.; Focused tests or documented test plan prove the exporter contract.
+
+## Repo Inputs
+
+`#3471`; `docs/milestones/v0.91.4/C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md`; `docs/planning/C_SDLC_PROMPT_TEMPLATE_EDITOR_TRANSITION_PLAN.md`; `docs/templates/prompts/current.json`; `adl/tools/pr.sh`; `adl/src/cli/pr_cmd*`; local `.adl/v0.91.4/tasks/` card bundles as source inputs only
+
+## Dependencies
+
+Depends on `#3471` for final packet contract, but can proceed with the draft namespace and manifest shape if explicitly recorded.
+
+## Target Files / Surfaces
+
+`#3471`; `docs/milestones/v0.91.4/C_SDLC_TRACKED_WORKFLOW_STATE_MIGRATION_PLAN_v0.91.4.md`; `docs/planning/C_SDLC_PROMPT_TEMPLATE_EDITOR_TRANSITION_PLAN.md`; `docs/templates/prompts/current.json`; `adl/tools/pr.sh`; `adl/src/cli/pr_cmd*`; local `.adl/v0.91.4/tasks/` card bundles as source inputs only
+
+## Validation Plan
+
+Use `workflow-conductor` and the normal issue lifecycle.; Use focused tooling tests only unless Rust source changes require broader proof.
+
+## Demo Expectations
+
+No runtime demo required. A small exported sample packet may serve as proof.
+
+## Non-goals
+
+Do not bulk-export all historical cards.; Do not ingest into ObsMem directly.; Do not support every external tracker adapter in this issue.; Do not rewrite card content beyond safe redaction/sanitization required for public records.
+
+## Issue-Graph Notes
+
+Feeds the pilot packet/index issue and the validation gate issue.; May produce follow-on work for deeper Rust integration if the first pass lands as a helper.
+
+## Notes
+
+This should be the bridge from local execution cache to public workflow truth. It is a small but critical mechanical seam.
+
+## Tooling Notes
+
+Generated from docs/templates/prompts/1.0.0/.

--- a/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json
+++ b/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json
@@ -1,0 +1,78 @@
+{
+  "cards": [
+    {
+      "card_status": "ready",
+      "kind": "sip",
+      "public_rel_path": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md",
+      "source_rel_path": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md",
+      "template_version": "1.0.0",
+      "validation_state": "source_present_export_hygiene_passed"
+    },
+    {
+      "card_status": "ready",
+      "kind": "stp",
+      "public_rel_path": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md",
+      "source_rel_path": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/stp.md",
+      "template_version": "1.0.0",
+      "validation_state": "source_present_export_hygiene_passed"
+    },
+    {
+      "card_status": "ready",
+      "kind": "spp",
+      "public_rel_path": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md",
+      "source_rel_path": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/spp.md",
+      "template_version": "1.0.0",
+      "validation_state": "source_present_export_hygiene_passed"
+    },
+    {
+      "card_status": "approved",
+      "kind": "srp",
+      "public_rel_path": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md",
+      "source_rel_path": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/srp.md",
+      "template_version": "1.0.0",
+      "validation_state": "source_present_export_hygiene_passed"
+    },
+    {
+      "card_status": "ready",
+      "kind": "sor",
+      "public_rel_path": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md",
+      "source_rel_path": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sor.md",
+      "template_version": "1.0.0",
+      "validation_state": "source_present_export_hygiene_passed"
+    }
+  ],
+  "generated_by": "adl tooling public-prompt-packet export",
+  "issue_number": 3472,
+  "non_claims": [
+    "This packet does not make local .adl state canonical public truth.",
+    "This packet does not claim runtime validation was executed.",
+    "This packet preserves source card text after export hygiene checks."
+  ],
+  "output_dir": "docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter",
+  "redaction": {
+    "checks": [
+      "sip: no host paths, secret-like tokens, private key markers, or local scratch paths",
+      "stp: no host paths, secret-like tokens, private key markers, or local scratch paths",
+      "spp: no host paths, secret-like tokens, private key markers, or local scratch paths",
+      "srp: no host paths, secret-like tokens, private key markers, or local scratch paths",
+      "sor: no host paths, secret-like tokens, private key markers, or local scratch paths"
+    ],
+    "mode": "refuse_not_rewrite",
+    "status": "passed"
+  },
+  "schema": "adl.public_prompt_packet.v1",
+  "slug": "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter",
+  "source_bundle": ".adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter",
+  "template_registry": "docs/templates/prompts/current.json",
+  "tracker": {
+    "issue_number": 3472,
+    "provider": "github",
+    "url": "https://github.com/danielbaustin/agent-design-language/issues/3472"
+  },
+  "version": "v0.91.5",
+  "work_item": {
+    "id": "issue-3472",
+    "kind": "issue",
+    "slug": "v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter"
+  }
+}


### PR DESCRIPTION
Closes #3472

## Summary
Implemented a version-aware public C-SDLC prompt packet exporter under
`adl tooling public-prompt-packet export`. The command copies the five lifecycle
cards into a tracked public packet, writes `manifest.json` and `README.md`,
preserves template/status metadata, separates GitHub tracker identity from
tracker-agnostic work-item identity, and refuses obvious publication-unsafe
source card content.

## Artifacts
- `adl/src/cli/tooling_cmd/public_prompt_packet.rs`
- `adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs`
- `docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md`
- `docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md`

## Validation
- Validation commands and their purpose:
  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo fmt --manifest-path adl/Cargo.toml`
    Formatted Rust changes.
  - `CARGO_HOME=$ADL_TEMP_CARGO_HOME cargo test --manifest-path adl/Cargo.toml public_prompt_packet -- --nocapture`
    Verified the new exporter contract tests; 2 tests passed in `src/main.rs` and 2 tests passed in `src/bin/adl_csdlc.rs`.
  - `./adl/target/debug/adl tooling public-prompt-packet export --issue 3472 --slug v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter --version v0.91.5 --tracker-url https://github.com/danielbaustin/agent-design-language/issues/3472`
    Verified real packet generation from the `#3472` card bundle.
  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind sip --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sip.md`
    Verified exported SIP structure.
  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind stp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/stp.md`
    Verified exported STP structure.
  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind spp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/spp.md`
    Verified exported SPP structure.
  - `./adl/target/debug/adl tooling prompt-template validate-structure --kind srp --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/srp.md`
    Verified exported SRP structure.
  - `./adl/target/debug/adl tooling validate-structured-prompt --type sor --phase bootstrap --input docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md`
    Verified exported SOR execution-record contract.
  - `git diff --check`
    Verified whitespace hygiene.
  - `ruby -rjson -e 'JSON.parse(File.read("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/manifest.json")); puts "manifest json ok"'`
    Verified exported manifest JSON parses.
  - `rg -n PUBLIC_PACKET_REDACTION_SCAN docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter`
    Verified the exported packet has no matches for the focused redaction scan.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3472__v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/sor.md
- Idempotency-Key: v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-public-prompt-packet-rs-adl-src-cli-tooling-cmd-tests-rs-adl-src-cli-tooling-cmd-tests-public-prompt-packet-rs-docs-milestones-v0-91-5-features-public-prompt-records-v0-91-5-md-docs-milestones-v0-91-5-review-evidence-csdlc-issues-issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-adl-v0-91-5-tasks-issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-sip-md-adl-v0-91-5-tasks-issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter-sor-md