### PR TITLE
[v0.91.5][logging][WP-05] Add heartbeat timeout and progress diagnostics

### DIFF
--- a/adl/src/cli/agent_cmd.rs
+++ b/adl/src/cli/agent_cmd.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
+use crate::cli::observability::ProgressHeartbeat;
 use ::adl::long_lived_agent::{self, InspectOptions, RunOptions, TickOptions};
 
 pub(crate) fn real_agent(args: &[String]) -> Result<()> {
@@ -45,13 +46,41 @@ fn real_tick(args: &[String]) -> Result<()> {
         }
         i += 1;
     }
+    let spec_path = parsed.spec()?;
+    let heartbeat = ProgressHeartbeat::start(
+        "agent",
+        "agent_tick",
+        &[
+            ("process_class", "long_lived"),
+            ("spec", &spec_path.display().to_string()),
+        ],
+    );
     let status = long_lived_agent::tick(
-        &parsed.spec()?,
+        &spec_path,
         TickOptions {
             recover_stale_lease: parsed.recover_stale_lease,
         },
-    )?;
-    print_status(&status, parsed.json_output)
+    );
+    match status {
+        Ok(status) => {
+            let completed_cycles = status.completed_cycle_count.to_string();
+            heartbeat.completed(&[
+                ("agent_state", status_state_label(&status.state)),
+                ("completed_cycles", &completed_cycles),
+            ]);
+            print_status(&status, parsed.json_output)
+        }
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "agent_tick_failed"),
+                (
+                    "next_action_hint",
+                    "inspect_agent_status_and_cycle_artifacts",
+                ),
+            ]);
+            Err(err)
+        }
+    }
 }
 
 fn real_run(args: &[String]) -> Result<()> {
@@ -86,17 +115,50 @@ fn real_run(args: &[String]) -> Result<()> {
         }
         i += 1;
     }
+    let spec_path = parsed.spec()?;
     let max_cycles = max_cycles.ok_or_else(|| anyhow!("agent run requires --max-cycles <n>"))?;
+    let max_cycles_label = max_cycles.to_string();
+    let interval_secs_label = interval_secs
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "spec_default".to_string());
+    let no_sleep_label = if no_sleep { "true" } else { "false" }.to_string();
+    let heartbeat = ProgressHeartbeat::start(
+        "agent",
+        "agent_run",
+        &[
+            ("process_class", "long_lived"),
+            ("spec", &spec_path.display().to_string()),
+            ("max_cycles", &max_cycles_label),
+            ("interval_secs", &interval_secs_label),
+            ("no_sleep", &no_sleep_label),
+        ],
+    );
     let status = long_lived_agent::run(
-        &parsed.spec()?,
+        &spec_path,
         RunOptions {
             max_cycles,
             interval_secs,
             no_sleep,
             recover_stale_lease: parsed.recover_stale_lease,
         },
-    )?;
-    print_status(&status, parsed.json_output)
+    );
+    match status {
+        Ok(status) => {
+            let completed_cycles = status.completed_cycle_count.to_string();
+            heartbeat.completed(&[
+                ("agent_state", status_state_label(&status.state)),
+                ("completed_cycles", &completed_cycles),
+            ]);
+            print_status(&status, parsed.json_output)
+        }
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "agent_run_failed"),
+                ("next_action_hint", "inspect_agent_status_and_cycle_ledger"),
+            ]);
+            Err(err)
+        }
+    }
 }
 
 fn real_status(args: &[String]) -> Result<()> {
@@ -117,8 +179,35 @@ fn real_status(args: &[String]) -> Result<()> {
         }
         i += 1;
     }
-    let status = long_lived_agent::status(&parsed.spec()?)?;
-    print_status(&status, parsed.json_output)
+    let spec_path = parsed.spec()?;
+    let heartbeat = ProgressHeartbeat::start(
+        "agent",
+        "agent_status",
+        &[
+            ("process_class", "long_lived"),
+            ("spec", &spec_path.display().to_string()),
+        ],
+    );
+    match long_lived_agent::status(&spec_path) {
+        Ok(status) => {
+            let completed_cycles = status.completed_cycle_count.to_string();
+            heartbeat.completed(&[
+                ("agent_state", status_state_label(&status.state)),
+                ("completed_cycles", &completed_cycles),
+            ]);
+            print_status(&status, parsed.json_output)
+        }
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "agent_status_failed"),
+                (
+                    "next_action_hint",
+                    "inspect_agent_spec_and_status_artifacts",
+                ),
+            ]);
+            Err(err)
+        }
+    }
 }
 
 fn real_inspect(args: &[String]) -> Result<()> {
@@ -467,7 +556,11 @@ memory:
             "--spec requires a value",
         );
         assert_err_contains(real_agent(&args(&["tick", "--bogus"])), "unknown arg");
-        assert_err_contains(real_agent(&args(&["run"])), "requires --max-cycles");
+        assert_err_contains(real_agent(&args(&["run"])), "requires --spec");
+        assert_err_contains(
+            real_agent(&args(&["run", "--spec", "/tmp/example-agent.yaml"])),
+            "requires --max-cycles",
+        );
         assert_err_contains(
             real_agent(&args(&["run", "--max-cycles", "not-a-number"])),
             "expected unsigned integer",
@@ -546,5 +639,41 @@ memory:
         ]))
         .is_ok());
         assert!(root.join("state/stop.json").exists());
