### PR TITLE
[v0.91.5][WP-07][quality] Add public prompt packet validation and redaction gates

### DIFF
--- a/adl/src/cli/tooling_cmd/public_prompt_packet.rs
+++ b/adl/src/cli/tooling_cmd/public_prompt_packet.rs
@@ -1,16 +1,16 @@
 use anyhow::{bail, ensure, Result};
-use serde_json::json;
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::common::{
     contains_absolute_host_path_in_text, contains_secret_like_token, is_normalized_slug,
-    repo_relative_display, repo_root, valid_github_issue_url, valid_version,
+    is_repo_relative, repo_relative_display, repo_root, valid_github_issue_url, valid_version,
 };
 use super::structured_prompt::{
     validate_sip_text, validate_sor_text, validate_spp_text, validate_srp_text, validate_stp_text,
 };
-use super::tooling_usage;
 
 const CARD_KINDS: [&str; 5] = ["sip", "stp", "spp", "srp", "sor"];
 
@@ -21,17 +21,20 @@ pub(crate) fn real_public_prompt_packet(args: &[String]) -> Result<()> {
 
     match subcommand {
         "export" => export_public_prompt_packet(&args[1..]),
+        "validate" => validate_public_prompt_packet(&args[1..]),
         "--help" | "-h" | "help" => {
-            println!("{}", tooling_usage());
+            println!("{}", public_prompt_packet_usage());
             Ok(())
         }
-        other => bail!("unknown public-prompt-packet subcommand '{other}' (expected export)"),
+        other => {
+            bail!("unknown public-prompt-packet subcommand '{other}' (expected export | validate)")
+        }
     }
 }
 
 fn export_public_prompt_packet(args: &[String]) -> Result<()> {
     if has_help_arg(args) {
-        println!("{}", tooling_usage());
+        println!("{}", public_prompt_packet_usage());
         return Ok(());
     }
 
@@ -240,6 +243,352 @@ fn validate_public_card_text(kind: &str, source_path: &Path, text: &str) -> Resu
         _ => bail!("unsupported public prompt card kind: {kind}"),
     }
     Ok(())
