### PR TITLE
[v0.91.5][tools] Remove deprecated compatibility note from preferred pr.sh run flow

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -426,10 +426,12 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let repo = default_repo(&repo_root)?;
     let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
 
-    eprintln!(
-        "• Deprecated compatibility path: prefer `adl/tools/pr.sh run {}` for execution-context binding.",
-        parsed.issue
-    );
+    if std::env::var("ADL_PR_SUPPRESS_START_COMPAT_NOTE").as_deref() != Ok("1") {
+        eprintln!(
+            "• Deprecated compatibility path: prefer `adl/tools/pr.sh run {}` for execution-context binding.",
+            parsed.issue
+        );
+    }
 
     let mut title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1720,7 +1720,7 @@ cmd_run() {
     require_rust_pr_delegate
     adl_obs_event "pr.sh" "issue_bind" "started" "issue" "$1"
     note "Issue-mode run: binding execution context for issue $1"
-    delegate_pr_command_to_rust start "$@"
+    ADL_PR_SUPPRESS_START_COMPAT_NOTE=1 delegate_pr_command_to_rust start "$@"
     return 0
   fi
 
@@ -2223,7 +2223,7 @@ cmd_start() {
   adl_obs_event "pr.sh" "issue_bind" "started" "issue" "${1:-}"
   require_rust_pr_delegate
   note "Deprecated compatibility path: prefer 'adl/tools/pr.sh run <issue> ...' for execution-context binding."
-  delegate_pr_command_to_rust start "$@"
+  ADL_PR_SUPPRESS_START_COMPAT_NOTE=1 delegate_pr_command_to_rust start "$@"
 }
 
 


### PR DESCRIPTION
Closes #3790

## Summary
Implemented the bounded `#3790` CLI-noise fix. Preferred `adl/tools/pr.sh run for a numbered issue` now suppresses the delegated Rust `start` compatibility warning, while deprecated `adl/tools/pr.sh start for a numbered issue` still emits exactly one warning. Direct Rust `adl pr start` remains capable of warning unless the explicit suppression environment variable is supplied by a governed caller.

## Artifacts
- Modified `adl/tools/pr.sh`.
- Modified `adl/src/cli/pr_cmd.rs`.
- Local SOR execution record at `.adl/v0.91.5/tasks/issue-3790__v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow/sor.md`.

## Validation
- Validation commands and their purpose:
  - `cargo check --manifest-path adl/Cargo.toml --bin adl`
    Verified compile correctness for the touched Rust command path.
  - `cargo clippy --manifest-path adl/Cargo.toml --bin adl -- -D warnings`
    Verified warning-clean focused Rust quality for the touched binary.
  - `bash adl/tools/pr.sh run 3790 --version v0.91.5 --allow-open-pr-wave with stdout and stderr redirected to temporary capture files; rg "Deprecated compatibility path" ...`
    Verified no deprecated-path note appears on the preferred `run` path; nonzero exit was due `#3819`, not warning behavior.
  - `bash adl/tools/pr.sh start 3790 --version v0.91.5 with stdout and stderr redirected to temporary capture files; rg "Deprecated compatibility path" ...`
    Verified deprecated shell `start` still warns exactly once.
- Results:
  - PASS: compile.
  - PASS: focused clippy.
  - PASS_WITH_ROUTED_RESIDUAL: preferred run warning suppression proven; nested-worktree exit routed to `#3819`.
  - PASS: deprecated start warning retained exactly once.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3790__v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3790__v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow/sor.md
- Idempotency-Key: v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow-adl-tools-pr-sh-adl-src-cli-pr-cmd-rs-adl-v0-91-5-tasks-issue-3790-v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow-sip-md-adl-v0-91-5-tasks-issue-3790-v0-91-5-tools-remove-deprecated-compatibility-note-from-preferred-pr-sh-run-flow-sor-md