### PR TITLE
[v0.91.5][toolkit-simplification][6/9] Automate SOR evidence and enum normalization for docs-only issues

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -65,8 +65,7 @@ use self::finish_support::{
     finish_inputs_fingerprint, issue_bundle_issue_number_from_repo_relative,
     render_default_finish_validation, render_pr_body, run_finish_validation_rust,
     select_finish_validation_plan, stage_selected_paths_rust, staged_diff_is_empty,
-    staged_gitignore_change_present, tracked_issue_surface_paths, FinishValidationMode,
-    FinishValidationPlan,
+    staged_gitignore_change_present, tracked_issue_surface_paths,
 };
 use self::finish_support::{ensure_nonempty_file_path, validate_completed_sor};
 #[cfg(test)]

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -89,28 +89,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("finish", &input_path, PromptSurfaceKind::Sip)?;
     validate_structured_artifact(&repo_root, "finish", &plan_path, "spp")?;
     validate_structured_artifact(&repo_root, "finish", &review_policy_path, "srp")?;
-    validate_completed_sor(&repo_root, &output_path)?;
     ensure_issue_surfaces_are_local_only(&repo_root, &primary_root, &issue_ref, &source_path)?;
 
-    let canonical_output = lifecycle::sync_completed_output_surfaces(
-        &repo_root,
-        &primary_root,
-        &issue_ref,
-        &output_path,
-    )?;
-    if lifecycle::issue_is_closed_and_completed(parsed.issue, &repo)? {
-        lifecycle::ensure_closed_completed_issue_bundle_truth(
-            &primary_root,
-            &issue_ref,
-            &canonical_output,
-        )
-        .with_context(|| {
-            format!(
-                "finish: closed issue #{} has stale canonical sor truth; run closeout normalization before publication",
-                parsed.issue
-            )
-        })?;
-    }
+    normalize_sor_enum_aliases_for_finish(&output_path)?;
 
     stage_selected_paths_rust(&repo_root, &parsed.paths)?;
     ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
@@ -135,6 +116,28 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         select_finish_validation_plan_for_finish(&parsed.paths, &changed_paths)?;
     if !parsed.no_checks {
         run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
+        record_docs_only_validation_evidence_for_finish(&output_path, &finish_validation_plan)?;
+    }
+    validate_completed_sor(&repo_root, &output_path)?;
+
+    let canonical_output = lifecycle::sync_completed_output_surfaces(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &output_path,
+    )?;
+    if lifecycle::issue_is_closed_and_completed(parsed.issue, &repo)? {
+        lifecycle::ensure_closed_completed_issue_bundle_truth(
+            &primary_root,
+            &issue_ref,
+            &canonical_output,
+        )
+        .with_context(|| {
+            format!(
+                "finish: closed issue #{} has stale canonical sor truth; run closeout normalization before publication",
+                parsed.issue
+            )
+        })?;
     }
 
     let close_line = if parsed.no_close {
@@ -538,6 +541,316 @@ pub(super) fn validate_completed_sor(repo_root: &Path, output_path: &Path) -> Re
             output_path.display()
         )
     })
