### PR TITLE
[v0.91.5][tooling] Treat PR URL opener failure as warning

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use super::git_support::{
     branch_checked_out_worktree_path, commits_ahead_of_origin_main, current_branch, default_repo,
@@ -229,12 +231,111 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     )?;
     attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &pr_url)?;
 
+    println!("{pr_url}");
     if !parsed.no_open {
-        let _ = run_status_allow_failure("open", &[&pr_url])?;
+        let open_result = open_pr_url_nonblocking("open", &pr_url);
+        if !open_result.success {
+            eprintln!("{}", open_result.warning);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct OpenPrUrlResult {
+    pub(super) success: bool,
+    pub(super) warning: String,
+}
+
+const PR_URL_OPENER_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(super) fn open_pr_url_nonblocking(opener: &str, pr_url: &str) -> OpenPrUrlResult {
+    open_pr_url_nonblocking_with_timeout(opener, pr_url, PR_URL_OPENER_TIMEOUT)
+}
+
+pub(super) fn open_pr_url_nonblocking_with_timeout(
+    opener: &str,
+    pr_url: &str,
+    timeout: Duration,
+) -> OpenPrUrlResult {
+    let mut child = match Command::new(opener)
+        .arg(pr_url)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            return OpenPrUrlResult {
+                success: false,
+                warning: format!(
+                    "warning: local PR URL opener could not start; PR publication already succeeded. Open manually: {pr_url} ({err})"
+                ),
+            }
+        }
+    };
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => break,
+            Ok(None) if started.elapsed() < timeout => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return OpenPrUrlResult {
+                    success: false,
+                    warning: format!(
+                        "warning: local PR URL opener timed out after {}s; PR publication already succeeded. Open manually: {pr_url}",
+                        timeout.as_secs()
+                    ),
+                };
+            }
+            Err(err) => {
+                return OpenPrUrlResult {
+                    success: false,
+                    warning: format!(
+                        "warning: local PR URL opener could not be checked; PR publication already succeeded. Open manually: {pr_url} ({err})"
+                    ),
+                };
+            }
+        }
     }
 
-    println!("{pr_url}");
-    Ok(())
+    match child.wait_with_output() {
+        Ok(output) if output.status.success() => OpenPrUrlResult {
+            success: true,
+            warning: String::new(),
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr.trim();
+            let status = output
+                .status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "terminated_by_signal".to_string());
+            OpenPrUrlResult {
+                success: false,
+                warning: format!(
+                    "warning: local PR URL opener failed with status {status}; PR publication already succeeded. Open manually: {pr_url}{}",
+                    if detail.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({detail})")
+                    }
+                ),
+            }
+        }
+        Err(err) => OpenPrUrlResult {
+            success: false,
+            warning: format!(
+                "warning: local PR URL opener could not complete; PR publication already succeeded. Open manually: {pr_url} ({err})"
+            ),
+        },
+    }
 }
 
 pub(super) fn resolve_finish_issue_scope_and_slug(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
-    ensure_finish_task_bundle_surfaces, real_pr_finish, resolve_finish_issue_scope_and_slug,
+    ensure_finish_task_bundle_surfaces, open_pr_url_nonblocking,
+    open_pr_url_nonblocking_with_timeout, real_pr_finish, resolve_finish_issue_scope_and_slug,
     select_finish_validation_plan_for_finish,
 };
 
@@ -28,6 +29,72 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
     assert!(parsed.ready);
     assert!(parsed.allow_gitignore);
     assert!(parsed.no_open);
