### PR TITLE
[v0.91.5][tools][prompt-templates] Make SPP lifecycle status editable through values renderer

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -1078,6 +1078,8 @@ fn render_bootstrap_plan_card(
             ("<branch>", branch.to_string()),
             ("<timestamp>", timestamp),
             ("<card_status>", "draft".to_string()),
+            ("<status>", "draft".to_string()),
+            ("<activation_state>", "draft".to_string()),
             ("<issue_url>", issue_url),
             ("<source_issue_prompt>", source_rel),
             ("<stp_card>", stp_rel),

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -223,6 +223,96 @@ fn prompt_template_cli_edits_declared_values_and_fails_closed() {
 }
 
 #[test]
+fn prompt_template_cli_edits_spp_lifecycle_status_values() {
+    let repo = TempRepo::new("prompt-template-edit-spp-lifecycle");
+    let values_dir = repo.path().join("values");
+    let edited_values = repo.path().join("edited-spp.values.yaml");
+    let rendered = repo.path().join("edited-spp.md");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("spp.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "card_status=approved".to_string(),
+        "--set".to_string(),
+        "status=approved".to_string(),
+        "--set".to_string(),
+        "activation_state=approved".to_string(),
+        "--out".to_string(),
+        edited_values.to_string_lossy().to_string(),
+    ])
+    .expect("edit-values should update SPP lifecycle fields");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "render".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--values".to_string(),
+        edited_values.to_string_lossy().to_string(),
+        "--out".to_string(),
+        rendered.to_string_lossy().to_string(),
+    ])
+    .expect("edited SPP values should render");
+
+    let rendered_text = fs::read_to_string(&rendered).expect("rendered SPP");
+    assert!(rendered_text.contains("card_status: \"approved\""));
+    assert!(rendered_text.contains("status: \"approved\""));
+    assert!(rendered_text.contains("activation_state: \"approved\""));
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--input".to_string(),
+        rendered.to_string_lossy().to_string(),
+    ])
+    .expect("edited SPP structure should validate");
+
+    let invalid = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("spp.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "activation_state=design_time_ready".to_string(),
+    ])
+    .expect_err("invalid SPP lifecycle value should fail closed");
+    assert!(invalid
+        .to_string()
+        .contains("spp.activation_state must be one of"));
+}
+
+#[test]
 fn prompt_template_cli_imports_values_and_round_trips_rendered_card() {
     let repo = TempRepo::new("prompt-template-import-values");
     let values_dir = repo.path().join("values");

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -70,6 +70,7 @@ const PLACEHOLDERS: &[&str] = &[
     "validation_plan_inline",
     "notes_risks_inline",
     "status",
+    "activation_state",
     "timestamp",
     "branch_action",
     "findings_status",
@@ -227,7 +228,7 @@ pub fn render_sample_card(repo_root: &Path, kind: PromptCardKind) -> Result<Stri
         .iter()
         .find(|card| card.kind == kind)
         .ok_or_else(|| anyhow!("missing card model for {}", kind.key()))?;
-    let values = sample_values();
+    let values = sample_values_for_kind(kind);
     validate_values(card, &values)?;
     let rendered = render_template(&card.template, &values)?;
     validate_rendered_card_structure_from_repo(repo_root, card, &rendered)?;
@@ -1576,6 +1577,7 @@ pub fn sample_values() -> BTreeMap<String, String> {
             "Use Rust-generated metadata as the browser model.",
         ),
         ("status", "NOT_STARTED"),
+        ("activation_state", "draft"),
         ("timestamp", "2026-05-23T00:00:00Z"),
         (
             "branch_action",
@@ -1585,6 +1587,15 @@ pub fn sample_values() -> BTreeMap<String, String> {
         ("recommended_outcome", "not_run"),
     ] {
         values.insert(key.to_string(), value.to_string());
+    }
+    values
+}
+
+fn sample_values_for_kind(kind: PromptCardKind) -> BTreeMap<String, String> {
+    let mut values = sample_values();
+    if kind == PromptCardKind::Spp {
+        values.insert("status".to_string(), "draft".to_string());
+        values.insert("activation_state".to_string(), "draft".to_string());
     }
     values
 }
@@ -1796,6 +1807,27 @@ fn form_fields(kind: PromptCardKind) -> Vec<PromptField> {
             ));
         }
         PromptCardKind::Spp => {
+            fields.push(select(
+                "card_status",
+                "Card Status",
+                true,
+                "SPP lifecycle card status.",
+                CARD_STATUS_VALUES,
+            ));
+            fields.push(select(
+                "status",
+                "Status",
+                true,
+                "SPP frontmatter lifecycle status.",
+                CARD_STATUS_VALUES,
+            ));
+            fields.push(select(
+                "activation_state",
+                "Activation State",
+                true,
+                "SPP execution-readiness lifecycle state.",
+                CARD_STATUS_VALUES,
+            ));
             fields.push(read_only_textarea(
                 "stp_card",
                 "STP Card",

--- a/adl/src/csdlc_prompt_editor/values.rs
+++ b/adl/src/csdlc_prompt_editor/values.rs
@@ -203,7 +203,11 @@ fn yaml_scalar(value: &str) -> String {
 }
 
 pub(super) fn sample_values_document(kind: PromptCardKind) -> String {
-    let values = sample_values();
+    let mut values = sample_values();
+    if kind == PromptCardKind::Spp {
+        values.insert("status".to_string(), "draft".to_string());
+        values.insert("activation_state".to_string(), "draft".to_string());
+    }
     let editable_keys = form_fields(kind)
         .iter()
         .filter(|field| field.editable)

--- a/docs/templates/prompts/1.0.0/spp.md
+++ b/docs/templates/prompts/1.0.0/spp.md
@@ -10,8 +10,8 @@ title: "<title>"
 branch: "<branch>"
 generated_at: "<timestamp>"
 card_status: "<card_status>"
-status: "draft"
-activation_state: "draft"
+status: "<status>"
+activation_state: "<activation_state>"
 plan_revision: 1
 source_refs:
   - kind: "issue"


### PR DESCRIPTION
Closes #3754

## Summary
Implemented the issue-bound prompt-template fix so SPP lifecycle fields can be edited through the values renderer instead of hand-patching rendered Markdown. The SPP template now renders `status` and `activation_state` from values, and the Rust prompt editor declares SPP `card_status`, `status`, and `activation_state` as editable lifecycle select fields while preserving existing SOR status behavior through kind-scoped sample values.

## Artifacts
- `adl/src/csdlc_prompt_editor.rs`: declares editable SPP lifecycle fields and kind-scoped SPP sample lifecycle defaults.
- `adl/src/csdlc_prompt_editor/values.rs`: writes SPP sample values with SPP lifecycle defaults instead of SOR execution defaults.
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`: adds a regression test proving SPP lifecycle fields can be edited, rendered, structure-validated, and fail closed on invalid lifecycle values.
- `adl/src/cli/pr_cmd_cards/cards.rs`: keeps the direct PR-card bootstrap renderer aligned with the SPP lifecycle placeholders.
- `docs/templates/prompts/1.0.0/spp.md`: renders SPP `status` and `activation_state` from values.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_cli_edits_spp_lifecycle_status_values -- --nocapture`
    Proved the new SPP lifecycle edit path and invalid-value fail-closed behavior.
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_cli_renders_and_validates_all_five_cards_from_values -- --nocapture`
    Proved existing prompt-template render/validate behavior for all card kinds remains intact.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas --repo-root .`
    Proved schema parity after changing the SPP template.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Applied Rust formatting.
  - `git diff --check`
    Proved no whitespace errors in the diff.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ -- --nocapture`
    Proved the broader PR lifecycle bootstrap surface after adding SPP lifecycle placeholders.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3754__spp-lifecycle-status-editable-through-values-renderer/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3754__spp-lifecycle-status-editable-through-values-renderer/sor.md
- Idempotency-Key: v0-91-5-tools-prompt-templates-make-spp-lifecycle-status-editable-through-values-renderer-adl-v0-91-5-tasks-issue-3754-spp-lifecycle-status-editable-through-values-renderer-sip-md-adl-v0-91-5-tasks-issue-3754-spp-lifecycle-status-editable-through-values-renderer-sor-md