### PR TITLE
[v0.91.5][toolkit-simplification][5/8] Add docs-only pr finish fast path and non-closing PR support

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -725,11 +725,31 @@ fn finish_path_is_docs_only(path: &str) -> bool {
     if trimmed == "docs" || trimmed.starts_with("docs/") {
         return true;
     }
+    if trimmed.starts_with("adl/tools/skills/docs/") {
+        return finish_path_has_docs_artifact_extension(trimmed);
+    }
+    if trimmed.starts_with("adl/tools/skills/") {
+        if trimmed.ends_with("/SKILL.md") || trimmed.contains("/references/") {
+            return finish_path_has_docs_artifact_extension(trimmed);
+        }
+    }
     !trimmed.contains('/')
         && Path::new(trimmed)
             .extension()
             .and_then(|ext| ext.to_str())
             .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+}
+
+fn finish_path_has_docs_artifact_extension(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "md" | "yaml" | "yml" | "json"
+            )
+        })
 }
 
 fn finish_path_is_focused_local_ci_gated(path: &str) -> bool {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -728,10 +728,10 @@ fn finish_path_is_docs_only(path: &str) -> bool {
     if trimmed.starts_with("adl/tools/skills/docs/") {
         return finish_path_has_docs_artifact_extension(trimmed);
     }
-    if trimmed.starts_with("adl/tools/skills/") {
-        if trimmed.ends_with("/SKILL.md") || trimmed.contains("/references/") {
-            return finish_path_has_docs_artifact_extension(trimmed);
-        }
+    if trimmed.starts_with("adl/tools/skills/")
+        && (trimmed.ends_with("/SKILL.md") || trimmed.contains("/references/"))
+    {
+        return finish_path_has_docs_artifact_extension(trimmed);
     }
     !trimmed.contains('/')
         && Path::new(trimmed)

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -775,6 +775,41 @@ fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request()
 }
 
 #[test]
+fn finish_validation_profile_treats_issue_records_and_skill_docs_as_docs_only() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md".to_string(),
+            "adl/tools/skills/pr-finish/SKILL.md".to_string(),
+        ],
+    )
+    .expect("docs-only review artifact plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::DocsOnly);
+    assert_eq!(
+        plan.commands,
+        vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/tools/pr.sh".to_string(),
+            "docs/milestones/v0.91.5/DOCS_ONLY_VALIDATION_BUNDLE_3736.md".to_string(),
+        ],
+    )
+    .expect("behavioral tooling plan");
+
+    assert_ne!(plan.mode, FinishValidationMode::DocsOnly);
+}
+
+#[test]
 fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
     let plan = select_finish_validation_plan_for_finish(
         ".",

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -119,6 +119,11 @@ This skill must not:
 - silently merge
 - silently close the issue
 
+Use the normal no-closing publication path when the issue-local execution is
+done but the parent lifecycle surface must remain open, for example sprint
+umbrellas, review-hold closeout packets, or milestone truth updates with routed
+follow-ons. In the repo-native wrapper this is the `--no-close` finish mode.
+
 If the repo control plane reports `mismatched_publication_surface`, stop and
 rerun finish from the bound issue worktree. If it reports
 `rebind_to_issue_worktree_required`, re-establish the issue worktree through the


### PR DESCRIPTION
Closes #3737

## Summary
Narrowed `pr finish` docs-only validation selection so documentation-only skill
surfaces can publish without falling into the full Rust lane, while preserving
the existing non-closing `--no-close` PR path and keeping behavioral tooling
changes out of the docs-only fast path.

## Artifacts
- Updated finish-path classifier in `adl/src/cli/pr_cmd/finish_support.rs`
- Updated focused finish-path tests in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated `pr-finish` skill guidance in `adl/tools/skills/pr-finish/SKILL.md`
- Updated local execution record at `.adl/v0.91.5/tasks/issue-3737__v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render -- --nocapture`
    Verified docs-only skill-doc fast-path classification, behavioral-tooling fallback, and focused finish-path guardrails.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ensure_or_repair_pr_closing_linkage_is_noop_when_no_close_is_set -- --nocapture`
    Verified the non-closing finish path still skips closing-linkage enforcement.
  - `git diff --check`
    Verified whitespace and patch hygiene on the changed implementation and docs.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.5/tasks/issue-3737__v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support/srp.md`
    Verified final SRP contract compliance after recording review truth.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.5/tasks/issue-3737__v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support/sor.md`
    Verified final SOR contract compliance after recording execution truth.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3737__v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3737__v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support/sor.md
- Idempotency-Key: v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support-adl-v0-91-5-tasks-issue-3737-v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support-sip-md-adl-v0-91-5-tasks-issue-3737-v0-91-5-toolkit-simplification-5-8-add-docs-only-pr-finish-fast-path-and-non-closing-pr-support-sor-md