### PR TITLE
[v0.91.6][tools][csdlc] Converge GitHub PR truth on SOR and define card projection policy

### DIFF
--- a/docs/milestones/v0.91.6/DECISIONS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/DECISIONS_v0.91.6.md
@@ -21,6 +21,7 @@ Capture significant first-tranche bridge decisions and open questions.
 | D-04 | Public prompt records require redaction, validation, indexing, and security review before public consumption. | accepted | Local editable records are not automatically public-safe. | Export remains blocked until the feature doc proof path is met. | `features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md` |
 | D-05 | Provider/model reliability must include Gemma and multi-agent suitability limits. | accepted | Multi-agent reliability depends on role-appropriate model behavior, not only provider availability. | Reliability proof remains separate from product/training claims. | `features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md` |
 | D-06 | ACIP/A2A protobuf can be a decision point rather than forced implementation in `v0.91.6`. | accepted | Schema/access/security posture must come first. | Residual wire-format work may route to `v0.91.7`. | `features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md` |
+| D-07 | C-SDLC cards should remain authoritative while owned GitHub issue/PR surfaces converge into deterministic managed projections. | proposed | Partial projection without explicit ownership allows PR/issue drift to become workflow truth by accident. | `#3935` should define which surfaces are managed projections, drift-checked mirrors, linked surfaces, or card-local only. | `review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md` |
 
 ## Open Questions
 
@@ -28,6 +29,8 @@ Capture significant first-tranche bridge decisions and open questions.
   records?
 - Which tooling reliability fixes from `#3802`-`#3805` are required before
   `v0.92` refresh versus acceptable as routed residuals?
+- Which GitHub-facing surfaces should be automatically repaired from card truth
+  versus only classified as drift?
 - Which public prompt-record export checks must run locally versus in CI?
 - Which Observatory/Unity surfaces count as proof versus rehearsal?
 

--- a/docs/milestones/v0.91.6/README.md
+++ b/docs/milestones/v0.91.6/README.md
@@ -79,6 +79,8 @@ issues created during the feature-doc wave:
 - `#3803`: prompt-card enum diagnostics and lifecycle-state alignment
 - `#3804`: lifecycle-card absolute-path leakage diagnostic precision
 - `#3805`: octocrab token preflight diagnostics
+- `#3935`: `SOR`-driven PR-body convergence and generalized card-to-GitHub
+  projection policy
 
 These are not blockers for creating this planning package. They are required
 inputs to the `v0.91.6` tooling proof-loop work.
@@ -106,6 +108,7 @@ Expected `v0.91.7` residuals:
 - `#3780`: later `v0.92` activation and birthday refresh
 - `#3779`: feature-doc production wave setup
 - `#3802`-`#3805`: tooling reliability findings raised during this wave
+- `#3935`: card/GitHub projection convergence for PR and lifecycle truth
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `docs/planning/FEATURE_DOC_PRODUCTION_MINI_SPRINT_v0.91.5.md`
 - `docs/milestones/v0.91.5/PRE_V092_BRIDGE_FEATURE_DOC_LEDGER_v0.91.5.md`
@@ -127,6 +130,8 @@ Expected `v0.91.7` residuals:
 - Review and validation checklist:
   [REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md](REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md)
 - Feature directory index: [features/README.md](features/README.md)
+- Review packet:
+  [review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md](review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md)
 
 ## Non-Goals
 

--- a/docs/milestones/v0.91.6/README.md
+++ b/docs/milestones/v0.91.6/README.md
@@ -83,7 +83,8 @@ issues created during the feature-doc wave:
   projection policy
 
 These are not blockers for creating this planning package. They are required
-inputs to the `v0.91.6` tooling proof-loop work.
+inputs to the `v0.91.6` tooling proof-loop work, and `#3935` is expected to
+complete its first-tranche `SOR` convergence slice within this milestone.
 
 ## v0.91.7 Handoff
 

--- a/docs/milestones/v0.91.6/WBS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/WBS_v0.91.6.md
@@ -27,7 +27,7 @@ decision records, and proof-loop repairs before `v0.92` activation opens.
 | --- | --- | --- | --- | --- |
 | WP-01 | Planning promotion and issue-wave readiness | Promote this candidate package, reconcile `#3778`, open the issue wave, and prepare SIP/STP/SPP/SRP/SOR cards. | Opened issue wave and card bundles. | `#3778`, `#3800`. |
 | WP-02 | Resilience, persistence, and sleep/wake feature doc | Define retry/fault classes, health persistence, checkpoint/restore, sleep/wake, hibernation, simulation, migration, replay, and continuity proof. | Feature doc and acceptance checklist. | WP-01. |
