### PR TITLE
[v0.91.5][logging-mini-sprint][8/8] Update docs skills and closeout logging sprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,18 @@ These rules are mandatory for ADL issue work.
   values object first, render through the Rust tooling, then run structure and
   schema validation. Use editor skills for lifecycle truth and bounded repairs,
   not as a reason to bypass the renderer/schema path.
+- Treat observability as part of workflow truth, not optional garnish. When a
+  change touches workflow control-plane paths, runtime/provider execution,
+  watchdog behavior, or machine-readable command output, record the relevant
+  logging policy and proof in the issue artifacts.
+- Preserve the current logging channel contract unless the issue explicitly
+  changes it:
+  - machine-readable payloads belong on stdout
+  - human-oriented `adl_event` observability belongs on stderr by default
+  - compatibility redirection such as `ADL_OBSERVABILITY_STDERR=0` and
+    `ADL_OBSERVABILITY_LOG=<path>` must be documented truthfully when used
+- Do not claim OpenTelemetry, runtime/provider correlation, heartbeat coverage,
+  or JSON-safe observability beyond what the tracked proofs actually establish.
 
 ## Where To Start
 
@@ -135,6 +147,12 @@ For a normal tracked issue:
   checks that apply to the touched surface: values validation, rendered
   structure validation, schema parity validation, and the Python-readable schema
   smoke check when schema artifacts are touched.
+- Logging- or observability-affecting work should also record the smallest
+  proving checks for:
+  - stdout/stderr separation when machine-readable output is involved
+  - redaction and path hygiene for emitted log lines or durable log artifacts
+  - compatibility-log behavior when `ADL_OBSERVABILITY_LOG` or quiet-stderr
+    mode is part of the claimed workflow
 
 ## Review And Publication Rules
 

--- a/adl/tools/skills/documentation-specialist/SKILL.md
+++ b/adl/tools/skills/documentation-specialist/SKILL.md
@@ -118,6 +118,9 @@ Use the smallest useful validation set:
 - check referenced files exist when possible
 - run documented commands only when safe and bounded
 - run Markdown or contract tests when the repo provides them
+- when the doc covers logging or observability behavior, verify channel policy,
+  redaction/path claims, and compatibility-path claims against tracked proof
+  surfaces rather than paraphrasing them from memory
 - check generated docs for absolute host paths and secret markers when
   publication is possible
 - verify diagram or demo links only when they are part of the bounded target

--- a/adl/tools/skills/issue-watcher/SKILL.md
+++ b/adl/tools/skills/issue-watcher/SKILL.md
@@ -97,6 +97,17 @@ workflow surface, classify the watch as blocked or route a follow-up instead of
 silently falling back. Do not infer readiness only from stale local cards when
 live GitHub state is required.
 
+### Observability Expectations
+
+- Watch results may be accompanied by `adl_event` progress lines from the
+  underlying control-plane command path; treat those as observability evidence,
+  not as state mutation.
+- When a watched gate looks stuck, use the log story to classify whether the
+  state is merely pending, genuinely blocked, or suffering from a machine-
+  readable/output-channel defect.
+- Preserve queue-blocking or lifecycle-log details when they are the reason the
+  next issue cannot start.
+
 When watching PR checks, apply
 `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`. Continue watching stable
 check names (`adl-ci` and `adl-coverage`), but classify their meaning through

--- a/adl/tools/skills/pr-closeout/SKILL.md
+++ b/adl/tools/skills/pr-closeout/SKILL.md
@@ -70,6 +70,17 @@ Useful additional inputs:
 8. Prune the worktree safely.
 9. Emit a structured closeout result and stop.
 
+## Observability Expectations
+
+- Closeout should preserve any issue-local logging proof or compatibility-path
+  caveat that explains what was and was not established by the work.
+- If merged/closed truth was diagnosed partly through workflow logs or watcher
+  evidence, keep GitHub state authoritative and treat logs as supporting
+  evidence rather than as the closure authority.
+- When closeout resolves a logging-hardening issue, record any remaining
+  follow-ons explicitly instead of implying the broader observability program is
+  complete.
+
 ## Workflow
 
 ### 1. Resolve Closeout Target

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -93,6 +93,17 @@ When PR checks are used as validation evidence, apply
   coverage-required lane actually ran
 - do not cite docs-only PR-level coverage skips as release coverage evidence
 
