### PR TITLE
[v0.91.5][tools] Move PR validation off gh and onto ADL platform

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -12,7 +12,7 @@ use super::pr_cmd_args::parse_finish_args;
 use super::pr_cmd_args::{
     parse_closeout_args, parse_create_args, parse_doctor_args, parse_init_args,
     parse_preflight_args, parse_ready_args, parse_repair_issue_body_args, parse_start_args,
-    DoctorArgs, DoctorMode,
+    parse_validation_args, DoctorArgs, DoctorMode,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -153,7 +153,7 @@ fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closeout"
         );
     };
 
@@ -166,9 +166,81 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "ready" => real_pr_ready(&args[1..]),
         "preflight" => real_pr_preflight(&args[1..]),
         "finish" => finish_support::real_pr_finish(&args[1..]),
+        "validation" => real_pr_validation(&args[1..]),
         "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
+}
+
+fn real_pr_validation(args: &[String]) -> Result<()> {
+    let parsed = parse_validation_args(args)?;
+    let repo_root = repo_root()?;
+    let repo = parsed
+        .repo
+        .clone()
+        .or_else(|| repo_from_pr_ref(&parsed.pr_ref))
+        .unwrap_or(default_repo(&repo_root)?);
+    let report = if parsed.watch {
+        github::wait_for_pr_validation_report(&repo, &parsed.pr_ref)?
+    } else {
+        github::pr_validation_report(&repo, &parsed.pr_ref)?
+    };
+    if parsed.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("validation: failed to serialize validation report")?
+        );
+    } else {
+        println!(
+            "PR #{} validation: {} (checks: {}, failed: {}, pending: {})",
+            report.pr_number,
+            report.disposition,
+            report.checks.len(),
+            report.failed_checks.len(),
+            report.pending_checks.len()
+        );
+        for check in report
+            .failed_checks
+            .iter()
+            .chain(report.pending_checks.iter())
+        {
+            println!(
+                "- {} status={} conclusion={} job_run_id={}",
+                check.name, check.status, check.conclusion, check.job_run_id
+            );
+        }
+    }
+    if validation_disposition_blocks_shell_success(&report.disposition) {
+        bail!(
+            "validation: PR #{} is {}",
+            report.pr_number,
+            report.disposition
+        );
+    }
+    Ok(())
+}
+
+fn validation_disposition_blocks_shell_success(disposition: &str) -> bool {
+    matches!(
+        disposition,
+        "pending" | "failed" | "cancelled" | "timed_out"
+    )
+}
+
+fn repo_from_pr_ref(pr_ref: &str) -> Option<String> {
+    let trimmed = pr_ref.trim();
+    let marker = "github.com/";
+    let (_, tail) = trimmed.split_once(marker)?;
+    let path = tail.split(['?', '#']).next()?;
+    let mut parts = path.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    let pull_marker = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || pull_marker != "pull" {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
 }
 
 fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -116,6 +116,16 @@ struct PullRequestValidationRollup {
 #[derive(Debug, Clone, Deserialize)]
 struct PullRequestValidationContextConnection {
     nodes: Option<Vec<Option<PullRequestValidationContextNode>>>,
+    #[serde(rename = "pageInfo")]
+    page_info: PullRequestValidationPageInfo,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PullRequestValidationPageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    end_cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -165,6 +175,26 @@ struct PrValidationSnapshot {
     state: String,
     is_draft: bool,
     checks: Vec<PrValidationCheckSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct PrValidationCheckReport {
+    pub(super) name: String,
+    pub(super) status: String,
+    pub(super) conclusion: String,
+    pub(super) job_run_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct PrValidationReport {
+    pub(super) pr_number: u64,
+    pub(super) commit_sha: String,
+    pub(super) pr_state: String,
+    pub(super) is_draft: bool,
+    pub(super) disposition: String,
+    pub(super) checks: Vec<PrValidationCheckReport>,
+    pub(super) failed_checks: Vec<PrValidationCheckReport>,
+    pub(super) pending_checks: Vec<PrValidationCheckReport>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -446,6 +476,34 @@ fn merge_pr_octocrab(repo: &str, pr_ref: &str) -> Result<()> {
 }
 
 pub(super) fn wait_for_pr_validation_finish(repo: &str, pr_ref: &str) -> Result<()> {
+    let report = wait_for_pr_validation_report(repo, pr_ref)?;
+    match report.disposition.as_str() {
+        "success" | "skipped" => Ok(()),
+        "failed" => {
+            bail!(
+                "pr validation failed for PR #{pr}: at least one check failed",
+                pr = report.pr_number
+            )
+        }
+        "cancelled" => {
+            bail!(
+                "pr validation cancelled for PR #{pr}: at least one check was cancelled",
+                pr = report.pr_number
+            )
+        }
+        "timed_out" => bail!("pr validation timed out for PR #{}", report.pr_number),
+        other => bail!(
+            "pr validation ended with unsupported disposition for PR #{}: {}",
+            report.pr_number,
+            other
+        ),
+    }
+}
+
+pub(super) fn wait_for_pr_validation_report(
+    repo: &str,
+    pr_ref: &str,
+) -> Result<PrValidationReport> {
     let timeout = pr_validation_wait_timeout();
     let poll_delay = pr_validation_wait_poll_delay();
     let started = Instant::now();
@@ -463,30 +521,23 @@ pub(super) fn wait_for_pr_validation_finish(repo: &str, pr_ref: &str) -> Result<
         emit_pr_validation_wait_snapshot(&snapshot, disposition, started, poll_count, next_delay);
 
         match disposition {
-            PrValidationDisposition::Success | PrValidationDisposition::Skipped => return Ok(()),
-            PrValidationDisposition::Failed => {
-                bail!(
-                    "pr validation failed for PR #{pr}: at least one check failed",
-                    pr = snapshot.pr_number
-                )
-            }
-            PrValidationDisposition::Cancelled => {
-                bail!(
-                    "pr validation cancelled for PR #{pr}: at least one check was cancelled",
-                    pr = snapshot.pr_number
-                )
-            }
-            PrValidationDisposition::TimedOut => {
-                bail!("pr validation timed out for PR #{}", snapshot.pr_number)
+            PrValidationDisposition::Success
+            | PrValidationDisposition::Skipped
+            | PrValidationDisposition::Failed
+            | PrValidationDisposition::Cancelled
+            | PrValidationDisposition::TimedOut => {
+                return Ok(pr_validation_report_from_snapshot_with_disposition(
+                    &snapshot,
+                    disposition,
+                ))
             }
             PrValidationDisposition::Pending => {
                 if started.elapsed() >= timeout {
                     emit_pr_validation_wait_timeout(&snapshot, started, poll_count, Duration::ZERO);
-                    bail!(
-                        "pr validation timed out for PR #{} after {}ms",
-                        snapshot.pr_number,
-                        started.elapsed().as_millis()
-                    );
+                    return Ok(pr_validation_report_from_snapshot_with_disposition(
+                        &snapshot,
+                        PrValidationDisposition::TimedOut,
+                    ));
                 }
                 std::thread::sleep(poll_delay);
             }
@@ -494,13 +545,24 @@ pub(super) fn wait_for_pr_validation_finish(repo: &str, pr_ref: &str) -> Result<
     }
 }
 
+pub(super) fn pr_validation_report(repo: &str, pr_ref: &str) -> Result<PrValidationReport> {
+    let snapshot = pr_validation_status_octocrab(repo, pr_ref)?;
+    Ok(pr_validation_report_from_snapshot_with_disposition(
+        &snapshot,
+        classify_pr_validation_snapshot(&snapshot),
+    ))
+}
+
 fn pr_validation_status_octocrab(repo: &str, pr_ref: &str) -> Result<PrValidationSnapshot> {
     let repo_parts = parse_repo(repo)?;
     let number = parse_pr_number(pr_ref)? as i64;
     with_octocrab("pr.validation.status", |runtime, octo| {
-        let payload = serde_json::json!({
-            "query": r#"
-                query($owner: String!, $name: String!, $number: Int!) {
+        let mut after: Option<String> = None;
+        let mut snapshot: Option<PrValidationSnapshot> = None;
+        loop {
+            let payload = serde_json::json!({
+                "query": r#"
+                query($owner: String!, $name: String!, $number: Int!, $after: String) {
                   repository(owner: $owner, name: $name) {
                     pullRequest(number: $number) {
                       number
@@ -508,7 +570,7 @@ fn pr_validation_status_octocrab(repo: &str, pr_ref: &str) -> Result<PrValidatio
                       state
                       isDraft
                       statusCheckRollup {
-                        contexts(first: 100) {
+                        contexts(first: 100, after: $after) {
                           nodes {
                             __typename
                             ... on CheckRun {
@@ -527,37 +589,64 @@ fn pr_validation_status_octocrab(repo: &str, pr_ref: &str) -> Result<PrValidatio
                               state
                             }
                           }
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
                         }
                       }
                     }
                   }
                 }
             "#,
-            "variables": {
-                "owner": repo_parts.owner,
-                "name": repo_parts.name,
-                "number": number,
+                "variables": {
+                    "owner": repo_parts.owner,
+                    "name": repo_parts.name,
+                    "number": number,
+                    "after": after,
+                }
+            });
+            let response: PullRequestValidationStatusResponse =
+                block_on_octocrab(runtime, "pr.validation.status", || async {
+                    octo.graphql::<PullRequestValidationStatusResponse>(&payload)
+                        .await
+                })?;
+            let pr = response
+                .repository
+                .and_then(|repo| repo.pull_request)
+                .ok_or_else(|| {
+                    anyhow!("GitHub did not return validation status for PR {pr_ref}")
+                })?;
+            let (mut page_snapshot, page_info) = pr_validation_snapshot_from_response(pr);
+            if let Some(current) = snapshot.as_mut() {
+                current.checks.append(&mut page_snapshot.checks);
+            } else {
+                snapshot = Some(page_snapshot);
             }
-        });
-        let response: PullRequestValidationStatusResponse =
-            block_on_octocrab(runtime, "pr.validation.status", || async {
-                octo.graphql::<PullRequestValidationStatusResponse>(&payload)
-                    .await
-            })?;
-        response
-            .repository
-            .and_then(|repo| repo.pull_request)
-            .map(pr_validation_snapshot_from_response)
-            .ok_or_else(|| anyhow!("GitHub did not return validation status for PR {pr_ref}"))
+            if !page_info.has_next_page {
+                return snapshot.ok_or_else(|| {
+                    anyhow!("GitHub did not return validation status for PR {pr_ref}")
+                });
+            }
+            after = page_info.end_cursor;
+            if after.as_deref().unwrap_or_default().trim().is_empty() {
+                bail!(
+                    "GitHub validation status for PR {pr_ref} is paginated but did not return an end cursor"
+                );
+            }
+        }
     })
 }
 
 fn pr_validation_snapshot_from_response(
     pr: PullRequestValidationPullRequest,
-) -> PrValidationSnapshot {
-    let checks = pr
-        .status_check_rollup
-        .and_then(|rollup| rollup.contexts)
+) -> (PrValidationSnapshot, PullRequestValidationPageInfo) {
+    let contexts = pr.status_check_rollup.and_then(|rollup| rollup.contexts);
+    let page_info = contexts
+        .as_ref()
+        .map(|contexts| contexts.page_info.clone())
+        .unwrap_or_default();
+    let checks = contexts
         .and_then(|contexts| contexts.nodes)
         .unwrap_or_default()
         .into_iter()
@@ -595,13 +684,16 @@ fn pr_validation_snapshot_from_response(
             PullRequestValidationContextNode::Other => None,
         })
         .collect();
-    PrValidationSnapshot {
-        pr_number: pr.number,
-        commit_sha: pr.head_ref_oid,
-        state: pr.state,
-        is_draft: pr.is_draft,
-        checks,
-    }
+    (
+        PrValidationSnapshot {
+            pr_number: pr.number,
+            commit_sha: pr.head_ref_oid,
+            state: pr.state,
+            is_draft: pr.is_draft,
+            checks,
+        },
+        page_info,
+    )
 }
 
 fn classify_pr_validation_snapshot(snapshot: &PrValidationSnapshot) -> PrValidationDisposition {
@@ -642,6 +734,51 @@ fn classify_pr_validation_snapshot(snapshot: &PrValidationSnapshot) -> PrValidat
         return PrValidationDisposition::Skipped;
     }
     PrValidationDisposition::Success
+}
+
+fn pr_validation_report_from_snapshot_with_disposition(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+) -> PrValidationReport {
+    let checks = snapshot
+        .checks
+        .iter()
+        .map(pr_validation_check_report)
+        .collect::<Vec<_>>();
+    let failed_checks = snapshot
+        .checks
+        .iter()
+        .filter(|check| {
+            validation_conclusion_is_failed(&check.conclusion)
+                || status_context_failure_status(&check.status)
+        })
+        .map(pr_validation_check_report)
+        .collect::<Vec<_>>();
+    let pending_checks = snapshot
+        .checks
+        .iter()
+        .filter(|check| validation_check_is_pending(&check.status, &check.conclusion))
+        .map(pr_validation_check_report)
+        .collect::<Vec<_>>();
+    PrValidationReport {
+        pr_number: snapshot.pr_number,
+        commit_sha: snapshot.commit_sha.clone(),
+        pr_state: snapshot.state.clone(),
+        is_draft: snapshot.is_draft,
+        disposition: disposition.as_event_result().to_string(),
+        checks,
+        failed_checks,
+        pending_checks,
+    }
+}
+
+fn pr_validation_check_report(check: &PrValidationCheckSnapshot) -> PrValidationCheckReport {
+    PrValidationCheckReport {
+        name: check.name.clone(),
+        status: check.status.clone(),
+        conclusion: check.conclusion.clone(),
+        job_run_id: check.job_run_id.clone(),
+    }
 }
 
 fn emit_pr_validation_wait_snapshot(
@@ -2634,6 +2771,16 @@ mod tests {
         conclusion: Option<&str>,
         check_name: &str,
     ) -> String {
+        pr_validation_graphql_response_page(status, conclusion, check_name, false, None)
+    }
+
+    fn pr_validation_graphql_response_page(
+        status: &str,
+        conclusion: Option<&str>,
+        check_name: &str,
+        has_next_page: bool,
+        end_cursor: Option<&str>,
+    ) -> String {
         serde_json::json!({
             "data": {
                 "repository": {
@@ -2657,7 +2804,11 @@ mod tests {
                                             }
                                         }
                                     }
-                                ]
+                                ],
+                                "pageInfo": {
+                                    "hasNextPage": has_next_page,
+                                    "endCursor": end_cursor
+                                }
                             }
                         }
                     }
@@ -2665,6 +2816,77 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    fn spawn_validation_status_paginated_server() -> (String, thread::JoinHandle<Vec<String>>) {
+        let port = reserve_local_port();
+        let bind_addr = format!("127.0.0.1:{port}");
+        let server = Server::http(&bind_addr).expect("bind validation status pagination server");
+        let handle = thread::spawn(move || {
+            let mut seen = Vec::new();
+            for page in 1..=2 {
+                let Some(mut request) = server
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("validation pagination server receive")
+                else {
+                    break;
+                };
+                let method = request.method().as_str().to_string();
+                let url = request.url().to_string();
+                let mut body = String::new();
+                let _ = request.as_reader().read_to_string(&mut body);
+                seen.push(format!("{method} {url} {body}"));
+                let response = if page == 1 {
+                    pr_validation_graphql_response_page(
+                        "COMPLETED",
+                        Some("SUCCESS"),
+                        "adl-ci",
+                        true,
+                        Some("cursor-1"),
+                    )
+                } else {
+                    pr_validation_graphql_response_page(
+                        "COMPLETED",
+                        Some("SUCCESS"),
+                        "adl-coverage",
+                        false,
+                        None,
+                    )
+                };
+                let _ = request.respond(json_response(response));
+            }
+            seen
+        });
+        (format!("http://{bind_addr}"), handle)
+    }
+
+    fn spawn_validation_status_once_server(
+        status: &'static str,
+        conclusion: Option<&'static str>,
+        check_name: &'static str,
+    ) -> (String, thread::JoinHandle<Vec<String>>) {
+        let port = reserve_local_port();
+        let bind_addr = format!("127.0.0.1:{port}");
+        let server = Server::http(&bind_addr).expect("bind validation status single server");
+        let handle = thread::spawn(move || {
+            let mut seen = Vec::new();
+            let Some(mut request) = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("validation single server receive")
+            else {
+                return seen;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            let mut body = String::new();
+            let _ = request.as_reader().read_to_string(&mut body);
+            seen.push(format!("{method} {url} {body}"));
+            let _ = request.respond(json_response(pr_validation_graphql_response(
+                status, conclusion, check_name,
+            )));
+            seen
+        });
+        (format!("http://{bind_addr}"), handle)
     }
 
     fn spawn_validation_status_transient_server() -> (String, thread::JoinHandle<Vec<String>>) {
@@ -3326,6 +3548,66 @@ exit 1
             std::env::remove_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS");
             std::env::remove_var("ADL_OBSERVABILITY_STDERR");
             std::env::remove_var("ADL_OBSERVABILITY_LOG");
+        }
+        restore_github_policy_env(policy_env);
+    }
+
+    #[test]
+    fn pr_validation_status_query_paginates_status_rollup_contexts() {
+        let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
+        let (base_uri, server) = spawn_validation_status_paginated_server();
+        unsafe {
+            std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+            std::env::set_var("GITHUB_TOKEN", "test-token");
+            std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        }
+
+        let snapshot =
+            pr_validation_status_octocrab("owner/repo", "1159").expect("paginated snapshot");
+        assert_eq!(snapshot.checks.len(), 2);
+        assert_eq!(snapshot.checks[0].name, "adl-ci");
+        assert_eq!(snapshot.checks[1].name, "adl-coverage");
+
+        let seen = server.join().expect("server join");
+        assert_eq!(seen.len(), 2, "unexpected pagination calls: {seen:#?}");
+        assert!(seen[0].contains(r#""after":null"#));
+        assert!(seen[1].contains(r#""after":"cursor-1""#));
+
+        unsafe {
+            std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        }
+        restore_github_policy_env(policy_env);
+    }
+
+    #[test]
+    fn pr_validation_watch_returns_failed_report_without_second_fetch() {
+        let _guard = env_lock();
+        let policy_env = clear_github_policy_env();
+        let (base_uri, server) =
+            spawn_validation_status_once_server("COMPLETED", Some("FAILURE"), "adl-coverage");
+        unsafe {
+            std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+            std::env::set_var("GITHUB_TOKEN", "test-token");
+            std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        }
+
+        let report =
+            wait_for_pr_validation_report("owner/repo", "1159").expect("failed report returned");
+        assert_eq!(report.disposition, "failed");
+        assert_eq!(report.failed_checks.len(), 1);
+        assert_eq!(report.failed_checks[0].name, "adl-coverage");
+        assert_eq!(report.checks.len(), 1);
+
+        let seen = server.join().expect("server join");
+        assert_eq!(
+            seen.len(),
+            1,
+            "watch should not refetch after terminal state"
+        );
+
+        unsafe {
+            std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
         }
         restore_github_policy_env(policy_env);
     }

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -96,6 +96,14 @@ pub(crate) struct FinishArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidationArgs {
+    pub(crate) pr_ref: String,
+    pub(crate) repo: Option<String>,
+    pub(crate) watch: bool,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CloseoutArgs {
     pub(crate) issue: u32,
     pub(crate) slug: Option<String>,
@@ -521,6 +529,33 @@ pub(crate) fn parse_finish_args(args: &[String]) -> Result<FinishArgs> {
         bail!("finish: --merge requires checks; remove --no-checks");
     }
 
+    Ok(parsed)
+}
+
+pub(crate) fn parse_validation_args(args: &[String]) -> Result<ValidationArgs> {
+    let pr_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("validation: missing <pr> number or URL"))?
+        .clone();
+    let mut parsed = ValidationArgs {
+        pr_ref,
+        repo: None,
+        watch: false,
+        json: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "validation", args[i].as_str())?);
+                i += 1;
+            }
+            "--watch" | "--wait" => parsed.watch = true,
+            "--json" => parsed.json = true,
+            other => bail!("validation: unknown arg: {other}"),
+        }
+        i += 1;
+    }
     Ok(parsed)
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -56,6 +56,53 @@ fn parse_closeout_args_accepts_expected_flags() {
 }
 
 #[test]
+fn parse_validation_args_accepts_repo_watch_and_json_flags() {
+    let parsed = parse_validation_args(&[
+        "https://github.com/example/repo/pull/3849".to_string(),
+        "-R".to_string(),
+        "example/repo".to_string(),
+        "--watch".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse validation");
+    assert_eq!(parsed.pr_ref, "https://github.com/example/repo/pull/3849");
+    assert_eq!(parsed.repo.as_deref(), Some("example/repo"));
+    assert!(parsed.watch);
+    assert!(parsed.json);
+
+    let err = parse_validation_args(&["3849".to_string(), "--bogus".to_string()])
+        .expect_err("unknown validation arg");
+    assert!(err.to_string().contains("validation: unknown arg"));
+}
+
+#[test]
+fn repo_from_pr_ref_extracts_owner_and_repo_from_github_url() {
+    assert_eq!(
+        repo_from_pr_ref("https://github.com/example/repo/pull/3849"),
+        Some("example/repo".to_string())
+    );
+    assert_eq!(
+        repo_from_pr_ref("https://github.com/example/repo/pull/3849/files?foo=bar"),
+        Some("example/repo".to_string())
+    );
+    assert_eq!(repo_from_pr_ref("3849"), None);
+    assert_eq!(
+        repo_from_pr_ref("https://example.com/not-github/pull/3849"),
+        None
+    );
+}
+
+#[test]
+fn validation_disposition_blocks_pending_and_terminal_failures() {
+    assert!(!validation_disposition_blocks_shell_success("success"));
+    assert!(!validation_disposition_blocks_shell_success("skipped"));
+    assert!(validation_disposition_blocks_shell_success("pending"));
+    assert!(validation_disposition_blocks_shell_success("failed"));
+    assert!(validation_disposition_blocks_shell_success("cancelled"));
+    assert!(validation_disposition_blocks_shell_success("timed_out"));
+}
+
+#[test]
 fn render_generated_issue_prompt_uses_workflow_skill_bootstrap_template_for_tools_skill_titles() {
     let content = render_generated_issue_prompt(
         1443,
@@ -626,7 +673,7 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish"
+        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closeout"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2237,6 +2237,16 @@ cmd_finish() {
   delegate_pr_command_to_rust finish "$@"
 }
 
+cmd_validation() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_validation
+    return 0
+  fi
+  adl_obs_event "pr.sh" "validation" "started" "pr" "${1:-}"
+  require_rust_pr_delegate
+  delegate_pr_command_to_rust validation "$@"
+}
+
 cmd_closeout() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     usage_closeout
@@ -2299,6 +2309,7 @@ Commands:
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
   doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
+  validation <pr-number-or-url> [-R owner/repo] [--watch] [--json]
   closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Compatibility / maintenance commands:
@@ -2509,6 +2520,21 @@ Notes:
 EOF
 }
 
+usage_validation() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh validation <pr-number-or-url> [-R owner/repo] [--watch] [--json]
+
+Behavior:
+- delegates to the Rust-owned PR validation watcher
+- reads PR check status through the typed GitHub transport
+- infers `owner/repo` from a GitHub PR URL when `-R/--repo` is omitted; otherwise falls back to the current checkout repo
+- emits tail-friendly pr.validation.wait events when --watch is set
+- prints a JSON status report when --json is set
+- returns non-zero when validation is pending, failed, cancelled, or timed out
+EOF
+}
+
 usage_repair_issue_body() {
   cat <<'EOF'
 Usage:
@@ -2555,6 +2581,7 @@ main() {
     ready) cmd_ready "$@" ;;
     preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;
+    validation) cmd_validation "$@" ;;
     closeout) cmd_closeout "$@" ;;
     card) cmd_card "$@" ;;
     output) cmd_output "$@" ;;

--- a/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
+++ b/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
@@ -84,6 +84,24 @@ transport retries remain separate `stage=github_octocrab result=retry` events
 with `operation=pr.validation.status`, so a check failure and a GitHub transport
 failure are distinguishable in the same tail.
 
+For direct PR validation diagnosis without `gh pr checks`, use the Rust-owned
+status surface:
+
+```bash
+bash adl/tools/pr.sh validation <pr-number-or-url> --json
+bash adl/tools/pr.sh validation <pr-number-or-url> --watch --json
+```
+
+The JSON report includes the PR number, head commit, PR state, draft state,
+aggregate disposition, all checks, failed checks, and pending checks. `--watch`
+polls through the same `pr.validation.wait` event stream before printing the
+final report. The status query follows `statusCheckRollup.contexts` pagination
+instead of assuming the first page is complete. When the PR argument is a
+GitHub URL, the command infers `owner/repo` from that URL unless `-R` is
+supplied explicitly. Shell exit status is non-zero for `pending`, `failed`,
+`cancelled`, and `timed_out` dispositions so automation does not confuse “not
+done yet” with success.
+
 ## OTEL Mapping
 
 The event vocabulary is intentionally OTEL-ready:


### PR DESCRIPTION
Closes #3834

## Summary
Implemented the bounded ADL-owned PR validation status surface. `adl pr validation` and `adl/tools/pr.sh validation` now read PR validation state through the typed Octocrab transport, optionally wait through the existing structured wait event stream, print a JSON or human report, and preserve failed/pending check evidence without requiring `gh pr checks`.

## Artifacts
- Updated `adl/src/cli/pr_cmd.rs` with the `validation` subcommand.
- Updated `adl/src/cli/pr_cmd_args.rs` with validation command parsing.
- Updated `adl/src/cli/pr_cmd/github.rs` with typed validation reports and paginated status rollup collection.
- Updated `adl/src/cli/tests/pr_cmd_inline/basics.rs` with parser and dispatch coverage.
- Updated `adl/tools/pr.sh` with `validation` delegation and help text.
- Updated `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md` with the operator runbook.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for touched Rust files.
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_ -- --nocapture`
    Verified PR validation classification, structured wait events, transient retry handling, and paginated status rollup collection.
  - `cargo test --manifest-path adl/Cargo.toml parse_validation_args_accepts_repo_watch_and_json_flags -- --nocapture`
    Verified CLI parsing for the new validation command.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc pr_validation_ -- --nocapture`
    Verified PR validation report generation, wait classification, transient retry handling, and paginated status rollup collection.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc repo_from_pr_ref_extracts_owner_and_repo_from_github_url -- --nocapture`
    Verified GitHub PR URLs infer the correct repository.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc validation_disposition_blocks_pending_and_terminal_failures -- --nocapture`
    Verified shell exit behavior for pending and terminal failure dispositions.
  - `bash adl/tools/pr.sh validation --help`
    Verified wrapper usage and delegation for the validation command.
  - `git diff --check`
    Verified no whitespace errors in the tracked diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3834__v0-91-5-tools-move-pr-validation-off-gh-and-onto-adl-platform/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3834__v0-91-5-tools-move-pr-validation-off-gh-and-onto-adl-platform/sor.md
- Idempotency-Key: v0-91-5-tools-move-pr-validation-off-gh-and-onto-adl-platform-adl-v0-91-5-tasks-issue-3834-v0-91-5-tools-move-pr-validation-off-gh-and-onto-adl-platform-sip-md-adl-v0-91-5-tasks-issue-3834-v0-91-5-tools-move-pr-validation-off-gh-and-onto-adl-platform-sor-md