### PR TITLE
[v0.91.5][tools][observability] Fail closed when compatibility log sink is unavailable with stderr disabled

### DIFF
--- a/adl/src/cli/observability.rs
+++ b/adl/src/cli/observability.rs
@@ -11,6 +11,19 @@ pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&s
         return;
     }
 
+    let line = format_event_line(command, stage, result, fields);
+    let stderr_suppressed = env::var("ADL_OBSERVABILITY_STDERR").ok().as_deref() == Some("0");
+    if !stderr_suppressed {
+        eprintln!("{line}");
+    }
+    if let Some(log_path) = compatibility_log_path() {
+        if let Err(err) = append_to_compatibility_log(&log_path, &line) {
+            emit_compatibility_sink_failure(command, stage, &log_path, &err, stderr_suppressed);
+        }
+    }
+}
+
+fn format_event_line(command: &str, stage: &str, result: &str, fields: &[(&str, &str)]) -> String {
     let mut line = format!(
         "adl_event schema=adl.observability.event.v1 command={} stage={} result={}",
         sanitize_value(command),
@@ -23,19 +36,62 @@ pub(crate) fn emit_event(command: &str, stage: &str, result: &str, fields: &[(&s
         line.push('=');
         line.push_str(&sanitize_value(value));
     }
-    if env::var("ADL_OBSERVABILITY_STDERR").ok().as_deref() != Some("0") {
-        eprintln!("{line}");
+    line
+}
+
+fn compatibility_log_path() -> Option<String> {
+    env::var("ADL_OBSERVABILITY_LOG")
+        .ok()
+        .map(|path| path.trim().to_string())
+        .filter(|path| !path.is_empty())
+}
+
+fn append_to_compatibility_log(log_path: &str, line: &str) -> Result<(), String> {
+    if let Some(parent) = Path::new(log_path).parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "op=create_dir_all sink={} error={}",
+                sanitize_value(log_path),
+                sanitize_value(&err.to_string())
+            )
+        })?;
     }
-    if let Ok(log_path) = env::var("ADL_OBSERVABILITY_LOG") {
-        if !log_path.trim().is_empty() {
-            if let Some(parent) = Path::new(&log_path).parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_path) {
-                let _ = writeln!(file, "{line}");
-            }
-        }
-    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|err| {
+            format!(
+                "op=open sink={} error={}",
+                sanitize_value(log_path),
+                sanitize_value(&err.to_string())
+            )
+        })?;
+    writeln!(file, "{line}").map_err(|err| {
+        format!(
+            "op=write sink={} error={}",
+            sanitize_value(log_path),
+            sanitize_value(&err.to_string())
+        )
+    })?;
+    Ok(())
+}
+
+fn emit_compatibility_sink_failure(
+    command: &str,
+    stage: &str,
+    log_path: &str,
+    err: &str,
+    _stderr_suppressed: bool,
+) {
+    let line = format!(
+        "adl_event schema=adl.observability.event.v1 command={} stage=compatibility_log result=failed original_stage={} sink={} detail={}",
+        sanitize_value(command),
+        sanitize_value(stage),
+        sanitize_value(log_path),
+        sanitize_value(err),
+    );
+    eprintln!("{line}");
 }
 
 fn emit_event_owned(command: &str, stage: &str, result: &str, fields: &[(String, String)]) {
@@ -213,7 +269,10 @@ fn contains_secret_marker(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{emit_event, heartbeat_interval, sanitize_value, ProgressHeartbeat};
+    use super::{
+        append_to_compatibility_log, emit_event, format_event_line, heartbeat_interval,
+        sanitize_value, ProgressHeartbeat,
+    };
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -322,6 +381,34 @@ mod tests {
         assert!(contents.contains("result=completed"));
         assert!(contents.contains("artifact_ref="));
         assert!(!contents.contains("/repo/adl/docs/proof.md"));
+    }
+
+    #[test]
+    fn format_event_line_preserves_expected_schema_shape() {
+        let line = format_event_line(
+            "adl",
+            "doctor",
+            "completed",
+            &[("artifact_ref", "/repo/adl/docs/proof.md")],
+        );
+        assert!(line.contains("schema=adl.observability.event.v1"));
+        assert!(line.contains("command=adl"));
+        assert!(line.contains("stage=doctor"));
+        assert!(line.contains("result=completed"));
+        assert!(line.contains("artifact_ref="));
+    }
+
+    #[test]
+    fn append_to_compatibility_log_reports_open_failures() {
+        let temp = unique_temp_dir("adl-observability-bad-log-open");
+        let _env = MultiEnvGuard::set_all(&[("ADL_OBSERVABILITY_REPO_ROOT", "/repo/adl")]);
+        let err = append_to_compatibility_log(
+            temp.to_str().expect("temp utf8"),
+            "adl_event schema=adl.observability.event.v1 command=adl stage=doctor result=completed",
+        )
+        .expect_err("directory path should not be append-openable");
+        assert!(err.contains("op=open"));
+        assert!(err.contains("sink=<path>"));
     }
 
     #[test]

--- a/adl/tools/test_control_plane_observability.sh
+++ b/adl/tools/test_control_plane_observability.sh
@@ -12,6 +12,11 @@ source "$OBS"
 export ADL_OBSERVABILITY_REPO_ROOT="$ROOT_DIR"
 export ADL_OBSERVABILITY_LOG="$TMP_DIR/events.log"
 
+TOOLING_BIN="$ROOT_DIR/adl/target/debug/adl"
+if [[ ! -x "$TOOLING_BIN" ]]; then
+  TOOLING_BIN=""
+fi
+
 adl_obs_event "pr.sh" "doctor" "started" \
   "path" "$ROOT_DIR/.adl/v0.91.5/tasks/example/sor.md" \
   "token" "super-secret-token" \
@@ -63,5 +68,40 @@ grep -Fq "stage=json_mode" "$TMP_DIR/events.log" || {
   echo "json-mode event missing from durable log" >&2
   exit 1
 }
+
+bad_sink_parent="$TMP_DIR/not-a-dir"
+bad_sink="$bad_sink_parent/events.log"
+printf 'occupied\n' >"$bad_sink_parent"
+bad_stderr="$TMP_DIR/bad-sink-stderr.log"
+bad_stdout="$TMP_DIR/bad-sink-stdout.log"
+validate_cmd=(
+  tooling validate-structured-prompt
+  --type sor
+  --phase bootstrap
+  --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3807__v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled/sor.md"
+)
+if [[ -n "$TOOLING_BIN" ]]; then
+  ADL_OBSERVABILITY_STDERR=0 ADL_OBSERVABILITY_LOG="$bad_sink" \
+    "$TOOLING_BIN" "${validate_cmd[@]}" >"$bad_stdout" 2>"$bad_stderr"
+else
+  ADL_OBSERVABILITY_STDERR=0 ADL_OBSERVABILITY_LOG="$bad_sink" \
+    cargo run --manifest-path "$ROOT_DIR/adl/Cargo.toml" --quiet --bin adl -- \
+    "${validate_cmd[@]}" >"$bad_stdout" 2>"$bad_stderr"
+fi
+grep -Fq "stage=compatibility_log" "$bad_stderr" || {
+  echo "bad compatibility sink did not emit fallback failure signal" >&2
+  cat "$bad_stderr" >&2
+  exit 1
+}
+grep -Fq "result=failed" "$bad_stderr" || {
+  echo "compatibility sink fallback line missing failed result" >&2
+  cat "$bad_stderr" >&2
+  exit 1
+}
+if grep -Fq "$TMP_DIR" "$bad_stderr"; then
+  echo "compatibility sink fallback leaked absolute temp path" >&2
+  cat "$bad_stderr" >&2
+  exit 1
+fi
 
 echo "PASS test_control_plane_observability"

--- a/docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md
@@ -53,7 +53,9 @@ The current policy is now explicit and shared across the tracked contracts:
 Under that compatibility mode, stdout remains JSON-only while observability is
 still preserved on a separate explicit compatibility mirror. The governed
 durable machine-readable layer remains JSON/JSONL and is not replaced by this
-file sink.
+file sink. If the compatibility sink cannot be created or written while
+`ADL_OBSERVABILITY_STDERR=0` is active, the Rust helper now emits one bounded
+fallback failure event on stderr instead of silently dropping observability.
 
 ## Proof Commands
 
@@ -68,7 +70,10 @@ Expected proof:
 - repo/home/tmp path redaction still works;
 - `ADL_OBSERVABILITY=0` still fully disables emission;
 - `ADL_OBSERVABILITY_STDERR=0` suppresses terminal output while durable logging
-  continues in the compatibility mirror file.
+  continues in the compatibility mirror file;
+- when the compatibility sink path is invalid under quiet-stderr mode, the
+  helper emits one bounded `stage=compatibility_log result=failed` fallback
+  line instead of losing the event silently.
 
 ### Rust observability helper
 
@@ -82,7 +87,8 @@ Expected proof:
 - Rust helper appends to `ADL_OBSERVABILITY_LOG`;
 - Rust helper remains compatible with the quiet-stderr configuration used by
   shell-level proof, without changing the governed JSON/JSONL durable-layer
-  contract.
+  contract;
+- sink-open/write failures are classified explicitly instead of being ignored.
 
 ### Octocrab transport path
 


### PR DESCRIPTION
Closes #3807

## Summary
Completed the bounded `#3807` observability hardening slice in the bound issue
worktree. Rust observability now classifies compatibility-log sink failures
instead of ignoring them, and quiet-stderr compatibility mode emits one bounded
fallback failure event on stderr when the mirror log cannot be created or
written.

## Artifacts
- `adl/src/cli/observability.rs`
- `adl/tools/test_control_plane_observability.sh`
- `docs/milestones/v0.91.5/review/logging_observability/CONTROL_PLANE_LOGGING_PROOF_3706.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml cli::observability::tests -- --nocapture`
    Verified focused Rust observability behavior, including compatibility-log
    failure classification.
  - `bash adl/tools/test_control_plane_observability.sh`
    Verified the operator-visible shell proof for quiet-stderr compatibility
    mode and the new fallback failure signal.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter cleanliness.
  - `git diff --check`
    Verified whitespace and patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3807__v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3807__v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled/sor.md
- Idempotency-Key: v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled-adl-v0-91-5-tasks-issue-3807-v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled-sip-md-adl-v0-91-5-tasks-issue-3807-v0-91-5-tools-observability-fail-closed-when-compatibility-log-sink-is-unavailable-with-stderr-disabled-sor-md