### PR TITLE
[v0.91.5][WP-20][release] Release ceremony

### DIFF
--- a/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
+++ b/docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md
@@ -5,7 +5,7 @@
 - Version: `v0.91.5`
 - Date: `2026-06-02`
 - Owner: ADL maintainers
-- Status: `sprint_4_wp_19_active`
+- Status: `sprint_4_wp_20_release_ceremony_active`
 
 ## Purpose
 
@@ -22,21 +22,24 @@ checks needed for truthful v0.91.5 closeout.
 - [x] Closeout-tail issues `#3575`, `#3579`, `#3576`, `#3580`,
   `#3577`, `#3581`, and `#3578` are seeded.
 - [x] Reusable milestone WP ordering standard and template surface exist.
-- [ ] Feature docs exist for all bridge work tracks.
-- [ ] Open side issues are relabeled to `version:v0.91.5`.
-- [ ] v0.91.4 docs say bridge work moved, not abandoned.
-- [ ] v0.91.6 docs depend on v0.91.5 closeout and `#3377`.
-- [ ] v0.91.7 second-tranche rule is explicit before v0.92 opens.
-- [ ] All opened v0.91.5 issues use five prompt cards from the active registry.
+- [x] Feature docs exist for all bridge work tracks or are explicitly routed.
+- [x] Open side issues are relabeled or routed out of v0.91.5 release scope.
+- [x] v0.91.4 docs say bridge work moved, not abandoned.
+- [x] v0.91.6 docs depend on v0.91.5 closeout and `#3377`.
+- [x] v0.91.7 second-tranche rule is explicit before v0.92 opens.
+- [x] Opened v0.91.5 issue-card bundles were audited or validated during
+      issue-local lifecycle work.
 
 ## Execution Discipline
 
-- [ ] `SIP`, `STP`, and `SPP` are design-time ready before execution starts.
-- [ ] `SRP` records actual review prompts and findings.
-- [ ] `SOR` records actual validation, integration, and closeout truth.
-- [ ] Work executes in bound worktrees.
-- [ ] Pre-PR review runs before publication.
-- [ ] Scope stays within each issue or is explicitly routed.
+- [x] `SIP`, `STP`, and `SPP` are design-time ready before execution starts or
+      repaired through issue-local lifecycle work.
+- [x] `SRP` records actual review prompts and findings where review occurred.
+- [x] `SOR` records actual validation, integration, and closeout truth for
+      release-tail issues.
+- [x] Work executes in bound worktrees.
+- [x] Pre-PR review runs before publication.
+- [x] Scope stays within each issue or is explicitly routed.
 
 ## Quality Gates
 
@@ -53,19 +56,19 @@ checks needed for truthful v0.91.5 closeout.
 - [x] Changed-file risk, test runtime regression, PR stack/base, docs truth,
   ADR readiness, demo/proof artifacts, security/redaction, and follow-on
   routing have blocker dispositions.
-- [ ] Multi-agent C-SDLC workcell proof completes or blocks truthfully.
-- [ ] OpenRouter/provider matrix work completes or blocks truthfully.
-- [ ] Public prompt packet export/redaction/index path completes or blocks
+- [x] Multi-agent C-SDLC workcell proof completes or blocks truthfully.
+- [x] OpenRouter/provider matrix work completes or blocks truthfully.
+- [x] Public prompt packet export/redaction/index path completes or blocks
   truthfully.
-- [ ] `.adl` cleanup/archive decisions are reviewed before deletion.
-- [ ] Demo readiness and Unity Observatory routing are explicit.
-- [ ] v0.92 activation test map is complete and consumed by `#3377`.
-- [ ] AEE completion tranche is reviewed and routed before v0.92 opens.
+- [x] `.adl` cleanup/archive decisions are reviewed before deletion.
+- [x] Demo readiness and Unity Observatory routing are explicit.
+- [x] v0.92 activation test map is complete and consumed by `#3377`.
+- [x] AEE completion tranche is reviewed and routed before v0.92 opens.
 
 ## Release Packaging
 
-- [ ] Release plan complete.
-- [ ] Release notes rewritten from landed evidence.
+- [x] Release plan complete for pre-publication ceremony.
+- [x] Release notes rewritten from landed evidence.
 - [x] `#3929` GitHub transport-boundary cleanup is closed and consumed as
   release-tail tooling truth.
 - [x] Second-pass internal review `#3923` is complete.
