### PR TITLE
[v0.91.5] Record final closeout truth for logging and tools sprints

### DIFF
--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -141,7 +141,8 @@ Supporting / domain-specific docs:
 
 Sprint and review support:
 
-- Logging mini-sprint closeout packet and review-hold note for open umbrella `#3703`: [LOGGING_MINI_SPRINT_CLOSEOUT_3703.md](review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md)
+- Logging mini-sprint closeout packet for umbrella `#3703`: [LOGGING_MINI_SPRINT_CLOSEOUT_3703.md](review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md)
+- Tools remediation sprint closeout packet for umbrella `#3845`: [TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md](review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md)
 
 ## Document Map
 

--- a/docs/milestones/v0.91.5/review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md
+++ b/docs/milestones/v0.91.5/review/logging_observability/LOGGING_MINI_SPRINT_CLOSEOUT_3703.md
@@ -3,7 +3,8 @@
 Sprint issue: #3703  
 Final child: #3711  
 Captured: 2026-06-15  
-Status: review_hold_open_until_follow_ons_land
+Updated: 2026-06-16
+Status: ready_for_final_umbrella_closeout
 
 ## Summary
 
@@ -16,10 +17,13 @@ This packet is the reviewer-facing summary for the sprint. It states what the
 sprint completed, what remains deferred, and what must not be overclaimed when
 v0.92 or later work relies on these surfaces.
 
-The original child issue wave is complete, but the sprint umbrella should
-remain open until the routed observability/tooling follow-ons are resolved.
-This packet is therefore a review-hold closeout surface, not a final
-sprint-closed claim.
+The original child issue wave is complete. The routed observability/tooling
+follow-ons that materially affected this packet's closeout truth have also
+landed, including `#3807`, `#3808`, and `#3809`.
+
+This packet is therefore ready to support final `#3703` umbrella closeout. It
+does not broaden the sprint's technical claims beyond the proof surfaces listed
+below.
 
 ## Child Issue Outcomes
 
@@ -103,11 +107,10 @@ Unsafe reliance after this sprint:
 - claiming every provider/runtime/long-lived-agent surface is fully unified
 - treating unresolved tool defects as if the sprint solved them
 
-## Remaining Follow-Ons
+## Follow-On Resolution
 
 The sprint surfaced bounded observability/tooling follow-ons during review.
-Several have already landed since the first closeout packet was written and
-should remain recorded as completed follow-on work rather than invisible
+They are recorded here as completed follow-on work rather than invisible
 backlog:
 
 - `#3789` machine-readable JSON surface cleanup is already completed and should
@@ -120,25 +123,11 @@ backlog:
 - `#3837` bootstrap/init now generates issue-specific `STP` and `SPP` cards
 - `#3807` fail-closed compatibility log behavior has landed
 - `#3808` embedded absolute-path redaction has landed
+- `#3809` bounded uniqueness for redacted provider artifact refs has landed
 
-The remaining logging-tail work must not be silently treated as done:
-
-- `#3809` bounded uniqueness for redacted provider artifact refs remains the
-  explicit remaining provider-logging follow-on from this packet
-- sprint-state / issue / PR closeout truth drift remains a routed tooling
-  concern unless its owning issue closes it separately
-
-Those follow-ons must not be silently treated as done by this sprint.
-
-The umbrella issue `#3703` should remain open and continue through the
-currently routed observability follow-ons that materially affect
-logging/observability review truth. At this point the active logging-tail item
-named by this packet is:
-
-- `#3809` bounded uniqueness for redacted provider artifact refs
-
-That issue now forms the active remaining sprint tail for `#3703` unless a
-later reviewed routing packet adds or removes follow-ons.
+No active logging-tail issue remains from this packet. Later toolkit
+simplification work, including the `#3733` refresh of the `#3704` gap audit,
+is a separate post-sprint refresh path and should not keep `#3703` open.
 
 ## Reviewer Checklist
 
@@ -147,12 +136,13 @@ Reviewers should confirm:
 - the child proofs above exist and are internally consistent
 - `#3711` guidance changes teach operators when logging proof is required
 - no packet in this sprint overclaims OTEL or repo-wide JSON cleanliness
-- deferred tool defects remain visible and are not mislabeled as sprint wins
+- deferred tool defects remain visible and are either closed or routed outside
+  this sprint
 
 ## Bottom Line
 
 The logging mini-sprint is a real hardening tranche, not a cosmetic docs wave.
 It gives ADL a usable observability contract and proof baseline, while
-preserving explicit boundaries around the work that still remains. Keep
-`#3703` open until the routed observability follow-ons above land; closeout is
-not final before then.
+preserving explicit boundaries around work that remains outside this sprint.
+The routed follow-ons named by this packet have landed, so `#3703` is ready for
+final umbrella closeout.

