### PR TITLE
[codex] Refresh Sprint 4 release-tail and first-pass remediation truth

### DIFF
--- a/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
+++ b/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
@@ -6,15 +6,18 @@
 
 ## Current Phase
 
-WP-14 was applied on 2026-06-17 at the start of Sprint 4. The milestone is in
-the review/remediation/release tail and is not release-ready.
+WP-14 was applied and closed on `2026-06-17` at the start of Sprint 4. The
+milestone remains in the review/remediation/release tail and is not
+release-ready.
 
 - Sprint 4 umbrella `#3574` remains open.
-- WP-14 quality gate `#3575` is the active child issue.
-- WP-15 `#3579`, WP-16 `#3576`, WP-17 `#3580`, WP-18 `#3577`, WP-19 `#3581`,
-  and WP-20 `#3578` all remain open.
+- WP-14 quality gate `#3575` closed on `2026-06-17`.
+- WP-15 `#3579` closed on `2026-06-17`.
+- WP-16 `#3576`, WP-17 `#3580`, WP-18 `#3577`, WP-19 `#3581`, and WP-20
+  `#3578` remain open.
 - Second-pass internal review `#3923` is also open, so this gate must treat
-  review readiness as a handoff surface rather than a completed fact.
+  review readiness as an active execution/handoff surface rather than a
+  completed fact.
 
 ## Gate Outcome
 
@@ -35,13 +38,15 @@ surface.
   - sampled closeout truth is not uniformly clean; recent closed issue `#3891`
     still has a stale local SOR that reports `Integration state: worktree_only`
     despite the issue being closed
-  - multiple v0.91.5 milestone docs still carry stale `active_wp_01_opening`
-    or opening-era status language and must be normalized in WP-15
+  - second-pass internal review and later Sprint 4 release-tail work remain
+    incomplete, so release readiness still cannot be claimed
 
 ## Evidence Packets
 
 - Checklist application packet:
   [V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md](review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md)
+- WP-15 docs/review alignment packet:
+  [V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md](review/internal_review/V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md)
 - Internal-review readiness plan:
   [V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md](review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md)
 

--- a/docs/milestones/v0.91.5/README.md
+++ b/docs/milestones/v0.91.5/README.md
@@ -18,10 +18,13 @@ Current status: `sprint_4_release_tail_active`
 - Planning: v0.91.5 bridge package, issue wave, sprint umbrellas, and closeout
   tail are seeded and in use.
 - Execution: Sprint 1, Sprint 2, and Sprint 3 delivery are materially landed;
-  the first internal-review remediation mini-sprint closed through `#3899`.
-- Current frontier: Sprint 4 `#3574` is active through WP-14 `#3575`,
-  WP-15 `#3579`, WP-16 `#3576`, WP-17 `#3580`, WP-18 `#3577`, WP-19 `#3581`,
-  WP-20 `#3578`, and second-pass internal review follow-on `#3923`.
+  the first internal-review remediation mini-sprint closed through `#3899` on
+  `2026-06-17`.
+- Current frontier: Sprint 4 `#3574` remains active after WP-14 `#3575` and
+  WP-15 `#3579` closed on `2026-06-17`; the remaining active release-tail
+  issues are WP-16 `#3576`, WP-17 `#3580`, WP-18 `#3577`, WP-19 `#3581`,
+  WP-20 `#3578`, and the open second-pass internal-review execution slice
+  `#3923`.
 - Validation: focused milestone docs, issue-state, quality-gate, and review
   packet validation is active in the release tail.
 - Release readiness: `blocked_for_release_tail` until Sprint 4 closeout truth,
@@ -42,11 +45,14 @@ Setup truth:
   after prompt templates v1.1 lands through `#3553`.
 - `#3571`, `#3572`, and `#3573` are closed.
 - `#3574` remains open as the active Sprint 4 umbrella.
-- `#3575`, `#3579`, `#3576`, `#3580`, `#3577`, `#3581`, and `#3578`
-  are the active closeout-tail issues.
-- `#3899` is closed as the first internal-review remediation tranche.
-- `#3923` is open as the second-pass internal-review issue and remains
-  downstream from WP-15.
+- `#3575` and `#3579` closed on `2026-06-17` as the completed WP-14 and WP-15
+  release-tail steps.
+- `#3576`, `#3580`, `#3577`, `#3581`, and `#3578` are the remaining open
+  closeout-tail issues.
+- `#3899` closed on `2026-06-17` as the completed first internal-review
+  remediation tranche.
+- `#3923` is open as the active second-pass internal-review issue and now
+  serves as the live review-entry follow-on under the WP-16 / Sprint 4 lane.
 
 ## Purpose
 
