### PR TITLE
[v0.91.5][tooling] Align prompt-card enum diagnostics with lifecycle states

### DIFF
--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -26,6 +26,27 @@ const ALLOWED_CARD_STATUS: &[&str] = &[
     "superseded",
 ];
 
+fn allowed_values_error(field: &str, actual: &str, allowed: &[&str]) -> String {
+    let actual = if actual.trim().is_empty() {
+        "<empty>"
+    } else {
+        actual
+    };
+    format!(
+        "{field} must be one of: {}; actual: {actual}",
+        allowed.join(", ")
+    )
+}
+
+fn ensure_allowed_value(field: &str, actual: &str, allowed: &[&str]) -> Result<()> {
+    ensure!(
+        allowed.contains(&actual),
+        "{}",
+        allowed_values_error(field, actual, allowed)
+    );
+    Ok(())
+}
+
 pub(super) fn real_lint_prompt_spec(args: &[String]) -> Result<()> {
     let input = resolve_issue_or_input_arg(args)?;
     ensure_file(&input, "input card")?;
@@ -363,10 +384,7 @@ fn validate_reference_sequence(fm: &serde_yaml::Mapping, key: &str) -> Result<()
 
 fn validate_optional_front_matter_card_status(fm: &serde_yaml::Mapping) -> Result<()> {
     if let Some(card_status) = mapping_string(fm, "card_status") {
-        ensure!(
-            ALLOWED_CARD_STATUS.contains(&card_status.as_str()),
-            "card_status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded"
-        );
+        ensure_allowed_value("card_status", &card_status, ALLOWED_CARD_STATUS)?;
     }
     Ok(())
 }
@@ -399,10 +417,7 @@ fn validate_completed_srp_card_status(fm: &serde_yaml::Mapping) -> Result<()> {
 
 fn validate_optional_markdown_card_status(text: &str) -> Result<()> {
     if let Some(card_status) = markdown_field(text, "Card Status") {
-        ensure!(
-            ALLOWED_CARD_STATUS.contains(&card_status.as_str()),
-            "Card Status must be one of: draft, ready, reviewed, approved, completed, blocked, superseded"
-        );
+        ensure_allowed_value("Card Status", &card_status, ALLOWED_CARD_STATUS)?;
     }
     Ok(())
 }
@@ -458,16 +473,14 @@ pub(super) fn validate_stp_text(text: &str) -> Result<()> {
         "issue_number must be an integer"
     );
     let status = mapping_string(fm, "status").unwrap_or_default();
-    ensure!(
-        ["draft", "active", "complete"].contains(&status.as_str()),
-        "status must be one of: draft, active, complete"
-    );
+    ensure_allowed_value("status", &status, &["draft", "active", "complete"])?;
     validate_optional_front_matter_card_status(fm)?;
     let action = mapping_string(fm, "action").unwrap_or_default();
-    ensure!(
-        ["create", "edit", "close", "split", "supersede"].contains(&action.as_str()),
-        "action must be one of: create, edit, close, split, supersede"
-    );
+    ensure_allowed_value(
+        "action",
+        &action,
+        &["create", "edit", "close", "split", "supersede"],
+    )?;
     ensure!(
         mapping_contains(fm, "depends_on"),
         "missing required field: depends_on"
@@ -642,12 +655,13 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         "Integration state",
     )
     .unwrap_or_default();
-    ensure!(
-        integration_state.is_empty()
-            || ["worktree_only", "pr_open", "merged", "closed_no_pr"]
-                .contains(&integration_state.as_str()),
-        "Main Repo Integration.Integration state must be one of: worktree_only, pr_open, merged, closed_no_pr"
-    );
+    if !integration_state.is_empty() {
+        ensure_allowed_value(
+            "Main Repo Integration.Integration state",
+            &integration_state,
+            &["worktree_only", "pr_open", "merged", "closed_no_pr"],
+        )?;
+    }
     let branch = markdown_field(text, "Branch").unwrap_or_default();
     let branch_ok = if phase == Some("bootstrap") {
         valid_branch(&branch) || branch.eq_ignore_ascii_case("not bound yet")
@@ -668,10 +682,7 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         }
     );
     let status = markdown_field(text, "Status").unwrap_or_default();
-    ensure!(
-        ALLOWED_OUTPUT_STATUS.contains(&status.as_str()),
-        "Status must be one of: NOT_STARTED, IN_PROGRESS, DONE, FAILED"
-    );
+    ensure_allowed_value("Status", &status, ALLOWED_OUTPUT_STATUS)?;
     let start = markdown_block_field(text, "Execution", "Start Time").unwrap_or_default();
     ensure!(
         start.is_empty() || valid_iso8601_datetime(&start),
@@ -688,17 +699,18 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         "Verification scope",
     )
     .unwrap_or_default();
-    ensure!(
-        verification_scope.is_empty()
-            || ["worktree", "pr_branch", "main_repo"].contains(&verification_scope.as_str()),
-        "Main Repo Integration.Verification scope must be one of: worktree, pr_branch, main_repo"
-    );
+    if !verification_scope.is_empty() {
+        ensure_allowed_value(
+            "Main Repo Integration.Verification scope",
+            &verification_scope,
+            &["worktree", "pr_branch", "main_repo"],
+        )?;
+    }
     let result = markdown_block_field(text, "Main Repo Integration (REQUIRED)", "Result")
         .unwrap_or_default();
-    ensure!(
-        result.is_empty() || ["PASS", "FAIL"].contains(&result.as_str()),
-        "Main Repo Integration.Result must be one of: PASS, FAIL"
-    );
+    if !result.is_empty() {
+        ensure_allowed_value("Main Repo Integration.Result", &result, &["PASS", "FAIL"])?;
+    }
     if markdown_field(text, "Card Status").as_deref() == Some("completed") {
         let worktree_only = markdown_block_field(
             text,
@@ -845,11 +857,12 @@ pub(super) fn validate_spp_text(text: &str) -> Result<()> {
         valid_branch(&branch) || branch.eq_ignore_ascii_case("not bound yet"),
         "branch must be a codex/ branch or `not bound yet`"
     );
-    ensure!(
-        ["draft", "ready", "reviewed", "approved"]
-            .contains(&mapping_string(fm, "status").unwrap_or_default().as_str()),
-        "status must be one of: draft, ready, reviewed, approved"
-    );
+    let status = mapping_string(fm, "status").unwrap_or_default();
+    ensure_allowed_value(
+        "status",
+        &status,
+        &["draft", "ready", "reviewed", "approved"],
+    )?;
     validate_optional_front_matter_card_status(fm)?;
     ensure!(
         mapping_string(fm, "plan_revision")
@@ -867,10 +880,7 @@ pub(super) fn validate_spp_text(text: &str) -> Result<()> {
         "missing required field: constraints"
     );
     let confidence = mapping_string(fm, "confidence").unwrap_or_default();
-    ensure!(
-        ["low", "medium", "high"].contains(&confidence.as_str()),
-        "confidence must be one of: low, medium, high"
-    );
+    ensure_allowed_value("confidence", &confidence, &["low", "medium", "high"])?;
     ensure!(
         !mapping_string(fm, "plan_summary")
             .unwrap_or_default()
@@ -939,10 +949,11 @@ pub(super) fn validate_spp_text(text: &str) -> Result<()> {
         let step = mapping_string(item, "step").unwrap_or_default();
         ensure!(!step.is_empty(), "codex_plan.step must be non-empty");
         let status = mapping_string(item, "status").unwrap_or_default();
-        ensure!(
-            ["pending", "in_progress", "completed"].contains(&status.as_str()),
-            "codex_plan.status must be one of: pending, in_progress, completed"
-        );
+        ensure_allowed_value(
+            "codex_plan.status",
+            &status,
+            &["pending", "in_progress", "completed"],
+        )?;
     }
 
     Ok(())
@@ -1012,11 +1023,8 @@ pub(super) fn validate_srp_text(text: &str) -> Result<()> {
         valid_branch(&branch) || branch.eq_ignore_ascii_case("not bound yet"),
         "branch must be a codex/ branch or `not bound yet`"
     );
-    ensure!(
-        ["draft", "ready", "approved"]
-            .contains(&mapping_string(fm, "status").unwrap_or_default().as_str()),
-        "status must be one of: draft, ready, approved"
-    );
+    let status = mapping_string(fm, "status").unwrap_or_default();
+    ensure_allowed_value("status", &status, &["draft", "ready", "approved"])?;
     validate_optional_front_matter_card_status(fm)?;
     validate_completed_srp_card_status(fm)?;
     validate_reference_sequence(fm, "source_refs")?;

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -1,5 +1,9 @@
 use super::support::*;
 use super::*;
+use crate::cli::tooling_cmd::structured_prompt::{
+    prompt_spec_bool, prompt_spec_review_surfaces, prompt_spec_sections, real_lint_prompt_spec,
+    validate_spp_text,
+};
 
 #[test]
 fn structured_prompt_validators_accept_canonical_cards() {
@@ -232,6 +236,71 @@ fn validate_structured_prompt_accepts_all_supported_prompt_types() {
 }
 
 #[test]
+fn structured_prompt_lint_prompt_spec_and_helpers_cover_prompt_spec_contract() {
+    let repo = TempRepo::new("structured-prompt-spec-lint");
+    let sip_text = valid_sip_text(1374, repo.path());
+    let sip = repo.write_rel(".tmp/tooling_cmd_tests/sip.md", &sip_text);
+
+    real_lint_prompt_spec(&["--input".to_string(), sip.to_string_lossy().to_string()])
+        .expect("valid SIP prompt spec should lint");
+
+    let spec = extract_prompt_spec_yaml(&sip_text).expect("extract prompt spec");
+    let sections = prompt_spec_sections(&spec);
+    assert!(sections.contains(&"goal".to_string()));
+    assert!(sections.contains(&"validation_plan".to_string()));
+    assert_eq!(prompt_spec_bool(&spec, "disallow_secrets"), Some(true));
+    assert_eq!(prompt_spec_bool(&spec, "not_a_prompt_key"), None);
+    assert_eq!(
+        prompt_spec_review_surfaces(&sip_text),
+        super::common::REQUIRED_REVIEW_SURFACES
+            .iter()
+            .map(|surface| surface.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn structured_prompt_cli_rejects_bad_args_and_unresolved_template_placeholders() {
+    assert!(real_validate_structured_prompt(&["--help".to_string()]).is_ok());
+
+    let err = real_validate_structured_prompt(&[
+        "--type".to_string(),
+        "unknown".to_string(),
+        "--input".to_string(),
+        "missing.md".to_string(),
+    ])
+    .expect_err("missing file should fail before unsupported type");
+    assert!(err.to_string().contains("input"));
+
+    let err = real_validate_structured_prompt(&[
+        "--type".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+    ])
+    .expect_err("missing --input value should fail");
+    assert!(err.to_string().contains("missing value for --input"));
+
+    let repo = TempRepo::new("structured-unresolved-placeholder");
+    let stp = repo.write_rel(
+        ".tmp/tooling_cmd_tests/stp-placeholder.md",
+        &format!(
+            "Canonical Template Source: `docs/templates/prompts/1.0.0/stp.md`\n\n{}",
+            valid_stp_text().replace("## Summary", "## Summary\n\n<summary>\n")
+        ),
+    );
+    let err = real_validate_structured_prompt(&[
+        "--type".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+        stp.to_string_lossy().to_string(),
+    ])
+    .expect_err("unresolved template placeholder should fail");
+    assert!(err
+        .to_string()
+        .contains("unresolved prompt-template placeholder"));
+}
+
+#[test]
 fn structured_prompt_spp_validator_rejects_invalid_codex_plan_status() {
     let repo = TempRepo::new("structured-spp-invalid");
     let spp = repo.write_rel(
@@ -246,6 +315,101 @@ fn structured_prompt_spp_validator_rejects_invalid_codex_plan_status() {
     ])
     .expect_err("invalid codex plan status should fail");
     assert!(err.to_string().contains("codex_plan.status"));
+    assert!(err.to_string().contains("actual: queued"));
+}
+
+#[test]
+fn structured_prompt_srp_status_diagnostic_includes_actual_and_allowed_values() {
+    let srp = valid_srp_text(1374).replace("status: \"draft\"", "status: \"completed\"");
+
+    let err = validate_srp_text(&srp).expect_err("invalid SRP lifecycle status should fail");
+    let message = err.to_string();
+    assert!(message.contains("status"));
+    assert!(message.contains("draft, ready, approved"));
+    assert!(message.contains("actual: completed"));
+}
+
+#[test]
+fn structured_prompt_sor_verification_scope_diagnostic_includes_actual_and_allowed_values() {
+    let sor = valid_sor_text().replace(
+        "Verification scope: main_repo",
+        "Verification scope: issue worktree",
+    );
+
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("invalid SOR verification scope should fail");
+    let message = err.to_string();
+    assert!(message.contains("Main Repo Integration.Verification scope"));
+    assert!(message.contains("worktree, pr_branch, main_repo"));
+    assert!(message.contains("actual: issue worktree"));
+}
+
+#[test]
+fn structured_prompt_stp_status_and_action_diagnostics_include_actual_values() {
+    let stp = valid_stp_text().replace("status: \"draft\"", "status: \"queued\"");
+    let err = validate_stp_text(&stp).expect_err("invalid STP status should fail");
+    let message = err.to_string();
+    assert!(message.contains("status"));
+    assert!(message.contains("draft, active, complete"));
+    assert!(message.contains("actual: queued"));
+
+    let stp = valid_stp_text().replace("action: \"edit\"", "action: \"rewrite\"");
+    let err = validate_stp_text(&stp).expect_err("invalid STP action should fail");
+    let message = err.to_string();
+    assert!(message.contains("action"));
+    assert!(message.contains("create, edit, close, split, supersede"));
+    assert!(message.contains("actual: rewrite"));
+}
+
+#[test]
+fn structured_prompt_spp_status_and_confidence_diagnostics_include_actual_values() {
+    let spp = valid_spp_text(1374).replace("status: \"draft\"", "status: \"started\"");
+    let err = validate_spp_text(&spp).expect_err("invalid SPP status should fail");
+    let message = err.to_string();
+    assert!(message.contains("status"));
+    assert!(message.contains("draft, ready, reviewed, approved"));
+    assert!(message.contains("actual: started"));
+
+    let spp = valid_spp_text(1374).replace("confidence: \"medium\"", "confidence: \"certain\"");
+    let err = validate_spp_text(&spp).expect_err("invalid SPP confidence should fail");
+    let message = err.to_string();
+    assert!(message.contains("confidence"));
+    assert!(message.contains("low, medium, high"));
+    assert!(message.contains("actual: certain"));
+}
+
+#[test]
+fn structured_prompt_sor_status_integration_and_result_diagnostics_include_actual_values() {
+    let sor = valid_sor_text().replace("Status: DONE", "Status: COMPLETE");
+    let err =
+        validate_sor_text(&sor, Some("completed")).expect_err("invalid SOR status should fail");
+    let message = err.to_string();
+    assert!(message.contains("Status"));
+    assert!(message.contains("NOT_STARTED, IN_PROGRESS, DONE, FAILED"));
+    assert!(message.contains("actual: COMPLETE"));
+
+    let sor = valid_sor_text().replace("Integration state: merged", "Integration state: done");
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("invalid SOR integration state should fail");
+    let message = err.to_string();
+    assert!(message.contains("Main Repo Integration.Integration state"));
+    assert!(message.contains("worktree_only, pr_open, merged, closed_no_pr"));
+    assert!(message.contains("actual: done"));
+
+    let sor = valid_sor_text().replace("Result: PASS", "Result: MAYBE");
+    let err =
+        validate_sor_text(&sor, Some("completed")).expect_err("invalid SOR result should fail");
+    let message = err.to_string();
+    assert!(message.contains("Main Repo Integration.Result"));
+    assert!(message.contains("PASS, FAIL"));
+    assert!(message.contains("actual: MAYBE"));
+}
+
+#[test]
+fn structured_prompt_missing_enum_values_report_empty_actual_value() {
+    let stp = valid_stp_text().replace("status: \"draft\"", "status: \"\"");
+    let err = validate_stp_text(&stp).expect_err("empty STP status should fail");
+    assert!(err.to_string().contains("actual: <empty>"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #3803

## Summary
Improved structured prompt enum diagnostics without loosening lifecycle validation. Invalid enum failures now include the field name, accepted values, and the actual invalid value for SRP/SOR and related lifecycle enum checks.

## Artifacts
- Updated `adl/src/cli/tooling_cmd/structured_prompt.rs` with a shared enum diagnostic helper.
- Updated `adl/src/cli/tooling_cmd/tests/structured_prompt.rs` with focused regression coverage for invalid SRP status, invalid SOR verification scope, and invalid `codex_plan.status` diagnostic content.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml cli::tooling_cmd::tests::structured_prompt -- --nocapture`
    Verified the structured prompt validator rejects invalid enum values and reports field, accepted values, and actual invalid value; result PASS.
  - `git diff --check`
    Verified diff whitespace hygiene; result PASS.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3803__v0-91-5-tooling-align-prompt-card-enum-diagnostics-with-lifecycle-states/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3803__v0-91-5-tooling-align-prompt-card-enum-diagnostics-with-lifecycle-states/sor.md
- Idempotency-Key: v0-91-5-tooling-align-prompt-card-enum-diagnostics-with-lifecycle-states-adl-v0-91-5-tasks-issue-3803-v0-91-5-tooling-align-prompt-card-enum-diagnostics-with-lifecycle-states-sip-md-adl-v0-91-5-tasks-issue-3803-v0-91-5-tooling-align-prompt-card-enum-diagnostics-with-lifecycle-states-sor-md