+    }
+
+    #[test]
+    fn agent_run_emits_heartbeat_for_long_lived_processes() {
+        let root = temp_dir("heartbeat");
+        let spec = write_spec(&root);
+        let observability = root.join("observability.log");
+        unsafe {
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var("ADL_OBSERVABILITY_LOG", &observability);
+            std::env::set_var("ADL_OBSERVABILITY_HEARTBEAT_MS", "25");
+        }
+
+        assert!(real_agent(&args(&[
+            "run",
+            "--spec",
+            spec.to_str().expect("spec path"),
+            "--max-cycles",
+            "2",
+            "--interval-secs",
+            "1",
+        ]))
+        .is_ok());
+
+        let log_text = fs::read_to_string(&observability).expect("read observability log");
+        assert!(log_text.contains("command=agent"));
+        assert!(log_text.contains("stage=agent_run"));
+        assert!(log_text.contains("process_class=long_lived"));
+        assert!(log_text.contains("result=heartbeat"));
+        assert!(log_text.contains("result=completed"));
+
+        unsafe {
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
+            std::env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
     }
 }

--- a/adl/src/cli/observability.rs
+++ b/adl/src/cli/observability.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&str, &str)]) {
     if env::var("ADL_OBSERVABILITY").ok().as_deref() == Some("0") {
@@ -33,6 +36,129 @@ pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&s
             }
         }
     }
