### PR TITLE
[v0.91.5][tools][ci] Make PR closing-linkage guard resilient to stale event payloads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,10 @@ jobs:
         run: bash adl/tools/check_no_new_legacy_swarm_refs.sh
         working-directory: .
 
+      - name: guardrail contract (issue PR closing linkage)
+        run: bash adl/tools/test_pr_closing_linkage.sh
+        working-directory: .
+
       - name: guardrail (issue PR closing linkage)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/adl/tools/check_pr_closing_linkage.sh
+++ b/adl/tools/check_pr_closing_linkage.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 event_name="${GITHUB_EVENT_NAME:-}"
 event_path="${GITHUB_EVENT_PATH:-}"
 head_ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+repo="${GITHUB_REPOSITORY:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -17,6 +18,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --head-ref)
       head_ref="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo="${2:-}"
       shift 2
       ;;
     *)
@@ -42,8 +47,56 @@ if [[ ! "$head_ref" =~ (^|/)codex/([0-9]+)- ]]; then
 fi
 
 issue="${BASH_REMATCH[2]}"
+live_body_path=""
+live_status="unavailable"
 
-python3 - "$event_path" "$issue" <<'PY'
+if [[ -n "$repo" ]]; then
+  payload_repo="$repo"
+else
+  payload_repo="$(python3 - "$event_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+print(((payload.get("repository") or {}).get("full_name") or "").strip())
+PY
+)"
+  repo="$payload_repo"
+fi
+
+pr_number="$(python3 - "$event_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+number = (payload.get("pull_request") or {}).get("number") or ""
+print(number)
+PY
+)"
+
+gh_bin="${CHECK_PR_CLOSING_LINKAGE_GH_BIN:-gh}"
+if [[ -n "$repo" && -n "$pr_number" && ( -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ) ]]; then
+  if command -v "$gh_bin" >/dev/null 2>&1; then
+    live_body_path="$(mktemp)"
+    if "$gh_bin" pr view "$pr_number" --repo "$repo" --json body --jq '.body // ""' >"$live_body_path" 2>"$live_body_path.err"; then
+      live_status="available"
+    else
+      live_status="failed"
+    fi
+  else
+    live_status="missing_gh"
+  fi
+fi
+
+cleanup() {
+  [[ -n "$live_body_path" ]] && rm -f "$live_body_path" "$live_body_path.err"
+  true
+}
+trap cleanup EXIT
+
+python3 - "$event_path" "$issue" "$live_status" "$live_body_path" <<'PY'
 import json
 import re
 import sys
@@ -51,27 +104,58 @@ from pathlib import Path
 
 event_path = Path(sys.argv[1])
 issue = sys.argv[2]
+live_status = sys.argv[3]
+live_body_path = sys.argv[4]
 payload = json.loads(event_path.read_text())
-body = (payload.get("pull_request") or {}).get("body") or ""
 pr_number = (payload.get("pull_request") or {}).get("number") or "unknown"
+event_body = (payload.get("pull_request") or {}).get("body") or ""
 
-if re.search(r"\bNon-closing lifecycle PR\b", body, flags=re.IGNORECASE):
-    print(
-        f"check_pr_closing_linkage: PR #{pr_number} declares non-closing lifecycle work for issue #{issue}"
-    )
-    raise SystemExit(0)
+def has_non_closing(body: str) -> bool:
+    return bool(re.search(r"\bNon-closing lifecycle PR\b", body, flags=re.IGNORECASE))
 
 closing = re.compile(
     rf"\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#?{re.escape(issue)}\b",
     flags=re.IGNORECASE,
 )