+}
+
+fn validate_public_prompt_packet(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", public_prompt_packet_usage());
+        return Ok(());
+    }
+
+    let mut packet: Option<PathBuf> = None;
+    let mut root_override: Option<PathBuf> = None;
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--packet" => {
+                idx += 1;
+                packet = Some(PathBuf::from(value_arg(args, idx, "--packet")?));
+            }
+            "--repo-root" => {
+                idx += 1;
+                root_override = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            other => bail!("unknown arg for tooling public-prompt-packet validate: {other}"),
+        }
+        idx += 1;
+    }
+
+    let root = root_override.unwrap_or(repo_root()?);
+    let packet = packet.ok_or_else(|| anyhow::anyhow!("validate requires --packet"))?;
+    let packet = absolutize_against(&root, &packet);
+    ensure!(
+        packet.is_dir(),
+        "packet path is not a directory: {}",
+        packet.display()
+    );
+
+    let manifests = manifest_paths_for_packet_input(&packet)?;
+    ensure!(
+        !manifests.is_empty(),
+        "no public prompt packet manifests found under {}",
+        packet.display()
+    );
+
+    let mut warnings = Vec::new();
+    for manifest_path in &manifests {
+        validate_one_packet(&root, manifest_path, &mut warnings)?;
+    }
+
+    for warning in &warnings {
+        eprintln!("WARN: {warning}");
+    }
+    println!(
+        "PASS: public prompt packet validation passed for {} packet(s){}",
+        manifests.len(),
+        if warnings.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " with {} completed-card diagnostic warning(s)",
+                warnings.len()
+            )
+        }
+    );
+    Ok(())
+}
+
+fn manifest_paths_for_packet_input(packet: &Path) -> Result<Vec<PathBuf>> {
+    let direct = packet.join("manifest.json");
+    if direct.is_file() {
+        return Ok(vec![direct]);
+    }
+    let mut manifests = Vec::new();
+    for entry in fs::read_dir(packet)? {
+        let entry = entry?;
+        let path = entry.path().join("manifest.json");
+        if path.is_file() {
+            manifests.push(path);
+        }
+    }
+    manifests.sort();
+    Ok(manifests)
+}
+
+fn validate_one_packet(
+    root: &Path,
+    manifest_path: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let packet_dir = manifest_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("manifest has no parent: {}", manifest_path.display()))?;
+    let manifest_text = fs::read_to_string(manifest_path)?;
+    ensure_public_text_is_safe("manifest", manifest_path, &manifest_text)?;
+    let manifest: Value = serde_json::from_str(&manifest_text)?;
+
+    ensure!(
+        manifest.get("schema").and_then(Value::as_str) == Some("adl.public_prompt_packet.v1"),
+        "{} schema must be adl.public_prompt_packet.v1",
+        manifest_path.display()
+    );
+    let version = required_str(&manifest, "version", manifest_path)?;
+    ensure!(
+        valid_version(version),
+        "{} version must be a milestone version",
+        manifest_path.display()
+    );
+    let issue = manifest
+        .get("issue_number")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} issue_number must be a positive integer",
+                manifest_path.display()
+            )
+        })?;
+    ensure!(
+        issue > 0,
+        "{} issue_number must be positive",
+        manifest_path.display()
+    );
+    let slug = required_str(&manifest, "slug", manifest_path)?;
+    ensure!(
+        is_normalized_slug(slug),
+        "{} slug must be normalized kebab-case",
+        manifest_path.display()
+    );
+    let source_bundle = required_str(&manifest, "source_bundle", manifest_path)?;
+    ensure_safe_source_provenance(source_bundle, manifest_path)?;
+    let output_dir = required_str(&manifest, "output_dir", manifest_path)?;
+    ensure_repo_relative_public_path(output_dir, manifest_path)?;
+    ensure!(
+        root.join(output_dir).is_dir() || packet_dir == root.join(output_dir),
+        "{} output_dir must point at the packet directory",
+        manifest_path.display()
+    );
+    validate_tracker(&manifest, issue, manifest_path)?;
+    validate_redaction_block(&manifest, manifest_path)?;
+
+    let cards = manifest
+        .get("cards")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("{} cards must be an array", manifest_path.display()))?;
+    ensure!(
+        cards.len() == CARD_KINDS.len(),
+        "{} cards must contain five lifecycle cards",
+        manifest_path.display()
+    );
+    let mut seen = BTreeSet::new();
+    for card in cards {
+        let kind = required_str(card, "kind", manifest_path)?;
+        ensure!(
+            CARD_KINDS.contains(&kind),
+            "{} has unsupported card kind {kind}",
+            manifest_path.display()
+        );
+        ensure!(
+            seen.insert(kind.to_string()),
+            "{} has duplicate card kind {kind}",
+            manifest_path.display()
+        );
+        let source_rel = required_str(card, "source_rel_path", manifest_path)?;
+        ensure_safe_source_provenance(source_rel, manifest_path)?;
+        let public_rel = required_str(card, "public_rel_path", manifest_path)?;
+        ensure_repo_relative_public_path(public_rel, manifest_path)?;
+        ensure!(
+            !public_rel.contains(".adl/"),
+            "{} public_rel_path must not point into .adl: {public_rel}",
+            manifest_path.display()
+        );
+        let public_path = root.join(public_rel);
+        ensure!(
+            public_path.is_file(),
+            "{} public card path does not exist: {public_rel}",
+            manifest_path.display()
+        );
+        let text = fs::read_to_string(&public_path)?;
+        ensure_public_text_is_safe(kind, &public_path, &text)?;
+        validate_public_card_for_packet(kind, &public_path, &text, warnings)?;
+    }
+    for kind in CARD_KINDS {
+        ensure!(
+            seen.contains(kind),
+            "{} missing {kind} card",
+            manifest_path.display()
+        );
+    }
+
+    let readme = packet_dir.join("README.md");
+    ensure!(
+        readme.is_file(),
+        "{} packet README.md is missing",
+        packet_dir.display()
+    );
+    ensure_public_text_is_safe("README.md", &readme, &fs::read_to_string(&readme)?)?;
+    Ok(())
+}
+
+fn required_str<'a>(value: &'a Value, key: &str, manifest_path: &Path) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} missing required string field {key}",
+                manifest_path.display()
+            )
+        })
+}
+
+fn validate_tracker(manifest: &Value, issue: u64, manifest_path: &Path) -> Result<()> {
+    let tracker = manifest
+        .get("tracker")
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow::anyhow!("{} tracker must be an object", manifest_path.display()))?;
+    ensure!(
+        tracker.get("provider").and_then(Value::as_str) == Some("github"),
+        "{} tracker.provider must be github",
+        manifest_path.display()
+    );
+    ensure!(
+        tracker.get("issue_number").and_then(Value::as_u64) == Some(issue),
+        "{} tracker.issue_number must match issue_number",
+        manifest_path.display()
+    );
+    let url = tracker.get("url").and_then(Value::as_str).ok_or_else(|| {
+        anyhow::anyhow!("{} tracker.url must be present", manifest_path.display())
+    })?;
+    ensure!(
+        valid_github_issue_url(url),
+        "{} tracker.url must be a GitHub issue URL",
+        manifest_path.display()
+    );
+    Ok(())
+}
+
+fn validate_redaction_block(manifest: &Value, manifest_path: &Path) -> Result<()> {
+    let redaction = manifest
+        .get("redaction")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            anyhow::anyhow!("{} redaction must be an object", manifest_path.display())
+        })?;
+    ensure!(
+        redaction.get("status").and_then(Value::as_str) == Some("passed"),
+        "{} redaction.status must be passed",
+        manifest_path.display()
+    );
+    ensure!(
+        redaction.get("mode").and_then(Value::as_str) == Some("refuse_not_rewrite"),
+        "{} redaction.mode must be refuse_not_rewrite",
+        manifest_path.display()
+    );
+    ensure!(
+        redaction
+            .get("checks")
+            .and_then(Value::as_array)
+            .is_some_and(|checks| !checks.is_empty()),
+        "{} redaction.checks must be a non-empty array",
+        manifest_path.display()
+    );
+    Ok(())
+}
+
+fn ensure_repo_relative_public_path(value: &str, manifest_path: &Path) -> Result<()> {
+    ensure!(
+        is_repo_relative(value),
+        "{} path must be repo-relative and must not contain traversal: {value}",
+        manifest_path.display()
+    );
+    ensure!(
+        !contains_local_scratch_marker(value),
+        "{} path contains local scratch/worktree marker: {value}",
+        manifest_path.display()
+    );
+    Ok(())
+}
+
+fn ensure_safe_source_provenance(value: &str, manifest_path: &Path) -> Result<()> {
+    ensure_repo_relative_public_path(value, manifest_path)?;
+    if value.contains(".adl/") {
+        ensure!(
+            value.starts_with(".adl/")
+                && value.contains("/tasks/")
+                && !value.contains(".worktrees/")
+                && !value.contains(".codex/"),
+            "{} .adl provenance must be a repo-relative task-bundle path, not scratch/private state: {value}",
+            manifest_path.display()
+        );
+    }
+    Ok(())
+}
+
+fn ensure_public_text_is_safe(label: &str, path: &Path, text: &str) -> Result<()> {
+    if contains_absolute_host_path_in_text(text)
+        || contains_secret_like_token(text)
+        || contains_private_key_marker(text)
+        || contains_local_scratch_marker(text)
+    {
+        bail!(
+            "public prompt packet {label} contains disallowed public content: {}",
+            path.display()
+        );
+    }
+    ensure!(
+        !text.contains("{{") && !text.contains("}}"),
+        "public prompt packet {label} contains unresolved template markers: {}",
+        path.display()
+    );
+    Ok(())
+}
+
+fn validate_public_card_for_packet(
+    kind: &str,
+    public_path: &Path,
+    text: &str,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    match kind {
+        "sip" => validate_sip_text(text, public_path, Some("bootstrap"))?,
+        "stp" => validate_stp_text(text)?,
+        "spp" => validate_spp_text(text)?,
+        "srp" => validate_srp_text(text)?,
+        "sor" => match validate_sor_text(text, Some("completed")) {
+            Ok(()) => {}
+            Err(completed_err) => {
+                validate_sor_text(text, Some("bootstrap")).map_err(|bootstrap_err| {
+                    anyhow::anyhow!(
+                        "{} SOR must satisfy completed or bootstrap structured prompt validation; completed: {completed_err}; bootstrap: {bootstrap_err}",
+                        public_path.display()
+                    )
+                })?;
+                warnings.push(format!(
+                    "{} accepted as bootstrap-phase SOR; completed-phase diagnostic: {completed_err}",
+                    public_path.display()
+                ));
+            }
+        },
+        _ => bail!("unsupported public prompt card kind: {kind}"),
+    }
+    Ok(())
+}
+
+fn public_prompt_packet_usage() -> &'static str {
+    "adl tooling public-prompt-packet export --issue <number> --slug <slug> --version <version> [--source <dir>] [--out-root <dir>] [--tracker-url <url>] [--repo-root <path>]\n\
+adl tooling public-prompt-packet validate --packet <dir> [--repo-root <path>]"
 }
 
 fn contains_private_key_marker(text: &str) -> bool {

--- a/adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs
+++ b/adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs
@@ -28,6 +28,17 @@ fn public_prompt_packet_export_writes_manifest_readme_and_cards() {
     let packet = repo
         .path()
         .join("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-public-card-export");
+
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--packet".to_string(),
+        packet.to_string_lossy().to_string(),
+    ])
+    .expect("validate exported public prompt packet");
+
     assert!(packet.join("README.md").is_file());
     assert!(packet.join("cards/sip.md").is_file());
     assert!(packet.join("cards/stp.md").is_file());
