### PR TITLE
[v0.91.5] Clarify Rust refactoring test-placement policy

### DIFF
--- a/docs/milestones/v0.95/features/CONTROL_PLANE_RUST_MIGRATION_AND_TOOLING_HARDENING_v0.95.md
+++ b/docs/milestones/v0.95/features/CONTROL_PLANE_RUST_MIGRATION_AND_TOOLING_HARDENING_v0.95.md
@@ -89,6 +89,17 @@ Do not repeat the old pattern of splitting large files into generic `parts`
 modules. Each extraction must name the responsibility it owns and the proof it
 keeps local.
 
+Test placement should follow the same rule. Rust `#[cfg(test)]` modules do not
+ship in normal production binaries, so the sprint must not claim production
+binary-size savings from moving inline tests. The real concern is production
+source maintainability: large inline tests make production modules harder to
+read, widen reviewer context, and couple narrow behavior changes to broad
+fixture surfaces. Tiny private-helper invariant tests may remain inline when
+they document the code beside them; fixture-heavy suites, CLI lifecycle
+scenarios, GitHub/mock transport tests, argument-rendering matrices, and broad
+behavioral tests should move into focused test modules or files when that
+creates a smaller proof lane.
+
 Preferred slice shapes:
 
 - **Operation family modules**: for example GitHub issue operations, PR body
@@ -102,6 +113,10 @@ Preferred slice shapes:
   reduce duplication without hiding behavior.
 - **Boundary tests**: characterization tests that prove the extracted unit
   preserves the old behavior and can be run without the full workflow.
+- **Test-surface extraction**: move large inline `#[cfg(test)]` modules or
+  oversized scenario matrices into focused test modules/files only when the
+  moved tests retain characterization coverage and enable a narrower command
+  for the next expected change.
 
 Rejected slice shapes:
 
@@ -110,14 +125,17 @@ Rejected slice shapes:
 - moving tests away from the behavior they characterize
 - broad reformatting mixed with behavior-preserving moves
 - workspace splits without a concrete validation-speed hypothesis
+- claiming production binary shrinkage from moving `#[cfg(test)]` tests
+- moving tiny local invariant tests out of a source module when doing so would
+  make the invariant harder to understand
 
 ## Candidate Work Packages
 
 | Work package | Primary target | Boundary | Local proof goal |
 | --- | --- | --- | --- |
-| WP-R1 | `adl/src/cli/pr_cmd/github.rs` | GitHub operation families and transport helpers | Focused mock-octocrab tests for the touched operation family without exercising every PR command path. |
-| WP-R2 | `adl/src/cli/pr_cmd/finish_support.rs` | Finish validation policy and publication prep | Unit tests for changed-path/validation selection that can run without full finish publication. |
-| WP-R3 | `adl/src/csdlc_prompt_editor.rs` | Prompt editor import/render/value/schema responsibilities | Prompt-template/editor tests grouped by responsibility rather than one broad editor surface. |
+| WP-R1 | `adl/src/cli/pr_cmd/github.rs` | GitHub operation families and transport helpers | Focused mock-octocrab tests for the touched operation family without exercising every PR command path; large inline transport tests should move beside the operation family they characterize, while tiny helper tests may remain inline. |
+| WP-R2 | `adl/src/cli/pr_cmd/finish_support.rs` | Finish validation policy and publication prep | Unit tests for changed-path/validation selection that can run without full finish publication; policy and argument tests should live in focused test modules instead of bloating the production support module. |
+| WP-R3 | `adl/src/csdlc_prompt_editor.rs` | Prompt editor import/render/value/schema responsibilities | Prompt-template/editor tests grouped by responsibility rather than one broad editor surface; fixture-heavy editor tests should be separated by concern. |
 | WP-R4 | `adl/src/cli/tests/pr_cmd_inline/basics.rs` and `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` | PR command inline fixture families | Smaller setup/assertion helpers and argument-rendering characterization tests that can run without scanning one broad fixture matrix. |
 | WP-R5 | `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs` | Start/run readiness fixtures and helpers | Smaller lifecycle fixture tests with clear setup helpers and no hidden branch/worktree side effects. |
 | WP-R6 | `adl/src/cli/run_artifacts_types.rs` | Run-artifact contract families | Serde and schema characterization per artifact family. |
@@ -157,6 +175,9 @@ Before the first implementation child starts, the sprint should have:
 - card-rendered `SIP`, `STP`, and `SPP` surfaces for every child issue
 - a baseline validation-burden note for each target, naming the current broad
   command and the intended narrower command
+- a test-placement note for each target, naming which tests stay inline, which
+  fixture-heavy tests move out, and why that improves review or validation
+  locality
 - a no-behavior-change invariant unless a child issue explicitly includes
   characterization proof and behavior acceptance
 - a review route for any extraction that touches GitHub, card, publication, or
@@ -184,6 +205,8 @@ Every refactoring implementation issue spawned from this plan should state:
 
 - the current large-module evidence used
 - the named responsibility boundary being extracted
+- the test-placement decision: inline invariant tests retained, fixture-heavy
+  suites moved, or no test movement needed
 - the behavior-preserving characterization test before or with the move
 - the smaller validation command expected after the extraction
 - what broad validation remains CI/release-only
@@ -199,6 +222,8 @@ Line-count reduction alone is not sufficient.
 - destabilizing MVP delivery for migration purity alone
 - treating migration-only work as a user-visible feature demo obligation
 - generic file splitting without a named responsibility boundary
+- mechanical separation of all inline tests regardless of locality value
+- production-binary-size claims for moving Rust `#[cfg(test)]` code
 - claiming validation-speed improvement without measured or reviewable proof
 - refactoring provider/runtime feature code merely because it is large when the
   next planned change is elsewhere


### PR DESCRIPTION
Closes #3889

## Summary
Updated the v0.95 Rust refactoring mini-sprint plan to clarify test-placement policy. The plan now states that Rust `#[cfg(test)]` modules do not ship in normal production binaries, while still directing the sprint to move large inline or fixture-heavy tests when that reduces production source size, reviewer context, and change-specific validation burden.

## Artifacts
- `docs/milestones/v0.95/features/CONTROL_PLANE_RUST_MIGRATION_AND_TOOLING_HARDENING_v0.95.md`
- Local ignored output card at `.adl/v0.91.5/tasks/issue-3889__v0-91-5-planning-clarify-rust-refactoring-test-placement-policy/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check -- docs/milestones/v0.95/features/CONTROL_PLANE_RUST_MIGRATION_AND_TOOLING_HARDENING_v0.95.md`
    Verified whitespace cleanliness for the intended tracked doc.
  - `python3 - <<'PY' ... PY`
    Verified required test-placement policy text is present after whitespace normalization.
  - `python3 - <<'PY' ... PY`
    Verified the binary-size caveat is explicit.
  - Bounded subagent review with model `gpt-5.4`
    Verified the policy is technically accurate and scope-bounded.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
  - `git diff --check`
    Verified whitespace and patch hygiene on the docs-only changed surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3889__v0-91-5-planning-clarify-rust-refactoring-test-placement-policy/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3889__v0-91-5-planning-clarify-rust-refactoring-test-placement-policy/sor.md
- Idempotency-Key: v0-91-5-clarify-rust-refactoring-test-placement-policy-docs-milestones-v0-95-features-control-plane-rust-migration-and-tooling-hardening-v0-95-md-adl-v0-91-5-tasks-issue-3889-v0-91-5-planning-clarify-rust-refactoring-test-placement-policy-sip-md-adl-v0-91-5-tasks-issue-3889-v0-91-5-planning-clarify-rust-refactoring-test-placement-policy-sor-md