### PR TITLE
[v0.91.5][review-remediation-mini-sprint] Refresh first internal review remediation truth

### DIFF
--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -6,11 +6,11 @@
 - Start date: `2026-06-02`
 - End date: `pending`
 - Owner: ADL maintainers
-- Status: `sprint_2_review_remediation_in_progress`
+- Status: `first_internal_review_remediation_active`
 
 ## Status
 
-`sprint_2_review_remediation_in_progress`
+`first_internal_review_remediation_active`
 
 ## How To Use
 
@@ -23,8 +23,8 @@
 
 v0.91.5 is split into ordered sprint bands after WP-01 opens the milestone and
 confirms issue/card/sprint readiness. Sprint 1 is complete, Sprint 2 child
-execution is complete, and Sprint 2 umbrella review/remediation is now the
-active public planning state.
+execution is complete, and the first internal-review remediation queue is now
+the active execution-prep state before the remaining Sprint 4 closeout tail.
 
 Planned scope:
 
@@ -33,6 +33,22 @@ Planned scope:
 - provider/model matrix and multi-agent proof;
 - demo matrix/showcase readiness;
 - review, remediation, final v0.92 preflight, and release.
+
+## Current Execution Focus
+
+- First internal-review remediation is active under `#3899`.
+- The active remediation wave covers `#3891` through `#3898` in the retained
+  order recorded by the mini-sprint tracker.
+- `#3891` is merged, `#3892` is closed out after PR `#3900`, `#3893` is
+  closed out, and `#3894` / `#3895` are published as draft PRs.
+- `#3896` surfaced a repo-native publication tooling gap: `pr finish` does not
+  classify `adl/src/cli/observability.rs` into any supported finish-validation
+  lane yet, so that blocker must be treated as a remediation finding rather
+  than hidden operator error.
+- `#3574` remains the canonical Sprint 4 umbrella, but closeout-tail execution
+  should resume through the queued `#3899` remediation wave before external
+  review, final preflight, next-milestone planning, and release ceremony move
+  forward.
 
 ## Bridge Sprint Work
 
@@ -84,12 +100,12 @@ Make v0.92 openable without hidden operational debt.
 | 10 | Multi-agent proof | `#3415`, `#3503`, `#3504` (`#3484` satisfied/closed evidence) | ADL maintainers | closed |
 | 11 | Sprint 3 umbrella: demo matrix / demo showcase refresh | `#3573` | ADL maintainers | seeded |
 | 12 | Demo matrix / demo showcase refresh | `#3455` with `#3460`, `#3461` as supporting demo inputs | ADL maintainers | moved |
-| 13 | Sprint 4 umbrella: coverage, review, remediation, planning, release | `#3574` | ADL maintainers | seeded |
+| 13 | Sprint 4 umbrella: coverage, review, remediation, planning, release | `#3574` | ADL maintainers | queued behind `#3899` |
 | 14 | Coverage / quality gate | `#3575`, consuming `#3531` | ADL maintainers | seeded |
 | 15 | Docs + review alignment | `#3579` | ADL maintainers | seeded |
-| 16 | Internal review | `#3576` | ADL maintainers | seeded |
-| 17 | External / 3rd-party review | `#3580` | ADL maintainers | seeded |
-| 18 | Review findings remediation + final v0.92 preflight | `#3577`, consuming `#3502`, `#3534`, `#3377` | ADL maintainers | seeded |
+| 16 | Internal review | `#3576` | ADL maintainers | first findings routed to `#3899` |
+| 17 | External / 3rd-party review | `#3580` | ADL maintainers | queued after `#3899` |
+| 18 | Review findings remediation + final v0.92 preflight | `#3577`, consuming `#3502`, `#3534`, `#3377` | ADL maintainers | queued via `#3899` |
 | 19 | Next milestone planning | `#3581` | ADL maintainers | seeded |
 | 20 | Release ceremony | `#3578` | ADL maintainers | seeded |
 

--- a/docs/milestones/v0.91.5/WBS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WBS_v0.91.5.md
@@ -5,13 +5,13 @@
 - Version: `v0.91.5`
 - Date: `2026-06-02`
 - Owner: ADL maintainers
-- Status: `sprint_2_review_remediation_in_progress`
+- Status: `first_internal_review_remediation_active`
 - Canonical WP standard: [ADL_MILESTONE_WP_ORDERING_STANDARD.md](../../planning/ADL_MILESTONE_WP_ORDERING_STANDARD.md)
 
 ## Status
 
