### PR TITLE
[v0.91.5][tools] Separate observability events from machine-readable JSON surfaces

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2259,7 +2259,7 @@ cmd_ready() {
     return 0
   fi
   require_rust_pr_delegate
-  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode ready ...'."
+  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode ready ...'." >&2
   delegate_pr_command_to_rust ready "$@"
 }
 
@@ -2269,7 +2269,7 @@ cmd_preflight() {
     return 0
   fi
   require_rust_pr_delegate
-  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode preflight ...'."
+  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode preflight ...'." >&2
   delegate_pr_command_to_rust preflight "$@"
 }
 

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -122,8 +122,12 @@ When conductor routing depends on doctor/readiness/PR state:
   output on some paths
 - do not treat those observability lines as corruption when the command still
   returns the authoritative structured payload
-- do not assume stdout/stderr separation or JSON cleanliness unless the
-  relevant issue or proof packet explicitly established it
+- for repo-native `pr.sh` / `adl pr` JSON readiness surfaces proven by
+  `#3789`, treat stdout as the authoritative parse-safe JSON channel while
+  `adl_event` lines may still appear on stderr or an explicit compatibility log
+- outside those proven JSON surfaces, do not assume stdout/stderr separation or
+  machine-readable cleanliness unless the relevant issue or proof packet
+  explicitly established it
 - when a routing result depends on wait state, queue blocking, or PR inference,
   preserve the relevant log-policy caveat in the output or handoff notes
 

--- a/adl/tools/test_pr_json_observability.sh
+++ b/adl/tools/test_pr_json_observability.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+OBS_SRC="$ROOT_DIR/adl/tools/observability.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$repo/adl" "$mockbin"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+cp "$OBS_SRC" "$repo/adl/tools/observability.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+
+cat >"$mockbin/adl-delegate" <<'EOF_DELEGATE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TMP_DELEGATE_ARGS"
+if [[ "${1:-}" != "pr" ]]; then
+  echo "unexpected delegate invocation: $*" >&2
+  exit 1
+fi
+mode="${2:-}"
+case "$mode" in
+  ready|preflight|doctor)
+    printf 'adl_event schema=adl.observability.event.v1 command=adl stage=%s result=started\n' "$mode" >&2
+    printf '{\n  "schema": "adl.pr.doctor.v1",\n  "mode": "%s"\n}\n' "$mode"
+    ;;
+  *)
+    echo "unexpected mode: $mode" >&2
+    exit 1
+    ;;
+esac
+EOF_DELEGATE
+chmod +x "$mockbin/adl-delegate"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+export TMP_DELEGATE_ARGS="$tmpdir/delegate_args.txt"
+export ADL_PR_RUST_BIN="$mockbin/adl-delegate"
+export PATH="$mockbin:$PATH"
+
+run_json_command() {
+  local name="$1"
+  shift
+  local stdout_file="$tmpdir/${name}.stdout"
+  local stderr_file="$tmpdir/${name}.stderr"
+  (
+    cd "$repo"
+    "$BASH_BIN" adl/tools/pr.sh "$@" >"$stdout_file" 2>"$stderr_file"
+  )
+  python3 - <<'PY' "$stdout_file" "$name"
+import json
+import pathlib
+import sys
+payload = pathlib.Path(sys.argv[1]).read_text()
+json.loads(payload)
+print(f"validated {sys.argv[2]}")
+PY
+  if grep -Fq 'adl_event schema=adl.observability.event.v1' "$stdout_file"; then
+    echo "$name stdout was polluted by observability events" >&2
+    cat "$stdout_file" >&2
+    exit 1
+  fi
+  grep -Fq 'adl_event schema=adl.observability.event.v1' "$stderr_file" || {
+    echo "$name stderr did not preserve observability events" >&2
+    cat "$stderr_file" >&2
+    exit 1
+  }
+}
+
+run_json_command ready ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
+run_json_command preflight preflight 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
+run_json_command doctor doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json
+
+args="$(cat "$TMP_DELEGATE_ARGS")"
+[[ "$args" == *"pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json"* ]] || {
+  echo "expected ready delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr preflight 1152 --slug rust-start --no-fetch-issue --version v0.86 --json"* ]] || {
+  echo "expected preflight delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json"* ]] || {
+  echo "expected doctor delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+
+echo "PASS test_pr_json_observability"


### PR DESCRIPTION
Closes #3789

## Summary
Separated compatibility notices from machine-readable JSON stdout on `pr.sh` readiness surfaces, added focused regression proof, and documented the proven stdout/stderr contract for workflow routing.

## Artifacts
- Updated wrapper behavior in `adl/tools/pr.sh`
- Added focused proof in `adl/tools/test_pr_json_observability.sh`
- Updated workflow guidance in `adl/tools/skills/workflow-conductor/SKILL.md`
- Updated local execution record at `.adl/v0.91.5/tasks/issue-3789__v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_json_observability.sh`
    Verified parse-safe JSON stdout for repo-native `ready`, `preflight`, and `doctor` surfaces while preserving stderr observability.
  - `bash adl/tools/test_control_plane_observability.sh`
    Verified the existing control-plane observability contract still preserves stderr suppression and compatibility-log mirroring.
- Results:
  - PASS
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3789__v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3789__v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces/sor.md
- Idempotency-Key: v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces-adl-tools-pr-sh-adl-tools-test-pr-json-observability-sh-adl-tools-skills-workflow-conductor-skill-md-adl-v0-91-5-tasks-issue-3789-v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces-sip-md-adl-v0-91-5-tasks-issue-3789-v0-91-5-tools-separate-observability-events-from-machine-readable-json-surfaces-sor-md