### PR TITLE
[v0.91.5][tools][markdown-ast] Allow intentional section-local removals in replace-section

### DIFF
--- a/adl/src/cli/tooling_cmd/markdown_ast_edit.rs
+++ b/adl/src/cli/tooling_cmd/markdown_ast_edit.rs
@@ -129,44 +129,64 @@ fn replace_section(args: ReplaceSectionArgs) -> Result<()> {
         Ok(shape) => shape,
         Err(err) => return fail_closed(&args, &input_abs, &err.to_string()),
     };
+    let before_neutralized =
+        neutralize_section_body(&input_text, &args.heading).context("neutralize input section")?;
+    let after_neutralized =
+        neutralize_section_body(&edited, &args.heading).context("neutralize edited section")?;
+    let before_preserved_shape = inspect_markdown_shape("input-preserved", &before_neutralized)
+        .map_err(|err| anyhow!("preserved-surface guard failed: {err}"))?;
+    let after_preserved_shape = inspect_markdown_shape("edited-preserved", &after_neutralized)
+        .map_err(|err| anyhow!("preserved-surface guard failed: {err}"))?;
     ensure!(
         before_shape.has_front_matter == after_shape.has_front_matter,
         "front matter preservation guard failed"
     );
     ensure!(
-        after_shape.code_fences >= before_shape.code_fences,
-        "code fence preservation guard failed"
+        before_preserved_shape.code_fences == after_preserved_shape.code_fences,
+        "code fence preservation guard failed outside replaced section"
     );
     ensure!(
-        after_shape.tables >= before_shape.tables,
-        "table preservation guard failed"
+        before_preserved_shape.tables == after_preserved_shape.tables,
+        "table preservation guard failed outside replaced section"
     );
     ensure!(
-        before_shape
-            .links
-            .iter()
-            .collect::<BTreeSet<_>>()
-            .is_subset(&after_shape.links.iter().collect::<BTreeSet<_>>()),
-        "link preservation guard failed"
+        before_preserved_shape.links.iter().collect::<BTreeSet<_>>()
+            == after_preserved_shape.links.iter().collect::<BTreeSet<_>>(),
+        "link preservation guard failed outside replaced section"
     );
     ensure!(
-        before_shape
+        before_preserved_shape
             .headings
             .iter()
             .map(|(_, text)| text)
             .collect::<BTreeSet<_>>()
-            .is_subset(
-                &after_shape
-                    .headings
-                    .iter()
-                    .map(|(_, text)| text)
-                    .collect::<BTreeSet<_>>()
-            ),
-        "heading preservation guard failed"
+            == after_preserved_shape
+                .headings
+                .iter()
+                .map(|(_, text)| text)
+                .collect::<BTreeSet<_>>(),
+        "heading preservation guard failed outside replaced section"
+    );
+    ensure!(
+        after_shape
+            .headings
+            .iter()
+            .any(|(_, text)| text == args.heading.trim()),
+        "replaced section heading preservation guard failed"
     );
 
     ensure_parent_dir(&args.out)?;
     fs::write(&args.out, edited).with_context(|| format!("failed to write {}", args.out.display()))
+}
+
+fn neutralize_section_body(input: &str, heading: &str) -> Result<String> {
+    let lines = input.lines().map(str::to_string).collect::<Vec<_>>();
+    let (start, end) = locate_section_bounds(&lines, heading)?;
+    let mut out = Vec::new();
+    out.extend_from_slice(&lines[..=start]);
+    out.push(String::new());
+    out.extend_from_slice(&lines[end..]);
+    Ok(format!("{}\n", trim_trailing_blank_lines(out).join("\n")))
 }
 
 fn fail_closed(args: &ReplaceSectionArgs, input: &Path, reason: &str) -> Result<()> {
@@ -223,8 +243,7 @@ fn strip_matching_heading(text: &str, heading: &str) -> Result<String> {
     Ok(text.trim().to_string())
 }
 
-fn replace_markdown_section_body(input: &str, heading: &str, replacement: &str) -> Result<String> {
-    let lines = input.lines().map(str::to_string).collect::<Vec<_>>();
+fn locate_section_bounds(lines: &[String], heading: &str) -> Result<(usize, usize)> {
     let mut in_fence = false;
     let mut start = None;
     let mut target_depth = None;
@@ -252,6 +271,12 @@ fn replace_markdown_section_body(input: &str, heading: &str, replacement: &str) 
     }
 
     let start = start.ok_or_else(|| anyhow!("heading '{heading}' not found"))?;
+    Ok((start, end))
+}
+
+fn replace_markdown_section_body(input: &str, heading: &str, replacement: &str) -> Result<String> {
+    let lines = input.lines().map(str::to_string).collect::<Vec<_>>();
+    let (start, end) = locate_section_bounds(&lines, heading)?;
     let mut out = Vec::new();
     out.extend_from_slice(&lines[..=start]);
     out.push(String::new());

--- a/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
+++ b/adl/src/cli/tooling_cmd/tests/markdown_ast_edit.rs
@@ -108,7 +108,7 @@ fn markdown_ast_edit_fails_closed_when_output_targets_lifecycle_card() {
 }
 
 #[test]
-fn markdown_ast_edit_rejects_replacements_that_remove_existing_protected_nodes() {
+fn markdown_ast_edit_allows_section_local_removal_of_protected_nodes() {
     let repo = TempRepo::new("markdown-ast-protected-node-guard");
     let input = repo.write_rel(
         ".tmp/tooling_cmd_tests/doc.md",
@@ -120,7 +120,7 @@ fn markdown_ast_edit_rejects_replacements_that_remove_existing_protected_nodes()
     );
     let out = repo.path().join(".tmp/tooling_cmd_tests/out.md");
 
-    let err = real_tooling(&[
+    real_tooling(&[
         "markdown-ast-edit".to_string(),
         "replace-section".to_string(),
         "--input".to_string(),
@@ -132,10 +132,12 @@ fn markdown_ast_edit_rejects_replacements_that_remove_existing_protected_nodes()
         "--out".to_string(),
         out.to_string_lossy().to_string(),
     ])
-    .expect_err("replacement that removes protected nodes should fail");
+    .expect("section-local removal should be allowed");
 
-    assert!(err.to_string().contains("code fence preservation guard"));
-    assert!(!out.exists());
+    let edited = fs::read_to_string(out).expect("edited markdown");
+    assert!(edited.contains("## Evidence\n\nNo protected nodes.\n"));
+    assert!(!edited.contains("```rust"));
+    assert!(!edited.contains("[source](https://example.com)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow intentional removals inside the replaced markdown section
- preserve unrelated document safety by comparing preserved surfaces outside the target section
- add focused markdown AST regression coverage

## Validation
- cargo test --manifest-path adl/Cargo.toml markdown_ast_edit -- --nocapture

Closes #3898
