### PR TITLE
[v0.91.5][tools] Add toolkit issue body repair command

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -11,7 +11,8 @@ use std::sync::{Mutex, OnceLock};
 use super::pr_cmd_args::parse_finish_args;
 use super::pr_cmd_args::{
     parse_closeout_args, parse_create_args, parse_doctor_args, parse_init_args,
-    parse_preflight_args, parse_ready_args, parse_start_args, DoctorArgs, DoctorMode,
+    parse_preflight_args, parse_ready_args, parse_repair_issue_body_args, parse_start_args,
+    DoctorArgs, DoctorMode,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -31,7 +32,9 @@ use super::pr_cmd_prompt::{
     validate_issue_prompt_exists, version_from_labels_csv, version_from_title,
     WorkflowQueueResolution,
 };
-use super::pr_cmd_validate::{validate_authored_prompt_surface, PromptSurfaceKind};
+use super::pr_cmd_validate::{
+    bootstrap_stub_reason, validate_authored_prompt_surface, PromptSurfaceKind,
+};
 use ::adl::control_plane::{
     card_output_path, resolve_cards_root, resolve_primary_checkout_root, sanitize_slug, IssueRef,
 };
@@ -150,13 +153,14 @@ fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | closeout"
         );
     };
 
     match subcommand {
         "create" => real_pr_create(&args[1..]),
         "init" => real_pr_init(&args[1..]),
+        "repair-issue-body" => real_pr_repair_issue_body(&args[1..]),
         "start" => real_pr_start(&args[1..]),
         "doctor" => real_pr_doctor(&args[1..]),
         "ready" => real_pr_ready(&args[1..]),
@@ -165,6 +169,125 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
+}
+
+fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
+    let parsed = parse_repair_issue_body_args(args)?;
+    let repo_root = repo_root()?;
+    let repo = default_repo(&repo_root)?;
+    let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
+    let raw_title = if let Some(title) = parsed.title_arg.clone() {
+        title
+    } else {
+        gh_issue_title(parsed.issue, &repo)?
+            .ok_or_else(|| anyhow!("repair-issue-body: could not fetch issue #{} title; pass --title or check GitHub token/repo configuration", parsed.issue))?
+    };
+    let version = if let Some(version) = parsed.version.clone() {
+        version
+    } else if let Some((local_version, _)) = local_identity.as_ref() {
+        local_version.clone()
+    } else {
+        resolve_version_for_existing_issue(
+            &repo_root,
+            &repo,
+            parsed.issue,
+            None,
+            false,
+            "repair-issue-body",
+        )?
+    };
+    let title = normalize_issue_title_for_version(&raw_title, &version);
+    let slug = parsed
+        .slug
+        .clone()
+        .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
+        .unwrap_or_else(|| sanitize_slug(&title));
+    let slug = sanitize_slug(&slug);
+    if slug.is_empty() {
+        bail!("repair-issue-body: slug is empty after sanitization");
+    }
+    let fetched_labels = if parsed.labels.is_some() {
+        String::new()
+    } else {
+        fetched_issue_labels_csv(&repo, parsed.issue)?
+    };
+    let label_source = parsed.labels.as_deref().unwrap_or_else(|| {
+        if fetched_labels.trim().is_empty() {
+            DEFAULT_NEW_LABELS
+        } else {
+            &fetched_labels
+        }
+    });
+    let normalized_labels = normalize_labels_csv(label_source, &version);
+    let body = resolve_issue_body(parsed.body.clone(), parsed.body_file.as_deref())?;
+    validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &body)?;
+
+    let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
+    ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
+    let source_path = issue_ref.issue_prompt_path(&repo_root);
+    if source_path.is_file() && !parsed.force {
+        let current = fs::read_to_string(&source_path)
+            .with_context(|| format!("failed to read {}", source_path.display()))?;
+        if bootstrap_stub_reason(&current, PromptSurfaceKind::IssuePrompt).is_none() {
+            bail!(
+                "repair-issue-body: refusing to overwrite authored source prompt without --force: {}",
+                source_path.display()
+            );
+        }
+    }
+
+    let issue_url = format!("https://github.com/{repo}/issues/{}", parsed.issue);
+    gh_issue_edit_body(&repo, parsed.issue, &body)?;
+    let source_path = write_source_issue_prompt(
+        &repo_root,
+        &issue_ref,
+        &title,
+        &normalized_labels,
+        &issue_url,
+        &body,
+    )?;
+    validate_bootstrap_stp(&repo_root, &source_path)?;
+    validate_authored_prompt_surface(
+        "repair-issue-body",
+        &source_path,
+        PromptSurfaceKind::IssuePrompt,
+    )?;
+
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo_root);
+    if bundle_dir.is_dir() {
+        fs::remove_dir_all(&bundle_dir)
+            .with_context(|| format!("failed to remove stale bundle {}", bundle_dir.display()))?;
+    }
+    let (stp_path, bundle_input, bundle_output, bundle_dir) =
+        bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
+
+    println!("• Repaired issue body/source prompt:");
+    println!("  ISSUE     #{}", parsed.issue);
+    println!("  VERSION   {version}");
+    println!("  SLUG      {slug}");
+    println!(
+        "  SOURCE    {}",
+        path_relative_to_repo(&repo_root, &source_path)
+    );
+    println!(
+        "  STP       {}",
+        path_relative_to_repo(&repo_root, &stp_path)
+    );
+    println!(
+        "  SIP       {}",
+        path_relative_to_repo(&repo_root, &bundle_input)
+    );
+    println!(
+        "  SOR       {}",
+        path_relative_to_repo(&repo_root, &bundle_output)
+    );
+    println!(
+        "  BUNDLE    {}",
+        path_relative_to_repo(&repo_root, &bundle_dir)
+    );
+    println!("  STATE     ISSUE_BODY_AND_BUNDLE_REPAIRED");
+    println!("• Done.");
+    Ok(())
 }
 
 fn real_pr_create(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -11,6 +11,18 @@ pub(crate) struct InitArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RepairIssueBodyArgs {
+    pub(crate) issue: u32,
+    pub(crate) slug: Option<String>,
+    pub(crate) title_arg: Option<String>,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<PathBuf>,
+    pub(crate) labels: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CreateArgs {
     pub(crate) slug: Option<String>,
     pub(crate) title_arg: Option<String>,
@@ -181,6 +193,72 @@ pub(crate) fn parse_create_args(args: &[String]) -> Result<CreateArgs> {
     }
     if parsed.body.is_some() && parsed.body_file.is_some() {
         bail!("create: pass only one of --body or --body-file");
+    }
+
+    Ok(parsed)
+}
+
+pub(crate) fn parse_repair_issue_body_args(args: &[String]) -> Result<RepairIssueBodyArgs> {
+    let issue_raw = args
+        .first()
+        .ok_or_else(|| anyhow!("repair-issue-body: missing <issue> number"))?;
+    let issue = issue_raw
+        .parse::<u32>()
+        .with_context(|| format!("invalid issue number: {issue_raw}"))?;
+    let mut parsed = RepairIssueBodyArgs {
+        issue,
+        slug: None,
+        title_arg: None,
+        body: None,
+        body_file: None,
+        labels: None,
+        version: None,
+        force: false,
+    };
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--slug" => {
+                parsed.slug = Some(require_value(args, i, "repair-issue-body", "--slug")?);
+                i += 1;
+            }
+            "--title" => {
+                parsed.title_arg = Some(require_value(args, i, "repair-issue-body", "--title")?);
+                i += 1;
+            }
+            "--body" => {
+                parsed.body = Some(require_value(args, i, "repair-issue-body", "--body")?);
+                i += 1;
+            }
+            "--body-file" => {
+                parsed.body_file = Some(PathBuf::from(require_value(
+                    args,
+                    i,
+                    "repair-issue-body",
+                    "--body-file",
+                )?));
+                i += 1;
+            }
+            "--labels" => {
+                parsed.labels = Some(require_value(args, i, "repair-issue-body", "--labels")?);
+                i += 1;
+            }
+            "--version" => {
+                parsed.version = Some(require_value(args, i, "repair-issue-body", "--version")?);
+                i += 1;
+            }
+            "--force" => parsed.force = true,
+            other => bail!("repair-issue-body: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+
+    if parsed.body.is_some() && parsed.body_file.is_some() {
+        bail!("repair-issue-body: pass only one of --body or --body-file");
+    }
+    if parsed.body.is_none() && parsed.body_file.is_none() {
+        bail!("repair-issue-body: --body or --body-file is required");
     }
 
     Ok(parsed)

--- a/adl/src/cli/tests/open_usage.rs
+++ b/adl/src/cli/tests/open_usage.rs
@@ -128,5 +128,6 @@ fn code_review_filter_covers_global_usage_entry() {
         "adl tooling code-review --out artifacts/reviews/pr-review --backend fixture --visibility packet-only"
     ));
     assert!(text.contains("adl pr finish <issue> --title <title>"));
+    assert!(text.contains("adl pr repair-issue-body <issue>"));
     assert!(text.contains("adl runtime-v2 contract-market-demo"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -375,6 +375,182 @@ fn parse_create_args_accepts_dot_suffixed_version() {
 }
 
 #[test]
+fn parse_repair_issue_body_args_accepts_body_and_force_flags() {
+    let parsed = parse_repair_issue_body_args(&[
+        "3779".to_string(),
+        "--title".to_string(),
+        "[v0.91.5][planning] Feature-doc production wave setup".to_string(),
+        "--slug".to_string(),
+        "feature-doc-production-wave-setup".to_string(),
+        "--body-file".to_string(),
+        "issue-body.md".to_string(),
+        "--labels".to_string(),
+        "track:backlog,type:docs,area:docs".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+        "--force".to_string(),
+    ])
+    .expect("parse");
+    assert_eq!(parsed.issue, 3779);
+    assert_eq!(
+        parsed.title_arg.as_deref(),
+        Some("[v0.91.5][planning] Feature-doc production wave setup")
+    );
+    assert_eq!(
+        parsed.slug.as_deref(),
+        Some("feature-doc-production-wave-setup")
+    );
+    assert_eq!(
+        parsed.body_file.as_deref(),
+        Some(Path::new("issue-body.md"))
+    );
+    assert_eq!(
+        parsed.labels.as_deref(),
+        Some("track:backlog,type:docs,area:docs")
+    );
+    assert_eq!(parsed.version.as_deref(), Some("v0.91.5"));
+    assert!(parsed.force);
+}
+
+#[test]
+fn parse_repair_issue_body_args_requires_body_source() {
+    let err = parse_repair_issue_body_args(&["3779".to_string()]).expect_err("missing body");
+    assert!(err
+        .to_string()
+        .contains("repair-issue-body: --body or --body-file is required"));
+
+    let err = parse_repair_issue_body_args(&[
+        "3779".to_string(),
+        "--body".to_string(),
+        "inline".to_string(),
+        "--body-file".to_string(),
+        "body.md".to_string(),
+    ])
+    .expect_err("conflicting body inputs");
+    assert!(err
+        .to_string()
+        .contains("repair-issue-body: pass only one of --body or --body-file"));
+}
+
+fn authored_repair_body() -> String {
+    "## Summary\n\nRepair an existing tracked issue body through the C-SDLC toolkit.\n\n## Goal\n\nMake issue body repair deterministic and reviewable.\n\n## Required Outcome\n\nThe issue body, source prompt, and root task bundle agree after repair.\n\n## Deliverables\n\n- repair command\n- focused tests\n\n## Acceptance Criteria\n\n- the command updates GitHub and local source prompt state\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- unrelated lifecycle redesign\n\n## Issue-Graph Notes\n\n- test fixture\n\n## Notes\n\n- authored repair body\n\n## Tooling Notes\n\n- should pass source-prompt validation\n"
+        .to_string()
+}
+
+#[test]
+fn real_pr_repair_issue_body_updates_github_source_prompt_and_bundle() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-issue-body");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    let issue_body_log = repo.join("issue_body.log");
+    write_executable(
+        &fixture,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            issue_body_log.display()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    let body_path = repo.join("repair-body.md");
+    fs::write(&body_path, authored_repair_body()).expect("write body");
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let result = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1301".to_string(),
+        "--slug".to_string(),
+        "repair-body".to_string(),
+        "--body-file".to_string(),
+        body_path.display().to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    result.expect("repair issue body");
+
+    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_calls.contains("issue view 1301"));
+    assert!(gh_calls.contains("issue edit 1301"));
+    let edited_body = fs::read_to_string(&issue_body_log).expect("edited body");
+    assert!(edited_body.contains("## Summary"));
+    assert!(edited_body.contains("## Tooling Notes"));
+
+    let source = repo.join(".adl/v0.91.5/bodies/issue-1301-repair-body.md");
+    assert!(source.is_file(), "repair should write the source prompt");
+    let prompt = fs::read_to_string(&source).expect("read source prompt");
+    assert!(prompt.contains("issue_number: 1301"));
+    assert!(prompt.contains("title: \"[v0.91.5][tools] Repair body\""));
+    assert!(prompt.contains("## Required Outcome"));
+    assert!(
+        repo.join(".adl/v0.91.5/tasks/issue-1301__repair-body/stp.md")
+            .is_file(),
+        "repair should regenerate STP"
+    );
+    assert!(
+        repo.join(".adl/v0.91.5/tasks/issue-1301__repair-body/spp.md")
+            .is_file(),
+        "repair should regenerate SPP"
+    );
+}
+
+#[test]
+fn real_pr_repair_issue_body_blocks_duplicate_identity_before_github_edit() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-duplicate-identity");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &fixture,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    fs::create_dir_all(repo.join(".adl/v0.91.5/tasks/issue-1302__old-slug")).expect("old bundle");
+    let body_path = repo.join("repair-body.md");
+    fs::write(&body_path, authored_repair_body()).expect("write body");
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1302".to_string(),
+        "--slug".to_string(),
+        "new-slug".to_string(),
+        "--body-file".to_string(),
+        body_path.display().to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect_err("duplicate identity should block repair");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    assert!(err
+        .to_string()
+        .contains("duplicate local issue identities detected"));
+    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(
+        !gh_calls.contains("issue edit"),
+        "duplicate guard should run before GitHub mutation"
+    );
+}
+
+#[test]
 fn parse_init_args_rejects_unknown_arg() {
     let err = parse_init_args(&["1151".to_string(), "--bogus".to_string()]).expect_err("err");
     assert!(err.to_string().contains("init: unknown arg"));
@@ -450,7 +626,7 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish"
+        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -45,6 +45,7 @@ pub fn usage() -> &'static str {
   adl provider setup <family> [--model <provider_model_id>] [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
+  adl pr repair-issue-body <issue> [--slug <slug>] [--title <title>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>] [--force]
   adl pr run <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   adl pr run <adl.yaml> [--trace] [--signature-key <public_key_path>] [--allow-embedded-signature-key] [--allow-unsigned] [--runs-root <dir>] [--out <dir>]
   adl pr doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -15,6 +15,7 @@
 #   adl/tools/pr.sh help
 #   adl/tools/pr.sh create  --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v0.85|v0.87.1>]
 #   adl/tools/pr.sh init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85|v0.87.1>]
+#   adl/tools/pr.sh repair-issue-body <issue> [--slug <slug>] [--title "<title>"] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v0.85|v0.87.1>] [--force]
 #   adl/tools/pr.sh run     <issue> [--slug <slug>] [--title "<title>"] [--prefix codex] [--no-fetch-issue] [--version <v0.85|v0.87.1>] [--allow-open-pr-wave]
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
@@ -2205,6 +2206,15 @@ cmd_create() {
   delegate_pr_command_to_rust create "$@"
 }
 
+cmd_repair_issue_body() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_repair_issue_body
+    return 0
+  fi
+  require_rust_pr_delegate
+  delegate_pr_command_to_rust repair-issue-body "$@"
+}
+
 cmd_start() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     usage_start
@@ -2497,6 +2507,19 @@ Notes:
 EOF
 }
 
+usage_repair_issue_body() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh repair-issue-body <issue> [--slug <slug>] [--title "<title>"] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v>] [--force]
+
+Behavior:
+- validates an authored issue body against the C-SDLC source-prompt contract
+- updates the GitHub issue body through the Rust/Octocrab-backed PR command
+- rewrites the canonical local source prompt and regenerates the root task bundle
+- refuses to overwrite an authored local source prompt unless --force is supplied
+EOF
+}
+
 usage_closeout() {
   cat <<'EOF'
 Usage:
@@ -2523,6 +2546,7 @@ main() {
     help) usage ;;
     create) cmd_create "$@" ;;
     init) cmd_init "$@" ;;