-| WP-03 | Logging/tooling proof-loop fixes | Plan validation split, CI runtime-budget observability, logging/Otel consumption, PR proof-loop reliability, issues `#3802`-`#3805`, and card-to-GitHub projection convergence including `#3935`. | Tooling reliability feature doc, review packet, and issue routes. | WP-01. |
+| WP-03 | Logging/tooling proof-loop fixes | Plan and complete validation split, CI runtime-budget observability, logging/Otel consumption, PR proof-loop reliability, issues `#3802`-`#3805`, and card-to-GitHub projection convergence including `#3935`. | Tooling reliability feature doc, review packet, completed `#3935` convergence slice, and issue routes. | WP-01. |
 | WP-04 | Public prompt records | Define local editable authoring, export, redaction, validation, indexing, evidence, and security review boundaries. | Public prompt-record feature doc. | WP-01, security review inputs. |
 | WP-05 | Provider/model reliability and multi-agent readiness | Define hosted/local/remote/OpenRouter/Gemma lanes, role suitability, known failures, and proof limits. | Provider/model reliability feature doc and matrix update. | WP-01, prior provider/multi-agent evidence. |
 | WP-06 | ACIP/A2A/provider communications decisions | Decide schema catalog, access rules, external-agent posture, provider communications, WebSocket boundary, JSON projection, and protobuf routing. | Decision record plus feature-doc route. | WP-01, WP-07 security input. |
@@ -48,6 +48,8 @@ decision records, and proof-loop repairs before `v0.92` activation opens.
 - Tooling reliability must classify whether PR/issue GitHub surfaces are
   card-owned managed projections, drift-checked mirrors, linked-only review
   surfaces, or card-local only.
+- Tooling reliability must complete the `SOR`-owned PR body and closing-linkage
+  convergence slice in `v0.91.6`, not leave it as an unbounded later follow-on.
 - Public prompt records must preserve local editable authoring and public export
   boundaries.
 - Provider/model reliability must include Gemma reliability and multi-agent

--- a/docs/milestones/v0.91.6/WBS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/WBS_v0.91.6.md
@@ -27,7 +27,7 @@ decision records, and proof-loop repairs before `v0.92` activation opens.
 | --- | --- | --- | --- | --- |
 | WP-01 | Planning promotion and issue-wave readiness | Promote this candidate package, reconcile `#3778`, open the issue wave, and prepare SIP/STP/SPP/SRP/SOR cards. | Opened issue wave and card bundles. | `#3778`, `#3800`. |
 | WP-02 | Resilience, persistence, and sleep/wake feature doc | Define retry/fault classes, health persistence, checkpoint/restore, sleep/wake, hibernation, simulation, migration, replay, and continuity proof. | Feature doc and acceptance checklist. | WP-01. |
-| WP-03 | Logging/tooling proof-loop fixes | Plan validation split, CI runtime-budget observability, logging/Otel consumption, PR proof-loop reliability, and issues `#3802`-`#3805`. | Tooling reliability feature doc and issue routes. | WP-01. |
+| WP-03 | Logging/tooling proof-loop fixes | Plan validation split, CI runtime-budget observability, logging/Otel consumption, PR proof-loop reliability, issues `#3802`-`#3805`, and card-to-GitHub projection convergence including `#3935`. | Tooling reliability feature doc, review packet, and issue routes. | WP-01. |
 | WP-04 | Public prompt records | Define local editable authoring, export, redaction, validation, indexing, evidence, and security review boundaries. | Public prompt-record feature doc. | WP-01, security review inputs. |
 | WP-05 | Provider/model reliability and multi-agent readiness | Define hosted/local/remote/OpenRouter/Gemma lanes, role suitability, known failures, and proof limits. | Provider/model reliability feature doc and matrix update. | WP-01, prior provider/multi-agent evidence. |
 | WP-06 | ACIP/A2A/provider communications decisions | Decide schema catalog, access rules, external-agent posture, provider communications, WebSocket boundary, JSON projection, and protobuf routing. | Decision record plus feature-doc route. | WP-01, WP-07 security input. |
@@ -45,6 +45,9 @@ decision records, and proof-loop repairs before `v0.92` activation opens.
   proof, not just retry language.
 - Tooling reliability must include issues `#3802`-`#3805` or explicitly route
   them out.
