### PR TITLE
[v0.91.5][logging][WP-04] Unify runtime and provider action logging

### DIFF
--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -100,6 +100,7 @@ pub fn execute_provider_invocation(
                     attempts,
                     final_status: ProviderInvocationFinalStatusV1::Ok,
                     duration_ms: started.elapsed().as_millis() as u64,
+                    request_id: request.request_id.clone(),
                     output_text: Some(output_text.clone()),
                     output_text_excerpt: Some(redacted_response_marker(&output_text)),
                     failure: None,
@@ -172,6 +173,7 @@ fn failed_result(
         attempts,
         final_status: ProviderInvocationFinalStatusV1::Failed,
         duration_ms,
+        request_id: request.request_id,
         output_text: None,
         output_text_excerpt: None,
         failure: Some(failure),
@@ -999,6 +1001,7 @@ mod tests {
         drop(logger);
 
         assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.request_id.as_deref(), Some("req-test"));
         assert_eq!(result.output_text.as_deref(), Some("adapter success"));
         let log = fs::read_to_string(&path).expect("read log");
         assert!(log.contains("attempt_success"));
@@ -1295,6 +1298,7 @@ mod tests {
         drop(logger);
 
         assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(result.request_id.as_deref(), Some("req-test"));
         assert_eq!(
             result.failure.as_ref().map(|failure| failure.kind.clone()),
             Some(ProviderFailureKindV1::ProviderAuthMissing)

--- a/adl/src/provider_adapter_cli.rs
+++ b/adl/src/provider_adapter_cli.rs
@@ -6,8 +6,9 @@ use crate::provider_communication::{
 };
 use anyhow::{Context, Result};
 use clap::Parser;
+use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Parser)]
 #[command(name = "adl-provider-adapter")]
@@ -51,9 +52,16 @@ pub fn run_provider_adapter_cli(args: ProviderAdapterCliArgs) -> Result<()> {
             ),
         ],
     );
-    let mut logger = ProviderRunLoggerV1::create(&args.log, run_id)
+    let log_ref = normalize_observability_ref(&args.log);
+    let mut logger = ProviderRunLoggerV1::create_with_context(
+        &args.log,
+        run_id,
+        request.request_id.clone(),
+        Some(log_ref.clone()),
+    )
         .with_context(|| format!("open run log {}", args.log.display()))?;
-    let result = execute_provider_invocation(request, &mut logger);
+    let mut result = execute_provider_invocation(request, &mut logger);
+    result.artifact_ref = Some(normalize_observability_ref(&args.out));
     let attempts = result.attempts.len().to_string();
     let terminal_event = provider_terminal_event(&result, &attempts);
     let result_text = serde_json::to_string_pretty(&result)? + "\n";
@@ -178,6 +186,66 @@ fn failure_kind_label(kind: &ProviderFailureKindV1) -> &'static str {
     }
 }
 
+fn normalize_observability_ref(path: &PathBuf) -> String {
+    let path = resolved_path(path);
+    if let Some(repo_relative) = repo_relative_observability_ref(&path) {
+        return repo_relative;
+    }
+    let temp_dir = env::temp_dir();
+    if path.starts_with(&temp_dir) {
+        return format!(
+            "<tmp>/{}",
+            path.file_name().unwrap_or_default().to_string_lossy()
+        );
+    }
+    if let Ok(canonical_temp_dir) = temp_dir.canonicalize() {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if canonical.starts_with(&canonical_temp_dir) {
+            return format!(
+                "<tmp>/{}",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            );
+        }
+    }
+    if let Some(home_dir) = env::var_os("HOME") {
+        let home_path = PathBuf::from(home_dir);
+        if path.starts_with(&home_path) {
+            return format!(
+                "<home>/{}",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            );
+        }
+    }
+    format!(
+        "<absolute>/{}",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    )
+}
+
+fn resolved_path(path: &PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path.clone()
+    } else {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
+}
+
+fn repo_relative_observability_ref(path: &Path) -> Option<String> {
+    let mut cursor = path.parent();
+    while let Some(candidate) = cursor {
+        if candidate.join(".git").exists() {
+            if let Ok(relative) = path.strip_prefix(candidate) {
+                return Some(relative.display().to_string());
+            }
+            return None;
+        }
+        cursor = candidate.parent();
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,8 +332,22 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("provider_auth_missing")
         );
+        assert_eq!(
+            result.get("request_id").and_then(serde_json::Value::as_str),
+            Some("req-cli-test")
+        );
+        let expected_result_ref = format!("<tmp>/{}", out.file_name().unwrap().to_string_lossy());
+        assert_eq!(
+            result
+                .get("artifact_ref")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_result_ref.as_str())
+        );
         let log_text = fs::read_to_string(&log).unwrap();
         assert!(log_text.contains("run-cli-test"));