-Active WBS for post-Sprint 1 execution, Sprint 2 review/remediation, and the
-remaining Sprint 3 / Sprint 4 execution bands.
+Active WBS for post-Sprint 1 execution, the first internal-review remediation
+execution under `#3899`, and the remaining Sprint 3 / Sprint 4 execution bands.
 
 ## How To Use
 
@@ -24,7 +24,11 @@ together.
 v0.91.5 contains four sprint bands after WP-01: prompt-template/public prompt
 records and portable ADL readiness, provider/model and multi-agent proof, demo
 matrix/showcase refresh, and coverage/review/remediation/next-milestone/release
-closeout.
+closeout. The current retained execution-prep state is the first internal
+review remediation queue `#3899`, which stages the initial WP-18 remediation
+wave before the remaining closeout-tail issues advance. Live execution also
+surfaced repo-native tooling gaps that must be captured as WP-18 remediation
+inputs rather than lost as operator-side residue.
 
 ## Candidate WP Sequence
 
@@ -92,6 +96,15 @@ to the reusable standard at
 | Sprint 3 | `#3573` | Demo matrix and demo showcase refresh. | `#3455`; supporting inputs `#3460`, `#3461` |
 | Sprint 4 | `#3574` | Coverage, review, remediation, next-milestone planning, and release. | `#3575`, `#3579`, `#3576`, `#3580`, `#3577`, `#3581`, `#3578`; supporting inputs `#3531`, `#3502`, `#3534`, `#3377` |
 
+## Queued Review-Remediation Mini-Sprint
+
+- `#3899` is the queued first internal-review remediation umbrella created from
+  WP-16 review output.
+- Its child execution order is `#3891`, `#3892`, `#3893`, parallel-safe
+  `#3894` / `#3895`, then parallel-safe `#3896` / `#3897` / `#3898`.
+- This queue is a bounded staging wave under WP-18 and does not replace the
+  canonical Sprint 4 umbrella `#3574`.
+
 ## Sequencing
 
 1. Route issue truth first.
@@ -100,7 +113,8 @@ to the reusable standard at
 4. Run multi-agent proof before relying on it for v0.92.
 5. Prepare demos and activation readiness before first-birthday preflight.
 6. Route AEE completion explicitly before v0.92 consumes the bridge.
-7. Review, remediate, preflight v0.92, then release.
+7. Run the first internal-review remediation queue `#3899`.
+8. Review, remediate, preflight v0.92, then release.
 
 ## Sequencing Notes
 
@@ -123,7 +137,10 @@ is explicit.
 - WP-13 -> demo matrix and showcase readiness are explicit.
 - WP-14 through WP-20 -> coverage/quality, docs/review alignment, internal
   review, external review, remediation/final v0.92 preflight, next-milestone
-  planning, and release close the bridge in the standard order.
+  planning, and release close the bridge in the standard order. The first
+  remediation tranche is currently staged through `#3899` and child issues
+  `#3891` through `#3898` before the broader WP-18 final-preflight issue
+  `#3577` should claim completion.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
+++ b/docs/milestones/v0.91.5/WP_ISSUE_WAVE_v0.91.5.yaml
@@ -1,5 +1,5 @@
 milestone: v0.91.5
-status: sprint_2_review_remediation_in_progress
+status: first_internal_review_remediation_active
 owner_issue: 3506
 owner_issue_state: closed_setup_umbrella
 setup_child_issues: [3507, 3508, 3509, 3510, 3511]
@@ -16,6 +16,10 @@ notes:
   - Canonical milestone WP ordering was closed through #3567; portable ADL project adapter planning and templates are routed through #3569.
   - Downstream v0.91.5 card rewrite/normalization waits for prompt templates v1.1 and is tracked through #3582 instead of blocking WP-01.
   - Sprint 1 #3571 is closed, Sprint 2 #3572 remains open with post-execution review/remediation active, and Sprint 3 #3573 plus Sprint 4 #3574 remain open for later execution; closeout-tail issues #3575, #3579, #3576, #3580, #3577, #3581, and #3578 remain seeded/open.
