### PR TITLE
[v0.91.5][toolkit-simplification][8/9] Update AGENTS skills templates and close out simplification sprint

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -130,7 +130,10 @@ cd ./adl/ && bash tools/enforce_coverage_gates.sh coverage-summary.json
 ./adl/tools/report_large_rust_modules.sh
 
 # generate deterministic execution prompt from an input card
-adl tooling card-prompt --issue <issue_num> --out /tmp/prompt.txt
+adl-csdlc tooling card-prompt --issue <issue_num> --out /tmp/prompt.txt
+
+# fresh checkout fallback when adl-csdlc is not yet on PATH
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling card-prompt --issue <issue_num> --out /tmp/prompt.txt
 
 # finish issue and open/update PR
 bash ./adl/tools/pr.sh finish <issue_num> --title "<title>" --paths "<paths>"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -118,12 +118,20 @@ For new or fully re-rendered prompt cards, prefer the Rust-owned values
 renderer and structure-schema validator before editing Markdown directly:
 
 ```bash
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind <kind> --values <kind>.values.yaml
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind <kind> --values <kind>.values.yaml --out <kind>.md
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind <kind> --input <kind>.md
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-schemas
+adl-csdlc tooling prompt-template validate-values --kind <kind> --values <kind>.values.yaml
+adl-csdlc tooling prompt-template render --kind <kind> --values <kind>.values.yaml --out <kind>.md
+adl-csdlc tooling prompt-template validate-structure --kind <kind> --input <kind>.md
+adl-csdlc tooling prompt-template validate-schemas
 python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same owner-binary commands
+through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`
+from a fresh checkout.
+
+For docs-only, milestone-truth, or workflow-doc issues, prefer the
+`docs-bounded` fast path described later in this guide instead of reflexively
+running broad Rust or runtime validation when no executable behavior changed.
 
 The editor skills remain authoritative for lifecycle-truth normalization:
 branch/worktree truth, issue-specific readiness, review results, validation

--- a/adl/tools/skills/sip-editor/SKILL.md
+++ b/adl/tools/skills/sip-editor/SKILL.md
@@ -23,11 +23,14 @@ prompt-template values renderer and structure/schema validators before using
 Markdown as lifecycle state:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sip --values <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind sip --values <path> --set <field=value> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sip --values <path> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sip --input <path>
+adl-csdlc tooling prompt-template validate-values --kind sip --values <path>
+adl-csdlc tooling prompt-template edit-values --kind sip --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind sip --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind sip --input <path>
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same commands from a fresh
+checkout through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`.
 
 Use this skill for SIP truth repairs: issue-specific intent, branch/worktree
 truth, target surfaces, validation guidance, and placeholder cleanup. Do not use

--- a/adl/tools/skills/sor-editor/SKILL.md
+++ b/adl/tools/skills/sor-editor/SKILL.md
@@ -23,11 +23,14 @@ prompt-template values renderer and structure/schema validators before using
 Markdown as lifecycle state:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind sor --values <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind sor --values <path> --set <field=value> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind sor --values <path> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind sor --input <path>
+adl-csdlc tooling prompt-template validate-values --kind sor --values <path>
+adl-csdlc tooling prompt-template edit-values --kind sor --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind sor --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind sor --input <path>
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same commands from a fresh
+checkout through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`.
 
 Use this skill for SOR truth repairs: execution result, changed paths,
 validation actually run, integration state, PR state, residual risks, and

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -29,11 +29,14 @@ prompt-template values renderer and structure/schema validators before using
 Markdown as lifecycle state:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind spp --values <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind spp --values <path> --set <field=value> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind spp --values <path> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind spp --input <path>
+adl-csdlc tooling prompt-template validate-values --kind spp --values <path>
+adl-csdlc tooling prompt-template edit-values --kind spp --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind spp --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind spp --input <path>
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same commands from a fresh
+checkout through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`.
 
 Use this skill for SPP truth repairs: issue-local plan readiness, `codex_plan`
 status normalization, assumptions, stop conditions, dependencies, and

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -23,11 +23,14 @@ prompt-template values renderer and structure/schema validators before using
 Markdown as lifecycle state:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind srp --values <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind srp --values <path> --set <field=value> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind srp --values <path> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind srp --input <path>
+adl-csdlc tooling prompt-template validate-values --kind srp --values <path>
+adl-csdlc tooling prompt-template edit-values --kind srp --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind srp --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind srp --input <path>
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same commands from a fresh
+checkout through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`.
 
 Use this skill for SRP truth repairs: review scope, review prompts, findings,
 dispositions, reviewer notes, residual risks, and recommended outcome. Do not