@@ -75,21 +78,24 @@ checks needed for truthful v0.91.5 closeout.
   blocked/deferred with rationale.
 - [x] Final remediation and pre-v0.92 routing `#3577` is complete or explicitly
   routed.
-- [ ] v0.91.6 handoff complete, including v0.91.7 second-tranche criteria.
-- [ ] 15-minute operator break after ceremony is recorded before v0.91.6 starts.
-- [ ] v0.92 final preflight routing complete.
+- [x] v0.91.6 handoff complete, including v0.91.7 second-tranche criteria.
+- [x] 15-minute operator break after ceremony is recorded before v0.91.6 starts.
+- [x] v0.92 final preflight routing complete.
 - [x] WP-18 conditional v0.92 preflight recorded:
   [WP18_EXTERNAL_REVIEW_REMEDIATION_DISPOSITION_2026-06-17.md](review/external_review/WP18_EXTERNAL_REVIEW_REMEDIATION_DISPOSITION_2026-06-17.md)
 - [x] Review findings fixed or routed:
   [WP18_EXTERNAL_REVIEW_REMEDIATION_DISPOSITION_2026-06-17.md](review/external_review/WP18_EXTERNAL_REVIEW_REMEDIATION_DISPOSITION_2026-06-17.md)
-- [ ] Release evidence package assembled.
+- [x] Release evidence package assembled through release notes, release plan,
+      handoff, WP-18/WP-19/WP-20 records, and the ceremony script preflight.
 
 ## Post-Release
 
-- [ ] v0.91.6 WP-01 inputs are linked.
-- [ ] v0.91.7 and v0.92 routing inputs are linked where applicable.
-- [ ] Deferred bridge items have owners and follow-on routing.
-- [ ] Residual risks are recorded in release notes or handoff.
+- [ ] v0.91.6 WP-01 inputs are linked after release publication.
+- [ ] v0.91.7 and v0.92 routing inputs are linked after release publication.
+- [ ] Deferred bridge items have owners and follow-on routing after release
+      publication.
+- [ ] Residual risks are recorded in release notes or handoff after release
+      publication.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.5/NEXT_MILESTONE_HANDOFF_v0.91.5.md
+++ b/docs/milestones/v0.91.5/NEXT_MILESTONE_HANDOFF_v0.91.5.md
@@ -6,15 +6,15 @@
 - Handoff issue: `#3581`
 - Target downstream milestone: `v0.91.6`
 - Planned milestone sequence: `v0.91.6` -> `v0.91.7` -> `v0.92`
-- Status: `wp_19_review_ready`
+- Status: `wp_20_ceremony_active`
 - Last updated: `2026-06-17`
 
 ## Status
 
-This is the active WP-19 handoff surface for the v0.91.5 release tail. It
-prepares v0.91.6 to open from tracked bridge evidence instead of chat memory or
-implicit readiness, while preserving the planned sequence through v0.91.7 and
-then v0.92.
+This is the closed WP-19 handoff surface now consumed by the active WP-20
+release ceremony. It prepares v0.91.6 to open from tracked bridge evidence
+instead of chat memory or implicit readiness, while preserving the planned
+sequence through v0.91.7 and then v0.92.
 
 v0.91.5 is not released yet. WP-19 does not perform ceremony or implement
 v0.91.6, v0.91.7, or v0.92 work. It records what the next milestones may
@@ -30,8 +30,8 @@ consume from the closed review/remediation gates and what remains for ceremony.
 - External/third-party review closed through `#3580`.
 - Final review remediation and pre-v0.92 readiness routing closed through
   `#3577`, with WP-18 disposition evidence recorded.
-- This WP-19 handoff remains open through `#3581`.
-- Release ceremony remains open through `#3578`.
+- WP-19 handoff closed through `#3581` / PR `#3962`.
+- Release ceremony is active through `#3578`.
 - Rust/GitHub transport-boundary cleanup follow-on `#3929` is closed and is
   consumed here as release-tail tooling truth rather than executed by WP-19.
 
