### PR TITLE
[v0.91.5][tools][workflow] Fix pr-finish card/template adoption seams

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cli::pr_cmd_cards::{validate_bootstrap_output_card, StructuredBundlePaths};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 mod card_lifecycle;
 mod preflight;
@@ -47,6 +47,33 @@ fn doctor_mode_name(mode: &DoctorMode) -> &'static str {
         DoctorMode::Ready => "ready",
         DoctorMode::Preflight => "preflight",
     }
+}
+
+pub(super) fn resolve_doctor_issue_prompt_path(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<PathBuf> {
+    let mut roots = vec![repo_root.to_path_buf()];
+    let worktree_path = issue_ref.default_worktree_path(
+        repo_root,
+        std::env::var_os("ADL_WORKTREE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+    );
+    if !roots.iter().any(|root| root == &worktree_path) {
+        roots.push(worktree_path);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if !roots.iter().any(|root| root == &cwd) {
+            roots.push(cwd);
+        }
+    }
+    for root in roots {
+        if let Ok(path) = resolve_issue_prompt_path(&root, issue_ref) {
+            return Ok(path);
+        }
+    }
+    resolve_issue_prompt_path(repo_root, issue_ref)
 }
 
 pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -9,7 +9,7 @@ pub(super) fn run_doctor_preflight(
     issue_ref: &IssueRef,
     branch: &str,
 ) -> Result<DoctorPreflightResult> {
-    let source_path = resolve_issue_prompt_path(repo_root, issue_ref)?;
+    let source_path = resolve_doctor_issue_prompt_path(repo_root, issue_ref)?;
     let target_queue = resolve_issue_prompt_workflow_queue(&source_path)?;
     let unresolved =
         unresolved_milestone_pr_wave(repo, version, &target_queue.queue, Some(branch))?;

--- a/adl/src/cli/pr_cmd/doctor/ready.rs
+++ b/adl/src/cli/pr_cmd/doctor/ready.rs
@@ -8,13 +8,25 @@ pub(super) fn run_doctor_ready(
     issue_ref: &IssueRef,
     branch: &str,
 ) -> Result<DoctorReadyResult> {
-    let worktree_path = issue_ref.default_worktree_path(
+    let mut worktree_path = issue_ref.default_worktree_path(
         repo_root,
         std::env::var_os("ADL_WORKTREE_ROOT")
             .map(PathBuf::from)
             .as_deref(),
     );
-    let source_path = resolve_issue_prompt_path(repo_root, issue_ref)?;
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd != repo_root && cwd.join(".git").exists() {
+            if let Ok(current_branch) = run_capture(
+                "git",
+                &["-C", path_str(&cwd)?, "rev-parse", "--abbrev-ref", "HEAD"],
+            ) {
+                if current_branch.trim() == branch {
+                    worktree_path = cwd;
+                }
+            }
+        }
+    }
+    let source_path = resolve_doctor_issue_prompt_path(repo_root, issue_ref)?;
     let root_stp = issue_ref.task_bundle_stp_path(repo_root);
     let wt_stp = issue_ref.task_bundle_stp_path(&worktree_path);
     let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
@@ -63,6 +75,78 @@ pub(super) fn run_doctor_ready(
                 &root_bundle_output,
             ),
             status: "PASS",
+        });
+    }
+    let root_bundle_complete = [
+        &root_stp,
+        &root_bundle_input,
+        &root_bundle_output,
+        &root_bundle_plan,
+        &root_bundle_review_policy,
+    ]
+    .iter()
+    .all(|path| path.is_file());
+    let wt_bundle_complete = [
+        &wt_stp,
+        &wt_bundle_input,
+        &wt_bundle_output,
+        &wt_bundle_plan,
+        &wt_bundle_review_policy,
+    ]
+    .iter()
+    .all(|path| path.is_file());
+    if !root_bundle_complete && worktree_path.is_dir() && wt_bundle_complete {
+        let wt_branch = run_capture(
+            "git",
+            &[
+                "-C",
+                path_str(&worktree_path)?,
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD",
+            ],
+        )?;
+        if wt_branch.trim() != branch {
+            bail!(
+                "doctor: worktree branch mismatch for {}",
+                worktree_path.display()
+            );
+        }
+        validate_bootstrap_stp(&worktree_path, &wt_stp)?;
+        validate_authored_prompt_surface("doctor", &wt_stp, PromptSurfaceKind::Stp)?;
+        validate_ready_cards(
+            &worktree_path,
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            wt_branch.trim(),
+            &wt_bundle_input,
+            &wt_bundle_output,
+            StructuredBundlePaths {
+                plan_path: &wt_bundle_plan,
+                review_policy_path: &wt_bundle_review_policy,
+            },
+        )?;
+        let card_lifecycle = build_doctor_card_lifecycle(
+            repo_root,
+            &wt_bundle_input,
+            &wt_stp,
+            &wt_bundle_plan,
+            &wt_bundle_review_policy,
+            &wt_bundle_output,
+        );
+        let status = doctor_ready_status_for(&card_lifecycle);
+        return Ok(DoctorReadyResult {
+            lifecycle_state: "run_bound",
+            worktree: Some(path_relative_to_repo(repo_root, &worktree_path)),
+            source: path_relative_to_repo(repo_root, &source_path),
+            root_stp: path_relative_to_repo(repo_root, &root_stp),
+            root_input: path_relative_to_repo(repo_root, &root_bundle_input),
+            root_output: path_relative_to_repo(repo_root, &root_bundle_output),
+            wt_stp: Some(path_relative_to_repo(repo_root, &wt_stp)),
+            wt_input: Some(path_relative_to_repo(repo_root, &wt_bundle_input)),
+            wt_output: Some(path_relative_to_repo(repo_root, &wt_bundle_output)),
+            card_lifecycle,
+            status,
         });
     }
     if !root_stp.is_file() {

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -4,6 +4,27 @@ use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
+fn doctor_issue_prompt_resolution_falls_back_to_bound_worktree_prompt() {
+    let repo = lifecycle_temp_repo("doctor-source-worktree-fallback");
+    let issue_ref = IssueRef::new(
+        3766,
+        "v0.91.5".to_string(),
+        "v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams".to_string(),
+    )
+    .expect("issue ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let source_path = issue_ref.issue_prompt_path(&worktree);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("create bodies dir");
+    fs::write(&source_path, "---\nissue: 3766\n---\n\n# Source issue\n")
+        .expect("write source prompt");
+
+    let resolved =
+        resolve_doctor_issue_prompt_path(&repo, &issue_ref).expect("doctor source prompt");
+
+    assert_eq!(resolved, source_path);
+}
+
+#[test]
 fn card_lifecycle_marks_legacy_srp_policy_as_not_finish_ready() {
     let repo = lifecycle_temp_repo("legacy-srp-policy");
     let paths = write_lifecycle_fixture(

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -37,11 +37,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     let _ = run_status_allow_failure("git", &["fetch", "origin"]);
 
-    let inferred = resolve_issue_scope_and_slug_from_local_state(&primary_root, parsed.issue)?
-        .unwrap_or((
-            DEFAULT_VERSION.to_string(),
-            format!("issue-{}", parsed.issue),
-        ));
+    let inferred = resolve_finish_issue_scope_and_slug(&repo_root, &primary_root, parsed.issue)?;
     let issue_ref = IssueRef::new(parsed.issue, inferred.0.clone(), inferred.1.clone())?;
     let expected_branch = issue_ref.branch_name("codex");
     ensure_finish_uses_bound_checkout(&repo_root, &expected_branch)?;
@@ -57,7 +53,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         );
     }
 
-    let source_path = resolve_issue_prompt_path(&primary_root, &issue_ref)?;
+    let source_path =
+        resolve_finish_source_issue_prompt_path(&repo_root, &primary_root, &issue_ref)?;
+    ensure_finish_task_bundle_surfaces(&repo_root, &issue_ref)?;
     let stp_path = issue_ref.task_bundle_stp_path(&repo_root);
 
     let input_path = parsed
@@ -280,6 +278,83 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     Ok(())
 }
 
+pub(super) fn resolve_finish_issue_scope_and_slug(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue: u32,
+) -> Result<(String, String)> {
+    if let Some(identity) = resolve_issue_scope_and_slug_from_local_state(repo_root, issue)? {
+        return Ok(identity);
+    }
+    if primary_root != repo_root {
+        if let Some(identity) = resolve_issue_scope_and_slug_from_local_state(primary_root, issue)?
+        {
+            return Ok(identity);
+        }
+    }
+    Ok((DEFAULT_VERSION.to_string(), format!("issue-{issue}")))
+}
+
+pub(super) fn resolve_finish_source_issue_prompt_path(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<PathBuf> {
+    if let Ok(path) = resolve_issue_prompt_path(repo_root, issue_ref) {
+        return Ok(path);
+    }
+    if primary_root != repo_root {
+        return resolve_issue_prompt_path(primary_root, issue_ref);
+    }
+    resolve_issue_prompt_path(repo_root, issue_ref)
+}
+
+pub(super) fn ensure_finish_task_bundle_surfaces(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let canonical_dir = issue_ref.task_bundle_dir_path(repo_root);
+    let candidate_dirs = lifecycle::matching_task_bundle_dirs(repo_root, issue_ref)?;
+    let required_files = ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"];
+    let mut copied_any = false;
+
+    for file_name in required_files {
+        let canonical_path = canonical_dir.join(file_name);
+        if ensure_nonempty_file_path(&canonical_path)? {
+            continue;
+        }
+        let source_path = candidate_dirs
+            .iter()
+            .filter(|candidate| *candidate != &canonical_dir)
+            .map(|candidate| candidate.join(file_name))
+            .find(|candidate| ensure_nonempty_file_path(candidate).unwrap_or(false));
+        if let Some(source_path) = source_path {
+            fs::create_dir_all(&canonical_dir).with_context(|| {
+                format!(
+                    "finish: failed to create canonical task bundle {}",
+                    canonical_dir.display()
+                )
+            })?;
+            fs::copy(&source_path, &canonical_path).with_context(|| {
+                format!(
+                    "finish: failed to restore canonical {} from slug-drifted task bundle {}",
+                    canonical_path.display(),
+                    source_path.display()
+                )
+            })?;
+            copied_any = true;
+        }
+    }
+
+    if copied_any {
+        eprintln!(
+            "finish: restored missing canonical task-bundle cards for #{} from matching issue bundle",
+            issue_ref.issue_number()
+        );
+    }
+    Ok(())
+}
+
 fn ensure_finish_uses_bound_checkout(repo_root: &Path, branch: &str) -> Result<()> {
     let Some(bound_worktree) = branch_checked_out_worktree_path(branch)? else {
         return Ok(());
@@ -469,7 +544,7 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             );
             push_finish_validation_command(
                 &mut commands,
-                "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd",
+                "cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd",
             );
         }
         if paths
@@ -729,13 +804,15 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
-                "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd" => {
+                "cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd" => {
                     run_finish_validation_status(
                         "cargo",
                         &[
                             "test",
                             "--manifest-path",
                             path_str(&manifest)?,
+                            "--bin",
+                            "adl",
                             "cli::pr_cmd",
                         ],
                     )?;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
-    real_pr_finish, select_finish_validation_plan_for_finish,
+    ensure_finish_task_bundle_surfaces, real_pr_finish, resolve_finish_issue_scope_and_slug,
+    select_finish_validation_plan_for_finish,
 };
 
 #[test]
@@ -499,7 +500,7 @@ fn finish_validation_plan_supports_focused_local_ci_gated_mode() {
         .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
     assert!(plan
         .commands
-        .contains(&"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd".to_string()));
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()));
     assert!(plan
         .commands
         .contains(&"bash adl/tools/test_check_coverage_impact.sh".to_string()));
@@ -581,7 +582,7 @@ fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request()
     assert_eq!(focused_plan.mode, FinishValidationMode::FocusedLocalCiGated);
     assert!(focused_plan
         .commands
-        .contains(&"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd".to_string()));
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()));
     assert!(!focused_plan
         .commands
         .iter()
@@ -648,7 +649,7 @@ fn finish_validation_profile_keeps_finish_support_changes_narrow() {
     ));
     assert!(!plan
         .commands
-        .contains(&"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd".to_string()));
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()));
     assert!(!plan
         .commands
         .iter()
@@ -657,6 +658,57 @@ fn finish_validation_profile_keeps_finish_support_changes_narrow() {
         .commands
         .iter()
         .any(|command| command.contains("cargo nextest")));
+}
+
+#[test]
+fn finish_restores_missing_canonical_cards_from_slug_drifted_issue_bundle() {
+    let repo = unique_temp_dir("adl-pr-finish-slug-drift");
+    let issue_ref = IssueRef::new(
+        3766,
+        "v0.91.5".to_string(),
+        "canonical-finish-slug".to_string(),
+    )
+    .expect("issue ref");
+    let tasks_dir = repo.join(".adl").join("v0.91.5").join("tasks");
+    let drifted_dir = tasks_dir.join("issue-3766__v0-91-5-tools-title-derived-slug");
+    fs::create_dir_all(&drifted_dir).expect("drifted bundle dir");
+    for file_name in ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"] {
+        fs::write(
+            drifted_dir.join(file_name),
+            format!("{file_name} restored from title-derived slug\n"),
+        )
+        .expect("write drifted card");
+    }
+
+    ensure_finish_task_bundle_surfaces(&repo, &issue_ref).expect("restore canonical cards");
+
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    for file_name in ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"] {
+        let restored = fs::read_to_string(canonical_dir.join(file_name)).expect("read restored");
+        assert_eq!(
+            restored,
+            format!("{file_name} restored from title-derived slug\n")
+        );
+    }
+}
+
+#[test]
+fn finish_identity_resolution_prefers_bound_worktree_local_bundle() {
+    let primary = unique_temp_dir("adl-pr-finish-identity-primary");
+    let worktree = unique_temp_dir("adl-pr-finish-identity-worktree");
+    fs::create_dir_all(worktree.join(".adl/v0.91.5/tasks/issue-3766__worktree-local-finish-slug"))
+        .expect("worktree bundle");
+
+    let identity =
+        resolve_finish_issue_scope_and_slug(&worktree, &primary, 3766).expect("identity");
+
+    assert_eq!(
+        identity,
+        (
+            "v0.91.5".to_string(),
+            "worktree-local-finish-slug".to_string()
+        )
+    );
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -518,7 +518,7 @@ fn real_pr_doctor_full_blocks_invalid_root_spp() {
     env::set_current_dir(prev_dir).expect("restore cwd");
     let err = err.to_string();
     assert!(err.contains("doctor: spp failed validation"));
-    assert!(err.contains("status must be one of: draft, reviewed, approved"));
+    assert!(err.contains("status must be one of: draft, ready, reviewed, approved"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -656,6 +656,141 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
 }
 
 #[test]
+fn real_pr_doctor_full_succeeds_with_worktree_only_card_bundle() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-doctor-worktree-only-cards");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor worktree-only cards\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1198, "v0.86", "doctor-worktree-only-cards").expect("issue ref");
+    let title = "[v0.86][tools] Doctor worktree-only cards";
+    let branch = "codex/1198-doctor-worktree-only-cards";
+    write_authored_issue_prompt(&repo, &issue_ref, title);
+    write_design_time_ready_cards(&repo, &issue_ref, title, branch);
+    real_pr(&[
+        "start".to_string(),
+        "1198".to_string(),
+        "--slug".to_string(),
+        "doctor-worktree-only-cards".to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    write_authored_issue_prompt(&worktree, &issue_ref, title);
+    let wt_sip = issue_ref.task_bundle_input_path(&worktree);
+    write_authored_sip(
+        &wt_sip,
+        &issue_ref,
+        title,
+        branch,
+        &issue_ref.issue_prompt_path(&worktree),
+        &worktree,
+    );
+
+    fs::remove_file(issue_ref.issue_prompt_path(&repo)).expect("remove primary issue prompt");
+    for stale_primary_card in [
+        issue_ref.task_bundle_input_path(&repo),
+        issue_ref.task_bundle_stp_path(&repo),
+        issue_ref.task_bundle_plan_path(&repo),
+        issue_ref.task_bundle_review_policy_path(&repo),
+    ] {
+        fs::remove_file(stale_primary_card).expect("remove primary card");
+    }
+
+    env::set_current_dir(&worktree).expect("chdir worktree");
+    let doctor = real_pr(&[
+        "doctor".to_string(),
+        "1198".to_string(),
+        "--slug".to_string(),
+        "doctor-worktree-only-cards".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+        "--json".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    doctor.expect("doctor with worktree-only card bundle");
+}
+
+#[test]
 fn real_pr_preflight_reports_open_milestone_prs() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-preflight");

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -846,9 +846,9 @@ pub(super) fn validate_spp_text(text: &str) -> Result<()> {
         "branch must be a codex/ branch or `not bound yet`"
     );
     ensure!(
-        ["draft", "reviewed", "approved"]
+        ["draft", "ready", "reviewed", "approved"]
             .contains(&mapping_string(fm, "status").unwrap_or_default().as_str()),
-        "status must be one of: draft, reviewed, approved"
+        "status must be one of: draft, ready, reviewed, approved"
     );
     validate_optional_front_matter_card_status(fm)?;
     ensure!(

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -249,6 +249,22 @@ fn structured_prompt_spp_validator_rejects_invalid_codex_plan_status() {
 }
 
 #[test]
+fn structured_prompt_spp_validator_accepts_ready_lifecycle_status() {
+    let repo = TempRepo::new("structured-spp-ready-status");
+    let spp = repo.write_rel(
+        ".tmp/tooling_cmd_tests/spp-ready.md",
+        &valid_spp_text(1374).replace("status: \"draft\"", "status: \"ready\""),
+    );
+    real_validate_structured_prompt(&[
+        "--type".to_string(),
+        "spp".to_string(),
+        "--input".to_string(),
+        spp.to_string_lossy().to_string(),
+    ])
+    .expect("SPP ready lifecycle status should validate");
+}
+
+#[test]
 fn structured_prompt_srp_validator_requires_refusal_policy() {
     let repo = TempRepo::new("structured-srp-invalid");
     let srp = repo.write_rel(


### PR DESCRIPTION
Closes #3766

## Summary
Implemented the #3766 workflow adoption seam fixes for `pr finish` and prompt-card validation. The finish path now restores missing canonical task-bundle cards from matching slug-drifted issue bundles before validation, SPP structured prompt validation accepts the renderer/editor `status: "ready"` lifecycle state, and focused finish validation now runs the `cli::pr_cmd` proof in the single intended `adl` binary instead of the previous unqualified duplicate-binary cargo test path.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs`
- `adl/src/cli/tooling_cmd/structured_prompt.rs`
- `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace cleanliness.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_spp_validator_accepts_ready_lifecycle_status -- --nocapture`
    Proved the SPP lifecycle status alignment fix.
  - `cargo test --manifest-path adl/Cargo.toml finish_restores_missing_canonical_cards_from_slug_drifted_issue_bundle -- --nocapture`
    Proved slug-drifted task-bundle repair before finish validation.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request -- --nocapture`
    Proved finish validation profile selection remains path-sensitive.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_plan_supports_focused_local_ci_gated_mode -- --nocapture`
    Proved the focused local CI-gated profile remains selected for eligible paths.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_profile_keeps_finish_support_changes_narrow -- --nocapture`
    Proved finish-support edits avoid full Rust validation when focused proof is enough.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_spp_validator_rejects_invalid_codex_plan_status -- --nocapture`
    Proved nested SPP plan status validation still rejects invalid values.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd -- --nocapture`
    Proved the narrowed single-binary command still covers the PR workflow surface.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3766__v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3766__v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams/sor.md
- Idempotency-Key: v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-pr-cmd-doctor-rs-adl-src-cli-pr-cmd-doctor-preflight-rs-adl-src-cli-pr-cmd-doctor-ready-rs-adl-src-cli-pr-cmd-doctor-tests-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-diagnosis-rs-adl-src-cli-tooling-cmd-structured-prompt-rs-adl-src-cli-tooling-cmd-tests-structured-prompt-rs-adl-v0-91-5-tasks-issue-3766-v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams-sip-md-adl-v0-91-5-tasks-issue-3766-v0-91-5-tools-workflow-fix-pr-finish-card-template-adoption-seams-sor-md