### PR TITLE
[v0.91.5][logging-mini-sprint][7/8] Define Observatory consumption of ADL logs

### DIFF
--- a/docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md
+++ b/docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md
@@ -1,0 +1,292 @@
+# Observatory Log Consumption Contract (#3710)
+
+Issue: #3710  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: design_contract
+
+## Purpose
+
+The logging mini-sprint now gives ADL a truthful local observability baseline:
+
+- control-plane `adl_event` stage diagnostics;
+- runtime action-log projections;
+- provider invocation and review-provider logs;
+- long-lived-agent ledgers and status artifacts;
+- explicit OTEL boundary and redaction rules.
+
+What is still missing is the consumer-side contract for Unity Observatory and
+other operator-facing long-running runtime surfaces. This document defines how
+Observatory should ingest, classify, retain, redact, and correlate ADL logs so
+it consumes the same governed truth instead of inventing a parallel telemetry
+model.
+
+## Scope
+
+This issue defines:
+
+- which existing ADL observability artifacts Observatory may consume;
+- the minimum normalized fields Observatory should project;
+- audience/redaction boundaries for operator, reviewer, `public_report_view`,
+  and `observatory_projection` surfaces;
+- retention and correlation requirements for long-running runtime use;
+- a small example event stream and expected display treatment.
+
+## Non-Goals
+
+- This issue does not build the Unity app.
+- This issue does not require a live OTEL collector.
+- This issue does not create a new canonical runtime truth source.
+- This issue does not authorize raw prompt, secret, host-path, or private-state
+  exposure in public or reviewer-facing Observatory views.
+
+## Source Inputs
+
+Primary contract inputs:
+
+- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`
+- `docs/milestones/v0.91.5/SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md`
+- `docs/milestones/v0.91.5/OPEN_TELEMETRY_INTEGRATION_BOUNDARY_3709.md`
+- `docs/milestones/v0.91.5/features/DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md`
+
+Implementation/reference inputs:
+
+- `adl/src/csm_observatory.rs`
+- `adl/src/runtime_v2/contracts.rs`
+- `adl/src/trace_schema_v1.rs`
+- `adl/src/acc/*`
+- `adl/src/agent_comms.rs`
+
+Planning inputs:
+
+- `docs/milestones/v0.92/DEMO_MATRIX_v0.92.md`
+- `docs/milestones/v0.92/DESIGN_v0.92.md`
+
+## Consumer Model
+
+Observatory is a consumer and projector of governed ADL artifacts.
+
+It must not:
+
+- become the authority for run truth;
+- replace runtime traces, action logs, provider logs, or issue/PR records;
+- infer additional state that the source artifacts do not prove.
+
+It may:
+
+- ingest bounded event streams from governed local artifacts;
+- classify those records for operators by stage/result/severity;
+- project redacted views for operators, reviewers, `public_report_view`, and
+  `observatory_projection` audiences;
+- correlate related records across issue, run, provider, and agent contexts;
+- surface missing evidence or stale telemetry as explicit gaps instead of
+  fabricating health.
+
+## Ingestion Sources
+
+Observatory should consume only declared, schema-bearing or contract-governed
+local artifacts:
+
+| Source | Role in Observatory |
+| --- | --- |
+| `adl_event` / compatibility mirror | Operator-facing stage/progress heartbeat for control-plane and CLI operations. |
+| `logs/action_log.jsonl` | Runtime action summaries and execution outcomes. |
+| Provider invocation / review-provider logs | Provider-side execution status, failure reasons, and model/provider identity. |
+| Long-lived-agent status and ledgers | Continuity, cycle state, lease recovery, and operator event history. |
+| Runtime/CSM/Observatory packets | Redacted higher-order projections and reviewer/operator reports. |
+| Trace / governed execution artifacts | Evidence linkage and downstream drill-through, not raw public display. |
+
+Observatory must not require unsupported sources such as:
+
+- hosted collectors;
+- undocumented stdout scraping beyond the governed compatibility layer;
+- machine-local absolute paths;
+- raw provider payload dumps;
+- raw prompt bodies.
+
+## Required Projection Fields
+
+Observatory should normalize consumed events to one bounded projection shape,
+even when the source artifact still uses older field names.
+
+Minimum projection fields:
+
+| Field | Meaning | Source guidance |
+| --- | --- | --- |
+| `schema` | Source schema/version. | Required |
+| `source_kind` | `control_plane`, `runtime_action_log`, `provider_log`, `long_lived_agent`, `trace_projection`, `review_packet`. | Required |
+| `component` | Emitting subsystem such as `control_plane`, `runtime`, `provider`, `long_lived_agent`, `observability`, `polis`. | Required |
+| `stage` | Bounded operational stage such as `doctor`, `provider_call`, `heartbeat`, `closeout`, `cycle`, `projection`. | Required |
+| `result` | Bounded normalized status such as `started`, `progress`, `heartbeat`, `completed`, `failed`, `blocked`, `skipped`, `timeout`, `recorded`. | Required |
+| `severity` | `info`, `warning`, `error`, or bounded equivalent. | Recommended |
+| `reason_code` | Safe compact failure/policy explanation. | Recommended for non-success |
+| `timestamp` | Event or artifact timestamp. | Required |
+| `elapsed_ms` / `duration_ms` | Timing when available. | Recommended |
+| `issue_ref` | Issue identifier when issue-bound execution exists. | Recommended |
+| `pr_ref` | PR identifier for review/publication phases. | Optional |
+| `run_id` | Runtime run correlation id. | Recommended when present |
+| `cycle_id` | Long-lived cycle correlation id. | Recommended when present |
+| `agent_instance_id` | Long-lived or delegated agent identity. | Recommended when present |
+| `request_id` / `review_request_id` | Provider/review-provider invocation correlation. | Recommended when present |
+| `provider_ref` / `provider_model_id` / `runtime_surface` | Provider/model execution context. | Required for provider-facing events |
+| `artifact_refs` | Repo-relative or governed artifact references. | Recommended |
+| `redaction_view` | `operator`, `reviewer`, `public_report_view`, `observatory_projection`, or a stricter governed visibility alias already modeled by ACC/trace artifacts. | Required |
+
+Legacy/source-specific names such as `event_type`, `final_status`, `state`,
+`event`, `artifact_ref`, `correlation_id`, or `observatory_projection` may be
+carried through in a source-details block, but Observatory should render the
+normalized fields above as the primary operator surface.
+
+## Correlation Requirements
+
+Observatory must support drill-through across the following reference classes
+when they exist:
+
+- issue / PR (`issue_ref`, `pr_ref`);
+- run / cycle (`run_id`, `cycle_id`);
+- agent identity (`agent_instance_id`);
+- provider execution (`provider_ref`, `provider_model_id`, `runtime_surface`,
+  `request_id`, `review_request_id`);
+- artifact and trace linkage (`artifact_ref`, `artifact_refs`, `trace_ref`);
+- ACIP / multi-agent conversation linkage (`correlation_id`, conversation or
+  causal message refs) where already present in governed artifacts.
+
+Required behavior:
+
+- if a ref is absent in the source artifact, Observatory must display it as
+  unavailable rather than synthesizing one;
+- if multiple sources disagree on a ref, Observatory should display the mismatch
+  as a correlation warning, not silently collapse them;
+- if a public/reviewer view cannot safely show a ref, it must present a redacted
+  stable placeholder or omit it with rationale.
+
+## Audience And Redaction Policy
+
+Observatory must inherit the repo’s fail-closed visibility and redaction rules.
+
+Audience tiers:
+
+- `operator`
+  - may see the richest local operational view available under existing source
+    contracts;
+  - still must not expose secrets, raw prompts, raw provider payloads, or
+    machine-local absolute paths.
+- `reviewer`
+  - may see bounded evidence refs, redacted projections, and issue/PR/runtime
+    correlation needed for review;
+  - must not depend on private-state-only data.
+- `public_report_view`
+  - must use redacted, bounded projections only;
+  - must not show host paths, secrets, raw prompts, private payloads, or
+    personally identifying operator environment state.
+- `observatory_projection`
+  - may exist as a separate governed audience when the source artifact already
+    distinguishes Observatory-facing projections from broader public-report
+    surfaces;
+  - must remain at least as strict as the corresponding public/reviewer
+    redaction posture.
+
+Specific projection rules:
+
+- host paths -> repo-relative, `<repo>/...`, `<home>/...`, or `<tmp>/...`
+- raw prompts -> never shown
+- raw provider payloads -> never shown
+- private-state markers -> reduced to governed redaction projections
+- reviewer/public-report/observatory-projection views -> use the same
+  fail-closed logic modeled by ACC visibility matrices and redaction examples
+
+## Retention Policy
+
+Observatory should distinguish between:
+
+- ephemeral terminal progress;
+- durable local operational logs;
+- tracked review packets;
+- public-report / Observatory projections.
+
+Required retention behavior:
+
+- control-plane and runtime event projections may be cached for operator
+  sessions, but the canonical source remains the governed artifact, not the
+  rendered Observatory cache;
+- long-lived-agent ledgers and status views must preserve append-only or
+  state-authoritative semantics from their source artifacts;
+- reviewer/public-report/observatory-projection packets should reference durable
+  tracked artifacts rather than becoming the only copy of evidence;
+- stale or pruned source artifacts should surface as an explicit missing-source
+  state in Observatory.
+
+## Display Classification
+
+Observatory should classify events into at least these operator buckets:
+
+| Bucket | Typical source/result patterns |
+| --- | --- |
+| `progress` | `started`, `progress`, `heartbeat` |
+| `attention` | `blocked`, `timeout`, correlation mismatch, missing artifact |
+| `failure` | `failed`, provider/runtime refusal or unrecoverable error |
+| `completed` | `completed`, `recorded`, bounded successful closeout |
+| `deferred` | `skipped`, policy-deferred, follow-on-required |
+
+Suggested display rules:
+
+- show newest active progress items first for live operator workflows;
+- group by strongest available correlation key (`issue_ref`, then `run_id`,
+  then `cycle_id`, then `request_id`);
+- allow drill-through from projection to canonical artifact refs;
+- if a source artifact is missing or only partially trusted, display that as
+  state rather than silently omitting the event.
+
+## Example Event Stream Contract
+
+The tracked example packet for this issue is:
+
+- `docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json`
+
+That example proves:
+
+- mixed control-plane, provider, and long-lived/runtime-oriented events can be
+  shown in one normalized stream;
+- issue/run/request/agent correlation can be expressed without inventing new
+  runtime truth;
+- public-report / Observatory projection classification can remain redacted and
+  bounded.
+
+## v0.92 Dependency Boundary
+
+This issue is a readiness and routing surface for v0.92 Unity/Observatory work.
+
+It proves:
+
+- what Observatory must consume;
+- how it should classify and redact that consumption;
+- which refs are needed for drill-through and operator use.
+
+It does not prove:
+
+- Unity app implementation;
+- OTEL collector export;
+- production-grade dashboard persistence;
+- all multi-agent / ACIP transport work is complete.
+
+Those remain implementation or later-milestone concerns and must be cited as
+such in downstream planning.
+
+## Acceptance Mapping
+
+This issue is complete when:
+
+- Observatory requirements explicitly consume the shared observability contract;
+- long-running-process needs are distinguished from one-shot CLI needs;
+- the projection model supports local development without external services;
+- public-report / Observatory projection surfaces are fail-closed and redacted;
+- remaining implementation work is routed to v0.92 or a specific follow-on.
+
+## Non-Claims
+
+- This document does not claim Unity Observatory is already built.
+- This document does not claim OTEL exporter support exists locally.
+- This document does not claim every existing artifact already carries every
+  preferred correlation field.
+- This document does not authorize public exposure of private runtime state.

--- a/docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json
+++ b/docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": "adl.observatory.event_stream_example.v1",
+  "issue_ref": "#3710",
+  "purpose": "bounded observatory consumption example",
+  "claim_boundary": "Example projection only. The source artifacts remain authoritative.",
+  "events": [
+    {
+      "schema": "adl.observability.event.v1",
+      "timestamp": "2026-06-15T21:29:52Z",
+      "source_kind": "control_plane",
+      "component": "control_plane",
+      "stage": "doctor",
+      "result": "started",
+      "severity": "info",
+      "issue_ref": "#3707",
+      "redaction_view": "operator",
+      "artifact_refs": [
+        ".adl/v0.91.5/tasks/issue-3707__v0-91-5-logging-mini-sprint-unify-runtime-and-provider-action-logging/sor.md"
+      ],
+      "display_bucket": "progress",
+      "display_summary": "Issue doctor started for #3707."
+    },
+    {
+      "schema": "provider_communication.v1",
+      "timestamp": "2026-06-15T21:36:24Z",
+      "source_kind": "provider_log",
+      "component": "provider",
+      "stage": "provider_call",
+      "result": "heartbeat",
+      "severity": "info",
+      "issue_ref": "#3707",
+      "run_id": "run-logging-001",
+      "request_id": "req-provider-001",
+      "provider_ref": "openrouter",
+      "provider_model_id": "google/gemini-2.5-flash-lite",
+      "runtime_surface": "hosted_api",
+      "redaction_view": "operator",
+      "artifact_refs": [
+        "artifacts/run-logging-001/logs/provider_run.jsonl"
+      ],
+      "display_bucket": "progress",
+      "display_summary": "Provider call is still active; operator should inspect the provider run log before treating the command as wedged."
+    },
+    {
+      "schema": "provider_communication.v1",
+      "timestamp": "2026-06-15T21:36:57Z",
+      "source_kind": "provider_log",
+      "component": "provider",
+      "stage": "provider_call",
+      "result": "timeout",
+      "severity": "warning",
+      "issue_ref": "#3708",
+      "run_id": "run-logging-002",
+      "request_id": "req-provider-002",
+      "provider_ref": "openrouter",
+      "provider_model_id": "anthropic/claude-3.5-haiku",
+      "runtime_surface": "hosted_api",
+      "reason_code": "provider_timeout",
+      "redaction_view": "operator",
+      "artifact_refs": [
+        "artifacts/run-logging-002/logs/provider_run.jsonl"
+      ],
+      "display_bucket": "attention",
+      "display_summary": "Provider timed out; show retry guidance and the governed log ref."
+    },
+    {
+      "schema": "adl.long_lived_agent_operator_event.v1",
+      "timestamp": "2026-06-15T21:37:10Z",
+      "source_kind": "long_lived_agent",
+      "component": "long_lived_agent",
+      "stage": "cycle",
+      "result": "completed",
+      "severity": "info",
+      "run_id": "run-agent-001",
+      "cycle_id": "cycle-0004",
+      "agent_instance_id": "agent-001",
+      "redaction_view": "reviewer",
+      "artifact_refs": [
+        "artifacts/run-agent-001/operator_events.jsonl",
+        "artifacts/run-agent-001/cycle_ledger.jsonl"
+      ],
+      "display_bucket": "completed",
+      "display_summary": "Long-lived cycle completed with durable ledger refs available for review."
+    },
+    {
+      "schema": "trace.v2",
+      "timestamp": "2026-06-15T21:37:19Z",
+      "source_kind": "trace_projection",
+      "component": "observability",
+      "stage": "projection",
+      "result": "recorded",
+      "severity": "info",
+      "run_id": "run-agent-001",
+      "artifact_refs": [
+        "artifacts/run-agent-001/logs/trace_v1.json"
+      ],
+      "redaction_view": "public_report_view",
+      "display_bucket": "completed",
+      "display_summary": "Public report view shows only the redacted Observatory projection and trace reference, never private-state payloads."
+    }
+  ]
+}

--- a/docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md
@@ -1,0 +1,142 @@
+# Observatory Log Consumption Proof (#3710)
+
+Issue: #3710  
+Status: draft_reviewable
+
+## Scope
+
+This packet proves a bounded design outcome:
+
+- how Unity/Observatory should consume ADL logging artifacts;
+- how Observatory should normalize and classify those artifacts;
+- how redaction, retention, and correlation rules should constrain that
+  consumption;
+- how v0.92 planning should depend on this surface without overclaiming
+  implementation.
+
+## Inputs Reviewed
+
+- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`
+- `docs/milestones/v0.91.5/SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md`
+- `docs/milestones/v0.91.5/OPEN_TELEMETRY_INTEGRATION_BOUNDARY_3709.md`
+- `docs/milestones/v0.91.5/features/DEMO_AND_UNITY_OBSERVATORY_READINESS_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md`
+- `docs/milestones/v0.92/DEMO_MATRIX_v0.92.md`
+- `docs/milestones/v0.92/DESIGN_v0.92.md`
+- `adl/src/csm_observatory.rs`
+- `adl/src/runtime_v2/contracts.rs`
+- `adl/src/trace_schema_v1.rs`
+- `adl/src/acc/*`
+- `adl/src/agent_comms.rs`
+
+## Artifacts Added
+
+- `docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md`
+- `docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json`
+
+## What This Proves
+
+- Observatory is a governed consumer/projection layer, not a new canonical
+  runtime truth source.
+- Existing ADL logging surfaces are sufficient to define a first consumer-side
+  contract without requiring OTEL collector wiring.
+- The required normalized projection fields, correlation refs, and redaction
+  rules are concrete enough for v0.92 Unity/Observatory planning.
+- A bounded multi-source event stream can be shown with operator, reviewer,
+  `public_report_view`, and `observatory_projection` distinctions without
+  leaking raw prompts, secrets, private payloads, or host-local absolute paths.
+
+## What This Does Not Prove
+
+- Unity Observatory implementation exists.
+- OTEL export is live.
+- Every current source artifact already carries every preferred correlation
+  field.
+- `public_report_view` / `observatory_projection` views are implemented in
+  code; this issue defines the contract they must follow.
+
+## Example Event Stream Reading
+
+`OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json` demonstrates:
+
+- control-plane progress (`doctor started`);
+- provider heartbeat and timeout classifications;
+- long-lived-agent cycle completion with durable artifact refs;
+- a public-report-safe trace projection that preserves the separate governed
+  `observatory_projection` boundary.
+
+The example intentionally stays redacted and bounded. It uses stable refs,
+reason codes, and display buckets instead of raw payloads or machine-local
+paths.
+
+## Validation Commands
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+contract = Path("docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md")
+proof = Path("docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md")
+contract_text = contract.read_text()
+proof_text = proof.read_text()
+assert "This document does not claim Unity Observatory is already built." in contract_text
+assert "This document does not claim OTEL exporter support exists locally." in contract_text
+assert "This issue does not require a live OTEL collector." in contract_text
+assert "This issue does not build the Unity app." in contract_text
+assert "What This Does Not Prove" in proof_text
+print(contract.name, len(contract_text.splitlines()))
+print(proof.name, len(proof_text.splitlines()))
+PY
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+packet = json.loads(Path("docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json").read_text())
+assert packet["schema_version"] == "adl.observatory.event_stream_example.v1"
+assert len(packet["events"]) >= 4
+for event in packet["events"]:
+    for key in ("schema", "source_kind", "component", "stage", "result", "redaction_view", "display_bucket"):
+        assert key in event, (event, key)
+assert packet["events"][0]["schema"] == "adl.observability.event.v1"
+assert packet["events"][1]["schema"] == "provider_communication.v1"
+assert packet["events"][2]["schema"] == "provider_communication.v1"
+assert packet["events"][3]["schema"] == "adl.long_lived_agent_operator_event.v1"
+assert packet["events"][4]["schema"] == "trace.v2"
+assert packet["events"][4]["redaction_view"] == "public_report_view"
+print("events", len(packet["events"]))
+PY
+
+rg -n "Observatory|observatory|redaction|correlation|public_report_view|observatory_projection|operator|reviewer" \
+  docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md \
+  docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md \
+  docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json
+
+git diff --check
+```
+
+## Validation Results
+
+- The contract/proof docs are present and readable.
+- The example stream parses as JSON and contains the required normalized
+  fields, including per-event `schema`.
+- The contract/proof/example surfaces consistently mention Observatory
+  consumption, correlation, and redaction boundaries.
+- No whitespace-hygiene issues are introduced by this bounded docs-only slice.
+
+## Residual Risks
+
+- Actual Unity/Observatory implementation could still drift if future issues do
+  not follow the contract.
+- Some upstream artifacts still lack the strongest possible correlation refs,
+  which means Observatory must remain truthful about unavailable linkage.
+- `public_report_view` / `observatory_projection` safe projections remain a
+  contract requirement until later code paths implement them directly.
+
+## Reviewer Conclusion
+
+`#3710` should be evaluated as a truthful consumer-side contract for
+Observatory readiness:
+
+- enough to route v0.92 work onto governed ADL logging truth;
+- enough to define normalized fields, correlation, retention, and redaction
+  expectations;
+- not a claim that the Unity app or OTEL export is complete.


### PR DESCRIPTION
Closes #3710

## Summary
Refreshed `#3710` against the current logging mini-sprint state and kept the
work bounded to the missing consumer-side contract for Unity/Observatory. The
issue now lands a tracked contract, example event stream, and reviewer packet
that define which governed ADL logging artifacts Observatory may consume, which
normalized fields and correlation refs it should project, and how
`public_report_view` / `observatory_projection` redaction must stay fail-closed
without claiming the Unity app or OTEL exporter is already implemented.

## Artifacts
- `docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md`
- `docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json`
- `docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md`

## Validation
- Validation commands and their purpose:
  - `python3 - <<'PY' ... PY`
    Verified contract/proof readability, non-claims, and final audience
    vocabulary alignment.
  - `python3 - <<'PY' ... PY`
    Verified the example event stream parses, contains required normalized
    fields, and uses source-grounded schema identifiers.
  - `rg -n "Observatory|observatory|redaction|correlation|public_report_view|observatory_projection|operator|reviewer" docs/milestones/v0.91.5/OBSERVATORY_LOG_CONSUMPTION_CONTRACT_3710.md docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md docs/milestones/v0.91.5/review/logging_observability/OBSERVATORY_EVENT_STREAM_EXAMPLE_3710.json`
    Verified the tracked packet consistently names Observatory-facing
    correlation and redaction boundaries.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template import-values --kind srp --input .adl/v0.91.5/tasks/issue-3710__v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs/srp.md --out TMP_REDACTED/3710-srp-values.yaml`
    Verified SRP importability through the active prompt-template path.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template import-values --kind sor --input .adl/v0.91.5/tasks/issue-3710__v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs/sor.md --out TMP_REDACTED/3710-sor-values.yaml`
    Verified SOR importability through the active prompt-template path.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind srp --values TMP_REDACTED/3710-srp-values.yaml --out TMP_REDACTED/3710-srp-rendered.md`
    Verified the supported SRP values still render cleanly.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind srp --input TMP_REDACTED/3710-srp-rendered.md`
    Verified SRP rendered structure validity.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sor --values TMP_REDACTED/3710-sor-values.yaml --out TMP_REDACTED/3710-sor-rendered.md`
    Verified the supported SOR values still render cleanly.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sor --input TMP_REDACTED/3710-sor-rendered.md`
    Verified SOR rendered structure validity.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3710__v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3710__v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs/sor.md
- Idempotency-Key: v0-91-5-logging-mini-sprint-7-8-define-observatory-consumption-of-adl-logs-adl-v0-91-5-tasks-issue-3710-v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs-sip-md-adl-v0-91-5-tasks-issue-3710-v0-91-5-logging-mini-sprint-define-observatory-consumption-of-adl-logs-sor-md