### PR TITLE
[v0.91.5][tools][refactor] Split C-SDLC validators and editors into small single-purpose binaries

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -27,6 +27,18 @@ name = "adl-review"
 path = "src/bin/adl_review.rs"
 
 [[bin]]
+name = "adl-validate-structured-prompt"
+path = "src/bin/adl_validate_structured_prompt.rs"
+
+[[bin]]
+name = "adl-lint-prompt-spec"
+path = "src/bin/adl_lint_prompt_spec.rs"
+
+[[bin]]
+name = "adl-prompt-template"
+path = "src/bin/adl_prompt_template.rs"
+
+[[bin]]
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 

--- a/adl/src/bin/adl_lint_prompt_spec.rs
+++ b/adl/src/bin/adl_lint_prompt_spec.rs
@@ -1,0 +1,162 @@
+use std::process;
+
+#[allow(dead_code)]
+mod cli_observability {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/cli/observability.rs"
+    ));
+}
+
+mod tooling_cmd {
+    #[allow(dead_code)]
+    pub(super) fn tooling_usage() -> &'static str {
+        "adl-lint-prompt-spec --issue <number>\n\
+adl-lint-prompt-spec --input <path>\n\
+\n\
+Runs Prompt Spec lint directly without routing through the broad `adl tooling` dispatch surface.\n"
+    }
+
+    #[allow(dead_code)]
+    pub mod common {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/common.rs"
+        ));
+    }
+    #[allow(dead_code)]
+    pub mod markdown {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/markdown.rs"
+        ));
+    }
+    #[allow(dead_code)]
+    pub mod structured_prompt {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/structured_prompt.rs"
+        ));
+    }
+
+    pub(super) fn run_lint_prompt_spec(args: &[String]) -> anyhow::Result<()> {
+        structured_prompt::real_lint_prompt_spec(args)
+    }
+}
+
+fn print_error_chain(err: &anyhow::Error) {
+    eprintln!("Error: {err}");
+    let mut n = 0;
+    let mut cur = err.source();
+    while let Some(cause) = cur {
+        eprintln!("  {n}: {cause}");
+        n += 1;
+        cur = cause.source();
+    }
+}
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    cli_observability::emit_event("adl-lint-prompt-spec", "command", "started", &[]);
+    match tooling_cmd::run_lint_prompt_spec(args) {
+        Ok(()) => {
+            cli_observability::emit_event("adl-lint-prompt-spec", "command", "completed", &[]);
+            Ok(())
+        }
+        Err(err) => {
+            let reason = err.to_string();
+            cli_observability::emit_event(
+                "adl-lint-prompt-spec",
+                "command",
+                "failed",
+                &[("reason", reason.as_str())],
+            );
+            Err(err)
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        print_error_chain(&err);
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+fn binary_help_probe() -> String {
+    tooling_cmd::tooling_usage().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_log_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time ok")
+            .as_nanos();
+        std::env::temp_dir().join(format!("adl-{name}-{unique}.md"))
+    }
+
+    fn valid_prompt_spec_card() -> String {
+        r#"# Prompt Spec Fixture
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+outputs:
+  output_card: .adl/cards/1374/output_1374.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn help_mentions_direct_lint_binary() {
+        let output = super::binary_help_probe();
+        assert!(output.contains("adl-lint-prompt-spec"));
+        assert!(output.contains("without routing through the broad `adl tooling` dispatch surface"));
+    }
+
+    #[test]
+    fn run_valid_input_succeeds() {
+        let input = temp_log_path("lint-card");
+        fs::write(&input, valid_prompt_spec_card()).expect("write card");
+        run(&["--input".to_string(), input.display().to_string()]).expect("lint succeeds");
+    }
+
+    #[test]
+    fn run_invalid_args_fail() {
+        let err = run(&["--bogus".to_string()]).expect_err("invalid args fail");
+        assert!(err.to_string().contains("unknown arg"));
+    }
+}

--- a/adl/src/bin/adl_prompt_template.rs
+++ b/adl/src/bin/adl_prompt_template.rs
@@ -1,0 +1,136 @@
+use std::process;
+
+#[allow(dead_code)]
+mod cli_observability {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/cli/observability.rs"
+    ));
+}
+
+mod tooling_cmd {
+    #[allow(dead_code)]
+    pub(super) fn tooling_usage() -> &'static str {
+        "adl-prompt-template render --kind <sip|stp|spp|srp|sor> --values <values.yaml> --out <card.md> [--repo-root <path>]\n\
+adl-prompt-template render-all --values-dir <dir> --out-dir <dir> [--repo-root <path>]\n\
+adl-prompt-template edit-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> --set <field=value> [--set <field=value> ...] [--out <values.yaml>] [--repo-root <path>]\n\
+adl-prompt-template edit-rendered --kind <sip|stp|spp|srp|sor> --input <card.md> --set <field=value> [--set <field=value> ...] --out <card.md> [--values-out <values.yaml>] [--repo-root <path>]\n\
+adl-prompt-template import-values --kind <sip|stp|spp|srp|sor> --input <card.md> --out <values.yaml> [--normalized-out <card.md>] [--repo-root <path>]\n\
+adl-prompt-template validate-values --kind <sip|stp|spp|srp|sor> --values <values.yaml> [--repo-root <path>]\n\
+adl-prompt-template validate-structure --kind <sip|stp|spp|srp|sor> --input <card.md> [--repo-root <path>]\n\
+adl-prompt-template validate-schemas [--repo-root <path>]\n\
+adl-prompt-template write-sample-values --out-dir <dir>\n\
+adl-prompt-template write-structure-schemas --out-dir <dir> [--repo-root <path>]\n\
+\n\
+Runs prompt-template editor and renderer operations directly without routing through the broad `adl tooling` dispatch surface.\n"
+    }
+
+    #[allow(dead_code)]
+    pub mod prompt_template {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/prompt_template.rs"
+        ));
+    }
+}
+
+fn print_error_chain(err: &anyhow::Error) {
+    eprintln!("Error: {err}");
+    let mut n = 0;
+    let mut cur = err.source();
+    while let Some(cause) = cur {
+        eprintln!("  {n}: {cause}");
+        n += 1;
+        cur = cause.source();
+    }
+}
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    let subcommand = args.first().map(String::as_str).unwrap_or("");
+    cli_observability::emit_event(
+        "adl-prompt-template",
+        "command",
+        "started",
+        &[("subcommand", subcommand)],
+    );
+    match tooling_cmd::prompt_template::real_prompt_template(args) {
+        Ok(()) => {
+            cli_observability::emit_event(
+                "adl-prompt-template",
+                "command",
+                "completed",
+                &[("subcommand", subcommand)],
+            );
+            Ok(())
+        }
+        Err(err) => {
+            let reason = err.to_string();
+            cli_observability::emit_event(
+                "adl-prompt-template",
+                "command",
+                "failed",
+                &[("subcommand", subcommand), ("reason", reason.as_str())],
+            );
+            Err(err)
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        print_error_chain(&err);
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+fn binary_help_probe() -> String {
+    tooling_cmd::tooling_usage().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use anyhow::Context;
+    use std::path::Path;
+
+    fn repo_root() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("repo root")
+    }
+
+    #[test]
+    fn help_mentions_direct_prompt_template_binary() {
+        let output = super::binary_help_probe();
+        assert!(output.contains("adl-prompt-template render"));
+        assert!(output.contains("without routing through the broad `adl tooling` dispatch surface"));
+    }
+
+    #[test]
+    fn run_validate_schemas_succeeds() {
+        run(&[
+            "validate-schemas".to_string(),
+            "--repo-root".to_string(),
+            repo_root().display().to_string(),
+        ])
+        .expect("validate-schemas succeeds");
+    }
+
+    #[test]
+    fn run_invalid_args_fail() {
+        let err = run(&["bogus".to_string()]).expect_err("invalid args fail");
+        assert!(err
+            .to_string()
+            .contains("unknown prompt-template subcommand"));
+    }
+
+    #[test]
+    fn print_error_chain_handles_nested_error() {
+        let err = Err::<(), _>(anyhow::anyhow!("root cause"))
+            .context("outer")
+            .expect_err("error");
+        super::print_error_chain(&err);
+    }
+}

--- a/adl/src/bin/adl_validate_structured_prompt.rs
+++ b/adl/src/bin/adl_validate_structured_prompt.rs
@@ -1,0 +1,140 @@
+use std::process;
+
+#[allow(dead_code)]
+mod cli_observability {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/cli/observability.rs"
+    ));
+}
+
+mod tooling_cmd {
+    #[allow(dead_code)]
+    pub(super) fn tooling_usage() -> &'static str {
+        "adl-validate-structured-prompt --type <sip|stp|spp|srp|sor> --input <path> [--phase <phase>]\n\
+\n\
+Runs the structured-prompt validator directly without routing through the broad `adl tooling` dispatch surface.\n"
+    }
+
+    #[allow(dead_code)]
+    pub mod common {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/common.rs"
+        ));
+    }
+    #[allow(dead_code)]
+    pub mod markdown {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/markdown.rs"
+        ));
+    }
+    #[allow(dead_code)]
+    pub mod structured_prompt {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/cli/tooling_cmd/structured_prompt.rs"
+        ));
+    }
+
+    pub(super) fn run_validate_structured_prompt(args: &[String]) -> anyhow::Result<()> {
+        structured_prompt::real_validate_structured_prompt(args)
+    }
+}
+
+fn print_error_chain(err: &anyhow::Error) {
+    eprintln!("Error: {err}");
+    let mut n = 0;
+    let mut cur = err.source();
+    while let Some(cause) = cur {
+        eprintln!("  {n}: {cause}");
+        n += 1;
+        cur = cause.source();
+    }
+}
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    let prompt_type = args
+        .windows(2)
+        .find(|pair| pair[0] == "--type")
+        .map(|pair| pair[1].as_str())
+        .unwrap_or("");
+    cli_observability::emit_event(
+        "adl-validate-structured-prompt",
+        "command",
+        "started",
+        &[("type", prompt_type)],
+    );
+    match tooling_cmd::run_validate_structured_prompt(args) {
+        Ok(()) => {
+            cli_observability::emit_event(
+                "adl-validate-structured-prompt",
+                "command",
+                "completed",
+                &[("type", prompt_type)],
+            );
+            Ok(())
+        }
+        Err(err) => {
+            let reason = err.to_string();
+            cli_observability::emit_event(
+                "adl-validate-structured-prompt",
+                "command",
+                "failed",
+                &[("type", prompt_type), ("reason", reason.as_str())],
+            );
+            Err(err)
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        print_error_chain(&err);
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+fn binary_help_probe() -> String {
+    tooling_cmd::tooling_usage().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use anyhow::Context;
+
+    #[test]
+    fn help_mentions_direct_validator_binary() {
+        let output = super::binary_help_probe();
+        assert!(output.contains("adl-validate-structured-prompt"));
+        assert!(output.contains("without routing through the broad `adl tooling` dispatch surface"));
+    }
+
+    #[test]
+    fn run_help_with_type_succeeds() {
+        run(&[
+            "--type".to_string(),
+            "spp".to_string(),
+            "--help".to_string(),
+        ])
+        .expect("help succeeds");
+    }
+
+    #[test]
+    fn run_invalid_args_fail() {
+        let err = run(&["--bogus".to_string()]).expect_err("invalid args fail");
+        assert!(err.to_string().contains("unknown arg"));
+    }
+
+    #[test]
+    fn print_error_chain_handles_nested_error() {
+        let err = Err::<(), _>(anyhow::anyhow!("root cause"))
+            .context("outer")
+            .expect_err("error");
+        super::print_error_chain(&err);
+    }
+}

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -187,6 +187,9 @@ candidate_filter_for_path() {
     adl/src/cli/mod.rs|adl/src/cli/tests.rs)
       printf 'cli'
       ;;
+    adl/src/bin/adl_lint_prompt_spec.rs|adl/src/bin/adl_prompt_template.rs|adl/src/bin/adl_validate_structured_prompt.rs)
+      printf 'tooling_cmd'
+      ;;
     adl/src/cli/run_artifacts/runtime/*.rs)
       printf 'run_state'
       ;;

--- a/adl/tools/lint_prompt_spec.sh
+++ b/adl/tools/lint_prompt_spec.sh
@@ -24,8 +24,28 @@ resolve_manifest_root() {
 }
 
 ROOT_DIR="$(resolve_manifest_root)"
-TOOLING_BIN="${ADL_TOOLING_RUST_BIN:-${ADL_PR_RUST_BIN:-}}"
-if [[ -n "$TOOLING_BIN" ]]; then
-  exec "$TOOLING_BIN" tooling lint-prompt-spec "$@"
+LEGACY_TOOLING_BIN="${ADL_TOOLING_RUST_BIN:-${ADL_PR_RUST_BIN:-}}"
+LINT_BIN="${ADL_LINT_PROMPT_SPEC_BIN:-}"
+
+if [[ -n "$LEGACY_TOOLING_BIN" && ! -x "$LEGACY_TOOLING_BIN" ]]; then
+  LEGACY_TOOLING_BIN=""
 fi
-exec cargo run --quiet --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl -- tooling lint-prompt-spec "$@"
+
+if [[ -n "$LINT_BIN" && ! -x "$LINT_BIN" ]]; then
+  LINT_BIN=""
+fi
+
+if [[ -n "$LEGACY_TOOLING_BIN" ]]; then
+  exec "$LEGACY_TOOLING_BIN" tooling lint-prompt-spec "$@"
+fi
+
+if [[ -n "$LINT_BIN" ]]; then
+  exec "$LINT_BIN" "$@"
+fi
+
+DEFAULT_BIN="$ROOT_DIR/adl/target/debug/adl-lint-prompt-spec"
+if [[ -x "$DEFAULT_BIN" ]]; then
+  exec "$DEFAULT_BIN" "$@"
+fi
+
+exec cargo run --quiet --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl-lint-prompt-spec -- "$@"

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -263,6 +263,12 @@ filter_token_for_path() {
     adl/src/demo/*/*/*/*.rs|adl/src/demo/*/*/*/*/*.rs)
       return 1
       ;;
