### PR TITLE
[v0.91.5][tools] Add pre-finish stale-base guard

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -7,9 +7,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use super::git_support::{
-    branch_checked_out_worktree_path, commits_ahead_of_origin_main, current_branch, default_repo,
-    ensure_not_on_main_branch, has_uncommitted_changes, path_str, primary_checkout_root, repo_root,
-    run_capture, run_capture_allow_failure, run_status, run_status_allow_failure,
+    branch_checked_out_worktree_path, commits_ahead_of_origin_main, commits_behind_origin_main,
+    current_branch, default_repo, ensure_not_on_main_branch, has_uncommitted_changes, path_str,
+    primary_checkout_root, repo_root, run_capture, run_capture_allow_failure, run_status,
+    run_status_allow_failure,
 };
 use super::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
@@ -38,8 +39,6 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     let repo_root = repo_root()?;
     let primary_root = primary_checkout_root()?;
     let repo = default_repo(&repo_root)?;
-
-    let _ = run_status_allow_failure("git", &["fetch", "origin"]);
 
     let inferred = resolve_finish_issue_scope_and_slug(&repo_root, &primary_root, parsed.issue)?;
     let issue_ref = IssueRef::new(parsed.issue, inferred.0.clone(), inferred.1.clone())?;
@@ -116,7 +115,10 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     stage_selected_paths_rust(&repo_root, &parsed.paths)?;
     ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
     let has_uncommitted = has_uncommitted_changes(&repo_root)?;
+    run_status("git", &["fetch", "origin", "main"])
+        .context("finish: failed to fetch origin/main before stale-base guard")?;
     let ahead = commits_ahead_of_origin_main(&repo_root)?;
+    ensure_finish_branch_not_behind_origin_main(&repo_root)?;
     if staged_diff_is_empty(&repo_root)? {
         if !has_uncommitted && ahead == 0 {
             bail!("No changes detected and branch has no commits ahead of origin/main. Nothing to PR.");
@@ -336,6 +338,16 @@ pub(super) fn open_pr_url_nonblocking_with_timeout(
             ),
         },
     }
+}
+
+pub(super) fn ensure_finish_branch_not_behind_origin_main(repo_root: &Path) -> Result<()> {
+    let behind = commits_behind_origin_main(repo_root)?;
+    if behind == 0 {
+        return Ok(());
+    }
+    bail!(
+        "finish: branch is behind origin/main by {behind} commit(s); rebase before publication to avoid stale-base validation and coverage-impact false positives. Suggested recovery: git fetch origin main && git rebase origin/main --autostash, then rerun pr finish from the bound issue worktree."
+    )
 }
 
 pub(super) fn resolve_finish_issue_scope_and_slug(

--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -158,7 +158,40 @@ pub(super) fn commits_ahead_of_origin_main(repo_root: &Path) -> Result<usize> {
             "origin/main..HEAD",
         ],
     )?;
-    Ok(count.trim().parse::<usize>().unwrap_or(0))
+    count
+        .trim()
+        .parse::<usize>()
+        .with_context(|| "failed to parse origin/main ahead count")
+}
+
+pub(super) fn commits_behind_origin_main(repo_root: &Path) -> Result<usize> {
+    let local_origin_main = run_status_allow_failure(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "rev-parse",
+            "--verify",
+            "origin/main",
+        ],
+    )?;
+    if !local_origin_main {
+        return Ok(0);
+    }
+    let count = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "rev-list",
+            "--count",
+            "HEAD..origin/main",
+        ],
+    )?;
+    count
+        .trim()
+        .parse::<usize>()
+        .with_context(|| "failed to parse origin/main behind count")
 }
 
 pub(super) fn fetch_origin_main_with_fallback() -> Result<()> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -484,6 +484,11 @@ fn finish_guard_blocks_branch_behind_origin_main_before_validation() {
         .current_dir(&repo)
         .status()
         .expect("git push");
+    Command::new("git")
+        .args(["symbolic-ref", "HEAD", "refs/heads/main"])
+        .current_dir(&origin)
+        .status()
+        .expect("git origin head");
     ensure_finish_branch_not_behind_origin_main(&repo).expect("fresh branch");
 
     let upstream = temp.join("upstream");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
-    ensure_finish_task_bundle_surfaces, open_pr_url_nonblocking,
-    open_pr_url_nonblocking_with_timeout, real_pr_finish, resolve_finish_issue_scope_and_slug,
-    select_finish_validation_plan_for_finish,
+    ensure_finish_branch_not_behind_origin_main, ensure_finish_task_bundle_surfaces,
+    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, real_pr_finish,
+    resolve_finish_issue_scope_and_slug, select_finish_validation_plan_for_finish,
 };