+    repair-issue-body) cmd_repair_issue_body "$@" ;;
     run) cmd_run "$@" ;;
     start) cmd_start "$@" ;;
     doctor) cmd_doctor "$@" ;;


### PR DESCRIPTION
## Summary
Implemented a bounded toolkit command, `adl pr repair-issue-body`, so existing GitHub issues can be repaired through the C-SDLC control plane instead of raw GitHub edits. The command validates authored issue bodies, uses strict fetched metadata unless the operator supplies explicit title/labels, guards against duplicate local identities before GitHub mutation, updates the GitHub issue body through the existing Octocrab-backed edit path, rewrites the canonical source issue prompt, regenerates the root task bundle, and preserves overwrite safety unless `--force` is explicitly supplied.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd_args.rs`
- `adl/src/cli/tests/open_usage.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/usage.rs`
- `adl/tools/pr.sh`
- Local ignored output-card record at `.adl/v0.91.5/tasks/issue-3784__v0-91-5-tools-add-toolkit-issue-body-repair-command/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Formatted the Rust workspace after implementation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl parse_repair_issue_body_args -- --nocapture`
    Ran focused parser tests for the new command.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl repair_issue_body -- --nocapture`
    Ran parser and behavior tests for the new repair command.
  - `bash adl/tools/pr.sh repair-issue-body --help`
    Verified wrapper command dispatch.
  - `cargo check --manifest-path adl/Cargo.toml --bin adl`
    Verified the changed CLI binary compiles.
  - `git diff --check`
    Verified whitespace cleanliness.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified Rust formatting after final rebase.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_dispatch_rejects_missing_and_unknown_subcommands -- --nocapture`
    Verified dispatch error text includes the new subcommand.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl code_review_filter_covers_global_usage_entry -- --nocapture`
    Verified global usage text includes the new command.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-pr_cmd.json -- pr_cmd`
    Produced focused coverage for PR command implementation files.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-usage.json -- usage`
    Produced focused coverage for global usage text.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified merged focused coverage evidence passes for the changed Rust source files.
  - `GITHUB_TOKEN=(redacted) cargo run --manifest-path adl/Cargo.toml --bin adl -- pr repair-issue-body ...`
    Exercised the new command against #3779, #3778, #3780, #3781, and #3782.
  - `GITHUB_TOKEN=(redacted) adl pr doctor ... --json`
    Verified repaired planning/ADR issues no longer fail the bootstrap-stub source prompt gate.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3784__v0-91-5-tools-add-toolkit-issue-body-repair-command/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3784__v0-91-5-tools-add-toolkit-issue-body-repair-command/sor.md
- Idempotency-Key: v0-91-5-tools-add-toolkit-issue-body-repair-command-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-open-usage-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-usage-rs-adl-tools-pr-sh-adl-v0-91-5-tasks-issue-3784-v0-91-5-tools-add-toolkit-issue-body-repair-command-sip-md-adl-v0-91-5-tasks-issue-3784-v0-91-5-tools-add-toolkit-issue-body-repair-command-sor-md

Closes #3784