+    adl/src/bin/adl_lint_prompt_spec.rs|\
+    adl/src/bin/adl_prompt_template.rs|\
+    adl/src/bin/adl_validate_structured_prompt.rs)
+      printf 'tooling_cmd'
+      return 0
+      ;;
     adl/src/bin/[^/]*.rs)
       basename "$path" .rs
       return 0

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -86,6 +86,20 @@ run_artifacts_runtime_filters="$TMP/run-artifacts-runtime-filters.txt"
 bash "$SCRIPT" --changed-files "$run_artifacts_runtime_changed" --print-risk-filters >"$run_artifacts_runtime_filters"
 grep -Fx "run_state" "$run_artifacts_runtime_filters" >/dev/null
 
+direct_tooling_binaries_changed="$TMP/direct-tooling-binaries-changed.txt"
+cat >"$direct_tooling_binaries_changed" <<'EOF'
+A	adl/src/bin/adl_lint_prompt_spec.rs
+M	adl/src/bin/adl_prompt_template.rs
+M	adl/src/bin/adl_validate_structured_prompt.rs
+EOF
+direct_tooling_binaries_filters="$TMP/direct-tooling-binaries-filters.txt"
+bash "$SCRIPT" --changed-files "$direct_tooling_binaries_changed" --print-risk-filters >"$direct_tooling_binaries_filters"
+grep -Fx "tooling_cmd" "$direct_tooling_binaries_filters" >/dev/null
+if [ "$(wc -l <"$direct_tooling_binaries_filters" | tr -d ' ')" -ne 1 ]; then
+  echo "expected direct tooling binaries to collapse to the shared tooling_cmd filter" >&2
+  exit 1
+fi
+
 gws_live_changed="$TMP/gws-live-changed.txt"
 cat >"$gws_live_changed" <<'EOF'
 A	adl/src/gws_live_capability_execution_surface.rs

