### PR TITLE
[v0.91.5][tools][octocrab] Implement native release and watcher GitHub support

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -8,6 +8,8 @@ mod code_review;
 mod common;
 #[path = "tooling_cmd/csdlc_prompt_editor.rs"]
 mod csdlc_prompt_editor;
+#[path = "tooling_cmd/github_release.rs"]
+mod github_release;
 #[path = "tooling_cmd/markdown.rs"]
 mod markdown;
 #[path = "tooling_cmd/markdown_ast_edit.rs"]
@@ -30,6 +32,7 @@ mod wp_issue_wave;
 use card_prompt::real_card_prompt;
 use code_review::real_code_review;
 use csdlc_prompt_editor::real_csdlc_prompt_editor;
+use github_release::real_github_release;
 use markdown_ast_edit::real_markdown_ast_edit;
 use portable_project_doctor::real_portable_project_doctor;
 use prompt_template::real_prompt_template;
@@ -63,7 +66,7 @@ use structured_prompt::{
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "tooling requires a subcommand: card-prompt | code-review | csdlc-prompt-editor | lint-prompt-spec | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
+            "tooling requires a subcommand: card-prompt | code-review | csdlc-prompt-editor | github-release | lint-prompt-spec | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
         ));
     };
 
@@ -72,6 +75,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
         "code-review" => real_code_review(&args[1..]),
         "csdlc-prompt-editor" => real_csdlc_prompt_editor(&args[1..]),
         "generate-wp-issue-wave" => real_generate_wp_issue_wave(&args[1..]),
+        "github-release" => real_github_release(&args[1..]),
         "lint-prompt-spec" => real_lint_prompt_spec(&args[1..]),
         "markdown-ast-edit" => real_markdown_ast_edit(&args[1..]),
         "portable-project-doctor" => real_portable_project_doctor(&args[1..]),
@@ -87,7 +91,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | csdlc-prompt-editor | generate-wp-issue-wave | lint-prompt-spec | portable-project-doctor | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
+            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | csdlc-prompt-editor | generate-wp-issue-wave | github-release | lint-prompt-spec | portable-project-doctor | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
         )),
     }
 }
@@ -98,6 +102,7 @@ adl tooling card-prompt --input <path> [--out <path>]\n\
 adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--timeout-secs <n>] [--include-working-tree] [--file <path> ...] [--fixture-case clean|blocked]\n\
 adl tooling csdlc-prompt-editor [--repo-root <path>] [--emit-model-js <path>] [--render-samples <dir>]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\
+adl tooling github-release ensure-absent|ensure-present|draft|publish --repo <owner/repo> --tag <tag> [--name <name>] [--notes-file <path>] [--target <branch>]\n\
 adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\
 adl tooling markdown-ast-edit replace-section --input <path> --heading <heading> --replacement <path> --out <path> [--repair-note-out <path>]\n\