+        assert!(log_text.contains("req-cli-test"));
+        let expected_log_ref = format!("<tmp>/{}", log.file_name().unwrap().to_string_lossy());
+        assert!(log_text.contains(&expected_log_ref));
         assert!(!log_text.contains("secret prompt"));
 
         let _ = fs::remove_file(request);
@@ -448,5 +530,27 @@ mod tests {
         let _ = fs::remove_file(request);
         let _ = fs::remove_file(log);
         let _ = fs::remove_file(observability);
+    }
+
+    #[test]
+    fn normalize_observability_ref_prefers_repo_relative_and_redacts_absolute_paths() {
+        let repo_relative =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/provider_adapter_cli.rs");
+        assert_eq!(
+            normalize_observability_ref(&repo_relative),
+            "adl/src/provider_adapter_cli.rs"
+        );
+
+        let temp_path = env::temp_dir().join("provider-log.jsonl");
+        assert_eq!(
+            normalize_observability_ref(&temp_path),
+            "<tmp>/provider-log.jsonl"
+        );
+
+        let home_path = PathBuf::from(env::var("HOME").unwrap()).join("provider-log.jsonl");
+        assert_eq!(
+            normalize_observability_ref(&home_path),
+            "<home>/provider-log.jsonl"
+        );
     }
 }

--- a/adl/src/provider_adapter_cli.rs
+++ b/adl/src/provider_adapter_cli.rs
@@ -59,7 +59,7 @@ pub fn run_provider_adapter_cli(args: ProviderAdapterCliArgs) -> Result<()> {
         request.request_id.clone(),
         Some(log_ref.clone()),
     )