@@ -152,11 +158,11 @@ Sprint and review support:
 - Tools remediation sprint closeout packet for umbrella `#3845`: [TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md](review/tooling_adoption/TOOLS_REMEDIATION_SPRINT_CLOSEOUT_3845.md)
 - Strategic Cognitive Reserve project bootstrap closeout for `#3868`: [STRATEGIC_COGNITIVE_RESERVE_PROJECT_BOOTSTRAP_3868.md](review/tooling_adoption/STRATEGIC_COGNITIVE_RESERVE_PROJECT_BOOTSTRAP_3868.md)
 - TBD documentation backlog closeout for `#3635`: [TBD_DOCUMENTATION_BACKLOG_CLOSEOUT_3635.md](review/tooling_adoption/TBD_DOCUMENTATION_BACKLOG_CLOSEOUT_3635.md)
-- First internal-review findings register: [V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md](review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md)
-- First internal-review remediation queue: [V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md](review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md)
+- Historical first internal-review findings register: [V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md](review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md)
+- Historical first internal-review remediation queue: [V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md](review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md)
 - WP-14 quality-gate application: [V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md](review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md)
 - WP-15 docs/review alignment packet: [V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md](review/internal_review/V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md)
-- Second-pass internal-review handoff plan: [V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md](review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md)
+- Current second-pass internal-review handoff plan: [V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md](review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md)
 
 ## Document Map
 

--- a/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
+++ b/docs/milestones/v0.91.5/SPRINT_v0.91.5.md
@@ -6,11 +6,11 @@
 - Start date: `2026-06-02`
 - End date: `pending`
 - Owner: ADL maintainers
-- Status: `first_internal_review_remediation_active`
+- Status: `second_pass_internal_review_active`
 
 ## Status
 
-`first_internal_review_remediation_active`
+`second_pass_internal_review_active`
 
 ## How To Use
 
@@ -23,8 +23,8 @@
 
 v0.91.5 is split into ordered sprint bands after WP-01 opens the milestone and
 confirms issue/card/sprint readiness. Sprint 1 is complete, Sprint 2 child
-execution is complete, and the first internal-review remediation queue is now
-the active execution-prep state before the remaining Sprint 4 closeout tail.
+execution is complete, the first internal-review remediation queue closed on
+`2026-06-17`, and the remaining Sprint 4 closeout tail has now resumed.
 
 Planned scope:
 
@@ -36,19 +36,17 @@ Planned scope:
 
 ## Current Execution Focus
 
-- First internal-review remediation is active under `#3899`.
-- The active remediation wave covers `#3891` through `#3898` in the retained
-  order recorded by the mini-sprint tracker.
-- `#3891` is merged, `#3892` is closed out after PR `#3900`, `#3893` is
-  closed out, and `#3894` / `#3895` are published as draft PRs.
-- `#3896` surfaced a repo-native publication tooling gap: `pr finish` does not
-  classify `adl/src/cli/observability.rs` into any supported finish-validation
-  lane yet, so that blocker must be treated as a remediation finding rather
-  than hidden operator error.
-- `#3574` remains the canonical Sprint 4 umbrella, but closeout-tail execution
-  should resume through the queued `#3899` remediation wave before external
-  review, final preflight, next-milestone planning, and release ceremony move
-  forward.
+- First internal-review remediation closed under `#3899` on `2026-06-17` after
+  child issues `#3891` through `#3898` closed.
+- WP-14 `#3575` closed on `2026-06-17` with a truthful blocked quality-gate
+  result recorded in the tracked packet.
+- WP-15 `#3579` closed on `2026-06-17` after aligning release-tail docs and
+  reviewer entry surfaces to the post-remediation Sprint 4 state.
+- `#3923` is now the active second-pass internal-review execution slice, while
+  `#3576` remains the canonical WP-16 issue.
+- `#3574` remains the canonical Sprint 4 umbrella; the remaining closeout-tail
+  work proceeds through second-pass internal review, external review, final
+  remediation/preflight, next-milestone planning, and release ceremony.
 
 ## Bridge Sprint Work
 
@@ -100,14 +98,14 @@ Make v0.92 openable without hidden operational debt.
 | 10 | Multi-agent proof | `#3415`, `#3503`, `#3504` (`#3484` satisfied/closed evidence) | ADL maintainers | closed |
 | 11 | Sprint 3 umbrella: demo matrix / demo showcase refresh | `#3573` | ADL maintainers | seeded |
 | 12 | Demo matrix / demo showcase refresh | `#3455` with `#3460`, `#3461` as supporting demo inputs | ADL maintainers | moved |
