### PR TITLE
[v0.91.5][tools] Keep GitHub issue operations on ADL path

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1132,7 +1132,7 @@ fn github_credential_preflight_hint(
     config: &crate::cli::pr_cmd::github_client::AdlGithubClientConfig,
 ) -> String {
     match config.token_source {
-        None => "credential_status=missing_token; set GITHUB_TOKEN or GH_TOKEN before live C-SDLC GitHub operations; if you already use GitHub CLI auth, export its token into GITHUB_TOKEN for this command without echoing it".to_string(),
+        None => "credential_status=missing_token; set GITHUB_TOKEN or GH_TOKEN before live C-SDLC GitHub operations; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
         Some(source) => format!(
             "credential_status=token_present source={}; ADL_GITHUB_CLIENT=gh is not a supported mutation fallback for covered operations; use ADL_GITHUB_CLIENT=auto or ADL_GITHUB_CLIENT=octocrab",
             source.env_name()
@@ -4542,6 +4542,8 @@ sys.exit(9)
         assert!(err_debug.contains("github_client.gh_fallback_removed"));
         assert!(err_debug.contains("credential_status=missing_token"));
         assert!(err_debug.contains("set GITHUB_TOKEN or GH_TOKEN"));
+        assert!(err_debug.contains("operator-approved secret source"));
+        assert!(err_debug.contains("do not fall back to direct gh commands"));
         assert!(err_debug.contains("credential values are never printed"));
 
         restore_github_policy_env(policy_env);

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -9,7 +9,9 @@
 #
 # Requirements:
 # - git
-# - GitHub token in GITHUB_TOKEN or GH_TOKEN for Rust octocrab-backed GitHub operations
+# - GitHub token in GITHUB_TOKEN or GH_TOKEN for Rust octocrab-backed GitHub operations.
+#   Load tokens from an operator-approved secret source and pass them only to
+#   the ADL command environment. Do not use direct `gh` commands as a fallback.
 # - Rust toolchain for `adl/` checks (fmt, clippy, test)
 #
 #   adl/tools/pr.sh help
@@ -2470,6 +2472,10 @@ Usage:
 
 Notes:
 - Creates the GitHub issue and bootstraps the local root STP/SIP/SPP/SRP/SOR bundle.
+- Requires GITHUB_TOKEN or GH_TOKEN for live GitHub operations; load the token
+  from an operator-approved secret source without printing it. If no token is
+  present, stop and fix the ADL command environment; do not fall back to direct
+  `gh` commands or connector issue APIs.
 - Runs the doctor-ready structural check immediately after bootstrap and fails if the new issue is not ready for the next step.
 - Does not create the branch or worktree execution context.
 - After create, do qualitative SIP/STP/SPP/SRP design-time review and then run `adl/tools/pr.sh run <issue> ...`.
@@ -2629,6 +2635,10 @@ Usage:
 Behavior:
 - delegates to the Rust-owned issue inspection surface
 - uses the typed GitHub transport rather than raw `gh issue list/view`
+- requires GITHUB_TOKEN or GH_TOKEN for live GitHub operations; if no token is
+  present, stop and fix the ADL command environment by loading one from an
+  operator-approved secret source without echoing it; do not fall back to direct
+  `gh` commands or connector issue APIs
 - defaults `-R/--repo` from the current checkout when omitted
 - infers `owner/repo` from a GitHub issue URL on `issue view` when possible
 - keeps machine-readable JSON on stdout when `--json` is set

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -216,6 +216,11 @@ Use the Rust-owned issue inspection commands before execution, review, or
 closeout when you need live GitHub issue truth without falling back to raw
 `gh issue` commands.
 
+Live GitHub issue operations require `GITHUB_TOKEN` or `GH_TOKEN` in the ADL
+command environment. Load that value from an operator-approved secret source
+without echoing it. If the token is missing, stop and fix the ADL command
+environment; do not use direct `gh` or connector issue calls as a fallback.
+
 Preferred commands:
 
 ```bash

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -63,6 +63,12 @@ Minimum init contract:
 
 ## 2) Confirm GitHub Issue Exists And Inspect Live Issue Truth
 
+Live GitHub issue operations use the ADL typed GitHub transport. Provide
+`GITHUB_TOKEN` or `GH_TOKEN` from an operator-approved secret source in the
+command environment without printing the token. Do not fall back to direct
+`gh` commands or connector-specific issue APIs when the ADL issue surface needs
+credentials.
+
 ```bash
 bash ./adl/tools/pr.sh issue view <issue_num> --json
 ```


### PR DESCRIPTION
Closes #3908

## Summary
Implemented a narrow ADL-only GitHub issue-operation guidance fix for #3908. The change removes wording that nudged agents toward GitHub CLI auth, adds explicit no-direct-`gh` and no-connector-fallback guidance to `pr.sh` help, and records the same credential boundary in the default workflow and operational skills guide.

## Artifacts
- Updated Rust diagnostic and regression assertions in `adl/src/cli/pr_cmd/github.rs`.
- Updated `pr.sh` requirements, `create --help`, and `issue help` wording in `adl/tools/pr.sh`.
- Updated operator workflow guidance in `docs/default_workflow.md`.
- Updated operational skill guidance in `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`.

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene for changed tracked files.
  - `cargo fmt --check`
    Verified Rust formatting for the changed diagnostic/test surface.
  - `cargo test -p adl live_github_policy_explains_missing_token_before_spawn`
    Verified the focused Rust regression test for the missing-token diagnostic across generated binary test targets without exposing credential values.
  - `bash adl/tools/pr.sh issue help | sed -n '1,42p'`
    Verified `issue` help now tells operators to load credentials into the ADL command environment and not fall back to direct `gh` or connector issue APIs.
  - `bash adl/tools/pr.sh create --help | sed -n '1,28p'`
    Verified `create` help carries the same no-fallback boundary.
  - `GITHUB_TOKEN=REDACTED bash adl/tools/pr.sh issue list --state open --limit 3 --json`
    Verified live issue inspection through the ADL path with no token printed.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3908__adl-issue-operations-only-github-path/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3908__adl-issue-operations-only-github-path/sor.md
- Idempotency-Key: v0-91-5-tools-keep-github-issue-operations-on-adl-path-adl-src-cli-pr-cmd-github-rs-adl-tools-pr-sh-adl-tools-skills-docs-operational-skills-guide-md-docs-default-workflow-md-adl-v0-91-5-tasks-issue-3908-adl-issue-operations-only-github-path-sip-md-adl-v0-91-5-tasks-issue-3908-adl-issue-operations-only-github-path-sor-md