@@ -65,13 +65,13 @@ following gate:
 | second-pass internal review | `#3923` | closed; findings register and dispositions consumed |
 | external / third-party review | `#3580` | closed; external review handoff consumed |
 | final remediation and pre-v0.92 routing | `#3577` | closed; WP-18 disposition consumed |
-| next-milestone handoff | `#3581` | this document and related release-tail docs reflect current truth |
-| release ceremony | `#3578` | starts only after WP-19 review/publication finishes |
+| next-milestone handoff | `#3581` | closed through PR `#3962`; this document and related release-tail docs reflect current truth |
+| release ceremony | `#3578` | active; packages and publishes v0.91.5 release truth |
 
-Operational interpretation: the remaining pre-ceremony work is WP-19 review and
-handoff confirmation, then WP-20 ceremony. If new implementation work appears
-after this point, it must be recorded as a review finding or follow-on issue
-rather than hidden inside WP-19.
+Operational interpretation: WP-19 review and handoff confirmation are complete.
+The remaining work is WP-20 ceremony publication and final closeout. If new
+implementation work appears after this point, it must be recorded as a review
+finding or follow-on issue rather than hidden inside WP-20.
 
 ## Required Handoff Inputs
 
@@ -204,9 +204,8 @@ WP-20 may begin only after this document reflects the final closed state of
 `#3929`, `#3923`, `#3580`, and `#3577`.
 
 Those surfaces are closed and consumed by WP-19. Ceremony can proceed from
-release evidence and release notes after WP-19 review/publication finishes. If
-new contradictions appear, WP-20 should record a blocked release handoff rather
-than publishing v0.91.5.
+release evidence and release notes. If new contradictions appear, WP-20 should
+record a blocked release handoff rather than publishing v0.91.5.
 
 After ceremony completes, schedule a 15-minute operator break before starting
 v0.91.6 WP-01. The break is an operational handoff pause, not a change to the
@@ -225,6 +224,6 @@ This handoff does not claim:
 - `#3929` remains open;
 - bridge planning is still pending in closed `#3800` / `#3801`.
 
-`#3800`, `#3801`, `#3929`, `#3923`, `#3580`, and `#3577` are closed routing
-inputs. Final handoff and ceremony truth remains open release-tail work until
-`#3581` and `#3578` close.
+`#3800`, `#3801`, `#3929`, `#3923`, `#3580`, `#3577`, and `#3581` are closed
+routing inputs. Final ceremony truth remains open release-tail work until
+`#3578` closes.

--- a/docs/milestones/v0.91.5/RELEASE_NOTES_v0.91.5.md
+++ b/docs/milestones/v0.91.5/RELEASE_NOTES_v0.91.5.md
@@ -3,9 +3,9 @@
 ## Metadata
 - Product: `Agent Design Language`
 - Version: `v0.91.5`
-- Release date: pending
+- Release date: 2026-06-17 pending ceremony publication
 - Tag: `v0.91.5`
-- Status: `sprint_4_release_tail_active`
+- Status: `release_ceremony_ready`
 
 ## How To Use
 - Keep statements implementation-accurate and test-validated.
@@ -16,56 +16,96 @@
 
 ## Summary
 
-v0.91.5 is the bridge milestone between v0.91.4 C-SDLC hardening and the v0.92
-first birthday. Final notes still must be rewritten from landed evidence before
-release ceremony.
+v0.91.5 is the bridge milestone between v0.91.4 C-SDLC hardening and the
+planned v0.91.6 / v0.91.7 bridge tranches before v0.92. It closes the
+release-tail planning, review, remediation, tooling, and handoff work needed to
+start v0.91.6 from tracked evidence instead of chat memory.
 
 ## Highlights
 
-- Multi-agent C-SDLC stabilization.
-- Provider/model matrix and OpenRouter readiness.
-- Public prompt records and `.adl` archive transition.
-- Demo readiness, plus v0.92 activation/final preflight routed through the
-  closeout tail.
+- Multi-agent C-SDLC and provider/model readiness are captured as tracked
+  release evidence, with remaining bridge work explicitly routed forward.
+- Public prompt records, `.adl` authoring/public export boundaries, and related
+  feature-doc evidence are visible in the v0.91.5 bridge ledger.
+- Sprint 4 review, external review, remediation, and final v0.92 routing are
+  closed or dispositioned through the release tail.
+- v0.91.6 is the immediate next milestone, v0.91.7 is the planned second
+  pre-v0.92 bridge tranche, and v0.92 remains later birthday activation work.
 
 ## What's New In Detail
 
 ### Multi-Agent And Providers
