### PR TITLE
[v0.91.6][tools][pr-finish] Execute owner-binary focused adl test selector chosen by finish validation plan

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1429,6 +1429,18 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                        ],
+                    )?;
+                }
                 "cargo test --manifest-path adl/Cargo.toml --bin adl github_token" => {
                     run_finish_validation_status(
                         "cargo",

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1361,6 +1361,55 @@ fn finish_runtime_paths_run_module_focused_validation_and_runtime_lane() {
 }
 
 #[test]
+fn finish_owner_binary_paths_run_owner_binary_focused_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-owner-binary-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let plan = select_finish_validation_plan("adl/src/lib.rs").expect("owner binary plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("owner binary focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("fmt --manifest-path"));
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--bin adl"));
+    assert!(!cargo_calls.contains("github_token"));
+    assert!(!cargo_calls.contains(" cli::pr_cmd"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
+}
+
+#[test]
 fn finish_output_card_guards_cover_not_started_and_completed_validation_failures() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-finish-output-guards");


### PR DESCRIPTION
Closes #4049

## Summary
Fixed the finish-control-plane planner/executor drift that still blocked `#3986` after `#4044`: `run_finish_validation_rust` now supports the owner-binary focused `cargo test --manifest-path adl/Cargo.toml --bin adl` command that the finish validation planner can emit for `adl/src/lib.rs`, and focused execution-level proof now covers that path.

## Artifacts
- Tracked finish executor update in `adl/src/cli/pr_cmd/finish_support.rs`
- Tracked focused regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Local ignored review/execution record updates in this issue bundle

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene for the tracked issue diff.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the touched Rust files remain correctly formatted.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_owner_binary_paths_run_owner_binary_focused_validation`
    Verified the owner-binary focused plan for `adl/src/lib.rs` executes `cargo test --manifest-path adl/Cargo.toml --bin adl`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation`
    Verified the bounded finish validation-profile suite remains green after the executor change.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4049__v0-91-6-tools-pr-finish-execute-owner-binary-focused-adl-test-selector-chosen-by-finish-validation-plan/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4049__v0-91-6-tools-pr-finish-execute-owner-binary-focused-adl-test-selector-chosen-by-finish-validation-plan/sor.md
- Idempotency-Key: v0-91-6-tools-pr-finish-execute-owner-binary-focused-adl-test-selector-chosen-by-finish-validation-plan-adl-v0-91-6-tasks-issue-4049-v0-91-6-tools-pr-finish-execute-owner-binary-focused-adl-test-selector-chosen-by-finish-validation-plan-sip-md-adl-v0-91-6-tasks-issue-4049-v0-91-6-tools-pr-finish-execute-owner-binary-focused-adl-test-selector-chosen-by-finish-validation-plan-sor-md