### PR TITLE
[v0.91.5][WP-02][tools][validation] Split pr finish focused cli::pr_cmd validation lane

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -451,6 +451,23 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             );
             push_finish_validation_command(
                 &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_validation",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_pr_cmd_lifecycle_focused_validation(path))
+        {
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
                 "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd",
             );
         }
@@ -602,9 +619,15 @@ fn finish_path_is_focused_local_ci_gated(path: &str) -> bool {
 
 fn finish_path_needs_pr_finish_rust_focused_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
-    trimmed == "adl/src/cli/pr_cmd.rs"
-        || trimmed.starts_with("adl/src/cli/pr_cmd/")
+    trimmed == "adl/src/cli/pr_cmd/finish_support.rs"
         || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
+}
+
+fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/cli/pr_cmd.rs"
+        || (trimmed.starts_with("adl/src/cli/pr_cmd/")
+            && trimmed != "adl/src/cli/pr_cmd/finish_support.rs")
 }
 
 fn finish_path_needs_coverage_tooling_focused_validation(path: &str) -> bool {
@@ -713,6 +736,32 @@ pub(super) fn run_finish_validation_rust(
                             "--manifest-path",
                             path_str(&manifest)?,
                             "cli::pr_cmd",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_validation" => {
+                    run_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-csdlc",
+                            "cli::pr_cmd::tests::finish::arg_render::finish_validation",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation" => {
+                    run_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-csdlc",
+                            "cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -546,6 +546,43 @@ fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
 }
 
 #[test]
+fn finish_validation_profile_keeps_finish_support_changes_narrow() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+            "docs/default_workflow.md".to_string(),
+        ],
+    )
+    .expect("finish support plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_validation"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation"
+            .to_string()
+    ));
+    assert!(!plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo nextest")));
+}
+
+#[test]
 fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-focused-validation");
@@ -615,6 +652,60 @@ fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("coverage"));
     assert!(focused_calls.contains("path-policy"));
+}
+
+#[test]
+fn finish_helper_paths_run_narrow_finish_focused_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-narrow-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/src/cli/pr_cmd/finish_support.rs,adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs,docs/default_workflow.md",
+    )
+    .expect("narrow finish-focused plan");
+    assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    run_finish_validation_rust(&repo, &plan).expect("narrow focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("fmt --manifest-path"));
+    assert!(cargo_calls
+        .contains("--bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_validation"));
+    assert!(cargo_calls.contains(
+        "--bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation"
+    ));
+    assert!(!cargo_calls.contains(" cli::pr_cmd\n"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
 }
 
 #[test]

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -157,6 +157,14 @@ paths without forcing full local Rust validation, because the selector uses the
 actual changed tracked paths after staging and treats docs as non-widening when
 the code side is already covered by an explicit focused lane.
 
+Not every focused C-SDLC path uses the same Rust selector. Finish-validation
+planner changes such as `adl/src/cli/pr_cmd/finish_support.rs` and
+`adl/src/cli/tests/pr_cmd_inline/finish/*` are proved by formatter checks plus
+narrow `adl-csdlc` filtered tests for finish validation planning and focused
+runner dispatch. Broader lifecycle surfaces such as `doctor`, `git_support`,
+`github`, and `lifecycle` still use the broader `cli::pr_cmd` filtered test
+until they have their own narrower proof lane.
+
 Public prompt packet tooling is also a focused lane: changes to
 `adl/src/cli/tooling_cmd/public_prompt_packet.rs` or its paired
 `public_prompt_packet` tests are proved by formatter checks and the


### PR DESCRIPTION
Closes #3682

## Summary
Implemented a narrower `pr finish` focused-validation lane for finish planner/support changes. Finish-validation path changes now select narrow `adl-csdlc` filtered tests instead of the broad `cli::pr_cmd` selector, while doctor/lifecycle paths still retain the broader safety net.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `docs/default_workflow.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting after implementation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_validation -- --nocapture`
    Verified finish validation profile selection, including the new narrow finish-support path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation -- --nocapture`
    Verified focused validation command dispatch for the existing mixed focused lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_narrow_finish_focused_validation -- --nocapture`
    Verified the new narrow finish-focused command dispatch avoids broad `cli::pr_cmd`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render -- --nocapture`
    Verified the whole bounded finish arg-render module, including the real finish happy path.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3682__v0-91-5-wp-02-tools-validation-split-pr-finish-focused-cli-pr-cmd-validation-lane/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3682__v0-91-5-wp-02-tools-validation-split-pr-finish-focused-cli-pr-cmd-validation-lane/sor.md
- Idempotency-Key: v0-91-5-wp-02-tools-validation-split-pr-finish-focused-cli-pr-cmd-validation-lane-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-default-workflow-md-adl-v0-91-5-tasks-issue-3682-v0-91-5-wp-02-tools-validation-split-pr-finish-focused-cli-pr-cmd-validation-lane-sip-md-adl-v0-91-5-tasks-issue-3682-v0-91-5-wp-02-tools-validation-split-pr-finish-focused-cli-pr-cmd-validation-lane-sor-md