### PR TITLE
[v0.91.5][tools][observability] Redact embedded absolute paths inside observability strings

### DIFF
--- a/adl/src/cli/observability.rs
+++ b/adl/src/cli/observability.rs
@@ -168,24 +168,28 @@ pub(crate) fn sanitize_value(value: &str) -> String {
         return "<redacted>".to_string();
     }
 
-    if let Ok(root) = env::var("ADL_OBSERVABILITY_REPO_ROOT") {
-        let root = root.trim_end_matches('/');
+    let repo_root = if let Ok(root) = env::var("ADL_OBSERVABILITY_REPO_ROOT") {
+        Some(root.trim_end_matches('/').to_string())
+    } else if let Ok(root) = env::current_dir() {
+        root.to_str()
+            .map(|root| root.trim_end_matches('/').to_string())
+    } else {
+        None
+    };
+    let home_root = env::var("HOME")
+        .ok()
+        .map(|home| home.trim_end_matches('/').to_string());
+
+    sanitized = sanitize_embedded_paths(&sanitized, repo_root.as_deref(), home_root.as_deref());
+
+    if let Some(root) = repo_root.as_deref() {
         let prefix = format!("{root}/");
         if sanitized.starts_with(&prefix) {
             return format!("<repo>/{}", &sanitized[prefix.len()..]);
         }
-    } else if let Ok(root) = env::current_dir() {
-        if let Some(root) = root.to_str() {
-            let root = root.trim_end_matches('/');
-            let prefix = format!("{root}/");
-            if sanitized.starts_with(&prefix) {
-                return format!("<repo>/{}", &sanitized[prefix.len()..]);
-            }
-        }
     }
 
-    if let Ok(home) = env::var("HOME") {
-        let home = home.trim_end_matches('/');
+    if let Some(home) = home_root.as_deref() {
         let prefix = format!("{home}/");
         if sanitized.starts_with(&prefix) {
             return format!("<home>/{}", &sanitized[prefix.len()..]);
@@ -201,6 +205,76 @@ pub(crate) fn sanitize_value(value: &str) -> String {
     }
 
     sanitized
+}
+
+fn sanitize_embedded_paths(
+    value: &str,
+    repo_root: Option<&str>,
+    home_root: Option<&str>,
+) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.char_indices().peekable();
+    while let Some((start, ch)) = chars.next() {
+        if ch != '/' {
+            out.push(ch);
+            continue;
+        }
+
+        let mut end = value.len();
+        while let Some((idx, next)) = chars.peek().copied() {
+            if is_path_delimiter(next) {
+                end = idx;
+                break;
+            }
+            chars.next();
+        }
+
+        let segment = &value[start..end];
+        if let Some(replacement) = sanitize_path_segment(segment, repo_root, home_root) {
+            out.push_str(&replacement);
+        } else {
+            out.push_str(segment);
+        }
+    }
+    out
+}
+
+fn sanitize_path_segment(
+    segment: &str,
+    repo_root: Option<&str>,
+    home_root: Option<&str>,
+) -> Option<String> {
+    if let Some(root) = repo_root {
+        let prefix = format!("{root}/");
+        if segment.starts_with(&prefix) {
+            return Some(format!("<repo>/{}", &segment[prefix.len()..]));
+        }
+    }
+
+    if let Some(home) = home_root {
+        let prefix = format!("{home}/");
+        if segment.starts_with(&prefix) {
+            return Some(format!("<home>/{}", &segment[prefix.len()..]));
+        }
+    }
+
+    if segment.starts_with("/private/tmp/")
+        || segment.starts_with("/tmp/")
+        || segment.starts_with("/var/folders/")
+        || Path::new(segment).is_absolute()
+    {
+        return Some("<path>".to_string());
+    }
+
+    None
+}
+
+fn is_path_delimiter(ch: char) -> bool {
+    ch.is_whitespace()
+        || matches!(
+            ch,
+            '\'' | '"' | ',' | ';' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>'
+        )
 }
 
 fn contains_secret_marker(value: &str) -> bool {
@@ -292,6 +366,18 @@ mod tests {
         );
         assert_eq!(sanitize_value("/private/tmp/example"), "<path>");
         assert_eq!(sanitize_value("/elsewhere/example"), "<path>");
+        assert_eq!(
+            sanitize_value(
+                "argv_excerpt=cargo run --input /repo/adl/docs/example.md --cache /home/operator/.adl/state.json --tmp /private/tmp/proof.json"
+            ),
+            "argv_excerpt=cargo run --input <repo>/docs/example.md --cache <home>/.adl/state.json --tmp <path>"
+        );
+        assert_eq!(
+            sanitize_value(
+                "diagnostic path=/Users/daniel/elsewhere/example.txt, fallback=/tmp/proof.json"
+            ),
+            "diagnostic path=<path>, fallback=<path>"
+        );
 
         env::remove_var("ADL_OBSERVABILITY_REPO_ROOT");
     }


### PR DESCRIPTION
Closes #3808

## Summary
Extended observability string sanitization so embedded absolute paths inside
diagnostic strings, command excerpts, and mixed-value payloads are redacted
without requiring the entire field to begin with the path. Added focused unit
coverage for embedded repo, home, temp, and generic absolute-path segments.

## Artifacts
- Updated runtime sanitization logic in `adl/src/cli/observability.rs`
- Updated local execution record at `.adl/v0.91.5/tasks/issue-3808__v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml cli::observability::tests -- --nocapture`
    Verified focused observability sanitization helpers and redaction behavior, including the new embedded-path cases.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the modified Rust source remains formatted.
  - `git diff --check`
    Verified the patch is free of whitespace and patch-hygiene errors.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.5/tasks/issue-3808__v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings/sor.md`
    Verified the final SOR contract after recording execution truth.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3808__v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3808__v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings/sor.md
- Idempotency-Key: v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings-adl-v0-91-5-tasks-issue-3808-v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings-sip-md-adl-v0-91-5-tasks-issue-3808-v0-91-5-tools-observability-redact-embedded-absolute-paths-inside-observability-strings-sor-md