### PR TITLE
[v0.91.5][tools][coverage-impact] Make pr_cmd risky-file guidance more specific

### DIFF
--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -160,6 +160,9 @@ changed_line_delta_for_path() {
 candidate_filter_for_path() {
   local path="$1"
   case "$path" in
+    adl/src/cli/pr_cmd/finish_support.rs)
+      printf 'finish'
+      ;;
     adl/src/governed_executor_parts/*.rs|adl/src/governed_executor.rs)
       printf 'governed_executor'
       ;;
@@ -199,6 +202,18 @@ candidate_filter_for_path() {
   esac
 }
 
+extra_guidance_for_path() {
+  local path="$1"
+  case "$path" in
+    adl/src/cli/pr_cmd/github.rs)
+      cat <<'EOF'
+    note: github.rs is a mixed-purpose pr_cmd helper surface, so the fail-closed candidate filter remains pr_cmd.
+    bounded finish-only helper edits may justify a smaller approved synthesis path, but that narrower path should only be used when the changed behavior is explicitly limited to finish-path helpers.
+EOF
+      ;;
+  esac
+}
+
 focused_summary_command_for_filter() {
   local filter="$1"
   printf 'cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- %s' "$filter"
@@ -223,6 +238,7 @@ print_next_actions_for_path() {
   filter="$(candidate_filter_for_path "$path")"
   echo "    candidate filter: ${filter}"
   echo "    ${context}: $(focused_summary_command_for_filter "$filter")"
+  extra_guidance_for_path "$path"
   echo "    rerun preflight: $(rerun_preflight_command)"
 }
 

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -56,6 +56,18 @@ control_plane_filters="$TMP/control-plane-filters.txt"
 bash "$SCRIPT" --changed-files "$control_plane_changed" --print-risk-filters >"$control_plane_filters"
 grep -Fx "pr_cmd" "$control_plane_filters" >/dev/null
 
+finish_helper_changed="$TMP/finish-helper-changed.txt"
+printf 'A\tadl/src/cli/pr_cmd/finish_support.rs\n' >"$finish_helper_changed"
+finish_helper_filters="$TMP/finish-helper-filters.txt"
+bash "$SCRIPT" --changed-files "$finish_helper_changed" --print-risk-filters >"$finish_helper_filters"
+grep -Fx "finish" "$finish_helper_filters" >/dev/null
+
+mixed_pr_cmd_helper_changed="$TMP/mixed-pr-cmd-helper-changed.txt"
+printf 'A\tadl/src/cli/pr_cmd/github.rs\n' >"$mixed_pr_cmd_helper_changed"
+mixed_pr_cmd_helper_filters="$TMP/mixed-pr-cmd-helper-filters.txt"
+bash "$SCRIPT" --changed-files "$mixed_pr_cmd_helper_changed" --print-risk-filters >"$mixed_pr_cmd_helper_filters"
+grep -Fx "pr_cmd" "$mixed_pr_cmd_helper_filters" >/dev/null
+
 split_runtime_changed="$TMP/split-runtime-changed.txt"
 printf 'A\tadl/src/runtime_v2/cultivating_intelligence_parts/builder.rs\n' >"$split_runtime_changed"
 split_runtime_filters="$TMP/split-runtime-filters.txt"
@@ -124,6 +136,20 @@ grep -F "new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "candidate filter: new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base origin/main --changed-files $changed --summary adl/target/coverage-impact-summary.json --require-summary-for-risk" /tmp/coverage-impact-missing.out >/dev/null
+
+if bash "$SCRIPT" --changed-files "$finish_helper_changed" --require-summary-for-risk >/tmp/coverage-impact-finish-helper-missing.out 2>&1; then
+  echo "expected bounded finish helper guidance to fail without summary" >&2
+  exit 1
+fi
+grep -F "candidate filter: finish" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- finish" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
+
+if bash "$SCRIPT" --changed-files "$mixed_pr_cmd_helper_changed" --require-summary-for-risk >/tmp/coverage-impact-mixed-helper-missing.out 2>&1; then
+  echo "expected mixed pr_cmd helper guidance to fail without summary" >&2
+  exit 1
+fi
+grep -F "candidate filter: pr_cmd" /tmp/coverage-impact-mixed-helper-missing.out >/dev/null
+grep -F "github.rs is a mixed-purpose pr_cmd helper surface" /tmp/coverage-impact-mixed-helper-missing.out >/dev/null
 
 branch_diff_changed="$TMP/branch-diff-changed.txt"
 printf 'A\tadl/src/runtime_v2/branch_mode_surface.rs\n' >"$branch_diff_changed"


### PR DESCRIPTION
Closes #3829

## Summary
Refined coverage-impact guidance so bounded `finish_support.rs` changes now recommend the narrower `finish` coverage filter, while mixed-purpose `github.rs` changes stay fail-closed on the broad `pr_cmd` guidance with an explicit bounded-finish note.

## Artifacts
- Updated risky-file guidance in `adl/tools/check_coverage_impact.sh`
- Focused shell regression coverage in `adl/tools/test_check_coverage_impact.sh`
- Local ignored execution record at `.adl/v0.91.5/tasks/issue-3829__v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_check_coverage_impact.sh`
    Verified the updated risky-file guidance contract and regression coverage.
  - `bash adl/tools/check_coverage_impact.sh --changed-files <(printf 'A\tadl/src/cli/pr_cmd/finish_support.rs\n') --require-summary-for-risk`
    Verified `finish_support.rs` now emits the narrower `finish` candidate filter guidance.
  - `bash adl/tools/check_coverage_impact.sh --changed-files <(printf 'A\tadl/src/cli/pr_cmd/github.rs\n') --require-summary-for-risk`
    Verified `github.rs` remains fail-closed on `pr_cmd` guidance and includes the mixed-purpose explanatory note.
  - `git diff --check`
    Verified patch hygiene on the final tracked diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3829__v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3829__v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific/sor.md
- Idempotency-Key: v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific-adl-v0-91-5-tasks-issue-3829-v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific-sip-md-adl-v0-91-5-tasks-issue-3829-v0-91-5-tools-coverage-impact-make-pr-cmd-risky-file-guidance-more-specific-sor-md