### PR TITLE
[v0.91.5][tools] Repair sprint child closeout drift handling

### DIFF
--- a/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
@@ -40,19 +40,39 @@ def require_truth_gate(state: dict[str, Any], issue_number: int) -> None:
     if truth_check.get('status') == 'matched' and truth_check.get('gate_passed') is True:
         return
     if truth_check.get('status') == 'drift_detected':
-        notes = truth_check.get('notes') or []
-        if len(notes) != 1:
-            raise SystemExit(
-                'Refusing to record child closeout while additional GitHub truth drift is present.'
-            )
+        eligible_drift_issues: set[int] = set()
+        blocking_drift: list[str] = []
         for record in state.get('issue_records', []):
-            if record.get('issue_number') != issue_number:
-                continue
-            if (
-                record.get('github_issue_state') == 'CLOSED'
-                and record.get('status') in DETERMINISTIC_CLOSEOUT_ELIGIBLE_STATUSES
-            ):
-                return
+            record_issue = record.get('issue_number')
+            github_issue_state = record.get('github_issue_state')
+            local_status = record.get('status', 'pending')
+            if github_issue_state == 'CLOSED' and local_status != 'closed_out':
+                if (
+                    isinstance(record_issue, int)
+                    and local_status in DETERMINISTIC_CLOSEOUT_ELIGIBLE_STATUSES
+                ):
+                    eligible_drift_issues.add(record_issue)
+                else:
+                    blocking_drift.append(
+                        f'issue #{record_issue} is CLOSED on GitHub but local status is {local_status}'
+                    )
+            elif github_issue_state == 'OPEN' and local_status == 'closed_out':
+                blocking_drift.append(
+                    f'issue #{record_issue} is OPEN on GitHub but local status is closed_out'
+                )
+        closeout_notes = [
+            note
+            for note in truth_check.get('notes', [])
+            if isinstance(note, str)
+            and 'record_child_issue_closeout.py must run before sprint state can advance' in note
+        ]
+        if blocking_drift:
+            raise SystemExit(
+                'Refusing to record child closeout while non-closeout GitHub truth drift is present: '
+                + '; '.join(blocking_drift)
+            )
+        if issue_number in eligible_drift_issues and len(closeout_notes) == len(eligible_drift_issues):
+            return
     raise SystemExit('Refusing to record child closeout without a fresh matched GitHub truth check.')
 
 

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -531,23 +531,6 @@ if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_
   exit 1
 fi
 
-if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py" \
-  --state "${state_path}" \
-  --issue-number 2827 \
-  --issue-closed true \
-  --pr-state merged \
-  --root-sor-status done \
-  --worktree-status pruned \
-  --pr-url "https://github.com/danielbaustin/agent-design-language/pull/4001" >/dev/null 2>&1; then
-  echo "expected record_child_issue_closeout.py to refuse closeout when multiple child issues are drifting" >&2
-  exit 1
-fi
-
-printf 'OPEN\n' > "${issue_2828_state_file}"
-python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
-  --repo-root "${fake_repo}" \
-  --state "${state_path}" >/dev/null
-
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py" \
   --state "${state_path}" \
   --issue-number 2827 \
@@ -570,6 +553,8 @@ assert state["current_issue_number"] == 2828
 assert state["continuation"] == "continue"
 assert state["truth_check"]["gate_passed"] is False
 PY
+
+printf 'OPEN\n' > "${issue_2828_state_file}"
 
 deferred_state_path="${tmpdir}/sprint-state-deferred-next.json"
 cp "${state_path}" "${deferred_state_path}"


### PR DESCRIPTION
Closes #3794

## Summary
Implemented a bounded sprint-conductor repair so `record_child_issue_closeout.py` can reconcile a selected child issue when multiple child issues have the same deterministic drift shape: GitHub issue is closed but local sprint state has not yet recorded closeout. The helper still fails closed for unrelated drift, blocked/deferred child states, reopened issues, missing structured prompt preflight, or missing consumed truth gates.

## Artifacts
- Updated sprint closeout helper: `adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py`
- Updated focused regression test: `adl/tools/test_sprint_conductor_helpers.sh`
- Subagent pre-PR review result: no findings; residual risk limited to the two-file review scope

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py`
    Verified syntax for the changed Python closeout helper.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified the sprint-conductor helper contract, including the new multiple deterministic drift repair path and existing fail-closed cases.
- Results:
  - PASS
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3794__v0-91-5-tools-repair-non-closing-issue-pr-sprint-state-truth-drift-after-merge/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3794__v0-91-5-tools-repair-non-closing-issue-pr-sprint-state-truth-drift-after-merge/sor.md
- Idempotency-Key: v0-91-5-tools-repair-sprint-child-closeout-drift-handling-adl-tools-skills-sprint-conductor-scripts-record-child-issue-closeout-py-adl-tools-test-sprint-conductor-helpers-sh-adl-v0-91-5-tasks-issue-3794-v0-91-5-tools-repair-non-closing-issue-pr-sprint-state-truth-drift-after-merge-sip-md-adl-v0-91-5-tasks-issue-3794-v0-91-5-tools-repair-non-closing-issue-pr-sprint-state-truth-drift-after-merge-sor-md