### PR TITLE
[v0.91.5][process] Document forked-subagent model inheritance

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -65,6 +65,13 @@ The first four roles may run independently when the operator wants parallel
 review. The suite treats documentation review as required for all internal and
 external review packets unless a lane is explicitly skipped.
 
+When these roles are delegated to forked review subagents, do not request an
+explicit model override in the spawn request. Forked review agents inherit the
+parent session's model. If model choice matters for the review, select the
+desired model for the parent session before forking, or use a non-forked
+minimal-context handoff only when the specialist task does not need full review
+history.
+
 For this suite, the synthesis role must run after at least one specialist
 artifact is available, and ideally after all required roles have reported.
 When a required role is intentionally skipped, record an explicit skip reason,

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -299,6 +299,15 @@ worktree, allowed scope, stop boundary, and a reminder not to merge, close,
 reset, recreate branches, or widen issue scope without explicit operator
 direction.
 
+Forked subagents inherit the parent session's model and should not be given an
+explicit model override in full-history or forked-context review handoffs. When
+a stronger or cheaper model is required for a bounded review, start the parent
+session on that model before forking, or use a non-forked minimal-context
+handoff only when the task does not require full thread history. If a subagent
+spawn fails with an explicit-model or model-override error, retry once without
+the model override and record the inherited-model assumption in the handoff or
+review notes.
+
 Issue classification comes before validation selection.
 
 Classify the issue using the narrowest truthful class:

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -241,6 +241,8 @@ Bounded review-subagent exception:
 - child issue execution remains issue-skill driven rather than subagent driven
 - sprint review may use one bounded reviewer subagent when sprint policy
   explicitly enables that exception
+- forked reviewer subagents inherit the parent session's model; do not pass an
+  explicit model override in the forked review-subagent handoff
 - if the exception is disabled, the sprint review must remain local and record
   that no review subagent was used
 - the bundle should validate this boundary mechanically before review execution

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -115,6 +115,8 @@ Bounded review-subagent exception:
 - child issue execution stays local to the normal issue skill path
 - one bounded reviewer subagent may be used during sprint review when sprint
   policy explicitly enables it
+- forked reviewer subagents inherit the parent session's model; do not pass an
+  explicit model override in forked review-subagent handoffs
 - if disabled, record that no review subagent was used
 - validate the declared reviewer-subagent set before review execution:
   - `python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1`


### PR DESCRIPTION
Closes #3852

## Summary
Documented the forked-review-subagent model inheritance rule across the operational skill guidance and sprint review surfaces. Forked/full-history review subagents now have explicit guidance to inherit the parent model and avoid unsupported explicit model overrides.

## Artifacts
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
- Local issue cards under `.adl/v0.91.5/tasks/issue-3852__v0-91-5-process-document-forked-subagent-model-inheritance-for-bounded-reviews/`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace-safe tracked diff.
  - `rg -n "Forked subagents inherit|forked review subagents|explicit model override|model override|spawn fails" adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md adl/tools/skills/sprint-conductor/SKILL.md adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
    Verified the new model-inheritance and troubleshooting guidance is present.
  - `rg -n "gpt-5\\.4|model override|explicit model|Preferred Model" adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md adl/tools/skills/sprint-conductor/SKILL.md adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
    Verified no contradictory explicit model override guidance was added to forked review-subagent docs.
  - Bounded sidecar review of the docs diff
    Verified no findings against contradiction, overclaim, or acceptance-criteria fit.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3852__v0-91-5-process-document-forked-subagent-model-inheritance-for-bounded-reviews/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3852__v0-91-5-process-document-forked-subagent-model-inheritance-for-bounded-reviews/sor.md
- Idempotency-Key: v0-91-5-process-document-forked-subagent-model-inheritance-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sprint-conductor-references-conductor-playbook-md-adl-v0-91-5-tasks-issue-3852-v0-91-5-process-document-forked-subagent-model-inheritance-for-bounded-reviews-sip-md-adl-v0-91-5-tasks-issue-3852-v0-91-5-process-document-forked-subagent-model-inheritance-for-bounded-reviews-sor-md