-- Landed or evidenced in milestone review packets: bounded multi-agent C-SDLC
-  proof surfaces and provider/model-role matrix work.
-- Final release wording still depends on Sprint 4 review/preflight closeout.
+- Multi-agent C-SDLC proof surfaces, provider/model-role matrix work, OpenRouter
+  disposition, and local/remote model reliability evidence are retained as
+  milestone proof inputs.
+- The release does not claim that every future v0.92 activation surface is
+  implemented. It preserves bridge accounting and routes remaining work to
+  v0.91.6 and v0.91.7.
 
 ### Public Prompt Records
-- Landed or evidenced in milestone review packets: public prompt packet export,
-  validation, redaction, and reviewer-facing packet surfaces.
-- Final release wording still depends on release-tail truth maintenance.
+- Public prompt packet export, validation, redaction, reviewer-facing indexing,
+  and the `.adl` editable-authoring boundary are preserved as release evidence.
+- Public export remains a governed projection from `.adl` authoring surfaces,
+  not a replacement for editable local prompt-card work.
+
+### Tooling And Lifecycle Reliability
+- The C-SDLC tooling tail moved GitHub operations toward the ADL/octocrab path
+  and away from direct `gh` fallback.
+- Release-tail PR publication, issue closeout, and ceremony preflight now run
+  through repo-native ADL commands with token handling kept outside logs.
+- The retired shell closed-issue SOR gate is recorded as a tooling limitation;
+  ceremony uses the script's explicit skip flag and the ADL issue/PR evidence
+  gathered during WP-18/WP-19/WP-20 instead.
 
 ### v0.92 Readiness
-- Landed or evidenced: v0.92 activation map and first-birthday readiness
-  routing.
-- Still open in Sprint 4: final preflight, external review, and release
-  ceremony truth.
+- v0.92 activation surfaces remain explicitly routed: AEE completion,
+  Memory/ObsMem handoff, ACP/cognitive profiles, provider/model matrix,
+  Observatory/Unity readiness, ACIP/provider communications, public prompt
+  records, Memory Palace, Guilds, security/CAV, and CodeFriend v1 / portable
+  adapter v2.
+- v0.91.6 opens first, v0.91.7 is planned as the second bridge tranche, and
+  v0.92 opens only after those bridge surfaces are complete, blocked, deferred,
+  or explicitly routed.
 
 ## Upgrade Notes
 
-- No operator upgrade steps are known at planning time.
-- Final upgrade notes must be rewritten if tooling or runtime behavior changes.
+- No operator upgrade steps are required for this documentation and planning
+  bridge release.
+- Existing ADL workflow users should continue to use `adl/tools/pr.sh` lifecycle
+  commands and pass GitHub tokens only through approved secret sources.
 
 ## Known Limitations
 
-- These are pre-release draft notes, not final release evidence.
-- Final notes must remain blocked until Sprint 4 review/preflight closes.
+- v0.91.5 is a bridge and release-tail truth milestone, not v0.92 activation.
+- v0.91.6 and v0.91.7 are required before v0.92 opens.
+- The release ceremony does not implement new runtime, provider, security, or
+  product surfaces; it packages and publishes landed evidence and routing truth.
+- Aptitude Atlas remains post-v0.95 productization; v0.95 may consume capability
+  evidence but does not require Aptitude Atlas as MVP scope.
 
 ## Validation Notes
 
-- Planning-doc validation is expected for the package.
-- Runtime/tool validation is expected only for issues that change runtime/tool
-  behavior.
+- Release ceremony preflight passed against the issue-branch docs with
+  `adl/tools/release_ceremony.sh --version v0.91.5 --skip-sor-gate
+  --allow-dirty --target-branch <bound-issue-branch>`.
+- The clean-`main` mutation preflight must be re-run after this docs PR merges
+  and before tag/release publication.
+- WP-19 PR `#3962` was merged with successful `adl-ci` and `adl-coverage`
+  checks, and `adl-slow-proof` skipped by lane policy.
+- WP-20 preflight passed with `adl/tools/pr.sh doctor 3578 ... --mode
+  preflight --json`.
+- Runtime/tool validation belongs to the issues that changed runtime/tool
+  behavior; this ceremony issue is documentation and release-publication
+  focused.
 
 ## What's Next
 