--- a/adl/tools/skills/stp-editor/SKILL.md
+++ b/adl/tools/skills/stp-editor/SKILL.md
@@ -23,11 +23,14 @@ prompt-template values renderer and structure/schema validators before using
 Markdown as lifecycle state:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-values --kind stp --values <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template edit-values --kind stp --values <path> --set <field=value> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template render --kind stp --values <path> --out <path>
-cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template validate-structure --kind stp --input <path>
+adl-csdlc tooling prompt-template validate-values --kind stp --values <path>
+adl-csdlc tooling prompt-template edit-values --kind stp --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind stp --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind stp --input <path>
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same commands from a fresh
+checkout through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`.
 
 Use this skill for STP truth repairs: task intent, required outcome,
 acceptance criteria, bounded scope, validation plan, and placeholder cleanup. Do

--- a/docs/milestones/v0.91.5/review/tooling_adoption/TOOLKIT_SIMPLIFICATION_SPRINT_CLOSEOUT_3740.md
+++ b/docs/milestones/v0.91.5/review/tooling_adoption/TOOLKIT_SIMPLIFICATION_SPRINT_CLOSEOUT_3740.md
@@ -1,0 +1,89 @@
+# Toolkit Simplification Sprint Closeout (#3740)
+
+Sprint issue: #3732  
+Closeout issue: #3740  
+Captured: 2026-06-16  
+Status: ready_for_final_issue_closeout
+
+## Summary
+
+The v0.91.5 toolkit-simplification sprint completed the guidance and scan work
+needed to keep the simplified tool surface truthful in live issue workflow.
+The sprint did not complete a full small-binary rewrite of every remaining
+tooling path. That deeper decomposition was explicitly carried forward into
+`#3838` and should be treated as deferred continuation work, not hidden scope
+inside this closeout.
+
+This packet records the final sprint truth for the repo-tracked guidance wave:
+
+- the active workflow spine still teaches `adl/tools/pr.sh` for tracked issue
+  execution;
+- prompt-template authoring and validation guidance now teaches the direct
+  `adl-csdlc tooling prompt-template ...` surface in repo-tracked skill/docs
+  guidance;
+- docs-only and workflow-doc issues keep the focused `docs-bounded` validation
+  fast path instead of pretending broad runtime proof is required;
+- compatibility shims remain retained until separate scan-backed cut issues
+  close them explicitly.
+
+## What This Sprint Removed
+
+- Repo-tracked skill and template guidance no longer needs to teach
+  `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template ...`
+  as the normal operator-facing prompt-template workflow path.
+- The simplification sprint no longer depends on an implicit "all work finished
+  in the original 8-card wave" story; the closeout truth now records the later
+  `8/9` expansion and the deferred continuation issue explicitly.
+
+## What This Sprint Retained
+
+- `adl/tools/pr.sh` remains the canonical tracked-issue workflow wrapper.
+- `workflow-conductor` remains the required lifecycle router.
+- Compatibility shims such as direct `adl pr ...`, `adl tooling ...`, and
+  `adl/tools/codex_pr.sh` remain governed compatibility surfaces rather than
+  silent removals.
+- Historical records are preserved as readability evidence instead of being
+  rewritten just to remove old command strings.
+
+## What This Sprint Deferred
+
+- `#3838`: remaining direct small-binary decomposition work beyond the first
+  simplification wave.
+- Active and unknown command-reference findings recorded in
+  `docs/milestones/v0.91.5/ACTIVE_COMMAND_REFERENCE_SCAN_3735.md`.
+- Any future compatibility-cut or fail-closed removal work that depends on the
+  scan gate and bounded follow-on issues.
+
+## Key Evidence
+
+- `AGENTS.md`
+- `docs/templates/prompts/current.json`
+- `docs/milestones/v0.91.5/CLI_SHIM_DEPRECATION_POLICY_3615.md`
+- `docs/milestones/v0.91.5/CLI_WRAPPER_MIGRATION_CONTRACT_3597.md`
+- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`
+- `docs/milestones/v0.91.5/TOOL_SURFACE_REGISTRY_3734.md`
+- `docs/milestones/v0.91.5/ACTIVE_COMMAND_REFERENCE_SCAN_3735.md`
+
+## Residual Risks
+
+- The active-command scan still reports retained `active` and `unknown`
+  references for legacy command families, so shim deletion remains unsafe.
+- Some milestone and inventory docs still describe future owner-command shapes
+  as planning truth rather than live workflow guidance; those remain follow-on
+  cleanup rather than evidence that this sprint failed.
+- The broader all-tools simplification goal now spans beyond the original
+  sprint wave and should not be silently collapsed back into `#3740`.
+
+## Validation Performed
+
+- Focused repo-guidance update review against the active workflow contract in
+  `AGENTS.md`, the prompt-template registry in `docs/templates/prompts/current.json`,
+  and the scan/registry packets `#3734` and `#3735`.
+- Command-guidance cleanup for repo-tracked skill/docs surfaces that still
+  taught older prompt-template invocation forms.
+
+## Closeout Decision
+
+`#3740` is ready to close once its paired guidance edits, review card truth,
+and SOR outcome record are complete. The broader simplification story remains
+open only through the explicit deferred follow-ons, especially `#3838`.

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -69,7 +69,7 @@ Use the Rust tool to regenerate schemas only when template structure changes
 intentionally:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template \
