### PR TITLE
[v0.91.5][tools][github-client] Clarify or remediate gh-fallback hard-fail behavior on GitHub read paths

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1134,7 +1134,7 @@ fn github_credential_preflight_hint(
     match config.token_source {
         None => "credential_status=missing_token; set GITHUB_TOKEN or GH_TOKEN before live C-SDLC GitHub operations; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
         Some(source) => format!(
-            "credential_status=token_present source={}; ADL_GITHUB_CLIENT=gh is not a supported mutation fallback for covered operations; use ADL_GITHUB_CLIENT=auto or ADL_GITHUB_CLIENT=octocrab",
+            "credential_status=token_present source={}; ADL_GITHUB_CLIENT=gh is not a supported read or mutation fallback for covered operations; use ADL_GITHUB_CLIENT=auto or ADL_GITHUB_CLIENT=octocrab",
             source.env_name()
         ),
     }
@@ -4511,6 +4511,7 @@ sys.exit(9)
         assert!(err_debug.contains("pr.list.current_branch"));
         assert!(err_debug.contains("github_client.gh_fallback_removed"));
         assert!(err_debug.contains("credential_status=token_present"));
+        assert!(err_debug.contains("read or mutation fallback"));
         assert!(err_debug.contains("source=GITHUB_TOKEN"));
         assert!(!err_debug.contains("test-token"));
         let err = gh_issue_edit_body("owner/repo", 3672, "body")
@@ -4518,6 +4519,7 @@ sys.exit(9)
         let err_debug = format!("{err:?}");
         assert!(err_debug.contains("github_client.gh_fallback_removed"));
         assert!(err_debug.contains("credential_status=token_present"));
+        assert!(err_debug.contains("read or mutation fallback"));
         assert!(!err_debug.contains("test-token"));
         assert!(
             !gh_log.exists(),

--- a/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
+++ b/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
@@ -42,7 +42,8 @@ instead of silently spawning `gh`.
 - `ADL_GITHUB_CLIENT=octocrab` requires `GITHUB_TOKEN` or `GH_TOKEN` and fails
   closed without a token.
 - `ADL_GITHUB_CLIENT=gh` is no longer an operational fallback for covered
-  C-SDLC GitHub workflow operations.
+  C-SDLC GitHub workflow operations, including bounded read paths such as live
+  current-PR lookup and other covered issue/PR metadata reads.
 - Missing token, explicit `gh` fallback, or unsupported operations fail closed
   rather than spawning `gh`.
 


### PR DESCRIPTION
Closes #3916

## Summary
Kept the fail-closed GitHub client behavior but clarified the operator-facing contract so explicit `ADL_GITHUB_CLIENT=gh` is documented and reported as unsupported for covered read and mutation paths, with tests and docs aligned.

## Artifacts
- Updated `adl/src/cli/pr_cmd/github.rs`
- Updated `docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md`
- Updated in-flight output record at `.adl/v0.91.5/tasks/issue-3916__v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl live_github_policy_blocks_explicit_gh_fallback_before_spawn`
    Verified the clarified diagnostic wording for covered read-path fallback rejection.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter-clean Rust changes before publication.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd`
    Verified the larger `cli::pr_cmd` surface stays green with the clarified GitHub fallback contract.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3916__v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3916__v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths/sor.md
- Idempotency-Key: v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths-adl-src-cli-pr-cmd-github-rs-docs-tooling-adl-octocrab-migration-review-md-adl-v0-91-5-tasks-issue-3916-v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths-sip-md-adl-v0-91-5-tasks-issue-3916-v0-91-5-tools-github-client-clarify-or-remediate-gh-fallback-hard-fail-behavior-on-github-read-paths-sor-md