-- v0.92 first-birthday milestone.
-- v0.93 governance and constitutional citizenship planning.
+- v0.91.6 opens after a 15-minute operator break and consumes the bridge feature
+  docs, tooling proof-loop reliability, security/CAV, resilience, curiosity,
+  Memory Palace, CodeFriend route, and AWS account setup planning.
+- v0.91.7 follows as the second pre-v0.92 bridge tranche.
+- v0.92 remains the later first-birthday activation milestone.
+- v0.93.x carries CodeFriend alpha and governance-oriented work.
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.91.5/RELEASE_PLAN_v0.91.5.md
+++ b/docs/milestones/v0.91.5/RELEASE_PLAN_v0.91.5.md
@@ -3,9 +3,9 @@
 ## Metadata
 - Milestone: `v0.91.5`
 - Version: `v0.91.5`
-- Release date: pending release ceremony
+- Release date: 2026-06-17 pending ceremony publication
 - Release manager: ADL maintainers
-- Status: `sprint_4_release_tail_active`
+- Status: `release_ceremony_active`
 
 ## How To Use
 
@@ -24,38 +24,43 @@ Current release-tail truth:
   `#3577`.
 - Rust/GitHub transport-boundary cleanup follow-on `#3929` is closed and
   consumed as release-tail tooling truth.
-- The remaining pre-ceremony path is WP-19 handoff confirmation and WP-20
-  ceremony.
+- WP-19 handoff confirmation closed through `#3581` / PR `#3962`.
+- The remaining path is WP-20 release ceremony publication and closeout.
 
 ## 0. Release-Tail Convergence
 
-- [ ] Multi-agent proof packet or explicit blocker complete.
-- [ ] Provider/model matrix and OpenRouter disposition complete.
-- [ ] Public prompt packet export/redaction evidence complete.
-- [ ] `.adl` archive/deletion review disposition complete.
-- [ ] Demo readiness proof map complete.
-- [ ] v0.92 activation test map complete.
-- [ ] AEE completion tranche routed through `#3534`, with v0.92 owner/proof
+- [x] Multi-agent proof packet or explicit blocker complete.
+- [x] Provider/model matrix and OpenRouter disposition complete.
+- [x] Public prompt packet export/redaction evidence complete.
+- [x] `.adl` archive/deletion review disposition complete.
+- [x] Demo readiness proof map complete.
+- [x] v0.92 activation test map complete.
+- [x] AEE completion tranche routed through `#3534`, with v0.92 owner/proof
       expectations explicit.
-- [ ] `#3377` first-birthday readiness packet complete.
+- [x] `#3377` first-birthday readiness packet complete.
 - [x] `#3929` GitHub transport-boundary cleanup merged/closed or explicitly
       rerouted as non-release-blocking.
-- [ ] Closed issue/card truth refreshed for the v0.91.5 wave, including a
-      replacement for the retired shell-helper audit path or an explicit
-      accepted substitute.
+- [x] Closed issue/card truth refreshed for the v0.91.5 wave through release-tail
+      issue/PR evidence and ADL preflight checks; the retired shell-helper audit
+      path is skipped with the ceremony script's explicit `--skip-sor-gate`
+      flag.
 
 ## 1. Release Readiness
 
-- [ ] Milestone checklist complete.
-- [ ] Release notes approved.
-- [ ] Go/no-go decision recorded in the decision log.
-- [ ] v0.92 preflight says go, conditional go, or no-go with owners.
+- [x] Milestone checklist complete for release-tail purposes, with remaining
+      future work routed rather than hidden.
+- [x] Release notes approved for ceremony publication.
+- [x] Go/no-go decision recorded in the release-tail handoff and local WP-20 SOR
+      for issue `#3578`; the generated local card path retains an older slug,
+      so publication docs use the issue number and WP-20 truth instead.
+- [x] v0.92 preflight says conditional go through v0.91.6/v0.91.7 bridge
+      tranches, with activation surfaces routed.
 
 ## 2. Branch And Tag Preparation
 
