### PR TITLE
[v0.91.5][tools][templates] Prove AST-backed default card editing path

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -110,6 +110,7 @@ adl tooling portable-project-doctor --project <adl_project.json> [--adl-home <pa
 adl tooling prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
 adl tooling prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
 adl tooling prompt-template edit-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> --set <field=value> [--set <field=value> ...] [--out <values.yaml>] [--repo-root <path>]\n\
+adl tooling prompt-template edit-rendered --kind <sip|stp|spp|srp|sor> --input <card.md> --set <field=value> [--set <field=value> ...] --out <card.md> [--values-out <values.yaml>] [--repo-root <path>]\n\
 adl tooling prompt-template import-values --kind <sip|stp|spp|srp|sor> --input <card.md> --out <values.yaml> [--normalized-out <card.md>] [--repo-root <path>]\n\
 adl tooling prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
 adl tooling prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\

--- a/adl/src/cli/tooling_cmd/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/prompt_template.rs
@@ -12,13 +12,14 @@ use super::tooling_usage;
 
 pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
-        bail!("prompt-template requires a subcommand: render | render-all | edit-values | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas");
+        bail!("prompt-template requires a subcommand: render | render-all | edit-values | edit-rendered | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas");
     };
 
     match subcommand {
         "render" => render_one(&args[1..]),
         "render-all" => render_all(&args[1..]),
         "edit-values" => edit_values(&args[1..]),
+        "edit-rendered" => edit_rendered(&args[1..]),
         "import-values" => import_values(&args[1..]),
         "validate-values" => validate_one(&args[1..]),
         "validate-structure" => validate_structure_one(&args[1..]),
@@ -30,7 +31,7 @@ pub(crate) fn real_prompt_template(args: &[String]) -> Result<()> {
             Ok(())
         }
         other => bail!(
-            "unknown prompt-template subcommand '{other}' (expected render | render-all | edit-values | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
+            "unknown prompt-template subcommand '{other}' (expected render | render-all | edit-values | edit-rendered | import-values | validate-values | validate-structure | validate-schemas | write-sample-values | write-structure-schemas)"
         ),
     }
 }
@@ -125,6 +126,82 @@ fn edit_values(args: &[String]) -> Result<()> {
     let values = values.ok_or_else(|| anyhow::anyhow!("edit-values requires --values"))?;
     let target = edit_values_file(&root, kind, &values, &updates, out.as_deref())?;
     println!("PASS: edited {} values at {}", kind.key(), target.display());
+    Ok(())
+}
+
+fn edit_rendered(args: &[String]) -> Result<()> {
+    if has_help_arg(args) {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+    let mut repo_root: Option<PathBuf> = None;
+    let mut kind: Option<PromptCardKind> = None;
+    let mut input: Option<PathBuf> = None;
+    let mut out: Option<PathBuf> = None;
+    let mut values_out: Option<PathBuf> = None;
+    let mut updates: Vec<(String, String)> = Vec::new();
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--repo-root" => {
+                idx += 1;
+                repo_root = Some(PathBuf::from(value_arg(args, idx, "--repo-root")?));
+            }
+            "--kind" => {
+                idx += 1;
+                kind = Some(PromptCardKind::parse_key(value_arg(args, idx, "--kind")?)?);
+            }
+            "--input" => {
+                idx += 1;
+                input = Some(PathBuf::from(value_arg(args, idx, "--input")?));
+            }
+            "--out" => {
+                idx += 1;
+                out = Some(PathBuf::from(value_arg(args, idx, "--out")?));
+            }
+            "--values-out" => {
+                idx += 1;
+                values_out = Some(PathBuf::from(value_arg(args, idx, "--values-out")?));
+            }
+            "--set" => {
+                idx += 1;
+                updates.push(parse_set_arg(value_arg(args, idx, "--set")?)?);
+            }
+            "--help" | "-h" | "help" => {
+                println!("{}", tooling_usage());
+                return Ok(());
+            }
+            other => bail!("unknown arg for tooling prompt-template edit-rendered: {other}"),
+        }
+        idx += 1;
+    }
+
+    ensure!(
+        !updates.is_empty(),
+        "edit-rendered requires at least one --set field=value update"
+    );
+    let root = repo_root_from_arg(repo_root)?;
+    let kind = kind.ok_or_else(|| anyhow::anyhow!("edit-rendered requires --kind"))?;
+    let input = input.ok_or_else(|| anyhow::anyhow!("edit-rendered requires --input"))?;
+    let out = out.ok_or_else(|| anyhow::anyhow!("edit-rendered requires --out"))?;
+    let values_target = values_out.unwrap_or_else(|| out.with_extension("values.yaml"));
+
+    let report = import_values_from_rendered_card_file(&root, kind, &input, &values_target, None)?;
+    edit_values_file(&root, kind, &values_target, &updates, None)?;
+    let rendered = render_card_from_values_file(&root, kind, &values_target)?;
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&out, rendered)?;
+    validate_rendered_card_structure_file(&root, kind, &out)?;
+    println!(
+        "PASS: edited rendered {} card to {} via values {} (round_trip={})",
+        kind.key(),
+        out.display(),
+        values_target.display(),
+        report.comparison.as_str()
+    );
     Ok(())
 }
 

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -478,6 +478,61 @@ fn prompt_template_cli_imports_lifecycle_updated_spp_values() {
 }
 
 #[test]