+## Observability Expectations
+
+- When finish or publication claims depend on logging/observability behavior,
+  record the exact proof surface instead of implying the contract from a green
+  PR alone.
+- If a machine-readable command path was part of the change, preserve whether
+  the issue proved stdout-only payload safety, stderr observability, and any
+  compatibility-log redirection behavior.
+- Treat `adl_event` lines during finish as current workflow evidence, but do
+  not claim machine-readable cleanliness unless the issue explicitly proved it.
+
 ### 3. Run Finish Through The Repo Control Plane
 
 Prefer repo-native finish commands rather than manual git/PR surgery.

--- a/adl/tools/skills/pr-janitor/SKILL.md
+++ b/adl/tools/skills/pr-janitor/SKILL.md
@@ -96,6 +96,16 @@ If there is no concrete PR-progress target, stop and report `blocked`.
 4. Apply only bounded fixes if policy and evidence support them.
 5. Emit a structured progress result and stop.
 
+## Observability Expectations
+
+- Use workflow/control-plane logs as supporting evidence when diagnosing stuck
+  PR lanes, queue gates, draft-state transitions, or GitHub transport failures.
+- Distinguish between a real command failure and log noise on stderr; current
+  repo-native paths may emit `adl_event` lines even when the underlying
+  structured state is healthy.
+- When janitor notes a logging defect, separate that follow-on from the current
+  PR blocker unless the logging defect itself is why the PR cannot advance.
+
 ## Workflow
 
 ### 1. Resolve PR Target

--- a/adl/tools/skills/pr-ready/SKILL.md
+++ b/adl/tools/skills/pr-ready/SKILL.md
@@ -112,6 +112,17 @@ If there is no concrete target, stop and report `blocked` with the missing targe
 10. Apply only clearly safe bounded repairs if permitted.
 11. Emit a structured readiness result and stop.
 
+## Observability Expectations
+
+- Current doctor/readiness commands may emit `adl_event` lines before the
+  structured JSON payload; treat the JSON body as authoritative while recording
+  the logging caveat truthfully when it matters.
+- If the readiness result depends on queue gating, draft PR state, or linked
+  PR inference, preserve those details explicitly instead of compressing them
+  into a generic `blocked` summary.
+- When the changed surface touches machine-readable command output, note whether
+  stdout/stderr separation was part of the readiness proof.
+
 ## Workflow
 
 ### 1. Resolve Target Context

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -142,6 +142,19 @@ Default rule:
   - default ADL/Codex behavior is to stop and report `blocked_now`
   - if the caller explicitly wants execution despite the gate, record that the run proceeded under override
 
+### Observability Expectations
+
+- Preserve the execution-time log story for the issue:
+  - what command/binder path was used
+  - whether execution proceeded under an explicit queue or preflight override
+  - what durable or compatibility log behavior was relied on, if any
+- When the issue changes machine-readable command surfaces, include proof for
+  stdout/stderr separation and any `ADL_OBSERVABILITY_STDERR=0` /
+  `ADL_OBSERVABILITY_LOG` compatibility path that is claimed.
+- Do not treat emitted `adl_event` lines as a validation failure by themselves;
+  classify them as part of the current observability contract unless the issue
+  explicitly changes that contract.
+
 ### 3. Bind Branch And Worktree
 
 Use the repo's canonical `run` surface to create or confirm the issue execution branch and worktree at the last responsible moment.

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -170,6 +170,16 @@ This skill enforces:
 - healthy child waiting states are monitored issue-local lifecycle states, not default operator stop states
 - merged-but-not-closeouted children are immediate closeout work, not natural pause points
 
+## Observability Expectations
+
+- Treat workflow/control-plane logs as supporting sprint evidence when they help
+  explain queue gates, waiting states, merge drift, or closeout behavior.
+- Keep GitHub truth authoritative; logs explain state, but they do not replace
+  the live issue/PR check gates.
+- When a sprint is blocked by a workflow/logging defect outside the active
+  child issue, record that as a follow-on rather than hiding it inside sprint
+  completion claims.
+
 Preferred per-issue routing model:
 - sprint-wide structured prompt preflight not ready ->
   `check_sprint_structured_prompt_readiness.py`, then route flagged child issues

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -114,6 +114,19 @@ If there is no concrete target, stop and report `blocked`.
 7. When explicit dispatch mode is enabled, dispatch one bounded downstream skill subtask.
 8. Stop without absorbing the selected skill's logic.
 