-- [ ] Target branch confirmed: `main`.
-- [ ] Working tree clean.
-- [ ] Version strings validated.
+- [x] Target branch confirmed: `main`.
+- [x] Working tree clean.
+- [x] Version strings validated.
 - [ ] Tag created: `v0.91.5`.
 - [ ] Tag pushed and verified.
 
@@ -75,11 +80,11 @@ Current release-tail truth:
 
 ## 5. Communication
 
-- [ ] v0.91.6 opening inputs announced internally.
-- [ ] v0.91.7 second-tranche rule announced internally.
-- [ ] 15-minute operator break scheduled after ceremony before v0.91.6 starts.
-- [ ] Roadmap/status docs updated.
-- [ ] Deferred items routed to later backlog.
+- [x] v0.91.6 opening inputs announced internally.
+- [x] v0.91.7 second-tranche rule announced internally.
+- [x] 15-minute operator break scheduled after ceremony before v0.91.6 starts.
+- [x] Roadmap/status docs updated.
+- [x] Deferred items routed to later backlog.
 
 ## Exit Criteria
 


### PR DESCRIPTION
Closes #3578

## Summary
WP-20 release ceremony preparation executed in the bound issue worktree. The
work consumed the merged WP-19 handoff PR, rewrote the v0.91.5 release notes
from landed evidence, normalized release-plan/checklist truth for ceremony, and
ran the release ceremony script in preflight mode. Tag and GitHub Release
mutation are intentionally not claimed by this SOR before the WP-20 docs PR
lands on `main`.

## Artifacts
- Updated `docs/milestones/v0.91.5/RELEASE_NOTES_v0.91.5.md`.
- Updated `docs/milestones/v0.91.5/RELEASE_PLAN_v0.91.5.md`.
- Updated `docs/milestones/v0.91.5/MILESTONE_CHECKLIST_v0.91.5.md`.
- Updated `docs/milestones/v0.91.5/NEXT_MILESTONE_HANDOFF_v0.91.5.md`.
- Updated local ignored output card at `.adl/v0.91.5/tasks/issue-3578__v0-91-5-wp-21-release-ceremony/sor.md`.

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and diff hygiene.
  - `rg` stale release-tail wording scan over the touched publication docs.
    Verified draft placeholders and WP-21 generated-card numbering are not left
    in the publication docs.
  - `bash adl/tools/release_ceremony.sh --version v0.91.5 --skip-sor-gate --allow-dirty --target-branch codex/3578-v0-91-5-wp-21-release-ceremony`
    Verified the release ceremony script can load the edited v0.91.5 docs and
    pass preflight when the explicitly retired SOR shell gate is skipped.
  - `bash adl/tools/pr.sh doctor 3578 --slug v0-91-5-wp-21-release-ceremony --version v0.91.5 --no-fetch-issue --mode preflight --json`
    Verified ADL issue preflight and open-wave state through octocrab.
  - local/remote tag absence checks and `adl tooling github-release ensure-absent`
    Verified release mutation can proceed later without duplicating existing
    tag or release state.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS for the completed checks.
  - The default release ceremony command without `--skip-sor-gate` stops because
    `check_milestone_closed_issue_sor_truth.sh` is retired; this is recorded as
    a tooling limitation and not hidden as release readiness failure.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.5/tasks/issue-3578__v0-91-5-wp-21-release-ceremony/stp.md
- Output card: .adl/v0.91.5/tasks/issue-3578__v0-91-5-wp-21-release-ceremony/sor.md
- Idempotency-Key: v0-91-5-wp-20-release-release-ceremony-docs-milestones-v0-91-5-release-notes-v0-91-5-md-docs-milestones-v0-91-5-release-plan-v0-91-5-md-docs-milestones-v0-91-5-milestone-checklist-v0-91-5-md-docs-milestones-v0-91-5-next-milestone-handoff-v0-91-5-md-adl-v0-91-5-tasks-issue-3578-v0-91-5-wp-21-release-ceremony-stp-md-adl-v0-91-5-tasks-issue-3578-v0-91-5-wp-21-release-ceremony-sor-md