### PR TITLE
[v0.91.6][tools] Make GitHub token loading deterministic and reusable

### DIFF
--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -1,0 +1,383 @@
+use anyhow::{anyhow, Result};
+use std::fmt;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+pub(crate) const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
+pub(crate) const GH_TOKEN_ENV: &str = "GH_TOKEN";
+pub(crate) const ADL_GITHUB_TOKEN_FILE_ENV: &str = "ADL_GITHUB_TOKEN_FILE";
+pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE";
+pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GithubTokenSource {
+    GithubToken,
+    GhToken,
+    TokenFile,
+    Keychain,
+}
+
+impl GithubTokenSource {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::GithubToken => GITHUB_TOKEN_ENV,
+            Self::GhToken => GH_TOKEN_ENV,
+            Self::TokenFile => ADL_GITHUB_TOKEN_FILE_ENV,
+            Self::Keychain => ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV,
+        }
+    }
+
+    pub(crate) fn env_name(self) -> &'static str {
+        self.label()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedGithubToken {
+    value: String,
+    source: GithubTokenSource,
+}
+
+impl fmt::Debug for ResolvedGithubToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedGithubToken")
+            .field("value", &"<redacted>")
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+impl ResolvedGithubToken {
+    pub(crate) fn new(value: impl Into<String>, source: GithubTokenSource) -> Option<Self> {
+        let value = value.into();
+        let value = value.trim();
+        (!value.is_empty()).then(|| Self {
+            value: value.to_string(),
+            source,
+        })
+    }
+
+    pub(crate) fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub(crate) fn source(&self) -> GithubTokenSource {
+        self.source
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct TokenResolutionKey {
+    github_token: Option<String>,
+    gh_token: Option<String>,
+    token_file: Option<String>,
+    keychain_service: Option<String>,
+    keychain_account: Option<String>,
+}
+
+#[derive(Clone)]
+struct CachedTokenResolution {
+    key: TokenResolutionKey,
+    result: Result<Option<ResolvedGithubToken>, String>,
+}
+
+static TOKEN_CACHE: OnceLock<Mutex<Option<CachedTokenResolution>>> = OnceLock::new();
+
+pub(crate) fn resolve_github_token() -> Result<Option<ResolvedGithubToken>> {
+    resolve_github_token_from_env(&RealTokenReader)
+}
+
+fn resolve_github_token_from_env(reader: &dyn TokenReader) -> Result<Option<ResolvedGithubToken>> {
+    let key = TokenResolutionKey::from_env();
+    let cache = TOKEN_CACHE.get_or_init(|| Mutex::new(None));
+    if let Some(cached) = cache
+        .lock()
+        .map_err(|_| anyhow!("github_token.cache_poisoned"))?
+        .as_ref()
+        .filter(|cached| cached.key == key)
+        .cloned()
+    {
+        return cached
+            .result
+            .map_err(|message| anyhow!("{}", redact_for_github_token_diagnostics(&message)));
+    }
+
+    let result = resolve_uncached(&key, reader).map_err(|err| err.to_string());
+    *cache
+        .lock()
+        .map_err(|_| anyhow!("github_token.cache_poisoned"))? = Some(CachedTokenResolution {
+        key,
+        result: result.clone(),
+    });
+    result.map_err(|message| anyhow!("{}", redact_for_github_token_diagnostics(&message)))
+}
+
+impl TokenResolutionKey {
+    fn from_env() -> Self {
+        Self {
+            github_token: std::env::var(GITHUB_TOKEN_ENV).ok(),
+            gh_token: std::env::var(GH_TOKEN_ENV).ok(),
+            token_file: std::env::var(ADL_GITHUB_TOKEN_FILE_ENV).ok(),
+            keychain_service: std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV).ok(),
+            keychain_account: std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV).ok(),
+        }
+    }
+}
+
+fn resolve_uncached(
+    key: &TokenResolutionKey,
+    reader: &dyn TokenReader,
+) -> Result<Option<ResolvedGithubToken>> {
+    if let Some(token) = key
+        .github_token
+        .as_deref()
+        .and_then(|value| ResolvedGithubToken::new(value, GithubTokenSource::GithubToken))
+    {
+        return Ok(Some(token));
+    }
+    if let Some(token) = key
+        .gh_token
+        .as_deref()
+        .and_then(|value| ResolvedGithubToken::new(value, GithubTokenSource::GhToken))
+    {
+        return Ok(Some(token));
+    }
+    if let Some(path) = key
+        .token_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        let value = reader.read_token_file(&PathBuf::from(path))?;
+        return Ok(ResolvedGithubToken::new(
+            value,
+            GithubTokenSource::TokenFile,
+        ));
+    }
+    if let Some(service) = key
+        .keychain_service
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        let value = reader.read_keychain_token(
+            service,
+            key.keychain_account
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty()),
+        )?;
+        return Ok(ResolvedGithubToken::new(value, GithubTokenSource::Keychain));
+    }
+    Ok(None)
+}
+
+trait TokenReader {
+    fn read_token_file(&self, path: &PathBuf) -> Result<String>;
+    fn read_keychain_token(&self, service: &str, account: Option<&str>) -> Result<String>;
+}
+
+struct RealTokenReader;
+
+impl TokenReader for RealTokenReader {
+    fn read_token_file(&self, path: &PathBuf) -> Result<String> {
+        std::fs::read_to_string(path)
+            .map_err(|_| anyhow!("github_token.file_read_failed: configured token file unreadable"))
+    }
+
+    fn read_keychain_token(&self, service: &str, account: Option<&str>) -> Result<String> {
+        #[cfg(target_os = "macos")]
+        {
+            let mut command = Command::new("security");
+            command.args(["find-generic-password", "-s", service, "-w"]);
+            if let Some(account) = account {
+                command.args(["-a", account]);
+            }
+            let output = command
+                .output()
+                .map_err(|_| anyhow!("github_token.keychain_read_failed"))?;
+            if !output.status.success() {
+                return Err(anyhow!("github_token.keychain_read_failed"));
+            }
+            String::from_utf8(output.stdout)
+                .map_err(|_| anyhow!("github_token.keychain_invalid_utf8"))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (service, account);
+            Err(anyhow!("github_token.keychain_unsupported_platform"))
+        }
+    }
+}
+
+pub(crate) fn redact_for_github_token_diagnostics(input: &str) -> String {
+    input
+        .split_whitespace()
+        .map(|token| {
+            let lower = token.to_ascii_lowercase();
+            if lower.contains("token=")
+                || lower.contains("authorization:")
+                || lower.starts_with("ghp_")
+                || lower.starts_with("gho_")
+                || lower.starts_with("ghu_")
+                || lower.starts_with("ghs_")
+                || lower.starts_with("ghr_")
+                || lower.starts_with("github_pat_")
+            {
+                "<redacted>"
+            } else {
+                token
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::tests::env_lock as cli_env_lock;
+    use std::cell::Cell;
+    use std::cell::RefCell;
+
+    struct StubReader {
+        file_value: &'static str,
+        keychain_value: &'static str,
+        file_reads: Cell<usize>,
+        keychain_reads: Cell<usize>,
+        last_keychain_request: RefCell<Option<(String, Option<String>)>>,
+    }
+
+    impl StubReader {
+        fn new(file_value: &'static str, keychain_value: &'static str) -> Self {
+            Self {
+                file_value,
+                keychain_value,
+                file_reads: Cell::new(0),
+                keychain_reads: Cell::new(0),
+                last_keychain_request: RefCell::new(None),
+            }
+        }
+    }
+
+    impl TokenReader for StubReader {
+        fn read_token_file(&self, _path: &PathBuf) -> Result<String> {
+            self.file_reads.set(self.file_reads.get() + 1);
+            Ok(self.file_value.to_string())
+        }
+
+        fn read_keychain_token(&self, service: &str, account: Option<&str>) -> Result<String> {
+            self.keychain_reads.set(self.keychain_reads.get() + 1);
+            *self.last_keychain_request.borrow_mut() =
+                Some((service.to_string(), account.map(ToString::to_string)));
+            Ok(self.keychain_value.to_string())
+        }
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        cli_env_lock()
+    }
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var(GITHUB_TOKEN_ENV);
+            std::env::remove_var(GH_TOKEN_ENV);
+            std::env::remove_var(ADL_GITHUB_TOKEN_FILE_ENV);
+            std::env::remove_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV);
+            std::env::remove_var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV);
+        }
+        *TOKEN_CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap() = None;
+    }
+
+    #[test]
+    fn resolver_prefers_environment_then_file_then_keychain() {
+        let _guard = env_lock();
+        clear_env();
+        let reader = StubReader::new("file-token", "keychain-token");
+        unsafe {
+            std::env::set_var(ADL_GITHUB_TOKEN_FILE_ENV, "/tmp/token");
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "adl-github-token");
+            std::env::set_var(GH_TOKEN_ENV, "gh-token");
+            std::env::set_var(GITHUB_TOKEN_ENV, "github-token");
+        }
+
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "github-token");
+        assert_eq!(token.source(), GithubTokenSource::GithubToken);
+        assert_eq!(reader.file_reads.get(), 0);
+        assert_eq!(reader.keychain_reads.get(), 0);
+
+        clear_env();
+        unsafe {
+            std::env::set_var(ADL_GITHUB_TOKEN_FILE_ENV, "/tmp/token");
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "adl-github-token");
+        }
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "file-token");
+        assert_eq!(token.source(), GithubTokenSource::TokenFile);
+        assert_eq!(reader.file_reads.get(), 1);
+        assert_eq!(reader.keychain_reads.get(), 0);
+
+        clear_env();
+        unsafe {
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "adl-github-token");
+        }
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "keychain-token");
+        assert_eq!(token.source(), GithubTokenSource::Keychain);
+        assert_eq!(reader.keychain_reads.get(), 1);
+        clear_env();
+    }
+
+    #[test]
+    fn resolver_caches_file_reads_for_same_process_configuration() {
+        let _guard = env_lock();
+        clear_env();
+        let reader = StubReader::new("file-token", "keychain-token");
+        unsafe {
+            std::env::set_var(ADL_GITHUB_TOKEN_FILE_ENV, "/tmp/token");
+        }
+
+        let first = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        let second = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(first.value(), second.value());
+        assert_eq!(reader.file_reads.get(), 1);
+        clear_env();
+    }
+
+    #[test]
+    fn resolver_passes_keychain_service_and_optional_account() {
+        let _guard = env_lock();
+        clear_env();
+        let reader = StubReader::new("file-token", "keychain-token");
+        unsafe {
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "adl-github-token");
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV, "agent-logic");
+        }
+
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "keychain-token");
+        assert_eq!(token.source(), GithubTokenSource::Keychain);
+        assert_eq!(reader.keychain_reads.get(), 1);
+        assert_eq!(
+            reader.last_keychain_request.borrow().as_ref(),
+            Some(&(
+                "adl-github-token".to_string(),
+                Some("agent-logic".to_string())
+            ))
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn resolver_redacts_github_token_prefixes_in_diagnostics() {
+        let text = redact_for_github_token_diagnostics(
+            "Authorization: token=ghp_secret ghp_secret github_pat_secret ghs_secret ordinary",
+        );
+        assert!(!text.contains("ghp_secret"));
+        assert!(!text.contains("github_pat_secret"));
+        assert!(!text.contains("ghs_secret"));
+        assert!(text.contains("ordinary"));
+    }
+}

