### PR TITLE
[v0.91.5][tooling] Refine lifecycle-card absolute-path leakage diagnostics

### DIFF
--- a/adl/src/cli/tooling_cmd/common.rs
+++ b/adl/src/cli/tooling_cmd/common.rs
@@ -170,8 +170,31 @@ pub(super) fn ensure_no_absolute_host_path(path: &Path, prompt_type: &str) -> Re
 pub(super) fn contains_absolute_host_path_in_text(text: &str) -> bool {
     ["/Users/", "/home/", "/tmp/", "/var/folders/"]
         .iter()
-        .any(|needle| text.contains(needle))
+        .any(|needle| contains_unix_absolute_host_path(text, needle))
         || text.contains(":\\")
+}
+
+fn contains_unix_absolute_host_path(text: &str, prefix: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(index) = text[offset..].find(prefix) {
+        let end = offset + index + prefix.len();
+        if !text[end..]
+            .chars()
+            .next()
+            .is_none_or(is_safe_scan_pattern_delimiter)
+        {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+fn is_safe_scan_pattern_delimiter(ch: char) -> bool {
+    matches!(
+        ch,
+        '`' | '\'' | '"' | ')' | ']' | '}' | ',' | ';' | ':' | '\n' | '\r'
+    ) || ch.is_whitespace()
 }
 
 pub(super) fn contains_secret_like_token(text: &str) -> bool {

--- a/adl/src/cli/tooling_cmd/tests/common_helpers.rs
+++ b/adl/src/cli/tooling_cmd/tests/common_helpers.rs
@@ -107,6 +107,18 @@ fn code_review_filter_covers_common_helpers_argument_and_content_guards() {
     assert!(contains_secret_like_token("ghs_1234567890"));
     assert!(!contains_secret_like_token("mask sk_short"));
     assert!(contains_absolute_host_path_in_text("/tmp/example"));
+    assert!(contains_absolute_host_path_in_text(
+        "/Users/daniel/tmp/artifact.txt"
+    ));
+    assert!(contains_absolute_host_path_in_text("/tmp/@artifact"));
+    assert!(contains_absolute_host_path_in_text("/tmp//artifact"));
+    assert!(contains_absolute_host_path_in_text("/tmp/[artifact]"));
+    assert!(!contains_absolute_host_path_in_text(
+        "scan patterns: /Users/, /home/, /tmp/, /var/folders/"
+    ));
+    assert!(!contains_absolute_host_path_in_text(
+        "scan pattern token: `/tmp/`"
+    ));
     assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
     assert!(!contains_absolute_host_path_in_text("relative/path"));
 
@@ -152,6 +164,11 @@ fn code_review_filter_covers_common_helpers_safety_and_path_branches() {
 
     assert!(contains_absolute_host_path_in_text(
         "/Users/example/project"
+    ));
+    assert!(contains_absolute_host_path_in_text("/tmp/@artifact"));
+    assert!(contains_absolute_host_path_in_text("/tmp//artifact"));
+    assert!(!contains_absolute_host_path_in_text(
+        "safe scan pattern names: /Users/ and /tmp/"
     ));
     assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
     assert!(!contains_absolute_host_path_in_text("relative/path"));

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -181,6 +181,17 @@ fn structured_prompt_sor_completed_card_status_requires_full_closeout_truth() {
 }
 
 #[test]
+fn structured_prompt_sor_allows_safe_absolute_path_scan_pattern_description() {
+    let sor = valid_sor_text().replace(
+        "- Absolute path leakage check: passed",
+        "- Absolute path leakage check: scanned host-local path patterns `/Users/`, `/home/`, `/tmp/`, and `/var/folders/`; no concrete host-local paths were recorded.",
+    );
+
+    validate_sor_text(&sor, Some("completed"))
+        .expect("safe scan pattern descriptions should not count as host-path leaks");
+}
+
+#[test]
 fn validate_structured_prompt_accepts_all_supported_prompt_types() {
     let repo = TempRepo::new("structured");
     let stp = repo.write_rel(".tmp/tooling_cmd_tests/stp.md", &valid_stp_text());

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -140,6 +140,14 @@ Execution preflight is intentionally stricter than enum validation:
 - `SOR` may be `completed` only after terminal closeout truth is present.
 - `SOR` execution `Status` remains separate from card lifecycle `Card Status`.
 
+## Host-Path Scan Wording
+
+Lifecycle cards must not record concrete machine-local absolute paths. It is
+acceptable to describe the scan patterns that were checked, such as `/Users/`,
+`/home/`, `/tmp/`, and `/var/folders/`, when the card also states that no
+concrete host-local paths were recorded. Do not include example usernames,
+temporary directories, or full local artifact paths in durable cards.
+
 ## Compatibility
 
 Older files under `adl/templates/cards/` and legacy structured-prompt template


### PR DESCRIPTION
Closes #3804

## Summary
Refined lifecycle-card absolute-path leakage diagnostics so documented scan-pattern examples remain allowed, while concrete host-path artifacts under those prefixes are rejected. Added focused tests and README guidance for safe scan-pattern wording.

## Artifacts
- Updated detector logic in `adl/src/cli/tooling_cmd/common.rs`
- Added focused helper coverage in `adl/src/cli/tooling_cmd/tests/common_helpers.rs`
- Added structured-prompt regression coverage in `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`
- Documented safe scan-pattern wording in `docs/templates/prompts/README.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml tooling_cmd::tests -- --nocapture`
    Verified focused tooling command behavior and the absolute-path leakage diagnostics regressions.
  - `git diff --check`
    Verified whitespace hygiene for changed files.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind srp --input .adl/v0.91.5/tasks/issue-3804__v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics/srp.md`
    Verified SRP structure after review-result repair.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase finish --input .adl/v0.91.5/tasks/issue-3804__v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics/sor.md`
    Verified final SOR lifecycle contract compliance after execution-truth repair.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3804__v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3804__v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics/sor.md
- Idempotency-Key: v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics-adl-v0-91-5-tasks-issue-3804-v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics-sip-md-adl-v0-91-5-tasks-issue-3804-v0-91-5-tooling-refine-lifecycle-card-absolute-path-leakage-diagnostics-sor-md