+}
+
+fn normalize_sor_enum_aliases_for_finish(output_path: &Path) -> Result<()> {
+    let original = fs::read_to_string(output_path).with_context(|| {
+        format!(
+            "finish: failed to read output card {}",
+            output_path.display()
+        )
+    })?;
+    let normalized = normalize_docs_only_sor_aliases(&original);
+    if normalized != original {
+        fs::write(output_path, normalized).with_context(|| {
+            format!(
+                "finish: failed to write normalized docs-only output card {}",
+                output_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn record_docs_only_validation_evidence_for_finish(
+    output_path: &Path,
+    plan: &FinishValidationPlan,
+) -> Result<()> {
+    if plan.mode != FinishValidationMode::DocsOnly {
+        return Ok(());
+    }
+    let original = fs::read_to_string(output_path).with_context(|| {
+        format!(
+            "finish: failed to read output card {}",
+            output_path.display()
+        )
+    })?;
+    let normalized = normalize_docs_only_validation_evidence(&original, &plan.commands);
+    if normalized != original {
+        fs::write(output_path, normalized).with_context(|| {
+            format!(
+                "finish: failed to write docs-only validation evidence into output card {}",
+                output_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn normalize_docs_only_sor_text(text: &str, commands: &[String]) -> String {
+    let mut updated = normalize_docs_only_sor_aliases(text);
+    updated = normalize_docs_only_validation_evidence(&updated, commands);
+    updated
+}
+
+fn normalize_docs_only_sor_aliases(text: &str) -> String {
+    let mut updated = text.to_string();
+    updated = normalize_sor_enum_line(
+        &updated,
+        "- Integration state:",
+        normalize_integration_state_alias,
+    );
+    updated = normalize_sor_enum_line(
+        &updated,
+        "- Verification scope:",
+        normalize_verification_scope_alias,
+    );
+    updated
+}
+
+fn normalize_docs_only_validation_evidence(text: &str, commands: &[String]) -> String {
+    let mut updated = text.to_string();
+    updated = ensure_docs_only_validation_entries(&updated, commands);
+    updated = ensure_docs_only_checks_run_entries(&updated, commands);
+    updated
+}
+
+fn normalize_sor_enum_line(
+    text: &str,
+    prefix: &str,
+    normalizer: fn(&str) -> Option<&'static str>,
+) -> String {
+    let mut changed = false;
+    let lines = text
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if let Some(value) = trimmed.strip_prefix(prefix) {
+                if let Some(normalized) = normalizer(value.trim()) {
+                    let indent_len = line.len() - trimmed.len();
+                    let indent = &line[..indent_len];
+                    let rewritten = format!("{indent}{prefix} {normalized}");
+                    if rewritten != line {
+                        changed = true;
+                        return rewritten;
+                    }
+                }
+            }
+            line.to_string()
+        })
+        .collect::<Vec<_>>();
+    if changed {
+        format!("{}\n", lines.join("\n"))
+    } else {
+        text.to_string()
+    }
+}
+
+fn normalize_integration_state_alias(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "worktree-only" | "worktree only" | "worktree" => Some("worktree_only"),
+        "pr" | "open_pr" | "open-pr" | "pr-ready" | "pr_ready" => Some("pr_open"),
+        "closed-no-pr" | "closed_no_pr" | "no-pr" | "no_pr" => Some("closed_no_pr"),
+        "merged-pr" | "merged_pr" => Some("merged"),
+        _ => None,
+    }
+}
+
+fn normalize_verification_scope_alias(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "main" | "main repo" | "main-repo" | "repo" => Some("main_repo"),
+        "pr" | "pr branch" | "pr-branch" | "branch" => Some("pr_branch"),
+        "worktree-only" | "worktree_only" => Some("worktree"),
+        _ => None,
+    }
+}
+
+fn ensure_docs_only_validation_entries(text: &str, commands: &[String]) -> String {
+    let Some(validation_body) = markdown_section_body_local(text, "Validation") else {
+        return text.to_string();
+    };
+    let replacement = ensure_command_entries_before_marker(
+        &validation_body,
+        commands,
+        "- Results:",
+        render_docs_only_validation_entry,
+    );
+    replace_markdown_section_body(text, "Validation", &replacement)
+        .unwrap_or_else(|_| text.to_string())
+}
+
+fn ensure_docs_only_checks_run_entries(text: &str, commands: &[String]) -> String {
+    let Some(summary_body) = markdown_section_body_local(text, "Verification Summary") else {
+        return text.to_string();
+    };
+    let replacement = ensure_yaml_checks_run_entries(&summary_body, commands);
+    replace_markdown_section_body(text, "Verification Summary", &replacement)
+        .unwrap_or_else(|_| text.to_string())
+}
+
+fn ensure_command_entries_before_marker(
+    body: &str,
+    commands: &[String],
+    marker: &str,
+    render_entry: fn(&str) -> String,
+) -> String {
+    let mut lines = body.lines().map(str::to_string).collect::<Vec<_>>();
+    let insert_at = lines
+        .iter()
+        .position(|line| line.trim_start() == marker)
+        .unwrap_or(lines.len());
+    let mut insertion = Vec::new();
+    for command in commands {
+        let needle = format!("`{command}`");
+        if body.contains(&needle) {
+            continue;
+        }
+        insertion.extend(render_entry(command).lines().map(str::to_string));
+    }
+    if insertion.is_empty() {
+        return body.to_string();
+    }
+    if insert_at > 0 && !lines[insert_at - 1].trim().is_empty() {
+        insertion.insert(0, String::new());
+    }
+    lines.splice(insert_at..insert_at, insertion);
+    trim_trailing_blank_lines(lines).join("\n")
+}
+
+fn render_docs_only_validation_entry(command: &str) -> String {
+    format!(
+        "  - `{command}`\n    {}",
+        docs_only_command_description(command)
+    )
+}
+
+fn docs_only_command_description(command: &str) -> &'static str {
+    match command {
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh" => {
+            "Verified no tracked local-only ADL issue-record residue remained staged for publication."
+        }
+        "git diff --check" => {
+            "Verified whitespace and patch hygiene on the docs-only changed surfaces."
+        }
+        _ => "Verified the docs-only finish validation command completed successfully.",
+    }
+}
+
+fn ensure_yaml_checks_run_entries(body: &str, commands: &[String]) -> String {
+    let mut lines = body.lines().map(str::to_string).collect::<Vec<_>>();
+    let Some(checks_run_idx) = lines.iter().position(|line| line.trim() == "checks_run:") else {
+        return body.to_string();
+    };
+    let list_end = lines
+        .iter()
+        .enumerate()
+        .skip(checks_run_idx + 1)
+        .find(|(_, line)| line.starts_with("  ") && !line.starts_with("      - "))
+        .map(|(idx, _)| idx)
+        .unwrap_or(lines.len());
+    let mut insert_at = list_end;
+    for command in commands {
+        let rendered = format!("      - \"{command}\"");
+        if lines.iter().any(|line| line.trim() == rendered.trim()) {
+            continue;
+        }
+        lines.insert(insert_at, rendered);
+        insert_at += 1;
+    }
+    trim_trailing_blank_lines(lines).join("\n")
+}
+
+fn replace_markdown_section_body(input: &str, heading: &str, replacement: &str) -> Result<String> {
+    let lines = input.lines().map(str::to_string).collect::<Vec<_>>();
+    let mut in_fence = false;
+    let mut start = None;
+    let mut target_depth = None;
+    let mut end = lines.len();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some((depth, text)) = parse_heading_line(line) {
+            if start.is_none() && text == heading.trim() {
+                start = Some(idx);
+                target_depth = Some(depth);
+                continue;
+            }
+            if start.is_some() && depth <= target_depth.expect("target depth") {
+                end = idx;
+                break;
+            }
+        }
+    }
+
+    let start = start.ok_or_else(|| anyhow::anyhow!("heading '{heading}' not found"))?;
+    let mut out = Vec::new();
+    out.extend_from_slice(&lines[..=start]);
+    out.push(String::new());
+    if !replacement.trim().is_empty() {
+        out.extend(replacement.trim().lines().map(str::to_string));
+        out.push(String::new());
+    }
+    out.extend_from_slice(&lines[end..]);
+    Ok(format!("{}\n", trim_trailing_blank_lines(out).join("\n")))
+}
+
+fn markdown_section_body_local(text: &str, heading: &str) -> Option<String> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let mut in_fence = false;
+    let mut start = None;
+    let mut target_depth = None;
+    let mut end = lines.len();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some((depth, text)) = parse_heading_line(line) {
+            if start.is_none() && text == heading.trim() {
+                start = Some(idx + 1);
+                target_depth = Some(depth);
+                continue;
+            }
+            if start.is_some() && depth <= target_depth.expect("target depth") {
+                end = idx;
+                break;
+            }
+        }
+    }
+
+    let start = start?;
+    Some(lines[start..end].join("\n").trim().to_string())
+}
+
+fn parse_heading_line(line: &str) -> Option<(usize, String)> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    let rest = trimmed.get(hashes..)?;
+    if !rest.starts_with(' ') {
+        return None;
+    }
+    Some((hashes, rest.trim().to_string()))
+}
+
+fn trim_trailing_blank_lines(mut lines: Vec<String>) -> Vec<String> {
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+    lines
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
     ensure_finish_branch_not_behind_origin_main, ensure_finish_task_bundle_surfaces,
-    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, real_pr_finish,
-    resolve_finish_issue_scope_and_slug, select_finish_validation_plan_for_finish,
+    normalize_docs_only_sor_text, open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout,
+    real_pr_finish, resolve_finish_issue_scope_and_slug, select_finish_validation_plan_for_finish,
+    FinishValidationMode, FinishValidationPlan,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 
@@ -198,6 +199,131 @@ fn render_pr_body_defaults_docs_only_validation_when_needed() {
     assert!(!body.contains("cargo clippy --all-targets -- -D warnings"));
     assert!(!body.contains("cargo nextest run"));
     assert!(!body.contains("cargo test"));
+}
+
+#[test]
+fn docs_only_sor_normalization_repairs_aliases_and_ingests_validation_evidence() {
+    let input = r#"# issue-3738
+
+Task ID: issue-3738
+Run ID: issue-3738
+Version: v0.91.5
+Title: Example
+Branch: codex/example
+Card Status: ready
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5
+- Provider: OpenAI
+- Start Time: 2026-06-16T00:00:00Z
+- End Time: 2026-06-16T00:00:01Z
+
+## Summary
+
+done
+
+## Artifacts produced
+- docs/example.md
+
+## Actions taken
+- did the thing
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated:
+  - `docs/example.md`
+- Worktree-only paths remaining: none
+- Worktree prune result: not_run
+- Integration state: open_pr
+- Verification scope: main-repo
+- Integration method used: manual
+- Verification performed:
+  - `python3 - <<'PY' ...`
+    Existing docs-only proof.
+- Result: PASS
+
+## Validation
+- Validation commands and their purpose:
+  - `python3 - <<'PY' ...`
+    Existing docs-only proof.
+- Results:
+  - PASS
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "python3 - <<'PY' ..."
+  determinism:
+    status: NOT_RUN
+```
+
+## Determinism Evidence
+- not_run
+
+## Security / Privacy Checks
+- ok
+
+## Replay Artifacts
+- not_applicable
+
+## Artifact Verification
+- docs/example.md
+
+## Decisions / Deviations
+- none
+
+## Follow-ups / Deferred work
+- none
+"#;
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::DocsOnly,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+        ],
+    };
+
+    let normalized = normalize_docs_only_sor_text(input, &plan.commands);
+
+    assert!(normalized.contains("- Integration state: pr_open"));
+    assert!(normalized.contains("- Verification scope: main_repo"));
+    assert!(normalized.contains("`bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`"));
+    assert!(normalized.contains("`git diff --check`"));
+    assert!(normalized.contains("\"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh\""));
+    assert!(normalized.contains("\"git diff --check\""));
+}
+
+#[test]
+fn docs_only_sor_normalization_is_idempotent_for_existing_entries() {
+    let input = r#"## Validation
+- Validation commands and their purpose:
+  - `git diff --check`
+    Verified whitespace and patch hygiene on the docs-only changed surfaces.
+- Results:
+  - PASS
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git diff --check"
+  determinism:
+    status: NOT_RUN
+```
+"#;
+
+    let commands = vec!["git diff --check".to_string()];
+    let normalized = normalize_docs_only_sor_text(input, &commands);
+    assert_eq!(normalized.matches("git diff --check").count(), 2);
 }
 
 #[test]
@@ -1141,6 +1267,12 @@ fn finish_path_tracking_covers_staged_vs_head_changes_and_local_only_issue_surfa
         vec!["tracked.txt".to_string()]
     );
 
