### PR TITLE
[v0.91.5][review] Preserve closed-issue card-truth blocker evidence in tracked packet

### DIFF
--- a/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
+++ b/docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
@@ -32,9 +32,10 @@ surface.
   - ADR readiness remains `not_applicable` for this docs-only gate pass
 - Blockers:
   - Sprint 4 release-tail issues remain open
-  - sampled closeout truth is not uniformly clean; recent closed issue `#3891`
-    still has a stale local SOR that reports `Integration state: worktree_only`
-    despite the issue being closed
+  - sampled closeout truth is not uniformly clean; the tracked closed-issue
+    card-truth evidence packet shows that recent closed issue `#3891` still had
+    a historically sampled local SOR excerpt reporting `Integration state:
+    worktree_only` despite the issue being closed
   - multiple v0.91.5 milestone docs still carry stale `active_wp_01_opening`
     or opening-era status language and must be normalized in WP-15
 
@@ -42,6 +43,8 @@ surface.
 
 - Checklist application packet:
   [V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md](review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md)
+- Closed-issue card-truth evidence packet:
+  [V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md](review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md)
 - Internal-review readiness plan:
   [V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md](review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md)
 

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md
@@ -1,0 +1,83 @@
+# v0.91.5 Closed-Issue Card-Truth Evidence
+
+Date: `2026-06-17`
+Issue: `#3942`
+Related milestone issue: `#3575`
+Purpose: preserve the WP-14 closed-issue card-truth blocker evidence in a
+tracked packet instead of relying on ignored local issue-bundle paths.
+
+## Summary
+
+This packet records the exact closed-issue truth mismatch that kept the
+`v0.91.5` quality gate blocked during the 2026-06-17 WP-14 application pass.
+
+It preserves:
+
+- the live GitHub closeout truth for sampled issues `#3891` and `#3898`
+- the historically sampled local-card fields that informed the blocker
+- the reason the blocker was real on 2026-06-17 without treating the sampled
+  local card text as a portable canonical source
+
+It intentionally does not publish raw ignored `.adl` card paths, absolute host
+paths, or secrets.
+
+## Scope Boundary
+
+This packet is only the durable evidence sidecar for the closed-issue
+card-truth blocker cited by:
+
+- `docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md`
+- `docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md`
+
+It does not reopen `#3891` or `#3898`, does not normalize their retained local
+cards, and does not widen into broader release-tail closeout repair.
+
+## Live GitHub Issue Truth
+
+The current live issue state shows both sampled issues are closed:
+
+| Issue | Current state | Closed at | Closing PR | Interpretation |
+| --- | --- | --- | --- | --- |
+| `#3891` | `CLOSED` | `2026-06-17T07:47:26Z` | `#3901` | The issue is terminal in GitHub, so any sampled local card still claiming in-flight integration truth is historical residue rather than live workflow state. |
+| `#3898` | `CLOSED` | `2026-06-17T08:51:08Z` | `#3906` | The issue is also terminal in GitHub and provides a comparison point for a more-normalized sampled local record. |
+
+## Historical Local-Card Excerpts Preserved Here
+
+During the 2026-06-17 WP-14 quality-gate application, the reviewer sampled the
+ignored local SOR snapshots for `#3891` and `#3898`. This packet keeps only the
+minimal excerpted fields needed for the blocker claim.
+
+| Issue | Historical sampled fields | Why it matters |
+| --- | --- | --- |
+| `#3891` | `Status: DONE`; `Card Status: ready`; `Integration state: worktree_only` | This combination conflicts with the now-closed GitHub issue state because it still reads like a pre-publication or pre-closeout record. |
+| `#3898` | `Status: DONE`; `Integration state: merged` | This sample shows the same review sweep could observe a more-terminal local record, which is why the blocker was mixed closeout truth rather than a claim that every sampled closed issue was stale. |
+
+## Why The Blocker Was Truthful
+
+On 2026-06-17, the WP-14 gate was correct to remain blocked because:
+
+1. the sampled local closeout layer did not tell one uniformly terminal story;
+2. `#3891` still exposed retained historical card fields associated with an
+   in-flight issue state; and
+3. release-tail docs should not pretend that closeout truth is uniformly clean
+   when sampled evidence still shows residue.
+
+This remains a historical blocker-evidence packet, not a claim that GitHub
+issue truth was wrong.
+
+## Durable Reference Contract
+
+Quality-gate and review packets should reference this tracked packet for the
+closed-issue card-truth blocker instead of citing ignored local card paths
+directly.
+
+If future work fully normalizes the retained local closeout layer, that work
+should update the active quality-gate packet and cite this document as
+historical context rather than deleting the blocker evidence.
+
+## Redaction And Path Hygiene
+
+- No absolute host paths are recorded.
+- No secret values or token-bearing command lines are recorded.
+- No ignored local card paths are used as the durable reference surface.
+- Only minimal field excerpts needed for the blocker claim are preserved.

