### PR TITLE
[v0.91.5][tools] Extend pr-finish validation lane classification for rust-refactor slices

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -948,6 +948,20 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_owner_binary_rust_slice_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl",
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_public_prompt_packet_focused_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1101,6 +1115,8 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md"
             | "adl/src/cli/pr_cmd.rs"
             | "adl/src/lib.rs"
+            | "adl/src/csdlc_prompt_editor.rs"
+            | "adl/src/cli/run_artifacts_types.rs"
             | "adl/schemas/structured_implementation_prompt.contract.yaml"
             | "adl/schemas/structured_output_record.contract.yaml"
             | "adl/schemas/structured_task_prompt.contract.yaml"
@@ -1128,6 +1144,8 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
             | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
+        || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
+        || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
         || trimmed.starts_with("docs/milestones/v0.91.4/review/merge_readiness/")
         || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
 }
@@ -1143,6 +1161,14 @@ fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
     trimmed == "adl/src/cli/pr_cmd.rs"
         || (trimmed.starts_with("adl/src/cli/pr_cmd/")
             && trimmed != "adl/src/cli/pr_cmd/finish_support.rs")
+}
+
+fn finish_path_needs_owner_binary_rust_slice_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/csdlc_prompt_editor.rs"
+        || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
+        || trimmed == "adl/src/cli/run_artifacts_types.rs"
+        || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
 }
 
 fn finish_path_needs_coverage_tooling_focused_validation(path: &str) -> bool {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -813,6 +813,39 @@ fn finish_validation_plan_classifies_owner_validation_lanes() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_rust_refactor_slices() {
+    let prompt_editor_plan = select_finish_validation_plan(
+        "adl/src/csdlc_prompt_editor.rs,adl/src/csdlc_prompt_editor/structure.rs",
+    )
+    .expect("prompt editor refactor plan");
+    assert_eq!(
+        prompt_editor_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
+    assert!(prompt_editor_plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(prompt_editor_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl".to_string()));
+
+    let run_artifacts_plan = select_finish_validation_plan(
+        "adl/src/cli/run_artifacts_types.rs,adl/src/cli/run_artifacts_types/state.rs",
+    )
+    .expect("run artifacts refactor plan");
+    assert_eq!(
+        run_artifacts_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
+    assert!(run_artifacts_plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(run_artifacts_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl".to_string()));
+}
+
+#[test]
 fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request() {
     let docs_plan = select_finish_validation_plan_for_finish(
         ".",


### PR DESCRIPTION
Closes #3914

## Summary
Extended `pr finish` validation-lane classification so the prompt-editor and run-artifact Rust refactor slices route into a truthful larger-binary focused finish profile, with focused regression coverage for both path families.

## Artifacts
- Updated `adl/src/cli/pr_cmd/finish_support.rs`
- Updated `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated in-flight output record at `.adl/v0.91.5/tasks/issue-3914__v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_validation_plan_classifies_rust_refactor_slices`
    Verified that the two bounded Rust refactor slices are classified into the intended finish lane.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter-clean Rust changes before publication.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_helper_paths_run_focused_local_ci_gated_validation`
    Verified the finish helper still runs the focused local CI-gated validation path correctly.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3914__v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3914__v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices/sor.md
- Idempotency-Key: v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-5-tasks-issue-3914-v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices-sip-md-adl-v0-91-5-tasks-issue-3914-v0-91-5-tools-extend-pr-finish-validation-lane-classification-for-rust-refactor-slices-sor-md