### PR TITLE
[v0.91.5][WP-08][provider] Add OpenRouter provider for broad model-matrix testing

### DIFF
--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -1,6 +1,6 @@
 //! HTTP-based provider implementations and request transport helpers.
 //!
-//! Supports OpenAI, Anthropic, DeepSeek, generic HTTP, and Ollama-HTTP style backends.
+//! Supports OpenAI, Anthropic, DeepSeek, OpenRouter, generic HTTP, and Ollama-HTTP style backends.
 use super::*;
 use std::thread;
 use std::time::Duration;
@@ -258,6 +258,10 @@ fn extract_deepseek_output_text(json: &Value) -> Option<String> {
     (!joined.is_empty()).then_some(joined)
 }
 
+fn extract_openrouter_output_text(json: &Value) -> Option<String> {
+    extract_deepseek_output_text(json)
+}
+
 #[derive(Debug, Clone)]
 /// OpenAI-compatible provider backed by HTTP/requests API.
 pub struct OpenAiProvider {
@@ -470,6 +474,84 @@ impl Provider for DeepSeekProvider {
             runtime_error_non_retryable("deepseek", "response missing message content")
         })?;
         write_native_invocation_record("deepseek", &self.model, prompt, &output, http_status)?;
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone)]
+/// OpenRouter native provider using the OpenAI-compatible chat completions format.
+pub struct OpenRouterProvider {
+    endpoint: String,
+    auth_env: String,
+    model: String,
+    max_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl OpenRouterProvider {
+    /// Build an OpenRouter provider from normalized invocation target.
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        let endpoint = vendor_endpoint(
+            spec,
+            target,
+            OPENROUTER_CHAT_COMPLETIONS_ENDPOINT,
+            "openrouter",
+        )?;
+        let auth_env = auth_env_for(spec, "OPENROUTER_API_KEY")?;
+        validate_vendor_credential_endpoint(
+            spec,
+            "openrouter",
+            &endpoint,
+            &auth_env,
+            "OPENROUTER_API_KEY",
+            &["openrouter.ai"],
+        )?;
+        Ok(Self {
+            endpoint,
+            auth_env,
+            model: target.provider_model_id.clone(),
+            max_tokens: cfg_u64(&spec.config, "max_tokens")
+                .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
+                .unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for OpenRouterProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let token = env::var(&self.auth_env).map_err(|_| {
+            invalid_config(
+                "openrouter",
+                format!("missing required auth env var '{}'", self.auth_env),
+            )
+        })?;
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build OpenRouter client")
+            .map_err(|err| runtime_error("openrouter", err.to_string()))?;
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": self.max_tokens,
+                "stream": false,
+            }));
+        let (json, http_status) = provider_http_json("openrouter", req)?;
+        let output = extract_openrouter_output_text(&json).ok_or_else(|| {
+            runtime_error_non_retryable("openrouter", "response missing message content")
+        })?;
+        write_native_invocation_record("openrouter", &self.model, prompt, &output, http_status)?;
         Ok(output)
     }
 }

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -514,6 +514,125 @@ fn deepseek_provider_complete_records_chat_completion_request() {
 }
 
 #[test]
