### PR TITLE
[v0.91.5][tooling] Use fast structured prompt validator binary

### DIFF
--- a/adl/tools/test_validate_structured_prompt_parallel.sh
+++ b/adl/tools/test_validate_structured_prompt_parallel.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+FAKE_ROOT="$TMPDIR/fake-root"
+mkdir -p "$FAKE_ROOT/adl"
+touch "$FAKE_ROOT/adl/Cargo.toml"
+
+set +e
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/stdout.txt" 2>"$TMPDIR/stderr.txt"
+status=$?
+set -e
+
+if [[ "$status" -ne 75 ]]; then
+  echo "expected missing-binary diagnostic exit 75, got $status" >&2
+  cat "$TMPDIR/stderr.txt" >&2
+  exit 1
+fi
+
+grep -Fq "missing dedicated adl-validate-structured-prompt binary" "$TMPDIR/stderr.txt"
+grep -Fq "ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK=1" "$TMPDIR/stderr.txt"
+
+FAKE_LEGACY_BIN="$TMPDIR/fake-legacy-adl"
+cat > "$FAKE_LEGACY_BIN" <<'SH'
+#!/usr/bin/env bash
+echo "legacy tooling bin should not run without explicit fallback" >&2
+exit 42
+SH
+chmod +x "$FAKE_LEGACY_BIN"
+set +e
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_TOOLING_RUST_BIN="$FAKE_LEGACY_BIN" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/legacy-stdout.txt" 2>"$TMPDIR/legacy-stderr.txt"
+legacy_status=$?
+set -e
+if [[ "$legacy_status" -ne 75 ]]; then
+  echo "expected legacy tooling bin to be gated by missing dedicated binary diagnostic, got $legacy_status" >&2
+  cat "$TMPDIR/legacy-stderr.txt" >&2
+  exit 1
+fi
+if grep -Fq "legacy tooling bin should not run" "$TMPDIR/legacy-stderr.txt"; then
+  echo "legacy tooling bin ran without explicit fallback" >&2
+  exit 1
+fi
+
+LOCK_DIR="$TMPDIR/cargo-fallback.lock"
+set +e
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK=1 \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_DIR="$LOCK_DIR" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_TIMEOUT_SECS=0 \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/cargo-stdout.txt" 2>"$TMPDIR/cargo-stderr.txt"
+cargo_status=$?
+set -e
+if [[ "$cargo_status" -eq 0 ]]; then
+  echo "expected fake cargo fallback to fail" >&2
+  exit 1
+fi
+if [[ -d "$LOCK_DIR" ]]; then
+  echo "cargo fallback lock directory was not cleaned up after failure" >&2
+  cat "$TMPDIR/cargo-stderr.txt" >&2
+  exit 1
+fi
+
+FRESH_LOCK_DIR="$TMPDIR/missing-parent/validator.lock"
+set +e
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK=1 \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_DIR="$FRESH_LOCK_DIR" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_TIMEOUT_SECS=0 \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/fresh-lock-stdout.txt" 2>"$TMPDIR/fresh-lock-stderr.txt"
+fresh_status=$?
+set -e
+if [[ "$fresh_status" -eq 75 ]] && grep -Fq "already running" "$TMPDIR/fresh-lock-stderr.txt"; then
+  echo "fresh checkout fallback lock parent was misclassified as contention" >&2
+  cat "$TMPDIR/fresh-lock-stderr.txt" >&2
+  exit 1
+fi
+if [[ -d "$FRESH_LOCK_DIR" ]]; then
+  echo "fresh fallback lock directory was not cleaned up after failure" >&2
+  cat "$TMPDIR/fresh-lock-stderr.txt" >&2
+  exit 1
+fi
+
+echo "validate_structured_prompt_parallel: ok"

--- a/adl/tools/validate_structured_prompt.sh
+++ b/adl/tools/validate_structured_prompt.sh
@@ -23,29 +23,106 @@ resolve_manifest_root() {
   exit 1
 }
 
