### PR TITLE
[v0.91.5][tools][markdown] Implement AST-backed Markdown editing substrate

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -10,6 +10,8 @@ mod common;
 mod csdlc_prompt_editor;
 #[path = "tooling_cmd/markdown.rs"]
 mod markdown;
+#[path = "tooling_cmd/markdown_ast_edit.rs"]
+mod markdown_ast_edit;
 #[path = "tooling_cmd/portable_project_doctor.rs"]
 mod portable_project_doctor;
 #[path = "tooling_cmd/prompt_template.rs"]
@@ -28,6 +30,7 @@ mod wp_issue_wave;
 use card_prompt::real_card_prompt;
 use code_review::real_code_review;
 use csdlc_prompt_editor::real_csdlc_prompt_editor;
+use markdown_ast_edit::real_markdown_ast_edit;
 use portable_project_doctor::real_portable_project_doctor;
 use prompt_template::real_prompt_template;
 use public_prompt_packet::real_public_prompt_packet;
@@ -70,6 +73,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
         "csdlc-prompt-editor" => real_csdlc_prompt_editor(&args[1..]),
         "generate-wp-issue-wave" => real_generate_wp_issue_wave(&args[1..]),
         "lint-prompt-spec" => real_lint_prompt_spec(&args[1..]),
+        "markdown-ast-edit" => real_markdown_ast_edit(&args[1..]),
         "portable-project-doctor" => real_portable_project_doctor(&args[1..]),
         "prompt-template" => real_prompt_template(&args[1..]),
         "public-prompt-packet" => real_public_prompt_packet(&args[1..]),
