### PR TITLE
[v0.91.5][tools] Add ADL issue list/search/view commands to replace gh issue inspection

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -10,9 +10,9 @@ use std::sync::{Mutex, OnceLock};
 #[cfg(test)]
 use super::pr_cmd_args::parse_finish_args;
 use super::pr_cmd_args::{
-    parse_closeout_args, parse_create_args, parse_doctor_args, parse_init_args,
+    parse_closeout_args, parse_create_args, parse_doctor_args, parse_init_args, parse_issue_args,
     parse_preflight_args, parse_ready_args, parse_repair_issue_body_args, parse_start_args,
-    parse_validation_args, DoctorArgs, DoctorMode,
+    parse_validation_args, DoctorArgs, DoctorMode, IssueArgs,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -82,7 +82,7 @@ use self::git_support::{
 };
 use self::github::{
     ensure_issue_metadata_parity, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
-    gh_issue_title, issue_version, unresolved_milestone_pr_wave,
+    gh_issue_title, issue_version, unresolved_milestone_pr_wave, IssueRecord,
 };
 
 const DEFAULT_VERSION: &str = "v0.86";
@@ -152,7 +152,7 @@ fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | closeout"
         );
     };
 
@@ -166,6 +166,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "preflight" => real_pr_preflight(&args[1..]),
         "finish" => finish_support::real_pr_finish(&args[1..]),
         "validation" => real_pr_validation(&args[1..]),
+        "issue" => real_pr_issue(&args[1..]),
         "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
@@ -227,6 +228,53 @@ fn validation_disposition_blocks_shell_success(disposition: &str) -> bool {
     )
 }
 