+fn openrouter_provider_complete_records_chat_completion_request() {
+    let _guard = env_lock();
+    let Some((endpoint, captured, handle)) = spawn_json_server(
+        200,
+        r#"{"choices":[{"message":{"role":"assistant","content":"openrouter ok"}}]}"#,
+    ) else {
+        return;
+    };
+
+    let artifact = std::env::temp_dir().join(format!(
+        "adl-provider-invocations-{}-openrouter.json",
+        std::process::id()
+    ));
+    let artifact_display = artifact.to_string_lossy().to_string();
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    let prev_key = env::var_os("OPENROUTER_API_KEY");
+    env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", &artifact_display);
+    env::set_var("OPENROUTER_API_KEY", "test-openrouter-token");
+
+    let spec = provider_spec(
+        "openrouter",
+        &format!("{endpoint}/api/v1/chat/completions"),
+        Some("OPENROUTER_API_KEY"),
+        &[],
+    );
+    let target = provider_target(
+        "openrouter",
+        format!("{endpoint}/api/v1/chat/completions"),
+        "deepseek/deepseek-chat",
+    );
+    let provider = OpenRouterProvider::from_target(&spec, &target).expect("provider");
+
+    let output = provider.complete("hello openrouter").expect("completion");
+    assert_eq!(output, "openrouter ok");
+
+    let captured = captured.lock().expect("capture").clone().expect("request");
+    assert_eq!(captured.url, "/api/v1/chat/completions");
+    assert!(captured
+        .body
+        .contains(r#""model":"deepseek/deepseek-chat""#));
+    assert!(captured.body.contains(r#""content":"hello openrouter""#));
+    assert!(captured.body.contains(r#""stream":false"#));
+    assert!(captured.headers.iter().any(
+        |(k, v)| k.eq_ignore_ascii_case("authorization") && v == "Bearer test-openrouter-token"
+    ));
+
+    let payload = std::fs::read_to_string(&artifact).expect("artifact");
+    assert!(!payload.contains("test-openrouter-token"));
+    let json: serde_json::Value = serde_json::from_str(&payload).expect("json artifact");
+    assert_eq!(json["invocations"][0]["family"], "openrouter");
+    assert_eq!(json["invocations"][0]["model"], "deepseek/deepseek-chat");
+    assert_eq!(json["invocations"][0]["output_chars"], 13);
+
+    match prev_artifact {
+        Some(v) => env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", v),
+        None => env::remove_var("ADL_PROVIDER_INVOCATIONS_PATH"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("OPENROUTER_API_KEY", v),
+        None => env::remove_var("OPENROUTER_API_KEY"),
+    }
+
+    let _ = handle.join();
+}
+
+#[test]
+fn openrouter_provider_rejects_missing_credentials_and_bad_response_shape() {
+    let _guard = env_lock();
+    let prev_key = env::var_os("OPENROUTER_API_KEY");
+    env::remove_var("OPENROUTER_API_KEY");
+
+    let spec = provider_spec(
+        "openrouter",
+        OPENROUTER_CHAT_COMPLETIONS_ENDPOINT,
+        Some("OPENROUTER_API_KEY"),
+        &[],
+    );
+    let target = provider_target(
+        "openrouter",
+        OPENROUTER_CHAT_COMPLETIONS_ENDPOINT.to_string(),
+        "openai/gpt-4o-mini",
+    );
+    let provider = OpenRouterProvider::from_target(&spec, &target).expect("provider");
+    let missing_key = provider
+        .complete("hello")
+        .expect_err("missing credential should fail");
+    assert!(missing_key
+        .to_string()
+        .contains("missing required auth env var 'OPENROUTER_API_KEY'"));
+
+    env::set_var("OPENROUTER_API_KEY", "test-openrouter-token");
+    let Some((endpoint, _captured, handle)) = spawn_json_server(200, r#"{"choices":[]}"#) else {
+        restore_env_var("OPENROUTER_API_KEY", prev_key);
+        return;
+    };
+    let bad_spec = provider_spec(
+        "openrouter",
+        &format!("{endpoint}/api/v1/chat/completions"),
+        Some("OPENROUTER_API_KEY"),
+        &[],
+    );
+    let bad_target = provider_target(
+        "openrouter",
+        format!("{endpoint}/api/v1/chat/completions"),
+        "openai/gpt-4o-mini",
+    );
+    let bad_provider = OpenRouterProvider::from_target(&bad_spec, &bad_target).expect("provider");
+    let bad_shape = bad_provider
+        .complete("hello")
+        .expect_err("missing message content should fail");
+    assert!(bad_shape
+        .to_string()
+        .contains("response missing message content"));
+
+    restore_env_var("OPENROUTER_API_KEY", prev_key);
+    let _ = handle.join();
+}
+
+#[test]
 fn deepseek_provider_rejects_missing_credentials_and_bad_response_shape() {
     let _guard = env_lock();
     let prev_key = env::var_os("DEEPSEEK_API_KEY");
@@ -724,6 +843,25 @@ fn http_provider_complete_and_helper_errors_cover_status_and_validation() {
     )
     .expect_err("default DeepSeek credentials should not go to untrusted remote endpoints");
     assert!(untrusted_deepseek_err
+        .to_string()
+        .contains("config.trust_custom_endpoint"));
+
+    let untrusted_openrouter_spec = provider_spec(
+        "openrouter",
+        "https://proxy.example.com/api/v1/chat/completions",
+        Some("OPENROUTER_API_KEY"),
+        &[],
+    );
+    let untrusted_openrouter_err = OpenRouterProvider::from_target(
+        &untrusted_openrouter_spec,
+        &provider_target(
+            "openrouter",
+            "https://proxy.example.com/api/v1/chat/completions".to_string(),
+            "openai/gpt-4o-mini",
+        ),
+    )
+    .expect_err("default OpenRouter credentials should not go to untrusted remote endpoints");
+    assert!(untrusted_openrouter_err
         .to_string()
         .contains("config.trust_custom_endpoint"));
 

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -23,14 +23,15 @@ mod http_family;
 mod local;
 mod profiles;
 
-pub use http_family::DeepSeekProvider;
 pub use http_family::{AnthropicProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider};
+pub use http_family::{DeepSeekProvider, OpenRouterProvider};
 pub use local::{MockProvider, OllamaProvider};
 pub use profiles::{expand_provider_profiles, provider_profile_names};
 
 pub(crate) use profiles::{
     is_allowed_ollama_endpoint, is_allowed_remote_endpoint, ANTHROPIC_MESSAGES_ENDPOINT,
     ANTHROPIC_VERSION, DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT, OPENAI_RESPONSES_ENDPOINT,
+    OPENROUTER_CHAT_COMPLETIONS_ENDPOINT,
 };
 
 /// A minimal blocking provider abstraction used by runtime execution paths.
@@ -70,8 +71,8 @@ impl ProviderError {
             kind: ProviderErrorKind::UnknownKind,
             provider: None,
             message: format!(
-                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek). \
-Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek. The remote provider surfaces are HTTPS-only."
+                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter). \
+Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter. The remote provider surfaces are HTTPS-only."
             ),
         }
     }
@@ -236,7 +237,7 @@ pub fn build_provider_for_id(
 ) -> Result<Box<dyn Provider>> {
     match spec.kind.trim() {
         "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic"
-        | "deepseek" => {}
+        | "deepseek" | "openrouter" => {}
         other => return Err(unknown_kind(other)),
     }
 
@@ -250,6 +251,7 @@ pub fn build_provider_for_id(
             "openai" => Ok(Box::new(OpenAiProvider::from_target(spec, &target)?)),
             "anthropic" => Ok(Box::new(AnthropicProvider::from_target(spec, &target)?)),
             "deepseek" => Ok(Box::new(DeepSeekProvider::from_target(spec, &target)?)),
+            "openrouter" => Ok(Box::new(OpenRouterProvider::from_target(spec, &target)?)),
             other => Err(unknown_kind(other)),
         },
         provider_substrate::ProviderTransportV1::LocalCli
@@ -353,6 +355,10 @@ mod tests {
 
         let deepseek = provider_spec("deepseek", Some("deepseek-chat"));
         build_provider_for_id("deepseek_primary", &deepseek, None).expect("deepseek provider");
+
+        let openrouter = provider_spec("openrouter", Some("openai/gpt-4o-mini"));
+        build_provider_for_id("openrouter_primary", &openrouter, None)
+            .expect("openrouter provider");
     }
 
     #[test]

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -57,6 +57,8 @@ pub(crate) const OPENAI_RESPONSES_ENDPOINT: &str = "https://api.openai.com/v1/re
 pub(crate) const ANTHROPIC_MESSAGES_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
 pub(crate) const DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT: &str =
     "https://api.deepseek.com/chat/completions";
+pub(crate) const OPENROUTER_CHAT_COMPLETIONS_ENDPOINT: &str =
+    "https://openrouter.ai/api/v1/chat/completions";
 /// Canonical Anthropic API version used by the HTTP adapter.
 pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";
 

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -16,6 +16,8 @@ use std::time::{Duration, Instant};
 const DEFAULT_OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
 const DEFAULT_ANTHROPIC_MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
 const DEFAULT_DEEPSEEK_CHAT_COMPLETIONS_URL: &str = "https://api.deepseek.com/chat/completions";
+const DEFAULT_OPENROUTER_CHAT_COMPLETIONS_URL: &str =
+    "https://openrouter.ai/api/v1/chat/completions";
 const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
 const DEFAULT_BACKOFF_MS: u64 = 1_000;
@@ -227,6 +229,7 @@ fn execute_hosted(
         "openai" | "chatgpt" => execute_hosted_openai(request, policy),
         "anthropic" | "claude" => execute_hosted_anthropic(request, policy),
         "deepseek" => execute_hosted_deepseek(request, policy),
+        "openrouter" => execute_hosted_openrouter(request, policy),
         "google" | "gemini" => execute_hosted_gemini(request, policy),
         _ => Err(ProviderFailureV1 {
             kind: ProviderFailureKindV1::ProviderError,
@@ -325,6 +328,41 @@ fn execute_hosted_deepseek(
     decode_text_response(
         response,
         extract_deepseek_output_text,
+        RuntimeSurfaceV1::HostedApi,
+    )
+}
+
+fn execute_hosted_openrouter(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let key = resolve_credential(
+        request.route.credential_ref.as_deref(),
+        "OPENROUTER_API_KEY",
+    )?;
+    let url = request
+        .route
+        .endpoint_ref
+        .as_deref()
+        .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
+        .unwrap_or(DEFAULT_OPENROUTER_CHAT_COMPLETIONS_URL);
+    let response = client(policy)?
+        .post(url)
+        .bearer_auth(key)
+        .json(&json!({
+            "model": request.route.provider_model_id,
+            "messages": [{
+                "role": "user",
+                "content": request.input_text.as_deref().unwrap_or_default(),
+            }],
+            "max_tokens": 256,
+            "stream": false,
+        }))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        extract_chat_completion_output_text,
         RuntimeSurfaceV1::HostedApi,
     )
 }
@@ -652,6 +690,10 @@ fn extract_anthropic_output_text(json: &Value) -> Option<String> {
 }
 
 fn extract_deepseek_output_text(json: &Value) -> Option<String> {
+    extract_chat_completion_output_text(json)
+}
+
+fn extract_chat_completion_output_text(json: &Value) -> Option<String> {
     json.get("choices")
         .and_then(Value::as_array)
         .and_then(|choices| choices.first())
@@ -1078,6 +1120,43 @@ mod tests {
         assert!(!log.contains("deepseek success"));
         let _ = fs::remove_file(path);
         env::remove_var("ADL_PROVIDER_ADAPTER_DEEPSEEK_KEY");
+    }
+
+    #[test]
+    fn openrouter_hosted_adapter_returns_output_and_redacts_log() {
+        env::set_var("ADL_PROVIDER_ADAPTER_OPENROUTER_KEY", "test-key");
+        let (endpoint, rx) = capture_one_request_server(
+            r#"{"choices":[{"message":{"content":"openrouter success"}}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("openrouter");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "openrouter".to_string();
+        req.route.provider_model_id = "anthropic/claude-3.5-haiku".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_OPENROUTER_KEY".to_string());
+        req.model_identity = hosted_model_identity(
+            "openrouter",
+            "anthropic/claude-3.5-haiku",
+            "reviewer/fast",
+            Some("test".to_string()),
+        );
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("openrouter success"));
+        let raw_request = rx.recv().expect("captured request");
+        assert!(raw_request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-key"));
+        assert!(raw_request.contains(r#""model":"anthropic/claude-3.5-haiku""#));
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("openrouter success"));
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_OPENROUTER_KEY");
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -125,6 +125,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
                 "mock" => return "mock".to_string(),
                 "chatgpt" => return "openai".to_string(),
                 "claude" => return "anthropic".to_string(),
+                "openrouter" => return "openrouter".to_string(),
                 "http" => return "generic_http".to_string(),
                 _ => {}
             }
@@ -152,6 +153,9 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         if lower.contains("deepseek") {
             return "deepseek".to_string();
         }
+        if lower.contains("openrouter") {
+            return "openrouter".to_string();
+        }
         if lower.contains("ollama") || lower.contains("11434") {
             return "ollama".to_string();
         }
@@ -163,6 +167,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         "openai" => "openai".to_string(),
         "anthropic" => "anthropic".to_string(),
         "deepseek" => "deepseek".to_string(),
+        "openrouter" => "openrouter".to_string(),
         "http" | "http_remote" => "generic_http".to_string(),
         other if !other.is_empty() => other.to_lowercase(),
         _ => "unknown".to_string(),
@@ -178,7 +183,7 @@ fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
                 Ok(ProviderTransportV1::LocalCli)
             }
         }
-        "http" | "http_remote" | "openai" | "anthropic" | "deepseek" => {
+        "http" | "http_remote" | "openai" | "anthropic" | "deepseek" | "openrouter" => {
             Ok(ProviderTransportV1::Http)
         }
         "local_ollama" => Ok(ProviderTransportV1::LocalCli),
@@ -268,7 +273,9 @@ fn infer_capability_defaults(
         };
     }
 
-    if matches!(transport, ProviderTransportV1::Http) && vendor == "deepseek" {
+    if matches!(transport, ProviderTransportV1::Http)
+        && (vendor == "deepseek" || vendor == "openrouter")
+    {
         return ProviderCapabilitiesV1 {
             tool_calling: CapabilitySupportV1 {
                 supported: false,
@@ -539,7 +546,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_substrate_accepts_native_openai_anthropic_and_deepseek_kinds() {
+    fn provider_substrate_accepts_native_openai_anthropic_deepseek_and_openrouter_kinds() {
         let mut openai = provider_spec("openai");
         openai.default_model = Some("gpt-test".to_string());
         let openai_substrate =
@@ -572,6 +579,55 @@ mod tests {
             deepseek_substrate.capabilities.structured_json.mode,
             CapabilityModeV1::PromptBased
         );
+
+        let mut openrouter = provider_spec("openrouter");
+        openrouter.default_model = Some("openai/gpt-4o-mini".to_string());
+        let openrouter_substrate =
+            provider_substrate_v1("openrouter_primary", &openrouter).expect("openrouter substrate");
+        assert_eq!(openrouter_substrate.vendor, "openrouter");
+        assert_eq!(openrouter_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(openrouter_substrate.provider_kind, "openrouter");
+        assert!(!openrouter_substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            openrouter_substrate.capabilities.tool_calling.mode,
+            CapabilityModeV1::None
+        );
+        assert_eq!(
+            openrouter_substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
+    }
+
+    #[test]
+    fn provider_substrate_infers_openrouter_endpoint_vendor_and_preserves_model_id() {
+        let mut spec = provider_spec("openrouter");
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("https://openrouter.ai/api/v1/chat/completions"),
+        );
+        spec.default_model = Some("reasoning/default".to_string());
+        spec.config.insert(
+            "provider_model_id".to_string(),
+            json!("anthropic/claude-3.5-haiku"),
+        );
+
+        let substrate = provider_substrate_v1("openrouter_primary", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "openrouter");
+        assert_eq!(
+            substrate.provider_default_model_id.as_deref(),
+            Some("anthropic/claude-3.5-haiku")
+        );
+
+        let target =
+            provider_invocation_target_v1("openrouter_primary", &spec, None).expect("target");
+        assert_eq!(target.model_ref, "reasoning/default");
+        assert_eq!(target.provider_model_id, "anthropic/claude-3.5-haiku");
+        assert_eq!(target.model_identity.provider_kind, "openrouter");
+        assert_eq!(
+            target.model_identity.provider_model_id,
+            "anthropic/claude-3.5-haiku"
+        );
+        assert_eq!(target.model_identity.runtime_surface, "hosted_http");
     }
 
     #[test]

--- a/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
+++ b/docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md
@@ -40,10 +40,12 @@ OpenRouter.
 | OpenAI | `openai` | `OPENAI_API_KEY` | `https://api.openai.com/v1/responses` | implemented |
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | `https://api.anthropic.com/v1/messages` | implemented |
 | DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/chat/completions` | implemented in `#3549` |
+| OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1/chat/completions` | implemented in `#3505`; live matrix proof remains `#3501` |
 | Gemini | none yet | `GEMINI_API_KEY` | n/a | compatibility/profile lane only |
 
 Compatibility profiles such as `http:deepseek-chat` remain useful for gateway
-tests, but they must not be confused with the native `deepseek` provider path.
+tests, but they must not be confused with the native `deepseek` or
+`openrouter` provider paths.
 
 ## Design
 
@@ -55,7 +57,7 @@ tests, but they must not be confused with the native `deepseek` provider path.
 ## Execution Flow
 
 1. Inventory available local and remote models.
-2. Add OpenRouter provider or a bounded implementation plan.
+2. Use the native OpenRouter provider for broad hosted model-lane probes.
 3. Test small role-specific prompts.
 4. Feed results into multi-agent execution planning.
 
@@ -72,7 +74,13 @@ private prompt content.
 ## Validation
 
 Validation should include provider smoke tests, role probes, skipped-state
-records, and OpenRouter disposition.
+records, and explicit separation between OpenRouter substrate proof and live
+model-matrix evidence.
+
+OpenRouter capability support is model-dependent. The native provider preserves
+the OpenRouter lane and exact routed model identifier, but role probes must
+record any native tool/JSON capability as explicit lane evidence or a configured
+capability override rather than assuming gateway-wide support.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Closes #3505

## Summary
Implemented a native OpenRouter provider substrate for v0.91.5 provider/model matrix testing. The change adds the `openrouter` provider kind to provider normalization, provider construction, native HTTP execution, and provider-adapter hosted execution while preserving exact routed model identifiers such as `anthropic/claude-3.5-haiku`.

The implementation is intentionally offline-testable. It does not call live OpenRouter, does not record secrets, and does not claim live model aptitude or availability. OpenRouter capability defaults are conservative because gateway support varies by underlying model; model-role probes must record native tool/JSON capability as explicit lane evidence or configuration.

## Artifacts
- `adl/src/provider/http_family.rs`
- `adl/src/provider/http_family/tests.rs`
- `adl/src/provider/mod.rs`
- `adl/src/provider/profiles.rs`
- `adl/src/provider_adapter.rs`
- `adl/src/provider_substrate.rs`
- `docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml provider::http_family::tests::openrouter -- --nocapture`
    Verified OpenRouter native provider success and failure paths.
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate::tests::provider_substrate_ -- --nocapture`
    Verified provider substrate behavior including OpenRouter identity and capability posture.
  - `cargo test --manifest-path adl/Cargo.toml provider_adapter::tests::openrouter_hosted_adapter_returns_output_and_redacts_log -- --nocapture`
    Verified provider adapter OpenRouter hosted route and log redaction.
  - `cargo test --manifest-path adl/Cargo.toml provider::tests::provider_mod_build_provider_dispatches_supported_native_and_compatibility_kinds -- --nocapture`
    Verified provider factory dispatch.
  - `cargo test --manifest-path adl/Cargo.toml provider::http_family::tests::http_provider_complete_and_helper_errors_cover_status_and_validation -- --nocapture`
    Verified helper status/error handling and OpenRouter credential endpoint guardrail.
  - `python3 adl/tools/validate_planning_template.py --template feature_doc --input docs/milestones/v0.91.5/features/PROVIDER_MODEL_MATRIX_v0.91.5.md`
    Verified feature-doc structure.
  - `git diff --check`
    Verified whitespace hygiene.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- provider`
    Generated focused provider coverage summary for the changed Rust source files.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight for the touched Rust source files.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3505__v0-91-5-wp-08-provider-add-openrouter-provider-for-broad-model-matrix-testing/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3505__v0-91-5-wp-08-provider-add-openrouter-provider-for-broad-model-matrix-testing/sor.md
- Idempotency-Key: v0-91-5-wp-08-provider-add-openrouter-provider-for-broad-model-matrix-testing-adl-src-provider-http-family-rs-adl-src-provider-http-family-tests-rs-adl-src-provider-mod-rs-adl-src-provider-profiles-rs-adl-src-provider-adapter-rs-adl-src-provider-substrate-rs-docs-milestones-v0-91-5-features-provider-model-matrix-v0-91-5-md-adl-v0-91-5-tasks-issue-3505-v0-91-5-wp-08-provider-add-openrouter-provider-for-broad-model-matrix-testing-sip-md-adl-v0-91-5-tasks-issue-3505-v0-91-5-wp-08-provider-add-openrouter-provider-for-broad-model-matrix-testing-sor-md