--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
@@ -174,14 +175,14 @@ fn resolve_uncached(
 }
 
 trait TokenReader {
-    fn read_token_file(&self, path: &PathBuf) -> Result<String>;
+    fn read_token_file(&self, path: &Path) -> Result<String>;
     fn read_keychain_token(&self, service: &str, account: Option<&str>) -> Result<String>;
 }
 
 struct RealTokenReader;
 
 impl TokenReader for RealTokenReader {
-    fn read_token_file(&self, path: &PathBuf) -> Result<String> {
+    fn read_token_file(&self, path: &Path) -> Result<String> {
         std::fs::read_to_string(path)
             .map_err(|_| anyhow!("github_token.file_read_failed: configured token file unreadable"))
     }
@@ -262,7 +263,7 @@ mod tests {
     }
 
     impl TokenReader for StubReader {
-        fn read_token_file(&self, _path: &PathBuf) -> Result<String> {
+        fn read_token_file(&self, _path: &Path) -> Result<String> {
             self.file_reads.set(self.file_reads.get() + 1);
             Ok(self.file_value.to_string())
         }

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -5,6 +5,7 @@ mod artifact_cmd;
 mod commands;
 mod csm_cmd;
 mod demo_cmd;
+mod github_token;
 mod godel_cmd;
 mod identity_cmd;
 mod observability;

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1010,6 +1010,28 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_github_token_focused_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_token",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_client",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_release_octocrab_covers_absent_draft_present_publish",
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_owner_binary_rust_slice_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1176,8 +1198,11 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md"
             | "docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md"
             | "adl/src/cli/pr_cmd.rs"
+            | "adl/src/cli/mod.rs"
+            | "adl/src/cli/github_token.rs"
             | "adl/src/lib.rs"
             | "adl/src/cli/tests/pr_cmd_inline/basics.rs"
+            | "adl/src/cli/tests/pr_cmd_inline/support.rs"
             | "adl/src/csdlc_prompt_editor.rs"
             | "adl/src/cli/run_artifacts_types.rs"
             | "adl/schemas/structured_implementation_prompt.contract.yaml"
@@ -1205,6 +1230,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
             | "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
+            | "adl/src/cli/tooling_cmd/github_release.rs"
             | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
@@ -1224,9 +1250,20 @@ fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     trimmed == "adl/src/cli/pr_cmd.rs"
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/basics.rs"
+        || trimmed == "adl/src/cli/tests/pr_cmd_inline/support.rs"
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
         || (trimmed.starts_with("adl/src/cli/pr_cmd/")
             && trimmed != "adl/src/cli/pr_cmd/finish_support.rs")
+}
+
+fn finish_path_needs_github_token_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/cli/mod.rs"
+            | "adl/src/cli/github_token.rs"
+            | "adl/src/cli/tooling_cmd/github_release.rs"
+    )
 }
 
 fn finish_path_needs_owner_binary_rust_slice_validation(path: &str) -> bool {
@@ -1356,6 +1393,45 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_token" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "github_token",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_client" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "github_client",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_release_octocrab_covers_absent_draft_present_publish" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "github_release_octocrab_covers_absent_draft_present_publish",
+                        ],
+                    )?;
+                }
                 "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation" => {
                     run_finish_validation_status(
                         "cargo",
@@ -1441,6 +1517,9 @@ const FINISH_VALIDATION_SANITIZED_ENVS: &[&str] = &[
     "ADL_GITHUB_OCTOCRAB_BASE_URI",
     "GITHUB_TOKEN",
     "GH_TOKEN",
+    "ADL_GITHUB_TOKEN_FILE",
+    "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE",
+    "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT",
 ];
 
 fn run_finish_validation_status(program: &str, args: &[&str]) -> Result<()> {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -176,7 +176,7 @@ fn github_credential_preflight_hint(
     config: &crate::cli::pr_cmd::github_client::AdlGithubClientConfig,
 ) -> String {
     match config.token_source {
-        None => "credential_status=missing_token; set GITHUB_TOKEN or GH_TOKEN before live C-SDLC GitHub operations; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
+        None => "credential_status=missing_token; configure GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE before live C-SDLC GitHub operations; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
         Some(source) => format!(
             "credential_status=token_present source={}; ADL_GITHUB_CLIENT=gh is not a supported read or mutation fallback for covered operations; use ADL_GITHUB_CLIENT=auto or ADL_GITHUB_CLIENT=octocrab",
             source.env_name()

--- a/adl/src/cli/pr_cmd/github/tests.rs
+++ b/adl/src/cli/pr_cmd/github/tests.rs
@@ -58,6 +58,9 @@ fn clear_github_policy_env() -> Vec<(&'static str, Option<String>)> {
         "ADL_TEST_GITHUB_CLI_FIXTURE",
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "ADL_GITHUB_TOKEN_FILE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT",
     ];
     let saved = keys
         .into_iter()

--- a/adl/src/cli/pr_cmd/github/tests/policy.rs
+++ b/adl/src/cli/pr_cmd/github/tests/policy.rs
@@ -108,7 +108,10 @@ fn live_github_policy_explains_missing_token_before_spawn() {
     let err_debug = format!("{err:?}");
     assert!(err_debug.contains("github_client.gh_fallback_removed"));
     assert!(err_debug.contains("credential_status=missing_token"));
-    assert!(err_debug.contains("set GITHUB_TOKEN or GH_TOKEN"));
+    assert!(err_debug.contains("GITHUB_TOKEN"));
+    assert!(err_debug.contains("GH_TOKEN"));
+    assert!(err_debug.contains("ADL_GITHUB_TOKEN_FILE"));
+    assert!(err_debug.contains("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE"));
     assert!(err_debug.contains("operator-approved secret source"));
     assert!(err_debug.contains("do not fall back to direct gh commands"));
     assert!(err_debug.contains("credential values are never printed"));

--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -6,12 +6,15 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::marker::PhantomData;
 
+use super::super::github_token::{
+    redact_for_github_token_diagnostics, resolve_github_token, GithubTokenSource,
+    ResolvedGithubToken,
+};
+
 const ADL_GITHUB_CLIENT_ENV: &str = "ADL_GITHUB_CLIENT";
 const ADL_GITHUB_DISABLE_GH_FALLBACK_ENV: &str = "ADL_GITHUB_DISABLE_GH_FALLBACK";
 #[cfg(test)]
 const ADL_GITHUB_OCTOCRAB_BASE_URI_ENV: &str = "ADL_GITHUB_OCTOCRAB_BASE_URI";
-const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
-const GH_TOKEN_ENV: &str = "GH_TOKEN";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum GithubClientMode {
@@ -61,21 +64,6 @@ impl GithubClientBackend {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum GithubTokenSource {
-    GithubToken,
-    GhToken,
-}
-
-impl GithubTokenSource {
-    pub(super) fn env_name(self) -> &'static str {
-        match self {
-            Self::GithubToken => GITHUB_TOKEN_ENV,
-            Self::GhToken => GH_TOKEN_ENV,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct AdlGithubClientConfig {
     pub(super) requested_mode: GithubClientMode,
@@ -102,13 +90,15 @@ impl fmt::Debug for AdlGithubClient {
 
 impl AdlGithubClient {
     pub(super) fn from_env() -> Result<Self, AdlGithubClientError> {
-        Self::from_values_with_fallback_policy(
-            std::env::var(ADL_GITHUB_CLIENT_ENV).ok().as_deref(),
-            std::env::var(GITHUB_TOKEN_ENV).ok().as_deref(),
-            std::env::var(GH_TOKEN_ENV).ok().as_deref(),
-            std::env::var(ADL_GITHUB_DISABLE_GH_FALLBACK_ENV)
-                .ok()
-                .as_deref(),
+        let requested_mode = std::env::var(ADL_GITHUB_CLIENT_ENV).ok();
+        let disable_gh_fallback = std::env::var(ADL_GITHUB_DISABLE_GH_FALLBACK_ENV).ok();
+        let token = resolve_github_token().map_err(|err| {
+            AdlGithubClientError::new(AdlGithubClientErrorKind::Transport, err.to_string())
+        })?;
+        Self::from_resolved_token_with_fallback_policy(
+            requested_mode.as_deref(),
+            token,
+            disable_gh_fallback.as_deref(),
         )
     }
 
@@ -126,9 +116,18 @@ impl AdlGithubClient {
         gh_token: Option<&str>,
         disable_gh_fallback: Option<&str>,
     ) -> Result<Self, AdlGithubClientError> {
+        let token = token_value(github_token, gh_token);
+        Self::from_resolved_token_with_fallback_policy(requested_mode, token, disable_gh_fallback)
+    }
+
+    fn from_resolved_token_with_fallback_policy(
+        requested_mode: Option<&str>,
+        token: Option<ResolvedGithubToken>,
+        disable_gh_fallback: Option<&str>,
+    ) -> Result<Self, AdlGithubClientError> {
         let requested_mode = GithubClientMode::parse(requested_mode)?;
         let gh_fallback_disabled = parse_disable_gh_fallback(disable_gh_fallback)?;
-        let token_source = discover_token_source(github_token, gh_token);
+        let token_source = token.as_ref().map(ResolvedGithubToken::source);
         let backend = match (requested_mode, token_source) {
             (GithubClientMode::Gh, _) => GithubClientBackend::GhFallback,
             (GithubClientMode::Auto, Some(_)) | (GithubClientMode::Octocrab, Some(_)) => {
@@ -139,7 +138,8 @@ impl AdlGithubClient {
                 return Err(AdlGithubClientError::new(
                     AdlGithubClientErrorKind::MissingToken,
                     format!(
-                        "octocrab GitHub client requires {GITHUB_TOKEN_ENV} or {GH_TOKEN_ENV}; covered C-SDLC GitHub workflow operations no longer use shell fallback"
+                        "{}; covered C-SDLC GitHub workflow operations no longer use shell fallback",
+                        missing_token_message()
                     ),
                 ));
             }
@@ -148,10 +148,11 @@ impl AdlGithubClient {
             return Err(AdlGithubClientError::new(
                 AdlGithubClientErrorKind::FallbackDisabled,
                 format!(
-                    "{ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}=1 disables gh fallback; set {GITHUB_TOKEN_ENV} or {GH_TOKEN_ENV} for octocrab-backed mode, or unset {ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}"
+                    "{ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}=1 disables gh fallback; set a shared GitHub token source for octocrab-backed mode, or unset {ADL_GITHUB_DISABLE_GH_FALLBACK_ENV}"
                 ),
             ));
         }
+        let token_value = token.map(|token| token.value().to_string());
         Ok(Self {
             config: AdlGithubClientConfig {
                 requested_mode,
@@ -161,7 +162,7 @@ impl AdlGithubClient {
                     && !gh_fallback_disabled,
                 gh_fallback_disabled,
             },
-            token: token_value(github_token, gh_token),
+            token: token_value,
             _octocrab: PhantomData,
         })
     }
@@ -174,7 +175,7 @@ impl AdlGithubClient {
         let token = self.token.as_deref().ok_or_else(|| {
             AdlGithubClientError::new(
                 AdlGithubClientErrorKind::MissingToken,
-                "octocrab GitHub transport requires GITHUB_TOKEN or GH_TOKEN",
+                missing_token_message(),
             )
         })?;
         let builder = octocrab::Octocrab::builder().personal_token(token.to_string());
@@ -198,25 +199,12 @@ impl AdlGithubClient {
     }
 }
 
-fn discover_token_source(
-    github_token: Option<&str>,
-    gh_token: Option<&str>,
-) -> Option<GithubTokenSource> {
-    if github_token.is_some_and(|value| !value.trim().is_empty()) {
-        Some(GithubTokenSource::GithubToken)
-    } else if gh_token.is_some_and(|value| !value.trim().is_empty()) {
-        Some(GithubTokenSource::GhToken)
-    } else {
-        None
-    }
-}
-
-fn token_value(github_token: Option<&str>, gh_token: Option<&str>) -> Option<String> {
+fn token_value(github_token: Option<&str>, gh_token: Option<&str>) -> Option<ResolvedGithubToken> {
     github_token
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .or_else(|| gh_token.map(str::trim).filter(|value| !value.is_empty()))
-        .map(ToString::to_string)
+        .and_then(|value| ResolvedGithubToken::new(value, GithubTokenSource::GithubToken))
+        .or_else(|| {
+            gh_token.and_then(|value| ResolvedGithubToken::new(value, GithubTokenSource::GhToken))
+        })
 }
 
 fn parse_disable_gh_fallback(raw: Option<&str>) -> Result<bool, AdlGithubClientError> {
@@ -232,6 +220,10 @@ fn parse_disable_gh_fallback(raw: Option<&str>) -> Result<bool, AdlGithubClientE
             ),
         )),
     }
+}
+
+fn missing_token_message() -> &'static str {
+    "octocrab GitHub transport requires GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -295,20 +287,7 @@ pub(super) fn map_github_status(status: u16, message: impl Into<String>) -> AdlG
 }
 
 pub(super) fn redact_for_diagnostics(input: &str) -> String {
-    let mut redacted = Vec::new();
-    for token in input.split_whitespace() {
-        let lower = token.to_ascii_lowercase();
-        if lower.contains("token=")
-            || lower.contains("authorization:")
-            || lower.starts_with("ghp_")
-            || lower.starts_with("github_pat_")
-        {
-            redacted.push("<redacted>");
-        } else {
-            redacted.push(token);
-        }
-    }
-    redacted.join(" ")
+    redact_for_github_token_diagnostics(input)
 }
 
 pub(super) fn issue_labels_from_csv_in_order(labels_csv: &str) -> Vec<String> {
@@ -497,6 +476,7 @@ fn closing_keyword_match_targets_issue(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::github_token::{GH_TOKEN_ENV, GITHUB_TOKEN_ENV};
     use crate::cli::tests::env_lock as cli_env_lock;
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {

--- a/adl/src/cli/pr_cmd_cards/prompt.rs
+++ b/adl/src/cli/pr_cmd_cards/prompt.rs
@@ -275,6 +275,9 @@ mod tests {
         let old_disable = std::env::var("ADL_GITHUB_DISABLE_GH_FALLBACK").ok();
         let old_github_token = std::env::var("GITHUB_TOKEN").ok();
         let old_gh_token = std::env::var("GH_TOKEN").ok();
+        let old_token_file = std::env::var("ADL_GITHUB_TOKEN_FILE").ok();
+        let old_keychain_service = std::env::var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE").ok();
+        let old_keychain_account = std::env::var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT").ok();
         let mut path_entries = vec![bin_dir.clone()];
         path_entries.extend(std::env::split_paths(old_path.as_deref().unwrap_or("")));
         unsafe {
@@ -286,6 +289,9 @@ mod tests {
             std::env::remove_var("ADL_GITHUB_DISABLE_GH_FALLBACK");
             std::env::remove_var("GITHUB_TOKEN");
             std::env::remove_var("GH_TOKEN");
+            std::env::remove_var("ADL_GITHUB_TOKEN_FILE");
+            std::env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
+            std::env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
         }
 
         assert_eq!(
@@ -312,5 +318,8 @@ mod tests {
         restore_env("ADL_GITHUB_DISABLE_GH_FALLBACK", old_disable);
         restore_env("GITHUB_TOKEN", old_github_token);
         restore_env("GH_TOKEN", old_gh_token);
+        restore_env("ADL_GITHUB_TOKEN_FILE", old_token_file);
+        restore_env("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE", old_keychain_service);
+        restore_env("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT", old_keychain_account);
     }
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -687,7 +687,7 @@ fn finish_validation_sanitizes_live_github_transport_env() {
     write_executable(
         &bin_dir.join("cargo"),
         &format!(
-            "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'args=%s ADL_GITHUB_CLIENT=%s ADL_GITHUB_DISABLE_GH_FALLBACK=%s ADL_GITHUB_OCTOCRAB_BASE_URI=%s GITHUB_TOKEN=%s GH_TOKEN=%s\\n' \"$*\" \"${{ADL_GITHUB_CLIENT-}}\" \"${{ADL_GITHUB_DISABLE_GH_FALLBACK-}}\" \"${{ADL_GITHUB_OCTOCRAB_BASE_URI-}}\" \"${{GITHUB_TOKEN-}}\" \"${{GH_TOKEN-}}\" >> '{}'\nexit 0\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'args=%s ADL_GITHUB_CLIENT=%s ADL_GITHUB_DISABLE_GH_FALLBACK=%s ADL_GITHUB_OCTOCRAB_BASE_URI=%s GITHUB_TOKEN=%s GH_TOKEN=%s ADL_GITHUB_TOKEN_FILE=%s ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE=%s ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT=%s\\n' \"$*\" \"${{ADL_GITHUB_CLIENT-}}\" \"${{ADL_GITHUB_DISABLE_GH_FALLBACK-}}\" \"${{ADL_GITHUB_OCTOCRAB_BASE_URI-}}\" \"${{GITHUB_TOKEN-}}\" \"${{GH_TOKEN-}}\" \"${{ADL_GITHUB_TOKEN_FILE-}}\" \"${{ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE-}}\" \"${{ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT-}}\" >> '{}'\nexit 0\n",
             cargo_log.display()
         ),
     );
@@ -699,6 +699,9 @@ fn finish_validation_sanitizes_live_github_transport_env() {
         "ADL_GITHUB_OCTOCRAB_BASE_URI",
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "ADL_GITHUB_TOKEN_FILE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT",
     ];
     let old_github_envs = github_envs
         .iter()
@@ -711,6 +714,9 @@ fn finish_validation_sanitizes_live_github_transport_env() {
         env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", "http://127.0.0.1:9");
         env::set_var("GITHUB_TOKEN", "github-secret-token");
         env::set_var("GH_TOKEN", "gh-secret-token");
+        env::set_var("ADL_GITHUB_TOKEN_FILE", "/tmp/secret-token-file");
+        env::set_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE", "secret-service");
+        env::set_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT", "secret-account");
     }
 
     run_finish_validation_rust(
@@ -736,6 +742,9 @@ fn finish_validation_sanitizes_live_github_transport_env() {
     assert!(!cargo_env.contains("octocrab"));
     assert!(!cargo_env.contains("github-secret-token"));
     assert!(!cargo_env.contains("gh-secret-token"));
+    assert!(!cargo_env.contains("/tmp/secret-token-file"));
+    assert!(!cargo_env.contains("secret-service"));
+    assert!(!cargo_env.contains("secret-account"));
     assert!(!cargo_env.contains("127.0.0.1:9"));
     assert!(cargo_env
         .lines()
@@ -948,6 +957,42 @@ fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
         .commands
         .iter()
         .any(|command| command.contains("--doc --all-features")));
+}
+
+#[test]
+fn finish_validation_profile_classifies_github_token_loading_surfaces() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/src/cli/github_token.rs".to_string(),
+            "adl/src/cli/mod.rs".to_string(),
+            "adl/src/cli/tooling_cmd/github_release.rs".to_string(),
+            "adl/src/cli/pr_cmd/github_client.rs".to_string(),
+            "adl/src/cli/pr_cmd/github.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/support.rs".to_string(),
+            "adl/tools/pr.sh".to_string(),
+            "docs/default_workflow.md".to_string(),
+        ],
+    )
+    .expect("github token loading plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl github_token".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl github_client".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl github_release_octocrab_covers_absent_draft_present_publish"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -72,6 +72,9 @@ pub(crate) fn force_gh_cli_transport_env() -> GithubTransportEnvGuard {
         "ADL_TEST_GITHUB_CLI_FIXTURE",
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "ADL_GITHUB_TOKEN_FILE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE",
+        "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT",
     ];
     let old_values = keys
         .into_iter()

--- a/adl/src/cli/tooling_cmd/github_release.rs
+++ b/adl/src/cli/tooling_cmd/github_release.rs
@@ -3,6 +3,8 @@ use octocrab::models::repos::Release;
 use std::fs;
 use std::path::PathBuf;
 
+use super::super::github_token::resolve_github_token;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ReleaseAction {
     EnsureAbsent,
@@ -237,17 +239,14 @@ fn release_id_u64(release: &Release) -> Result<u64> {
 }
 
 fn build_octocrab() -> Result<octocrab::Octocrab> {
-    let token = std::env::var("GITHUB_TOKEN")
-        .ok()
-        .or_else(|| std::env::var("GH_TOKEN").ok())
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+    let token = resolve_github_token()
+        .context("github-release token resolver failed")?
         .ok_or_else(|| {
             anyhow!(
-                "github-release requires GITHUB_TOKEN or GH_TOKEN; release operations do not use gh fallback"
+                "github-release requires GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE; release operations do not use gh fallback"
             )
         })?;
-    let builder = octocrab::Octocrab::builder().personal_token(token);
+    let builder = octocrab::Octocrab::builder().personal_token(token.value().to_string());
     #[cfg(test)]
     let builder = if let Ok(base_uri) = std::env::var("ADL_GITHUB_OCTOCRAB_BASE_URI") {
         builder

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -9,9 +9,10 @@
 #
 # Requirements:
 # - git
-# - GitHub token in GITHUB_TOKEN or GH_TOKEN for Rust octocrab-backed GitHub operations.
-#   Load tokens from an operator-approved secret source and pass them only to
-#   the ADL command environment. Do not use direct `gh` commands as a fallback.
+# - GitHub token for Rust octocrab-backed GitHub operations. Supported shared
+#   sources are GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or
+#   ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE. Do not use direct `gh` commands as a
+#   fallback.
 # - Rust toolchain for `adl/` checks (fmt, clippy, test)
 #
 #   adl/tools/pr.sh help
@@ -2472,10 +2473,12 @@ Usage:
 
 Notes:
 - Creates the GitHub issue and bootstraps the local root STP/SIP/SPP/SRP/SOR bundle.
-- Requires GITHUB_TOKEN or GH_TOKEN for live GitHub operations; load the token
-  from an operator-approved secret source without printing it. If no token is
-  present, stop and fix the ADL command environment; do not fall back to direct
-  `gh` commands or connector issue APIs.
+- Requires a shared GitHub token source for live GitHub operations. Supported
+  sources are GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or
+  ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE. The keychain source uses macOS
+  `security find-generic-password`. If no token is present, stop and fix the ADL
+  command environment; do not fall back to direct `gh` commands or connector
+  issue APIs.
 - Runs the doctor-ready structural check immediately after bootstrap and fails if the new issue is not ready for the next step.
 - Does not create the branch or worktree execution context.
 - After create, do qualitative SIP/STP/SPP/SRP design-time review and then run `adl/tools/pr.sh run <issue> ...`.
@@ -2635,10 +2638,12 @@ Usage:
 Behavior:
 - delegates to the Rust-owned issue inspection surface
 - uses the typed GitHub transport rather than raw `gh issue list/view`
-- requires GITHUB_TOKEN or GH_TOKEN for live GitHub operations; if no token is
-  present, stop and fix the ADL command environment by loading one from an
-  operator-approved secret source without echoing it; do not fall back to direct
-  `gh` commands or connector issue APIs
+- requires a shared GitHub token source for live GitHub operations. Supported
+  sources are GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or
+  ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE. The keychain source uses macOS
+  `security find-generic-password`; if no token is present, stop and fix the ADL
+  command environment without echoing it; do not fall back to direct `gh`
+  commands or connector issue APIs
 - defaults `-R/--repo` from the current checkout when omitted
 - infers `owner/repo` from a GitHub issue URL on `issue view` when possible
 - keeps machine-readable JSON on stdout when `--json` is set

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -216,10 +216,14 @@ Use the Rust-owned issue inspection commands before execution, review, or
 closeout when you need live GitHub issue truth without falling back to raw
 `gh issue` commands.
 
-Live GitHub issue operations require `GITHUB_TOKEN` or `GH_TOKEN` in the ADL
-command environment. Load that value from an operator-approved secret source
-without echoing it. If the token is missing, stop and fix the ADL command
-environment; do not use direct `gh` or connector issue calls as a fallback.
+Live GitHub issue operations require one shared GitHub token source in the ADL
+command environment. Supported sources are `GITHUB_TOKEN`, `GH_TOKEN`,
+`ADL_GITHUB_TOKEN_FILE`, and `ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`. The keychain
+source uses the macOS `security find-generic-password` command; keychain users
+may also set `ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT`. Load or configure the source
+without echoing token material. If the token is missing, stop and fix the ADL
+command environment; do not use direct `gh` or connector issue calls as a
+fallback.
 
 Preferred commands:
 

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -63,11 +63,14 @@ Minimum init contract:
 
 ## 2) Confirm GitHub Issue Exists And Inspect Live Issue Truth
 
-Live GitHub issue operations use the ADL typed GitHub transport. Provide
-`GITHUB_TOKEN` or `GH_TOKEN` from an operator-approved secret source in the
-command environment without printing the token. Do not fall back to direct
-`gh` commands or connector-specific issue APIs when the ADL issue surface needs
-credentials.
+Live GitHub issue operations use the ADL typed GitHub transport. Configure one
+shared token source for the ADL command environment without printing the token:
+`GITHUB_TOKEN`, `GH_TOKEN`, `ADL_GITHUB_TOKEN_FILE`, or
+`ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`. The keychain source uses the macOS
+`security find-generic-password` command; when using it, optionally set
+`ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT` to disambiguate the keychain item. Do not
+fall back to direct `gh` commands or connector-specific issue APIs when the ADL
+issue surface needs credentials.
 
 ```bash
 bash ./adl/tools/pr.sh issue view <issue_num> --json


### PR DESCRIPTION
Closes #3963

## Summary
Implemented a shared GitHub token resolver for ADL CLI GitHub operations. The resolver supports `GITHUB_TOKEN`, `GH_TOKEN`, `ADL_GITHUB_TOKEN_FILE`, and `ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`, with optional `ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT`, process-local caching, redacted diagnostics, and focused tests.

The PR/issue Octocrab client and GitHub release tooling now consume the shared resolver instead of each command path reading only ad hoc environment variables. Operator-facing docs and `pr.sh` usage text now describe the shared token sources.

## Artifacts
- `adl/src/cli/github_token.rs`
- `adl/src/cli/mod.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/github/tests.rs`
- `adl/src/cli/pr_cmd/github/tests/policy.rs`
- `adl/src/cli/pr_cmd/github_client.rs`
- `adl/src/cli/pr_cmd_cards/prompt.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/src/cli/tooling_cmd/github_release.rs`
- `adl/tools/pr.sh`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `docs/default_workflow.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Formatted Rust changes.
  - `cargo check --manifest-path adl/Cargo.toml`
    Verified the ADL crate compiles after resolver integration.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_token`
    Verified resolver precedence, file-read caching, and diagnostic redaction tests.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_client`
    Verified existing GitHub client policy and helper tests after routing through the shared resolver.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl live_github_policy_explains_missing_token_before_spawn`
    Verified missing-token preflight explains the supported shared sources without falling back to direct `gh`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_release_octocrab_covers_absent_draft_present_publish`
    Verified GitHub release tooling still builds and uses Octocrab successfully with the shared resolver path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_github_token_loading_surfaces`
    Verified `pr finish` classifies the token resolver, CLI module entrypoint, release tooling, PR GitHub client, wrapper, and docs paths into a focused validation lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_sanitizes_live_github_transport_env`
    Verified finish validation subprocesses remove all live GitHub transport and shared token source variables before running focused tests.
  - `ADL_GITHUB_TOKEN_FILE=<operator-approved-token-file> cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd`
    Verified the PR-command test slice remains isolated from parent shared-token configuration.
  - `env -u GITHUB_TOKEN -u GH_TOKEN ADL_GITHUB_TOKEN_FILE=<operator-approved-token-file> bash adl/tools/pr.sh issue view 3963 --json`
    Verified live ADL issue inspection succeeds through the token-file source while isolating the higher-precedence `GITHUB_TOKEN` and `GH_TOKEN` sources.
  - `env -u GITHUB_TOKEN -u GH_TOKEN -u ADL_GITHUB_TOKEN_FILE -u ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE bash adl/tools/pr.sh issue view 3963 --json`
    Verified missing shared token source fails closed with a non-secret diagnostic naming supported sources.
  - `git diff --check`
    Verified no whitespace errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3963__github-token-loading-deterministic-reusable/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3963__github-token-loading-deterministic-reusable/sor.md
- Idempotency-Key: v0-91-6-tools-make-github-token-loading-deterministic-and-reusable-adl-src-cli-github-token-rs-adl-src-cli-mod-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-rs-adl-src-cli-pr-cmd-github-tests-policy-rs-adl-src-cli-pr-cmd-github-client-rs-adl-src-cli-pr-cmd-cards-prompt-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-src-cli-tooling-cmd-github-release-rs-adl-tools-pr-sh-adl-tools-skills-docs-operational-skills-guide-md-docs-default-workflow-md-adl-v0-91-6-tasks-issue-3963-github-token-loading-deterministic-reusable-sip-md-adl-v0-91-6-tasks-issue-3963-github-token-loading-deterministic-reusable-sor-md