+- Tooling reliability must classify whether PR/issue GitHub surfaces are
+  card-owned managed projections, drift-checked mirrors, linked-only review
+  surfaces, or card-local only.
 - Public prompt records must preserve local editable authoring and public export
   boundaries.
 - Provider/model reliability must include Gemma reliability and multi-agent

--- a/docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md
@@ -61,7 +61,8 @@ Out of scope:
 ## v0.92 Consumption
 
 `v0.92` may consume a bounded proof-loop contract only after validator,
-GitHub, and logging failure modes are classified or routed.
+GitHub, logging, and card-projection failure modes are classified, with
+`SOR`-owned PR publication truth completed for the first tranche.
 
 ## Non-Goals
 

--- a/docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md
@@ -24,7 +24,8 @@ In scope:
 - absolute-path leakage false positives;
 - octocrab token preflight;
 - PR merge false-negative and GitHub checks transient classification;
-- logging/Otel consumption for proof loops.
+- logging/Otel consumption for proof loops;
+- card-to-GitHub projection reliability for PR publication and closeout truth.
 
 Out of scope:
 
@@ -38,10 +39,14 @@ Out of scope:
 - Which GitHub/API failures are retryable versus blocking?
 - Which observability events are release-gating proof versus diagnostic noise?
 - Which docs-only fast paths can be used without bypassing review?
+- Which GitHub issue/PR surfaces should be card-owned managed projections
+  versus drift-checked mirrors?
 
 ## Dependencies
 
 - Existing remediation issues `#3802`-`#3805`, `#3811`, `#3822`, and `#3823`.
+- `#3935` for `SOR`-driven PR-body convergence and generalized card-projection
+  policy.
 - Logging mini-sprint outputs.
 - Toolkit simplification sprint.
 
@@ -51,6 +56,7 @@ Out of scope:
 - Record transient failures and retry evidence.
 - Verify no token or secret is logged.
 - Review SOR truth for local versus CI proof.
+- Review the card/GitHub projection policy before implementation claims.
 
 ## v0.92 Consumption
 
@@ -62,3 +68,5 @@ GitHub, and logging failure modes are classified or routed.
 - No hidden fallback to deprecated `gh` paths.
 - No broad rewrite of lifecycle tooling in this feature doc.
 - No claim that all tooling debt is gone.
+- No collapse of `SIP -> STP -> SPP -> SRP -> SOR` into one GitHub-facing text
+  surface.