@@ -121,6 +132,141 @@ fn public_prompt_packet_export_refuses_host_paths_and_secret_markers() {
     assert!(err
         .to_string()
         .contains("contains disallowed public-packet content"));
+}
+
+#[test]
+fn public_prompt_packet_validate_fails_closed_on_manifest_and_redaction_drift() {
+    let repo = TempRepo::new("public-prompt-packet-validate-fail");
+    let source = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3472__public-card-export");
+    render_sample_cards(&repo, &source);
+
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3472".to_string(),
+        "--slug".to_string(),
+        "public-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+        "--tracker-url".to_string(),
+        "https://github.com/danielbaustin/agent-design-language/issues/3472".to_string(),
+    ])
+    .expect("export public prompt packet");
+
+    let packet = repo
+        .path()
+        .join("docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-public-card-export");
+    let manifest_path = packet.join("manifest.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["tracker"]["url"] = serde_json::Value::Null;
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap() + "\n",
+    )
+    .unwrap();
+
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--packet".to_string(),
+        packet.to_string_lossy().to_string(),
+    ])
+    .expect_err("missing tracker URL should fail closed");
+    assert!(err.to_string().contains("tracker.url must be present"));
+
+    manifest["tracker"]["url"] = serde_json::Value::String(
+        "https://github.com/danielbaustin/agent-design-language/issues/3472".to_string(),
+    );
+    manifest["source_bundle"] = serde_json::Value::String(
+        "/Users/example/agent-design-language/.worktrees/adl-wp-3472/.adl/v0.91.5/tasks/issue-3472__public-card-export".to_string(),
+    );
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap() + "\n",
+    )
+    .unwrap();
+
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--packet".to_string(),
+        packet.to_string_lossy().to_string(),
+    ])
+    .expect_err("absolute source path should fail closed");
+    assert!(err.to_string().contains("disallowed public content"));
+}
+
+#[test]
+fn public_prompt_packet_validate_covers_root_help_and_missing_artifacts() {
+    let repo = TempRepo::new("public-prompt-packet-validate-root");
+    let source = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3472__public-card-export");
+    render_sample_cards(&repo, &source);
+
+    real_tooling(&["public-prompt-packet".to_string(), "help".to_string()])
+        .expect("public prompt packet help should render");
+
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+    ])
+    .expect_err("missing packet arg should fail");
+    assert!(err.to_string().contains("validate requires --packet"));
+
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "export".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--issue".to_string(),
+        "3472".to_string(),
+        "--slug".to_string(),
+        "public-card-export".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+        "--tracker-url".to_string(),
+        "https://github.com/danielbaustin/agent-design-language/issues/3472".to_string(),
+    ])
+    .expect("export public prompt packet");
+
+    let packet_root = repo
+        .path()
+        .join("docs/milestones/v0.91.5/review/evidence/csdlc/issues");
+    real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--packet".to_string(),
+        packet_root.to_string_lossy().to_string(),
+    ])
+    .expect("validate packet root");
+
+    let packet = packet_root.join("issue-3472-public-card-export");
+    fs::remove_file(packet.join("README.md")).unwrap();
+    let err = real_tooling(&[
+        "public-prompt-packet".to_string(),
+        "validate".to_string(),
+        "--repo-root".to_string(),
+        repo.path().to_string_lossy().to_string(),
+        "--packet".to_string(),
+        packet.to_string_lossy().to_string(),
+    ])
+    .expect_err("missing readme should fail");
+    assert!(err.to_string().contains("packet README.md is missing"));
 }
 
 fn render_sample_cards(repo: &TempRepo, source: &Path) {

--- a/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md
@@ -77,6 +77,35 @@ host-local absolute paths, secret-like tokens, private key markers, local scratc
 paths, or unresolved template markers. Later redaction gates may add richer
 review, but this first exporter must not silently sanitize away lifecycle truth.
 
+## Validation Command
+
+Public prompt packets are validated with the paired read-only command:
+
+```bash
+adl tooling public-prompt-packet validate \
+  --packet <packet-dir-or-packet-root> \
+  [--repo-root <repo-root>]
+```
+
+The command accepts either one packet directory containing `manifest.json` or a
+packet root whose direct children contain public prompt packet manifests. It
+fails closed when a packet is missing required manifest fields, has non-GitHub
+tracker metadata for the current v1 packet shape, points public paths into
+`.adl/`, references missing card files, contains unresolved template markers,
+or contains obvious host-local paths, local scratch/worktree paths, private-key
+markers, or secret-like tokens.
+
+The validator treats `.adl/<version>/tasks/...` as allowable source provenance
+only when it is recorded as a repo-relative task-bundle path. `.worktrees/`,
+`.codex/`, absolute checkout paths, and temp/scratch paths are not valid public
+packet provenance.
+
+The gate also runs the structured prompt validators over all five exported
+cards. `SIP`, `STP`, `SPP`, and `SRP` must satisfy their current structured
+prompt contracts. `SOR` may satisfy either the completed-phase or bootstrap
+structured contract so the gate can validate both completed public records and
+freshly rendered sample packets without rewriting card truth.
+
 ## Execution Flow
 
 1. Define/export prompt packets.
@@ -96,8 +125,10 @@ Public packet generation must not depend on host paths or hidden local state.
 
 ## Validation
 
-Validation should include prompt packet structure, redaction scan, link checks,
-and archive/deletion review checklist.
+Validation should include prompt packet structure, manifest shape, tracker
+metadata, redaction/path safety scanning, structured prompt-card checks, link
+checks, and archive/deletion review checklist. The public packet validator is a
+focused docs/tooling gate, not a runtime proof lane.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Closes #3475

## Summary
Implemented a read-only public prompt packet validation gate for `adl tooling
public-prompt-packet validate`. The gate validates packet manifests, tracker
metadata, redaction status, source provenance, public card paths, unresolved
template markers, host-local/scratch/secret-like content, and structured
prompt-card contracts. It accepts completed-phase or bootstrap-phase `SOR`
records so it can validate both completed public packets and freshly rendered
sample packets without rewriting lifecycle truth.

## Artifacts
- `adl/src/cli/tooling_cmd/public_prompt_packet.rs`
- `adl/src/cli/tooling_cmd.rs`
- `adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs`
- `docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`
    Confirmed Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet -- --nocapture`
    Confirmed public packet export/validate behavior and fail-closed regression coverage.
  - `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling public-prompt-packet validate --packet docs/milestones/v0.91.5/review/evidence/csdlc/issues --repo-root .`
    Confirmed the public packet root present on this branch validates.
  - `git diff --check`
    Confirmed whitespace hygiene.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- public_prompt_packet`
    Confirmed coverage-impact evidence for the changed public-prompt-packet validator surface.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Confirmed the coverage-impact guard passed before PR publication.
- Results:
  - PASS: `cargo fmt --manifest-path adl/Cargo.toml -- --check`
  - PASS: `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet -- --nocapture`
  - PASS: `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling public-prompt-packet validate --packet docs/milestones/v0.91.5/review/evidence/csdlc/issues --repo-root .`
  - PASS: `git diff --check`
  - PASS: `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- public_prompt_packet`
  - PASS: `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3475__v0-91-5-wp-07-quality-add-public-prompt-packet-validation-and-redaction-gates/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3475__v0-91-5-wp-07-quality-add-public-prompt-packet-validation-and-redaction-gates/sor.md
- Idempotency-Key: v0-91-5-wp-07-quality-add-public-prompt-packet-validation-and-redaction-gates-adl-src-cli-tooling-cmd-public-prompt-packet-rs-adl-src-cli-tooling-cmd-tests-public-prompt-packet-rs-docs-milestones-v0-91-5-features-public-prompt-records-v0-91-5-md-adl-v0-91-5-tasks-issue-3475-v0-91-5-wp-07-quality-add-public-prompt-packet-validation-and-redaction-gates-sip-md-adl-v0-91-5-tasks-issue-3475-v0-91-5-wp-07-quality-add-public-prompt-packet-validation-and-redaction-gates-sor-md