--- a/docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md
+++ b/docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md
@@ -22,9 +22,8 @@ sampled closeout-truth drift on recent closed issue `#3891`.
 - live issue truth for `#3531`, `#3574`, `#3575`, `#3576`, `#3577`, `#3578`,
   `#3579`, `#3580`, `#3581`, and `#3923`
 - `bash adl/tools/report_large_rust_modules.sh --format tsv`
-- sampled recent closeout records:
-  - `.adl/v0.91.5/tasks/issue-3891__v0-91-5-tools-validation-treat-merged-green-prs-as-successful-in-pr-validation/sor.md`
-  - `.adl/v0.91.5/tasks/issue-3898__allow-intentional-section-local-removals-in-replace-section/sor.md`
+- tracked closed-issue card-truth evidence packet:
+  - `docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md`
 
 ## Checklist Application
 
@@ -32,7 +31,7 @@ sampled closeout-truth drift on recent closed issue `#3891`.
 | --- | --- | --- |
 | Test coverage gap analysis | `deferred` | No dedicated v0.91.5 coverage-gap packet was found in this sweep. This gate records the gap explicitly and routes it to internal review / WP-18 remediation instead of pretending coverage truth exists. |
 | Rust module size tracker | `passed` | `bash adl/tools/report_large_rust_modules.sh --format tsv` ran successfully. The manual tracker path named in earlier docs was not present in this bound worktree, so the live report was used as the proving surface. |
-| Issue closeout truth | `blocked` | Sampled closed issues show mixed truth. `#3898` looks locally normalized, but `#3891` still says `Integration state: worktree_only` and `Card Status: ready` despite the GitHub issue being closed. |
+| Issue closeout truth | `blocked` | Sampled closed issues show mixed truth. The tracked evidence packet preserves the historical local-card excerpts: `#3898` already shows a terminal `merged` integration state, while `#3891` still records `Integration state: worktree_only` and `Card Status: ready` despite the issue being closed in GitHub. |
 | Internal review readiness | `passed` | A second-pass internal review plan is now recorded at `docs/milestones/v0.91.5/review/internal_review/V0915_SECOND_PASS_INTERNAL_REVIEW_PLAN_2026-06-17.md`. |
 | PVF lane health | `deferred` | This docs/control-plane gate did not rerun lane executions. Existing lane contracts remain an input to WP-16 and WP-18, and no new lane-health proof was generated here. |
 | Changed-file risk review | `passed` | Current high-risk areas remain GitHub/client workflow control, prompt-template/editor plumbing, provider/runtime breadth, and release-truth docs. This gate keeps those surfaces visible instead of collapsing them into a green release claim. |
@@ -59,10 +58,17 @@ This gate records the tracker check; it does not create new refactor scope.
 
 ## Closeout Truth Sample
 
-- `#3898`: sampled SOR is locally normalized to `Integration state: merged`
-  and `Status: DONE`.
-- `#3891`: sampled SOR is stale against live issue truth, still recording
-  `Integration state: worktree_only` and `Card Status: ready`.
+Tracked packet:
+
+- `docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md`
+
+Key comparison preserved there:
+
+- `#3898`: historical sampled local record already showed `Integration state:
+  merged` and `Status: DONE`.
+- `#3891`: historical sampled local record remained stale against live issue
+  truth, still recording `Integration state: worktree_only` and
+  `Card Status: ready`.
 
 Disposition:
 


### PR DESCRIPTION
Closes #3942

## Summary
- add a tracked packet for the v0.91.5 closed-issue card-truth blocker evidence
- rewire the WP-14 packet and quality gate to cite the tracked packet instead of ignored local card paths
- keep the evidence redacted and scoped to the blocker only

## Validation
- gh issue view 3891 --json number,state,closedAt,title,url,labels,closedByPullRequestsReferences
- gh issue view 3898 --json number,state,closedAt,title,url,labels,closedByPullRequestsReferences
- rg -n "worktrees/adl-wp-3942|github\.token|GH_TOKEN|GITHUB_TOKEN|\.adl/v0\.91\.5/tasks/issue-3891|\.adl/v0\.91\.5/tasks/issue-3898" docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
- test -f docs/milestones/v0.91.5/review/internal_review/V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17.md && rg -n "V0915_CLOSED_ISSUE_CARD_TRUTH_EVIDENCE_2026-06-17\.md" docs/milestones/v0.91.5/review/internal_review/V0915_WP14_QUALITY_GATE_APPLICATION_2026-06-17.md docs/milestones/v0.91.5/QUALITY_GATE_v0.91.5.md
- bash adl/tools/validate_structured_prompt.sh --type srp --phase execution --input .adl/v0.91.5/tasks/issue-3942__v0-91-5-review-preserve-closed-issue-card-truth-blocker-evidence-in-tracked-packet/srp.md
- bash adl/tools/validate_structured_prompt.sh --type sor --phase execution --input .adl/v0.91.5/tasks/issue-3942__v0-91-5-review-preserve-closed-issue-card-truth-blocker-evidence-in-tracked-packet/sor.md
