### PR TITLE
[v0.91.5][tools][octocrab] Replace remaining gh finish and merge residue

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -11,8 +11,9 @@ use super::git_support::{
 };
 use super::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
-    ensure_or_repair_pr_closing_linkage, run_gh_capture, run_gh_status,
-    run_gh_status_allow_failure,
+    ensure_or_repair_pr_closing_linkage, pr_create_finish, pr_edit_finish_existing,
+    pr_merge_finish, pr_ready_finish_allow_failure, pr_ready_finish_merge_allow_failure,
+    pr_view_base_ref_finish_existing,
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
@@ -181,40 +182,11 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     let pr_url = if let Some(existing) = current_pr_url(&repo, &branch)? {
         ensure_existing_pr_base_matches(&repo, &existing, &pr_base)?;
-        run_gh_status(
-            "pr.edit.finish_existing",
-            &[
-                "pr",
-                "edit",
-                "-R",
-                &repo,
-                &existing,
-                "--title",
-                &parsed.title,
-                "--body-file",
-                path_str(&pr_body_file)?,
-            ],
-        )?;
+        pr_edit_finish_existing(&repo, &existing, &parsed.title, &pr_body_file)?;
         existing
     } else {
-        let created = run_gh_capture(
-            "pr.create.finish",
-            &[
-                "pr",
-                "create",
-                "-R",
-                &repo,
-                "--base",
-                &pr_base,
-                "--head",
-                &branch,
-                "--title",
-                &parsed.title,
-                "--body-file",
-                path_str(&pr_body_file)?,
-                "--draft",
-            ],
-        )?;
+        let created =
+            pr_create_finish(&repo, &parsed.title, &branch, &pr_base, &pr_body_file, true)?;
         created.trim().to_string()
     };
 