--- a/adl/tools/test_prompt_spec_lint.sh
+++ b/adl/tools/test_prompt_spec_lint.sh
@@ -66,6 +66,24 @@ EOF
   ./adl/tools/lint_prompt_spec.sh --input .adl/cards/761/input_761.md >/dev/null
 )
 
+cat > "$repo/fake-tooling-delegate" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$FAKE_TOOLING_ARGS"
+exit 0
+EOF
+chmod +x "$repo/fake-tooling-delegate"
+(
+  cd "$repo"
+  FAKE_TOOLING_ARGS="$repo/fake-tooling-args.txt" \
+    ADL_TOOLING_RUST_BIN="$repo/fake-tooling-delegate" \
+    ./adl/tools/lint_prompt_spec.sh --input .adl/cards/761/input_761.md >/dev/null
+)
+grep -Fqx -- "tooling" "$repo/fake-tooling-args.txt"
+grep -Fqx -- "lint-prompt-spec" "$repo/fake-tooling-args.txt"
+grep -Fqx -- "--input" "$repo/fake-tooling-args.txt"
+grep -Fqx -- ".adl/cards/761/input_761.md" "$repo/fake-tooling-args.txt"
+
 cat > "$repo/.adl/cards/761/input_task_bundle_761.md" <<'EOF'
 # ADL Input Card
 