+resolve_primary_root() {
+  local root="$1"
+  if [[ -n "${ADL_PRIMARY_CHECKOUT_ROOT:-}" ]]; then
+    if [[ -f "$ADL_PRIMARY_CHECKOUT_ROOT/adl/Cargo.toml" ]]; then
+      printf '%s\n' "$ADL_PRIMARY_CHECKOUT_ROOT"
+      return 0
+    fi
+    echo "ERROR: ADL_PRIMARY_CHECKOUT_ROOT does not contain adl/Cargo.toml: $ADL_PRIMARY_CHECKOUT_ROOT" >&2
+    exit 1
+  fi
+
+  case "$root" in
+    */.worktrees/*)
+      printf '%s\n' "${root%%/.worktrees/*}"
+      ;;
+    *)
+      printf '%s\n' "$root"
+      ;;
+  esac
+}
+
+acquire_build_lock() {
+  local lock_dir="$1"
+  local timeout_secs="$2"
+  local start now
+  start="$(date +%s)"
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    now="$(date +%s)"
+    if (( now - start >= timeout_secs )); then
+      cat >&2 <<MSG
+ERROR: structured prompt validator cargo fallback is already running.
+Another validator invocation is probably compiling adl-validate-structured-prompt through cargo.
+Use the dedicated adl-validate-structured-prompt binary, or rerun after the active build finishes.
+lock_dir=$lock_dir
+timeout_seconds=$timeout_secs
+MSG
+      exit 75
+    fi
+    sleep 0.2
+  done
+  ADL_VALIDATOR_BUILD_LOCK_HELD="$lock_dir"
+  trap 'if [[ -n "${ADL_VALIDATOR_BUILD_LOCK_HELD:-}" ]]; then rmdir "$ADL_VALIDATOR_BUILD_LOCK_HELD" 2>/dev/null || true; fi' EXIT
+}
+
+run_if_executable() {
+  local candidate="$1"
+  shift
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    exec "$candidate" "$@"
+  fi
+}
+
 ROOT_DIR="$(resolve_manifest_root)"
+PRIMARY_ROOT="$(resolve_primary_root "$ROOT_DIR")"
+EXPLICIT_VALIDATOR_BIN="${ADL_STRUCTURED_PROMPT_VALIDATOR_BIN:-}"
+ALLOW_CARGO_FALLBACK="${ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK:-0}"
+DISABLE_PATH_LOOKUP="${ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP:-0}"
+
+if [[ -n "$EXPLICIT_VALIDATOR_BIN" && ! -x "$EXPLICIT_VALIDATOR_BIN" ]]; then
+  echo "ERROR: ADL_STRUCTURED_PROMPT_VALIDATOR_BIN is not executable: $EXPLICIT_VALIDATOR_BIN" >&2
+  exit 1
+fi
+
+run_if_executable "$EXPLICIT_VALIDATOR_BIN" "$@"
+run_if_executable "$ROOT_DIR/adl/target/debug/adl-validate-structured-prompt" "$@"
+run_if_executable "$PRIMARY_ROOT/adl/target/debug/adl-validate-structured-prompt" "$@"
+if [[ "$DISABLE_PATH_LOOKUP" != "1" ]] && command -v adl-validate-structured-prompt >/dev/null 2>&1; then
+  exec adl-validate-structured-prompt "$@"
+fi
+
+if [[ "$ALLOW_CARGO_FALLBACK" != "1" ]]; then
+  cat >&2 <<MSG
+ERROR: missing dedicated adl-validate-structured-prompt binary.
+Expected one of:
+- ADL_STRUCTURED_PROMPT_VALIDATOR_BIN
+- $ROOT_DIR/adl/target/debug/adl-validate-structured-prompt
+- $PRIMARY_ROOT/adl/target/debug/adl-validate-structured-prompt
+- adl-validate-structured-prompt on PATH
+Build it first with: cargo build --manifest-path $PRIMARY_ROOT/adl/Cargo.toml --bin adl-validate-structured-prompt
+Set ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK=1 only for explicit bootstrap/debug use.
+MSG
+  exit 75
+fi
+
 LEGACY_TOOLING_BIN="${ADL_TOOLING_RUST_BIN:-${ADL_PR_RUST_BIN:-}}"
-VALIDATOR_BIN="${ADL_STRUCTURED_PROMPT_VALIDATOR_BIN:-}"
-
-if [[ -n "$LEGACY_TOOLING_BIN" && ! -x "$LEGACY_TOOLING_BIN" ]]; then
-  LEGACY_TOOLING_BIN=""
-fi
-
-if [[ -n "$VALIDATOR_BIN" && ! -x "$VALIDATOR_BIN" ]]; then
-  VALIDATOR_BIN=""
-fi
-
-if [[ -n "$LEGACY_TOOLING_BIN" ]]; then
+if [[ -n "$LEGACY_TOOLING_BIN" && -x "$LEGACY_TOOLING_BIN" ]]; then
   exec "$LEGACY_TOOLING_BIN" tooling validate-structured-prompt "$@"
 fi
 
-if [[ -n "$VALIDATOR_BIN" ]]; then
-  exec "$VALIDATOR_BIN" "$@"
-fi
+BUILD_LOCK_DIR="${ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_DIR:-$PRIMARY_ROOT/adl/target/.adl-validate-structured-prompt-build.lock}"
+BUILD_LOCK_TIMEOUT_SECS="${ADL_STRUCTURED_PROMPT_VALIDATOR_BUILD_LOCK_TIMEOUT_SECS:-5}"
+mkdir -p "$(dirname "$BUILD_LOCK_DIR")"
+ADL_VALIDATOR_BUILD_LOCK_HELD=""
+acquire_build_lock "$BUILD_LOCK_DIR" "$BUILD_LOCK_TIMEOUT_SECS"
 
-DEFAULT_BIN="$ROOT_DIR/adl/target/debug/adl-validate-structured-prompt"
-if [[ -x "$DEFAULT_BIN" ]]; then
-  exec "$DEFAULT_BIN" "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl-validate-structured-prompt -- "$@"
+set +e
+cargo run --quiet --manifest-path "$PRIMARY_ROOT/adl/Cargo.toml" --bin adl-validate-structured-prompt -- "$@"
+status="$?"
+set -e
+rmdir "$BUILD_LOCK_DIR" 2>/dev/null || true
+ADL_VALIDATOR_BUILD_LOCK_HELD=""
+trap - EXIT
+exit "$status"


### PR DESCRIPTION
Closes #3802

## Summary
Fixed structured prompt validation so normal worktree calls use the dedicated `adl-validate-structured-prompt` binary instead of silently falling back to `cargo run`. Missing-binary and explicit cargo-fallback paths now fail boundedly or use a guarded build lock with cleanup.

## Artifacts
- Updated wrapper: `adl/tools/validate_structured_prompt.sh`
- Added focused regression test: `adl/tools/test_validate_structured_prompt_parallel.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validate_structured_prompt_parallel.sh`
    Verified missing dedicated-binary diagnostics, legacy fallback gating, explicit cargo-fallback lock cleanup, and fresh lock-parent handling.
  - `/usr/bin/time -p bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.5/tasks/issue-3802__v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics/srp.md`
    Verified normal SRP validation uses the dedicated binary path and completes in about `0.01s`.
  - `/usr/bin/time -p bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.5/tasks/issue-3802__v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics/sor.md`
    Verified normal SOR validation uses the dedicated binary path and completes in about `0.01s`.
  - Concurrent SRP/SOR validation smoke command
    Verified two validators can run together and emit independent PASS output.
  - `git diff --check`
    Verified whitespace/path diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3802__v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3802__v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics/sor.md
- Idempotency-Key: v0-91-5-tooling-use-fast-structured-prompt-validator-binary-adl-tools-validate-structured-prompt-sh-adl-tools-test-validate-structured-prompt-parallel-sh-adl-v0-91-5-tasks-issue-3802-v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics-sip-md-adl-v0-91-5-tasks-issue-3802-v0-91-5-tooling-fix-parallel-prompt-card-validation-hang-diagnostics-sor-md