+}
+
+#[test]
+fn local_pr_url_opener_failure_is_non_blocking_warning() {
+    let temp = unique_temp_dir("adl-pr-url-opener-warning");
+    let opener = temp.join("open");
+    write_executable(
+        &opener,
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'No application knows how to open URL' >&2\nexit 42\n",
+    );
+
+    let result = open_pr_url_nonblocking(
+        path_str(&opener).expect("opener path"),
+        "https://github.com/danielbaustin/agent-design-language/pull/3830",
+    );
+
+    assert!(!result.success);
+    assert!(result
+        .warning
+        .contains("warning: local PR URL opener failed"));
+    assert!(result.warning.contains("PR publication already succeeded"));
+    assert!(result.warning.contains(
+        "Open manually: https://github.com/danielbaustin/agent-design-language/pull/3830"
+    ));
+    assert!(result
+        .warning
+        .contains("No application knows how to open URL"));
+}
+
+#[test]
+fn local_pr_url_opener_spawn_failure_is_non_blocking_warning() {
+    let result = open_pr_url_nonblocking(
+        "/definitely/missing/adl-pr-url-opener",
+        "https://github.com/danielbaustin/agent-design-language/pull/3830",
+    );
+
+    assert!(!result.success);
+    assert!(result
+        .warning
+        .contains("warning: local PR URL opener could not start"));
+    assert!(result.warning.contains("PR publication already succeeded"));
+    assert!(result.warning.contains(
+        "Open manually: https://github.com/danielbaustin/agent-design-language/pull/3830"
+    ));
+}
+
+#[test]
+fn local_pr_url_opener_timeout_is_non_blocking_warning() {
+    let temp = unique_temp_dir("adl-pr-url-opener-timeout");
+    let opener = temp.join("open");
+    write_executable(&opener, "#!/usr/bin/env bash\nset -euo pipefail\nsleep 5\n");
+
+    let result = open_pr_url_nonblocking_with_timeout(
+        path_str(&opener).expect("opener path"),
+        "https://github.com/danielbaustin/agent-design-language/pull/3830",
+        std::time::Duration::from_millis(100),
+    );
+
+    assert!(!result.success);
+    assert!(result
+        .warning
+        .contains("warning: local PR URL opener timed out"));
+    assert!(result.warning.contains("PR publication already succeeded"));
+    assert!(result.warning.contains(
+        "Open manually: https://github.com/danielbaustin/agent-design-language/pull/3830"
+    ));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -123,9 +123,11 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
     let closeout_log = temp.join("closeout.log");
+    let open_log = temp.join("open.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
     let closeout_path = bin_dir.join("closeout");
+    let open_path = bin_dir.join("open");
     write_executable(
             &gh_path,
             &format!(
@@ -145,6 +147,13 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         &format!(
             "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
             closeout_log.display()
+        ),
+    );
+    write_executable(
+        &open_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\necho 'No application knows how to open URL' >&2\nexit 42\n",
+            open_log.display()
         ),
     );
 
@@ -175,7 +184,6 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         "--output".to_string(),
         path_relative_to_repo(&repo, &output),
         "--no-checks".to_string(),
-        "--no-open".to_string(),
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
@@ -246,6 +254,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
     let janitor_calls = fs::read_to_string(&janitor_log).expect("read janitor log");
     let closeout_calls = fs::read_to_string(&closeout_log).expect("read closeout log");
+    let open_calls = fs::read_to_string(&open_log).expect("read open log");
     assert!(gh_calls.contains("pr create"));
     assert!(gh_calls.contains("pr view"));
     assert!(gh_calls.contains("danielbaustin/agent-design-language"));
@@ -258,6 +267,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     assert!(janitor_calls.contains("--expected-pr-state draft"));
     assert!(closeout_calls.contains("--issue 1153"));
     assert!(closeout_calls.contains("--branch codex/1153-rust-finish-test"));
+    assert!(open_calls.contains("https://github.com/danielbaustin/agent-design-language/pull/1159"));
     assert!(closeout_calls
         .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
 }


### PR DESCRIPTION
Closes #3831

## Summary
Implemented bounded PR-publication UX handling so a local browser/opener failure after successful PR creation is reported as a warning instead of a lifecycle failure. The PR URL is printed before the opener attempt so manual access remains available even if macOS LaunchServices, `open`, or another local opener fails.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified no whitespace errors were introduced.
  - `cargo test --manifest-path adl/Cargo.toml local_pr_url_opener -- --nocapture`
    Verified opener failure helper behavior directly, including nonzero exit, spawn failure, and timeout.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture`
    Verified PR creation success remains authoritative when the local URL opener fails afterward.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3831__v0-91-5-tooling-do-not-fail-or-alarm-when-local-url-opener-cannot-open-created-pr/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3831__v0-91-5-tooling-do-not-fail-or-alarm-when-local-url-opener-cannot-open-created-pr/sor.md
- Idempotency-Key: v0-91-5-tooling-treat-pr-url-opener-failure-as-warning-adl-adl-v0-91-5-tasks-issue-3831-v0-91-5-tooling-do-not-fail-or-alarm-when-local-url-opener-cannot-open-created-pr-sip-md-adl-v0-91-5-tasks-issue-3831-v0-91-5-tooling-do-not-fail-or-alarm-when-local-url-opener-cannot-open-created-pr-sor-md