+adl-csdlc tooling prompt-template \
   write-structure-schemas \
   --out-dir docs/templates/prompts/1.0.0/schemas
 ```
@@ -77,9 +77,13 @@ cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-templ
 Then run both Rust and Python-readable schema checks:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-schemas
+adl-csdlc tooling prompt-template validate-schemas
 python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
+
+If `adl-csdlc` is not already on `PATH`, run the same owner-binary commands
+through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`
+from a fresh checkout.
 
 `current.json` should not move to a new active template set until all five card
 kinds have renderer fixtures, values validation, and compatibility notes.


### PR DESCRIPTION
Closes #3740

## Summary
Updated repo-tracked toolkit guidance to teach the simplified owner-binary and
docs-bounded workflow surfaces, added the sprint closeout packet for `#3740`,
and recorded focused validation proving the guidance changes align with the
current wrapper-migration and prompt-template contracts. Pre-PR review and
finish/closeout truth remain pending.

## Artifacts
- Updated tracked guidance surfaces under `adl/tools/skills/`, `adl/tools/`,
  and `docs/templates/prompts/`
- Sprint closeout packet at `docs/milestones/v0.91.5/review/tooling_adoption/TOOLKIT_SIMPLIFICATION_SPRINT_CLOSEOUT_3740.md`
- In-flight issue record updates in the paired `SPP`, `SRP`, and `SOR`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the edited guidance and closeout files have no whitespace or patch-shape errors.
  - `bash adl/tools/test_cli_owner_command_guidance.sh`
    Verified live CLI owner-command guidance still aligns with wrapper migration policy after the doc updates.
  - `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling prompt-template validate-schemas`
    Built and ran the source-owned `adl-csdlc` binary to verify the prompt-template schema surface still matches the active templates.
  - `python3 adl/tools/test_prompt_template_structure_schemas.py`
    Verified the active prompt-card structure schema artifacts remain Python-readable after the guidance updates.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3740__v0-91-5-toolkit-simplification-8-8-update-agents-skills-templates-and-close-out-simplification-sprint/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3740__v0-91-5-toolkit-simplification-8-8-update-agents-skills-templates-and-close-out-simplification-sprint/sor.md
- Idempotency-Key: v0-91-5-toolkit-simplification-8-9-update-agents-skills-templates-and-close-out-simplification-sprint-adl-tools-readme-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-sip-editor-skill-md-adl-tools-skills-stp-editor-skill-md-adl-tools-skills-spp-editor-skill-md-adl-tools-skills-srp-editor-skill-md-adl-tools-skills-sor-editor-skill-md-docs-templates-prompts-readme-md-docs-milestones-v0-91-5-review-tooling-adoption-toolkit-simplification-sprint-closeout-3740-md-adl-v0-91-5-tasks-issue-3740-v0-91-5-toolkit-simplification-8-8-update-agents-skills-templates-and-close-out-simplification-sprint-sip-md-adl-v0-91-5-tasks-issue-3740-v0-91-5-toolkit-simplification-8-8-update-agents-skills-templates-and-close-out-simplification-sprint-sor-md