### PR TITLE
[v0.91.5][tools][validation] Treat merged green PRs as successful in pr validation

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -762,7 +762,7 @@ fn pr_validation_snapshot_from_response(
 }
 
 fn classify_pr_validation_snapshot(snapshot: &PrValidationSnapshot) -> PrValidationDisposition {
-    if snapshot.state == "CLOSED" || snapshot.state == "MERGED" {
+    if snapshot.state == "CLOSED" {
         return PrValidationDisposition::Cancelled;
     }
     if snapshot.is_draft {
@@ -3247,6 +3247,21 @@ mod tests {
                 job_run_id: "8801".to_string(),
             }])),
             PrValidationDisposition::Cancelled
+        );
+
+        let merged_success = PrValidationSnapshot {
+            state: "MERGED".to_string(),
+            checks: vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "8804".to_string(),
+            }],
+            ..snapshot(Vec::new())
+        };
+        assert_eq!(
+            classify_pr_validation_snapshot(&merged_success),
+            PrValidationDisposition::Success
         );
     }
 


### PR DESCRIPTION
Closes #3891

## Summary
Fixed merged-PR validation classification so merged pull requests with successful checks are treated as successful terminal states instead of cancelled failures, then added focused regression coverage and live proof against merged PR `#3888`.

## Artifacts
- `adl/src/cli/pr_cmd/github.rs`
- Local execution record at `.adl/v0.91.5/tasks/issue-3891__v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_wait_classifies_pending_failed_successful_and_skipped_states -- --nocapture`
    Verified the focused merged-success classifier regression passes.
  - `bash adl/tools/pr.sh validation 3888 --json`
    Verified live merged PR validation now reports `success` instead of `cancelled`.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3891__v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3891__v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation/sor.md
- Idempotency-Key: v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation-adl-v0-91-5-tasks-issue-3891-v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation-sip-md-adl-v0-91-5-tasks-issue-3891-v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation-sor-md