+  - WP-16 internal review has now produced a first routed remediation queue under #3899 with child issues #3891 through #3898.
+  - Child issue #3892 has now been closed out after draft PR #3900 merged cleanly.
+  - Live execution exposed a finish-tooling classifier gap: `pr finish` does not yet classify `adl/src/cli/observability.rs` or `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` plus its focused test surface into supported finish-validation lanes, so that publication blocker must remain tracked as remediation truth under #3899.
+  - #3574 remains the canonical Sprint 4 umbrella, but closeout-tail execution should resume through queued review-remediation issue #3899 before WP-17, WP-18 final preflight, WP-19, and WP-20 advance.
   - Multi-agent C-SDLC execution must work by milestone closeout or be truthfully blocked before v0.92 depends on it.
   - v0.92 activation testing must include every known feature surface that comes alive during first birthday.
   - AEE completion must be routed as a named closure tranche before v0.92 opens; it must not be left implicit until v0.95 convergence.

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
@@ -1,0 +1,81 @@
+# v0.91.5 First Internal Review Findings Register
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Source review issue: `#3576`
+- Register date: `2026-06-16`
+- Register status: `routed_to_remediation_queue`
+- Canonical remediation umbrella: `#3899`
+
+## Summary
+
+- The expected retained local first-internal-review findings register was
+  missing during `#3899` readiness repair.
+- This reconstructed register preserves routing truth from the live remediation
+  issue set `#3891` through `#3898` without inventing missing severity or
+  approval fields.
+- `#3892` already has draft PR `#3900` in flight and should keep that state
+  during execution.
+- Use this register as the retained review-to-remediation bridge for the queued
+  first internal-review mini-sprint.
+
+## Reconstruction Note
+
+This packet is reconstructed from the routed remediation issues created from the
+first v0.91.5 internal review:
+
+- `#3891` through `#3898`
+- queue umbrella `#3899`
+
+The available retained local packet set did not preserve severity rankings in a
+standalone findings register at the expected path, so this register records
+`severity: not_retained` rather than guessing.
+
+## Findings
+
+| Routed issue | Area | Severity | Finding summary | Current route |
+| --- | --- | --- | --- | --- |
+| `#3891` | validation | `not_retained` | Treat merged green PRs as successful in `pr validation` instead of misclassifying them as cancelled. | Execute as the first validation-truth remediation slice under `#3899`. |
+| `#3892` | proof | `not_retained` | Extend small-binary delegation proof coverage to `finish`, `validation`, and `closeout`. | Preserve in-flight draft PR `#3900`; continue under `#3899`. |
+| `#3893` | lifecycle | `not_retained` | Repair toolkit sprint closeout and card truth so retained sprint/card state matches GitHub closeout truth. | Execute after `#3891` / `#3892` under `#3899`. |
+| `#3894` | docs | `not_retained` | Refresh proof coverage, quality-gate, handoff, and WP-tail docs so review-facing planning truth matches the current bridge state. | Parallel-safe docs remediation group under `#3899`. |
+| `#3895` | evidence | `not_retained` | Redact private LAN endpoint details from tracked public proof packets without weakening evidence meaning. | Parallel-safe evidence hygiene group under `#3899`. |
+| `#3896` | observability | `not_retained` | Preserve quiet stderr when compatibility log sink setup fails. | Parallel-safe tooling remediation group under `#3899`. |
+| `#3897` | GitHub linkage | `not_retained` | Support standard GitHub autoclose syntax in fallback PR close-link detection. | Parallel-safe tooling remediation group under `#3899`. |
+| `#3898` | markdown-ast | `not_retained` | Allow intentional section-local removals in `replace-section` while preserving unrelated-document safety. | Parallel-safe tooling remediation group under `#3899`. |
+
+## Supplemental Operator-Reported Findings
+
+These additional tooling/adapter findings were observed during live execution of
+the remediation flow and should be treated as part of the same bounded
+mini-sprint rather than as separate unscheduled residue.
+
+| Route band | Area | Severity | Finding summary | Current route |
+| --- | --- | --- | --- | --- |
+| `#3896-#3898` tooling tranche | worktree bootstrap | `operator_reported` | New issue worktrees can miss required prompt-template scaffolding such as `docs/templates/prompts`, forcing manual bridge repair before execution. | Route into the tooling remediation tranche under `#3899`; likely owner is the worktree/bootstrap/control-plane surface rather than docs-only cleanup. |
+| `#3896-#3898` tooling tranche | worktree bootstrap | `operator_reported` | New issue worktrees can miss repo-local `adl/tools` wrappers such as `adl/tools/pr.sh` and `adl/tools/validate_structured_prompt.sh`, forcing manual copy/bridge repair. | Route into the tooling remediation tranche under `#3899`; fix together with prompt-template bridging so bound worktrees preserve expected local execution surfaces. |
+| `#3896-#3898` tooling tranche | execution assumptions | `operator_reported` | `pr.sh run` can bind a worktree that lacks repo-local helper-path assumptions required by the workflow, so binding succeeds but execution fails until hand-patched. | Route into the tooling remediation tranche under `#3899`; treat as a bootstrap/adapter correctness gap, not as operator error. |
+| `#3896-#3898` tooling tranche | GitHub auth handoff | `operator_reported` | `adl/tools/pr.sh issue list/view/create` may require explicit `GITHUB_TOKEN` env wiring even when local GitHub auth already exists. | Route into the tooling remediation tranche under `#3899`; fix auth inheritance/handoff rather than teaching manual wrappers as normal operator practice. |
+| `#3896-#3898` tooling tranche | issue-body validation UX | `operator_reported` | Create/run flow can fail on strict required issue-body sections such as `Issue-Graph Notes` without surfacing the canonical missing section early enough for smooth repair. | Route into the tooling remediation tranche under `#3899`; preserve strict validation but improve early missing-section/operator guidance. |
+| `#3896-#3898` tooling tranche | stale baseline detection | `operator_reported` | `run` can bind a new issue worktree onto a baseline missing prerequisite in-flight issue state without surfacing an early warning. | Route into the tooling remediation tranche under `#3899`; add earlier stale-baseline/prerequisite-output warning rather than silently binding to an incomplete base. |
+| `#3896-#3898` tooling tranche | repeatability | `operator_reported` | Current workflow still depends on manual knowledge of local bridge repairs for prompt-template and `adl/tools` surfaces. | Route into the tooling remediation tranche under `#3899`; encode the repair knowledge in the adapter/bootstrap path instead of relying on session memory. |
+| `#3896-#3898` tooling tranche | finish validation routing | `operator_reported` | Repo-native `pr finish` does not classify `adl/src/cli/observability.rs` or `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` plus its focused test surface into docs-only, small-binary focused, or larger-binary focused finish-validation lanes, which blocks normal publication for the quiet-stderr remediation even after focused proof passes. | Route into the tooling remediation tranche under `#3899`; fix finish-path classification truth instead of bypassing the workflow silently. |
+
+## Queue Linkage
+
+Ordered execution route retained by the queue umbrella:
+
+1. `#3891` and `#3892`
+2. `#3893`
+3. `#3894` and `#3895`
+4. `#3896`, `#3897`, and `#3898`
+5. Close `#3899` only after child issues are closed or explicitly rerouted
+
+## Residual Risks
+
+- The original standalone local review register was absent at the expected
+  retained path; this packet restores routing truth but does not reconstruct
+  missing severity rankings.
+- External review, final v0.92 preflight, next-milestone planning, and release
+  ceremony remain downstream work and must not be inferred from this packet.

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
@@ -17,6 +17,8 @@
   approval fields.
 - `#3892` already has draft PR `#3900` in flight and should keep that state
   during execution.
