### PR TITLE
[v0.91.6][tools][pr-finish] Classify resilience and provider communication paths into finish validation lanes

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1075,6 +1075,24 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             .any(|path| finish_path_needs_runtime_owner_lane_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
+            if paths
+                .iter()
+                .any(|path| finish_path_needs_provider_communication_focused_validation(path))
+            {
+                push_finish_validation_command(
+                    &mut commands,
+                    "cargo test --manifest-path adl/Cargo.toml --lib provider_communication",
+                );
+            }
+            if paths
+                .iter()
+                .any(|path| finish_path_needs_resilience_focused_validation(path))
+            {
+                push_finish_validation_command(
+                    &mut commands,
+                    "cargo test --manifest-path adl/Cargo.toml --lib resilience",
+                );
+            }
             commands
                 .push("bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string());
         }
@@ -1177,6 +1195,8 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md"
             | "adl/src/cli/pr_cmd.rs"
             | "adl/src/lib.rs"
+            | "adl/src/provider_communication.rs"
+            | "adl/src/resilience.rs"
             | "adl/src/cli/tests/pr_cmd_inline/basics.rs"
             | "adl/src/csdlc_prompt_editor.rs"
             | "adl/src/cli/run_artifacts_types.rs"
@@ -1231,7 +1251,8 @@ fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
 
 fn finish_path_needs_owner_binary_rust_slice_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
-    trimmed == "adl/src/csdlc_prompt_editor.rs"
+    trimmed == "adl/src/lib.rs"
+        || trimmed == "adl/src/csdlc_prompt_editor.rs"
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
         || trimmed == "adl/src/cli/run_artifacts_types.rs"
         || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
@@ -1298,7 +1319,22 @@ fn finish_path_needs_csdlc_owner_lane_validation(path: &str) -> bool {
 
 fn finish_path_needs_runtime_owner_lane_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
-    matches!(trimmed, "adl/tools/test_adl_runtime_compatibility.sh")
+    matches!(
+        trimmed,
+        "adl/tools/test_adl_runtime_compatibility.sh"
+            | "adl/src/provider_communication.rs"
+            | "adl/src/resilience.rs"
+    )
+}
+
+fn finish_path_needs_provider_communication_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/provider_communication.rs"
+}
+
+fn finish_path_needs_resilience_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/resilience.rs"
 }
 
 fn finish_path_needs_review_owner_lane_validation(path: &str) -> bool {
@@ -1418,6 +1454,30 @@ pub(super) fn run_finish_validation_rust(
                 "bash adl/tools/run_owner_validation_lane.sh runtime --build" => {
                     let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?, "runtime", "--build"])?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --lib provider_communication" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--lib",
+                            "provider_communication",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --lib resilience" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--lib",
+                            "resilience",
+                        ],
+                    )?;
                 }
                 "bash adl/tools/run_owner_validation_lane.sh review --build" => {
                     let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -821,7 +821,69 @@ fn finish_validation_plan_classifies_owner_validation_lanes() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_resilience_runtime_publication_paths() {
+    let provider_plan = select_finish_validation_plan("adl/src/provider_communication.rs")
+        .expect("provider communication runtime plan");
+    assert_eq!(
+        provider_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
+    assert!(provider_plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --lib provider_communication".to_string()
+    ));
+    assert!(provider_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string()));
+    assert!(!provider_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+
+    let resilience_plan =
+        select_finish_validation_plan("adl/src/resilience.rs").expect("resilience runtime plan");
+    assert_eq!(
+        resilience_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
+    assert!(resilience_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --lib resilience".to_string()));
+    assert!(resilience_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string()));
+    assert!(!resilience_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+
+    let mixed_plan = select_finish_validation_plan(
+        "adl/src/lib.rs,adl/src/provider_communication.rs,adl/src/resilience.rs,docs/milestones/v0.91.6/features/RESILIENCE_PERSISTENCE_SLEEP_WAKE_v0.91.6.md",
+    )
+    .expect("mixed resilience runtime plan");
+    assert_eq!(mixed_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(mixed_plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --lib provider_communication".to_string()
+    ));
+    assert!(mixed_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --lib resilience".to_string()));
+    assert!(mixed_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string()));
+    assert!(!mixed_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
 fn finish_validation_plan_classifies_rust_refactor_slices() {
+    let lib_plan = select_finish_validation_plan("adl/src/lib.rs").expect("lib plan");
+    assert_eq!(lib_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(lib_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl".to_string()));
+
     let prompt_editor_plan = select_finish_validation_plan(
         "adl/src/csdlc_prompt_editor.rs,adl/src/csdlc_prompt_editor/structure.rs",
     )
@@ -1188,6 +1250,69 @@ fn finish_helper_paths_run_narrow_finish_focused_validation() {
     ));
     assert!(!cargo_calls.contains(" cli::pr_cmd\n"));
     assert!(!cargo_calls.contains("clippy --manifest-path"));
+}
+
+#[test]
+fn finish_runtime_paths_run_module_focused_validation_and_runtime_lane() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-runtime-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/run_owner_validation_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan =
+        select_finish_validation_plan("adl/src/provider_communication.rs,adl/src/resilience.rs")
+            .expect("runtime focused plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("runtime focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--lib provider_communication"));
+    assert!(cargo_calls.contains("--lib resilience"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("runtime --build"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4044

## Summary
Implemented the bounded `pr finish` lane-classification unblock for `#3986` by routing `adl/src/provider_communication.rs` and `adl/src/resilience.rs` into the runtime owner-validation lane, adding focused module-level Rust validation for those runtime/provider surfaces, and tightening `adl/src/lib.rs` so it no longer falls through to a larger-binary bucket without focused proof.

## Artifacts
- Tracked code changes in `adl/src/cli/pr_cmd/finish_support.rs`
- Tracked focused regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Local ignored review/execution record updates in this issue bundle

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene for the tracked issue diff.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the touched Rust files remain correctly formatted.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_plan_classifies_resilience_runtime_publication_paths`
    Verified provider-only, resilience-only, and mixed resilience/provider path plans all classify into the expected focused runtime lane with the intended commands.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_runtime_paths_run_module_focused_validation_and_runtime_lane`
    Verified runtime/provider path plans execute module-focused `cargo test --lib` selectors plus the runtime owner lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_plan_classifies_rust_refactor_slices`
    Verified `adl/src/lib.rs` now receives focused owner-binary validation instead of falling through to hygiene-only validation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation`
    Re-verified the bounded `adl-pr-finish` validation-profile suite after the lane changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4044__v0-91-6-tools-pr-finish-classify-resilience-and-provider-communication-paths-into-finish-validation-lanes/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4044__v0-91-6-tools-pr-finish-classify-resilience-and-provider-communication-paths-into-finish-validation-lanes/sor.md
- Idempotency-Key: v0-91-6-tools-pr-finish-classify-resilience-and-provider-communication-paths-into-finish-validation-lanes-adl-v0-91-6-tasks-issue-4044-v0-91-6-tools-pr-finish-classify-resilience-and-provider-communication-paths-into-finish-validation-lanes-sip-md-adl-v0-91-6-tasks-issue-4044-v0-91-6-tools-pr-finish-classify-resilience-and-provider-communication-paths-into-finish-validation-lanes-sor-md