-if closing.search(body):
-    print(f"check_pr_closing_linkage: PR #{pr_number} closes issue #{issue}")
+
+def has_closing(body: str) -> bool:
+    return bool(closing.search(body))
+
+def accept_body(body: str, source: str) -> bool:
+    if has_non_closing(body):
+        print(
+            f"check_pr_closing_linkage: PR #{pr_number} declares non-closing lifecycle work for issue #{issue} ({source})"
+        )
+        return True
+    if has_closing(body):
+        print(f"check_pr_closing_linkage: PR #{pr_number} closes issue #{issue} ({source})")
+        return True
+    return False
+
+if live_status == "available":
+    live_body = Path(live_body_path).read_text() if live_body_path else ""
+    if accept_body(live_body, "live PR metadata"):
+        raise SystemExit(0)
+    print(
+        f"check_pr_closing_linkage: live PR body for PR #{pr_number} is missing closing linkage to issue #{issue}; "
+        f"update the PR body with a closing keyword such as 'Closes #{issue}' or declare a non-closing lifecycle PR",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+if accept_body(event_body, "event payload"):
     raise SystemExit(0)
 
+live_note = {
+    "unavailable": "live PR metadata was unavailable because repo, PR number, or token context was missing",
+    "missing_gh": "live PR metadata was unavailable because the gh CLI was not found",
+    "failed": "live PR metadata fetch failed",
+}.get(live_status, "live PR metadata was unavailable")
 print(
     f"check_pr_closing_linkage: PR #{pr_number} is missing closing linkage to issue #{issue}; "
-    f"include a closing keyword such as 'Closes #{issue}' or declare a non-closing lifecycle PR",
+    f"include a closing keyword such as 'Closes #{issue}' or declare a non-closing lifecycle PR. "
+    f"{live_note}. If this is a rerun after a PR-body-only repair, GitHub may be reusing a stale pull_request event payload; "
+    f"rerun with token/repo context for live metadata validation or push a fresh commit to refresh the event payload.",
     file=sys.stderr,
 )
 raise SystemExit(1)

--- a/adl/tools/test_pr_closing_linkage.sh
+++ b/adl/tools/test_pr_closing_linkage.sh
@@ -6,6 +6,14 @@ SCRIPT="$ROOT/adl/tools/check_pr_closing_linkage.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
+run_event_payload_only() {
+  env -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_REPOSITORY "$@"
+}
+
+run_with_fake_live_metadata() {
+  env -u GITHUB_REPOSITORY "$@"
+}
+
 make_event() {
   local path="$1"
   local body="$2"
@@ -29,26 +37,101 @@ PY
 
 event_ok="$TMPDIR/ok.json"
 make_event "$event_ok" "Closes #1414"
-bash "$SCRIPT" --event-name pull_request --event-path "$event_ok" --head-ref "codex/1414-remediation"
+run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_ok" --head-ref "codex/1414-remediation"
 
 event_fix="$TMPDIR/fix.json"
 make_event "$event_fix" $'Some notes\n\nFixes #1414'
-bash "$SCRIPT" --event-name pull_request --event-path "$event_fix" --head-ref "codex/1414-remediation"
+run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_fix" --head-ref "codex/1414-remediation"
 
 event_bad="$TMPDIR/bad.json"
 make_event "$event_bad" "Refs #1414"
-if bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref "codex/1414-remediation"; then
+if run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref "codex/1414-remediation"; then
   echo "expected failure for missing closing linkage" >&2
   exit 1
 fi
+if run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref "codex/1414-remediation" 2>"$TMPDIR/bad.err"; then
+  echo "expected failure for stale-event fallback diagnostic" >&2
+  exit 1
+fi
+grep -F "stale pull_request event payload" "$TMPDIR/bad.err" >/dev/null
+grep -F "push a fresh commit to refresh the event payload" "$TMPDIR/bad.err" >/dev/null
 
 event_non_closing="$TMPDIR/non-closing.json"
 make_event "$event_non_closing" "Non-closing lifecycle PR: issue 1414 remains open"
-bash "$SCRIPT" --event-name pull_request --event-path "$event_non_closing" --head-ref "codex/1414-remediation"
+run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_non_closing" --head-ref "codex/1414-remediation"
+
+fake_bin="$TMPDIR/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "${3:-}" == "77" ]]; then
+  repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [[ "$repo" != "example/repo" ]]; then
+    echo "unexpected fake gh repo: $repo" >&2
+    exit 2
+  fi
+  printf '%s\n' "${FAKE_GH_PR_BODY:-}"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 2
+SH
+chmod +x "$fake_bin/gh"
+
+event_stale="$TMPDIR/stale.json"
+make_event "$event_stale" "Refs #1414"
+GH_TOKEN="test-token" FAKE_GH_PR_BODY="Closes #1414" PATH="$fake_bin:$PATH" \
+  run_with_fake_live_metadata \
+  bash "$SCRIPT" --event-name pull_request --event-path "$event_stale" --head-ref "codex/1414-remediation"
+
+GH_TOKEN="test-token" FAKE_GH_PR_BODY="Non-closing lifecycle PR: issue 1414 remains open" PATH="$fake_bin:$PATH" \
+  run_with_fake_live_metadata \
+  bash "$SCRIPT" --event-name pull_request --event-path "$event_stale" --head-ref "codex/1414-remediation"
+
+if GH_TOKEN="test-token" FAKE_GH_PR_BODY="Refs #1414" PATH="$fake_bin:$PATH" \
+  run_with_fake_live_metadata \
+  bash "$SCRIPT" --event-name pull_request --event-path "$event_stale" --head-ref "codex/1414-remediation" 2>"$TMPDIR/live-missing.err"; then
+  echo "expected failure for live PR body missing closing linkage" >&2
+  exit 1
+fi
+grep -F "live PR body for PR #77 is missing closing linkage" "$TMPDIR/live-missing.err" >/dev/null
+
+cat >"$fake_bin/gh-fail" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "simulated gh failure with sensitive-looking text" >&2
+exit 1
+SH
+chmod +x "$fake_bin/gh-fail"
+if GH_TOKEN="test-token" CHECK_PR_CLOSING_LINKAGE_GH_BIN="$fake_bin/gh-fail" \
+  run_with_fake_live_metadata \
+  bash "$SCRIPT" --event-name pull_request --event-path "$event_stale" --head-ref "codex/1414-remediation" 2>"$TMPDIR/live-failed.err"; then
+  echo "expected failure for failed live PR body fetch" >&2
+  exit 1
+fi
+grep -F "live PR metadata fetch failed" "$TMPDIR/live-failed.err" >/dev/null
+if grep -F "sensitive-looking text" "$TMPDIR/live-failed.err" >/dev/null; then
+  echo "raw gh stderr leaked into fallback diagnostic" >&2
+  exit 1
+fi
 
 event_other="$TMPDIR/other.json"
 make_event "$event_other" "Refs #1414"
-bash "$SCRIPT" --event-name push --event-path "$event_other" --head-ref "codex/1414-remediation"
-bash "$SCRIPT" --event-name pull_request --event-path "$event_other" --head-ref "feature/no-issue-branch"
+run_event_payload_only bash "$SCRIPT" --event-name push --event-path "$event_other" --head-ref "codex/1414-remediation"
+run_event_payload_only bash "$SCRIPT" --event-name pull_request --event-path "$event_other" --head-ref "feature/no-issue-branch"
 
 echo "test_pr_closing_linkage.sh: PASS"


### PR DESCRIPTION
Closes #3797

## Summary
Implemented a bounded repair for the PR closing-linkage guard so stale pull-request event payloads no longer trap PR-body-only repairs when live PR metadata is available.

## Artifacts
- `adl/tools/check_pr_closing_linkage.sh`
- `adl/tools/test_pr_closing_linkage.sh`
- `.github/workflows/ci.yaml`
- Local ignored review/output card updates under `.adl/v0.91.5/tasks/issue-3797__v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads/`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/check_pr_closing_linkage.sh && bash -n adl/tools/test_pr_closing_linkage.sh && bash adl/tools/test_pr_closing_linkage.sh`
    Verified script syntax and focused guard behavior, including stale event payload fallback, live PR metadata success, non-closing lifecycle success, live missing-linkage failure, failed live fetch fallback, and no raw `gh` stderr leakage.
  - `git diff --check`
    Verified diff whitespace hygiene.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.5/tasks/issue-3797__v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads/spp.md`
    Verified SPP structure after adding the CI proof surface.
  - `GITHUB_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 3797 --mode ready --json`
    Verified ready-state lifecycle checks; preflight reported open tools PR wave `#3856` and `#3855`.
  - `shellcheck adl/tools/check_pr_closing_linkage.sh adl/tools/test_pr_closing_linkage.sh`
    Not run because `shellcheck` is unavailable in this local environment.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3797__v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3797__v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads/sor.md
- Idempotency-Key: v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads-github-workflows-ci-yaml-adl-tools-check-pr-closing-linkage-sh-adl-tools-test-pr-closing-linkage-sh-adl-v0-91-5-tasks-issue-3797-v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads-sip-md-adl-v0-91-5-tasks-issue-3797-v0-91-5-tools-ci-make-pr-closing-linkage-guard-resilient-to-stale-event-payloads-sor-md