### PR TITLE
[v0.91.5][WP-18][tools] Prove pr finish commits finish-written SOR truth

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -111,9 +111,18 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     let changed_paths = finish_changed_paths(&repo_root, has_uncommitted)?;
-    validate_milestone_doc_drift_for_finish(&repo_root, issue_ref.scope(), &changed_paths)?;
+    let validation_changed_paths = if changed_paths.is_empty() {
+        finish_declared_paths_for_validation(&parsed.paths)
+    } else {
+        changed_paths.clone()
+    };
+    validate_milestone_doc_drift_for_finish(
+        &repo_root,
+        issue_ref.scope(),
+        &validation_changed_paths,
+    )?;
     let finish_validation_plan =
-        select_finish_validation_plan_for_finish(&parsed.paths, &changed_paths)?;
+        select_finish_validation_plan_for_finish(&parsed.paths, &validation_changed_paths)?;
     if !parsed.no_checks {
         run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
         record_docs_only_validation_evidence_for_finish(&output_path, &finish_validation_plan)?;
@@ -180,7 +189,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         parsed.title.clone()
     };
 
-    if has_uncommitted {
+    let has_uncommitted_after_finish_truth = has_uncommitted_changes(&repo_root)?;
+    if has_uncommitted_after_finish_truth {
         run_status(
             "git",
             &["-C", path_str(&repo_root)?, "commit", "-m", &commit_msg],
@@ -498,6 +508,15 @@ pub(super) fn finish_changed_paths(repo_root: &Path, has_uncommitted: bool) -> R
         .filter(|line| !line.is_empty())
         .map(ToString::to_string)
         .collect())
+}
+
+pub(super) fn finish_declared_paths_for_validation(paths: &str) -> Vec<String> {
+    paths
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 pub(super) fn ensure_nonempty_file_path(path: &Path) -> Result<bool> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,11 +1,19 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
     ensure_finish_branch_not_behind_origin_main, ensure_finish_task_bundle_surfaces,
-    normalize_docs_only_sor_text, open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout,
-    real_pr_finish, resolve_finish_issue_scope_and_slug, select_finish_validation_plan_for_finish,
-    FinishValidationMode, FinishValidationPlan,
+    finish_declared_paths_for_validation, normalize_docs_only_sor_text, open_pr_url_nonblocking,
+    open_pr_url_nonblocking_with_timeout, real_pr_finish, resolve_finish_issue_scope_and_slug,
+    select_finish_validation_plan_for_finish, FinishValidationMode, FinishValidationPlan,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
+
+#[test]
+fn finish_declared_paths_for_validation_splits_operator_surface() {
+    assert_eq!(
+        finish_declared_paths_for_validation("docs, adl/src , ,README.md"),
+        vec!["docs", "adl/src", "README.md"]
+    );
+}
 
 #[test]
 fn parse_finish_args_requires_title_and_accepts_finish_flags() {
@@ -1884,6 +1892,22 @@ verification_summary:
         .success());
 
     fs::write(repo.join("docs/notes.md"), "updated notes\n").expect("update docs");
+    assert!(Command::new("git")
+        .args(["add", "docs/notes.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add branch change")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "pre-finish docs change"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit branch change")
+        .success());
+    assert!(
+        !has_uncommitted_changes(&repo).expect("clean before finish"),
+        "regression requires finish to sample a clean worktree before it writes validation truth"
+    );
 
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");


### PR DESCRIPTION
Closes #3953

## Summary
Resolved external review finding R1 by making `pr finish` recompute uncommitted state after finish-written output truth is synced and re-staged. Added focused regression coverage for the clean-but-ahead branch path where `finish` itself writes docs-only validation evidence after the initial dirty-state sample.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml finish_declared_paths_for_validation_splits_operator_surface -- --nocapture`
    Verified the new declared-path fallback helper preserves operator path intent without empty entries.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_restages_tracked_output_truth_written_during_validation -- --nocapture`
    Verified the external-review residual path: branch clean at initial sample, branch already ahead, finish writes validation truth, and the final commit includes that truth.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3953__wp18-prove-pr-finish-commits-finish-written-sor-truth/sip.md
- Output card: .adl/v0.91.5/tasks/issue-3953__wp18-prove-pr-finish-commits-finish-written-sor-truth/sor.md
- Idempotency-Key: v0-91-5-wp-18-tools-prove-pr-finish-commits-finish-written-sor-truth-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-5-tasks-issue-3953-wp18-prove-pr-finish-commits-finish-written-sor-truth-sip-md-adl-v0-91-5-tasks-issue-3953-wp18-prove-pr-finish-commits-finish-written-sor-truth-sor-md