--- a/docs/milestones/v0.91.5/review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md
+++ b/docs/milestones/v0.91.5/review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md
@@ -1,0 +1,78 @@
+# Tools Remediation Sprint Closeout (#3845)
+
+Sprint issue: #3845  
+Captured: 2026-06-16  
+Status: ready_for_final_umbrella_closeout
+
+## Summary
+
+The #3845 tools remediation sprint completed the remaining active tooling
+remediation issues in the #3802-#3835 band and the final sprint-tail issue
+#3797. Toolkit simplification and Rust refactoring remained outside this
+sprint, as intended.
+
+This closeout packet records live GitHub state observed during final review.
+It replaces the earlier local-only readiness note that said #3797 / PR #3858
+was still blocking closeout.
+
+## Ordered Child Outcomes
+
+| Issue | Final state | Closeout note |
+| --- | --- | --- |
+| `#3802` | CLOSED | Parallel prompt-card validation hang diagnostics completed. |
+| `#3803` | CLOSED | Prompt-card enum diagnostics aligned with lifecycle states. |
+| `#3804` | CLOSED | Lifecycle-card absolute-path leakage diagnostics refined. |
+| `#3805` | CLOSED | Octocrab token preflight diagnostics added. |
+| `#3809` | CLOSED | Redacted provider artifact refs preserve bounded uniqueness. |
+| `#3816` | CLOSED | Governed issue-body repair command exposed. |
+| `#3819` | CLOSED | Nested worktree binding from issue worktrees prevented. |
+| `#3822` | CLOSED | PR merge false-negative on local branch deletion repaired. |
+| `#3823` | CLOSED | Transient GitHub checks API failures classified during PR watch. |
+| `#3828` | CLOSED | Default Rust validation narrowed for focused `pr_cmd` changes. |
+| `#3829` | CLOSED | `pr_cmd` risky-file coverage guidance made more specific. |
+| `#3831` | CLOSED | Local URL opener failure no longer fails or alarms PR creation. |
+| `#3834` | CLOSED | PR validation moved off `gh` and onto the ADL platform path. |
+| `#3835` | CLOSED | Structured logging added for PR validation waits. |
+
+## Sprint-Tail Resolution
+
+The earlier #3845 readiness note correctly held the sprint open while #3797 /
+PR #3858 was still active.
+
+Final live state:
+
+- `#3797` is CLOSED.
+- PR `#3858` is MERGED.
+- PR `#3858` checks completed with `adl-ci` success, `adl-coverage` success,
+  and `adl-slow-proof` skipped.
+
+No #3845 sprint-tail issue remains open.
+
+## Validation Performed
+
+Final review used live GitHub and repo workflow state:
+
+- `bash adl/tools/pr.sh doctor 3845 --mode full --json`
+  - returned `PASS`, with no open PR wave blockers for the #3845 queue.
+- `gh issue view` over #3797, #3802, #3803, #3804, #3805, #3809, #3816, #3819,
+  #3822, #3823, #3828, #3829, #3831, #3834, and #3835
+  - confirmed every sprint child and tail issue is CLOSED.
+- `gh pr view 3858`
+  - confirmed PR #3858 is MERGED and its required checks succeeded or were
+    intentionally skipped.
+
+## Residual Boundaries
+
+The sprint does not close or absorb:
+
+- toolkit simplification work
+- Rust refactoring work
+- v0.91.6 planning-doc updates that consume the completed tool fixes
+- future ergonomics around issue-body validation wording
+
+Those are separate work queues. They should not keep #3845 open.
+
+## Closeout Decision
+
+#3845 is ready for final umbrella closeout.
+


### PR DESCRIPTION
## Summary

- Update the #3703 logging mini-sprint closeout packet now that #3807, #3808, and #3809 have landed.
- Add a tracked #3845 tools remediation sprint closeout packet now that #3797 / PR #3858 has closed.
- Link both closeout packets from the v0.91.5 README.

Closes #3703.
Closes #3845.

## Validation

- `bash adl/tools/pr.sh doctor 3703 --mode full --json` -> PASS
- `bash adl/tools/pr.sh doctor 3845 --mode full --json` -> PASS
- `git diff --check`
- Markdown link resolver over the changed docs
- Secret / host-path marker scan over the changed docs
- Stale blocker text scan over the changed docs
- Bounded gpt-5.4 subagent review: no findings

## Notes

This PR only records final sprint closeout truth. It does not absorb toolkit simplification, Rust refactoring, or v0.91.6 planning-doc refresh work.