### PR TITLE
[v0.91.5][tools][pr-run] Refuse stale dirty worktree reuse for issue execution

### DIFF
--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -291,6 +291,7 @@ fn normalize_existing_worktree_path(path: &Path) -> PathBuf {
 pub(super) fn ensure_worktree_for_branch(worktree_path: &Path, branch: &str) -> Result<()> {
     if let Some(existing) = branch_checked_out_worktree_path(branch)? {
         if existing == worktree_path {
+            ensure_reusable_worktree_is_clean(&existing, branch)?;
             eprintln!(
                 "• Reusing existing worktree for branch: {}",
                 worktree_path.display()
@@ -315,11 +316,40 @@ pub(super) fn ensure_worktree_for_branch(worktree_path: &Path, branch: &str) -> 
         )?;
         return Ok(());
     }
-    eprintln!(
-        "• Reusing existing worktree path: {}",
-        worktree_path.display()
-    );
-    Ok(())
+    bail!(
+        "start: unsafe_existing_worktree_path: target worktree path '{}' already exists but is not the clean checked-out worktree for branch '{}'. Remediation: preserve any local changes, then prune/remove the stale path before rerunning.",
+        worktree_path.display(),
+        branch
+    )
+}
+
+fn ensure_reusable_worktree_is_clean(worktree_path: &Path, branch: &str) -> Result<()> {
+    let status = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(worktree_path)?,
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        ],
+    )?;
+    if status.trim().is_empty() {
+        return Ok(());
+    }
+
+    let preview = status
+        .lines()
+        .take(8)
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\\n");
+    bail!(
+        "start: unsafe_existing_worktree_dirty: refusing to reuse worktree '{}' for branch '{}' because it has staged, unstaged, or untracked changes. Remediation: preserve or resolve those changes, then rerun; do not reset or prune until the dirty state is accounted for. Dirty status:\\n{}",
+        worktree_path.display(),
+        branch,
+        preview
+    )
 }
 
 pub(super) fn run_capture(program: &str, args: &[&str]) -> Result<String> {

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -381,7 +381,7 @@ fn ensure_worktree_for_branch_reuses_matching_path_and_creates_new_one() {
     write_executable(
             &bin_dir.join("git"),
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{0}'\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{2}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  if [ \"${{WT_MODE:-reuse}}\" = 'reuse' ]; then\n    cat <<'EOF'\nworktree {1}/.worktrees/reuse-me\nHEAD deadbeef\nbranch refs/heads/codex/reuse\nEOF\n    exit 0\n  fi\n  printf 'worktree {1}\\nHEAD deadbeef\\nbranch refs/heads/main\\n'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree add {1}/.worktrees/create-me' ]; then\n  mkdir -p {1}/.worktrees/create-me\n  exit 0\nfi\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{0}'\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{2}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  if [ \"${{WT_MODE:-reuse}}\" = 'reuse' ]; then\n    cat <<'EOF'\nworktree {1}/.worktrees/reuse-me\nHEAD deadbeef\nbranch refs/heads/codex/reuse\nEOF\n    exit 0\n  fi\n  printf 'worktree {1}\\nHEAD deadbeef\\nbranch refs/heads/main\\n'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = '-C {1}/.worktrees/reuse-me status' ]; then\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree add {1}/.worktrees/create-me' ]; then\n  mkdir -p {1}/.worktrees/create-me\n  exit 0\nfi\nexit 1\n",
                 git_log.display(),
                 repo.display(),
                 repo.join(".git").display()
@@ -415,6 +415,81 @@ fn ensure_worktree_for_branch_reuses_matching_path_and_creates_new_one() {
         "worktree add {} codex/create",
         create_path.display()
     )));