--- a/adl/tools/test_prompt_template_workflow_integration.sh
+++ b/adl/tools/test_prompt_template_workflow_integration.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-BIN=(cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" --bin adl-csdlc --)
+PROMPT_TEMPLATE_BIN=(cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" --bin adl-prompt-template --)
+VALIDATOR_BIN=(cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" --bin adl-validate-structured-prompt --)
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/adl-prompt-template-workflow.XXXXXX")"
 cleanup() {
   rm -rf "$WORKDIR"
@@ -15,39 +16,39 @@ EDITED_VALUES="$WORKDIR/edited-stp.values.yaml"
 EDITED_RENDERED="$WORKDIR/edited-stp.md"
 IMPORTED_VALUES="$WORKDIR/imported-stp.values.yaml"
 
-"${BIN[@]}" tooling prompt-template write-sample-values --out-dir "$VALUES_DIR"
-"${BIN[@]}" tooling prompt-template render-all --repo-root "$ROOT" --values-dir "$VALUES_DIR" --out-dir "$RENDERED_DIR"
+"${PROMPT_TEMPLATE_BIN[@]}" write-sample-values --out-dir "$VALUES_DIR"
+"${PROMPT_TEMPLATE_BIN[@]}" render-all --repo-root "$ROOT" --values-dir "$VALUES_DIR" --out-dir "$RENDERED_DIR"
 
 for kind in sip stp spp srp sor; do
-  "${BIN[@]}" tooling prompt-template validate-values --repo-root "$ROOT" --kind "$kind" --values "$VALUES_DIR/$kind.values.yaml"
-  "${BIN[@]}" tooling prompt-template validate-structure --repo-root "$ROOT" --kind "$kind" --input "$RENDERED_DIR/$kind.md"
+  "${PROMPT_TEMPLATE_BIN[@]}" validate-values --repo-root "$ROOT" --kind "$kind" --values "$VALUES_DIR/$kind.values.yaml"
+  "${PROMPT_TEMPLATE_BIN[@]}" validate-structure --repo-root "$ROOT" --kind "$kind" --input "$RENDERED_DIR/$kind.md"
   if [[ "$kind" == "sor" ]]; then
-    "${BIN[@]}" tooling validate-structured-prompt --type "$kind" --phase bootstrap --input "$RENDERED_DIR/$kind.md"
+    "${VALIDATOR_BIN[@]}" --type "$kind" --phase bootstrap --input "$RENDERED_DIR/$kind.md"
   else
-    "${BIN[@]}" tooling validate-structured-prompt --type "$kind" --input "$RENDERED_DIR/$kind.md"
+    "${VALIDATOR_BIN[@]}" --type "$kind" --input "$RENDERED_DIR/$kind.md"
   fi
  done
 
-"${BIN[@]}" tooling prompt-template edit-values \
+"${PROMPT_TEMPLATE_BIN[@]}" edit-values \
   --repo-root "$ROOT" \
   --kind stp \
   --values "$VALUES_DIR/stp.values.yaml" \
   --set 'summary=Edited through the #3714 workflow integration proof.' \
   --out "$EDITED_VALUES"
-"${BIN[@]}" tooling prompt-template validate-values --repo-root "$ROOT" --kind stp --values "$EDITED_VALUES"
-"${BIN[@]}" tooling prompt-template render --repo-root "$ROOT" --kind stp --values "$EDITED_VALUES" --out "$EDITED_RENDERED"
-"${BIN[@]}" tooling prompt-template validate-structure --repo-root "$ROOT" --kind stp --input "$EDITED_RENDERED"
+"${PROMPT_TEMPLATE_BIN[@]}" validate-values --repo-root "$ROOT" --kind stp --values "$EDITED_VALUES"
+"${PROMPT_TEMPLATE_BIN[@]}" render --repo-root "$ROOT" --kind stp --values "$EDITED_VALUES" --out "$EDITED_RENDERED"
+"${PROMPT_TEMPLATE_BIN[@]}" validate-structure --repo-root "$ROOT" --kind stp --input "$EDITED_RENDERED"
 
 grep -Fq 'Edited through the #3714 workflow integration proof.' "$EDITED_RENDERED"
 
-"${BIN[@]}" tooling prompt-template import-values \
+"${PROMPT_TEMPLATE_BIN[@]}" import-values \
   --repo-root "$ROOT" \
   --kind stp \
   --input "$EDITED_RENDERED" \
   --out "$IMPORTED_VALUES"
-"${BIN[@]}" tooling prompt-template validate-values --repo-root "$ROOT" --kind stp --values "$IMPORTED_VALUES"
+"${PROMPT_TEMPLATE_BIN[@]}" validate-values --repo-root "$ROOT" --kind stp --values "$IMPORTED_VALUES"
 
-"${BIN[@]}" tooling prompt-template validate-schemas --repo-root "$ROOT"
+"${PROMPT_TEMPLATE_BIN[@]}" validate-schemas --repo-root "$ROOT"
 python3 "$ROOT/adl/tools/test_prompt_template_structure_schemas.py"
 
 echo "PASS prompt-template workflow integration proof rendered all five cards, edited/imported values, and validated schemas"

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -106,6 +106,18 @@ assert_has "$cli_family_output" "mode=focused"
 assert_has "$cli_family_output" "filter_tokens=cli"
 assert_has "$cli_family_output" "filter_expression=test(cli)"
 
+direct_tooling_binaries="$TMP/direct_tooling_binaries.txt"
+cat >"$direct_tooling_binaries" <<'EOF'
+M	adl/src/bin/adl_lint_prompt_spec.rs
+M	adl/src/bin/adl_prompt_template.rs
+M	adl/src/bin/adl_validate_structured_prompt.rs
+EOF
+direct_tooling_binaries_output="$(bash "$SCRIPT" --changed-files "$direct_tooling_binaries" --print-plan)"
+assert_has "$direct_tooling_binaries_output" "mode=focused"
+assert_has "$direct_tooling_binaries_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$direct_tooling_binaries_output" "filter_tokens=tooling_cmd"
+assert_has "$direct_tooling_binaries_output" "filter_expression=test(tooling_cmd)"
+
 csdlc_prompt_editor_child="$TMP/csdlc_prompt_editor_child.txt"
 printf 'M\tadl/src/csdlc_prompt_editor/values.rs\n' >"$csdlc_prompt_editor_child"
 csdlc_prompt_editor_child_output="$(bash "$SCRIPT" --changed-files "$csdlc_prompt_editor_child" --print-plan)"

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -214,6 +214,38 @@ EOF
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_valid.md"
 "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_valid.md"
 
+cat >"$tmpdir/fake-validator" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$FAKE_VALIDATOR_ARGS"
+exit 0
+EOF
+chmod +x "$tmpdir/fake-validator"
+FAKE_VALIDATOR_ARGS="$tmpdir/fake-validator-args.txt" \
+  ADL_STRUCTURED_PROMPT_VALIDATOR_BIN="$tmpdir/fake-validator" \
+  "$VALIDATOR" --type stp --input "$tmpdir/stp_valid.md" >/dev/null
+grep -Fqx -- "--type" "$tmpdir/fake-validator-args.txt"
+grep -Fqx -- "stp" "$tmpdir/fake-validator-args.txt"
+grep -Fqx -- "--input" "$tmpdir/fake-validator-args.txt"
+grep -Fqx -- "$tmpdir/stp_valid.md" "$tmpdir/fake-validator-args.txt"
+
+cat >"$tmpdir/fake-tooling-delegate" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$FAKE_TOOLING_ARGS"
+exit 0
+EOF
+chmod +x "$tmpdir/fake-tooling-delegate"
+FAKE_TOOLING_ARGS="$tmpdir/fake-tooling-args.txt" \
+  ADL_TOOLING_RUST_BIN="$tmpdir/fake-tooling-delegate" \
+  "$VALIDATOR" --type stp --input "$tmpdir/stp_valid.md" >/dev/null
+grep -Fqx -- "tooling" "$tmpdir/fake-tooling-args.txt"
+grep -Fqx -- "validate-structured-prompt" "$tmpdir/fake-tooling-args.txt"
+grep -Fqx -- "--type" "$tmpdir/fake-tooling-args.txt"
+grep -Fqx -- "stp" "$tmpdir/fake-tooling-args.txt"
+grep -Fqx -- "--input" "$tmpdir/fake-tooling-args.txt"
+grep -Fqx -- "$tmpdir/stp_valid.md" "$tmpdir/fake-tooling-args.txt"
+
 cp "$tmpdir/stp_valid.md" "$tmpdir/stp_invalid_card_status.md"
 perl -0pi -e 's/status: "draft"/status: "draft"\ncard_status: "nearly-ready"/' "$tmpdir/stp_invalid_card_status.md"
 if "$VALIDATOR" --type stp --input "$tmpdir/stp_invalid_card_status.md" >"$tmpdir/stp_invalid_card_status.out" 2>&1; then

--- a/adl/tools/validate_structured_prompt.sh
+++ b/adl/tools/validate_structured_prompt.sh
@@ -24,8 +24,28 @@ resolve_manifest_root() {
 }
 
 ROOT_DIR="$(resolve_manifest_root)"
-TOOLING_BIN="${ADL_TOOLING_RUST_BIN:-${ADL_PR_RUST_BIN:-}}"
-if [[ -n "$TOOLING_BIN" ]]; then
-  exec "$TOOLING_BIN" tooling validate-structured-prompt "$@"
+LEGACY_TOOLING_BIN="${ADL_TOOLING_RUST_BIN:-${ADL_PR_RUST_BIN:-}}"
+VALIDATOR_BIN="${ADL_STRUCTURED_PROMPT_VALIDATOR_BIN:-}"
+
+if [[ -n "$LEGACY_TOOLING_BIN" && ! -x "$LEGACY_TOOLING_BIN" ]]; then
+  LEGACY_TOOLING_BIN=""
 fi
-exec cargo run --quiet --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl -- tooling validate-structured-prompt "$@"
+
+if [[ -n "$VALIDATOR_BIN" && ! -x "$VALIDATOR_BIN" ]]; then
+  VALIDATOR_BIN=""
+fi
+
+if [[ -n "$LEGACY_TOOLING_BIN" ]]; then
+  exec "$LEGACY_TOOLING_BIN" tooling validate-structured-prompt "$@"
+fi
+
+if [[ -n "$VALIDATOR_BIN" ]]; then
+  exec "$VALIDATOR_BIN" "$@"
+fi
+
+DEFAULT_BIN="$ROOT_DIR/adl/target/debug/adl-validate-structured-prompt"
+if [[ -x "$DEFAULT_BIN" ]]; then
+  exec "$DEFAULT_BIN" "$@"
+fi
+
+exec cargo run --quiet --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl-validate-structured-prompt -- "$@"

--- a/docs/milestones/v0.91.5/review/tooling_adoption/CSDLC_SMALL_BINARIES_PROOF_3832.md
+++ b/docs/milestones/v0.91.5/review/tooling_adoption/CSDLC_SMALL_BINARIES_PROOF_3832.md
@@ -1,0 +1,125 @@
+# C-SDLC Small Binaries Proof (`#3832`)
+
+## Summary
+
+`#3832` removes the structured-prompt validator path from recursive broad-binary
+invocation and adds direct small-binary entrypoints for the most common
+validator/editor surfaces:
+
+- `adl-validate-structured-prompt`
+- `adl-lint-prompt-spec`
+- `adl-prompt-template`
+
+`adl/tools/validate_structured_prompt.sh` and
+`adl/tools/lint_prompt_spec.sh` now act as thin compatibility shims to those
+direct binaries instead of routing through:
+
+```text
+adl -- tooling ...
+```
+
+## What Changed
+
+### Direct validator binaries
+
+- `adl-validate-structured-prompt` runs the structured-prompt validator
+  directly.
+- `adl-lint-prompt-spec` runs Prompt Spec lint directly.
+
+Both binaries emit direct stderr observability lines for:
+
+- command start
+- command completed
+- command failed
+
+### Direct editor / renderer binary
+
+- `adl-prompt-template` runs prompt-template render, edit, import, and schema
+  validation operations directly.
+
+It also emits direct stderr observability lines for:
+
+- command start
+- command completed
+- command failed
+
+### Compatibility shims
+
+The following wrappers remain compatible but are no longer broad-binary
+dispatchers:
+
+- `adl/tools/validate_structured_prompt.sh`
+- `adl/tools/lint_prompt_spec.sh`
+
+Current shim behavior:
+
+1. preserve legacy broad-delegate overrides from `ADL_TOOLING_RUST_BIN` /
+   `ADL_PR_RUST_BIN` by invoking `tooling <subcommand>` on that binary
+2. prefer an explicitly provided direct small-binary override for the specific
+   validator/lint surface
+3. prefer the built local debug binary under `adl/target/debug/`
+4. otherwise run the direct binary with `cargo run --bin <small-binary>`
+
+## Non-Claims
+
+- This issue does **not** split the full PR lifecycle into many binaries.
+- This issue does **not** remove `adl/tools/pr.sh`.
+- This issue does **not** remove the compatibility `adl tooling` subcommands.
+- This issue does **not** migrate every editor and transport surface yet.
+
+## Migration Truth
+
+### Direct owners now
+
+- structured-prompt validation:
+  - `adl-validate-structured-prompt`
+- Prompt Spec lint:
+  - `adl-lint-prompt-spec`
+- prompt-template editing/rendering/import/validation:
+  - `adl-prompt-template`
+
+### Compatibility paths retained as shims
+
+- `adl/tools/validate_structured_prompt.sh`
+- `adl/tools/lint_prompt_spec.sh`
+- `adl tooling validate-structured-prompt`
+- `adl tooling lint-prompt-spec`
+- `adl tooling prompt-template`
+
+### Future splits still deferred
+
+- remaining card editor binaries beyond prompt-template editor operations
+- queue / PR lifecycle / GitHub transport decomposition
+- any broader `pr.sh` lifecycle binary breakup
+
+## Validation
+
+Focused proofs that passed:
+
+- `cargo test --manifest-path adl/Cargo.toml help_mentions_direct_ -- --nocapture`
+- `bash adl/tools/test_structured_prompt_validation.sh`
+- `bash adl/tools/test_prompt_template_workflow_integration.sh`
+- `bash adl/tools/test_prompt_spec_lint.sh`
+- `cargo build --manifest-path adl/Cargo.toml --bin adl-validate-structured-prompt --bin adl-lint-prompt-spec --bin adl-prompt-template`
+- `git diff --check`
+
+## Warm-Path Timing
+
+Measured after building the direct binaries and then executing them directly on
+one generated STP card:
+
+- `adl-validate-structured-prompt`: `0.006748s`
+- `adl-prompt-template validate-structure`: `0.007149s`
+
+These measurements are direct built-binary runs, not `cargo run` startup times.
+They establish the intended fast path for single-card docs-only validation.
+
+## Compatibility-Shim Proof
+
+The shell proof now covers both compatibility routes:
+
+- direct small-binary override via `ADL_STRUCTURED_PROMPT_VALIDATOR_BIN`
+- legacy broad-delegate override via `ADL_TOOLING_RUST_BIN`, proving the shim
+  still dispatches `tooling validate-structured-prompt` /
+  `tooling lint-prompt-spec` correctly when callers still provide the older
+  delegate path


### PR DESCRIPTION
Closes #3832

## Summary
Split the structured-prompt validator/editor path away from recursive broad-binary invocation by introducing direct small binaries for structured-prompt validation, Prompt Spec lint, and prompt-template editing/rendering. Kept the existing shell lifecycle wrappers compatible by turning them into thin shims that dispatch to the direct binaries, and recorded measured warm-path single-card validation timings in the proof note.

## Artifacts
- `adl/src/bin/adl_validate_structured_prompt.rs`
- `adl/src/bin/adl_lint_prompt_spec.rs`
- `adl/src/bin/adl_prompt_template.rs`
- `adl/tools/validate_structured_prompt.sh`
- `adl/tools/lint_prompt_spec.sh`
- `adl/tools/test_structured_prompt_validation.sh`
- `adl/tools/test_prompt_template_workflow_integration.sh`
- `docs/milestones/v0.91.5/review/tooling_adoption/CSDLC_SMALL_BINARIES_PROOF_3832.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting consistency for the direct-binary split.
  - `cargo test --manifest-path adl/Cargo.toml help_mentions_direct_ -- --nocapture`
    Verified the new direct binaries expose their intended narrow command/help surfaces.
  - `bash adl/tools/test_structured_prompt_validation.sh`
    Verified the structured-prompt validator shim dispatches directly to the direct validator binary and preserves contract validation behavior.
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`
    Verified the prompt-template editor binary directly renders, edits, imports, validates structures, and pairs correctly with the direct validator binary.
  - `bash adl/tools/test_prompt_spec_lint.sh`
    Verified Prompt Spec lint still passes through the direct lint binary path.
  - `cargo build --manifest-path adl/Cargo.toml --bin adl-validate-structured-prompt --bin adl-lint-prompt-spec --bin adl-prompt-template`
    Verified the new direct binaries build cleanly as standalone execution surfaces.
  - direct built-binary timing proof:
    - `adl/target/debug/adl-prompt-template write-sample-values --out-dir TMPDIR/values`
    - `adl/target/debug/adl-prompt-template render --repo-root . --kind stp --values TMPDIR/values/stp.values.yaml --out TMPDIR/stp.md`
    - `adl/target/debug/adl-validate-structured-prompt --type stp --input TMPDIR/stp.md`
    - `adl/target/debug/adl-prompt-template validate-structure --repo-root . --kind stp --input TMPDIR/stp.md`
    Verified warm-path direct binary execution for one generated STP card and recorded elapsed timings in the proof note.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3832__v0-91-5-tools-refactor-split-c-sdlc-validators-and-editors-into-small-single-purpose-binaries/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3832__v0-91-5-tools-refactor-split-c-sdlc-validators-and-editors-into-small-single-purpose-binaries/sor.md
- Idempotency-Key: v0-91-5-tools-refactor-split-c-sdlc-validators-and-editors-into-small-single-purpose-binaries-adl-v0-91-5-tasks-issue-3832-v0-91-5-tools-refactor-split-c-sdlc-validators-and-editors-into-small-single-purpose-binaries-sip-md-adl-v0-91-5-tasks-issue-3832-v0-91-5-tools-refactor-split-c-sdlc-validators-and-editors-into-small-single-purpose-binaries-sor-md