+- `#3897` and `#3898` have now merged and been locally closed out, leaving
+  `#3896` as the remaining active tooling-remediation child.
 - Use this register as the retained review-to-remediation bridge for the queued
   first internal-review mini-sprint.
 
@@ -41,9 +43,9 @@ standalone findings register at the expected path, so this register records
 | `#3893` | lifecycle | `not_retained` | Repair toolkit sprint closeout and card truth so retained sprint/card state matches GitHub closeout truth. | Execute after `#3891` / `#3892` under `#3899`. |
 | `#3894` | docs | `not_retained` | Refresh proof coverage, quality-gate, handoff, and WP-tail docs so review-facing planning truth matches the current bridge state. | Parallel-safe docs remediation group under `#3899`. |
 | `#3895` | evidence | `not_retained` | Redact private LAN endpoint details from tracked public proof packets without weakening evidence meaning. | Parallel-safe evidence hygiene group under `#3899`. |
-| `#3896` | observability | `not_retained` | Preserve quiet stderr when compatibility log sink setup fails. | Parallel-safe tooling remediation group under `#3899`. |
-| `#3897` | GitHub linkage | `not_retained` | Support standard GitHub autoclose syntax in fallback PR close-link detection. | Parallel-safe tooling remediation group under `#3899`. |
-| `#3898` | markdown-ast | `not_retained` | Allow intentional section-local removals in `replace-section` while preserving unrelated-document safety. | Parallel-safe tooling remediation group under `#3899`. |
+| `#3896` | observability | `not_retained` | Preserve quiet stderr when compatibility log sink setup fails. | Active under `#3899` with green draft PR `#3907`; waiting on review/merge before closeout. |
+| `#3897` | GitHub linkage | `not_retained` | Support standard GitHub autoclose syntax in fallback PR close-link detection. | Merged by PR `#3905`; now locally closed out under `#3899`. |
+| `#3898` | markdown-ast | `not_retained` | Allow intentional section-local removals in `replace-section` while preserving unrelated-document safety. | Merged by PR `#3906`; now locally closed out under `#3899`. |
 
 ## Supplemental Operator-Reported Findings
 
