### PR TITLE
[v0.91.5][tools][octocrab] Enforce GitHub fallback policy on live gh-backed operations

### DIFF
--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -9,7 +9,7 @@ mod godel_cmd;
 mod identity_cmd;
 mod observability;
 mod open;
-mod pr_cmd;
+pub(crate) mod pr_cmd;
 mod pr_cmd_args;
 mod pr_cmd_cards;
 mod pr_cmd_prompt;

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -43,6 +43,8 @@ mod github;
 mod github_client;
 mod lifecycle;
 
+pub(crate) use self::github::run_gh_capture_allow_failure;
+
 #[cfg(test)]
 type CreatePostBootstrapHook = fn(&Path, &IssueRef) -> Result<()>;
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -10,7 +10,8 @@ use super::git_support::{
 };
 use super::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
-    ensure_or_repair_pr_closing_linkage,
+    ensure_or_repair_pr_closing_linkage, run_gh_capture, run_gh_status,
+    run_gh_status_allow_failure,
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
@@ -180,8 +181,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     let pr_url = if let Some(existing) = current_pr_url(&repo, &branch)? {
         ensure_existing_pr_base_matches(&repo, &existing, &pr_base)?;
-        run_status(
-            "gh",
+        run_gh_status(
+            "pr.edit.finish_existing",
             &[
                 "pr",
                 "edit",
@@ -196,8 +197,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         )?;
         existing
     } else {
-        let created = run_capture(
-            "gh",
+        let created = run_gh_capture(
+            "pr.create.finish",
             &[
                 "pr",
                 "create",
@@ -227,10 +228,13 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     if parsed.merge_mode {
         if parsed.ready {
-            let _ = run_status_allow_failure("gh", &["pr", "ready", "-R", &repo, &pr_url])?;
+            let _ = run_gh_status_allow_failure(
+                "pr.ready.finish_merge",
+                &["pr", "ready", "-R", &repo, &pr_url],
+            )?;
         }
-        run_status(
-            "gh",
+        run_gh_status(
+            "pr.merge.finish",
             &[
                 "pr",
                 "merge",
@@ -253,7 +257,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     if parsed.ready {
-        let _ = run_status_allow_failure("gh", &["pr", "ready", "-R", &repo, &pr_url])?;
+        let _ =
+            run_gh_status_allow_failure("pr.ready.finish", &["pr", "ready", "-R", &repo, &pr_url])?;
     }
 
     attach_pr_janitor(
@@ -817,8 +822,8 @@ fn resolve_finish_pr_base(repo_root: &Path, branch: &str) -> Result<String> {
 }
 
 fn ensure_existing_pr_base_matches(repo: &str, pr_url: &str, expected_base: &str) -> Result<()> {
-    let actual_base = run_capture(
-        "gh",
+    let actual_base = run_gh_capture(
+        "pr.view.base_ref.finish_existing",
         &[
             "pr",
             "view",

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,9 +1,10 @@
 use super::*;
+use crate::cli::pr_cmd::git_support::run_status_allow_failure;
 use crate::cli::pr_cmd::github_client::{
     body_contains_closing_linkage, issue_labels_from_csv, issue_labels_from_csv_in_order,
     issue_metadata_drift, linked_issue_numbers_from_lines, linked_issue_numbers_include,
-    plan_issue_metadata_parity, pr_matches_main_version_wave, IssueMetadataSnapshot,
-    PullRequestMetadataSnapshot,
+    plan_issue_metadata_parity, pr_matches_main_version_wave, AdlGithubClient, GithubClientBackend,
+    GithubClientMode, IssueMetadataSnapshot, PullRequestMetadataSnapshot,
 };
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use ::adl::control_plane::resolve_primary_checkout_root;
@@ -26,9 +27,54 @@ pub(super) struct OpenPullRequest {
     pub(super) queue: Option<String>,
 }
 
+fn ensure_live_gh_allowed(operation: &str) -> Result<()> {
+    let client = AdlGithubClient::from_env()
+        .with_context(|| format!("github client policy rejected gh operation '{operation}'"))?;
+    let config = client.config();
+    match config.backend {
+        GithubClientBackend::GhFallback => Ok(()),
+        GithubClientBackend::Octocrab
+            if config.requested_mode == GithubClientMode::Auto && config.gh_fallback_allowed =>
+        {
+            Ok(())
+        }
+        GithubClientBackend::Octocrab => {
+            bail!(
+                "github_client.live_octocrab_transport_unavailable: gh operation '{}' is not allowed because {} selected backend '{}' and live octocrab transport is not implemented for this operation; unset ADL_GITHUB_CLIENT or allow gh fallback to use the current shell-backed path",
+                operation,
+                config.requested_mode.as_str(),
+                config.backend.as_str()
+            )
+        }
+    }
+}
+
+pub(super) fn run_gh_capture(operation: &str, args: &[&str]) -> Result<String> {
+    ensure_live_gh_allowed(operation)?;
+    run_capture("gh", args)
+}
+
+pub(crate) fn run_gh_capture_allow_failure(
+    operation: &str,
+    args: &[&str],
+) -> Result<Option<String>> {
+    ensure_live_gh_allowed(operation)?;
+    run_capture_allow_failure("gh", args)
+}
+
+pub(super) fn run_gh_status(operation: &str, args: &[&str]) -> Result<()> {
+    ensure_live_gh_allowed(operation)?;
+    run_status("gh", args)
+}
+
+pub(super) fn run_gh_status_allow_failure(operation: &str, args: &[&str]) -> Result<bool> {
+    ensure_live_gh_allowed(operation)?;
+    run_status_allow_failure("gh", args)
+}
+
 pub(super) fn current_pr_url(repo: &str, branch: &str) -> Result<Option<String>> {
-    let out = run_capture_allow_failure(
-        "gh",
+    let out = run_gh_capture_allow_failure(
+        "pr.list.current_branch",
         &[
             "pr", "list", "-R", repo, "--head", branch, "--state", "open", "--json", "url", "--jq",
             ".[0].url",
@@ -52,8 +98,8 @@ pub(super) fn unresolved_milestone_pr_wave(
     target_queue: &str,
     exclude_branch: Option<&str>,
 ) -> Result<Vec<OpenPullRequest>> {
-    let out = run_capture_allow_failure(
-        "gh",
+    let out = run_gh_capture_allow_failure(
+        "pr.list.open_wave",
         &[
             "pr",
             "list",
@@ -113,8 +159,8 @@ pub(super) fn format_open_pr_wave(prs: &[OpenPullRequest]) -> String {
 }
 
 pub(super) fn pr_has_closing_linkage(repo: &str, pr_ref: &str, issue: u32) -> Result<bool> {
-    let linked = run_capture_allow_failure(
-        "gh",
+    let linked = run_gh_capture_allow_failure(
+        "pr.view.closing_issues",
         &[
             "pr",
             "view",
@@ -132,8 +178,8 @@ pub(super) fn pr_has_closing_linkage(repo: &str, pr_ref: &str, issue: u32) -> Re
     if linked_issue_numbers_include(&linked_issue_numbers, issue) {
         return Ok(true);
     }
-    let body = run_capture_allow_failure(
-        "gh",
+    let body = run_gh_capture_allow_failure(
+        "pr.view.body",
         &[
             "pr", "view", "-R", repo, pr_ref, "--json", "body", "--jq", ".body",
         ],
@@ -175,8 +221,8 @@ pub(super) fn ensure_or_repair_pr_closing_linkage(
     if pr_has_closing_linkage(repo, pr_ref, issue)? {
         return Ok(false);
     }
-    run_status(
-        "gh",
+    run_gh_status(
+        "pr.edit.body_file",
         &[
             "pr",
             "edit",
@@ -308,8 +354,8 @@ fn helper_command_path(repo_root: &Path, relative: &str) -> String {
 }
 
 pub(super) fn issue_version(issue: u32, repo: &str) -> Result<Option<String>> {
-    let labels = run_capture_allow_failure(
-        "gh",
+    let labels = run_gh_capture_allow_failure(
+        "issue.view.labels_for_version",
         &[
             "issue",
             "view",
@@ -340,6 +386,7 @@ pub(super) fn gh_issue_create(
     body: &str,
     labels_csv: &str,
 ) -> Result<String> {
+    ensure_live_gh_allowed("issue.create")?;
     let mut cmd = Command::new("gh");
     cmd.arg("issue")
         .arg("create")
@@ -374,8 +421,8 @@ pub(super) fn gh_issue_create(
 }
 
 fn issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>> {
-    let labels = run_capture_allow_failure(
-        "gh",
+    let labels = run_gh_capture_allow_failure(
+        "issue.view.labels",
         &[
             "issue",
             "view",
@@ -398,8 +445,8 @@ fn issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>> {
 }
 
 fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {
-    run_status(
-        "gh",
+    run_gh_status(
+        "issue.edit.title",
         &[
             "issue",
             "edit",
@@ -423,7 +470,7 @@ fn gh_issue_add_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> 
         args.push("--add-label");
         args.push(label);
     }
-    run_status("gh", &args)
+    run_gh_status("issue.edit.add_labels", &args)
         .with_context(|| format!("create: gh issue add labels failed for issue #{issue}"))
 }
 
@@ -437,7 +484,7 @@ fn gh_issue_remove_labels(repo: &str, issue: u32, labels: &[String]) -> Result<(
         args.push("--remove-label");
         args.push(label);
     }
-    run_status("gh", &args)
+    run_gh_status("issue.edit.remove_labels", &args)
         .with_context(|| format!("create: gh issue remove labels failed for issue #{issue}"))
 }
 
@@ -489,8 +536,8 @@ pub(super) fn ensure_issue_metadata_parity(
 
 pub(super) fn gh_issue_edit_body(repo: &str, issue: u32, body: &str) -> Result<()> {
     let body_file = write_temp_markdown("issue_body", body)?;
-    run_status(
-        "gh",
+    run_gh_status(
+        "issue.edit.body",
         &[
             "issue",
             "edit",
@@ -505,8 +552,8 @@ pub(super) fn gh_issue_edit_body(repo: &str, issue: u32, body: &str) -> Result<(
 }
 
 pub(super) fn gh_issue_title(issue: u32, repo: &str) -> Result<Option<String>> {
-    let out = run_capture_allow_failure(
-        "gh",
+    let out = run_gh_capture_allow_failure(
+        "issue.view.title",
         &[
             "issue",
             "view",
@@ -564,9 +611,35 @@ mod tests {
         }
     }
 
+    fn clear_github_policy_env() -> Vec<(&'static str, Option<String>)> {
+        let keys = [
+            "ADL_GITHUB_CLIENT",
+            "ADL_GITHUB_DISABLE_GH_FALLBACK",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        ];
+        let saved = keys
+            .into_iter()
+            .map(|key| (key, std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+        unsafe {
+            for (key, _) in &saved {
+                std::env::remove_var(key);
+            }
+        }
+        saved
+    }
+
+    fn restore_github_policy_env(saved: Vec<(&'static str, Option<String>)>) {
+        for (key, value) in saved {
+            restore_env(key, value);
+        }
+    }
+
     #[test]
     fn closing_linkage_helpers_cover_reference_body_repair_and_error_paths() {
         let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
         let temp = unique_temp_dir("adl-github-closing-linkage");
         let bin_dir = temp.join("bin");
         fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -673,6 +746,7 @@ mod tests {
         let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
         assert!(gh_calls
             .contains("pr edit -R owner/repo https://github.com/owner/repo/pull/1161 --body-file"));
+        restore_github_policy_env(policy_env);
     }
 
     #[test]
@@ -839,6 +913,7 @@ mod tests {
     #[test]
     fn github_helpers_cover_fallback_and_spawn_failure_paths() {
         let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
         let temp = unique_temp_dir("adl-github-helper-fallbacks");
         let bin_dir = temp.join("bin");
         fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -918,11 +993,13 @@ mod tests {
             std::env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
             std::env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
         }
+        restore_github_policy_env(policy_env);
     }
 
     #[test]
     fn issue_metadata_helpers_preserve_create_body_title_and_label_parity() {
         let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
         let temp = unique_temp_dir("adl-github-issue-metadata");
         let bin_dir = temp.join("bin");
         fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -1049,5 +1126,97 @@ sys.exit(9)
         assert!(calls.contains("'--add-label', 'area:tools'"));
         assert!(calls.contains("'--add-label', 'version:v0.91.5'"));
         assert!(calls.contains("'--remove-label', 'version:v0.91.4'"));
+        restore_github_policy_env(policy_env);
+    }
+
+    #[test]
+    fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
+        let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
+        let temp = unique_temp_dir("adl-github-disabled-fallback");
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_log = temp.join("gh.log");
+        write_executable(
+            &bin_dir.join("gh"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nprintf 'unexpected gh spawn\\n'\n",
+                gh_log.display()
+            ),
+        );
+        let old_path = std::env::var("PATH").ok();
+        let mut path_entries = vec![bin_dir.clone()];
+        path_entries.extend(std::env::split_paths(old_path.as_deref().unwrap_or("")));
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                std::env::join_paths(path_entries).expect("join PATH"),
+            );
+            std::env::set_var("ADL_GITHUB_DISABLE_GH_FALLBACK", "1");
+        }
+
+        let err = current_pr_url("owner/repo", "codex/3672-branch")
+            .expect_err("fallback-disabled current_pr_url should fail closed");
+        let err_debug = format!("{err:?}");
+        assert!(err_debug.contains("pr.list.current_branch"));
+        assert!(err_debug.contains("github_client.fallback_disabled"));
+        let err = gh_issue_edit_body("owner/repo", 3672, "body")
+            .expect_err("fallback-disabled issue edit should fail closed");
+        let err_debug = format!("{err:?}");
+        assert!(err_debug.contains("issue.edit.body"));
+        assert!(err_debug.contains("github_client.fallback_disabled"));
+        assert!(
+            !gh_log.exists(),
+            "policy guard should reject before spawning gh"
+        );
+
+        restore_env("PATH", old_path);
+        restore_github_policy_env(policy_env);
+    }
+
+    #[test]
+    fn live_gh_policy_guard_blocks_explicit_octocrab_before_spawn() {
+        let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
+        let temp = unique_temp_dir("adl-github-explicit-octocrab");
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_log = temp.join("gh.log");
+        write_executable(
+            &bin_dir.join("gh"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nprintf 'unexpected gh spawn\\n'\n",
+                gh_log.display()
+            ),
+        );
+        let old_path = std::env::var("PATH").ok();
+        let mut path_entries = vec![bin_dir.clone()];
+        path_entries.extend(std::env::split_paths(old_path.as_deref().unwrap_or("")));
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                std::env::join_paths(path_entries).expect("join PATH"),
+            );
+            std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+            std::env::set_var("GITHUB_TOKEN", "test-token");
+        }
+
+        let err = current_pr_url("owner/repo", "codex/3672-branch")
+            .expect_err("explicit octocrab current_pr_url should fail closed");
+        let err_debug = format!("{err:?}");
+        assert!(err_debug.contains("pr.list.current_branch"));
+        assert!(err_debug.contains("github_client.live_octocrab_transport_unavailable"));
+        let err = gh_issue_edit_body("owner/repo", 3672, "body")
+            .expect_err("explicit octocrab issue edit should fail closed");
+        let err_debug = format!("{err:?}");
+        assert!(err_debug.contains("issue.edit.body"));
+        assert!(err_debug.contains("github_client.live_octocrab_transport_unavailable"));
+        assert!(
+            !gh_log.exists(),
+            "policy guard should reject before spawning gh"
+        );
+
+        restore_env("PATH", old_path);
+        restore_github_policy_env(policy_env);
     }
 }

--- a/adl/src/cli/pr_cmd_cards/prompt.rs
+++ b/adl/src/cli/pr_cmd_cards/prompt.rs
@@ -3,6 +3,7 @@ use serde_yaml::Value;
 use std::fs;
 use std::path::Path;
 
+use super::super::pr_cmd::run_gh_capture_allow_failure;
 use super::super::pr_cmd_prompt::{
     infer_required_outcome_type, infer_workflow_queue, infer_wp_from_title, normalize_labels_csv,
     render_generated_issue_prompt,
@@ -205,8 +206,9 @@ fn render_issue_prompt_from_authored_front_matter(issue: u32, body: &str) -> Opt
 }
 
 fn fetch_issue_body(repo: &str, issue: u32) -> Result<Option<String>> {
-    let output = match std::process::Command::new("gh")
-        .args([
+    let Some(body) = run_gh_capture_allow_failure(
+        "issue.view.body_for_prompt",
+        &[
             "issue",
             "view",
             &issue.to_string(),
@@ -216,19 +218,115 @@ fn fetch_issue_body(repo: &str, issue: u32) -> Result<Option<String>> {
             "body",
             "-q",
             ".body",
-        ])
-        .output()
-    {
-        Ok(output) => output,
-        Err(_) => return Ok(None),
-    };
-    if !output.status.success() {
+        ],
+    )?
+    else {
         return Ok(None);
-    }
-    let body = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    };
+    let body = body.trim().to_string();
     if body.is_empty() || body.eq_ignore_ascii_case("null") {
         Ok(None)
     } else {
         Ok(Some(body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::tests::env_lock;
+    use std::path::{Path, PathBuf};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).expect("temp dir");
+        path
+    }
+
+    fn write_executable(path: &Path, body: &str) {
+        fs::write(path, body).expect("script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).expect("chmod");
+        }
+    }
+
+    fn restore_env(key: &str, value: Option<String>) {
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    #[test]
+    fn fetch_issue_body_respects_github_fallback_policy() {
+        let _guard = env_lock();
+        let temp = unique_temp_dir("adl-fetch-issue-body-policy");
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_log = temp.join("gh.log");
+        write_executable(
+            &bin_dir.join("gh"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nprintf 'Issue body from gh\\n'\n",
+                gh_log.display()
+            ),
+        );
+
+        let old_path = std::env::var("PATH").ok();
+        let old_client = std::env::var("ADL_GITHUB_CLIENT").ok();
+        let old_disable = std::env::var("ADL_GITHUB_DISABLE_GH_FALLBACK").ok();
+        let old_github_token = std::env::var("GITHUB_TOKEN").ok();
+        let old_gh_token = std::env::var("GH_TOKEN").ok();
+        let mut path_entries = vec![bin_dir.clone()];
+        path_entries.extend(std::env::split_paths(old_path.as_deref().unwrap_or("")));
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                std::env::join_paths(path_entries).expect("join PATH"),
+            );
+            std::env::remove_var("ADL_GITHUB_CLIENT");
+            std::env::remove_var("ADL_GITHUB_DISABLE_GH_FALLBACK");
+            std::env::remove_var("GITHUB_TOKEN");
+            std::env::remove_var("GH_TOKEN");
+        }
+
+        assert_eq!(
+            fetch_issue_body("owner/repo", 3672).expect("fetch body"),
+            Some("Issue body from gh".to_string())
+        );
+        fs::remove_file(&gh_log).expect("clear gh log");
+
+        unsafe {
+            std::env::set_var("ADL_GITHUB_DISABLE_GH_FALLBACK", "1");
+        }
+        let err = fetch_issue_body("owner/repo", 3672)
+            .expect_err("fallback-disabled body fetch should fail closed");
+        let err_debug = format!("{err:?}");
+        assert!(err_debug.contains("issue.view.body_for_prompt"));
+        assert!(err_debug.contains("github_client.fallback_disabled"));
+        assert!(
+            !gh_log.exists(),
+            "policy guard should reject before spawning gh"
+        );
+
+        restore_env("PATH", old_path);
+        restore_env("ADL_GITHUB_CLIENT", old_client);
+        restore_env("ADL_GITHUB_DISABLE_GH_FALLBACK", old_disable);
+        restore_env("GITHUB_TOKEN", old_github_token);
+        restore_env("GH_TOKEN", old_gh_token);
     }
 }

--- a/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
+++ b/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
@@ -26,6 +26,8 @@ The shared layer owns:
 - Fallback policy for `auto`, `octocrab`, and `gh` modes.
 - Fail-closed shell fallback disablement through
   `ADL_GITHUB_DISABLE_GH_FALLBACK`.
+- Live `gh` process guards for issue and PR workflow operations that have not
+  yet migrated to trait-backed octocrab transport.
 - Issue metadata parity planning.
 - PR wave filtering.
 - PR closing-linkage interpretation.
@@ -37,6 +39,9 @@ The shared layer owns:
 - Do not remove `gh` fallback in this migration slice.
 - Do not silently use `gh` fallback when `ADL_GITHUB_DISABLE_GH_FALLBACK`
   is enabled.
+- Do not silently use `gh` when `ADL_GITHUB_CLIENT=octocrab` explicitly selects
+  octocrab for a live operation that is still shell-backed; fail closed instead
+  until that operation has a real octocrab implementation.
 - Do not introduce GitHub App authentication in this migration slice.
 - Do not rename public workflow commands in this migration slice.
 
@@ -47,6 +52,8 @@ The focused ownership checks live in the Rust CLI tests:
 - `csdlc_dispatch_exposes_help_and_version_without_runtime_dispatch`
 - `csdlc_issue_run_maps_to_existing_pr_start_command`
 - `csdlc_github_client_boundary_doc_records_shared_ownership`
+- `live_gh_policy_guard_blocks_disabled_fallback_before_spawn`
+- `live_gh_policy_guard_blocks_explicit_octocrab_before_spawn`
 
 These checks prove that `adl-csdlc` remains a compatibility surface over the
 shared PR control-plane path instead of becoming a second GitHub workflow truth.

--- a/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
+++ b/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
@@ -24,6 +24,9 @@ operation now uses live octocrab network calls.
   `adl-csdlc` stays on the shared PR control-plane path.
 - `#3641` added fail-closed shell fallback disablement and this migration review
   packet.
+- `#3672` wires that fallback policy into live shell-backed issue and PR
+  workflow operations so disabled fallback and explicit octocrab mode fail
+  before spawning `gh`.
 
 ## Mode Policy
 
@@ -34,6 +37,10 @@ operation now uses live octocrab network calls.
 - `ADL_GITHUB_CLIENT=gh` explicitly selects `gh` fallback.
 - `ADL_GITHUB_DISABLE_GH_FALLBACK=1` disables shell fallback and fails closed
   for shell-backed modes.
+- Live operations that are still shell-backed may use `gh` only when fallback is
+  allowed. If `ADL_GITHUB_CLIENT=octocrab` explicitly selects octocrab, or
+  fallback is disabled, those live paths fail closed until a trait-backed
+  octocrab implementation exists for the operation.
 
 The stable failure code for disabled shell fallback is
 `github_client.fallback_disabled`.
@@ -49,7 +56,8 @@ The following operations still route through the existing `gh` command path:
 - live issue and PR linkage checks where the current code calls `gh`
 
 This is intentional for this migration wave. The typed helpers now own shared
-interpretation, but live network mutation was not migrated in this slice.
+interpretation and shell-fallback admission, but live network mutation was not
+migrated in this slice.
 
 ## Follow-On Routes
 


### PR DESCRIPTION
Closes #3672

## Summary
Implemented the octocrab P1 safety wiring so live shell-backed C-SDLC GitHub operations consult the typed GitHub client fallback policy before spawning `gh`.

## Artifacts
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md`
- `docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_client -- --nocapture`
    Verified typed GitHub client policy and existing octocrab migration boundary checks.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl live_gh_policy_guard -- --nocapture`
    Verified new policy guard regression tests.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests:: -- --nocapture`
    Verified existing guarded fake-`gh` helper compatibility tests.
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling validate-structured-prompt --type sor --phase bootstrap --input .adl/v0.91.5/tasks/issue-3672__v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations/sor.md`
    Verified SOR contract compliance after execution-record updates.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- pr_cmd`
    Generated coverage-impact summary for changed Rust PR command files.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight passed.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3672__v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3672__v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations/sor.md
- Idempotency-Key: v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-finish-support-rs-docs-tooling-adl-csdlc-github-client-boundary-md-docs-tooling-adl-octocrab-migration-review-md-adl-v0-91-5-tasks-issue-3672-v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations-sip-md-adl-v0-91-5-tasks-issue-3672-v0-91-5-tools-octocrab-enforce-github-fallback-policy-on-live-gh-backed-operations-sor-md