### PR TITLE
[v0.91.5][tools] Fix PR validation superseded cancelled checks

### DIFF
--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd::github::transport::pr_validation_report_from_snapshot_with_disposition;
 
 #[test]
 fn pr_validation_wait_classifies_pending_failed_successful_and_skipped_states() {
@@ -73,6 +74,112 @@ fn pr_validation_wait_classifies_pending_failed_successful_and_skipped_states() 
     assert_eq!(
         classify_pr_validation_snapshot(&merged_success),
         PrValidationDisposition::Success
+    );
+}
+
+#[test]
+fn pr_validation_classification_uses_latest_logical_check_state() {
+    let snapshot = |checks: Vec<PrValidationCheckSnapshot>| PrValidationSnapshot {
+        pr_number: 3933,
+        commit_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        state: "MERGED".to_string(),
+        is_draft: false,
+        checks,
+    };
+
+    assert_eq!(
+        classify_pr_validation_snapshot(&snapshot(vec![
+            PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "CANCELLED".to_string(),
+                job_run_id: "9101".to_string(),
+            },
+            PrValidationCheckSnapshot {
+                name: "adl-coverage".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "CANCELLED".to_string(),
+                job_run_id: "9102".to_string(),
+            },
+            PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "9201".to_string(),
+            },
+            PrValidationCheckSnapshot {
+                name: "adl-coverage".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "9202".to_string(),
+            },
+        ])),
+        PrValidationDisposition::Success
+    );
+
+    let reversed_rollup = snapshot(vec![
+        PrValidationCheckSnapshot {
+            name: "adl-ci".to_string(),
+            status: "COMPLETED".to_string(),
+            conclusion: "SUCCESS".to_string(),
+            job_run_id: "9201".to_string(),
+        },
+        PrValidationCheckSnapshot {
+            name: "adl-coverage".to_string(),
+            status: "COMPLETED".to_string(),
+            conclusion: "SUCCESS".to_string(),
+            job_run_id: "9202".to_string(),
+        },
+        PrValidationCheckSnapshot {
+            name: "adl-ci".to_string(),
+            status: "COMPLETED".to_string(),
+            conclusion: "CANCELLED".to_string(),
+            job_run_id: "9101".to_string(),
+        },
+        PrValidationCheckSnapshot {
+            name: "adl-coverage".to_string(),
+            status: "COMPLETED".to_string(),
+            conclusion: "CANCELLED".to_string(),
+            job_run_id: "9102".to_string(),
+        },
+    ]);
+    assert_eq!(
+        classify_pr_validation_snapshot(&reversed_rollup),
+        PrValidationDisposition::Success
+    );
+    let report = pr_validation_report_from_snapshot_with_disposition(
+        &reversed_rollup,
+        classify_pr_validation_snapshot(&reversed_rollup),
+    );
+    assert_eq!(report.disposition, "success");
+    assert_eq!(report.checks.len(), 4);
+    assert!(
+        report.failed_checks.is_empty(),
+        "stale duplicate failures must not remain in failed_checks: {:#?}",
+        report.failed_checks
+    );
+    assert!(
+        report.pending_checks.is_empty(),
+        "stale duplicate pending checks must not remain in pending_checks: {:#?}",
+        report.pending_checks
+    );
+
+    assert_eq!(
+        classify_pr_validation_snapshot(&snapshot(vec![
+            PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "9201".to_string(),
+            },
+            PrValidationCheckSnapshot {
+                name: "adl-coverage".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "FAILURE".to_string(),
+                job_run_id: "9202".to_string(),
+            },
+        ])),
+        PrValidationDisposition::Failed
     );
 }
 

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -735,28 +735,26 @@ pub(super) fn classify_pr_validation_snapshot(
     if snapshot.checks.is_empty() {
         return PrValidationDisposition::Pending;
     }
-    if snapshot
-        .checks
+    let effective_checks = effective_pr_validation_checks(&snapshot.checks);
+    if effective_checks
         .iter()
         .any(|check| validation_conclusion_is_cancelled(&check.conclusion))
     {
         return PrValidationDisposition::Cancelled;
     }
-    if snapshot.checks.iter().any(|check| {
+    if effective_checks.iter().any(|check| {
         validation_conclusion_is_failed(&check.conclusion)
             || status_context_failure_status(&check.status)
     }) {
         return PrValidationDisposition::Failed;
     }
-    if snapshot
-        .checks
+    if effective_checks
         .iter()
         .any(|check| validation_check_is_pending(&check.status, &check.conclusion))
     {
         return PrValidationDisposition::Pending;
     }
-    if snapshot
-        .checks
+    if effective_checks
         .iter()
         .all(|check| validation_conclusion_is_skipped(&check.conclusion))
     {
@@ -765,29 +763,62 @@ pub(super) fn classify_pr_validation_snapshot(
     PrValidationDisposition::Success
 }
 
-fn pr_validation_report_from_snapshot_with_disposition(
+fn effective_pr_validation_checks(
+    checks: &[PrValidationCheckSnapshot],
+) -> Vec<&PrValidationCheckSnapshot> {
+    let mut effective = Vec::new();
+    for check in checks {
+        if let Some(existing) = effective
+            .iter()
+            .position(|candidate: &&PrValidationCheckSnapshot| candidate.name == check.name)
+        {
+            if validation_check_is_newer(check, effective[existing]) {
+                effective[existing] = check;
+            }
+        } else {
+            effective.push(check);
+        }
+    }
+    effective
+}
+
+fn validation_check_is_newer(
+    candidate: &PrValidationCheckSnapshot,
+    current: &PrValidationCheckSnapshot,
+) -> bool {
+    match (
+        candidate.job_run_id.parse::<u64>(),
+        current.job_run_id.parse::<u64>(),
+    ) {
+        (Ok(candidate_id), Ok(current_id)) => candidate_id >= current_id,
+        (Ok(_), Err(_)) => true,
+        (Err(_), Ok(_)) => false,
+        (Err(_), Err(_)) => true,
+    }
+}
+
+pub(super) fn pr_validation_report_from_snapshot_with_disposition(
     snapshot: &PrValidationSnapshot,
     disposition: PrValidationDisposition,
 ) -> PrValidationReport {
+    let effective_checks = effective_pr_validation_checks(&snapshot.checks);
     let checks = snapshot
         .checks
         .iter()
-        .map(pr_validation_check_report)
+        .map(|check| pr_validation_check_report(check))
         .collect::<Vec<_>>();
-    let failed_checks = snapshot
-        .checks
+    let failed_checks = effective_checks
         .iter()
         .filter(|check| {
             validation_conclusion_is_failed(&check.conclusion)
                 || status_context_failure_status(&check.status)
         })
-        .map(pr_validation_check_report)
+        .map(|check| pr_validation_check_report(check))
         .collect::<Vec<_>>();
-    let pending_checks = snapshot
-        .checks
+    let pending_checks = effective_checks
         .iter()
         .filter(|check| validation_check_is_pending(&check.status, &check.conclusion))
-        .map(pr_validation_check_report)
+        .map(|check| pr_validation_check_report(check))
         .collect::<Vec<_>>();
     PrValidationReport {
         pr_number: snapshot.pr_number,

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -805,7 +805,7 @@ pub(super) fn pr_validation_report_from_snapshot_with_disposition(
     let checks = snapshot
         .checks
         .iter()
-        .map(|check| pr_validation_check_report(check))
+        .map(pr_validation_check_report)
         .collect::<Vec<_>>();
     let failed_checks = effective_checks
         .iter()


### PR DESCRIPTION
Closes #3938

## Summary
Implemented PR validation classification so duplicate logical checks are evaluated using the latest observed check state for each check name. This prevents older cancelled runs from dominating a merged PR whose newer required checks succeeded, while preserving the full historical check list in the report.

## Artifacts
- `adl/src/cli/pr_cmd/github/transport.rs`
- `adl/src/cli/pr_cmd/github/tests/validation.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::github::tests::validation -- --nocapture`
    Verified focused PR validation classification and retry/logging tests.
  - `GH_TOKEN=<redacted-from-operator-approved-secret-source> bash adl/tools/pr.sh validation 3933 --json`
    Verified the live merged PR with stale cancelled historical runs now reports success.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3938__v0-91-5-tools-fix-pr-validation-latest-check-handling-for-superseded-cancelled-runs/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3938__v0-91-5-tools-fix-pr-validation-latest-check-handling-for-superseded-cancelled-runs/sor.md
- Idempotency-Key: v0-91-5-tools-fix-pr-validation-superseded-cancelled-checks-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-validation-rs-adl-v0-91-5-tasks-issue-3938-v0-91-5-tools-fix-pr-validation-latest-check-handling-for-superseded-cancelled-runs-sip-md-adl-v0-91-5-tasks-issue-3938-v0-91-5-tools-fix-pr-validation-latest-check-handling-for-superseded-cancelled-runs-sor-md