-        .with_context(|| format!("open run log {}", args.log.display()))?;
+    .with_context(|| format!("open run log {}", args.log.display()))?;
     let mut result = execute_provider_invocation(request, &mut logger);
     result.artifact_ref = Some(normalize_observability_ref(&args.out));
     let attempts = result.attempts.len().to_string();

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -151,6 +151,8 @@ pub struct ProviderInvocationResultV1 {
     pub final_status: ProviderInvocationFinalStatusV1,
     pub duration_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_text_excerpt: Option<String>,
@@ -286,6 +288,8 @@ pub struct ProviderRunLogEventV1 {
     pub schema_version: String,
     pub timestamp: String,
     pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
     pub event_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
@@ -310,16 +314,29 @@ pub struct ProviderRunLogEventV1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fields: Option<Value>,
 }
 
 pub struct ProviderRunLoggerV1 {
     run_id: String,
+    request_id: Option<String>,
+    artifact_ref: Option<String>,
     writer: BufWriter<File>,
 }
 
 impl ProviderRunLoggerV1 {
     pub fn create(path: impl AsRef<Path>, run_id: impl Into<String>) -> Result<Self> {
+        Self::create_with_context(path, run_id, None, None)
+    }
+
+    pub fn create_with_context(
+        path: impl AsRef<Path>,
+        run_id: impl Into<String>,
+        request_id: Option<String>,
+        artifact_ref: Option<String>,
+    ) -> Result<Self> {
         let path = path.as_ref();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -327,6 +344,8 @@ impl ProviderRunLoggerV1 {
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self {
             run_id: run_id.into(),
+            request_id,
+            artifact_ref,
             writer: BufWriter::new(file),
         })
     }
@@ -334,6 +353,12 @@ impl ProviderRunLoggerV1 {
     pub fn event(&mut self, mut event: ProviderRunLogEventV1) -> Result<()> {
         event.schema_version = PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string();
         event.run_id = self.run_id.clone();
+        if event.request_id.is_none() {
+            event.request_id = self.request_id.clone();
+        }
+        if event.artifact_ref.is_none() {
+            event.artifact_ref = self.artifact_ref.clone();
+        }
         event.timestamp = observed_at_now_v1();
         scrub_log_event(&mut event);
         let line = serde_json::to_string(&event)?;
@@ -350,6 +375,7 @@ impl ProviderRunLogEventV1 {
             schema_version: PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string(),
             timestamp: observed_at_now_v1(),
             run_id: String::new(),
+            request_id: None,
             event_type: event_type.into(),
             provider: None,
             provider_kind: None,
@@ -362,6 +388,7 @@ impl ProviderRunLogEventV1 {
             status: None,
             failure_kind: None,
             message: None,
+            artifact_ref: None,
             fields: None,
         }
     }
@@ -889,6 +916,29 @@ mod tests {
     }
 
     #[test]
+    fn provider_run_logger_injects_request_and_artifact_refs_from_context() {
+        let path = temp_log_path();
+        let mut logger = ProviderRunLoggerV1::create_with_context(
+            &path,
+            "run-2",
+            Some("req-2".to_string()),
+            Some("logs/provider-run.jsonl".to_string()),
+        )
+        .unwrap();
+        logger
+            .event(ProviderRunLogEventV1::new("run_start"))
+            .unwrap();
+        drop(logger);
+
+        let raw = fs::read_to_string(&path).unwrap();
+        let row: ProviderRunLogEventV1 = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(row.run_id, "run-2");
+        assert_eq!(row.request_id.as_deref(), Some("req-2"));
+        assert_eq!(row.artifact_ref.as_deref(), Some("logs/provider-run.jsonl"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
     fn utf8_diagnostics_truncate_without_panic() {
         let diagnostic = format!("{}{}", "界".repeat(200), "é");
         let sanitized = sanitize_provider_message(&diagnostic);
@@ -951,6 +1001,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Ok,
             duration_ms: 10,
+            request_id: None,
             output_text: Some("{}".to_string()),
             output_text_excerpt: Some("{}".to_string()),
             failure: None,
@@ -990,6 +1041,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Failed,
             duration_ms: 10,
+            request_id: None,
             output_text: None,
             output_text_excerpt: None,
             failure: Some(failure),
@@ -1184,6 +1236,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Failed,
             duration_ms: 25,
+            request_id: Some("provider-request-1".to_string()),
             output_text: None,
             output_text_excerpt: None,
             failure: Some(provider_failure),
@@ -1257,6 +1310,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Ok,
             duration_ms: 25,
+            request_id: Some("provider-request-1".to_string()),
             output_text: None,
             output_text_excerpt: Some("[redacted review output]".to_string()),
             failure: None,
@@ -1345,6 +1399,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Failed,
             duration_ms: 25,
+            request_id: Some("provider-request-1".to_string()),
             output_text: None,
             output_text_excerpt: None,
             failure: Some(provider_failure),
@@ -1397,6 +1452,7 @@ mod tests {
             }],
             final_status: ProviderInvocationFinalStatusV1::Ok,
             duration_ms: 25,
+            request_id: Some("provider-request-1".to_string()),
             output_text: None,
             output_text_excerpt: Some("[redacted review output]".to_string()),
             failure: None,

--- a/docs/milestones/v0.91.5/review/logging_observability/RUNTIME_PROVIDER_LOGGING_PROOF_3707.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/RUNTIME_PROVIDER_LOGGING_PROOF_3707.md
@@ -1,0 +1,110 @@
+# Runtime And Provider Logging Correlation Proof (#3707)
+
+Issue: #3707  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: implementation_refreshed
+
+## Summary
+
+This packet records the refreshed `#3707` implementation slice after the
+logging mini-sprint was re-audited against current repo truth.
+
+The repo already had two real observability baselines:
+
+- runtime `logs/action_log.jsonl` projection from canonical trace events; and
+- provider invocation JSONL / result artifacts from the Rust provider adapter.
+
+The remaining gap was not "build a second runtime log system." It was provider
+correlation hygiene:
+
+1. provider results did not carry the stable `request_id` that downstream
+   reviewers and tooling need to correlate repeated invocations;
+2. provider run-log rows did not carry stable request or artifact references;
+3. the provider adapter CLI printed result/log paths for humans, but the JSON
+   evidence itself did not preserve those refs in a safe repo-relative or
+   explicitly redacted form.
+
+## Implemented Slice
+
+This issue makes one bounded correlation improvement on the provider side while
+keeping runtime action logs as the canonical runtime projection:
+
+- `ProviderInvocationResultV1` now preserves optional `request_id`.
+- `ProviderRunLogEventV1` now preserves optional `request_id` and
+  `artifact_ref`.
+- `ProviderRunLoggerV1` can inject request/log correlation context into every
+  emitted provider event.
+- `adl-provider-adapter` now writes a safe `artifact_ref` for the result
+  artifact and emits a safe `artifact_ref` on the provider run log.
+- absolute temp/home paths are normalized to bounded refs such as
+  `<tmp>/file.json` and `<home>/file.json`; repo files remain repo-relative.
+
+## Correlation Model
+
+The intended operator/reviewer read path is now:
+
+1. use runtime `logs/action_log.jsonl` for stage/result/reason chronology;
+2. use provider JSONL for attempt-by-attempt provider behavior;
+3. correlate by `run_id`, `request_id`, provider/model identity, and bounded
+   artifact refs;
+4. consult canonical trace/replay artifacts for deeper governed detail rather
+   than trying to turn the provider log into a second truth source.
+
+This keeps the runtime action log authoritative for runtime chronology while
+making provider artifacts much easier to inspect without raw prompts, payloads,
+credentials, or host-local absolute paths.
+
+## Proof Commands
+
+### Provider communication and log context
+
+```bash
+cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture
+```
+
+Expected proof:
+
+- provider result validation still works transitively;
+- provider-run logger flushes JSONL rows safely;
+- request/artifact context is injected into emitted provider log rows;
+- redaction still strips secrets and prompt bodies.
+
+### Provider adapter CLI correlation and path hygiene
+
+```bash
+cargo test --manifest-path adl/Cargo.toml provider_adapter_cli -- --nocapture
+```
+
+Expected proof:
+
+- failure results still normalize to stable failure kinds;
+- `request_id` survives into `ProviderInvocationResultV1` on the CLI failure
+  path and on direct adapter success/failure paths;
+- result and log artifact refs are preserved in bounded form;
+- repo files serialize repo-relative refs when possible;
+- temp or home paths are redacted instead of leaking absolute host-local paths.
+
+### Runtime action-log baseline
+
+```bash
+cargo test --manifest-path adl/Cargo.toml instrumentation::action_log -- --nocapture
+```
+
+Expected proof:
+
+- runtime action-log projection still emits deterministic `stage`, `component`,
+  `result`, `provider_ref`, `reason_code`, and `artifact_write` surfaces;
+- raw runtime failure messages are still not copied into the action log;
+- runtime evidence remains a projection over trace, not a competing truth
+  source.
+
+## Non-Claims
+
+- This issue does not claim that every runtime event now embeds provider
+  `request_id`; runtime chronology and provider invocation evidence remain
+  separate surfaces by design.
+- This issue does not redesign the canonical trace format.
+- This issue does not add hosted provider spend or live hosted proof.
+- This issue does not complete heartbeat/timeout observability; that remains
+  `#3708`.


### PR DESCRIPTION
Closes #3707

## Summary
Refreshed the `#3707` runtime/provider logging slice after re-auditing the
logging mini-sprint against current repo truth. The bounded implementation does
not add a second runtime log stream; it strengthens provider-side correlation
metadata so provider results and provider JSONL logs can be read alongside the
existing runtime action-log projection without leaking secrets or host-local
absolute paths.

## Artifacts
- `adl/src/provider_communication.rs`
- `adl/src/provider_adapter.rs`
- `adl/src/provider_adapter_cli.rs`
- `docs/milestones/v0.91.5/review/logging_observability/RUNTIME_PROVIDER_LOGGING_PROOF_3707.md`

## Validation
- Validation commands and their purpose:
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3707-target cargo test --manifest-path adl/Cargo.toml provider_adapter_cli -- --nocapture`
    Verified provider adapter CLI artifact-ref normalization, temp/home redaction, and failure-path `request_id` preservation.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3707-target cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture`
    Verified provider run-log context injection, provider-result validation, and redaction behavior.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3707-target cargo test --manifest-path adl/Cargo.toml instrumentation::action_log -- --nocapture`
    Verified the runtime action-log baseline still emits deterministic provider/policy/event surfaces without raw failure-message leakage.
  - `CARGO_TARGET_DIR=TMP_REDACTED/adl-wp-3707-target cargo test --manifest-path adl/Cargo.toml provider_adapter -- --nocapture`
    Verified direct provider adapter success/failure behavior, request-id preservation, and redacted provider logging across hosted and local surfaces.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3707__v0-91-5-logging-mini-sprint-unify-runtime-and-provider-action-logging/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3707__v0-91-5-logging-mini-sprint-unify-runtime-and-provider-action-logging/sor.md
- Idempotency-Key: v0-91-5-logging-wp-04-unify-runtime-and-provider-action-logging-adl-v0-91-5-tasks-issue-3707-v0-91-5-logging-mini-sprint-unify-runtime-and-provider-action-logging-sip-md-adl-v0-91-5-tasks-issue-3707-v0-91-5-logging-mini-sprint-unify-runtime-and-provider-action-logging-sor-md