+use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 
 #[test]
 fn parse_finish_args_requires_title_and_accepts_finish_flags() {
@@ -422,6 +423,118 @@ fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
     assert!(cargo_calls.contains("nextest run --manifest-path"));
     assert!(cargo_calls.contains("test --manifest-path"));
     assert!(cargo_calls.contains("--doc --all-features"));
+}
+
+#[test]
+fn finish_guard_blocks_branch_behind_origin_main_before_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-stale-base-guard");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    init_git_repo(&repo);
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config");
+    fs::write(repo.join("README.md"), "base\n").expect("readme");
+    Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit");
+    Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare");
+    Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url");
+    Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch");
+    Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push");
+    ensure_finish_branch_not_behind_origin_main(&repo).expect("fresh branch");
+
+    let upstream = temp.join("upstream");
+    Command::new("git")
+        .args([
+            "clone",
+            "-q",
+            path_str(&origin).expect("origin path"),
+            path_str(&upstream).expect("upstream path"),
+        ])
+        .status()
+        .expect("git clone");
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&upstream)
+        .status()
+        .expect("git config");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&upstream)
+        .status()
+        .expect("git config");
+    fs::write(upstream.join("README.md"), "upstream\n").expect("upstream readme");
+    Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&upstream)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-q", "-m", "upstream"])
+        .current_dir(&upstream)
+        .status()
+        .expect("git commit");
+    Command::new("git")
+        .args(["push", "-q", "origin", "main"])
+        .current_dir(&upstream)
+        .status()
+        .expect("git push");
+    Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch");
+
+    assert_eq!(commits_behind_origin_main(&repo).expect("behind count"), 1);
+    let err = ensure_finish_branch_not_behind_origin_main(&repo).expect_err("stale branch");
+    let message = err.to_string();
+    assert!(message.contains("finish: branch is behind origin/main by 1 commit(s)"));
+    assert!(message.contains("rebase before publication"));
+    assert!(message.contains("coverage-impact false positives"));
+    assert!(message.contains("git fetch origin main && git rebase origin/main --autostash"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #3865

## Summary
Added a pre-finish stale-base guard so `pr finish` stops when the issue branch is behind `origin/main`, before coverage-impact can classify unrelated upstream Rust changes as local risk.

## Artifacts
- `adl/src/cli/pr_cmd/git_support.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace-safe diff.
  - `cargo test --manifest-path adl/Cargo.toml finish_guard_blocks_branch_behind_origin_main_before_validation -- --nocapture`
    Verified the focused stale-base guard behavior and recovery message.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3865__v0-91-5-tools-add-pre-finish-stale-base-guard/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3865__v0-91-5-tools-add-pre-finish-stale-base-guard/sor.md
- Idempotency-Key: v0-91-5-tools-add-pre-finish-stale-base-guard-adl-src-cli-pr-cmd-git-support-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-5-tasks-issue-3865-v0-91-5-tools-add-pre-finish-stale-base-guard-sip-md-adl-v0-91-5-tasks-issue-3865-v0-91-5-tools-add-pre-finish-stale-base-guard-sor-md