### PR TITLE
[v0.91.5][rust-refactor][4/6] Refactor run-artifact type and schema boundaries

### DIFF
--- a/adl/src/cli/run_artifacts_types.rs
+++ b/adl/src/cli/run_artifacts_types.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::path::Path;
 
 use ::adl::execute;
 
-pub(crate) const RUN_STATE_SCHEMA_VERSION: &str = "run_state.v1";
-pub(crate) const PAUSE_STATE_SCHEMA_VERSION: &str = "pause_state.v1";
+mod state;
+
+pub(crate) use state::{
+    sanitize_pause_adl_path, PauseStateArtifact, RunStateArtifact, PAUSE_STATE_SCHEMA_VERSION,
+    RUN_STATE_SCHEMA_VERSION,
+};
+
 pub(crate) const RUN_STATUS_VERSION: u32 = 1;
 pub(crate) const RUN_SUMMARY_VERSION: u32 = 1;
 pub(crate) const SCORES_VERSION: u32 = 1;
@@ -36,75 +40,6 @@ pub(crate) const REASONING_GRAPH_CONTRACT_REF_SCHEMA_VERSION: &str =
 pub(crate) const UPSTREAM_DELEGATION_TRACE_RECORD_SCHEMA_VERSION: &str =
     "upstream_delegation.trace_record.v1";
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct RunStateArtifact {
-    pub(crate) schema_version: String,
-    pub(crate) run_id: String,
-    pub(crate) workflow_id: String,
-    pub(crate) version: String,
-    pub(crate) status: String,
-    pub(crate) error_message: Option<String>,
-    pub(crate) start_time_ms: u128,
-    pub(crate) end_time_ms: u128,
-    pub(crate) duration_ms: u128,
-    pub(crate) execution_plan_hash: String,
-    #[serde(default)]
-    pub(crate) scheduler_max_concurrency: Option<usize>,
-    #[serde(default)]
-    pub(crate) scheduler_policy_source: Option<String>,
-    #[serde(default)]
-    pub(crate) steering_history: Vec<execute::SteeringRecord>,
-    pub(crate) pause: Option<execute::PauseState>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct PauseStateArtifact {
-    pub(crate) schema_version: String,
-    pub(crate) run_id: String,
-    pub(crate) workflow_id: String,
-    pub(crate) version: String,
-    pub(crate) status: String,
-    pub(crate) adl_path: String,
-    pub(crate) execution_plan_hash: String,
-    #[serde(default)]
-    pub(crate) steering_history: Vec<execute::SteeringRecord>,
-    pub(crate) pause: execute::PauseState,
-}
-
-fn normalize_pause_adl_ref(path: &Path) -> String {
-    let mut parts = Vec::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
-            std::path::Component::ParentDir => parts.push("..".to_string()),
-            std::path::Component::RootDir | std::path::Component::Prefix(_) => {}
-        }
-    }
-    if parts.is_empty() {
-        "<unknown>".to_string()
-    } else {
-        parts.join("/")
-    }
-}
-
-pub(crate) fn sanitize_pause_adl_path(adl_path: &Path) -> String {
-    if !adl_path.is_absolute() {
-        return normalize_pause_adl_ref(adl_path);
-    }
-    if let Ok(cwd) = std::env::current_dir() {
-        if let Ok(rel) = adl_path.strip_prefix(&cwd) {
-            return normalize_pause_adl_ref(rel);
-        }
-    }
-    if let Some(file_name) = adl_path.file_name() {
-        return format!("external:/{}", file_name.to_string_lossy());
-    }
-    "external:/<unknown>".to_string()
-}
 
 #[cfg(test)]
 mod tests {

--- a/adl/src/cli/run_artifacts_types/state.rs
+++ b/adl/src/cli/run_artifacts_types/state.rs
@@ -1,0 +1,75 @@
+use super::execute;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub(crate) const RUN_STATE_SCHEMA_VERSION: &str = "run_state.v1";
+pub(crate) const PAUSE_STATE_SCHEMA_VERSION: &str = "pause_state.v1";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RunStateArtifact {
+    pub(crate) schema_version: String,
+    pub(crate) run_id: String,
+    pub(crate) workflow_id: String,
+    pub(crate) version: String,
+    pub(crate) status: String,
+    pub(crate) error_message: Option<String>,
+    pub(crate) start_time_ms: u128,
+    pub(crate) end_time_ms: u128,
+    pub(crate) duration_ms: u128,
+    pub(crate) execution_plan_hash: String,
+    #[serde(default)]
+    pub(crate) scheduler_max_concurrency: Option<usize>,
+    #[serde(default)]
+    pub(crate) scheduler_policy_source: Option<String>,
+    #[serde(default)]
+    pub(crate) steering_history: Vec<execute::SteeringRecord>,
+    pub(crate) pause: Option<execute::PauseState>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PauseStateArtifact {
+    pub(crate) schema_version: String,
+    pub(crate) run_id: String,
+    pub(crate) workflow_id: String,
+    pub(crate) version: String,
+    pub(crate) status: String,
+    pub(crate) adl_path: String,
+    pub(crate) execution_plan_hash: String,
+    #[serde(default)]
+    pub(crate) steering_history: Vec<execute::SteeringRecord>,
+    pub(crate) pause: execute::PauseState,
+}
+
+fn normalize_pause_adl_ref(path: &Path) -> String {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            std::path::Component::ParentDir => parts.push("..".to_string()),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {}
+        }
+    }
+    if parts.is_empty() {
+        "<unknown>".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+pub(crate) fn sanitize_pause_adl_path(adl_path: &Path) -> String {
+    if !adl_path.is_absolute() {
+        return normalize_pause_adl_ref(adl_path);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(rel) = adl_path.strip_prefix(&cwd) {
+            return normalize_pause_adl_ref(rel);
+        }
+    }
+    if let Some(file_name) = adl_path.file_name() {
+        return format!("external:/{}", file_name.to_string_lossy());
+    }
+    "external:/<unknown>".to_string()
+}


### PR DESCRIPTION
Closes #3749

## Summary
- extract the run/pause state artifact contract and pause-path sanitization into `adl/src/cli/run_artifacts_types/state.rs`
- preserve schema constants and downstream consumer imports through re-exports from `run_artifacts_types.rs`
- record focused proof, review truth, and the two routed tools follow-ups discovered during execution

## Validation
- `cargo test --manifest-path adl/Cargo.toml runtime_state -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml sanitize_pause_adl_path -- --nocapture`
- `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.5/tasks/issue-3749__v0-91-5-rust-refactor-4-6-refactor-run-artifact-type-and-schema-boundaries/spp.md`
- `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.5/tasks/issue-3749__v0-91-5-rust-refactor-4-6-refactor-run-artifact-type-and-schema-boundaries/sor.md`
- `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.5/tasks/issue-3749__v0-91-5-rust-refactor-4-6-refactor-run-artifact-type-and-schema-boundaries/srp.md`
- `git diff --check`

## Notes
- Follow-up `#3913` captures the authored issue-body `## Notes` validation defect discovered during bootstrap/doctor.
- Follow-up `#3914` captures the repo-native `pr finish` validation-lane classification gap that forced manual PR publication for this bounded Rust refactor slice.