--- a/adl/src/cli/tooling_cmd/github_release.rs
+++ b/adl/src/cli/tooling_cmd/github_release.rs
@@ -1,0 +1,452 @@
+use anyhow::{anyhow, bail, Context, Result};
+use octocrab::models::repos::Release;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReleaseAction {
+    EnsureAbsent,
+    EnsurePresent,
+    Draft,
+    Publish,
+}
+
+#[derive(Debug, Clone)]
+struct ReleaseArgs {
+    action: ReleaseAction,
+    repo: String,
+    tag: String,
+    name: Option<String>,
+    notes_file: Option<PathBuf>,
+    target: Option<String>,
+}
+
+pub(super) fn real_github_release(args: &[String]) -> Result<()> {
+    let args = parse_args(args)?;
+    let result = run_release_action(&args)?;
+    if !result.is_empty() {
+        println!("{result}");
+    }
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<ReleaseArgs> {
+    let Some(action) = args.first().map(String::as_str) else {
+        bail!("{}", usage());
+    };
+    let action = match action {
+        "ensure-absent" => ReleaseAction::EnsureAbsent,
+        "ensure-present" => ReleaseAction::EnsurePresent,
+        "draft" => ReleaseAction::Draft,
+        "publish" => ReleaseAction::Publish,
+        "--help" | "-h" | "help" => {
+            println!("{}", usage());
+            return Err(anyhow!("help requested"));
+        }
+        other => bail!("unknown github-release action '{other}'\n{}", usage()),
+    };
+
+    let mut repo = None;
+    let mut tag = None;
+    let mut name = None;
+    let mut notes_file = None;
+    let mut target = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--repo" => {
+                repo = Some(require_value(args, &mut i, "--repo")?);
+            }
+            "--tag" => {
+                tag = Some(require_value(args, &mut i, "--tag")?);
+            }
+            "--name" => {
+                name = Some(require_value(args, &mut i, "--name")?);
+            }
+            "--notes-file" => {
+                notes_file = Some(PathBuf::from(require_value(args, &mut i, "--notes-file")?));
+            }
+            "--target" => {
+                target = Some(require_value(args, &mut i, "--target")?);
+            }
+            other => bail!("unknown github-release argument '{other}'"),
+        }
+        i += 1;
+    }
+
+    let repo = repo.ok_or_else(|| anyhow!("github-release requires --repo <owner/repo>"))?;
+    if !valid_repo(&repo) {
+        bail!("github-release --repo must be owner/repo");
+    }
+    let tag = tag.ok_or_else(|| anyhow!("github-release requires --tag <tag>"))?;
+    if tag.trim().is_empty() {
+        bail!("github-release --tag cannot be empty");
+    }
+
+    Ok(ReleaseArgs {
+        action,
+        repo,
+        tag,
+        name,
+        notes_file,
+        target,
+    })
+}
+
+fn require_value(args: &[String], i: &mut usize, flag: &str) -> Result<String> {
+    *i += 1;
+    args.get(*i)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| anyhow!("{flag} requires a non-empty value"))
+}
+
+fn usage() -> &'static str {
+    "adl tooling github-release ensure-absent|ensure-present|draft|publish --repo <owner/repo> --tag <tag> [--name <name>] [--notes-file <path>] [--target <branch>]"
+}
+
+fn valid_repo(value: &str) -> bool {
+    let mut parts = value.split('/');
+    matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty()
+    )
+}
+
+fn run_release_action(args: &ReleaseArgs) -> Result<String> {
+    let (owner, repo) = args
+        .repo
+        .split_once('/')
+        .ok_or_else(|| anyhow!("github-release --repo must be owner/repo"))?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("github_release.octocrab_runtime: failed to build runtime")?;
+    let _guard = runtime.enter();
+    let octo = build_octocrab()?;
+    runtime.block_on(async move {
+        match args.action {
+            ReleaseAction::EnsureAbsent => {
+                if release_by_tag(&octo, owner, repo, &args.tag)
+                    .await?
+                    .is_some()
+                {
+                    bail!("GitHub release already exists for tag {}", args.tag);
+                }
+                Ok(format!("release_absent tag={}", args.tag))
+            }
+            ReleaseAction::EnsurePresent => {
+                let release = release_by_tag(&octo, owner, repo, &args.tag).await?;
+                if release.is_none() {
+                    bail!("GitHub release does not exist for tag {}", args.tag);
+                }
+                Ok(format!("release_present tag={}", args.tag))
+            }
+            ReleaseAction::Draft => {
+                if release_by_tag(&octo, owner, repo, &args.tag)
+                    .await?
+                    .is_some()
+                {
+                    bail!("GitHub release already exists for tag {}", args.tag);
+                }
+                let body = read_notes(args.notes_file.as_ref())?;
+                let name = args.name.as_deref().unwrap_or(&args.tag);
+                let repo_handler = octo.repos(owner, repo);
+                let releases = repo_handler.releases();
+                let mut builder = releases
+                    .create(&args.tag)
+                    .name(name)
+                    .body(&body)
+                    .draft(true)
+                    .prerelease(false);
+                if let Some(target) = args.target.as_deref() {
+                    builder = builder.target_commitish(target);
+                }
+                let release = builder.send().await.with_context(|| {
+                    format!(
+                        "github_release.octocrab_transport: failed to draft {}",
+                        args.tag
+                    )
+                })?;
+                Ok(format!(
+                    "release_drafted tag={} url={}",
+                    release.tag_name, release.html_url
+                ))
+            }
+            ReleaseAction::Publish => {
+                let release = release_by_tag(&octo, owner, repo, &args.tag)
+                    .await?
+                    .ok_or_else(|| anyhow!("GitHub release does not exist for tag {}", args.tag))?;
+                if !release.draft {
+                    bail!("GitHub release for tag {} is not a draft", args.tag);
+                }
+                let updated = octo
+                    .repos(owner, repo)
+                    .releases()
+                    .update(release_id_u64(&release)?)
+                    .draft(false)
+                    .send()
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "github_release.octocrab_transport: failed to publish {}",
+                            args.tag
+                        )
+                    })?;
+                Ok(format!(
+                    "release_published tag={} url={}",
+                    updated.tag_name, updated.html_url
+                ))
+            }
+        }
+    })
+}
+
+async fn release_by_tag(
+    octo: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    tag: &str,
+) -> Result<Option<Release>> {
+    match octo.repos(owner, repo).releases().get_by_tag(tag).await {
+        Ok(release) => Ok(Some(release)),
+        Err(octocrab::Error::GitHub { source, .. }) if source.status_code.as_u16() == 404 => {
+            Ok(None)
+        }
+        Err(err) => Err(anyhow!(
+            "github_release.octocrab_transport: failed to inspect release {tag}: {err}"
+        )),
+    }
+}
+
+fn read_notes(path: Option<&PathBuf>) -> Result<String> {
+    match path {
+        Some(path) => fs::read_to_string(path)
+            .with_context(|| format!("failed to read release notes file '{}'", path.display())),
+        None => Ok(String::new()),
+    }
+}
+
+fn release_id_u64(release: &Release) -> Result<u64> {
+    let raw = format!("{:?}", release.id);
+    raw.chars()
+        .filter(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse::<u64>()
+        .with_context(|| format!("failed to parse release id from {raw}"))
+}
+
+fn build_octocrab() -> Result<octocrab::Octocrab> {
+    let token = std::env::var("GITHUB_TOKEN")
+        .ok()
+        .or_else(|| std::env::var("GH_TOKEN").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "github-release requires GITHUB_TOKEN or GH_TOKEN; release operations do not use gh fallback"
+            )
+        })?;
+    let builder = octocrab::Octocrab::builder().personal_token(token);
+    #[cfg(test)]
+    let builder = if let Ok(base_uri) = std::env::var("ADL_GITHUB_OCTOCRAB_BASE_URI") {
+        builder
+            .base_uri(base_uri)
+            .map_err(|err| anyhow!("failed to configure octocrab test base URI: {err}"))?
+    } else {
+        builder
+    };
+    builder
+        .build()
+        .map_err(|err| anyhow!("github_release.octocrab_build: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::sync::{Mutex, OnceLock};
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tiny_http::{Header, Response, Server};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock poisoned")
+    }
+
+    fn reserve_local_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        listener.local_addr().expect("local addr").port()
+    }
+
+    fn json_response(body: String) -> Response<std::io::Cursor<Vec<u8>>> {
+        Response::from_string(body).with_header(
+            Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                .expect("json content-type"),
+        )
+    }
+
+    fn release_fixture(id: u64, tag: &str, draft: bool) -> String {
+        serde_json::json!({
+            "url": format!("https://api.github.test/repos/owner/repo/releases/{id}"),
+            "html_url": format!("https://github.com/owner/repo/releases/tag/{tag}"),
+            "assets_url": format!("https://api.github.test/repos/owner/repo/releases/{id}/assets"),
+            "upload_url": format!("https://uploads.github.test/repos/owner/repo/releases/{id}/assets{{?name,label}}"),
+            "tarball_url": null,
+            "zipball_url": null,
+            "id": id,
+            "node_id": format!("RE_kwDO{id}"),
+            "tag_name": tag,
+            "target_commitish": "main",
+            "name": format!("ADL {tag}"),
+            "body": "release notes",
+            "draft": draft,
+            "prerelease": false,
+            "immutable": false,
+            "created_at": "2026-06-15T00:00:00Z",
+            "published_at": if draft { serde_json::Value::Null } else { serde_json::json!("2026-06-15T00:01:00Z") },
+            "author": null,
+            "assets": []
+        })
+        .to_string()
+    }
+
+    fn spawn_release_server() -> (String, thread::JoinHandle<Vec<String>>) {
+        let port = reserve_local_port();
+        let bind_addr = format!("127.0.0.1:{port}");
+        let server = Server::http(&bind_addr).expect("bind release test server");
+        let handle = thread::spawn(move || {
+            let mut seen = Vec::new();
+            for _ in 0..6 {
+                let Some(mut request) = server
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("release test server receive")
+                else {
+                    break;
+                };
+                let method = request.method().as_str().to_string();
+                let url = request.url().to_string();
+                let mut body = String::new();
+                let _ = request.as_reader().read_to_string(&mut body);
+                seen.push(format!("{method} {url} {body}"));
+                let path = url.split('?').next().unwrap_or(url.as_str());
+                let response = match (method.as_str(), path) {
+                    ("GET", "/repos/owner/repo/releases/tags/v0.91.5-missing") => {
+                        Response::from_string(r#"{"message":"Not Found"}"#).with_status_code(404)
+                    }
+                    ("GET", "/repos/owner/repo/releases/tags/v0.91.5") => {
+                        json_response(release_fixture(123, "v0.91.5", true))
+                    }
+                    ("POST", "/repos/owner/repo/releases") => {
+                        json_response(release_fixture(124, "v0.91.5-missing", true))
+                    }
+                    ("PATCH", "/repos/owner/repo/releases/123") => {
+                        json_response(release_fixture(123, "v0.91.5", false))
+                    }
+                    _ => json_response(
+                        serde_json::json!({
+                            "message": format!("unexpected request {method} {url}")
+                        })
+                        .to_string(),
+                    )
+                    .with_status_code(500),
+                };
+                let _ = request.respond(response);
+            }
+            seen
+        });
+        (format!("http://{bind_addr}"), handle)
+    }
+
+    #[test]
+    fn github_release_octocrab_covers_absent_draft_present_publish() {
+        let _guard = env_lock();
+        let old_token = std::env::var("GITHUB_TOKEN").ok();
+        let old_gh_token = std::env::var("GH_TOKEN").ok();
+        let old_base = std::env::var("ADL_GITHUB_OCTOCRAB_BASE_URI").ok();
+        let (base_uri, server) = spawn_release_server();
+        let notes_path = std::env::temp_dir().join(format!(
+            "adl-release-notes-{}.md",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        fs::write(&notes_path, "release notes\n").expect("write notes");
+        unsafe {
+            std::env::set_var("GITHUB_TOKEN", "test-token");
+            std::env::remove_var("GH_TOKEN");
+            std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        }
+
+        real_github_release(&[
+            "ensure-absent".into(),
+            "--repo".into(),
+            "owner/repo".into(),
+            "--tag".into(),
+            "v0.91.5-missing".into(),
+        ])
+        .expect("ensure absent");
+        real_github_release(&[
+            "draft".into(),
+            "--repo".into(),
+            "owner/repo".into(),
+            "--tag".into(),
+            "v0.91.5-missing".into(),
+            "--name".into(),
+            "ADL v0.91.5-missing".into(),
+            "--notes-file".into(),
+            notes_path.to_string_lossy().to_string(),
+            "--target".into(),
+            "main".into(),
+        ])
+        .expect("draft release");
+        real_github_release(&[
+            "ensure-present".into(),
+            "--repo".into(),
+            "owner/repo".into(),
+            "--tag".into(),
+            "v0.91.5".into(),
+        ])
+        .expect("ensure present");
+        real_github_release(&[
+            "publish".into(),
+            "--repo".into(),
+            "owner/repo".into(),
+            "--tag".into(),
+            "v0.91.5".into(),
+        ])
+        .expect("publish release");
+
+        let seen = server.join().expect("server join");
+        assert_eq!(seen.len(), 6, "unexpected release API calls: {seen:#?}");
+        assert!(seen
+            .iter()
+            .any(|call| call.starts_with("POST /repos/owner/repo/releases ")));
+        assert!(seen.iter().any(|call| call.contains("\"draft\":true")));
+        assert!(seen
+            .iter()
+            .any(|call| call.starts_with("PATCH /repos/owner/repo/releases/123 ")));
+        assert!(seen.iter().any(|call| call.contains("\"draft\":false")));
+
+        restore_env("GITHUB_TOKEN", old_token);
+        restore_env("GH_TOKEN", old_gh_token);
+        restore_env("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base);
+        let _ = fs::remove_file(notes_path);
+    }
+
+    fn restore_env(name: &str, value: Option<String>) {
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(name, value);
+            } else {
+                std::env::remove_var(name);
+            }
+        }
+    }
+}

--- a/adl/tools/release_ceremony.sh
+++ b/adl/tools/release_ceremony.sh
@@ -13,6 +13,7 @@ CREATE_DRAFT_RELEASE=0
 PUBLISH_RELEASE=0
 ALLOW_DIRTY=0
 SKIP_SOR_GATE=0
+RELEASE_GITHUB_CMD="${ADL_RELEASE_GITHUB_CMD:-}"
 
 PLAN_FILE=""
 NOTES_FILE=""
@@ -121,6 +122,11 @@ assert_tag_absent_remote() {
 }
 
 resolve_repo_name() {
+  if [[ -n "${ADL_RELEASE_GITHUB_REPO:-}" ]]; then
+    echo "$ADL_RELEASE_GITHUB_REPO"
+    return 0
+  fi
+
   local url
   url="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
   if [[ "$url" =~ github.com[:/]+([^/]+/[^/.]+)(\.git)?$ ]]; then
@@ -130,12 +136,32 @@ resolve_repo_name() {
   fail "could not infer GitHub repo from origin remote; GitHub Release operations are not available from shell helpers"
 }
 
+release_github_cmd() {
+  if [[ -n "$RELEASE_GITHUB_CMD" ]]; then
+    "$RELEASE_GITHUB_CMD" "$@"
+    return
+  fi
+
+  local adl_bin="$ROOT/adl/target/debug/adl"
+  if [[ -x "$adl_bin" ]]; then
+    "$adl_bin" "$@"
+    return
+  fi
+
+  require_cmd cargo
+  cargo run --manifest-path "$ROOT/adl/Cargo.toml" -- "$@"
+}
+
 assert_release_absent() {
-  fail "GitHub Release absence checks are no longer available from shell helpers; implement this path through Rust/octocrab before using --draft-release"
+  local repo
+  repo="$(resolve_repo_name)"
+  release_github_cmd tooling github-release ensure-absent --repo "$repo" --tag "$TAG"
 }
 
 assert_release_present() {
-  fail "GitHub Release presence checks are no longer available from shell helpers; implement this path through Rust/octocrab before using --publish-release"
+  local repo
+  repo="$(resolve_repo_name)"
+  release_github_cmd tooling github-release ensure-present --repo "$repo" --tag "$TAG"
 }
 
 check_cargo_version() {
@@ -319,11 +345,20 @@ if [[ "$PUSH_TAG" == "1" ]]; then
 fi
 
 if [[ "$CREATE_DRAFT_RELEASE" == "1" ]]; then
-  fail "GitHub draft release creation is no longer available from shell helpers; implement this path through Rust/octocrab before using --draft-release"
+  info "creating draft GitHub release $TAG through Rust/octocrab"
+  repo="$(resolve_repo_name)"
+  release_github_cmd tooling github-release draft \
+    --repo "$repo" \
+    --tag "$TAG" \
+    --name "ADL $TAG" \
+    --notes-file "$NOTES_FILE" \
+    --target "$TARGET_BRANCH"
 fi
 
 if [[ "$PUBLISH_RELEASE" == "1" ]]; then
-  fail "GitHub release publication is no longer available from shell helpers; implement this path through Rust/octocrab before using --publish-release"
+  info "publishing GitHub release $TAG through Rust/octocrab"
+  repo="$(resolve_repo_name)"
+  release_github_cmd tooling github-release publish --repo "$repo" --tag "$TAG"
 fi
 
 info "release ceremony actions completed"

--- a/adl/tools/test_release_ceremony.sh
+++ b/adl/tools/test_release_ceremony.sh
@@ -90,45 +90,74 @@ setup_fake_gh() {
   mkdir -p "$FAKE_BIN"
   : >"$STATE_FILE"
 
-  cat >"$FAKE_BIN/gh" <<'EOF_FAKE'
+  cat >"$FAKE_BIN/adl" <<'EOF_FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 
 STATE_FILE="${RELEASE_STATE_FILE:?missing RELEASE_STATE_FILE}"
 
-if [[ "$1" == "repo" && "$2" == "view" ]]; then
-  echo "owner/repo"
-  exit 0
-fi
+if [[ "$1" == "tooling" && "$2" == "github-release" ]]; then
+  ACTION="$3"
+  shift 3
+  TAG=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --tag)
+        TAG="$2"
+        shift 2
+        ;;
+      --repo|--name|--notes-file|--target)
+        shift 2
+        ;;
+      *)
+        echo "unexpected github-release arg: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+  [[ -n "$TAG" ]] || {
+    echo "missing --tag" >&2
+    exit 1
+  }
 