--- a/docs/milestones/v0.91.6/review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md
+++ b/docs/milestones/v0.91.6/review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md
@@ -1,0 +1,259 @@
+# C-SDLC GitHub Projection Convergence Review
+
+## Metadata
+
+- Issue: `#3935`
+- Milestone: `v0.91.6`
+- Version: `v0.91.6`
+- Date: `2026-06-17`
+- Status: draft for review
+- Audience: ADL maintainers and workflow-tooling reviewers
+
+## Purpose
+
+Define how ADL should converge GitHub issue/PR surfaces on the canonical
+C-SDLC cards so publication and closeout truth remain templated, repairable,
+and reviewable instead of drifting through partially-managed duplicate text.
+
+## Source Evidence
+
+Current-state facts in this review are grounded in:
+
+- `adl/src/cli/pr_cmd/finish_support.rs`
+- `adl/src/cli/pr_cmd/github.rs`
+- `docs/cognitive-sdlc/card-lifecycle.md`
+- `docs/architecture/ADL_ARCHITECTURE.md`
+- `docs/templates/CARD_LIFECYCLE_TEMPLATE_TARGETS.md`
+- `docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md`
+
+Recommendations in this review are design proposals for `#3935`, not claims
+that the current tooling already behaves this way.
+
+## Current Observed State
+
+### Facts
+
+- `pr finish` already renders the PR body from selected `SOR` sections rather
+  than from the issue prompt or free-form operator text.
+- The current PR-body projection includes:
+  - closing line when closeout is enabled
+  - `Summary`
+  - `Artifacts produced`
+  - `Validation`
+  - optional notes
+  - local artifact references and an idempotency key
+- The `SOR` remains the card responsible for outcome truth: changed paths,
+  validation actually run, review actually performed, PR/merge state, closeout
+  state, unresolved follow-ons, and final issue truth.
+- The canonical card roles remain distinct:
+  - `SIP`: issue/problem truth
+  - `STP`: selected task/solution truth
+  - `SPP`: execution-plan truth
+  - `SRP`: review-result truth
+  - `SOR`: outcome/publication/closeout truth
+
+### Failure Mode Observed
+
+- The live GitHub PR body can still drift after publication because GitHub
+  remains an editable projection surface.
+- When the live body drifts far enough, downstream guards such as PR closing
+  linkage can fail even if the intended `SOR`-driven publication shape was
+  correct earlier.
+
+## Problem Statement
+
+ADL currently has a partial convergence model:
+
+- the cards are the intended C-SDLC authority
+- some GitHub surfaces are rendered from those cards
+- GitHub still allows independent edits that can become silently authoritative
+  in practice
+
+That split creates a control-plane truth gap. The repo can have:
+
+- a truthful `SOR`
+- a mostly-correct finish path
+- a drifted live PR body
+- a later failing linkage/closeout/janitor path
+
+The underlying issue is broader than PR-body text. ADL needs a policy for which
+GitHub surfaces are:
+
+- authoritative card-owned projections
+- drift-check-only mirrors
+- intentionally manual operator surfaces
+- card-local only and never projected outward
+
+## Proposed Convergence Rule
+
+Recommendation:
+
+- C-SDLC cards remain the authority.
+- GitHub issue/PR surfaces become deterministic managed projections where ADL
+  has claimed ownership.
+- Drift must be detected explicitly and repaired from the owning card instead
+  of normalized by ad hoc manual edits.
+
+This implies:
+
+1. GitHub should not be the source of truth for lifecycle state.
+2. GitHub projections should be templated from card-owned fields.
+3. Drift repair should flow from cards to GitHub, not from GitHub back into the
+   cards, except for deliberate bootstrap/import paths.
+
+## First Concrete Slice
+
+`#3935` should start with the smallest high-value convergence point:
+
+- make the issue `SOR` the explicit authority for PR publication body truth
+
+That slice should define:
+
+- the templated PR-body section set
+- the closing-keyword policy
+- the drift detection point
+- the repair owner in `finish`, `doctor`, `janitor`, and `closeout`
+
+Recommended PR-body projection contract:
+
+- `Closes #<issue>` or an explicit non-closing declaration
+- `## Summary`
+- `## Artifacts`
+- `## Validation`
+- `## Notes` when populated
+- durable local artifact references
+- publication fingerprint / idempotency key
+
+## Recommended First-Tranche Projection Ownership
+
+To keep the first implementation slice bounded, the initial `v0.91.6`
+recommendation should classify these surfaces now:
+
+| Surface | Owning card | First-tranche class | Expected first-tranche behavior |
+| --- | --- | --- | --- |
+| PR body | `SOR` | `managed_projection` | Render from `SOR`, detect drift, and repair from `SOR` automatically or fail closed when repair is required. |
+| PR closing linkage line | `SOR` | `managed_projection` | Treat `Closes #<issue>` or explicit non-closing state as part of the rendered `SOR` projection rather than a side-band edit. |
+| Closeout / merge summary comment | `SOR` | `drift_checked_projection` | Define the target shape now, but allow review before making automatic rewrite mandatory. |
+| GitHub issue body after bootstrap | `SIP` | `drift_checked_projection` | Classify drift against `SIP` truth, but defer auto-repair policy until bootstrap/import and operator-edit rules are settled. |
+| PR title | `STP` | `drift_checked_projection` | Decide the deterministic mapping before promoting it to managed projection. |
+| Review findings comments / summary comment | `SRP` | `linked_surface_only` | Prefer linking or summarizing `SRP`/review packets rather than mirroring full review truth into GitHub prose. |
+| Labels / milestone / queue metadata | mixed control-plane ownership | `drift_checked_projection` | Classify field ownership first; do not auto-repair until that boundary is explicit. |
+| `SPP` execution plan | `SPP` | `card_local_only` | Keep execution-plan truth in the card; do not force a GitHub projection in the first tranche. |
+
+## Generalized Card-To-GitHub Projection Model
+
+Longer-term target recommendation after the first-tranche boundary is approved:
+
+| Card | Canonical responsibility | GitHub-facing projection candidate | Policy |
+| --- | --- | --- | --- |
+| `SIP` | issue/problem truth, scope, acceptance, dependencies | authored issue body and selected issue metadata | drift-checked first; may later promote selected surfaces to managed projection once bootstrap/import and operator-edit rules are settled |
+| `STP` | chosen task/solution, touched surfaces, invariants | PR title and possibly bounded task-summary fragments | drift-checked first; may later promote deterministic fields to managed projection |
+| `SPP` | execution sequence, stop conditions, validation/replan plan | usually no durable GitHub text projection; maybe bounded checklists/comments later | card-local by default |
+| `SRP` | review instructions, findings, dispositions, residual risk | review summaries, routed findings comments, or linked review packets | linked-surface-first; do not mirror full review truth into GitHub prose |
+| `SOR` | outcome truth, validation run, integration/closeout state | PR body, closeout comment, merge/closure status assertions | managed projection for PR body and closing linkage first; drift-checked or linked-only for other GitHub-facing outcome surfaces until explicitly promoted |
+
+## Projection Classes
+
+To keep the model reviewable, each GitHub-facing surface should be assigned one
+of four classes:
+
+- `managed_projection`: GitHub content is rendered from a card and may be
+  auto-repaired
+- `drift_checked_projection`: GitHub content is compared against card truth but
+  may require explicit operator confirmation before repair
+- `linked_surface_only`: the card links to GitHub state or a packet, but does
+  not mirror the content
+- `card_local_only`: no GitHub projection is attempted
+
+The first-tranche table above is the operative scope for `#3935`. The
+generalized card table is the later target model and must not be read as
+promoting additional surfaces into managed projection during Slice 1.
+
+## Why This Should Not Collapse The Cards
+
+This proposal is not to flatten C-SDLC into GitHub text.
+
+The distinct cards still matter because:
+
+- `SIP` expresses problem truth that should outlive PR wording
+- `STP` captures the chosen implementation path, not just reviewer-facing prose
+- `SPP` is an execution-planning surface and should not be reduced to a PR
+  checklist by default
+- `SRP` records review truth that should not be swallowed by `SOR`
+- `SOR` summarizes outcome/publication truth but should not absorb all planning
+  or review details
+
+The goal is projection alignment, not lifecycle collapse.
+
+## Suggested Implementation Slices
+
+### Slice 1
+
+`SOR` owns PR body truth.
+
+- render a canonical PR-body block from `SOR`
+- store a publication fingerprint
+- detect and repair body drift from `SOR`
+- fail closed when a required closing line disappears
+- keep first-tranche managed projection scope limited to the PR body and its
+  closing-linkage line
+
+### Slice 2
+
+Define the `SIP` to GitHub issue-body ownership boundary.
+
+- distinguish bootstrap/import from ongoing authority
+- define which issue metadata fields are card-owned
+- specify when GitHub issue edits must be reflected from `SIP`
+
+### Slice 3
+
+Define `SRP` and review-surface projection boundaries.
+
+- keep review findings in `SRP`
+- decide whether GitHub comments are summary projections, linked packets, or
+  non-authoritative operator aids
+
+### Slice 4
+
+Classify all remaining GitHub-facing surfaces.
+
+- PR title
+- labels
+- milestone/queue metadata
+- closeout comments
+- linked review/evidence packets
+
+## Validation Expectations
+
+The first implementation slice should prove at minimum:
+
+- PR body render is fully derived from the intended `SOR` fields
+- live-body drift is detected deterministically
+- repair rewrites the live PR body back to the card-owned projection
+- closing-linkage guard can no longer fail after silent manual drift without
+  first classifying or repairing the mismatch
+- no issue-template/bootstrap text leaks into the rendered PR body
+
+## Open Questions For Review
+
+- Should PR title remain `STP`-derived, `SOR`-derived, or issue-prompt-derived?
+- Which GitHub metadata fields should stay manually editable by operators?
+- Should drift repair always be automatic for managed projections, or should
+  some surfaces require explicit operator approval?
+- How much of `SRP` should ever be projected into GitHub comments versus linked
+  as a durable packet?
+- Should `SIP` own GitHub issue-body updates after bootstrap, or should the
+  issue body become a bounded summary projection once cards exist?
+
+## Recommended Review Outcome
+
+Recommend review approval of the following direction:
+
+- accept `SOR` as the canonical authority for PR publication body truth
+- accept a generalized card-to-GitHub projection policy as a `v0.91.6`
+  tooling/control-plane requirement
+- accept the proposed first-tranche projection classification before broadening
+  automatic synchronization to other surfaces
+- route implementation in bounded slices so projection ownership becomes
+  deterministic without collapsing C-SDLC card roles