+fn prompt_template_cli_edit_rendered_card_uses_values_roundtrip_default_path() {
+    let repo = TempRepo::new("prompt-template-edit-rendered");
+    let values_dir = repo.path().join("values");
+    let rendered_dir = repo.path().join("rendered");
+    let edited = repo.path().join("edited-spp.md");
+    let values_out = repo.path().join("edited-spp.values.yaml");
+    render_sample_cards_for_structure_test(&values_dir, &rendered_dir);
+    let source = rendered_dir.join("spp.md");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-rendered".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--input".to_string(),
+        source.to_string_lossy().to_string(),
+        "--set".to_string(),
+        "card_status=approved".to_string(),
+        "--set".to_string(),
+        "status=approved".to_string(),
+        "--set".to_string(),
+        "activation_state=approved".to_string(),
+        "--values-out".to_string(),
+        values_out.to_string_lossy().to_string(),
+        "--out".to_string(),
+        edited.to_string_lossy().to_string(),
+    ])
+    .expect("edit-rendered should import, edit, render, and validate");
+
+    let rendered_text = fs::read_to_string(&edited).expect("edited rendered SPP");
+    assert!(rendered_text.contains("card_status: \"approved\""));
+    assert!(rendered_text.contains("status: \"approved\""));
+    assert!(rendered_text.contains("activation_state: \"approved\""));
+
+    let values_text = fs::read_to_string(&values_out).expect("edited values");
+    assert!(values_text.contains("card_status: \"approved\""));
+    assert!(values_text.contains("status: \"approved\""));
+    assert!(values_text.contains("activation_state: \"approved\""));
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--input".to_string(),
+        edited.to_string_lossy().to_string(),
+    ])
+    .expect("edit-rendered output should remain structure-valid");
+}
+
+#[test]
 fn prompt_template_cli_import_values_fails_closed_for_structure_drift() {
     let repo = TempRepo::new("prompt-template-import-values-drift");
     let values_dir = repo.path().join("values");
@@ -623,6 +678,12 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     .expect("edit-values help should succeed");
     real_tooling(&[
         "prompt-template".to_string(),
+        "edit-rendered".to_string(),
+        "--help".to_string(),
+    ])
+    .expect("edit-rendered help should succeed");
+    real_tooling(&[
+        "prompt-template".to_string(),
         "import-values".to_string(),
         "--help".to_string(),
     ])
@@ -714,6 +775,23 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     assert!(missing_input
         .to_string()
         .contains("validate-structure requires --input"));
+
+    let missing_rendered_set = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-rendered".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "spp".to_string(),
+        "--input".to_string(),
+        values.to_string_lossy().to_string(),
+        "--out".to_string(),
+        repo.path().join("spp.md").to_string_lossy().to_string(),
+    ])
+    .expect_err("edit-rendered requires a declared update");
+    assert!(missing_rendered_set
+        .to_string()
+        .contains("edit-rendered requires at least one --set"));
 }
 
 fn render_sample_cards_for_structure_test(


### PR DESCRIPTION
Closes #3774

## Summary
Implemented a supported prompt-template `edit-rendered` path so lifecycle-card edits can start from an existing rendered card, import declared values, apply field updates, render the card again, and validate rendered structure without hand-patching Markdown.

## Artifacts
- `adl/src/cli/tooling_cmd.rs`
- `adl/src/cli/tooling_cmd/prompt_template.rs`
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Rust formatting proof for the touched files.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl prompt_template_cli -- --nocapture`
    Focused behavior proof for prompt-template CLI operations, including the new rendered-card editing path.
  - Subagent review: `No actionable findings.`
    Independent bounded review proof before PR publication.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3774__v0-91-5-tools-templates-prove-ast-backed-default-card-editing-path/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3774__v0-91-5-tools-templates-prove-ast-backed-default-card-editing-path/sor.md
- Idempotency-Key: v0-91-5-tools-templates-prove-ast-backed-default-card-editing-path-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-prompt-template-rs-adl-src-cli-tooling-cmd-tests-prompt-template-rs-adl-v0-91-5-tasks-issue-3774-v0-91-5-tools-templates-prove-ast-backed-default-card-editing-path-sip-md-adl-v0-91-5-tasks-issue-3774-v0-91-5-tools-templates-prove-ast-backed-default-card-editing-path-sor-md