-if [[ "$1" == "release" && "$2" == "view" ]]; then
-  TAG="$3"
+  if [[ "$ACTION" == "ensure-absent" ]]; then
+    if [[ -f "$STATE_FILE" ]] && grep -Fqx "$TAG" "$STATE_FILE"; then
+      echo "GitHub release already exists for tag $TAG" >&2
+      exit 1
+    fi
+    exit 0
+  fi
+
+  if [[ "$ACTION" == "ensure-present" ]]; then
+    if [[ -f "$STATE_FILE" ]] && grep -Fqx "$TAG" "$STATE_FILE"; then
+      exit 0
+    fi
+    echo "GitHub release does not exist for tag $TAG" >&2
+    exit 1
+  fi
+
+  if [[ "$ACTION" == "draft" ]]; then
+    if ! grep -Fqx "$TAG" "$STATE_FILE" 2>/dev/null; then
+      printf '%s\n' "$TAG" >>"$STATE_FILE"
+    fi
+    exit 0
+  fi
+
+  if [[ "$ACTION" == "publish" ]]; then
   if [[ -f "$STATE_FILE" ]] && grep -Fqx "$TAG" "$STATE_FILE"; then
     exit 0
   fi
   exit 1
-fi
-
-if [[ "$1" == "release" && "$2" == "create" ]]; then
-  TAG="$3"
-  if ! grep -Fqx "$TAG" "$STATE_FILE" 2>/dev/null; then
-    printf '%s\n' "$TAG" >>"$STATE_FILE"
   fi