--- a/docs/milestones/v0.91.6/review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md
+++ b/docs/milestones/v0.91.6/review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md
@@ -26,8 +26,8 @@ Current-state facts in this review are grounded in:
 - `docs/templates/CARD_LIFECYCLE_TEMPLATE_TARGETS.md`
 - `docs/milestones/v0.91.6/features/TOOLING_PROOF_LOOP_RELIABILITY_v0.91.6.md`
 
-Recommendations in this review are design proposals for `#3935`, not claims
-that the current tooling already behaves this way.
+Recommendations in this review are the proposed completion contract for `#3935`
+in `v0.91.6`, not claims that the current tooling already behaves this way.
 
 ## Current Observed State
 
@@ -103,7 +103,7 @@ This implies:
 
 ## First Concrete Slice
 
-`#3935` should start with the smallest high-value convergence point:
+`#3935` should complete the smallest high-value convergence point in `v0.91.6`:
 
 - make the issue `SOR` the explicit authority for PR publication body truth
 
@@ -142,7 +142,8 @@ recommendation should classify these surfaces now:
 
 ## Generalized Card-To-GitHub Projection Model
 
-Longer-term target recommendation after the first-tranche boundary is approved:
+Target model that `v0.91.6` should define concretely even if some surfaces stay
+drift-checked or linked-only in the first implementation slice:
 
 | Card | Canonical responsibility | GitHub-facing projection candidate | Policy |
 | --- | --- | --- | --- |