@@ -60,7 +62,36 @@ mini-sprint rather than as separate unscheduled residue.
 | `#3896-#3898` tooling tranche | issue-body validation UX | `operator_reported` | Create/run flow can fail on strict required issue-body sections such as `Issue-Graph Notes` without surfacing the canonical missing section early enough for smooth repair. | Route into the tooling remediation tranche under `#3899`; preserve strict validation but improve early missing-section/operator guidance. |
 | `#3896-#3898` tooling tranche | stale baseline detection | `operator_reported` | `run` can bind a new issue worktree onto a baseline missing prerequisite in-flight issue state without surfacing an early warning. | Route into the tooling remediation tranche under `#3899`; add earlier stale-baseline/prerequisite-output warning rather than silently binding to an incomplete base. |
 | `#3896-#3898` tooling tranche | repeatability | `operator_reported` | Current workflow still depends on manual knowledge of local bridge repairs for prompt-template and `adl/tools` surfaces. | Route into the tooling remediation tranche under `#3899`; encode the repair knowledge in the adapter/bootstrap path instead of relying on session memory. |
-| `#3896-#3898` tooling tranche | finish validation routing | `operator_reported` | Repo-native `pr finish` does not classify `adl/src/cli/observability.rs` or `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` plus its focused test surface into docs-only, small-binary focused, or larger-binary focused finish-validation lanes, which blocks normal publication for the quiet-stderr remediation even after focused proof passes. | Route into the tooling remediation tranche under `#3899`; fix finish-path classification truth instead of bypassing the workflow silently. |
+| `#3896-#3898` tooling tranche | finish validation routing | `operator_reported` | Repo-native `pr finish` does not classify `adl/src/cli/observability.rs` into a supported finish-validation lane, so normal publication is blocked even after focused proof passes. | Route into the tooling remediation tranche under `#3899`; fix finish-path classification truth instead of bypassing the workflow silently. |
+| `#3896-#3898` tooling tranche | finish validation routing | `operator_reported` | Repo-native `pr finish` does not classify `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` plus its focused test surface into a supported finish-validation lane, so normal publication is blocked even after focused proof passes. | Route into the tooling remediation tranche under `#3899`; fix finish-path classification truth instead of bypassing the workflow silently. |
+| `#3896-#3898` tooling tranche | publication resilience | `operator_reported` | When `pr finish` lane classification fails, the current workflow has no first-class retained fallback path for truthful emergency publication, leaving operators to improvise manual branch/PR publication steps. | Route into the tooling remediation tranche under `#3899`; add an explicit bounded fallback or close the classification gaps so publication does not depend on session-local recovery knowledge. |
+
+## Tooling Remediation Inventory
+
+The live execution record under `#3899` surfaced the following concrete tool
+problems that should remain retained as remediation inputs until they are fixed
+or explicitly rerouted:
+
+1. Worktree bootstrap can omit prompt-template scaffolding under
+   `docs/templates/prompts`.
+2. Worktree bootstrap can omit repo-local `adl/tools` wrappers required by the
+   normal flow.
+3. Issue-mode binding can succeed even when repo-local helper-path assumptions
+   needed by later workflow steps are absent.
+4. `pr.sh issue` commands may require manual `GITHUB_TOKEN` wiring despite a
+   locally authenticated GitHub environment already existing.
+5. Issue-body validation does not always surface the canonical missing section
+   early enough, especially for required sections such as `Issue-Graph Notes`.
+6. `run` can bind onto a stale baseline missing prerequisite in-flight outputs
+   without an early warning.
+7. The current adapter/bootstrap path still depends on manual operator memory
+   for bridge repairs that should be encoded in tooling.
+8. `pr finish` lane classification is incomplete for at least the
+   observability-source surface touched in `#3896`.
+9. `pr finish` lane classification is incomplete for at least the
+   markdown-AST/tooling-command surface plus focused tests touched in `#3898`.
+10. Emergency publication after finish-path failure is not yet a first-class,
+    truthful, retained workflow path.
 
 ## Queue Linkage
 

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
@@ -24,10 +24,13 @@
 - `#3891` is merged.
 - `#3892` is merged and closed out after PR `#3900`.
 - `#3893` is closed out.