+}
+
+#[test]
+fn ensure_worktree_for_branch_rejects_dirty_matching_worktree() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-worktree-dirty-reuse");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
+    fs::create_dir_all(repo.join(".worktrees/reuse-me")).expect("reuse worktree");
+    write_executable(
+        &bin_dir.join("git"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree {0}/.worktrees/reuse-me\nHEAD deadbeef\nbranch refs/heads/codex/reuse\nEOF\n  exit 0\nfi\nif [ \"$1 $2 $3\" = '-C {0}/.worktrees/reuse-me status' ]; then\n  printf ' M README.md\\n?? scratch.txt\\n'\n  exit 0\nfi\nexit 1\n",
+            repo.display(),
+            repo.join(".git").display(),
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let err = ensure_worktree_for_branch(&repo.join(".worktrees/reuse-me"), "codex/reuse")
+        .expect_err("dirty matching worktree should fail closed");
+    env::set_current_dir(old_pwd).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let err = err.to_string();
+    assert!(err.contains("unsafe_existing_worktree_dirty"));
+    assert!(err.contains("README.md"));
+    assert!(err.contains("scratch.txt"));
+    assert!(err.contains("do not reset or prune until the dirty state is accounted for"));
+}
+
+#[test]
+fn ensure_worktree_for_branch_rejects_existing_path_without_matching_branch() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-worktree-stale-path");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
+    fs::create_dir_all(repo.join(".worktrees/stale")).expect("stale worktree");
+    write_executable(
+        &bin_dir.join("git"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree {0}\nHEAD deadbeef\nbranch refs/heads/main\nEOF\n  exit 0\nfi\nexit 1\n",
+            repo.display(),
+            repo.join(".git").display(),
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let err = ensure_worktree_for_branch(&repo.join(".worktrees/stale"), "codex/current")
+        .expect_err("existing stale path should fail closed");
+    env::set_current_dir(old_pwd).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let err = err.to_string();
+    assert!(err.contains("unsafe_existing_worktree_path"));
+    assert!(err.contains(".worktrees/stale"));
+    assert!(err.contains("codex/current"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #3756

## Summary
Implemented fail-closed reuse checks for `pr run` worktree preparation. Existing issue worktrees are now reused only when the target branch is actually checked out at the expected path and the worktree has no staged, unstaged, or untracked changes.

## Artifacts
- Updated `adl/src/cli/pr_cmd/git_support.rs` with clean-reuse validation and stale-path refusal.
- Updated `adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs` with focused fake-git regression tests for dirty matching worktrees and stale existing target paths.
- Preserved existing repair/bootstrap behavior for clean worktrees through focused lifecycle regression tests.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Formatted Rust code across the crate.
  - `cargo test --manifest-path adl/Cargo.toml ensure_worktree_for_branch_reuses_matching_path_and_creates_new_one -- --nocapture`
    Verified clean matching worktree reuse and new worktree creation still work.
  - `cargo test --manifest-path adl/Cargo.toml ensure_worktree_for_branch_rejects_dirty_matching_worktree -- --nocapture`
    Verified dirty matching worktrees are refused before execution binding.
  - `cargo test --manifest-path adl/Cargo.toml ensure_worktree_for_branch_rejects_existing_path_without_matching_branch -- --nocapture`
    Verified stale existing target paths are refused instead of silently reused.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_repairs_preexisting_worktree_missing_task_bundle -- --nocapture`
    Verified clean existing worktree repair behavior still succeeds.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
    Verified normal issue worktree bootstrap and ready doctor still succeed.
  - `git diff --check`
    Verified no whitespace errors in the pending diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3756__refuse-stale-dirty-worktree-reuse-for-issue-execution/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3756__refuse-stale-dirty-worktree-reuse-for-issue-execution/sor.md
- Idempotency-Key: v0-91-5-tools-pr-run-refuse-stale-dirty-worktree-reuse-for-issue-execution-adl-v0-91-5-tasks-issue-3756-refuse-stale-dirty-worktree-reuse-for-issue-execution-sip-md-adl-v0-91-5-tasks-issue-3756-refuse-stale-dirty-worktree-reuse-for-issue-execution-sor-md