### PR TITLE
[v0.91.5][tools] Prevent nested worktree binding from issue worktrees

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -423,6 +423,7 @@ fn real_pr_create(args: &[String]) -> Result<()> {
 fn real_pr_start(args: &[String]) -> Result<()> {
     let parsed = parse_start_args(args)?;
     let repo_root = repo_root()?;
+    let primary_root = primary_checkout_root()?;
     let repo = default_repo(&repo_root)?;
     let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
 
@@ -461,6 +462,14 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         if slug.is_empty() {
             slug = sanitize_slug(&title);
         }
+    }
+    if !same_checkout_root(&repo_root, &primary_root)? {
+        bail!(
+            "start: issue-mode run must be invoked from the primary checkout, not from an existing issue worktree. Current checkout: '{}'. Primary checkout: '{}'. Remediation: continue working in the current issue worktree if it already matches your target issue, or rerun `adl/tools/pr.sh run {}` from the primary checkout.",
+            repo_root.display(),
+            primary_root.display(),
+            parsed.issue
+        );
     }
     if title.is_empty() {
         title = slug.clone();

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -267,6 +267,131 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 }
 
 #[test]
+fn real_pr_start_rejects_invocation_from_existing_issue_worktree() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-nested-worktree-guard");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "nested guard placeholder\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let issue_ref = IssueRef::new(3819, "v0.91.5", "nested-worktree-guard").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.91.5][tools] Nested worktree guard");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.91.5][tools] Nested worktree guard",
+        "codex/3819-v0-91-5-tools-nested-worktree-guard",
+    );
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir repo");
+    real_pr(&[
+        "start".to_string(),
+        "3819".to_string(),
+        "--slug".to_string(),
+        "nested-worktree-guard".to_string(),
+        "--title".to_string(),
+        "[v0.91.5][tools] Nested worktree guard".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect("initial start");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    env::set_current_dir(&worktree).expect("chdir worktree");
+    let err = real_pr(&[
+        "start".to_string(),
+        "3819".to_string(),
+        "--slug".to_string(),
+        "nested-worktree-guard".to_string(),
+        "--title".to_string(),
+        "[v0.91.5][tools] Nested worktree guard".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect_err("issue worktree invocation should fail clearly");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let err = err.to_string();
+    assert!(err.contains("must be invoked from the primary checkout"));
+    assert!(err.contains(&repo.display().to_string()));
+    assert!(err.contains(&worktree.display().to_string()));
+    assert!(
+        !worktree.join(".worktrees").exists(),
+        "nested worktree root should not be created inside the issue worktree"
+    );
+}
+
+#[test]
 fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-repair-worktree-bundle");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2403,6 +2403,7 @@ Notes:
 - Deprecated compatibility shim. Prefer `adl/tools/pr.sh run <issue> ...`.
 - Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
 - Leaves the primary checkout on its current branch.
+- Must be invoked from the primary checkout; started issue worktrees should continue the bound issue work, not bind nested worktrees.
 - `--version` overrides inferred issue version when the caller already knows the intended milestone band.
 - Refuses to start a later issue when an open PR already exists in the same milestone queue unless `--allow-open-pr-wave` is passed.
 EOF
@@ -2417,6 +2418,7 @@ Usage:
 Notes:
 - Issue mode:
   - preferred public binder for execution-time branch and worktree creation
+  - run from the primary checkout; started issue worktrees should continue the bound issue work, not bind nested worktrees
   - delegates to the Rust PR control-plane binder
 - ADL file mode:
   - bounded v0.85 control-plane wrapper over `cargo run --bin adl -- ...`


### PR DESCRIPTION
Closes #3819

## Summary
Added an explicit guard in `real_pr_start` so issue-mode binding refuses to run from inside an existing issue worktree and instructs the operator to use the primary checkout or continue working in the current bound worktree. This prevents nested target paths like `.worktrees/adl-wp-3819/.worktrees/adl-wp-3819`.

## Artifacts
- Updated tracked implementation in `adl/src/cli/pr_cmd.rs`
- Added focused regression coverage in `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- Updated `adl/tools/pr.sh` usage text for the primary-checkout binding rule.
- Updated local ignored output record at `.adl/v0.91.5/tasks/issue-3819__v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_rejects_invocation_from_existing_issue_worktree -- --nocapture`
    Verified the focused lifecycle regression for issue-worktree invocation.
  - `bash adl/tools/pr.sh run 3819 --allow-open-pr-wave`
    Verified the live operator-facing error contract from inside the issue worktree. The expected command status was 1.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting on the touched Rust surface.
  - `bash -n adl/tools/pr.sh`
    Verified shell syntax after the usage-note update.
  - `git diff --check`
    Verified patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3819__v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3819__v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees/sor.md
- Idempotency-Key: v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-tools-pr-sh-adl-v0-91-5-tasks-issue-3819-v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees-sip-md-adl-v0-91-5-tasks-issue-3819-v0-91-5-tools-prevent-nested-worktree-binding-from-issue-worktrees-sor-md