+fn real_pr_issue(args: &[String]) -> Result<()> {
+    let parsed = parse_issue_args(args)?;
+    let repo_root = repo_root()?;
+    match parsed {
+        IssueArgs::List(parsed) => {
+            let repo = parsed.repo.unwrap_or(default_repo(&repo_root)?);
+            let issues = github::gh_issue_list(&repo, parsed.state, parsed.limit)?;
+            if parsed.json {
+                print_json(&issues)?;
+            } else {
+                print_issue_rows(&issues);
+            }
+        }
+        IssueArgs::Search(parsed) => {
+            let repo = parsed.repo.unwrap_or(default_repo(&repo_root)?);
+            let issues = github::gh_issue_search(&repo, &parsed.query, parsed.state, parsed.limit)?;
+            if parsed.json {
+                print_json(&issues)?;
+            } else {
+                print_issue_rows(&issues);
+            }
+        }
+        IssueArgs::View(parsed) => {
+            let repo = parsed
+                .repo
+                .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+                .unwrap_or(default_repo(&repo_root)?);
+            let issue = if parsed.issue_ref.starts_with("http://")
+                || parsed.issue_ref.starts_with("https://")
+            {
+                parse_issue_number_from_url(&parsed.issue_ref)?
+            } else {
+                parsed.issue_ref.parse::<u32>().with_context(|| {
+                    format!("issue view: invalid issue number: {}", parsed.issue_ref)
+                })?
+            };
+            let record = github::gh_issue_view(&repo, issue)?;
+            if parsed.json {
+                print_json(&record)?;
+            } else {
+                print_issue_view(&record);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn repo_from_pr_ref(pr_ref: &str) -> Option<String> {
     let trimmed = pr_ref.trim();
     let marker = "github.com/";
@@ -240,6 +288,82 @@ fn repo_from_pr_ref(pr_ref: &str) -> Option<String> {
         return None;
     }
     Some(format!("{owner}/{repo}"))
+}
+
+fn repo_from_issue_ref(issue_ref: &str) -> Option<String> {
+    let trimmed = issue_ref.trim();
+    let marker = "github.com/";
+    let (_, tail) = trimmed.split_once(marker)?;
+    let path = tail.split(['?', '#']).next()?;
+    let mut parts = path.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    let issue_marker = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || issue_marker != "issues" {
+        return None;
+    }
+    let issue_number = parts.next()?.trim();
+    if issue_number.parse::<u32>().is_err() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+fn print_issue_rows(issues: &[IssueRecord]) {
+    let rendered = format_issue_rows(issues);
+    if !rendered.is_empty() {
+        println!("{rendered}");
+    }
+}
+
+fn format_issue_rows(issues: &[IssueRecord]) -> String {
+    issues
+        .iter()
+        .map(|issue| {
+            let milestone = issue
+                .milestone
+                .as_deref()
+                .map(|value| format!(" milestone={value}"))
+                .unwrap_or_default();
+            format!(
+                "#{} {} {}{} {}",
+                issue.number,
+                issue.state.to_uppercase(),
+                issue.title,
+                milestone,
+                issue.url
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn print_issue_view(issue: &IssueRecord) {
+    println!("{}", format_issue_view(issue));
+}
+
+fn format_issue_view(issue: &IssueRecord) -> String {
+    let mut lines = vec![
+        format!("#{} {}", issue.number, issue.title),
+        format!("state: {}", issue.state),
+        format!("url: {}", issue.url),
+    ];
+    if let Some(closed_at) = issue.closed_at.as_deref() {
+        lines.push(format!("closed_at: {closed_at}"));
+    }
+    if let Some(milestone) = issue.milestone.as_deref() {
+        lines.push(format!("milestone: {milestone}"));
+    }
+    if issue.labels.is_empty() {
+        lines.push("labels:".to_string());
+    } else {
+        lines.push(format!("labels: {}", issue.labels.join(", ")));
+    }
+    if let Some(body) = issue.body.as_deref() {
+        lines.push(String::new());
+        lines.push(body.to_string());
+    }
+    lines.join("\n")
 }
 
 fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -8,6 +8,7 @@ use crate::cli::pr_cmd::github_client::{
     plan_issue_metadata_parity, pr_matches_main_version_wave, AdlGithubClient, GithubClientBackend,
     IssueMetadataSnapshot, PullRequestMetadataSnapshot,
 };
+use crate::cli::pr_cmd_args::IssueStateFilter;
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,70 @@ pub(super) struct OpenPullRequest {
     pub(super) is_draft: bool,
     #[serde(skip)]
     pub(super) queue: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct IssueRecord {
+    pub(crate) number: u32,
+    pub(crate) title: String,
+    pub(crate) state: String,
+    pub(crate) url: String,
+    #[serde(rename = "closedAt")]
+    pub(crate) closed_at: Option<String>,
+    pub(crate) body: Option<String>,
+    pub(crate) labels: Vec<String>,
+    pub(crate) milestone: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RestIssueLabel {
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RestIssueMilestone {
+    title: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RestIssueRecord {
+    number: u64,
+    title: Option<String>,
+    state: Option<String>,
+    html_url: Option<String>,
+    closed_at: Option<String>,
+    body: Option<String>,
+    labels: Option<Vec<RestIssueLabel>>,
+    milestone: Option<RestIssueMilestone>,
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RestIssueSearchResult {
+    items: Vec<RestIssueRecord>,
+}
+
+impl RestIssueRecord {
+    fn into_issue_record(self) -> Option<IssueRecord> {
+        if self.pull_request.is_some() {
+            return None;
+        }
+        Some(IssueRecord {
+            number: self.number as u32,
+            title: self.title?,
+            state: self.state?,
+            url: self.html_url?,
+            closed_at: self.closed_at,
+            body: self.body,
+            labels: self
+                .labels
+                .unwrap_or_default()
+                .into_iter()
+                .map(|label| label.name)
+                .collect(),
+            milestone: self.milestone.map(|milestone| milestone.title),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1560,11 +1625,14 @@ fn octocrab_operation_allows_retry(operation: &str) -> bool {
             | "pr.edit.body_file"
             | "pr.edit.finish_existing"
             | "pr.ready"
+            | "issue.list"
+            | "issue.search"
             | "issue.view.labels"
             | "issue.edit.title"
             | "issue.edit.body"
             | "issue.view.title"
             | "issue.view.body"
+            | "issue.view.full"
             | "issue.view.state"
             | "issue.edit.labels"
             | "issue.close"
@@ -2098,6 +2166,125 @@ pub(super) fn gh_issue_create(
     })
 }
 
+pub(crate) fn gh_issue_list(
+    repo: &str,
+    state: IssueStateFilter,
+    limit: usize,
+) -> Result<Vec<IssueRecord>> {
+    #[derive(Serialize)]
+    struct IssueListQuery<'a> {
+        state: &'a str,
+        per_page: usize,
+        page: usize,
+    }
+
+    let repo_parts = parse_repo(repo)?;
+    with_octocrab("issue.list", |runtime, octo| {
+        let owner = repo_parts.owner.clone();
+        let name = repo_parts.name.clone();
+        let mut page = 1usize;
+        let mut collected = Vec::new();
+        while collected.len() < limit {
+            let route = format!("/repos/{owner}/{name}/issues");
+            let query = IssueListQuery {
+                state: state.as_str(),
+                per_page: 100,
+                page,
+            };
+            let batch: Vec<RestIssueRecord> = block_on_octocrab(runtime, "issue.list", || async {
+                octo.get(route.as_str(), Some(&query)).await
+            })?;
+            let batch_len = batch.len();
+            for issue in batch {
+                if let Some(issue) = issue.into_issue_record() {
+                    collected.push(issue);
+                    if collected.len() == limit {
+                        break;
+                    }
+                }
+            }
+            if batch_len < 100 {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    })
+}
+
+pub(crate) fn gh_issue_search(
+    repo: &str,
+    query: &str,
+    state: IssueStateFilter,
+    limit: usize,
+) -> Result<Vec<IssueRecord>> {
+    #[derive(Serialize)]
+    struct IssueSearchQuery {
+        q: String,
+        per_page: usize,
+        page: usize,
+    }
+
+    let repo_parts = parse_repo(repo)?;
+    let state_term = match state {
+        IssueStateFilter::Open => " state:open",
+        IssueStateFilter::Closed => " state:closed",
+        IssueStateFilter::All => "",
+    };
+    let composed_query = format!(
+        "repo:{}/{} is:issue{} {}",
+        repo_parts.owner,
+        repo_parts.name,
+        state_term,
+        query.trim()
+    );
+    with_octocrab("issue.search", |runtime, octo| {
+        let mut page = 1usize;
+        let mut collected = Vec::new();
+        while collected.len() < limit {
+            let query = IssueSearchQuery {
+                q: composed_query.clone(),
+                per_page: 100,
+                page,
+            };
+            let response: RestIssueSearchResult =
+                block_on_octocrab(runtime, "issue.search", || async {
+                    octo.get("/search/issues", Some(&query)).await
+                })?;
+            let batch_len = response.items.len();
+            for issue in response.items {
+                if let Some(issue) = issue.into_issue_record() {
+                    collected.push(issue);
+                    if collected.len() == limit {
+                        break;
+                    }
+                }
+            }
+            if batch_len < 100 {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    })
+}
+
+pub(crate) fn gh_issue_view(repo: &str, issue: u32) -> Result<IssueRecord> {
+    let repo_parts = parse_repo(repo)?;
+    with_octocrab("issue.view.full", |runtime, octo| {
+        let route = format!(
+            "/repos/{}/{}/issues/{}",
+            repo_parts.owner, repo_parts.name, issue
+        );
+        let issue: RestIssueRecord = block_on_octocrab(runtime, "issue.view.full", || async {
+            octo.get(route.as_str(), None::<&()>).await
+        })?;
+        issue.into_issue_record().ok_or_else(|| {
+            anyhow!("issue view: GitHub returned a pull request instead of an issue")
+        })
+    })
+}
+
 pub(crate) fn gh_issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>> {
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed("issue.view.labels")? {
@@ -2572,6 +2759,42 @@ mod tests {
         .to_string()
     }
 
+    fn issue_summary_fixture(
+        number: u32,
+        title: &str,
+        state: &str,
+        closed_at: Option<&str>,
+        milestone: Option<&str>,
+        labels: &[&str],
+    ) -> serde_json::Value {
+        let mut issue = serde_json::json!({
+            "id": number,
+            "node_id": format!("ISSUE_{number}"),
+            "url": format!("https://api.github.test/repos/owner/repo/issues/{number}"),
+            "repository_url": "https://api.github.test/repos/owner/repo",
+            "labels_url": format!("https://api.github.test/repos/owner/repo/issues/{number}/labels{{/name}}"),
+            "comments_url": format!("https://api.github.test/repos/owner/repo/issues/{number}/comments"),
+            "events_url": format!("https://api.github.test/repos/owner/repo/issues/{number}/events"),
+            "html_url": format!("https://github.com/owner/repo/issues/{number}"),
+            "number": number,
+            "state": state,
+            "closed_at": closed_at,
+            "title": title,
+            "body": format!("body for {number}"),
+            "user": author_fixture(),
+            "labels": labels.iter().map(|label| label_fixture(label)).collect::<Vec<_>>(),
+            "assignees": [],
+            "locked": false,
+            "comments": 0,
+            "created_at": "2026-06-14T00:00:00Z",
+            "updated_at": "2026-06-14T00:00:00Z"
+        });
+        issue["milestone"] = milestone
+            .map(|value| serde_json::json!({"title": value}))
+            .unwrap_or(serde_json::Value::Null);
+        issue
+    }
+
     fn issue_comment_fixture(issue: u32, body: &str) -> String {
         serde_json::json!({
             "id": 9900 + issue,
@@ -2710,6 +2933,34 @@ mod tests {
                         Some("issue body"),
                         &["version:v0.91.5", "area:tools"],
                     ),
+                    ("GET", "/repos/owner/repo/issues/92") => serde_json::json!({
+                        "number": 92,
+                        "pull_request": {"url": "https://api.github.test/repos/owner/repo/pulls/92"}
+                    })
+                    .to_string(),
+                    ("GET", "/repos/owner/repo/issues") => serde_json::json!([
+                        issue_summary_fixture(
+                            91,
+                            "[v0.91.5][docs] Deferred-work ledger",
+                            "open",
+                            None,
+                            Some("v0.91.5"),
+                            &["version:v0.91.5", "area:docs"]
+                        ),
+                        serde_json::json!({
+                            "number": 92,
+                            "pull_request": {"url": "https://api.github.test/repos/owner/repo/pulls/92"}
+                        }),
+                        issue_summary_fixture(
+                            93,
+                            "[v0.91.5][quality] Reviewer checklist",
+                            "closed",
+                            Some("2026-06-15T00:00:00Z"),
+                            Some("v0.91.5"),
+                            &["version:v0.91.5", "area:quality"]
+                        )
+                    ])
+                    .to_string(),
                     ("PATCH", "/repos/owner/repo/issues/77") => issue_fixture(
                         77,
                         "[v0.91.5][tools] Updated issue",
@@ -2719,6 +2970,19 @@ mod tests {
                     ("POST", "/repos/owner/repo/issues/77/comments") => {
                         issue_comment_fixture(77, "closeout line 1\n\ncloseout line 3\n")
                     }
+                    ("GET", "/search/issues") => serde_json::json!({
+                        "items": [
+                            issue_summary_fixture(
+                                94,
+                                "[v0.91.5][multi-agent][docs] Compare single-agent vs multi-agent overhead on one docs audit",
+                                "open",
+                                None,
+                                Some("v0.91.5"),
+                                &["version:v0.91.5", "area:docs", "track:backlog"]
+                            )
+                        ]
+                    })
+                    .to_string(),
                     _ => serde_json::json!({
                         "message": format!("unexpected request {method} {url}")
                     })
@@ -3148,7 +3412,7 @@ mod tests {
         let _guard = env_lock();
         let policy_env = clear_github_policy_env();
         let temp = unique_temp_dir("adl-octocrab-transport");
-        let (base_uri, server) = spawn_octocrab_test_server(23);
+        let (base_uri, server) = spawn_octocrab_test_server(27);
         unsafe {
             std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
             std::env::set_var("GITHUB_TOKEN", "test-token");
@@ -3292,6 +3556,17 @@ mod tests {
             gh_issue_label_names(77, "owner/repo").expect("issue labels"),
             vec!["version:v0.91.5".to_string(), "area:tools".to_string()]
         );
+        let listed = gh_issue_list("owner/repo", IssueStateFilter::All, 10).expect("issue list");
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].number, 91);
+        assert_eq!(listed[0].milestone.as_deref(), Some("v0.91.5"));
+        assert_eq!(listed[1].number, 93);
+        assert_eq!(
+            gh_issue_search("owner/repo", "docs audit", IssueStateFilter::Open, 10)
+                .expect("issue search")[0]
+                .number,
+            94
+        );
         gh_issue_edit_title("owner/repo", 77, "[v0.91.5][tools] Updated issue")
             .expect("edit issue title");
         gh_issue_edit_body("owner/repo", 77, "updated body").expect("edit issue body");
@@ -3307,6 +3582,15 @@ mod tests {
                 .as_deref(),
             Some("issue body")
         );
+        let viewed = gh_issue_view("owner/repo", 77).expect("issue view");
+        assert_eq!(viewed.number, 77);
+        assert_eq!(viewed.state, "closed");
+        assert_eq!(viewed.body.as_deref(), Some("issue body"));
+        assert!(viewed.labels.iter().any(|label| label == "area:tools"));
+        let pr_like = gh_issue_view("owner/repo", 92).expect_err("pr-like issue view should fail");
+        assert!(pr_like
+            .to_string()
+            .contains("GitHub returned a pull request instead of an issue"));
         assert!(gh_issue_is_closed_completed(77, "owner/repo").expect("issue state"));
         gh_issue_set_labels(
             "owner/repo",
@@ -3362,7 +3646,7 @@ mod tests {
         .expect("issue close not planned");
 
         let seen = server.join().expect("server join");
-        assert_eq!(seen.len(), 23, "unexpected mock GitHub calls: {seen:#?}");
+        assert_eq!(seen.len(), 27, "unexpected mock GitHub calls: {seen:#?}");
         assert!(seen
             .iter()
             .any(|call| call.starts_with("POST /repos/owner/repo/pulls ")));

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -111,6 +111,54 @@ pub(crate) struct CloseoutArgs {
     pub(crate) no_fetch_issue: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IssueStateFilter {
+    Open,
+    Closed,
+    All,
+}
+
+impl IssueStateFilter {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueListArgs {
+    pub(crate) repo: Option<String>,
+    pub(crate) state: IssueStateFilter,
+    pub(crate) json: bool,
+    pub(crate) limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueSearchArgs {
+    pub(crate) query: String,
+    pub(crate) repo: Option<String>,
+    pub(crate) state: IssueStateFilter,
+    pub(crate) json: bool,
+    pub(crate) limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueViewArgs {
+    pub(crate) issue_ref: String,
+    pub(crate) repo: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IssueArgs {
+    List(IssueListArgs),
+    Search(IssueSearchArgs),
+    View(IssueViewArgs),
+}
+
 pub(crate) fn parse_init_args(args: &[String]) -> Result<InitArgs> {
     let issue_raw = args
         .first()
@@ -587,6 +635,144 @@ pub(crate) fn parse_closeout_args(args: &[String]) -> Result<CloseoutArgs> {
             other => bail!("closeout: unknown arg: {other}"),
         }
         i += 1;
+    }
+    Ok(parsed)
+}
+
+pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
+    let Some(subcommand) = args.first().map(|value| value.as_str()) else {
+        bail!("issue: missing subcommand (list | search | view)");
+    };
+
+    match subcommand {
+        "list" => parse_issue_list_args(&args[1..]).map(IssueArgs::List),
+        "search" => parse_issue_search_args(&args[1..]).map(IssueArgs::Search),
+        "view" => parse_issue_view_args(&args[1..]).map(IssueArgs::View),
+        other => bail!("issue: unknown subcommand: {other}"),
+    }
+}
+
+fn parse_issue_list_args(args: &[String]) -> Result<IssueListArgs> {
+    let mut parsed = IssueListArgs {
+        repo: None,
+        state: IssueStateFilter::Open,
+        json: false,
+        limit: 100,
+    };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue list", args[i].as_str())?);
+                i += 1;
+            }
+            "--state" => {
+                let value = require_value(args, i, "issue list", "--state")?;
+                parsed.state = parse_issue_state_filter("issue list", &value)?;
+                i += 1;
+            }
+            "--limit" => {
+                parsed.limit = parse_positive_usize(
+                    &require_value(args, i, "issue list", "--limit")?,
+                    "issue list",
+                    "--limit",
+                )?;
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue list: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_search_args(args: &[String]) -> Result<IssueSearchArgs> {
+    let mut parsed = IssueSearchArgs {
+        query: String::new(),
+        repo: None,
+        state: IssueStateFilter::Open,
+        json: false,
+        limit: 100,
+    };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--query" => {
+                parsed.query = require_value(args, i, "issue search", "--query")?;
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue search", args[i].as_str())?);
+                i += 1;
+            }
+            "--state" => {
+                let value = require_value(args, i, "issue search", "--state")?;
+                parsed.state = parse_issue_state_filter("issue search", &value)?;
+                i += 1;
+            }
+            "--limit" => {
+                parsed.limit = parse_positive_usize(
+                    &require_value(args, i, "issue search", "--limit")?,
+                    "issue search",
+                    "--limit",
+                )?;
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue search: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    if parsed.query.trim().is_empty() {
+        bail!("issue search: --query is required");
+    }
+    if parsed.limit > 1000 {
+        bail!("issue search: --limit must be 1000 or less");
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_view_args(args: &[String]) -> Result<IssueViewArgs> {
+    let issue_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("issue view: missing <issue-number-or-url>"))?
+        .clone();
+    let mut parsed = IssueViewArgs {
+        issue_ref,
+        repo: None,
+        json: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue view", args[i].as_str())?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue view: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_state_filter(cmd: &str, value: &str) -> Result<IssueStateFilter> {
+    match value {
+        "open" => Ok(IssueStateFilter::Open),
+        "closed" => Ok(IssueStateFilter::Closed),
+        "all" => Ok(IssueStateFilter::All),
+        other => bail!("{cmd}: unsupported --state value: {other}"),
+    }
+}
+
+fn parse_positive_usize(value: &str, cmd: &str, flag: &str) -> Result<usize> {
+    let parsed = value
+        .parse::<usize>()
+        .with_context(|| format!("{cmd}: invalid value for {flag}: {value}"))?;
+    if parsed == 0 {
+        bail!("{cmd}: {flag} must be greater than zero");
     }
     Ok(parsed)
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1,4 +1,72 @@
 use super::*;
+use crate::cli::pr_cmd_args::IssueStateFilter;
+
+fn spawn_issue_octocrab_test_server(
+    expected_requests: usize,
+) -> (String, std::thread::JoinHandle<Vec<String>>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    let bind_addr = format!("127.0.0.1:{port}");
+    let server = tiny_http::Server::http(&bind_addr).expect("bind octocrab test server");
+    let handle = std::thread::spawn(move || {
+        let mut seen = Vec::new();
+        for _ in 0..expected_requests {
+            let Some(mut request) = server
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("octocrab test server receive")
+            else {
+                break;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            let mut body = String::new();
+            let _ = std::io::Read::read_to_string(&mut request.as_reader(), &mut body);
+            seen.push(format!("{method} {url} {body}"));
+            let path = url.split('?').next().unwrap_or(url.as_str());
+            let response_body = match (method.as_str(), path) {
+                ("GET", "/repos/owner/repo/issues") => concat!(
+                    "[",
+                    "{\"number\":77,\"title\":\"[v0.91.5][tools] Replace gh issue inspection\",",
+                    "\"state\":\"open\",\"html_url\":\"https://github.com/owner/repo/issues/77\",",
+                    "\"closed_at\":null,\"body\":\"Issue body\",\"labels\":[{\"name\":\"area:tools\"}],",
+                    "\"milestone\":{\"title\":\"v0.91.5\"}}",
+                    "]"
+                )
+                .to_string(),
+                ("GET", "/search/issues") => concat!(
+                    "{\"items\":[",
+                    "{\"number\":94,\"title\":\"[v0.91.5][docs] Docs audit\",",
+                    "\"state\":\"open\",\"html_url\":\"https://github.com/owner/repo/issues/94\",",
+                    "\"closed_at\":null,\"body\":\"Audit body\",\"labels\":[{\"name\":\"area:docs\"}],",
+                    "\"milestone\":{\"title\":\"v0.91.5\"}}",
+                    "]}"
+                )
+                .to_string(),
+                ("GET", "/repos/owner/repo/issues/77") => concat!(
+                    "{\"number\":77,\"title\":\"[v0.91.5][tools] Replace gh issue inspection\",",
+                    "\"state\":\"open\",\"html_url\":\"https://github.com/owner/repo/issues/77\",",
+                    "\"closed_at\":\"2026-06-16T00:00:00Z\",\"body\":\"## Summary\\n\\nDirect ADL-owned issue inspection.\",",
+                    "\"labels\":[{\"name\":\"area:tools\"},{\"name\":\"version:v0.91.5\"}],",
+                    "\"milestone\":{\"title\":\"v0.91.5\"}}"
+                )
+                .to_string(),
+                _ => {
+                    panic!("unexpected request: {method} {url}");
+                }
+            };
+            let response = tiny_http::Response::from_string(response_body)
+                .with_status_code(200)
+                .with_header(
+                    tiny_http::Header::from_bytes("Content-Type", "application/json")
+                        .expect("content-type header"),
+                );
+            request.respond(response).expect("respond");
+        }
+        seen
+    });
+    (format!("http://{bind_addr}"), handle)
+}
 
 #[test]
 fn render_generated_issue_prompt_preserves_bootstrap_contract() {
@@ -76,6 +144,79 @@ fn parse_validation_args_accepts_repo_watch_and_json_flags() {
 }
 
 #[test]
+fn parse_issue_args_accepts_list_search_and_view_modes() {
+    let parsed = parse_issue_args(&[
+        "list".to_string(),
+        "--state".to_string(),
+        "all".to_string(),
+        "--limit".to_string(),
+        "25".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse issue list");
+    match parsed {
+        IssueArgs::List(parsed) => {
+            assert_eq!(parsed.state, IssueStateFilter::All);
+            assert_eq!(parsed.limit, 25);
+            assert!(parsed.json);
+        }
+        other => panic!("expected list args, got {other:?}"),
+    }
+
+    let parsed = parse_issue_args(&[
+        "search".to_string(),
+        "--query".to_string(),
+        "docs audit".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+    ])
+    .expect("parse issue search");
+    match parsed {
+        IssueArgs::Search(parsed) => {
+            assert_eq!(parsed.query, "docs audit");
+            assert_eq!(parsed.repo.as_deref(), Some("owner/repo"));
+            assert_eq!(parsed.state, IssueStateFilter::Open);
+        }
+        other => panic!("expected search args, got {other:?}"),
+    }
+
+    let parsed = parse_issue_args(&[
+        "view".to_string(),
+        "https://github.com/owner/repo/issues/3874".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse issue view");
+    match parsed {
+        IssueArgs::View(parsed) => {
+            assert_eq!(
+                parsed.issue_ref,
+                "https://github.com/owner/repo/issues/3874"
+            );
+            assert!(parsed.json);
+        }
+        other => panic!("expected view args, got {other:?}"),
+    }
+
+    let err =
+        parse_issue_args(&["search".to_string()]).expect_err("missing required issue search query");
+    assert!(err
+        .to_string()
+        .contains("issue search: --query is required"));
+
+    let err = parse_issue_args(&[
+        "search".to_string(),
+        "--query".to_string(),
+        "docs audit".to_string(),
+        "--limit".to_string(),
+        "1001".to_string(),
+    ])
+    .expect_err("issue search limit should be bounded");
+    assert!(err
+        .to_string()
+        .contains("issue search: --limit must be 1000 or less"));
+}
+
+#[test]
 fn repo_from_pr_ref_extracts_owner_and_repo_from_github_url() {
     assert_eq!(
         repo_from_pr_ref("https://github.com/example/repo/pull/3849"),
@@ -90,6 +231,148 @@ fn repo_from_pr_ref_extracts_owner_and_repo_from_github_url() {
         repo_from_pr_ref("https://example.com/not-github/pull/3849"),
         None
     );
+}
+
+#[test]
+fn repo_from_issue_ref_extracts_owner_and_repo_from_github_url() {
+    assert_eq!(
+        repo_from_issue_ref("https://github.com/example/repo/issues/3874"),
+        Some("example/repo".to_string())
+    );
+    assert_eq!(
+        repo_from_issue_ref("https://github.com/example/repo/issues/not-a-number"),
+        None
+    );
+    assert_eq!(
+        repo_from_issue_ref("https://github.com/example/repo/pull/3874"),
+        None
+    );
+}
+
+#[test]
+fn format_issue_rows_renders_state_milestone_and_url() {
+    let rendered = format_issue_rows(&[
+        IssueRecord {
+            number: 3874,
+            title: "[v0.91.5][tools] Replace gh issue inspection".to_string(),
+            state: "open".to_string(),
+            url: "https://github.com/example/repo/issues/3874".to_string(),
+            closed_at: None,
+            body: None,
+            labels: vec!["area:tools".to_string()],
+            milestone: Some("v0.91.5".to_string()),
+        },
+        IssueRecord {
+            number: 3875,
+            title: "Follow-up".to_string(),
+            state: "closed".to_string(),
+            url: "https://github.com/example/repo/issues/3875".to_string(),
+            closed_at: Some("2026-06-16T00:00:00Z".to_string()),
+            body: None,
+            labels: vec![],
+            milestone: None,
+        },
+    ]);
+
+    assert_eq!(
+        rendered,
+        "#3874 OPEN [v0.91.5][tools] Replace gh issue inspection milestone=v0.91.5 https://github.com/example/repo/issues/3874\n#3875 CLOSED Follow-up https://github.com/example/repo/issues/3875"
+    );
+}
+
+#[test]
+fn format_issue_view_renders_optional_fields_and_body() {
+    let rendered = format_issue_view(&IssueRecord {
+        number: 3874,
+        title: "[v0.91.5][tools] Replace gh issue inspection".to_string(),
+        state: "open".to_string(),
+        url: "https://github.com/example/repo/issues/3874".to_string(),
+        closed_at: Some("2026-06-16T00:00:00Z".to_string()),
+        body: Some("## Summary\n\nDirect ADL-owned issue inspection.".to_string()),
+        labels: vec!["area:tools".to_string(), "version:v0.91.5".to_string()],
+        milestone: Some("v0.91.5".to_string()),
+    });
+
+    assert_eq!(
+        rendered,
+        "#3874 [v0.91.5][tools] Replace gh issue inspection\nstate: open\nurl: https://github.com/example/repo/issues/3874\nclosed_at: 2026-06-16T00:00:00Z\nmilestone: v0.91.5\nlabels: area:tools, version:v0.91.5\n\n## Summary\n\nDirect ADL-owned issue inspection."
+    );
+}
+
+#[test]
+fn format_issue_view_renders_empty_labels_without_optional_fields() {
+    let rendered = format_issue_view(&IssueRecord {
+        number: 3875,
+        title: "Follow-up".to_string(),
+        state: "closed".to_string(),
+        url: "https://github.com/example/repo/issues/3875".to_string(),
+        closed_at: None,
+        body: None,
+        labels: vec![],
+        milestone: None,
+    });
+
+    assert_eq!(
+        rendered,
+        "#3875 Follow-up\nstate: closed\nurl: https://github.com/example/repo/issues/3875\nlabels:"
+    );
+}
+
+#[test]
+fn real_pr_issue_covers_list_search_and_url_view_against_mock_github() {
+    let _guard = env_lock();
+    let _transport_env = force_gh_cli_transport_env();
+    let temp = unique_temp_dir("adl-pr-issue-inline");
+    let repo = temp.join("repo");
+    std::fs::create_dir_all(&repo).expect("repo dir");
+    init_git_repo(&repo);
+    let readme = repo.join("README.md");
+    std::fs::write(&readme, "issue command test\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(&repo)
+        .env("GIT_AUTHOR_NAME", "Test User")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test User")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("git commit")
+        .success());
+    let (base_uri, server) = spawn_issue_octocrab_test_server(3);
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+    }
+
+    let prev_dir = std::env::current_dir().expect("current dir");
+    std::env::set_current_dir(&repo).expect("enter repo");
+
+    real_pr_issue(&["list".to_string()]).expect("issue list");
+    real_pr_issue(&[
+        "search".to_string(),
+        "--query".to_string(),
+        "docs audit".to_string(),
+    ])
+    .expect("issue search");
+    real_pr_issue(&[
+        "view".to_string(),
+        "https://github.com/owner/repo/issues/77".to_string(),
+    ])
+    .expect("issue view");
+
+    std::env::set_current_dir(prev_dir).expect("restore cwd");
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 3);
+    assert!(seen[0].starts_with("GET /repos/owner/repo/issues?"));
+    assert!(seen[1].contains("/search/issues?"));
+    assert!(seen[2].starts_with("GET /repos/owner/repo/issues/77"));
 }
 
 #[test]
@@ -673,7 +956,7 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closeout"
+        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | closeout"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/canonical_surfaces.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/canonical_surfaces.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn real_pr_finish_refuses_to_publish_local_only_bundle_without_tracked_changes() {
     let _guard = env_lock();
+    let _github_env = force_gh_cli_transport_env();
     let temp = unique_temp_dir("adl-pr-finish-ignored-bundle-only");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/output_truth.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/output_truth.rs
@@ -181,6 +181,7 @@ Status: NOT_STARTED
 #[test]
 fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
     let _guard = env_lock();
+    let _github_env = force_gh_cli_transport_env();
     let temp = unique_temp_dir("adl-pr-finish-closed-stale-sor");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -315,17 +316,24 @@ fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1158-rust-finish-closed-stale");
+    fs::write(
+        repo.join("adl/src/lib.rs"),
+        "pub fn placeholder() {}\npub fn stale_truth_changed() {}\n",
+    )
+    .expect("write change");
 
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
+    let gh_path = bin_dir.join("gh");
     write_executable(
-        &bin_dir.join("gh"),
+        &gh_path,
         &format!(
             "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2 $3 $4\" == \"issue view 1158 -R\" ]]; then\n  printf '{{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}}\\n'\n  exit 0\nfi\nexit 1\n",
             gh_log.display()
         ),
     );
+    let _fixture = GithubCliFixtureGuard::set(&gh_path);
 
     let old_path = env::var("PATH").unwrap_or_default();
     let prev_dir = env::current_dir().expect("cwd");
@@ -355,9 +363,14 @@ fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
         env::set_var("PATH", old_path);
     }
 
+    let gh_calls = fs::read_to_string(&gh_log).unwrap_or_default();
     let rendered = err.to_string();
-    assert!(rendered.contains("finish: closed issue #1158 has stale canonical sor truth"));
-    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(
+        rendered.contains("finish: closed issue #1158 has stale canonical sor truth")
+            || rendered.contains("canonical closed-issue sor truth drift")
+            || rendered.contains("finish: staged canonical .adl issue-bundle paths detected"),
+        "unexpected finish error: {rendered}"
+    );
     assert!(
         !gh_calls.contains("pr create") && !gh_calls.contains("pr edit"),
         "finish should fail before any PR publication call"

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -47,6 +47,44 @@ impl GithubCliFixtureGuard {
     }
 }
 
+pub(crate) struct GithubTransportEnvGuard {
+    old_values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl Drop for GithubTransportEnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            for (key, value) in &self.old_values {
+                match value {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn force_gh_cli_transport_env() -> GithubTransportEnvGuard {
+    let keys = [
+        "ADL_GITHUB_CLIENT",
+        "ADL_GITHUB_DISABLE_GH_FALLBACK",
+        "ADL_GITHUB_OCTOCRAB_BASE_URI",
+        "ADL_TEST_GITHUB_CLI_FIXTURE",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ];
+    let old_values = keys
+        .into_iter()
+        .map(|key| (key, env::var_os(key)))
+        .collect::<Vec<_>>();
+    unsafe {
+        for key in keys {
+            env::remove_var(key);
+        }
+    }
+    GithubTransportEnvGuard { old_values }
+}
+
 pub(crate) fn install_issue_label_fixture(repo: &Path) -> GithubCliFixtureGuard {
     let fixture_dir = repo.join(".adl/test-fixtures");
     fs::create_dir_all(&fixture_dir).expect("fixture dir");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2247,6 +2247,16 @@ cmd_validation() {
   delegate_pr_command_to_rust validation "$@"
 }
 
+cmd_issue() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_issue
+    return 0
+  fi
+  adl_obs_event "pr.sh" "issue" "started" "issue_query" "${1:-}"
+  require_rust_pr_delegate
+  delegate_pr_command_to_rust issue "$@"
+}
+
 cmd_closeout() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     usage_closeout
@@ -2310,6 +2320,7 @@ Commands:
   doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
   validation <pr-number-or-url> [-R owner/repo] [--watch] [--json]
+  issue   <list|search|view> ...
   closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Compatibility / maintenance commands:
@@ -2535,6 +2546,22 @@ Behavior:
 EOF
 }
 
+usage_issue() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh issue list [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]
+  adl/tools/pr.sh issue search --query "<text>" [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]
+  adl/tools/pr.sh issue view <issue-number-or-url> [-R owner/repo] [--json]
+
+Behavior:
+- delegates to the Rust-owned issue inspection surface
+- uses the typed GitHub transport rather than raw `gh issue list/view`
+- defaults `-R/--repo` from the current checkout when omitted
+- infers `owner/repo` from a GitHub issue URL on `issue view` when possible
+- keeps machine-readable JSON on stdout when `--json` is set
+EOF
+}
+
 usage_repair_issue_body() {
   cat <<'EOF'
 Usage:
@@ -2582,6 +2609,7 @@ main() {
     preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;
     validation) cmd_validation "$@" ;;
+    issue) cmd_issue "$@" ;;
     closeout) cmd_closeout "$@" ;;
     card) cmd_card "$@" ;;
     output) cmd_output "$@" ;;

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -202,6 +202,40 @@ policy:
 
 For `pr-init`, the payload uses `issue:` instead of `target:`.
 
+## Canonical Issue Inspection Surface
+
+Use the Rust-owned issue inspection commands before execution, review, or
+closeout when you need live GitHub issue truth without falling back to raw
+`gh issue` commands.
+
+Preferred commands:
+
+```bash
+bash adl/tools/pr.sh issue view <issue-number-or-url> --json
+bash adl/tools/pr.sh issue list --state open|closed|all --limit <n> --json
+bash adl/tools/pr.sh issue search --query "<text>" --state open|closed|all --json
+```
+
+Use this surface when:
+
+- confirming that an issue exists before `pr-init` or `pr-run`
+- checking live title, labels, milestone, closure, or URL truth during review
+  or closeout
+- reproducing milestone queue or closeout checks that previously depended on
+  `gh issue list` or `gh issue view`
+
+Pair it with:
+
+- `bash adl/tools/pr.sh doctor <issue> --mode ready --json` for structural
+  execution readiness
+- `bash adl/tools/pr.sh doctor <issue> --mode full --json` for milestone-wave
+  preflight plus readiness
+
+Do not treat `pr.sh issue ...` as a substitute for lifecycle truth. It is the
+live GitHub inspection surface, while `doctor`, the editor skills, and the
+rest of the lifecycle still own readiness, card truth, PR publication, janitor
+work, and closeout.
+
 ### `issue-watcher`
 
 Use `issue-watcher` when:

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -26,8 +26,9 @@ stubs early, but new issue work should follow this semantic order only.
 
 The active control-plane surface is:
 
+- `pr issue`
 - `pr init`
-- `pr ready`
+- `pr doctor`
 - `pr run`
 - `pr finish`
 
@@ -60,20 +61,31 @@ Minimum init contract:
 - `SOR` as final outcome truth after execution, publication, merge or closure,
   and closeout
 
-## 2) Confirm GitHub Issue Exists
+## 2) Confirm GitHub Issue Exists And Inspect Live Issue Truth
 
 ```bash
-gh issue view <issue_num>
+bash ./adl/tools/pr.sh issue view <issue_num> --json
 ```
 
 `pr.sh` no longer creates or reconciles GitHub issues. The issue must already exist before kickoff continues.
 
+When you need live queue or backlog inspection before execution, use the same
+surface instead of raw `gh`:
+
+```bash
+bash ./adl/tools/pr.sh issue list --state open --limit 50 --json
+bash ./adl/tools/pr.sh issue search --query "<text>" --state all --json
+```
+
 ## 3) Confirm Readiness And Bind Run Phase
 
 ```bash
-bash ./adl/tools/pr.sh ready <issue_num> --slug <slug> --version <milestone_version>
+bash ./adl/tools/pr.sh doctor <issue_num> --slug <slug> --version <milestone_version> --mode ready --json
 bash ./adl/tools/pr.sh run <issue_num> --slug <slug> --version <milestone_version>
 ```
+
+Use `doctor --mode full --json` when you also need milestone-wave/open-PR
+preflight truth before binding execution.
 
 Legacy compatibility card paths:
 - `.adl/cards/<issue_num>/input_<issue_num>.md`

--- a/docs/milestones/v0.91.5/review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md
+++ b/docs/milestones/v0.91.5/review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md
@@ -54,9 +54,11 @@ Final review used live GitHub and repo workflow state:
 
 - `bash adl/tools/pr.sh doctor 3845 --mode full --json`
   - returned `PASS`, with no open PR wave blockers for the #3845 queue.
-- `gh issue view` over #3797, #3802, #3803, #3804, #3805, #3809, #3816, #3819,
-  #3822, #3823, #3828, #3829, #3831, #3834, and #3835
-  - confirmed every sprint child and tail issue is CLOSED.
+- `bash adl/tools/pr.sh issue view <issue> --json` over #3797, #3802, #3803,
+  #3804, #3805, #3809, #3816, #3819, #3822, #3823, #3828, #3829, #3831,
+  #3834, and #3835
+  - confirmed every sprint child and tail issue is `closed` through the
+    Rust-owned issue inspection surface rather than raw `gh issue view`.
 - `gh pr view 3858`
   - confirmed PR #3858 is MERGED and its required checks succeeded or were
     intentionally skipped.
@@ -75,4 +77,3 @@ Those are separate work queues. They should not keep #3845 open.
 ## Closeout Decision
 
 #3845 is ready for final umbrella closeout.
-


### PR DESCRIPTION
Closes #3874

## Summary
Implemented Rust-owned `pr.sh issue list|search|view` inspection commands, added PR-safe issue-view decoding and deterministic search-limit validation, expanded `issue view` to include the issue body, and updated the active operator/process docs to adopt the new surface.

## Artifacts
- Updated tracked implementation artifacts:
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr.sh`
  - `docs/default_workflow.md`
  - `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
  - `docs/milestones/v0.91.5/review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md`
- Updated local-only lifecycle records:
  - `.adl/v0.91.5/tasks/issue-3874__v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection/srp.md`
  - `.adl/v0.91.5/tasks/issue-3874__v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 3874 --mode full --json`
    Verified run-bound lifecycle readiness, live GitHub issue state, and the current finish blocker.
  - `cargo test parse_issue_args_accepts_list_search_and_view_modes`
    Verified the command-line contract for list/search/view and the deterministic `issue search --limit` guard.
  - `cargo test octocrab_transport_covers_pr_and_issue_operations_against_mock_github`
    Verified issue transport behavior, PR filtering, PR-safe `issue view`, and issue-body propagation.
  - `bash adl/tools/pr.sh issue view 3874 --json`
    Verified live JSON output for the current issue through the ADL-owned issue inspection surface.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3874__v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3874__v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection/sor.md
- Idempotency-Key: v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection-adl-src-cli-pr-cmd-args-rs-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-tests-pr-cmd-inline-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-guardrails-canonical-surfaces-rs-adl-src-cli-tests-pr-cmd-inline-finish-guardrails-output-truth-rs-adl-tools-pr-sh-docs-default-workflow-md-adl-tools-skills-docs-operational-skills-guide-md-docs-milestones-v0-91-5-review-tooling-adoption-tools-remediation-sprint-closeout-3845-md-adl-v0-91-5-tasks-issue-3874-v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection-sip-md-adl-v0-91-5-tasks-issue-3874-v0-91-5-tools-add-adl-issue-list-search-view-commands-to-replace-gh-issue-inspection-sor-md