-| 13 | Sprint 4 umbrella: coverage, review, remediation, planning, release | `#3574` | ADL maintainers | queued behind `#3899` |
-| 14 | Coverage / quality gate | `#3575`, consuming `#3531` | ADL maintainers | seeded |
-| 15 | Docs + review alignment | `#3579` | ADL maintainers | seeded |
-| 16 | Internal review | `#3576` | ADL maintainers | first findings routed to `#3899` |
-| 17 | External / 3rd-party review | `#3580` | ADL maintainers | queued after `#3899` |
-| 18 | Review findings remediation + final v0.92 preflight | `#3577`, consuming `#3502`, `#3534`, `#3377` | ADL maintainers | queued via `#3899` |
-| 19 | Next milestone planning | `#3581` | ADL maintainers | seeded |
-| 20 | Release ceremony | `#3578` | ADL maintainers | seeded |
+| 13 | Sprint 4 umbrella: coverage, review, remediation, planning, release | `#3574` | ADL maintainers | active |
+| 14 | Coverage / quality gate | `#3575`, consuming `#3531` | ADL maintainers | closed |
+| 15 | Docs + review alignment | `#3579` | ADL maintainers | closed |
+| 16 | Internal review | `#3576`, with active execution slice `#3923` | ADL maintainers | active |
+| 17 | External / 3rd-party review | `#3580` | ADL maintainers | queued after second-pass internal review |
+| 18 | Review findings remediation + final v0.92 preflight | `#3577`, consuming `#3502`, `#3534`, `#3377` | ADL maintainers | queued after second-pass internal review |
+| 19 | Next milestone planning | `#3581` | ADL maintainers | queued |
+| 20 | Release ceremony | `#3578` | ADL maintainers | queued |
 
 ## Execution Policy
 

--- a/docs/milestones/v0.91.5/WBS_v0.91.5.md
+++ b/docs/milestones/v0.91.5/WBS_v0.91.5.md
@@ -5,13 +5,13 @@
 - Version: `v0.91.5`
 - Date: `2026-06-02`
 - Owner: ADL maintainers
-- Status: `first_internal_review_remediation_active`
+- Status: `second_pass_internal_review_active`
 - Canonical WP standard: [ADL_MILESTONE_WP_ORDERING_STANDARD.md](../../planning/ADL_MILESTONE_WP_ORDERING_STANDARD.md)
 
 ## Status
 
-Active WBS for post-Sprint 1 execution, the first internal-review remediation
-execution under `#3899`, and the remaining Sprint 3 / Sprint 4 execution bands.
+Active WBS for post-Sprint 1 execution, the completed first internal-review
+remediation tranche under `#3899`, and the remaining Sprint 4 execution bands.
 
 ## How To Use
 
@@ -24,11 +24,11 @@ together.
 v0.91.5 contains four sprint bands after WP-01: prompt-template/public prompt
 records and portable ADL readiness, provider/model and multi-agent proof, demo
 matrix/showcase refresh, and coverage/review/remediation/next-milestone/release
-closeout. The current retained execution-prep state is the first internal
-review remediation queue `#3899`, which stages the initial WP-18 remediation
-wave before the remaining closeout-tail issues advance. Live execution also
-surfaced repo-native tooling gaps that must be captured as WP-18 remediation
-inputs rather than lost as operator-side residue.
+closeout. The first internal-review remediation queue `#3899` is now complete
+and retained as historical first-pass evidence, while the live closeout-tail
+frontier has moved to the post-WP-15 second-pass internal-review lane. Live
+execution also surfaced repo-native tooling gaps that remain valid WP-18
+remediation inputs rather than operator-side residue.
 
 ## Candidate WP Sequence
 
@@ -96,14 +96,15 @@ to the reusable standard at
 | Sprint 3 | `#3573` | Demo matrix and demo showcase refresh. | `#3455`; supporting inputs `#3460`, `#3461` |
 | Sprint 4 | `#3574` | Coverage, review, remediation, next-milestone planning, and release. | `#3575`, `#3579`, `#3576`, `#3580`, `#3577`, `#3581`, `#3578`; supporting inputs `#3531`, `#3502`, `#3534`, `#3377` |
 
-## Queued Review-Remediation Mini-Sprint
+## Completed First Review-Remediation Mini-Sprint
 
-- `#3899` is the queued first internal-review remediation umbrella created from
-  WP-16 review output.
+- `#3899` is the closed first internal-review remediation umbrella created from
+  WP-16 review output and completed on `2026-06-17`.
 - Its child execution order is `#3891`, `#3892`, `#3893`, parallel-safe
   `#3894` / `#3895`, then parallel-safe `#3896` / `#3897` / `#3898`.