-- `#3894` and `#3895` are published as draft PRs.
-- `#3899` is structurally ready to run, but its doctor preflight remains
-  blocked by the existing open tools-wave PR, which is expected and should be
-  preserved rather than treated as corruption.
+- `#3894` and `#3895` are closed out.
+- `#3896` remains active with green draft PR `#3907`; checks are complete and
+  the issue is now waiting on review/merge before closeout.
+- `#3897` is merged via PR `#3905` and is now closed out.
+- `#3898` is merged via PR `#3906` and is now closed out.
+- `#3899` remains the open execution umbrella until the active tooling-tranche
+  child issues are closed or explicitly rerouted.
 - No Rust refactoring work is included in this queue.
 
 ## Supplemental Tooling Remediation Added During Execution
@@ -56,6 +59,35 @@ These findings do not justify widening beyond `#3891-#3899`, but they do mean
 the tooling tranche under `#3896-#3898` must absorb adapter/bootstrap/auth UX
 hardening rather than treating the original three issue titles as exhaustive.
 
+## Tooling Problems Captured for Remediation
+
+The current retained tooling problem set for the `#3896-#3898` tranche is:
+
+1. new worktrees can miss prompt-template scaffolding under
+   `docs/templates/prompts`
+2. new worktrees can miss repo-local `adl/tools` wrappers needed by the normal
+   workflow
+3. issue-mode binding can preserve too little of the repo-local helper
+   execution environment, so later steps fail after the worktree is already
+   bound
+4. `pr.sh issue` commands do not always inherit usable GitHub auth from the
+   local authenticated environment
+5. issue-body validation surfaces strict missing-section failures too late for
+   smooth operator repair
+6. `run` can bind onto a stale baseline missing prerequisite in-flight outputs
+   without warning early enough
+7. the adapter still relies on manual bridge-repair knowledge for repeatable
+   worktree startup
+8. `pr finish` lacks supported finish-validation routing for the
+   observability-source surface touched in `#3896`
+9. `pr finish` lacks supported finish-validation routing for the markdown-AST
+   tooling surface plus focused tests touched in `#3898`
+10. truthful emergency publication after finish-path failure is not yet a
+    first-class workflow path
+
+Keep these as explicit remediation inputs even if individual child issues merge
+before the broader adapter/tooling fixes land.
+
 ## Ordered Execution Plan
 
 1. `#3891` and `#3892`
@@ -72,8 +104,9 @@ hardening rather than treating the original three issue titles as exhaustive.
     disjoint.
   - Expanded scope inside the existing tranche: absorb the operator-reported
     worktree bootstrap, local bridge, GitHub auth handoff, issue-body