+## Observability Expectations
+
+When conductor routing depends on doctor/readiness/PR state:
+- prefer structured workflow evidence first, but expect current repo-native
+  commands to emit `adl_event` lines before or alongside the observed machine
+  output on some paths
+- do not treat those observability lines as corruption when the command still
+  returns the authoritative structured payload
+- do not assume stdout/stderr separation or JSON cleanliness unless the
+  relevant issue or proof packet explicitly established it
+- when a routing result depends on wait state, queue blocking, or PR inference,
+  preserve the relevant log-policy caveat in the output or handoff notes
+
 ## Routing Model
 
 Preferred next-skill mapping:

--- a/docs/milestones/v0.91.5/LOGGING_VALIDATION_CHECKLIST_3711.md
+++ b/docs/milestones/v0.91.5/LOGGING_VALIDATION_CHECKLIST_3711.md
@@ -1,0 +1,138 @@
+# Logging Validation Checklist (#3711)
+
+Issue: #3711  
+Parent sprint: #3703  
+Captured: 2026-06-15  
+Status: docs_validation_contract
+
+## Purpose
+
+This checklist defines the minimum proof bar for future logging or
+observability-affecting changes in ADL. It is not a blanket requirement to run
+every logging test on every issue. It is a scoped checklist for deciding what
+must be proven when a change touches the logging contract.
+
+## When To Use This Checklist
+
+Use this checklist when a change touches any of the following:
+
+- workflow or control-plane command logging
+- machine-readable command output that coexists with observability events
+- runtime action-log behavior
+- provider or review-provider durable logs
+- heartbeat, timeout, or long-running progress diagnostics
+- OTEL boundary or exporter policy
+- Observatory or downstream log-consumer contracts
+- docs or skill guidance that teaches operators how those surfaces work
+
+## Core Questions
+
+Answer these questions before publication:
+
+1. What logging surface changed?
+2. What is the claimed operator-visible behavior?
+3. What machine-readable or durable artifact is authoritative?
+4. What larger logging claim is explicitly *not* being made?
+
+If any answer is unclear, the issue is not review-ready.
+
+## Required Validation Categories
+
+### 1. Channel Policy
+
+If the change touches JSON or other machine-readable command payloads:
+
+- prove whether stdout remains machine-readable
+- prove whether observability remains on stderr, a compatibility log, or both
+- record any explicit compatibility mode such as:
+  - `ADL_OBSERVABILITY_STDERR=0`
+  - `ADL_OBSERVABILITY_LOG=<path>`
+
+Minimum proof:
+
+- one command transcript or focused test showing the channel behavior that is
+  being claimed
+
+### 2. Redaction And Path Hygiene
+
+If the change touches emitted logs or durable artifacts:
+
+- verify no raw secrets, raw prompts, private tool arguments, or unjustified
+  host-local absolute paths are newly exposed
+- record what surface was checked
+
+Minimum proof:
+
+- focused redaction/path-hygiene test, validator, or bounded transcript review
+
+### 3. Durable Artifact Truth
+
+If the change touches runtime/provider/Observatory/durable log artifacts:
+
+- name the authoritative artifact
+- prove the artifact is written or interpreted as claimed
+- distinguish projection artifacts from canonical truth
+
+Minimum proof:
+
+- focused artifact-level test, validator, or documented replay/readback command
+
+### 4. Progress / Heartbeat / Timeout Truth
+
+If the change touches long-running execution:
+
+- prove what visible progress signal exists
+- prove timeout or heartbeat reason codes if they are part of the claim
+- distinguish “pending but healthy” from “blocked or failed”
+
+Minimum proof:
+
+- one focused slow-path or fixture proving the claimed progress/timeout behavior
+
+### 5. Non-Claims
+
+Every logging-affecting issue must say what it does **not** prove. Examples:
+
+- full OpenTelemetry implementation
+- repo-wide runtime/provider correlation
+- complete progress coverage for every command
+- machine-readable cleanliness for every existing command path
+
+If the issue does not have non-claims, the review packet is incomplete.
+
+## Validation Selection Matrix
+
+| Change class | Expected local proof |
+| --- | --- |
+| Docs/skill guidance only | file existence, Markdown/path hygiene, claim-evidence alignment |
+| Control-plane logging | focused shell/Rust command proof, stderr/stdout policy proof |
+| Runtime/provider durable logs | focused Rust/unit/integration proof on the named artifact |
+| Heartbeat/timeout diagnostics | focused slow-path or fixture proving bounded progress behavior |
+| OTEL boundary docs | contract/proof packet validation, no overclaim review |
+| Observatory consumption docs | example stream validation, contract/path truth, no runtime overclaim |
+
+## Publication Rule
+
+Do not publish a logging-affecting issue with only a generic “tests passed”
+claim. The SOR and review packet must say:
+
+- what exact logging surface changed
+- what exact proof ran
+- what larger logging work remains deferred
+
+## Follow-On Routing
+
+If the issue uncovers a tooling defect outside its scope, route a follow-on
+instead of widening the current slice. Typical examples:
+
+- queue gating on unrelated PRs
+- machine-readable output pollution
+- overly generic cards emitted during issue bootstrap
+- sprint-state closeout drift
+
+## Related Proof Surfaces
+
+- [Shared observability contract](SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md)
+- [Control-plane observability contract](CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md)
+- [Runtime action-log contract](RUNTIME_ACTION_LOG_CONTRACT_3556.md)
+- [Logging gap map](review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md)

