### PR TITLE
[v0.91.5][logging-mini-sprint][3/8][tools] Complete C-SDLC control-plane logging

### DIFF
--- a/adl/src/cli/observability.rs
+++ b/adl/src/cli/observability.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 
 pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&str, &str)]) {
@@ -18,7 +20,19 @@ pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&s
         line.push('=');
         line.push_str(&sanitize_value(value));
     }
-    eprintln!("{line}");
+    if env::var("ADL_OBSERVABILITY_STDERR").ok().as_deref() != Some("0") {
+        eprintln!("{line}");
+    }
+    if let Ok(log_path) = env::var("ADL_OBSERVABILITY_LOG") {
+        if !log_path.trim().is_empty() {
+            if let Some(parent) = Path::new(&log_path).parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(file, "{line}");
+            }
+        }
+    }
 }
 
 pub(crate) fn sanitize_value(value: &str) -> String {
@@ -73,8 +87,63 @@ fn contains_secret_marker(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_value;
+    use super::{emit_event, sanitize_value};
     use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        match ENV_LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    struct MultiEnvGuard {
+        saved: Vec<(String, Option<std::ffi::OsString>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl MultiEnvGuard {
+        fn set_all(values: &[(&str, &str)]) -> Self {
+            let lock = env_lock();
+            let mut saved = Vec::with_capacity(values.len());
+            for (key, value) in values {
+                saved.push(((*key).to_string(), env::var_os(key)));
+                unsafe {
+                    env::set_var(key, value);
+                }
+            }
+            Self { saved, _lock: lock }
+        }
+    }
+
+    impl Drop for MultiEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                for (key, old) in self.saved.iter().rev() {
+                    match old {
+                        Some(value) => env::set_var(key, value),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let dir = env::temp_dir().join(format!("{label}-{now}-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
 
     #[test]
     fn sanitize_value_redacts_secret_markers() {
@@ -99,5 +168,33 @@ mod tests {
         assert_eq!(sanitize_value("/elsewhere/example"), "<path>");
 
         env::remove_var("ADL_OBSERVABILITY_REPO_ROOT");
+    }
+
+    #[test]
+    fn emit_event_appends_to_durable_log_when_configured() {
+        let temp = unique_temp_dir("adl-observability-log");
+        let log_path = temp.join("events.log");
+        let _env = MultiEnvGuard::set_all(&[
+            (
+                "ADL_OBSERVABILITY_LOG",
+                log_path.to_str().expect("log path utf8"),
+            ),
+            ("ADL_OBSERVABILITY_STDERR", "0"),
+            ("ADL_OBSERVABILITY_REPO_ROOT", "/repo/adl"),
+        ]);
+
+        emit_event(
+            "adl",
+            "doctor",
+            "completed",
+            &[("artifact_ref", "/repo/adl/docs/proof.md")],
+        );
+
+        let contents = fs::read_to_string(&log_path).expect("read observability log");
+        assert!(contents.contains("command=adl"));
+        assert!(contents.contains("stage=doctor"));
+        assert!(contents.contains("result=completed"));
+        assert!(contents.contains("artifact_ref="));
+        assert!(!contents.contains("/repo/adl/docs/proof.md"));
     }
 }

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::observability;
 #[cfg(test)]
 use crate::cli::pr_cmd::github_client::GithubClientMode;
 use crate::cli::pr_cmd::github_client::{
@@ -637,7 +638,12 @@ fn block_on_octocrab<T, Fut>(
 where
     Fut: std::future::Future<Output = octocrab::Result<T>>,
 {
-    eprintln!("adl_event schema=adl.observability.event.v1 command=adl stage=github_octocrab result=started operation={operation}");
+    observability::emit_event(
+        "adl",
+        "github_octocrab",
+        "started",
+        &[("operation", operation)],
+    );
     let _runtime_guard = runtime.enter();
     let mut attempt = 1usize;
     let max_attempts = octocrab_max_attempts();
@@ -649,14 +655,32 @@ where
                     && octocrab_operation_allows_retry(operation)
                     && octocrab_error_is_retryable(&err) =>
             {
-                eprintln!(
-                    "adl_event schema=adl.observability.event.v1 command=adl stage=github_octocrab result=retry operation={operation} attempt={attempt} max_attempts={max_attempts}"
+                let attempt_text = attempt.to_string();
+                let max_attempts_text = max_attempts.to_string();
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "retry",
+                    &[
+                        ("operation", operation),
+                        ("attempt", attempt_text.as_str()),
+                        ("max_attempts", max_attempts_text.as_str()),
+                    ],
                 );
                 std::thread::sleep(octocrab_retry_delay(attempt));
                 attempt += 1;
             }
             Err(err) => {
-                eprintln!("adl_event schema=adl.observability.event.v1 command=adl stage=github_octocrab result=failed operation={operation} attempts={attempt}");
+                let attempts_text = attempt.to_string();
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "failed",
+                    &[
+                        ("operation", operation),
+                        ("attempts", attempts_text.as_str()),
+                    ],
+                );
                 return Err(anyhow!(
                     "github_client.octocrab_transport: operation '{}' failed after {} attempt(s): {}",
                     operation,
@@ -666,7 +690,12 @@ where
             }
         }
     };
-    eprintln!("adl_event schema=adl.observability.event.v1 command=adl stage=github_octocrab result=completed operation={operation}");
+    observability::emit_event(
+        "adl",
+        "github_octocrab",
+        "completed",
+        &[("operation", operation)],
+    );
     Ok(result)
 }
 
@@ -1124,8 +1153,14 @@ pub(super) fn attach_post_merge_closeout(
         .ok()
         .filter(|value| !value.trim().is_empty())
     else {
-        eprintln!(
-            "adl_event schema=adl.observability.event.v1 command=adl stage=github_octocrab result=skipped operation=post_merge_closeout.attach reason=rust_closeout_no_background_watcher"
+        observability::emit_event(
+            "adl",
+            "github_octocrab",
+            "skipped",
+            &[
+                ("operation", "post_merge_closeout.attach"),
+                ("reason", "rust_closeout_no_background_watcher"),
+            ],
         );
         return Ok(());
     };
@@ -2163,6 +2198,55 @@ mod tests {
         );
         unsafe {
             std::env::remove_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS");
+        }
+        restore_github_policy_env(policy_env);
+    }
+
+    #[test]
+    fn octocrab_transport_honors_quiet_stderr_compatibility_log() {
+        let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
+        let temp = unique_temp_dir("adl-octocrab-observability-log");
+        let log_path = temp.join("events.log");
+        let (base_uri, server) = spawn_transient_octocrab_test_server();
+        unsafe {
+            std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+            std::env::set_var("GITHUB_TOKEN", "test-token");
+            std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+            std::env::set_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS", "2");
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var(
+                "ADL_OBSERVABILITY_LOG",
+                log_path.to_str().expect("log path utf8"),
+            );
+        }
+
+        assert_eq!(
+            gh_issue_title(88, "owner/repo")
+                .expect("transient issue title")
+                .as_deref(),
+            Some("[v0.91.5][tools] Retry succeeds")
+        );
+
+        let log = fs::read_to_string(&log_path).expect("read observability log");
+        assert!(log.contains("stage=github_octocrab"));
+        assert!(log.contains("result=started"));
+        assert!(log.contains("result=retry"));
+        assert!(log.contains("result=completed"));
+        assert!(log.contains("operation=issue.view.title"));
+
+        let seen = server.join().expect("server join");
+        assert_eq!(
+            seen,
+            vec![
+                "GET /repos/owner/repo/issues/88".to_string(),
+                "GET /repos/owner/repo/issues/88".to_string()
+            ]
+        );
+        unsafe {
+            std::env::remove_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS");
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
         }
         restore_github_policy_env(policy_env);
     }

--- a/adl/tools/observability.sh
+++ b/adl/tools/observability.sh
@@ -64,7 +64,9 @@ adl_obs_event() {
     line+=" ${key}=$(adl_obs_sanitize_value "$value")"
   done
 
-  printf '%s\n' "$line" >&2
+  if [[ "${ADL_OBSERVABILITY_STDERR:-1}" != "0" ]]; then
+    printf '%s\n' "$line" >&2
+  fi
   log_path="${ADL_OBSERVABILITY_LOG:-}"
   if [[ -n "$log_path" ]]; then
     mkdir -p "$(dirname "$log_path")"

--- a/adl/tools/test_control_plane_observability.sh
+++ b/adl/tools/test_control_plane_observability.sh
@@ -46,4 +46,22 @@ line_count="$(wc -l <"$TMP_DIR/events.log" | tr -d ' ')"
   exit 1
 }
 
+stderr_capture="$TMP_DIR/stderr.log"
+ADL_OBSERVABILITY_STDERR=0 adl_obs_event "pr.sh" "json_mode" "started" \
+  "artifact_ref" "$ROOT_DIR/docs/example.md" \
+  2>"$stderr_capture"
+[[ ! -s "$stderr_capture" ]] || {
+  echo "stderr suppression still wrote terminal output" >&2
+  exit 1
+}
+line_count="$(wc -l <"$TMP_DIR/events.log" | tr -d ' ')"
+[[ "$line_count" == "2" ]] || {
+  echo "stderr suppression did not preserve durable logging" >&2
+  exit 1
+}
+grep -Fq "stage=json_mode" "$TMP_DIR/events.log" || {
+  echo "json-mode event missing from durable log" >&2
+  exit 1
+}
+
 echo "PASS test_control_plane_observability"

--- a/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
+++ b/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
@@ -44,8 +44,17 @@ and temp or unrelated absolute paths to `<tmp>` or `<path>`.
 ## Terminal And Durable Logs
 
 By default, shell and Rust dispatch events are visible on stderr. If
-`ADL_OBSERVABILITY_LOG` is set, shell events are also appended to that durable
-log path.
+`ADL_OBSERVABILITY_LOG` is set, shell and Rust events may also be mirrored into
+that compatibility log path.
+
+If a machine-readable command needs completely quiet stderr while preserving
+observability, set:
+
+- `ADL_OBSERVABILITY_STDERR=0`
+- `ADL_OBSERVABILITY_LOG=<durable-log-path>`
+
+Under that explicit compatibility mode, the JSON payload remains stdout-only
+while observability events continue to flow into the compatibility mirror file.
 
 `ADL_OBSERVABILITY=0` disables event emission for compatibility tests that need
 a completely quiet stderr surface.

--- a/docs/milestones/v0.91.5/SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md
+++ b/docs/milestones/v0.91.5/SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md
@@ -173,6 +173,15 @@ This applies to:
 - Machine-readable command output on stdout must remain parse-safe.
 - If a command advertises JSON mode, stdout must contain only the declared JSON
   payload unless the interface explicitly says otherwise.
+- When a caller needs quiet stderr for JSON consumers, the supported
+  compatibility mode is `ADL_OBSERVABILITY_STDERR=0` together with
+  `ADL_OBSERVABILITY_LOG=<compatibility-log-path>`, so the payload stays
+  stdout-only while the event stream remains available on a separate explicit
+  compatibility mirror.
+
+This compatibility mirror is not the durable machine-readable observability
+layer. The governed durable layer still requires JSON or JSONL with a declared
+schema.
 
 ### Durable Log Channel
 

--- a/docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md
@@ -1,0 +1,114 @@
+# Control-Plane Logging Proof (#3706)
+
+Issue: #3706  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: implementation_refreshed
+
+## Summary
+
+This packet records the refreshed `#3706` proof slice after the logging
+mini-sprint was re-audited against current repo truth.
+
+The remaining bounded implementation gap was not "add logging everywhere from
+scratch." The repo already had:
+
+- shell `adl_event` emission in `adl/tools/observability.sh`;
+- Rust dispatcher/event emission in `adl/src/cli/observability.rs`;
+- Octocrab operation logs in `adl/src/cli/pr_cmd/github.rs`;
+- stage-oriented `doctor`, `finish`, and `closeout` control-plane work from
+  earlier logging fixes.
+
+The refreshed gap was consistency and policy:
+
+1. Octocrab transport still emitted raw `eprintln!` lines instead of the shared
+   Rust observability helper, so it bypassed durable-log mirroring and any
+   explicit stderr policy.
+2. JSON-mode compatibility needed a governed escape hatch for callers that need
+   stdout-only JSON *and* quiet stderr without disabling observability
+   entirely.
+
+## Implemented Slice
+
+The refreshed implementation does three bounded things:
+
+- Rust observability events now mirror to `ADL_OBSERVABILITY_LOG`, matching the
+  shell helper, as an explicit compatibility mirror rather than a governed
+  JSON/JSONL durable event store.
+- Rust and shell observability now honor the documented compatibility toggle
+  `ADL_OBSERVABILITY_STDERR=0`.
+- Octocrab transport events now route through the shared Rust observability
+  helper instead of direct `eprintln!` calls.
+
+## JSON-Mode Policy
+
+The current policy is now explicit and shared across the tracked contracts:
+
+- default behavior: observability stays on stderr and machine-readable payloads
+  remain on stdout;
+- compatibility behavior for strict JSON consumers:
+  - `ADL_OBSERVABILITY_STDERR=0`
+  - `ADL_OBSERVABILITY_LOG=<compatibility-log-path>`
+
+Under that compatibility mode, stdout remains JSON-only while observability is
+still preserved on a separate explicit compatibility mirror. The governed
+durable machine-readable layer remains JSON/JSONL and is not replaced by this
+file sink.
+
+## Proof Commands
+
+### Shell control-plane helper
+
+```bash
+bash adl/tools/test_control_plane_observability.sh
+```
+
+Expected proof:
+
+- repo/home/tmp path redaction still works;
+- `ADL_OBSERVABILITY=0` still fully disables emission;
+- `ADL_OBSERVABILITY_STDERR=0` suppresses terminal output while durable logging
+  continues in the compatibility mirror file.
+
+### Rust observability helper
+
+```bash
+cargo test --manifest-path adl/Cargo.toml cli::observability::tests -- --nocapture
+```
+
+Expected proof:
+
+- secret/path redaction still works;
+- Rust helper appends to `ADL_OBSERVABILITY_LOG`;
+- Rust helper remains compatible with the quiet-stderr configuration used by
+  shell-level proof, without changing the governed JSON/JSONL durable-layer
+  contract.
+
+### Octocrab transport path
+
+```bash
+cargo test --manifest-path adl/Cargo.toml \
+  octocrab_transport_honors_quiet_stderr_compatibility_log \
+  -- --nocapture
+
+cargo test --manifest-path adl/Cargo.toml \
+  octocrab_transport_covers_pr_and_issue_operations_against_mock_github \
+  -- --nocapture
+```
+
+Expected proof:
+
+- GitHub operation events still emit `started`/`completed` control-plane logs;
+- the path mirrors events into `ADL_OBSERVABILITY_LOG` under the explicit
+  quiet-stderr compatibility configuration;
+- the refreshed transport path compiles and runs through the shared
+  observability helper rather than direct transport-specific `eprintln!`
+  formatting.
+
+## Non-Claims
+
+- This issue does not prove bounded heartbeat/progress for every long-running
+  path; that remains `#3708`.
+- This issue does not add OTEL export wiring; that remains `#3709`.
+- This issue does not claim every JSON-producing tool path auto-enables quiet
+  stderr. The supported compatibility mode is explicit rather than implicit.


### PR DESCRIPTION
Closes #3706

## Summary
Completed the refreshed `#3706` logging-mini-sprint slice after re-auditing the
repo against current truth. The implementation kept the existing control-plane
logging model, then tightened the remaining gaps by routing Octocrab transport
events through the shared Rust observability helper, adding explicit
quiet-stderr compatibility support for shell and Rust helpers, and documenting
that `ADL_OBSERVABILITY_LOG` is a compatibility mirror rather than the governed
JSON/JSONL durable observability layer.

## Artifacts
- `adl/src/cli/observability.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/tools/observability.sh`
- `adl/tools/test_control_plane_observability.sh`
- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`
- `docs/milestones/v0.91.5/SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md`
- `docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md`
- `.adl/v0.91.5/tasks/issue-3706__v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging/srp.md`
- `.adl/v0.91.5/tasks/issue-3706__v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_control_plane_observability.sh`
    Verified shell-side observability redaction, disable mode, and quiet-stderr compatibility-log behavior.
  - `cargo test --manifest-path adl/Cargo.toml cli::observability::tests -- --nocapture`
    Verified Rust-side redaction and compatibility-log append behavior.
  - `cargo test --manifest-path adl/Cargo.toml octocrab_transport_honors_quiet_stderr_compatibility_log -- --nocapture`
    Verified Octocrab transport events mirror into the compatibility log under the quiet-stderr configuration.
  - `cargo test --manifest-path adl/Cargo.toml octocrab_transport_covers_pr_and_issue_operations_against_mock_github -- --nocapture`
    Verified the broader Octocrab transport path still emits started/completed control-plane events across PR and issue operations.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified touched Rust surfaces are formatter-clean.
  - `git diff --check`
    Verified patch hygiene across the issue diff.
- Results:
  - PASS after focused validation and post-review reruns.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3706__v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3706__v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging/sor.md
- Idempotency-Key: v0-91-5-logging-mini-sprint-3-8-tools-complete-c-sdlc-control-plane-logging-adl-v0-91-5-tasks-issue-3706-v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging-sip-md-adl-v0-91-5-tasks-issue-3706-v0-91-5-logging-mini-sprint-complete-csdlc-control-plane-logging-sor-md