-    validation UX, and stale-baseline warning findings surfaced during live
-    execution.
+    validation UX, stale-baseline warning findings, incomplete `pr finish`
+    lane classification, and missing truthful emergency-publication path
+    surfaced during live execution.
 5. `#3899` closeout
    - Close the umbrella only after child issues are closed or explicitly
      rerouted.

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
@@ -1,0 +1,111 @@
+# v0.91.5 First Internal Review Remediation Queue
+
+## Metadata
+
+- Milestone: `v0.91.5`
+- Source review issue: `#3576`
+- Queue umbrella: `#3899`
+- Queue date: `2026-06-16`
+- Queue status: `active_execution`
+- Doctor readiness: `#3899` returned `ready_status: PASS` on `2026-06-17`
+
+## Queue Summary
+
+- The first v0.91.5 internal review produced eight routed remediation issues:
+  `#3891` through `#3898`.
+- `#3574` remains the canonical Sprint 4 umbrella, but this queue is the
+  bounded first remediation tranche that should run before the remaining
+  closeout-tail work resumes.
+- The queue is intentionally execution-focused and does not claim v0.91.5
+  release readiness.
+
+## Current In-Flight State
+
+- `#3891` is merged.
+- `#3892` is merged and closed out after PR `#3900`.
+- `#3893` is closed out.
+- `#3894` and `#3895` are published as draft PRs.
+- `#3899` is structurally ready to run, but its doctor preflight remains
+  blocked by the existing open tools-wave PR, which is expected and should be
+  preserved rather than treated as corruption.
+- No Rust refactoring work is included in this queue.
+
+## Supplemental Tooling Remediation Added During Execution
+
+Live execution of the remediation flow surfaced additional adapter/worktree
+findings that belong inside this same bounded queue:
+
+- worktree bootstrap must preserve prompt-template scaffolding under
+  `docs/templates/prompts`
+- worktree bootstrap must preserve repo-local `adl/tools` wrappers needed by
+  the normal workflow
+- issue-mode binding must fail earlier or repair earlier when repo-local helper
+  assumptions are missing
+- `pr.sh issue` operations should inherit usable GitHub auth from the local
+  authenticated environment without requiring manual `GITHUB_TOKEN` wrapping
+- issue-body validation should surface required missing sections such as
+  `Issue-Graph Notes` earlier and more canonically
+- `run` should warn earlier when binding onto a stale baseline missing
+  prerequisite in-flight issue outputs
+- `pr finish` should classify observability-source changes such as
+  `adl/src/cli/observability.rs` and tooling-command sources such as
+  `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` into valid finish-validation lanes so normal
+  publication does not fail after focused proof is already complete
+
+These findings do not justify widening beyond `#3891-#3899`, but they do mean
+the tooling tranche under `#3896-#3898` must absorb adapter/bootstrap/auth UX
+hardening rather than treating the original three issue titles as exhaustive.
+
+## Ordered Execution Plan
+
+1. `#3891` and `#3892`
+   - Reason: validation-truth and delegation-proof surfaces affect how later
+     remediation and closeout truth should be interpreted.
+2. `#3893`
+   - Reason: toolkit sprint closeout and card truth should be repaired before
+     downstream review/remediation packets depend on them.
+3. `#3894` and `#3895`
+   - Reason: docs/evidence cleanup is parallel-safe once lifecycle truth is
+     repaired.
+4. `#3896`, `#3897`, and `#3898`
+  - Reason: tooling fixes are parallel-safe when file ownership remains
+    disjoint.
+  - Expanded scope inside the existing tranche: absorb the operator-reported
+    worktree bootstrap, local bridge, GitHub auth handoff, issue-body
+    validation UX, and stale-baseline warning findings surfaced during live
+    execution.
+5. `#3899` closeout
+   - Close the umbrella only after child issues are closed or explicitly
+     rerouted.
+
+## Parallel-Safe Grouping
+
+- Group A: `#3894` and `#3895`
+- Group B: `#3896`, `#3897`, and `#3898`
+
+Do not parallelize `#3893` ahead of `#3891` / `#3892`, and do not close the
+umbrella while child issues are still active.
+
+## Entry Conditions
+
+- Use `workflow-conductor` for every child issue.
+- Use the active prompt-template registry and normal issue-mode worktree flow.
+- Preserve existing in-flight state for `#3892` / PR `#3900`.
+- Run bounded pre-PR review for each child issue before publication.
+- Keep validation focused on the touched surface; do not widen into broad
+  milestone validation inside child remediations.
+
+## Exclusions
+
+- Rust refactoring mini-sprint `#3745` remains separate and not started.
+- External / third-party review `#3580` is not part of this queue.
+- Final v0.92 preflight `#3577`, next-milestone planning `#3581`, and release
+  ceremony `#3578` are downstream of this queue.
+
+## Handoff Notes
+
+- Use this queue packet together with:
+  - `docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md`
+  - issue umbrella `#3899`
+- Treat this packet as retained sequencing truth only. Child issues still own
+  their individual implementation, validation, review, and closeout records.


### PR DESCRIPTION
## Summary
- mark the first internal review remediation wave as active
- record child issue progress through the current PR set
- capture tooling/publication gaps surfaced during live execution, including finish-classifier misses

## Notes
- This umbrella stays open while child remediation issues remain active.
- The docs here are retained routing truth, not a claim that the mini-sprint is complete.

Refs #3899



Non-closing lifecycle PR
