### PR TITLE
[v0.91.5][tools] Harden validator binary target-dir lookup

### DIFF
--- a/adl/tools/test_validate_structured_prompt_parallel.sh
+++ b/adl/tools/test_validate_structured_prompt_parallel.sh
@@ -10,6 +10,48 @@ FAKE_ROOT="$TMPDIR/fake-root"
 mkdir -p "$FAKE_ROOT/adl"
 touch "$FAKE_ROOT/adl/Cargo.toml"
 
+write_fake_validator() {
+  local path="$1"
+  local marker="$2"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$marker:\$*"
+exit 0
+SH
+  chmod +x "$path"
+}
+
+write_fake_validator "$FAKE_ROOT/adl/target/debug/adl-validate-structured-prompt" "ordinary-debug-validator"
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/ordinary-debug-stdout.txt" 2>"$TMPDIR/ordinary-debug-stderr.txt"
+grep -Fq "ordinary-debug-validator:--type srp --input" "$TMPDIR/ordinary-debug-stdout.txt"
+rm -f "$FAKE_ROOT/adl/target/debug/adl-validate-structured-prompt"
+
+CARGO_TARGET_FIXTURE="$TMPDIR/cargo-target-fixture"
+write_fake_validator "$CARGO_TARGET_FIXTURE/debug/adl-validate-structured-prompt" "cargo-target-validator"
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+CARGO_TARGET_DIR="$CARGO_TARGET_FIXTURE" \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/cargo-target-stdout.txt" 2>"$TMPDIR/cargo-target-stderr.txt"
+grep -Fq "cargo-target-validator:--type srp --input" "$TMPDIR/cargo-target-stdout.txt"
+
+LLVM_COV_TARGET_FIXTURE="$TMPDIR/llvm-cov-target-fixture"
+write_fake_validator "$LLVM_COV_TARGET_FIXTURE/debug/adl-validate-structured-prompt" "llvm-cov-target-validator"
+ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
+ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \
+ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
+CARGO_LLVM_COV_TARGET_DIR="$LLVM_COV_TARGET_FIXTURE" \
+  "$SCRIPT" --type srp --input "$ROOT_DIR/.adl/v0.91.5/tasks/issue-3778__pre-v092-bridge-feature-doc-production/srp.md" \
+  >"$TMPDIR/llvm-cov-target-stdout.txt" 2>"$TMPDIR/llvm-cov-target-stderr.txt"
+grep -Fq "llvm-cov-target-validator:--type srp --input" "$TMPDIR/llvm-cov-target-stdout.txt"
+
 set +e
 ADL_TOOLING_MANIFEST_ROOT="$FAKE_ROOT" \
 ADL_PRIMARY_CHECKOUT_ROOT="$FAKE_ROOT" \

