### PR TITLE
[v0.91.5][tools][github] Support standard GitHub autoclose syntax in PR close-link detection

### DIFF
--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -461,7 +461,37 @@ pub(super) fn linked_issue_numbers_include(
 }
 
 pub(super) fn body_contains_closing_linkage(body: &str, issue: u32) -> bool {
-    body.contains(&format!("Closes #{issue}"))
+    let issue_ref = format!("#{issue}");
+    const CLOSING_KEYWORDS: [&str; 9] = [
+        "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
+    ];
+    body.lines().any(|line| {
+        let lower = line.to_ascii_lowercase();
+        CLOSING_KEYWORDS.iter().any(|keyword| {
+            lower.match_indices(keyword).any(|(idx, _)| {
+                closing_keyword_match_targets_issue(&lower, idx, keyword, &issue_ref)
+            })
+        })
+    })
+}
+
+fn closing_keyword_match_targets_issue(
+    line: &str,
+    keyword_idx: usize,
+    keyword: &str,
+    issue_ref: &str,
+) -> bool {
+    if keyword_idx > 0
+        && line[..keyword_idx]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| ch.is_ascii_alphanumeric())
+    {
+        return false;
+    }
+    let mut rest = &line[keyword_idx + keyword.len()..];
+    rest = rest.trim_start_matches(|ch: char| ch.is_ascii_whitespace() || ch == ':');
+    rest.starts_with(issue_ref)
 }
 
 #[cfg(test)]
@@ -781,12 +811,28 @@ mod tests {
             "Summary\n\nCloses #1153\n",
             1153
         ));
-        assert!(!body_contains_closing_linkage(
+        assert!(body_contains_closing_linkage(
             "Summary\n\ncloses #1153\n",
+            1153
+        ));
+        assert!(body_contains_closing_linkage(
+            "Summary\n\nFIXED #1153\n",
+            1153
+        ));
+        assert!(body_contains_closing_linkage(
+            "Summary\n\nResolved: #1153\n",
             1153
         ));
         assert!(!body_contains_closing_linkage(
             "Summary\n\nRefs #1153\n",
+            1153
+        ));
+        assert!(!body_contains_closing_linkage(
+            "Summary\n\nprefixcloses #1153\n",
+            1153
+        ));
+        assert!(!body_contains_closing_linkage(
+            "Summary\n\ncloses #9999\n",
             1153
         ));
     }


### PR DESCRIPTION
Closes #3897

## Summary
Expanded fallback PR-body closing-link detection to honor standard GitHub autoclose keyword variants case-insensitively, while keeping non-closing references and wrong-issue references rejected.

## Artifacts
- Updated fallback closing-link parser logic in `adl/src/cli/pr_cmd/github_client.rs`
- Extended focused linkage tests in `adl/src/cli/pr_cmd/github_client.rs`
- Updated review/output truth for issue `#3897`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml closing_linkage -- --nocapture`
    Verified the fallback closing-link parser accepts standard keyword variants and preserves bounded negative coverage for non-closing or wrong-issue references.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3897__support-standard-github-autoclose-syntax-in-pr-close-link-detection/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3897__support-standard-github-autoclose-syntax-in-pr-close-link-detection/sor.md
- Idempotency-Key: v0-91-5-tools-github-support-standard-github-autoclose-syntax-in-pr-close-link-detection-adl-src-cli-pr-cmd-github-client-rs-adl-v0-91-5-tasks-issue-3897-support-standard-github-autoclose-syntax-in-pr-close-link-detection-sip-md-adl-v0-91-5-tasks-issue-3897-support-standard-github-autoclose-syntax-in-pr-close-link-detection-sor-md