+}
+
+fn emit_event_owned(command: &str, stage: &str, result: &str, fields: &[(String, String)]) {
+    let borrowed = fields
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    emit_event(command, stage, result, &borrowed);
+}
+
+pub(crate) struct ProgressHeartbeat {
+    command: String,
+    stage: String,
+    started: Instant,
+    base_fields: Vec<(String, String)>,
+    stop: Option<Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ProgressHeartbeat {
+    pub(crate) fn start(command: &str, stage: &str, base_fields: &[(&str, &str)]) -> Self {
+        let started = Instant::now();
+        let base_fields = base_fields
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect::<Vec<_>>();
+        emit_event_owned(
+            command,
+            stage,
+            "started",
+            &event_fields(&base_fields, &[], started.elapsed()),
+        );
+        let interval = heartbeat_interval();
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let handle = if interval.is_zero() {
+            None
+        } else {
+            let command_owned = command.to_string();
+            let stage_owned = stage.to_string();
+            let base_fields_owned = base_fields.clone();
+            Some(thread::spawn(move || loop {
+                match stop_rx.recv_timeout(interval) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
+                    Err(RecvTimeoutError::Timeout) => emit_event_owned(
+                        &command_owned,
+                        &stage_owned,
+                        "heartbeat",
+                        &event_fields(&base_fields_owned, &[], started.elapsed()),
+                    ),
+                }
+            }))
+        };
+        Self {
+            command: command.to_string(),
+            stage: stage.to_string(),
+            started,
+            base_fields,
+            stop: Some(stop_tx),
+            handle,
+        }
+    }
+
+    pub(crate) fn completed(mut self, fields: &[(&str, &str)]) {
+        self.finish("completed", fields);
+    }
+
+    pub(crate) fn failed(mut self, fields: &[(&str, &str)]) {
+        self.finish("failed", fields);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn timeout(mut self, fields: &[(&str, &str)]) {
+        self.finish("timeout", fields);
+    }
+
+    fn finish(&mut self, result: &str, fields: &[(&str, &str)]) {
+        self.stop();
+        emit_event_owned(
+            &self.command,
+            &self.stage,
+            result,
+            &event_fields(&self.base_fields, fields, self.started.elapsed()),
+        );
+    }
+
+    fn stop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for ProgressHeartbeat {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn heartbeat_interval() -> Duration {
+    let millis = env::var("ADL_OBSERVABILITY_HEARTBEAT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(5_000);
+    Duration::from_millis(millis)
+}
+
+fn event_fields(
+    base_fields: &[(String, String)],
+    extra_fields: &[(&str, &str)],
+    elapsed: Duration,
+) -> Vec<(String, String)> {
+    let mut merged = base_fields.to_vec();
+    merged.push(("elapsed_ms".to_string(), elapsed.as_millis().to_string()));
+    merged.extend(
+        extra_fields
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
+    merged
 }
 
 pub(crate) fn sanitize_value(value: &str) -> String {
@@ -87,12 +213,12 @@ fn contains_secret_marker(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{emit_event, sanitize_value};
+    use super::{emit_event, heartbeat_interval, sanitize_value, ProgressHeartbeat};
     use std::env;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::{Mutex, MutexGuard, OnceLock};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -196,5 +322,86 @@ mod tests {
         assert!(contents.contains("result=completed"));
         assert!(contents.contains("artifact_ref="));
         assert!(!contents.contains("/repo/adl/docs/proof.md"));
+    }
+
+    #[test]
+    fn progress_heartbeat_emits_heartbeat_for_slow_operations() {
+        let temp = unique_temp_dir("adl-observability-heartbeat");
+        let log_path = temp.join("events.log");
+        let _env = MultiEnvGuard::set_all(&[
+            (
+                "ADL_OBSERVABILITY_LOG",
+                log_path.to_str().expect("log path utf8"),
+            ),
+            ("ADL_OBSERVABILITY_STDERR", "0"),
+            ("ADL_OBSERVABILITY_HEARTBEAT_MS", "25"),
+        ]);
+
+        let heartbeat = ProgressHeartbeat::start(
+            "finish",
+            "validation_subprocess",
+            &[("subprocess_class", "shell_validation")],
+        );
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        heartbeat.completed(&[("exit_code", "0")]);
+
+        let contents = fs::read_to_string(&log_path).expect("read observability log");
+        assert!(contents.contains("command=finish"));
+        assert!(contents.contains("stage=validation_subprocess"));
+        assert!(contents.contains("result=started"));
+        assert!(contents.contains("result=heartbeat"));
+        assert!(contents.contains("result=completed"));
+        assert!(contents.contains("subprocess_class=shell_validation"));
+    }
+
+    #[test]
+    fn progress_heartbeat_stays_quiet_for_fast_operations() {
+        let temp = unique_temp_dir("adl-observability-fast");
+        let log_path = temp.join("events.log");
+        let _env = MultiEnvGuard::set_all(&[
+            (
+                "ADL_OBSERVABILITY_LOG",
+                log_path.to_str().expect("log path utf8"),
+            ),
+            ("ADL_OBSERVABILITY_STDERR", "0"),
+            ("ADL_OBSERVABILITY_HEARTBEAT_MS", "250"),
+        ]);
+
+        let started = Instant::now();
+        let heartbeat = ProgressHeartbeat::start(
+            "provider_adapter",
+            "provider_call",
+            &[("provider", "openai")],
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        heartbeat.completed(&[("final_status", "ok")]);
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(150),
+            "fast operations should not wait for the full heartbeat interval to stop"
+        );
+
+        let contents = fs::read_to_string(&log_path).expect("read observability log");
+        assert!(contents.contains("result=started"));
+        assert!(contents.contains("result=completed"));
+        assert!(!contents.contains("result=heartbeat"));
+    }
+
+    #[test]
+    fn heartbeat_interval_defaults_and_overrides() {
+        let _guard = env_lock();
+        unsafe {
+            env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
+        assert_eq!(
+            heartbeat_interval(),
+            std::time::Duration::from_millis(5_000)
+        );
+        unsafe {
+            env::set_var("ADL_OBSERVABILITY_HEARTBEAT_MS", "42");
+        }
+        assert_eq!(heartbeat_interval(), std::time::Duration::from_millis(42));
+        unsafe {
+            env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
     }
 }

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -16,6 +16,7 @@ use super::github::{
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
+use crate::cli::observability::ProgressHeartbeat;
 use crate::cli::pr_cmd_args::parse_finish_args;
 use crate::cli::pr_cmd_cards::{
     path_relative_to_repo, validate_bootstrap_stp, validate_structured_artifact,
@@ -976,30 +977,127 @@ const FINISH_VALIDATION_SANITIZED_ENVS: &[&str] = &[
 ];
 
 fn run_finish_validation_status(program: &str, args: &[&str]) -> Result<()> {
+    let class = classify_finish_subprocess(program, args);
+    let excerpt = format_subprocess_excerpt(program, args);
+    let heartbeat = ProgressHeartbeat::start(
+        "finish",
+        "validation_subprocess",
+        &[
+            ("program", program),
+            ("subprocess_class", class),
+            ("argv_excerpt", &excerpt),
+        ],
+    );
     let mut command = Command::new(program);
     command.args(args);
     for key in FINISH_VALIDATION_SANITIZED_ENVS {
         command.env_remove(key);
     }
-    let status = command
-        .status()
-        .with_context(|| format!("failed to spawn '{program}'"))?;
+    let status = match command.status() {
+        Ok(status) => status,
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "validation_subprocess_spawn_failed"),
+                ("next_action_hint", "check_subprocess_path_and_permissions"),
+            ]);
+            return Err(err).with_context(|| format!("failed to spawn '{program}'"));
+        }
+    };
     if !status.success() {
+        let exit_code = status
+            .code()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "signal".to_string());
+        heartbeat.failed(&[
+            ("reason_code", "validation_subprocess_failed"),
+            ("next_action_hint", "inspect_subprocess_output"),
+            ("exit_code", &exit_code),
+        ]);
         bail!("{program} failed with status {:?}", status.code());
     }
+    let exit_code = status
+        .code()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_string());
+    heartbeat.completed(&[("exit_code", &exit_code)]);
     Ok(())
 }
 
 fn run_finish_validation_status_allow_failure(program: &str, args: &[&str]) -> Result<bool> {
+    let class = classify_finish_subprocess(program, args);
+    let excerpt = format_subprocess_excerpt(program, args);
+    let heartbeat = ProgressHeartbeat::start(
+        "finish",
+        "validation_subprocess",
+        &[
+            ("program", program),
+            ("subprocess_class", class),
+            ("argv_excerpt", &excerpt),
+        ],
+    );
     let mut command = Command::new(program);
     command.args(args);
     for key in FINISH_VALIDATION_SANITIZED_ENVS {
         command.env_remove(key);
     }
-    let status = command
-        .status()
-        .with_context(|| format!("failed to spawn '{program}'"))?;
+    let status = match command.status() {
+        Ok(status) => status,
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "validation_subprocess_spawn_failed"),
+                ("next_action_hint", "check_subprocess_path_and_permissions"),
+            ]);
+            return Err(err).with_context(|| format!("failed to spawn '{program}'"));
+        }
+    };
+    let exit_code = status
+        .code()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+    if status.success() {
+        heartbeat.completed(&[("exit_code", &exit_code)]);
+    } else {
+        heartbeat.failed(&[
+            ("reason_code", "validation_subprocess_failed"),
+            ("next_action_hint", "inspect_subprocess_output"),
+            ("exit_code", &exit_code),
+        ]);
+    }
     Ok(status.success())
+}
+
+fn classify_finish_subprocess(program: &str, args: &[&str]) -> &'static str {
+    match program {
+        "cargo" => "rust_validation",
+        "git" => "git_hygiene",
+        "bash" => {
+            if args
+                .iter()
+                .any(|arg| arg.contains("run_owner_validation_lane"))
+            {
+                "owner_validation_lane"
+            } else if args
+                .iter()
+                .any(|arg| arg.contains("coverage") || arg.contains("llvm-cov"))
+            {
+                "coverage_validation"
+            } else {
+                "shell_validation"
+            }
+        }
+        _ => "validation_subprocess",
+    }
+}
+
+fn format_subprocess_excerpt(program: &str, args: &[&str]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(program.to_string());
+    parts.extend(args.iter().take(4).map(|value| value.to_string()));
+    let mut joined = parts.join(" ");
+    if args.len() > 4 {
+        joined.push_str(" ...");
+    }
+    joined
 }
 
 fn resolve_finish_pr_base(repo_root: &Path, branch: &str) -> Result<String> {
@@ -1398,4 +1496,99 @@ pub(super) fn write_temp_markdown(prefix: &str, body: &str) -> Result<PathBuf> {
     path.push(format!("{prefix}-{nanos}.md"));
     fs::write(&path, body)?;
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_finish_validation_status;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        match ENV_LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "adl-finish-validation-{prefix}-{}-{}",
+            std::process::id(),
+            TEMP_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn finish_validation_emits_subprocess_heartbeat_and_classification() {
+        let _guard = env_lock();
+        let temp = temp_dir("heartbeat");
+        let script = temp.join("slow-validation.sh");
+        let log = temp.join("observability.log");
+        fs::write(&script, "#!/bin/sh\nsleep 0.08\nexit 0\n").expect("write script");
+        let mut perms = fs::metadata(&script).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("chmod");
+
+        unsafe {
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var("ADL_OBSERVABILITY_LOG", &log);
+            std::env::set_var("ADL_OBSERVABILITY_HEARTBEAT_MS", "25");
+        }
+
+        run_finish_validation_status("bash", &[script.to_str().expect("script path")])
+            .expect("validation command");
+
+        let contents = fs::read_to_string(&log).expect("read log");
+        assert!(contents.contains("command=finish"));
+        assert!(contents.contains("stage=validation_subprocess"));
+        assert!(contents.contains("program=bash"));
+        assert!(contents.contains("subprocess_class=shell_validation"));
+        assert!(contents.contains("result=heartbeat"));
+        assert!(contents.contains("result=completed"));
+
+        unsafe {
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
+            std::env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
+    }
+
+    #[test]
+    fn finish_validation_emits_failed_terminal_event_on_spawn_error() {
+        let _guard = env_lock();
+        let temp = temp_dir("spawn-error");
+        let log = temp.join("observability.log");
+
+        unsafe {
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var("ADL_OBSERVABILITY_LOG", &log);
+            std::env::set_var("ADL_OBSERVABILITY_HEARTBEAT_MS", "25");
+        }
+
+        let err =
+            run_finish_validation_status("definitely-not-a-real-finish-subprocess", &["--version"])
+                .expect_err("spawn should fail");
+        assert!(err.to_string().contains("failed to spawn"));
+
+        let contents = fs::read_to_string(&log).expect("read log");
+        assert!(contents.contains("result=started"));
+        assert!(contents.contains("result=failed"));
+        assert!(contents.contains("reason_code=validation_subprocess_spawn_failed"));
+        assert!(contents.contains("next_action_hint=check_subprocess_path_and_permissions"));
+
+        unsafe {
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
+            std::env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
+    }
 }

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -49,6 +49,7 @@ pub mod local_gemma_model_evaluation;
 pub mod long_lived_agent;
 pub mod model_identity;
 pub mod model_proposal_benchmark;
+pub mod observability;
 pub mod obsmem_adapter;
 pub mod obsmem_contract;
 pub mod obsmem_demo;

--- a/adl/src/observability.rs
+++ b/adl/src/observability.rs
@@ -1,0 +1,1 @@
+include!("cli/observability.rs");

--- a/adl/src/provider_adapter_cli.rs
+++ b/adl/src/provider_adapter_cli.rs
@@ -1,5 +1,9 @@
+use crate::observability::ProgressHeartbeat;
 use crate::provider_adapter::execute_provider_invocation;
-use crate::provider_communication::{ProviderInvocationRequestV1, ProviderRunLoggerV1};
+use crate::provider_communication::{
+    ProviderFailureKindV1, ProviderInvocationFinalStatusV1, ProviderInvocationRequestV1,
+    ProviderInvocationResultV1, ProviderRunLoggerV1,
+};
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
@@ -28,21 +32,169 @@ pub fn run_provider_adapter_cli(args: ProviderAdapterCliArgs) -> Result<()> {
         .run_id
         .clone()
         .unwrap_or_else(|| format!("{}:{}", request.lane_ref, request.route.provider_model_id));
+    let timeout_ms = request.attempt_policy.timeout_ms.to_string();
+    let heartbeat = ProgressHeartbeat::start(
+        "provider_adapter",
+        "provider_call",
+        &[
+            ("provider", &request.route.provider),
+            (
+                "runtime_surface",
+                runtime_surface_label(&request.route.runtime_surface),
+            ),
+            ("provider_model_id", &request.route.provider_model_id),
+            ("lane_ref", &request.lane_ref),
+            ("timeout_ms", &timeout_ms),
+            (
+                "request_id",
+                request.request_id.as_deref().unwrap_or("missing"),
+            ),
+        ],
+    );
     let mut logger = ProviderRunLoggerV1::create(&args.log, run_id)
         .with_context(|| format!("open run log {}", args.log.display()))?;
     let result = execute_provider_invocation(request, &mut logger);
-    fs::write(&args.out, serde_json::to_string_pretty(&result)? + "\n")
-        .with_context(|| format!("write result file {}", args.out.display()))?;
+    let attempts = result.attempts.len().to_string();
+    let terminal_event = provider_terminal_event(&result, &attempts);
+    let result_text = serde_json::to_string_pretty(&result)? + "\n";
+    if let Err(err) = fs::write(&args.out, result_text) {
+        heartbeat.failed(&[
+            ("reason_code", "result_write_failed"),
+            ("next_action_hint", "check_result_output_path"),
+        ]);
+        return Err(err).with_context(|| format!("write result file {}", args.out.display()));
+    }
+    emit_provider_terminal_event(heartbeat, terminal_event);
     println!("result={}", args.out.display());
     println!("run_log={}", args.log.display());
     println!("watch=tail -f {}", args.log.display());
     Ok(())
 }
 
+enum ProviderTerminalEvent<'a> {
+    Completed(Vec<(&'a str, String)>),
+    Failed(Vec<(&'a str, String)>),
+    Timeout(Vec<(&'a str, String)>),
+}
+
+fn provider_terminal_event<'a>(
+    result: &'a ProviderInvocationResultV1,
+    attempts: &'a str,
+) -> ProviderTerminalEvent<'a> {
+    match result.final_status {
+        ProviderInvocationFinalStatusV1::Ok => ProviderTerminalEvent::Completed(vec![
+            ("final_status", "ok".to_string()),
+            ("attempts", attempts.to_string()),
+        ]),
+        ProviderInvocationFinalStatusV1::Failed => {
+            match result.failure.as_ref().map(|failure| &failure.kind) {
+                Some(ProviderFailureKindV1::ProviderTimeout) => {
+                    ProviderTerminalEvent::Timeout(vec![
+                        ("reason_code", "provider_timeout".to_string()),
+                        (
+                            "next_action_hint",
+                            "check_provider_or_increase_timeout_ms".to_string(),
+                        ),
+                        ("attempts", attempts.to_string()),
+                    ])
+                }
+                Some(kind) => ProviderTerminalEvent::Failed(vec![
+                    ("reason_code", failure_kind_label(kind).to_string()),
+                    (
+                        "next_action_hint",
+                        "inspect_provider_run_log_and_result".to_string(),
+                    ),
+                    ("attempts", attempts.to_string()),
+                ]),
+                None => ProviderTerminalEvent::Failed(vec![
+                    ("reason_code", "provider_failed".to_string()),
+                    (
+                        "next_action_hint",
+                        "inspect_provider_run_log_and_result".to_string(),
+                    ),
+                    ("attempts", attempts.to_string()),
+                ]),
+            }
+        }
+        ProviderInvocationFinalStatusV1::Skipped => ProviderTerminalEvent::Completed(vec![
+            ("final_status", "skipped".to_string()),
+            ("reason_code", "provider_skipped".to_string()),
+            ("attempts", attempts.to_string()),
+        ]),
+        ProviderInvocationFinalStatusV1::Blocked => ProviderTerminalEvent::Failed(vec![
+            ("final_status", "blocked".to_string()),
+            ("reason_code", "provider_blocked".to_string()),
+            (
+                "next_action_hint",
+                "inspect_provider_run_log_and_result".to_string(),
+            ),
+            ("attempts", attempts.to_string()),
+        ]),
+    }
+}
+
+fn emit_provider_terminal_event(heartbeat: ProgressHeartbeat, event: ProviderTerminalEvent<'_>) {
+    match event {
+        ProviderTerminalEvent::Completed(fields) => heartbeat.completed(&borrow_fields(&fields)),
+        ProviderTerminalEvent::Failed(fields) => heartbeat.failed(&borrow_fields(&fields)),
+        ProviderTerminalEvent::Timeout(fields) => heartbeat.timeout(&borrow_fields(&fields)),
+    }
+}
+
+fn borrow_fields<'a>(fields: &'a [(&'a str, String)]) -> Vec<(&'a str, &'a str)> {
+    fields
+        .iter()
+        .map(|(key, value)| (*key, value.as_str()))
+        .collect::<Vec<_>>()
+}
+
+fn runtime_surface_label(
+    surface: &crate::provider_communication::RuntimeSurfaceV1,
+) -> &'static str {
+    match surface {
+        crate::provider_communication::RuntimeSurfaceV1::HostedApi => "hosted_api",
+        crate::provider_communication::RuntimeSurfaceV1::OllamaHttp => "ollama_http",
+        crate::provider_communication::RuntimeSurfaceV1::OllamaCli => "ollama_cli",
+        crate::provider_communication::RuntimeSurfaceV1::Mock => "mock",
+        crate::provider_communication::RuntimeSurfaceV1::Unknown => "unknown",
+    }
+}
+
+fn failure_kind_label(kind: &ProviderFailureKindV1) -> &'static str {
+    match kind {
+        ProviderFailureKindV1::ProviderAuthMissing => "provider_auth_missing",
+        ProviderFailureKindV1::ProviderAuthError => "provider_auth_error",
+        ProviderFailureKindV1::ProviderRateLimited => "provider_rate_limited",
+        ProviderFailureKindV1::ProviderTimeout => "provider_timeout",
+        ProviderFailureKindV1::ProviderTransientHttp => "provider_transient_http",
+        ProviderFailureKindV1::ProviderEmptyTextOutput => "provider_empty_text_output",
+        ProviderFailureKindV1::ProviderModelUnavailable => "provider_model_unavailable",
+        ProviderFailureKindV1::ProviderBillingBlocked => "provider_billing_blocked",
+        ProviderFailureKindV1::LocalRuntimeUnavailable => "local_runtime_unavailable",
+        ProviderFailureKindV1::LocalRuntimeBusy => "local_runtime_busy",
+        ProviderFailureKindV1::LocalRuntimeHung => "local_runtime_hung",
+        ProviderFailureKindV1::ProviderError => "provider_error",
+        ProviderFailureKindV1::Unknown => "unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        match ENV_LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
 
     fn temp_path(name: &str) -> PathBuf {
         let stamp = SystemTime::now()
@@ -119,5 +271,182 @@ mod tests {
         let _ = fs::remove_file(request);
         let _ = fs::remove_file(out);
         let _ = fs::remove_file(log);
+    }
+
+    #[test]
+    fn cli_run_emits_heartbeat_and_timeout_diagnostics_for_slow_provider_calls() {
+        let _guard = env_lock();
+        let request = temp_path("request-timeout");
+        let out = temp_path("result-timeout");
+        let log = temp_path("log-timeout");
+        let observability = temp_path("observability-timeout");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind timeout server");
+        let addr = listener.local_addr().expect("server addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buffer = [0_u8; 4096];
+            let _ = stream.read(&mut buffer);
+            thread::sleep(std::time::Duration::from_millis(150));
+            let body = r#"{"output_text":"too late"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+        fs::write(
+            &request,
+            format!(
+                r#"{{
+  "route": {{
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "runtime_surface": "hosted_api",
+    "provider_model_id": "test-model",
+    "endpoint_ref": "http://{addr}/v1/responses",
+    "credential_ref": "env:ADL_PROVIDER_ADAPTER_TIMEOUT_KEY"
+  }},
+  "model_identity": {{
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "model_ref": "test-model",
+    "provider_model_id": "test-model",
+    "runtime_surface": "hosted_api",
+    "identity_strength": "provider_asserted",
+    "observed_at": "unix:1"
+  }},
+  "prompt_contract_ref": "test.prompt.v1",
+  "lane_ref": "regular",
+  "run_id": "run-cli-timeout-test",
+  "request_id": "req-cli-timeout-test",
+  "attempt_policy": {{
+    "max_attempts": 1,
+    "timeout_ms": 50,
+    "retry_backoff_ms": 1
+  }},
+  "input_text": "slow prompt"
+}}
+"#
+            ),
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("ADL_PROVIDER_ADAPTER_TIMEOUT_KEY", "test-timeout-token");
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var("ADL_OBSERVABILITY_LOG", &observability);
+            std::env::set_var("ADL_OBSERVABILITY_HEARTBEAT_MS", "25");
+        }
+
+        run_provider_adapter_cli(ProviderAdapterCliArgs {
+            request: request.clone(),
+            out: out.clone(),
+            log: log.clone(),
+        })
+        .unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(
+            result
+                .get("final_status")
+                .and_then(serde_json::Value::as_str),
+            Some("failed")
+        );
+        assert_eq!(
+            result
+                .pointer("/failure/kind")
+                .and_then(serde_json::Value::as_str),
+            Some("provider_timeout")
+        );
+        let observability_text = fs::read_to_string(&observability).unwrap();
+        assert!(observability_text.contains("command=provider_adapter"));
+        assert!(observability_text.contains("stage=provider_call"));
+        assert!(observability_text.contains("result=heartbeat"));
+        assert!(observability_text.contains("result=timeout"));
+        assert!(observability_text.contains("reason_code=provider_timeout"));
+        assert!(
+            observability_text.contains("next_action_hint=check_provider_or_increase_timeout_ms")
+        );
+
+        unsafe {
+            std::env::remove_var("ADL_PROVIDER_ADAPTER_TIMEOUT_KEY");
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
+            std::env::remove_var("ADL_OBSERVABILITY_HEARTBEAT_MS");
+        }
+        let _ = fs::remove_file(request);
+        let _ = fs::remove_file(out);
+        let _ = fs::remove_file(log);
+        let _ = fs::remove_file(observability);
+    }
+
+    #[test]
+    fn cli_run_records_failed_terminal_event_when_result_write_fails() {
+        let _guard = env_lock();
+        let request = temp_path("request-write-fail");
+        let out_dir = temp_path("result-dir");
+        let out = out_dir.join("missing").join("result.json");
+        let log = temp_path("log-write-fail");
+        let observability = temp_path("observability-write-fail");
+        fs::write(
+            &request,
+            r#"{
+  "route": {
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "runtime_surface": "hosted_api",
+    "provider_model_id": "test-model",
+    "credential_ref": "env:ADL_PROVIDER_ADAPTER_CLI_MISSING_KEY"
+  },
+  "model_identity": {
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "model_ref": "test-model",
+    "provider_model_id": "test-model",
+    "runtime_surface": "hosted_api",
+    "identity_strength": "provider_asserted",
+    "observed_at": "unix:1"
+  },
+  "prompt_contract_ref": "test.prompt.v1",
+  "lane_ref": "regular",
+  "run_id": "run-cli-write-fail-test",
+  "request_id": "req-cli-write-fail-test",
+  "attempt_policy": {
+    "max_attempts": 1,
+    "timeout_ms": 1000,
+    "retry_backoff_ms": 1
+  },
+  "input_text": "secret prompt should not enter logs"
+}
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+            std::env::set_var("ADL_OBSERVABILITY_LOG", &observability);
+        }
+
+        let err = run_provider_adapter_cli(ProviderAdapterCliArgs {
+            request: request.clone(),
+            out: out.clone(),
+            log: log.clone(),
+        })
+        .expect_err("result write should fail");
+        assert!(err.to_string().contains("write result file"));
+
+        let observability_text = fs::read_to_string(&observability).unwrap();
+        assert!(observability_text.contains("result=failed"));
+        assert!(observability_text.contains("reason_code=result_write_failed"));
+        assert!(observability_text.contains("next_action_hint=check_result_output_path"));
+
+        unsafe {
+            std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+            std::env::remove_var("ADL_OBSERVABILITY_LOG");
+        }
+        let _ = fs::remove_file(request);
+        let _ = fs::remove_file(log);
+        let _ = fs::remove_file(observability);
     }
 }

--- a/docs/milestones/v0.91.5/HEARTBEAT_TIMEOUT_PROGRESS_POLICY_3708.md
+++ b/docs/milestones/v0.91.5/HEARTBEAT_TIMEOUT_PROGRESS_POLICY_3708.md
@@ -1,0 +1,130 @@
+# Heartbeat, Timeout, And Progress Policy (#3708)
+
+Issue: #3708  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: implemented_first_slice
+
+## Summary
+
+This policy defines the first bounded `#3708` answer to the operator question:
+"is it hung, waiting, or still making progress?"
+
+The policy does not try to make every ADL surface noisy. It separates:
+
+- short CLI commands that should normally emit only started/completed or
+  started/failed truth;
+- bounded long-running subprocesses that should emit heartbeat/progress while
+  waiting; and
+- long-lived processes that should stay visibly alive without pretending every
+  internal cycle detail belongs in one terminal stream.
+
+## Core Rules
+
+1. Fast commands stay quiet.
+   - If a command finishes before the heartbeat interval, it should not emit
+     repeated heartbeat noise.
+   - Started/completed or started/failed surfaces remain acceptable.
+
+2. Heartbeats are interval-based, not loop-spammed.
+   - The default operator-facing heartbeat interval is `5000 ms`.
+   - Tests may override the interval with `ADL_OBSERVABILITY_HEARTBEAT_MS`.
+   - The first heartbeat should appear only after the interval elapses.
+
+3. Long waits must expose classification.
+   - When ADL waits on a subprocess or provider call, the log must state what
+     class of work is in flight.
+   - Examples in this slice:
+     - `subprocess_class=shell_validation`
+     - `subprocess_class=rust_validation`
+     - `provider=<provider>`
+     - `runtime_surface=<surface>`
+
+4. Timeout outcomes must be stable and actionable.
+   - Timeouts should emit `result=timeout` and a bounded `reason_code`.
+   - Timeout records should also carry one bounded `next_action_hint`.
+   - In this slice, hosted/local provider waits use:
+     - `reason_code=provider_timeout`
+     - `next_action_hint=check_provider_or_increase_timeout_ms`
+
+5. Long-lived processes have different expectations from short CLI commands.
+   - Operator-facing long-lived commands such as `adl agent run` should emit
+     process-liveness heartbeat events while the run stays active.
+   - Canonical per-cycle detail remains in the long-lived-agent status, lease,
+     and cycle-ledger artifacts rather than being duplicated into a chatty
+     terminal stream.
+
+## Covered Surfaces In This Slice
+
+### Finish Validation Subprocesses
+
+`pr finish` local validation subprocesses now emit bounded observability with:
+
+- `command=finish`
+- `stage=validation_subprocess`
+- `program=<program>`
+- `subprocess_class=<classification>`
+- `argv_excerpt=<bounded command excerpt>`
+- `elapsed_ms=<duration>`
+
+This is intended to answer:
+
+- what validation subprocess is running;
+- whether it is still alive; and
+- whether it completed or failed.
+
+### Provider Adapter Calls
+
+`adl-provider-adapter` now emits bounded provider-call heartbeat/timeout
+observability with:
+
+- `command=provider_adapter`
+- `stage=provider_call`
+- `provider=<provider>`
+- `runtime_surface=<surface>`
+- `provider_model_id=<model>`
+- `request_id=<request>`
+- `timeout_ms=<policy>`
+- `elapsed_ms=<duration>`
+
+Timeouts emit:
+
+- `result=timeout`
+- `reason_code=provider_timeout`
+- `next_action_hint=check_provider_or_increase_timeout_ms`
+
+### Long-Lived Agent Runs
+
+`adl agent run`, `adl agent tick`, and `adl agent status` now emit
+operator-facing observability with:
+
+- `command=agent`
+- `stage=agent_run` / `agent_tick` / `agent_status`
+- `process_class=long_lived`
+- `spec=<bounded spec path>`
+- `elapsed_ms=<duration>`
+
+For `agent run`, the surface additionally records:
+
+- `max_cycles=<requested cycles>`
+- `interval_secs=<requested or spec default interval>`
+- `no_sleep=<true|false>`
+
+This is intended to answer whether the long-lived process is still alive
+without replacing the canonical cycle/status artifacts.
+
+## Bounded Non-Claims
+
+- This policy does not claim that every ADL command now has heartbeat coverage.
+- It does not implement OpenTelemetry export; that remains `#3709`.
+- It does not redefine runtime action logs, provider JSONL logs, or
+  long-lived-agent ledgers as one merged truth source.
+- It does not promise per-cycle or per-attempt progress detail for every
+  internal step of a long-lived run.
+
+## Follow-On Consumers
+
+- `#3709` should preserve these event/result semantics when defining the OTEL
+  boundary.
+- `#3710` should consume these fields as the Observatory-facing liveness and
+  timeout baseline rather than inventing a second incompatible heartbeat model.

--- a/docs/milestones/v0.91.5/review/logging_observability/HEARTBEAT_TIMEOUT_PROGRESS_PROOF_3708.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/HEARTBEAT_TIMEOUT_PROGRESS_PROOF_3708.md
@@ -1,0 +1,104 @@
+# Heartbeat, Timeout, And Progress Proof (#3708)
+
+Issue: #3708  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: implementation_refreshed
+
+## Summary
+
+This packet records the refreshed `#3708` slice after the logging mini-sprint
+was re-audited against current repo truth.
+
+The repo already had:
+
+- control-plane `adl_event` baselines (`#3609`, `#3706`);
+- provider JSONL run logs; and
+- long-lived-agent status, lease, and cycle-ledger artifacts.
+
+The remaining operator pain was narrower:
+
+1. long-running validation subprocesses could still look silent while waiting;
+2. provider adapter calls could time out without an operator-facing heartbeat
+   stream or bounded next-action hint; and
+3. long-lived agent commands could be alive for a while without a clear
+   operator-facing liveness signal.
+
+## Implemented Slice
+
+This issue adds one shared operator-facing heartbeat helper and uses it in three
+high-pain paths:
+
+- `pr finish` validation subprocesses
+- `adl-provider-adapter` provider-call execution
+- `adl agent run` / `tick` / `status`
+
+The helper is intentionally bounded:
+
+- default heartbeat interval is `5000 ms`
+- tests may override it with `ADL_OBSERVABILITY_HEARTBEAT_MS`
+- fast commands finish before the interval and therefore do not emit heartbeat
+  spam
+
+## Proof Commands
+
+### Shared heartbeat helper behavior
+
+```bash
+cargo test --manifest-path adl/Cargo.toml cli::observability -- --nocapture
+```
+
+Expected proof:
+
+- slow operations emit `started`, `heartbeat`, and `completed`
+- fast operations emit `started` and `completed` without heartbeat spam
+- heartbeat interval override works deterministically in tests
+
+### Validation subprocess heartbeat and classification
+
+```bash
+cargo test --manifest-path adl/Cargo.toml finish_validation_emits_subprocess_heartbeat_and_classification -- --nocapture
+```
+
+Expected proof:
+
+- `pr finish` validation subprocess waits emit
+  `stage=validation_subprocess`
+- the emitted log captures the program and bounded subprocess class
+- a delayed subprocess emits at least one heartbeat before completion
+
+### Provider timeout heartbeat and next-action hint
+
+```bash
+cargo test --manifest-path adl/Cargo.toml cli_run_emits_heartbeat_and_timeout_diagnostics_for_slow_provider_calls -- --nocapture
+```
+
+Expected proof:
+
+- the provider adapter emits heartbeat events while a request is still waiting
+- timeout exits emit `result=timeout`
+- timeout exits emit `reason_code=provider_timeout`
+- timeout exits emit
+  `next_action_hint=check_provider_or_increase_timeout_ms`
+
+### Long-lived process heartbeat
+
+```bash
+cargo test --manifest-path adl/Cargo.toml agent_run_emits_heartbeat_for_long_lived_processes -- --nocapture
+```
+
+Expected proof:
+
+- `adl agent run` emits operator-facing heartbeat events while the process is
+  still active
+- the completed event records a long-lived process classification rather than
+  pretending the command is an ordinary short validation step
+
+## Non-Claims
+
+- This issue does not claim complete heartbeat coverage for every ADL command.
+- It does not add OpenTelemetry export or collector integration.
+- It does not merge runtime action logs, provider JSONL logs, and
+  long-lived-agent ledgers into one canonical record.
+- It does not claim that long-lived-agent internal cycle details belong in the
+  same terminal/event stream as the operator-facing liveness heartbeat.


### PR DESCRIPTION
Closes #3708

## Summary
Refreshed the `#3708` slice after re-auditing the logging mini-sprint against
current repo truth. The bounded implementation adds a shared
`ProgressHeartbeat` helper and uses it in three high-pain operator-facing
surfaces: `pr finish` validation subprocesses, `adl-provider-adapter`
provider-call execution, and long-lived `adl agent` run/tick/status commands.
Fast commands remain quiet, slow paths emit bounded heartbeat events, and
timeouts/failures now carry stable reason codes and next-action hints instead
of forcing operators to infer liveness from silence.

## Artifacts
- `adl/src/cli/observability.rs`
- `adl/src/lib.rs`
- `adl/src/observability.rs`
- `adl/src/provider_adapter_cli.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/agent_cmd.rs`
- `docs/milestones/v0.91.5/HEARTBEAT_TIMEOUT_PROGRESS_POLICY_3708.md`
- `docs/milestones/v0.91.5/review/logging_observability/HEARTBEAT_TIMEOUT_PROGRESS_PROOF_3708.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml cli::observability -- --nocapture`
    Verified slow-path heartbeat emission, fast-path quiet behavior, and heartbeat interval override handling.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml provider_adapter_cli -- --nocapture`
    Verified provider timeout heartbeat, classification, and next-action diagnostics.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml cli_run_records_failed_terminal_event_when_result_write_fails -- --nocapture`
    Verified provider adapter emits a failed terminal event when result-file persistence fails.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml finish_validation_emits_subprocess_heartbeat_and_classification -- --nocapture`
    Verified validation subprocess heartbeat and bounded classification metadata.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml finish_validation_emits_failed_terminal_event_on_spawn_error -- --nocapture`
    Verified validation subprocess spawn failures emit a terminal failed event with a bounded reason code and next-action hint.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3708-target cargo test --manifest-path adl/Cargo.toml agent_run_emits_heartbeat_for_long_lived_processes -- --nocapture`
    Verified long-lived agent run heartbeat/completion emission.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3708__v0-91-5-logging-mini-sprint-add-heartbeat-timeout-and-progress-diagnostics/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3708__v0-91-5-logging-mini-sprint-add-heartbeat-timeout-and-progress-diagnostics/sor.md
- Idempotency-Key: v0-91-5-logging-wp-05-add-heartbeat-timeout-and-progress-diagnostics-adl-v0-91-5-tasks-issue-3708-v0-91-5-logging-mini-sprint-add-heartbeat-timeout-and-progress-diagnostics-sip-md-adl-v0-91-5-tasks-issue-3708-v0-91-5-logging-mini-sprint-add-heartbeat-timeout-and-progress-diagnostics-sor-md