-  exit 0
+
+  echo "unexpected github-release action: $ACTION" >&2
+  exit 1
 fi
 
-if [[ "$1" == "release" && "$2" == "edit" ]]; then
-  TAG="$3"
-  if ! grep -Fqx "$TAG" "$STATE_FILE" 2>/dev/null; then
-    exit 1
-  fi
-  exit 0
-fi
-
-echo "unexpected gh command: $*" >&2
+echo "unexpected adl command: $*" >&2
 exit 1
 EOF_FAKE
-  chmod +x "$FAKE_BIN/gh"
+  chmod +x "$FAKE_BIN/adl"
 }
 
 reset_git_state() {
@@ -146,6 +175,7 @@ run_release_case() {
   local output
   set +e
   output="$(cd "$FIXTURE" && PATH="$FAKE_BIN:$PATH" RELEASE_STATE_FILE="$STATE_FILE" \
+    ADL_RELEASE_GITHUB_CMD="$FAKE_BIN/adl" ADL_RELEASE_GITHUB_REPO="owner/repo" \
     "$BASH_BIN" adl/tools/release_ceremony.sh --version "$VERSION" \
     --skip-sor-gate --target-branch main --allow-dirty "$@" 2>&1)"
   local status=$?
@@ -210,26 +240,24 @@ git -C "$FIXTURE" tag -a "$TAG_NAME" -m "release fixture"
 run_release_case "push-tag succeeds when local tag exists and remote is absent" 0 "" --push-tag --tag "$TAG_NAME"
 assert_remote_tag_present
 
-# Draft/publish release operations are intentionally fail-closed until the
-# GitHub Release API path is implemented through Rust/octocrab. The shell
-# helper must not silently fall back to legacy GitHub Release CLI behavior.
+# Draft/publish release operations delegate to the Rust/octocrab release path.
 reset_git_state
 git -C "$FIXTURE" tag -a "$TAG_NAME" -m "release fixture"
 git -C "$FIXTURE" push -q origin "$TAG_NAME"
 run_release_case \
-  "draft-release fails closed until Rust/octocrab release support exists" \
-  1 \
-  "GitHub Release absence checks are no longer available from shell helpers" \
+  "draft-release delegates to Rust release support" \
+  0 \
+  "creating draft GitHub release" \
   --draft-release --tag "$TAG_NAME"
-assert_release_absent
+assert_release_present
 
 git -C "$FIXTURE" push -q origin ":refs/tags/$TAG_NAME" >/dev/null 2>&1 || true
 git -C "$FIXTURE" tag -d "$TAG_NAME" >/dev/null 2>&1 || true
 printf '%s\n' "$TAG_NAME" >"$STATE_FILE"
 run_release_case \
-  "publish-release fails closed until Rust/octocrab release support exists" \
-  1 \
-  "GitHub Release presence checks are no longer available from shell helpers" \
+  "publish-release delegates to Rust release support" \
+  0 \
+  "publishing GitHub release" \
   --publish-release --tag "$TAG_NAME"
 assert_release_present
 
@@ -249,16 +277,16 @@ git -C "$FIXTURE" push -q origin "$TAG_NAME"
 printf '%s
 ' "$TAG_NAME" >"$STATE_FILE"
 run_release_case \
-  "draft-release remains fail-closed even when release exists" \
+  "draft-release fails when release exists" \
   1 \
-  "GitHub Release absence checks are no longer available from shell helpers" \
+  "GitHub release already exists" \
   --draft-release --tag "$TAG_NAME"
 
 reset_git_state
 run_release_case \
-  "publish-release remains fail-closed when draft release is missing" \
+  "publish-release fails when draft release is missing" \
   1 \
-  "GitHub Release presence checks are no longer available from shell helpers" \
+  "GitHub release does not exist" \
   --publish-release --tag "$TAG_NAME"
 
 # Split-step invocation across mutation phases.
@@ -269,16 +297,15 @@ run_release_case "split-step phase 2: push-tag" 0 "" --push-tag --tag "$TAG_NAME
 assert_remote_tag_present
 assert_release_absent
 run_release_case \
-  "split-step phase 3: draft-release fails closed" \
-  1 \
-  "GitHub Release absence checks are no longer available from shell helpers" \
+  "split-step phase 3: draft-release" \
+  0 \
+  "creating draft GitHub release" \
   --draft-release --tag "$TAG_NAME"
-assert_release_absent
-printf '%s\n' "$TAG_NAME" >"$STATE_FILE"
+assert_release_present
 run_release_case \
-  "split-step phase 4: publish-release fails closed" \
-  1 \
-  "GitHub Release presence checks are no longer available from shell helpers" \
+  "split-step phase 4: publish-release" \
+  0 \
+  "publishing GitHub release" \
   --publish-release --tag "$TAG_NAME"
 assert_release_present
 

--- a/docs/milestones/v0.91.5/review/NATIVE_RELEASE_WATCHER_GITHUB_SUPPORT_3718.md
+++ b/docs/milestones/v0.91.5/review/NATIVE_RELEASE_WATCHER_GITHUB_SUPPORT_3718.md
@@ -57,6 +57,18 @@ bash adl/tools/test_release_ceremony.sh
 
 Result: passed.
 
+```bash
+cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- tooling_cmd
+```
+
+Result: passed; wrote `adl/target/coverage-impact-summary.json`.
+
+```bash
+bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk
+```
+
+Result: passed for changed Rust source files.
+
 ## Review Notes
 
 The proof is intentionally narrow. It shows the release ceremony's covered GitHub release actions now have a typed Rust/octocrab path and that the shell wrapper delegates to it. Remaining GitHub transport work should be routed as follow-on issues rather than hidden inside #3718.

--- a/docs/milestones/v0.91.5/review/NATIVE_RELEASE_WATCHER_GITHUB_SUPPORT_3718.md
+++ b/docs/milestones/v0.91.5/review/NATIVE_RELEASE_WATCHER_GITHUB_SUPPORT_3718.md
@@ -1,0 +1,62 @@
+# Native Release And Watcher GitHub Support Proof (#3718)
+
+Status: ready_for_review
+Issue: #3718
+Milestone: v0.91.5
+
+## Summary
+
+This packet records the focused proof for replacing the release-ceremony GitHub release operations with the Rust/octocrab ADL control-plane path.
+
+The implemented surface adds `adl tooling github-release` with native octocrab-backed operations for:
+
+- `ensure-absent`
+- `ensure-present`
+- `draft`
+- `publish`
+
+`adl/tools/release_ceremony.sh` now delegates covered GitHub release operations to that Rust command instead of calling `gh release` directly. The release ceremony test harness uses a fake `adl tooling github-release` command so the shell workflow proves delegation without touching real GitHub release state.
+
+## Covered Behavior
+
+- Release preflight can confirm that a release tag is absent.
+- Release preflight can confirm that a release tag is present.
+- Draft release creation is routed through the Rust/octocrab command surface.
+- Release publication is routed through the Rust/octocrab command surface.
+- The shell ceremony supports an explicit `ADL_RELEASE_GITHUB_CMD` override for tests and controlled environments.
+- The shell ceremony supports an explicit `ADL_RELEASE_GITHUB_REPO` override to avoid brittle remote parsing in tests.
+- The Rust command reads credentials from `GITHUB_TOKEN` or `GH_TOKEN` and does not log token values.
+
+## Watcher Boundary
+
+The `issue-watcher` skill remains an observation and routing skill. This issue does not introduce a daemon or background watcher.
+
+Watcher-related policy remains: use repo-native GitHub metadata surfaces where available, do not rely on `gh` as hidden authority, and fail closed or route follow-up when a covered operation lacks a native path.
+
+## Non-Claims
+
+- No real GitHub release was created, published, or deleted by this proof.
+- Release asset upload is not covered by this issue.
+- Release deletion is not covered by this issue.
+- This issue does not remove every unrelated legacy `gh` call in the repository.
+- This issue does not create a generalized GitHub event watcher.
+
+## Validation
+
+Focused validation was run from the bound #3718 worktree.
+
+```bash
+cargo test --manifest-path adl/Cargo.toml github_release -- --nocapture
+```
+
+Result: passed.
+
+```bash
+bash adl/tools/test_release_ceremony.sh
+```
+
+Result: passed.
+
+## Review Notes
+
+The proof is intentionally narrow. It shows the release ceremony's covered GitHub release actions now have a typed Rust/octocrab path and that the shell wrapper delegates to it. Remaining GitHub transport work should be routed as follow-on issues rather than hidden inside #3718.


### PR DESCRIPTION
Closes #3718

## Summary
Implemented native Rust/octocrab GitHub release support for the release ceremony's covered release operations and recorded a focused proof packet for #3718.

## Artifacts
- `adl/src/cli/tooling_cmd/github_release.rs`
- `adl/src/cli/tooling_cmd.rs`
- `adl/tools/release_ceremony.sh`
- `adl/tools/test_release_ceremony.sh`
- `docs/milestones/v0.91.5/review/NATIVE_RELEASE_WATCHER_GITHUB_SUPPORT_3718.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml github_release -- --nocapture`
    Verified the Rust/octocrab command behavior with a mock GitHub release API.
  - `bash adl/tools/test_release_ceremony.sh`
    Verified the shell release ceremony delegates covered GitHub release actions to the ADL command surface.
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Formatted the Rust source touched by this issue.
  - `git diff --check`
    Verified whitespace cleanliness.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.5/tasks/issue-3718__v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support/srp.md`
    Verified SRP structure.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.91.5/tasks/issue-3718__v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support/sor.md`
    Verified SOR structure.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3718__v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3718__v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support/sor.md
- Idempotency-Key: v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-github-release-rs-adl-tools-release-ceremony-sh-adl-tools-test-release-ceremony-sh-docs-milestones-v0-91-5-review-native-release-watcher-github-support-3718-md-adl-v0-91-5-tasks-issue-3718-v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support-sip-md-adl-v0-91-5-tasks-issue-3718-v0-91-5-tools-octocrab-implement-native-release-and-watcher-github-support-sor-md