--- a/adl/tools/validate_structured_prompt.sh
+++ b/adl/tools/validate_structured_prompt.sh
@@ -81,6 +81,8 @@ run_target_dir_validator_if_present() {
   if [[ -z "$target_dir" ]]; then
     return 0
   fi
+  # Keep this lookup order aligned with
+  # docs/tooling/structured-prompt-validator-binary-resolution.md.
   case "$target_dir" in
     /*)
       run_if_executable "$target_dir/debug/adl-validate-structured-prompt" "$@"

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -23,6 +23,7 @@ These docs describe the structured prompt surfaces used to shape issues, issue-c
 - [ADL Card Lifecycle](card-lifecycle.md)
 - [Active Card Lifecycle Migration Readiness](active-card-lifecycle-migration-readiness-v0.91.2.md)
 - [Structured Prompt Contracts](structured-prompt-contracts.md)
+- [Structured Prompt Validator Binary Resolution](structured-prompt-validator-binary-resolution.md)
 - [SRP, SOR, And ObsMem Handoff Model](srp-sor-obsmem-handoff-v0.91.2.md)
 - [Prompt/Reviewer Surface Mapping](prompt-review-surface-mapping.md)
 - [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings)
@@ -80,6 +81,7 @@ Important repo-local tooling surfaces include:
 - `adl tooling lint-prompt-spec` — Prompt Spec lint and validation
 - `adl tooling card-prompt` — deterministic prompt generation from cards
 - `adl tooling validate-structured-prompt` — structured prompt contract validation
+- `bash adl/tools/validate_structured_prompt.sh` — compatibility wrapper for the dedicated structured-prompt validator binary; see [binary resolution](structured-prompt-validator-binary-resolution.md)
 - `adl tooling generate-wp-issue-wave` — deterministic WBS/sprint-to-issue-wave planning generator
 - `adl tooling verify-review-output-provenance` — provenance verification for review-output artifacts
 - `adl tooling review-card-surface` — bounded deterministic review helper

--- a/docs/tooling/structured-prompt-validator-binary-resolution.md
+++ b/docs/tooling/structured-prompt-validator-binary-resolution.md
@@ -1,0 +1,69 @@
+# Structured Prompt Validator Binary Resolution
+
+`adl/tools/validate_structured_prompt.sh` is a compatibility wrapper around the
+dedicated `adl-validate-structured-prompt` binary. The wrapper is intentionally
+boring: it should find an already-built validator in known repo-owned layouts,
+or fail with an actionable diagnostic unless explicit cargo fallback is enabled.
+
+## Supported lookup order
+
+The wrapper resolves the ADL manifest root first, then tries validator binaries
+in this order:
+
+1. `ADL_STRUCTURED_PROMPT_VALIDATOR_BIN`
+2. `CARGO_TARGET_DIR/debug/adl-validate-structured-prompt`
+3. `CARGO_LLVM_COV_TARGET_DIR/debug/adl-validate-structured-prompt`
+4. `<resolved-root>/adl/target/debug/adl-validate-structured-prompt`
+5. `<primary-root>/adl/target/debug/adl-validate-structured-prompt`
+6. `<resolved-root>/adl/target/llvm-cov-target/debug/adl-validate-structured-prompt`
+7. `<primary-root>/adl/target/llvm-cov-target/debug/adl-validate-structured-prompt`
+8. `adl-validate-structured-prompt` on `PATH`, unless disabled
+9. legacy broad tooling binary fallback, only when explicit cargo fallback is
+   enabled
+10. `cargo run --bin adl-validate-structured-prompt`, only when explicit cargo
+    fallback is enabled
+
+For relative `CARGO_TARGET_DIR` or `CARGO_LLVM_COV_TARGET_DIR` values, the
+wrapper checks the current directory, resolved repo root, and primary checkout
+root forms. For absolute values, it checks the absolute target directory.
+
+## Coverage-target contract
+
+Coverage and fast-validation lanes may set `CARGO_TARGET_DIR` or
+`CARGO_LLVM_COV_TARGET_DIR`. If the dedicated validator binary is present under
+that target directory's `debug/` subdirectory, the wrapper must use it without
+falling back to `PATH` or `cargo run`.
+
+This is the supported non-default layout for coverage-style validation. The
+wrapper does not claim arbitrary Cargo target layouts beyond the documented
+target-dir forms and the fixed `target/llvm-cov-target` compatibility path.
+
+## Failure behavior
+
+When no dedicated validator binary is found and cargo fallback is not enabled,
+the wrapper exits with status `75` and lists the supported lookup surfaces.
+
+Enable cargo fallback only for explicit bootstrap or debugging:
+
+```sh
+ADL_STRUCTURED_PROMPT_VALIDATOR_ALLOW_CARGO_FALLBACK=1 \
+  bash adl/tools/validate_structured_prompt.sh --type stp --input path/to/stp.md
+```
+
+Normal workflow lanes should build or expose the dedicated binary instead.
+
+## Focused proof
+
+The focused proof lives in:
+
+```sh
+bash adl/tools/test_validate_structured_prompt_parallel.sh
+```
+
+That proof covers:
+
+- ordinary debug target lookup
+- `CARGO_TARGET_DIR` lookup
+- `CARGO_LLVM_COV_TARGET_DIR` lookup
+- missing-binary diagnostics
+- explicit cargo-fallback lock cleanup


### PR DESCRIPTION
Closes #3851

## Summary
Hardened the structured-prompt validator wrapper proof and documentation for normal debug and coverage-target binary layouts. The wrapper lookup order is now documented, the shell proof covers ordinary debug, `CARGO_TARGET_DIR`, and `CARGO_LLVM_COV_TARGET_DIR` layouts, and missing-binary diagnostics remain covered.

## Artifacts
- `adl/tools/validate_structured_prompt.sh`
- `adl/tools/test_validate_structured_prompt_parallel.sh`
- `docs/tooling/structured-prompt-validator-binary-resolution.md`
- `docs/tooling/README.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validate_structured_prompt_parallel.sh`
    Verified the focused binary-resolution contract and failure diagnostics.
  - `git diff --check`
    Verified patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3851__v0-91-5-tools-harden-structured-prompt-validator-binary-resolution-across-coverage-target-dirs/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3851__v0-91-5-tools-harden-structured-prompt-validator-binary-resolution-across-coverage-target-dirs/sor.md
- Idempotency-Key: v0-91-5-tools-harden-validator-binary-target-dir-lookup-adl-tools-validate-structured-prompt-sh-adl-tools-test-validate-structured-prompt-parallel-sh-docs-tooling-readme-md-docs-tooling-structured-prompt-validator-binary-resolution-md-adl-v0-91-5-tasks-issue-3851-v0-91-5-tools-harden-structured-prompt-validator-binary-resolution-across-coverage-target-dirs-sip-md-adl-v0-91-5-tasks-issue-3851-v0-91-5-tools-harden-structured-prompt-validator-binary-resolution-across-coverage-target-dirs-sor-md