@@ -96,6 +100,7 @@ adl tooling csdlc-prompt-editor [--repo-root <path>] [--emit-model-js <path>] [-
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\
 adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\
+adl tooling markdown-ast-edit replace-section --input <path> --heading <heading> --replacement <path> --out <path> [--repair-note-out <path>]\n\
 adl tooling portable-project-doctor --project <adl_project.json> [--adl-home <path>] [--json]\n\
 adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\

--- a/adl/src/cli/tooling_cmd/markdown_ast_edit.rs
+++ b/adl/src/cli/tooling_cmd/markdown_ast_edit.rs
@@ -1,0 +1,348 @@
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use markdown::{mdast::Node, ParseOptions};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::common::absolutize;
+use super::markdown::split_front_matter;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkdownShape {
+    headings: Vec<(u8, String)>,
+    code_fences: usize,
+    tables: usize,
+    links: Vec<String>,
+    has_front_matter: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ReplaceSectionArgs {
+    input: PathBuf,
+    heading: String,
+    replacement: PathBuf,
+    out: PathBuf,
+    repair_note_out: Option<PathBuf>,
+}
+
+pub(super) fn real_markdown_ast_edit(args: &[String]) -> Result<()> {
+    let Some(command) = args.first().map(|arg| arg.as_str()) else {
+        return Err(anyhow!(
+            "markdown-ast-edit requires a command: replace-section"
+        ));
+    };
+    match command {
+        "replace-section" => replace_section(parse_replace_section_args(&args[1..])?),
+        "--help" | "-h" | "help" => {
+            println!("{}", markdown_ast_edit_usage());
+            Ok(())
+        }
+        other => Err(anyhow!(
+            "unknown markdown-ast-edit command '{other}' (expected replace-section)"
+        )),
+    }
+}
+
+fn markdown_ast_edit_usage() -> &'static str {
+    "adl tooling markdown-ast-edit replace-section --input <path> --heading <heading> --replacement <path> --out <path> [--repair-note-out <path>]"
+}
+
+fn parse_replace_section_args(args: &[String]) -> Result<ReplaceSectionArgs> {
+    let mut input = None;
+    let mut heading = None;
+    let mut replacement = None;
+    let mut out = None;
+    let mut repair_note_out = None;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--input" => input = Some(PathBuf::from(next_arg(&mut iter, "--input")?)),
+            "--heading" => heading = Some(next_arg(&mut iter, "--heading")?),
+            "--replacement" => {
+                replacement = Some(PathBuf::from(next_arg(&mut iter, "--replacement")?))
+            }
+            "--out" => out = Some(PathBuf::from(next_arg(&mut iter, "--out")?)),
+            "--repair-note-out" => {
+                repair_note_out = Some(PathBuf::from(next_arg(&mut iter, "--repair-note-out")?))
+            }
+            "--help" | "-h" => {
+                bail!("{}", markdown_ast_edit_usage());
+            }
+            other => bail!("unexpected markdown-ast-edit argument: {other}"),
+        }
+    }
+
+    Ok(ReplaceSectionArgs {
+        input: input.ok_or_else(|| anyhow!("missing --input"))?,
+        heading: heading.ok_or_else(|| anyhow!("missing --heading"))?,
+        replacement: replacement.ok_or_else(|| anyhow!("missing --replacement"))?,
+        out: out.ok_or_else(|| anyhow!("missing --out"))?,
+        repair_note_out,
+    })
+}
+
+fn next_arg<'a>(iter: &mut impl Iterator<Item = &'a String>, flag: &str) -> Result<String> {
+    iter.next()
+        .cloned()
+        .ok_or_else(|| anyhow!("{flag} requires a value"))
+}
+
+fn replace_section(args: ReplaceSectionArgs) -> Result<()> {
+    let input_abs = absolutize(&args.input)?;
+    let input_text = fs::read_to_string(&args.input)
+        .with_context(|| format!("failed to read {}", args.input.display()))?;
+    let replacement_text = fs::read_to_string(&args.replacement)
+        .with_context(|| format!("failed to read {}", args.replacement.display()))?;
+
+    let out_abs = absolutize(&args.out)?;
+    if is_lifecycle_card_path(&input_abs) || is_lifecycle_card_path(&out_abs) {
+        return fail_closed(
+            &args,
+            &input_abs,
+            "lifecycle-card input or output path requires prompt-template/card-editor authority; markdown-ast-edit did not mutate it",
+        );
+    }
+
+    let before_shape = match inspect_markdown_shape("input", &input_text) {
+        Ok(shape) => shape,
+        Err(err) => return fail_closed(&args, &input_abs, &err.to_string()),
+    };
+    if !before_shape
+        .headings
+        .iter()
+        .any(|(_, text)| text == args.heading.trim())
+    {
+        return fail_closed(
+            &args,
+            &input_abs,
+            &format!("heading '{}' not found in input AST", args.heading),
+        );
+    }
+
+    let replacement_body = strip_matching_heading(&replacement_text, &args.heading)?;
+    inspect_markdown_shape("replacement", &replacement_body)
+        .map_err(|err| anyhow!("replacement failed AST guard: {err}"))?;
+    let edited = replace_markdown_section_body(&input_text, &args.heading, &replacement_body)
+        .map_err(|err| anyhow!("section replacement failed: {err}"))?;
+    let after_shape = match inspect_markdown_shape("edited", &edited) {
+        Ok(shape) => shape,
+        Err(err) => return fail_closed(&args, &input_abs, &err.to_string()),
+    };
+    ensure!(
+        before_shape.has_front_matter == after_shape.has_front_matter,
+        "front matter preservation guard failed"
+    );
+    ensure!(
+        after_shape.code_fences >= before_shape.code_fences,
+        "code fence preservation guard failed"
+    );
+    ensure!(
+        after_shape.tables >= before_shape.tables,
+        "table preservation guard failed"
+    );
+    ensure!(
+        before_shape
+            .links
+            .iter()
+            .collect::<BTreeSet<_>>()
+            .is_subset(&after_shape.links.iter().collect::<BTreeSet<_>>()),
+        "link preservation guard failed"
+    );
+    ensure!(
+        before_shape
+            .headings
+            .iter()
+            .map(|(_, text)| text)
+            .collect::<BTreeSet<_>>()
+            .is_subset(
+                &after_shape
+                    .headings
+                    .iter()
+                    .map(|(_, text)| text)
+                    .collect::<BTreeSet<_>>()
+            ),
+        "heading preservation guard failed"
+    );
+
+    ensure_parent_dir(&args.out)?;
+    fs::write(&args.out, edited).with_context(|| format!("failed to write {}", args.out.display()))
+}
+
+fn fail_closed(args: &ReplaceSectionArgs, input: &Path, reason: &str) -> Result<()> {
+    if let Some(note_path) = &args.repair_note_out {
+        ensure_parent_dir(note_path)?;
+        let note = format!(
+            "# Markdown AST edit repair note\n\n- Input: {}\n- Heading: {}\n- Status: not_mutated\n- Reason: {}\n\nThe editor failed closed. Use the prompt-template/card editor path for lifecycle cards or repair this document by hand before retrying.\n",
+            display_path(input),
+            args.heading,
+            reason
+        );
+        fs::write(note_path, note)
+            .with_context(|| format!("failed to write repair note {}", note_path.display()))?;
+    }
+    bail!("markdown AST edit failed closed: {reason}")
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn display_path(path: &Path) -> String {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    normalized
+        .find("agent-design-language/")
+        .map(|idx| normalized[idx + "agent-design-language/".len()..].to_string())
+        .unwrap_or(normalized)
+}
+
+fn is_lifecycle_card_path(path: &Path) -> bool {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    normalized.contains("/.adl/")
+        && normalized.contains("/tasks/issue-")
+        && matches!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("sip.md" | "stp.md" | "spp.md" | "srp.md" | "sor.md")
+        )
+}
+
+fn strip_matching_heading(text: &str, heading: &str) -> Result<String> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let Some(first_nonblank) = lines.iter().position(|line| !line.trim().is_empty()) else {
+        return Ok(String::new());
+    };
+    if let Some((_, text_heading)) = parse_heading_line(lines[first_nonblank]) {
+        if text_heading == heading.trim() {
+            return Ok(lines[first_nonblank + 1..].join("\n").trim().to_string());
+        }
+    }
+    Ok(text.trim().to_string())
+}
+
+fn replace_markdown_section_body(input: &str, heading: &str, replacement: &str) -> Result<String> {
+    let lines = input.lines().map(str::to_string).collect::<Vec<_>>();
+    let mut in_fence = false;
+    let mut start = None;
+    let mut target_depth = None;
+    let mut end = lines.len();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some((depth, text)) = parse_heading_line(line) {
+            if start.is_none() && text == heading.trim() {
+                start = Some(idx);
+                target_depth = Some(depth);
+                continue;
+            }
+            if start.is_some() && depth <= target_depth.expect("target depth") {
+                end = idx;
+                break;
+            }
+        }
+    }
+
+    let start = start.ok_or_else(|| anyhow!("heading '{heading}' not found"))?;
+    let mut out = Vec::new();
+    out.extend_from_slice(&lines[..=start]);
+    out.push(String::new());
+    if !replacement.trim().is_empty() {
+        out.extend(replacement.trim().lines().map(str::to_string));
+        out.push(String::new());
+    }
+    out.extend_from_slice(&lines[end..]);
+    Ok(format!("{}\n", trim_trailing_blank_lines(out).join("\n")))
+}
+
+fn parse_heading_line(line: &str) -> Option<(usize, String)> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    let rest = trimmed.get(hashes..)?;
+    if !rest.starts_with(' ') {
+        return None;
+    }
+    Some((hashes, rest.trim().to_string()))
+}
+
+fn trim_trailing_blank_lines(mut lines: Vec<String>) -> Vec<String> {
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+    lines
+}
+
+fn inspect_markdown_shape(label: &str, text: &str) -> Result<MarkdownShape> {
+    let (has_front_matter, body) = match split_front_matter(text) {
+        Ok((_front_matter, body)) => (true, body),
+        Err(_) => (false, text.to_string()),
+    };
+    let ast = markdown::to_mdast(&body, &ParseOptions::default())
+        .map_err(|err| anyhow!("{label} markdown-rs AST parse failed: {err}"))?;
+    let mut shape = MarkdownShape {
+        headings: Vec::new(),
+        code_fences: 0,
+        tables: 0,
+        links: Vec::new(),
+        has_front_matter,
+    };
+    collect_shape(label, &ast, &mut shape)?;
+    Ok(shape)
+}
+
+fn collect_shape(label: &str, node: &Node, shape: &mut MarkdownShape) -> Result<()> {
+    match node {
+        Node::Root(root) => {
+            for child in &root.children {
+                collect_shape(label, child, shape)?;
+            }
+        }
+        Node::Heading(heading) => {
+            shape
+                .headings
+                .push((heading.depth, children_plain_text(&heading.children)));
+        }
+        Node::Code(_) => shape.code_fences += 1,
+        Node::Table(_) => shape.tables += 1,
+        Node::Link(link) => shape.links.push(link.url.clone()),
+        Node::Html(_) => bail!("{label} contains unsupported raw HTML node"),
+        _ => {
+            if let Some(children) = node.children() {
+                for child in children {
+                    collect_shape(label, child, shape)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn children_plain_text(children: &[Node]) -> String {
+    children.iter().map(node_plain_text).collect::<String>()
+}
+
+fn node_plain_text(node: &Node) -> String {
+    match node {
+        Node::Text(text) => text.value.clone(),
+        Node::InlineCode(code) => code.value.clone(),
+        Node::Emphasis(emphasis) => children_plain_text(&emphasis.children),
+        Node::Strong(strong) => children_plain_text(&strong.children),
+        Node::Delete(delete) => children_plain_text(&delete.children),
+        Node::Link(link) => children_plain_text(&link.children),
+        _ => node
+            .children()
+            .map(|children| children_plain_text(children))
+            .unwrap_or_default(),
+    }
+}

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -10,6 +10,7 @@ pub(super) use std::path::Path;
 
 mod card_prompt;
 mod common_helpers;
+mod markdown_ast_edit;
 mod prompt_spec;
 mod prompt_template;
 mod public_prompt_packet;

--- a/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
+++ b/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
@@ -63,7 +63,9 @@ fn markdown_ast_edit_fails_closed_for_lifecycle_cards_and_writes_repair_note() {
     ])
     .expect_err("lifecycle card edit should fail closed");
 
-    assert!(err.to_string().contains("lifecycle-card input or output path"));
+    assert!(err
+        .to_string()
+        .contains("lifecycle-card input or output path"));
     assert!(!out.exists());
     let note_text = fs::read_to_string(note).expect("repair note");
     assert!(note_text.contains("Status: not_mutated"));
@@ -78,7 +80,9 @@ fn markdown_ast_edit_fails_closed_when_output_targets_lifecycle_card() {
         "# Demo\n\n## Summary\n\nOld.\n",
     );
     let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "New.\n");
-    let out = repo.path().join(".adl/v0.91.5/tasks/issue-3715__demo/sor.md");
+    let out = repo
+        .path()
+        .join(".adl/v0.91.5/tasks/issue-3715__demo/sor.md");
     let note = repo.path().join(".tmp/tooling_cmd_tests/repair.md");
 
     let err = real_tooling(&[
@@ -110,7 +114,10 @@ fn markdown_ast_edit_rejects_replacements_that_remove_existing_protected_nodes()
         ".tmp/tooling_cmd_tests/doc.md",
         "# Demo\n\n## Summary\n\nOld.\n\n## Evidence\n\n[source](https://example.com)\n\n```rust\nfn main() {}\n```\n",
     );
-    let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "No protected nodes.\n");
+    let replacement = repo.write_rel(
+        ".tmp/tooling_cmd_tests/replacement.md",
+        "No protected nodes.\n",
+    );
     let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
 
     let err = real_tooling(&[

--- a/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
+++ b/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
@@ -1,0 +1,165 @@
+use super::support::*;
+use super::*;
+
+#[test]
+fn markdown_ast_edit_replaces_section_and_preserves_structural_surfaces() {
+    let repo = TempRepo::new("markdown-ast-edit");
+    let input = repo.write_rel(
+        ".tmp/tooling_cmd_tests/doc.md",
+        "---\ntitle: Demo\n---\n# Demo\n\n## Summary\n\nOld summary.\n\n## Evidence\n\n| Key | Value |\n|---|---|\n| link | [source](https://example.com) |\n\n```rust\nfn main() {}\n```\n",
+    );
+    let replacement = repo.write_rel(
+        ".tmp/tooling_cmd_tests/replacement.md",
+        "New summary with [review](https://example.com/review).\n",
+    );
+    let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
+
+    real_tooling(&[
+        "markdown-ast-edit".to_string(),
+        "replace-section".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+        "--heading".to_string(),
+        "Summary".to_string(),
+        "--replacement".to_string(),
+        replacement.to_string_lossy().to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+    ])
+    .expect("AST-guarded section replacement should succeed");
+
+    let edited = fs::read_to_string(out).expect("edited markdown");
+    assert!(edited.contains("---\ntitle: Demo\n---"));
+    assert!(edited.contains("## Summary\n\nNew summary"));
+    assert!(edited.contains("| Key | Value |"));
+    assert!(edited.contains("[source](https://example.com)"));
+    assert!(edited.contains("```rust\nfn main() {}\n```"));
+}
+
+#[test]
+fn markdown_ast_edit_fails_closed_for_lifecycle_cards_and_writes_repair_note() {
+    let repo = TempRepo::new("markdown-ast-card-guard");
+    let input = repo.write_rel(
+        ".adl/v0.91.5/tasks/issue-3715__demo/sor.md",
+        "# SOR\n\n## Summary\n\nOld.\n",
+    );
+    let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "New.\n");
+    let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
+    let note = repo.path().join(".tmp/tooling_cmd_tests/repair.md");
+
+    let err = real_tooling(&[
+        "markdown-ast-edit".to_string(),
+        "replace-section".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+        "--heading".to_string(),
+        "Summary".to_string(),
+        "--replacement".to_string(),
+        replacement.to_string_lossy().to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+        "--repair-note-out".to_string(),
+        note.to_string_lossy().to_string(),
+    ])
+    .expect_err("lifecycle card edit should fail closed");
+
+    assert!(err.to_string().contains("lifecycle-card input or output path"));
+    assert!(!out.exists());
+    let note_text = fs::read_to_string(note).expect("repair note");
+    assert!(note_text.contains("Status: not_mutated"));
+    assert!(note_text.contains("prompt-template/card-editor authority"));
+}
+
+#[test]
+fn markdown_ast_edit_fails_closed_when_output_targets_lifecycle_card() {
+    let repo = TempRepo::new("markdown-ast-card-output-guard");
+    let input = repo.write_rel(
+        ".tmp/tooling_cmd_tests/doc.md",
+        "# Demo\n\n## Summary\n\nOld.\n",
+    );
+    let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "New.\n");
+    let out = repo.path().join(".adl/v0.91.5/tasks/issue-3715__demo/sor.md");
+    let note = repo.path().join(".tmp/tooling_cmd_tests/repair.md");
+
+    let err = real_tooling(&[
+        "markdown-ast-edit".to_string(),
+        "replace-section".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+        "--heading".to_string(),
+        "Summary".to_string(),
+        "--replacement".to_string(),
+        replacement.to_string_lossy().to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+        "--repair-note-out".to_string(),
+        note.to_string_lossy().to_string(),
+    ])
+    .expect_err("lifecycle card output edit should fail closed");
+
+    assert!(err.to_string().contains("lifecycle-card"));
+    assert!(!out.exists());
+    let note_text = fs::read_to_string(note).expect("repair note");
+    assert!(note_text.contains("input or output path"));
+}
+
+#[test]
+fn markdown_ast_edit_rejects_replacements_that_remove_existing_protected_nodes() {
+    let repo = TempRepo::new("markdown-ast-protected-node-guard");
+    let input = repo.write_rel(
+        ".tmp/tooling_cmd_tests/doc.md",
+        "# Demo\n\n## Summary\n\nOld.\n\n## Evidence\n\n[source](https://example.com)\n\n```rust\nfn main() {}\n```\n",
+    );
+    let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "No protected nodes.\n");
+    let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
+
+    let err = real_tooling(&[
+        "markdown-ast-edit".to_string(),
+        "replace-section".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+        "--heading".to_string(),
+        "Evidence".to_string(),
+        "--replacement".to_string(),
+        replacement.to_string_lossy().to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+    ])
+    .expect_err("replacement that removes protected nodes should fail");
+
+    assert!(err.to_string().contains("code fence preservation guard"));
+    assert!(!out.exists());
+}
+
+#[test]
+fn markdown_ast_edit_rejects_unsupported_html_with_repair_note() {
+    let repo = TempRepo::new("markdown-ast-html-guard");
+    let input = repo.write_rel(
+        ".tmp/tooling_cmd_tests/doc.md",
+        "# Demo\n\n## Summary\n\nOld.\n\n<div>unsupported</div>\n",
+    );
+    let replacement = repo.write_rel(".tmp/tooling_cmd_tests/replacement.md", "New.\n");
+    let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
+    let note = repo.path().join(".tmp/tooling_cmd_tests/repair.md");
+
+    let err = real_tooling(&[
+        "markdown-ast-edit".to_string(),
+        "replace-section".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().to_string(),
+        "--heading".to_string(),
+        "Summary".to_string(),
+        "--replacement".to_string(),
+        replacement.to_string_lossy().to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+        "--repair-note-out".to_string(),
+        note.to_string_lossy().to_string(),
+    ])
+    .expect_err("raw HTML should be unsupported");
+
+    assert!(err.to_string().contains("unsupported raw HTML"));
+    assert!(!out.exists());
+    let note_text = fs::read_to_string(note).expect("repair note");
+    assert!(note_text.contains("unsupported raw HTML"));
+}

--- a/docs/milestones/v0.91.5/review/MARKDOWN_AST_EDITING_SUBSTRATE_3715.md
+++ b/docs/milestones/v0.91.5/review/MARKDOWN_AST_EDITING_SUBSTRATE_3715.md
@@ -1,0 +1,76 @@
+# Markdown AST Editing Substrate Proof - #3715
+
+Status: implementation proof for review
+
+## Summary
+
+Issue `#3715` adds a bounded Markdown AST editing substrate for ADL docs work:
+
+```bash
+adl tooling markdown-ast-edit replace-section \
+  --input <path> \
+  --heading <heading> \
+  --replacement <path> \
+  --out <path> \
+  [--repair-note-out <path>]
+```
+
+The substrate uses `markdown-rs` (`markdown = "1.0.0"`) for AST inspection and
+guards edits before and after mutation. It intentionally does not introduce a
+full Markdown pretty-printer. The mutation is line-preserving and limited to
+heading-anchored section body replacement.
+
+## Supported Node Policy
+
+The initial supported preservation surface is:
+
+- headings
+- fenced code blocks
+- tables
+- links
+- YAML front matter
+
+The command parses the input and output with `markdown-rs`, verifies that the
+target heading exists in the AST, and verifies that original headings and front
+matter remain present after the edit. It also rejects edits that remove existing
+fenced code blocks, tables, or links.
+
+## Unsupported Node Policy
+
+Raw HTML is treated as unsupported for this initial substrate and fails closed.
+When `--repair-note-out` is supplied, the command writes a human-readable repair
+note with:
+
+- input path
+- target heading
+- `Status: not_mutated`
+- failure reason
+
+## Lifecycle Card Boundary
+
+Lifecycle cards remain governed by prompt-template rendering and card-editor
+skills. The command rejects `.adl/.../tasks/issue-.../{sip,stp,spp,srp,sor}.md`
+input and output paths and writes a repair note when requested. This prevents
+the AST editor from becoming an ungoverned parallel card editor.
+
+## Validation
+
+Focused tests were added in:
+
+- `adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs`
+
+The fixture coverage proves:
+
+- section replacement preserves front matter, headings, tables, links, and code
+  fences
+- lifecycle card mutation fails closed and writes a repair note
+- lifecycle-card output targeting fails closed and writes a repair note
+- unsupported raw HTML fails closed and writes a repair note
+- replacements that remove existing protected nodes fail closed
+
+## Non-Claims
+
+- This is not a general Markdown formatter.
+- This does not replace prompt-template rendering.
+- This does not authorize direct lifecycle-card mutation.
+- This does not claim all Markdown node types are safely editable.

--- a/docs/milestones/v0.91.5/review/OCTOCRAB_REFACTOR_TEMPLATE_AST_INTEGRATION_CHECKLIST_2026-06-14.md
+++ b/docs/milestones/v0.91.5/review/OCTOCRAB_REFACTOR_TEMPLATE_AST_INTEGRATION_CHECKLIST_2026-06-14.md
@@ -100,23 +100,35 @@ review cycles caused by tooling drift.
 
 ### 4. markdown.rs / AST editing
 
-- [ ] Markdown AST editing has an issue-bound implementation plan and does not
-  mutate lifecycle cards outside the renderer/editor policy.
-- [ ] The implementation plan names the concrete Rust Markdown parser/editor
-  dependency and the supported Markdown node set.
-- [ ] The implementation plan defines unsupported-node behavior and requires
-  fail-closed repair notes when safe mutation is impossible.
-- [ ] AST editing targets are classified by document type: prompt card, planning
-  doc, review packet, README/runbook, feature doc, or generated evidence.
-- [ ] For prompt cards, AST edits are limited to safe inspection or import paths
-  unless the active template system cannot represent the required change.
-- [ ] For planning and review docs, AST edits preserve headings, code fences,
-  tables, links, and front matter without text-regex drift.
-- [ ] AST editor validation includes a fixture corpus covering prompt cards,
-  planning docs, review packets, tables, links, code fences, and front matter.
-- [ ] AST editor validation includes round-trip stability checks with explicit
-  diff criteria on representative docs.
-- [ ] AST editor failures fail closed and produce a human-readable repair note.
+- [x] Markdown AST editing has an issue-bound implementation plan and does not
+  mutate lifecycle cards outside the renderer/editor policy. See
+  `adl tooling markdown-ast-edit replace-section` and the `#3715` proof packet.
+- [x] The implementation plan names the concrete Rust Markdown parser/editor
+  dependency and the supported Markdown node set. The bounded substrate uses
+  `markdown-rs` AST parsing and supports heading-anchored section replacement
+  with headings, code fences, tables, links, and YAML front matter preserved.
+- [x] The implementation plan defines unsupported-node behavior and requires
+  fail-closed repair notes when safe mutation is impossible. Raw HTML and
+  lifecycle-card input/output paths fail closed.
+- [x] AST editing targets are classified by document type: prompt card, planning
+  doc, review packet, README/runbook, feature doc, or generated evidence. Prompt
+  cards remain governed by prompt-template/card-editor authority.
+- [x] For prompt cards, AST edits are limited to safe inspection or import paths
+  unless the active template system cannot represent the required change. The
+  current command rejects lifecycle card input and output paths.
+- [x] For planning and review docs, AST edits preserve headings, code fences,
+  tables, links, and front matter without text-regex drift. The mutation is
+  line-preserving and AST-guarded before and after the edit.
+- [x] AST editor validation includes a focused fixture corpus covering a
+  representative docs packet with tables, links, code fences, and front matter;
+  lifecycle-card guardrails; unsupported raw HTML; and protected-node
+  preservation failures. See `adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs`.
+- [x] AST editor validation includes explicit preservation criteria on
+  representative docs. The focused tests assert preservation of front matter,
+  headings, tables, links, and code fences and reject edits that remove existing
+  protected nodes.
+- [x] AST editor failures fail closed and produce a human-readable repair note.
+  The lifecycle-card and unsupported-HTML tests prove this behavior.
 
 ### 5. Cross-system proof before broader rollout
 


### PR DESCRIPTION
Closes #3715

## Summary
Implemented a bounded Markdown AST editing substrate for ADL tooling. The new `adl tooling markdown-ast-edit replace-section` command performs AST-guarded, line-preserving heading-section replacement for docs surfaces, rejects lifecycle-card paths by default, and writes human-readable repair notes for fail-closed paths.

## Artifacts
- `adl/src/cli/tooling_cmd/markdown_ast_edit.rs`
- `adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs`
- `docs/milestones/v0.91.5/review/MARKDOWN_AST_EDITING_SUBSTRATE_3715.md`
- Updated `docs/milestones/v0.91.5/review/OCTOCRAB_REFACTOR_TEMPLATE_AST_INTEGRATION_CHECKLIST_2026-06-14.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml markdown_ast_edit -- --nocapture`
    Verified successful section replacement preserves front matter, tables, links, and code fences; lifecycle-card mutation fails closed; unsupported raw HTML fails closed; repair notes are written.
  - `git diff --check`
    Verified whitespace and patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3715__v0-91-5-tools-markdown-implement-ast-backed-markdown-editing-substrate/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3715__v0-91-5-tools-markdown-implement-ast-backed-markdown-editing-substrate/sor.md
- Idempotency-Key: v0-91-5-tools-markdown-implement-ast-backed-markdown-editing-substrate-adl-v0-91-5-tasks-issue-3715-v0-91-5-tools-markdown-implement-ast-backed-markdown-editing-substrate-sip-md-adl-v0-91-5-tasks-issue-3715-v0-91-5-tools-markdown-implement-ast-backed-markdown-editing-substrate-sor-md