-- This queue is a bounded staging wave under WP-18 and does not replace the
-  canonical Sprint 4 umbrella `#3574`.
+- This queue is historical first-pass remediation truth under WP-18 and does
+  not replace the canonical Sprint 4 umbrella `#3574` or the current
+  second-pass review lane.
 
 ## Sequencing
 
@@ -138,9 +139,9 @@ is explicit.
 - WP-14 through WP-20 -> coverage/quality, docs/review alignment, internal
   review, external review, remediation/final v0.92 preflight, next-milestone
   planning, and release close the bridge in the standard order. The first
-  remediation tranche is currently staged through `#3899` and child issues
-  `#3891` through `#3898` before the broader WP-18 final-preflight issue
-  `#3577` should claim completion.
+  remediation tranche is now closed through `#3899` and child issues `#3891`
+  through `#3898`; second-pass internal review remains active before the
+  broader WP-18 final-preflight issue `#3577` can claim completion.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_FINDINGS_REGISTER_2026-06-16.md
@@ -5,7 +5,7 @@
 - Milestone: `v0.91.5`
 - Source review issue: `#3576`
 - Register date: `2026-06-16`
-- Register status: `routed_to_remediation_queue`
+- Register status: `historical_first_pass_baseline`
 - Canonical remediation umbrella: `#3899`
 
 ## Summary
@@ -15,12 +15,23 @@
 - This reconstructed register preserves routing truth from the live remediation
   issue set `#3891` through `#3898` without inventing missing severity or
   approval fields.
-- `#3892` already has draft PR `#3900` in flight and should keep that state
-  during execution.
-- `#3897` and `#3898` have now merged and been locally closed out, leaving
-  `#3896` as the remaining active tooling-remediation child.
-- Use this register as the retained review-to-remediation bridge for the queued
-  first internal-review mini-sprint.
+- The first-pass remediation umbrella `#3899` closed on `2026-06-17` after all
+  child issues `#3891` through `#3898` closed.
+- This packet is now historical first-pass review evidence, not the active
+  remediation or release-tail control surface.
+- Use this register as the retained review-to-remediation bridge for the
+  completed first internal-review mini-sprint, then follow the current Sprint 4
+  control docs and second-pass review packet set for live state.
+
+## Current Authoritative Successor Surfaces
+
+For current release-tail and review truth, use:
+
+- `docs/milestones/v0.91.5/SPRINT_v0.91.5.md`
+- `docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md`
 
 ## Reconstruction Note
 
@@ -43,7 +54,7 @@ standalone findings register at the expected path, so this register records
 | `#3893` | lifecycle | `not_retained` | Repair toolkit sprint closeout and card truth so retained sprint/card state matches GitHub closeout truth. | Execute after `#3891` / `#3892` under `#3899`. |
 | `#3894` | docs | `not_retained` | Refresh proof coverage, quality-gate, handoff, and WP-tail docs so review-facing planning truth matches the current bridge state. | Parallel-safe docs remediation group under `#3899`. |
 | `#3895` | evidence | `not_retained` | Redact private LAN endpoint details from tracked public proof packets without weakening evidence meaning. | Parallel-safe evidence hygiene group under `#3899`. |
-| `#3896` | observability | `not_retained` | Preserve quiet stderr when compatibility log sink setup fails. | Active under `#3899` with green draft PR `#3907`; waiting on review/merge before closeout. |
+| `#3896` | observability | `not_retained` | Preserve quiet stderr when compatibility log sink setup fails. | Merged by PR `#3907`; now historically retained under closed umbrella `#3899`. |
 | `#3897` | GitHub linkage | `not_retained` | Support standard GitHub autoclose syntax in fallback PR close-link detection. | Merged by PR `#3905`; now locally closed out under `#3899`. |
 | `#3898` | markdown-ast | `not_retained` | Allow intentional section-local removals in `replace-section` while preserving unrelated-document safety. | Merged by PR `#3906`; now locally closed out under `#3899`. |
 
@@ -93,9 +104,9 @@ or explicitly rerouted:
 10. Emergency publication after finish-path failure is not yet a first-class,
     truthful, retained workflow path.
 
-## Queue Linkage
+## Historical Queue Linkage
 
-Ordered execution route retained by the queue umbrella:
+Ordered execution route retained by the now-closed queue umbrella:
 
 1. `#3891` and `#3892`
 2. `#3893`