@@ -165,9 +166,10 @@ of four classes:
   not mirror the content
 - `card_local_only`: no GitHub projection is attempted
 
-The first-tranche table above is the operative scope for `#3935`. The
-generalized card table is the later target model and must not be read as
-promoting additional surfaces into managed projection during Slice 1.
+The first-tranche table above is the operative implementation scope for
+`#3935`. The generalized card table is the target classification model that
+`v0.91.6` should finish defining, but it must not be read as promoting
+additional surfaces into managed projection during Slice 1.
 
 ## Why This Should Not Collapse The Cards
 
@@ -200,7 +202,8 @@ The goal is projection alignment, not lifecycle collapse.
 
 ### Slice 2
 
-Define the `SIP` to GitHub issue-body ownership boundary.
+Define and document the `SIP` to GitHub issue-body ownership boundary in
+`v0.91.6`.
 
 - distinguish bootstrap/import from ongoing authority
 - define which issue metadata fields are card-owned
@@ -208,7 +211,8 @@ Define the `SIP` to GitHub issue-body ownership boundary.
 
 ### Slice 3
 
-Define `SRP` and review-surface projection boundaries.
+Define and document `SRP` and review-surface projection boundaries in
+`v0.91.6`.
 
 - keep review findings in `SRP`
 - decide whether GitHub comments are summary projections, linked packets, or
@@ -216,7 +220,9 @@ Define `SRP` and review-surface projection boundaries.
 
 ### Slice 4
 
-Classify all remaining GitHub-facing surfaces.
+Classify all remaining GitHub-facing surfaces in `v0.91.6`, even where
+automatic synchronization remains deferred behind a drift-checked or
+linked-only policy.
 
 - PR title
 - labels
@@ -248,12 +254,13 @@ The first implementation slice should prove at minimum:
 
 ## Recommended Review Outcome
 
-Recommend review approval of the following direction:
+Recommend review approval of the following `v0.91.6` completion direction:
 
 - accept `SOR` as the canonical authority for PR publication body truth
 - accept a generalized card-to-GitHub projection policy as a `v0.91.6`
   tooling/control-plane requirement
 - accept the proposed first-tranche projection classification before broadening
   automatic synchronization to other surfaces
-- route implementation in bounded slices so projection ownership becomes
-  deterministic without collapsing C-SDLC card roles
+- require `#3935` to finish the projection classification and complete the
+  `SOR`-owned PR-body/closing-linkage slice within `v0.91.6`, without
+  collapsing C-SDLC card roles


### PR DESCRIPTION
Closes #3935

## Summary
- add a v0.91.6 review packet for converging GitHub issue/PR surfaces on canonical C-SDLC card truth
- wire the proposal into the v0.91.6 tooling proof-loop milestone docs and decisions
- require the `SOR`-owned PR body and closing-linkage convergence slice to complete in v0.91.6, not drift into an unbounded follow-on

## Validation
- git diff --check
- bounded subagent review of the packet, with findings resolved before publication