--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -133,8 +133,13 @@ Primary planning and proof sources:
 Supporting / domain-specific docs:
 
 - v0.92 activation test map: [V092_ACTIVATION_TEST_MAP_v0.91.5.md](V092_ACTIVATION_TEST_MAP_v0.91.5.md)
+- Logging validation checklist: [LOGGING_VALIDATION_CHECKLIST_3711.md](LOGGING_VALIDATION_CHECKLIST_3711.md)
 - Feature index: [features/README.md](features/README.md)
 - Issue wave: [WP_ISSUE_WAVE_v0.91.5.yaml](WP_ISSUE_WAVE_v0.91.5.yaml)
+
+Sprint and review support:
+
+- Logging mini-sprint closeout packet: [LOGGING_MINI_SPRINT_CLOSEOUT_3703.md](review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md)
 
 ## Document Map
 

--- a/docs/milestones/v0.91.5/review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md
@@ -1,0 +1,129 @@
+# Logging Mini-Sprint Closeout (#3703)
+
+Sprint issue: #3703  
+Final child: #3711  
+Captured: 2026-06-15  
+Status: review_closeout_packet
+
+## Summary
+
+The logging mini-sprint established a real first operating posture for ADL
+logging and observability across control-plane, runtime/provider correlation,
+heartbeat/timeout diagnostics, OTEL boundary documentation, and Observatory
+consumption rules.
+
+This packet is the reviewer-facing summary for the sprint. It states what the
+sprint completed, what remains deferred, and what must not be overclaimed when
+v0.92 or later work relies on these surfaces.
+
+## Child Issue Outcomes
+
+| Issue | Outcome | Primary proof surface |
+| --- | --- | --- |
+| `#3704` | Refreshed logging/observability gap inventory and routed the bounded work | [LOGGING_OBSERVABILITY_GAP_MAP_3704.md](LOGGING_OBSERVABILITY_GAP_MAP_3704.md) |
+| `#3705` | Defined one shared observability and OTEL-ready vocabulary | [SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md](../../SHARED_OBSERVABILITY_AND_OTEL_CONTRACT_3705.md) |
+| `#3706` | Hardened C-SDLC control-plane logging and documented JSON compatibility mode | [CONTROL_PLANE_LOGGING_PROOF_3706.md](CONTROL_PLANE_LOGGING_PROOF_3706.md) |
+| `#3707` | Added bounded runtime/provider correlation fields and proof | [RUNTIME_PROVIDER_LOGGING_PROOF_3707.md](RUNTIME_PROVIDER_LOGGING_PROOF_3707.md) |
+| `#3708` | Added heartbeat, timeout, and progress diagnostics proof | [HEARTBEAT_TIMEOUT_PROGRESS_PROOF_3708.md](HEARTBEAT_TIMEOUT_PROGRESS_PROOF_3708.md) |
+| `#3709` | Bound the OTEL integration policy surface without overclaiming implementation | [OTEL_INTEGRATION_BOUNDARY_PROOF_3709.md](OTEL_INTEGRATION_BOUNDARY_PROOF_3709.md) |
+| `#3710` | Defined how Observatory should consume ADL logs and event streams | [OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md](OBSERVATORY_LOG_CONSUMPTION_PROOF_3710.md) |
+| `#3711` | Updates docs, skills, validation guidance, and sprint closeout truth | this packet plus [LOGGING_VALIDATION_CHECKLIST_3711.md](../../LOGGING_VALIDATION_CHECKLIST_3711.md) |
+
+## #3711 Proof Run
+
+The final docs-only slice for `#3711` used focused validation rather than
+runtime or provider execution proof. The bounded proof run was:
+
+- `git diff --check`
+  - verified whitespace and patch hygiene on the changed docs/skill surfaces
+- repository-relative Markdown link resolution over the edited `#3711` files
+  - verified the new checklist, closeout packet, README links, and updated
+    skill references resolve on disk
+- `python3 adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py --review-root docs/milestones/v0.91.5/review/logging_observability --out .adl/reviews/review-readiness-cleanup/logging-mini-sprint-3711 --run-id logging-mini-sprint-3711-rerun`
+  - verified the logging review root remains structurally reviewable and that
+  remaining deferred follow-ons are explicit rather than hidden
+- bounded pre-PR docs review over the changed `AGENTS.md`, skill docs,
+  milestone docs, and logging packet surfaces
+  - used to catch date/status drift and output-channel overclaim before
+    publication
+
+This issue did not claim runtime validation, OTEL export proof, or JSON-clean
+proof for all command paths.
+
+## What Is Now Established
+
+The sprint establishes the following truths:
+
+- ADL has a shared observability vocabulary that spans control-plane,
+  runtime/provider, long-lived-agent, and Observatory-facing concepts.
+- Control-plane logging is real, bounded, and reviewer-visible; it is not just
+  an aspirational contract.
+- Runtime/provider observability has a first correlated slice rather than two
+  completely separate stories.
+- Long-running workflow surfaces now have an explicit heartbeat/progress/timeout
+  posture.
+- OTEL is an optional export boundary, not the current local source of truth.
+- Observatory must consume ADL event/durable-log truth rather than inventing a
+  separate telemetry contract.
+- Future issues now have a logging validation checklist and operator guidance
+  surfaces to avoid regressing into silent or overclaimed workflows.
+
+## What Is Still Deferred
+
+The sprint does **not** prove:
+
+- full OpenTelemetry exporter implementation
+- complete machine-readable cleanliness for every existing command path
+- full runtime/provider/C-SDLC correlation across every execution branch
+- exhaustive heartbeat/progress coverage for every long-running path
+- completion of every tool problem uncovered while dogfooding the logging lane
+
+These are deferred, not forgotten.
+
+## v0.92 / Multi-Agent Reliance Boundary
+
+The sprint improves v0.92 readiness, but it does not justify broad
+multi-agent/runtime observability claims by itself.
+
+Safe reliance after this sprint:
+
+- use the shared vocabulary and current contracts when authoring new work
+- rely on the documented control-plane and Observatory rules already proven
+- require focused issue-level proof when changing logging behavior
+
+Unsafe reliance after this sprint:
+
+- claiming full OTEL support
+- claiming every JSON command path is already clean
+- claiming every provider/runtime/long-lived-agent surface is fully unified
+- treating unresolved tool defects as if the sprint solved them
+
+## Remaining Follow-Ons
+
+The sprint surfaced bounded tooling follow-ons outside the sprint scope:
+
+- machine-readable JSON surfaces still need a cleaner observability contract
+- `pr.sh run` still emits a deprecated compatibility-path note on the preferred
+  execution path
+- open-PR-wave queue gating still misclassifies some stale non-closing residue
+- prompt-template import/edit round-trip remains brittle on some rendered cards
+- bootstrap/init can still generate generic `STP`/`SPP` cards from mirrored
+  issue bodies
+- sprint-state / issue / PR closeout truth can still drift after merge
+
+Those follow-ons must not be silently treated as done by this sprint.
+
+## Reviewer Checklist
+
+Reviewers should confirm:
+
+- the child proofs above exist and are internally consistent
+- `#3711` guidance changes teach operators when logging proof is required
+- no packet in this sprint overclaims OTEL or repo-wide JSON cleanliness
+- deferred tool defects remain visible and are not mislabeled as sprint wins
+
+## Bottom Line
+
+The logging mini-sprint is a real hardening tranche, not a cosmetic docs wave.
+It gives ADL a usable observability contract and proof baseline, while
+preserving explicit boundaries around the work that still remains.

