### PR TITLE
[v0.91.5][tools][validation] Make pr finish honor focused validation lanes

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -430,7 +430,7 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
     }
     if paths
         .iter()
-        .all(|path| finish_path_is_focused_local_ci_gated(path))
+        .all(|path| finish_path_is_docs_only(path) || finish_path_is_focused_local_ci_gated(path))
     {
         let mut commands = vec![
             "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
@@ -440,8 +440,27 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             .iter()
             .any(|path| finish_path_needs_pr_finish_rust_focused_validation(path))
         {
-            commands.push("cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string());
-            commands.push("cargo test --manifest-path adl/Cargo.toml cli::pr_cmd".to_string());
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd",
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_public_prompt_packet_focused_validation(path))
+        {
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet",
+            );
         }
         if paths
             .iter()
@@ -504,6 +523,12 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
     })
 }
 
+fn push_finish_validation_command(commands: &mut Vec<String>, command: &str) {
+    if !commands.iter().any(|existing| existing == command) {
+        commands.push(command.to_string());
+    }
+}
+
 pub(super) fn select_finish_validation_plan_for_finish(
     requested_paths_csv: &str,
     changed_paths: &[String],
@@ -563,6 +588,8 @@ fn finish_path_is_focused_local_ci_gated(path: &str) -> bool {
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
             | "adl/src/cli/pr_cmd/finish_support.rs"
+            | "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
+            | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("docs/milestones/v0.91.4/review/merge_readiness/")
         || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
@@ -582,6 +609,15 @@ fn finish_path_needs_coverage_tooling_focused_validation(path: &str) -> bool {
         ".github/workflows/ci.yaml"
             | "adl/tools/check_coverage_impact.sh"
             | "adl/tools/test_check_coverage_impact.sh"
+    )
+}
+
+fn finish_path_needs_public_prompt_packet_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
+            | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
     )
 }
 
@@ -672,6 +708,19 @@ pub(super) fn run_finish_validation_rust(
                             "--manifest-path",
                             path_str(&manifest)?,
                             "cli::pr_cmd",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet" => {
+                    run_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-csdlc",
+                            "public_prompt_packet",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -512,6 +512,40 @@ fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request()
 }
 
 #[test]
+fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/src/cli/tooling_cmd/public_prompt_packet.rs".to_string(),
+            "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs".to_string(),
+            "docs/milestones/v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md".to_string(),
+        ],
+    )
+    .expect("public prompt packet plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet"
+            .to_string()
+    ));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo nextest")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("--doc --all-features")));
+}
+
+#[test]
 fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-focused-validation");
@@ -558,7 +592,7 @@ fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     }
 
     let plan = select_finish_validation_plan(
-        "adl/src/cli/pr_cmd/doctor.rs,adl/src/cli/pr_cmd/lifecycle/tests.rs,.github/workflows/ci.yaml,adl/tools/check_coverage_impact.sh,adl/tools/ci_path_policy.sh,docs/tooling/merge_readiness_gate_policy_v0.91.4.md,docs/milestones/v0.91.4/review/merge_readiness/ct_demo_001_merge_gate_profile_report.md",
+        "adl/src/cli/pr_cmd/doctor.rs,adl/src/cli/pr_cmd/lifecycle/tests.rs,adl/src/cli/tooling_cmd/public_prompt_packet.rs,.github/workflows/ci.yaml,adl/tools/check_coverage_impact.sh,adl/tools/ci_path_policy.sh,docs/tooling/merge_readiness_gate_policy_v0.91.4.md,docs/milestones/v0.91.4/review/merge_readiness/ct_demo_001_merge_gate_profile_report.md",
     )
     .expect("focused plan");
     assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
@@ -575,6 +609,7 @@ fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
     assert!(cargo_calls.contains("fmt --manifest-path"));
     assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--bin adl-csdlc public_prompt_packet"));
     assert!(!cargo_calls.contains("clippy --manifest-path"));
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -152,8 +152,17 @@ Current implementation is intentionally narrower than the general policy: the
 focused `pr finish` lane currently applies only to docs-only paths and a
 bounded publication-control-plane slice (`pr_cmd`, `finish_support`, inline
 finish tests, CI path-policy / coverage-impact scripts, and the matching
-workflow/docs surfaces). Other actual changed paths still escalate to full
-local validation until more focused lanes are explicitly implemented and tested.
+workflow/docs surfaces). Docs-only paths may accompany these focused tooling
+paths without forcing full local Rust validation, because the selector uses the
+actual changed tracked paths after staging and treats docs as non-widening when
+the code side is already covered by an explicit focused lane.
+
+Public prompt packet tooling is also a focused lane: changes to
+`adl/src/cli/tooling_cmd/public_prompt_packet.rs` or its paired
+`public_prompt_packet` tests are proved by formatter checks and the
+`adl-csdlc public_prompt_packet` filtered test, while merge-context CI remains
+required before merge. Other actual changed paths still escalate to full local
+validation until more focused lanes are explicitly implemented and tested.
 
 Use full local validation for runtime, schema, security, release, broad tooling,
 or ambiguous changes.


### PR DESCRIPTION
Closes #3679

## Summary
Implemented a focused `pr finish` validation-profile repair for public prompt packet tooling. Finish validation now treats docs-only paths as non-widening when they accompany an explicit focused tooling lane, and public prompt packet tooling has a dedicated focused proof command instead of escalating to full local Rust validation.

## Artifacts
- Updated `adl/src/cli/pr_cmd/finish_support.rs` to classify public prompt packet tooling as focused-local-CI-gated and to dispatch the filtered `adl-csdlc public_prompt_packet` test.
- Updated `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` with regression coverage for the `#3475` path shape and execution of the new focused command.
- Updated `docs/default_workflow.md` to document docs-as-non-widening behavior and the public prompt packet focused lane.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for touched Rust files.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc finish_validation -- --nocapture`
    Verified the finish validation selector keeps public prompt packet tooling on the focused lane and preserves existing focused lane behavior.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet -- --nocapture`
    Verified the selected public prompt packet focused test command passes.
  - `git diff --check`
    Verified diff whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3679__v0-91-5-tools-validation-make-pr-finish-honor-focused-validation-lanes-for-tooling-docs-changes/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3679__v0-91-5-tools-validation-make-pr-finish-honor-focused-validation-lanes-for-tooling-docs-changes/sor.md
- Idempotency-Key: v0-91-5-tools-validation-make-pr-finish-honor-focused-validation-lanes-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-default-workflow-md-adl-v0-91-5-tasks-issue-3679-v0-91-5-tools-validation-make-pr-finish-honor-focused-validation-lanes-for-tooling-docs-changes-sip-md-adl-v0-91-5-tasks-issue-3679-v0-91-5-tools-validation-make-pr-finish-honor-focused-validation-lanes-for-tooling-docs-changes-sor-md