### PR TITLE
[v0.91.5][tools] Exclude unknown-queue PRs from queue blockers

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1110,11 +1110,7 @@ pub(super) fn unresolved_milestone_pr_wave(
             pr.queue = infer_workflow_queue(&pr.title, "", None).map(str::to_string);
             pr
         })
-        .filter(|pr| {
-            pr.queue
-                .as_deref()
-                .is_none_or(|queue| queue == target_queue)
-        })
+        .filter(|pr| pr.queue.as_deref() == Some(target_queue))
         .filter_map(|pr| match pr_has_any_closing_linkage(repo, &pr.url) {
             Ok(true) => Some(Ok(pr)),
             Ok(false) => None,
@@ -2358,6 +2354,14 @@ if [ "$1 $2" = 'pr list' ]; then
     "headRefName": "codex/real-active-blocker",
     "baseRefName": "main",
     "isDraft": true
+  },
+  {
+    "number": 2003,
+    "title": "[v0.91.5] Queue-less closing PR",
+    "url": "https://github.com/owner/repo/pull/2003",
+    "headRefName": "codex/queue-less-closing-pr",
+    "baseRefName": "main",
+    "isDraft": true
   }
 ]
 JSON
@@ -2369,6 +2373,10 @@ if [ "$1 $2" = 'pr view' ]; then
   fi
   if printf '%s ' "$@" | grep -q 'pull/2002'; then
     printf '3790\n'
+    exit 0
+  fi
+  if printf '%s ' "$@" | grep -q 'pull/2003'; then
+    printf '3841\n'
     exit 0
   fi
 fi


### PR DESCRIPTION
Closes #3841

## Summary
Repaired the open-PR wave queue filter so unknown-queue PRs no longer block concrete workflow queues. The fix keeps queue diagnostics intact while requiring an explicit queue match before a PR can block the requested queue.

## Artifacts
- Updated queue-wave filter and focused regression fixture: `adl/src/cli/pr_cmd/github.rs`
- Local ignored lifecycle output card: `.adl/v0.91.5/tasks/issue-3841__v0-91-5-tools-exclude-unknown-queue-prs-from-queue-wave-blockers/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml unresolved_wave_ignores_non_closing_stale_pr_residue -- --nocapture`
    Verified the changed queue-wave guard behavior with a fixture containing stale non-closing PR residue, a real tools blocker, and a queue-less closing PR.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3841__v0-91-5-tools-exclude-unknown-queue-prs-from-queue-wave-blockers/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3841__v0-91-5-tools-exclude-unknown-queue-prs-from-queue-wave-blockers/sor.md
- Idempotency-Key: v0-91-5-tools-exclude-unknown-queue-prs-from-queue-blockers-adl-src-cli-pr-cmd-github-rs-adl-v0-91-5-tasks-issue-3841-v0-91-5-tools-exclude-unknown-queue-prs-from-queue-wave-blockers-sip-md-adl-v0-91-5-tasks-issue-3841-v0-91-5-tools-exclude-unknown-queue-prs-from-queue-wave-blockers-sor-md