+    fs::write(repo.join("unstaged.rs"), "pub fn unrelated() {}\n").expect("write unrelated");
+    assert_eq!(
+        finish_changed_paths(&repo, true).expect("staged paths with unrelated unstaged edit"),
+        vec!["tracked.txt".to_string()]
+    );
+
     fs::write(repo.join("ahead.txt"), "ahead\n").expect("ahead file");
     assert!(Command::new("git")
         .args(["add", "ahead.txt", "tracked.txt"])
@@ -1485,6 +1617,16 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
     }
 
     result.expect("real_pr_finish success");
+
+    let output_text = fs::read_to_string(&output).expect("read output card");
+    assert!(
+        !output_text.contains("bash adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "--no-checks finish should not inject unrun validation commands into SOR"
+    );
+    assert!(
+        !output_text.contains("git diff --check"),
+        "--no-checks finish should not inject docs-only validation evidence into SOR"
+    );
 
     let head_subject = run_capture(
         "git",

--- a/docs/milestones/v0.91.5/DOCS_ONLY_VALIDATION_BUNDLE_3736.md
+++ b/docs/milestones/v0.91.5/DOCS_ONLY_VALIDATION_BUNDLE_3736.md
@@ -122,6 +122,13 @@ structure checks that ran. When redaction- or observability-facing docs are
 involved, the `SOR` should say whether the proof was contract-only or whether a
 real command/log proof was run.
 
+For bounded docs-only finish publication, `pr-finish` may normalize known
+`SOR` enum aliases and ingest the standard docs-only validation commands into
+the `Validation` section and `verification_summary.checks_run`. That automation
+is intentionally narrow: it applies only to the canonical docs-only bundle and
+does not replace explicit human truth judgment for unusual execution or
+integration state.
+
 ## Non-Closing Lifecycle PR Policy
 
 A docs-only PR may complete issue-local execution without closing a larger


### PR DESCRIPTION
Closes #3738

## Summary
Added a bounded finish-path helper for docs-only `SOR` normalization so known
enum aliases can be repaired safely and canonical docs-only validation evidence
can be ingested after the checks actually run, without widening the finish lane
to unrelated unstaged tracked files.

## Artifacts
- Updated finish-path implementation in `adl/src/cli/pr_cmd/finish_support.rs`
- Updated related imports in `adl/src/cli/pr_cmd.rs`
- Added focused regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated docs-only policy wording in `docs/milestones/v0.91.5/DOCS_ONLY_VALIDATION_BUNDLE_3736.md`
- Updated local execution record at `.adl/v0.91.5/tasks/issue-3738__v0-91-5-toolkit-simplification-6-8-automate-sor-evidence-and-enum-normalization-for-docs-only-issues/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting compliance for the touched finish-path sources and tests.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc cli::pr_cmd::tests::finish::arg_render -- --nocapture`
    Verified focused finish-path behavior, including docs-only normalization, no-checks truth preservation, staged-surface changed-path semantics, and the default finish happy-path fixture.
  - `git diff --check`
    Verified whitespace and patch hygiene for the touched code and docs.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3738__v0-91-5-toolkit-simplification-6-8-automate-sor-evidence-and-enum-normalization-for-docs-only-issues/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3738__v0-91-5-toolkit-simplification-6-8-automate-sor-evidence-and-enum-normalization-for-docs-only-issues/sor.md
- Idempotency-Key: v0-91-5-toolkit-simplification-6-9-automate-sor-evidence-and-enum-normalization-for-docs-only-issues-adl-v0-91-5-tasks-issue-3738-v0-91-5-toolkit-simplification-6-8-automate-sor-evidence-and-enum-normalization-for-docs-only-issues-sip-md-adl-v0-91-5-tasks-issue-3738-v0-91-5-toolkit-simplification-6-8-automate-sor-evidence-and-enum-normalization-for-docs-only-issues-sor-md