@@ -228,23 +200,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     if parsed.merge_mode {
         if parsed.ready {
-            let _ = run_gh_status_allow_failure(
-                "pr.ready.finish_merge",
-                &["pr", "ready", "-R", &repo, &pr_url],
-            )?;
+            let _ = pr_ready_finish_merge_allow_failure(&repo, &pr_url)?;
         }
-        run_gh_status(
-            "pr.merge.finish",
-            &[
-                "pr",
-                "merge",
-                "-R",
-                &repo,
-                "--squash",
-                "--delete-branch",
-                &pr_url,
-            ],
-        )?;
+        pr_merge_finish(&repo, &pr_url)?;
         lifecycle::wait_for_issue_closed_and_completed(parsed.issue, &repo)?;
         lifecycle::closeout_closed_completed_issue_bundle(
             &repo_root,
@@ -257,8 +215,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     if parsed.ready {
-        let _ =
-            run_gh_status_allow_failure("pr.ready.finish", &["pr", "ready", "-R", &repo, &pr_url])?;
+        let _ = pr_ready_finish_allow_failure(&repo, &pr_url)?;
     }
 
     attach_pr_janitor(
@@ -1131,20 +1088,7 @@ fn resolve_finish_pr_base(repo_root: &Path, branch: &str) -> Result<String> {
 }
 
 fn ensure_existing_pr_base_matches(repo: &str, pr_url: &str, expected_base: &str) -> Result<()> {
-    let actual_base = run_gh_capture(
-        "pr.view.base_ref.finish_existing",
-        &[
-            "pr",
-            "view",
-            "-R",
-            repo,
-            pr_url,
-            "--json",
-            "baseRefName",
-            "--jq",
-            ".baseRefName",
-        ],
-    )?;
+    let actual_base = pr_view_base_ref_finish_existing(repo, pr_url)?;
     let actual_base = actual_base.trim();
     if actual_base != expected_base {
         bail!(

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -403,6 +403,7 @@ fn github_client(operation: &str) -> Result<AdlGithubClient> {
     }
 }
 
+#[cfg(test)]
 pub(super) fn run_gh_capture(operation: &str, args: &[&str]) -> Result<String> {
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed(operation)? {
@@ -430,12 +431,142 @@ pub(super) fn run_gh_status(operation: &str, args: &[&str]) -> Result<()> {
     run_octocrab_status(operation, args)
 }
 
-pub(super) fn run_gh_status_allow_failure(operation: &str, args: &[&str]) -> Result<bool> {
+pub(super) fn pr_view_base_ref_finish_existing(repo: &str, pr_ref: &str) -> Result<String> {
     #[cfg(test)]
-    if test_gh_fixture_fallback_allowed(operation)? {
-        return run_gh_status_shell_allow_failure(operation, args);
+    if test_gh_fixture_fallback_allowed("pr.view.base_ref.finish_existing")? {
+        return run_gh_capture_shell(
+            "pr.view.base_ref.finish_existing",
+            &[
+                "pr",
+                "view",
+                "-R",
+                repo,
+                pr_ref,
+                "--json",
+                "baseRefName",
+                "--jq",
+                ".baseRefName",
+            ],
+        )
+        .map(|value| value.trim().to_string());
     }
-    run_octocrab_status(operation, args).map(|_| true)
+    pr_base_ref_octocrab(repo, pr_ref)
+}
+
+pub(super) fn pr_edit_finish_existing(
+    repo: &str,
+    pr_ref: &str,
+    title: &str,
+    body_file: &Path,
+) -> Result<()> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("pr.edit.finish_existing")? {
+        return run_gh_status_shell(
+            "pr.edit.finish_existing",
+            &[
+                "pr",
+                "edit",
+                "-R",
+                repo,
+                pr_ref,
+                "--title",
+                title,
+                "--body-file",
+                path_str(body_file)?,
+            ],
+        );
+    }
+    let body = std::fs::read_to_string(body_file)
+        .with_context(|| format!("failed to read PR body file '{}'", body_file.display()))?;
+    update_pr_title_body_octocrab(repo, pr_ref, title, &body)
+}
+
+pub(super) fn pr_create_finish(
+    repo: &str,
+    title: &str,
+    head: &str,
+    base: &str,
+    body_file: &Path,
+    draft: bool,
+) -> Result<String> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("pr.create.finish")? {
+        return run_gh_capture_shell(
+            "pr.create.finish",
+            &[
+                "pr",
+                "create",
+                "-R",
+                repo,
+                "--base",
+                base,
+                "--head",
+                head,
+                "--title",
+                title,
+                "--body-file",
+                path_str(body_file)?,
+                "--draft",
+            ],
+        )
+        .map(|value| value.trim().to_string());
+    }
+    let body = std::fs::read_to_string(body_file)
+        .with_context(|| format!("failed to read PR body file '{}'", body_file.display()))?;
+    create_pr_octocrab(repo, title, head, base, &body, draft)
+}
+
+fn pr_ready_with_optional_fixture_fallback(
+    _operation: &str,
+    repo: &str,
+    pr_ref: &str,
+) -> Result<()> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed(_operation)? {
+        return run_gh_status_shell(_operation, &["pr", "ready", "-R", repo, pr_ref]);
+    }
+    mark_pr_ready_octocrab(repo, pr_ref)
+}
+
+pub(super) fn pr_ready_finish(repo: &str, pr_ref: &str) -> Result<()> {
+    pr_ready_with_optional_fixture_fallback("pr.ready.finish", repo, pr_ref)
+}
+
+pub(super) fn pr_ready_finish_merge(repo: &str, pr_ref: &str) -> Result<()> {
+    pr_ready_with_optional_fixture_fallback("pr.ready.finish_merge", repo, pr_ref)
+}
+
+pub(super) fn pr_ready_finish_allow_failure(repo: &str, pr_ref: &str) -> Result<bool> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("pr.ready.finish")? {
+        return run_gh_status_shell_allow_failure(
+            "pr.ready.finish",
+            &["pr", "ready", "-R", repo, pr_ref],
+        );
+    }
+    pr_ready_finish(repo, pr_ref).map(|_| true)
+}
+
+pub(super) fn pr_ready_finish_merge_allow_failure(repo: &str, pr_ref: &str) -> Result<bool> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("pr.ready.finish_merge")? {
+        return run_gh_status_shell_allow_failure(
+            "pr.ready.finish_merge",
+            &["pr", "ready", "-R", repo, pr_ref],
+        );
+    }
+    pr_ready_finish_merge(repo, pr_ref).map(|_| true)
+}
+
+pub(super) fn pr_merge_finish(repo: &str, pr_ref: &str) -> Result<()> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("pr.merge.finish")? {
+        return run_gh_status_shell(
+            "pr.merge.finish",
+            &["pr", "merge", "-R", repo, "--squash", pr_ref],
+        );
+    }
+    merge_pr_octocrab(repo, pr_ref)
 }
 
 #[cfg(test)]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2322,7 +2322,7 @@ Flags:
   (cards)   --no-fetch-issue                   Do not fetch issue title/labels (uses issue-<n> title)
   (card/output) --version <v0.2>               Override detected version (otherwise inferred from issue labels version:vX.Y)
   (finish) --output-card <output_card.md>          REQUIRED: output card path (must exist)
-  (finish) --merge                              Opt-in: ready + squash-merge + delete branch.
+  (finish) --merge                              Opt-in: ready + squash-merge + local closeout; remote branch deletion is not implied.
   (finish) --idempotent                         Safe no-op only when existing merged PR matches current finish inputs.
   (card/run) --slug <slug>                     Use an explicit slug instead of fetching the issue title.
   (run)     --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.


### PR DESCRIPTION
Closes #3813

## Summary
Completed the bounded `#3813` finish-path cleanup in the bound issue worktree.
The slice replaces the remaining fake `gh` finish/edit/ready/merge residue in
the octocrab-backed PR lifecycle with typed helper calls, preserves the
existing shell-fixture fallback only under test configuration, and corrects
the `pr.sh finish --merge` help text so it no longer implies remote branch
deletion that the real merge path does not perform.

## Artifacts
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/tools/pr.sh`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter cleanliness for the touched Rust files.
  - `cargo clippy --manifest-path adl/Cargo.toml --bin adl -- -D warnings`
    Verified the bin target compiles without clippy warnings after the finish
    transport cleanup.
  - `cargo test --manifest-path adl/Cargo.toml octocrab_transport_covers_pr_and_issue_operations_against_mock_github -- --nocapture`
    Verified the mock-GitHub octocrab transport surface still passes.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_ -- --nocapture`
    Verified the real finish-path regression surface still passes.
  - bounded pre-PR code review over the changed `#3813` surfaces
    Verified no blocking findings remained after the fixture-fallback repair.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3813__v0-91-5-tools-octocrab-replace-remaining-gh-finish-and-merge-residue/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3813__v0-91-5-tools-octocrab-replace-remaining-gh-finish-and-merge-residue/sor.md
- Idempotency-Key: v0-91-5-tools-octocrab-replace-remaining-gh-finish-and-merge-residue-adl-v0-91-5-tasks-issue-3813-v0-91-5-tools-octocrab-replace-remaining-gh-finish-and-merge-residue-sip-md-adl-v0-91-5-tasks-issue-3813-v0-91-5-tools-octocrab-replace-remaining-gh-finish-and-merge-residue-sor-md