@@ -109,4 +120,5 @@ Ordered execution route retained by the queue umbrella:
   retained path; this packet restores routing truth but does not reconstruct
   missing severity rankings.
 - External review, final v0.92 preflight, next-milestone planning, and release
-  ceremony remain downstream work and must not be inferred from this packet.
+  ceremony remain downstream work and must not be inferred from this historical
+  first-pass packet.

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_FIRST_INTERNAL_REVIEW_REMEDIATION_QUEUE_2026-06-16.md
@@ -6,31 +6,40 @@
 - Source review issue: `#3576`
 - Queue umbrella: `#3899`
 - Queue date: `2026-06-16`
-- Queue status: `active_execution`
+- Queue status: `historical_closed`
 - Doctor readiness: `#3899` returned `ready_status: PASS` on `2026-06-17`
 
 ## Queue Summary
 
 - The first v0.91.5 internal review produced eight routed remediation issues:
   `#3891` through `#3898`.
-- `#3574` remains the canonical Sprint 4 umbrella, but this queue is the
-  bounded first remediation tranche that should run before the remaining
-  closeout-tail work resumes.
-- The queue is intentionally execution-focused and does not claim v0.91.5
-  release readiness.
+- `#3899` closed on `2026-06-17` after all child issues closed.
+- `#3574` remains the canonical Sprint 4 umbrella, but this queue is now a
+  historical first remediation tranche rather than the current active control
+  surface.
+- The queue remains intentionally execution-focused historical evidence and
+  does not claim v0.91.5 release readiness.
 
-## Current In-Flight State
+## Current Authoritative Successor Surfaces
+
+For current release-tail and review truth, use:
+
+- `docs/milestones/v0.91.5/SPRINT_v0.91.5.md`
+- `docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_WP15_DOCS_REVIEW_ALIGNMENT_2026-06-17.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md`
+
+## Final Child State (Historical)
 
 - `#3891` is merged.
 - `#3892` is merged and closed out after PR `#3900`.
 - `#3893` is closed out.
 - `#3894` and `#3895` are closed out.
-- `#3896` remains active with green draft PR `#3907`; checks are complete and
-  the issue is now waiting on review/merge before closeout.
+- `#3896` is merged via PR `#3907` and is now closed out.
 - `#3897` is merged via PR `#3905` and is now closed out.
 - `#3898` is merged via PR `#3906` and is now closed out.
-- `#3899` remains the open execution umbrella until the active tooling-tranche
-  child issues are closed or explicitly rerouted.
+- `#3899` is closed as the completed first remediation umbrella.
 - No Rust refactoring work is included in this queue.
 
 ## Supplemental Tooling Remediation Added During Execution
@@ -55,8 +64,8 @@ findings that belong inside this same bounded queue:
   `adl/src/cli/tooling_cmd/markdown_ast_edit.rs` into valid finish-validation lanes so normal
   publication does not fail after focused proof is already complete
 
-These findings do not justify widening beyond `#3891-#3899`, but they do mean
-the tooling tranche under `#3896-#3898` must absorb adapter/bootstrap/auth UX
+These findings did not justify widening beyond `#3891-#3899`, but they did mean
+the tooling tranche under `#3896-#3898` had to absorb adapter/bootstrap/auth UX
 hardening rather than treating the original three issue titles as exhaustive.
 
 ## Tooling Problems Captured for Remediation
@@ -85,8 +94,8 @@ The current retained tooling problem set for the `#3896-#3898` tranche is:
 10. truthful emergency publication after finish-path failure is not yet a
     first-class workflow path
 
-Keep these as explicit remediation inputs even if individual child issues merge
-before the broader adapter/tooling fixes land.
+Keep these as explicit historical remediation inputs and reference them when
+later Sprint 4 review/remediation work needs the first-pass execution context.
 
 ## Ordered Execution Plan
 


### PR DESCRIPTION
Closes #3940

## Summary
- refresh v0.91.5 Sprint 4 control docs to reflect that `#3899`, WP-14 `#3575`, and WP-15 `#3579` closed on June 17, 2026
- separate historical first-pass remediation packets from the active second-pass internal-review baseline
- keep release-tail truth blocked and evidence-bound while `#3574`, `#3576`, `#3580`, `#3577`, `#3581`, `#3578`, and `#3923` remain open

## Validation
- focused stale-state scan over the touched docs for first-pass-active wording and obsolete `#3899` / WP-14 / WP-15 status claims
- bounded docs review against live GitHub issue truth for `#3899`, `#3574`, `#3575`, `#3579`, and `#3923`

## Notes
- refs `#3940`
- refs `#3943`