--- a/docs/milestones/v0.91.5/review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md
@@ -46,7 +46,7 @@ JSON consumers depend on them.
 | Heartbeat, timeout, and progress policy is not unified. | Operators still ask “is it hung?” for long commands or long-lived processes. | #3708 | `finish`, `closeout`, validation subprocesses, provider calls, long-lived agents | Slow/hanging fixture proves bounded heartbeats/progress with stable timeout reason codes. |
 | OpenTelemetry is only planned/OTEL-ready, not implemented. | Claims of standard observability can overstate reality; future exporters may be bolted on inconsistently. | #3709 | Cargo/dependency plan and exporter boundary | No-op/stdout subscriber proof or design review; CI must not require a collector. |
 | Observatory consumption is not defined against the current event model. | Unity/Observatory could invent a separate telemetry truth instead of consuming ADL runtime/C-SDLC events. | #3710 | v0.92 Observatory docs and event examples | Example event stream and requirements for ingestion, display, retention, redaction, and correlation. |
-| Docs, skills, AGENTS, and validation do not yet enforce the completed logging model. | Implementation can land but future agents keep using old/silent paths. | #3711 | `AGENTS.md`, skills, docs, validation checklist | Skills and docs teach required logs; closeout packet records complete/deferred truth. |
+| Docs, skills, AGENTS, and validation must teach the completed logging model. | If guidance lags implementation, future agents can regress into old or silent paths. | #3711 | `AGENTS.md`, skills, docs, validation checklist | Skills and docs teach required logs; closeout packet records complete/deferred truth. |
 
 ## Not Missing After This Inventory
 
@@ -85,8 +85,9 @@ JSON consumers depend on them.
   not mapped into a shared observability contract.
 - Observatory/Unity consumption requirements are not yet tied to the ADL event
   model.
-- Skills and repo guidance do not yet make logging proof a standard part of
-  future issue work.
+- Repo-native logging guidance now exists, but future workflow/tooling issues
+  still need to apply it consistently and route follow-on defects instead of
+  overclaiming maturity.
 
 ## Recommended Execution Order
 


### PR DESCRIPTION
Closes #3711

## Summary
Completed the final logging mini-sprint docs tranche for `#3711` in the bound
issue worktree. The slice stays bounded to repo guidance, operational-skill
docs, a logging validation checklist, and a reviewer-facing mini-sprint
closeout packet so future logging-related issues know what must be proven,
which command-channel claims are still deferred, and what tooling follow-ons
remain outside the sprint scope.

## Artifacts
- `AGENTS.md`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/pr-ready/SKILL.md`
- `adl/tools/skills/pr-run/SKILL.md`
- `adl/tools/skills/pr-finish/SKILL.md`
- `adl/tools/skills/pr-janitor/SKILL.md`
- `adl/tools/skills/pr-closeout/SKILL.md`
- `adl/tools/skills/issue-watcher/SKILL.md`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/documentation-specialist/SKILL.md`
- `docs/milestones/v0.91.5/README.md`
- `docs/milestones/v0.91.5/LOGGING_VALIDATION_CHECKLIST_3711.md`
- `docs/milestones/v0.91.5/review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md`
- `docs/milestones/v0.91.5/review/logging_observability/LOGGING_OBSERVABILITY_GAP_MAP_3704.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene.
  - `python3 - <<'PY' ... PY`
    Verified repository-relative Markdown links resolve for the edited `#3711`
    files.
  - `python3 adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py --review-root docs/milestones/v0.91.5/review/logging_observability --out .adl/reviews/review-readiness-cleanup/logging-mini-sprint-3711 --run-id logging-mini-sprint-3711-rerun`
    Verified the logging review root remains structurally reviewable and that
    remaining follow-ons are explicit instead of hidden.
  - bounded pre-PR docs review over the changed `#3711` surfaces
    Verified no blocking docs-truth issues remained after remediation.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3711__v0-91-5-logging-mini-sprint-update-docs-skills-and-closeout-logging-sprint/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3711__v0-91-5-logging-mini-sprint-update-docs-skills-and-closeout-logging-sprint/sor.md
- Idempotency-Key: v0-91-5-logging-mini-sprint-8-8-update-docs-skills-and-closeout-logging-sprint-adl-v0-91-5-tasks-issue-3711-v0-91-5-logging-mini-sprint-update-docs-skills-and-closeout-logging-sprint-sip-md-adl-v0-91-5-tasks-issue-3711-v0-91-5-logging-mini-sprint-update-docs-skills-and-closeout-logging-sprint-sor-md