### PR TITLE
[v0.91.6][WP-04][public-records][P-01] Complete redaction and publication safety

### DIFF
--- a/docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md
@@ -9,30 +9,32 @@
 - Status: `wp_04_execution_active`
 - Related issues: `#3969`, `#4002`, `#4003`, `#4004`, `#4005`, `#4006`
 - Prior baseline: [PUBLIC_PROMPT_RECORDS_v0.91.5.md](../../v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md)
-- Contract proof note: [PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md)
+- Export contract proof note: [PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md)
+- Redaction/publication safety proof note: [PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md)
 
 ## Template Rules
 
 This is a feature-scope contract and bridge record. It defines what public prompt
 records must look like, what source-selection policy the bridge intends to
 preserve, and which parts of that policy are already proven versus still owned
-by later enforcement lanes. It does not by itself prove redaction clearance,
-public indexing readiness, security signoff, or release approval.
+by later enforcement lanes. It also defines the current redaction and
+publication-safety posture for public prompt records. It does not by itself
+prove public indexing readiness, security signoff, or release approval.
 
 ## Purpose
 
 Define the `v0.91.6` contract for exporting public prompt records from local
 C-SDLC authoring state without promoting local `.adl` records into public truth,
 while keeping enforcement claims aligned with the current exporter and validator
-surfaces.
+surfaces and making publication-safety rules explicit.
 
 ## Context
 
 `v0.91.5` established the first exporter and validator surface for public
-prompt packets. `v0.91.6` must now make the export shape, provenance, and source
-selection rules explicit enough that later redaction, validation, indexing, and
-security-review work can build on a stable contract instead of inferring one
-from implementation details.
+prompt packets. `v0.91.6` must now make the export shape, provenance,
+source-selection rules, and redaction/publication-safety boundaries explicit
+enough that later validation, indexing, and security-review work can build on a
+stable contract instead of inferring one from implementation details.
 
 Public prompt records remain projections of local authoring state. The canonical
 editable lifecycle state continues to live in local `.adl/<version>/tasks/...`
@@ -44,16 +46,18 @@ This feature owns:
 - export packet shape and required files
 - deterministic source-selection policy for the bridge
 - provenance and public metadata requirements
+- redaction and publication-safety policy for public prompt records
 - ineligible source and record categories
 - a truthful proof note for a representative selected-record export
+- a truthful proof note for allowed, redacted, and refused publication classes
 - explicit separation between already-proven enforcement and later hardening
 
 This feature does not yet own:
-- redaction implementation beyond defining non-exportable categories
 - public indexing publication
 - security approval for publication
 - final public release workflow
 - exporter hardening beyond what current repository evidence already proves
+- full threat modeling or CAV approval for public-record publication
 
 ## Overview
 
@@ -63,6 +67,8 @@ The public prompt-record bridge has two distinct layers:
    - issue-local `.adl` task bundles, source prompts, and review/output cards
 2. public projection truth
    - tracked public packets under `docs/milestones/<version>/review/evidence/csdlc/issues/...`
+   - other explicit reviewer/public projections whose redaction posture is
+     separately recorded and reviewed
 
 `v0.91.6` makes that boundary explicit. Export is intended to operate only from
 approved, issue-bounded authoring sources, but current enforcement is layered:
@@ -71,6 +77,11 @@ approved, issue-bounded authoring sources, but current enforcement is layered:
   hygiene checks on the selected bundle
 - the validator already proves packet-shape, tracker-metadata, and public
   provenance requirements for accepted packets
+- current public prompt packet export uses `refuse_not_rewrite` redaction mode
+  for source cards and public packet text
+- explicitly redacted reviewer/public projections may exist in other tracked
+  proof surfaces, but they require an explicit review-safe record rather than
+  silent exporter rewriting of local `.adl` source cards
 - stricter source-admission checks for explicit override paths remain a policy
   requirement for the bridge, but are not yet fully proven as export-time
   rejection behavior by `#4002`
@@ -155,41 +166,103 @@ Required provenance rules:
 - packets that do not satisfy the current tracker/provenance contract are not
   accepted as valid public prompt packets
 
-### Non-exportable categories
+### Redaction and publication-safety policy
 
-The following categories are not acceptable as public prompt-record inputs or
-public prompt-record provenance:
+Public prompt records are not public by default just because they are tracked.
+A record is publishable only when it fits one of the allowed public-safety
+classes below and carries the corresponding proof posture.
+
+Allowed public-safety classes:
+
+- `allowed_verbatim_packet`
+  - a public prompt packet exported from one issue-local bundle after the
+    exporter and validator safety checks pass
+  - current packet mode is `refuse_not_rewrite`
+- `allowed_redacted_projection`
+  - an explicit reviewer/public projection whose tracked artifact stores only
+    redacted excerpts, digests, counts, references, or other bounded public-safe
+    metadata instead of raw sensitive content
+  - this class requires an explicit review-safe record rather than implicit
+    exporter rewriting
+- `refused_public_record`
+  - any candidate packet or projection that contains disallowed sensitive
+    content, invalid public provenance, unresolved template residue, or
+    publication-unsafe local/private material
+
+Redaction/refusal rules for public prompt packets and related reviewer/public
+projections:
+
+- token values, private keys, secret-like tokens, and credentials must not
+  appear in durable public artifacts
+- local host paths, worktree paths, temp paths, and `.codex` scratch paths must
+  not appear in durable public artifacts
+- private provider logs, raw provider payloads, and raw prompt bodies are not
+  acceptable public prompt packet content by default
+- raw local `.adl` material is not publishable unless it has been converted into
+  an approved public packet or another explicitly reviewed public projection
+- unresolved template markers, incomplete scaffolds, or identity-ambiguous
+  bundles are refused
+- no issue in this feature lane may silently rewrite local source `.adl` cards
+  to make them public-safe
+- temp-path and `.codex` scratch-path treatment are carried here as bridge
+  policy and broader repo redaction expectations; `#4003` does not claim
+  packet-specific refused examples for those exact classes yet
+
+Explicit exception rule:
+- when a public-facing artifact must expose transformed or excerpted material
+  instead of refusing it, the artifact must carry an explicit review-safe record
+  describing the redaction posture, such as excerpt-plus-digest evidence,
+  redacted marker fields, or an equivalent bounded public-safe projection
+- such exceptions are not implicit exporter behavior and must remain separately
+  reviewable
+
+### Non-exportable / non-publishable categories
+
+The following categories are not acceptable as public prompt-record inputs,
+public prompt-record provenance, or durable reviewer/public prompt-record
+artifacts unless separately redacted into an explicit reviewed projection:
 
 - local execution scratch or transient worktree state
 - private machine-local paths or checkout-specific absolute paths
 - temp-file provenance
 - secret-like tokens, private-key markers, or similar sensitive material
 - unresolved template placeholders or incomplete rendered-card scaffolds
+- raw provider logs or other private provider diagnostic payloads
+- raw prompt text or raw model output where a redacted reviewer/public
+  projection is the appropriate surface instead
 - local archive/disposition inventories that are not themselves approved public
   review packets
 - any source bundle whose identity, lifecycle completeness, or provenance
   cannot be verified deterministically at review/validation time
+- unreviewed `.adl` material outside the bounded issue/task-bundle contract
 
 Current enforcement note:
 - the exporter already refuses obvious unsafe card content
 - the validator already refuses invalid public packet provenance and tracker
   shape for accepted packets
+- the current refused examples directly prove host-local absolute-path,
+  worktree-provenance, missing-tracker-url, and secret-marker failures
 - broader source-admission hardening remains future tooling work unless and
   until separately proven
+- temp-path and `.codex` scratch-path handling remain policy-level here unless
+  and until a later issue adds explicit public-packet refusal proof
+- richer redacted public projections are allowed only when their own review-safe
+  packet or proof note makes the transformation explicit
 
 ### Relationship to later WP-04 issues
 
-- `#4003` owns redaction and publication-safety policy on top of this contract
 - `#4004` owns validation and public indexing behavior on top of this contract
 - `#4005` owns security review and CAV handoff expectations
 - `#4006` owns end-to-end distribution proof and closeout truth
 
-## Dry-Run / Fixture Proof Surface
+## Proof Surfaces
 
-`#4002` uses the real `#3472` exported public packet as its representative
-selected-record proof surface because that packet already demonstrates the
-current happy-path exporter output shape and repo-relative provenance without
-inventing a toy fixture. See:
+### Export-shape proof surface
+
+`#4002` uses the current tracked `#3472` exported public packet as its
+representative selected-record proof surface because that packet now
+demonstrates the repaired happy-path exporter output shape and repo-relative
+provenance without inventing a toy fixture. See:
 
 - [PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md)
 - [#3472 exported packet README](../../v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md)
@@ -198,24 +271,44 @@ inventing a toy fixture. See:
 What this proof surface establishes:
 - packet root shape and required files
 - lifecycle-card export membership/order
-- repo-relative provenance on the default bundle path
+- repo-relative provenance on the current tracked packet after the `#3474`
+  metadata-normalization repair
 - GitHub tracker identity separation from work-item identity
 
 What this proof surface does not establish by itself:
 - full exporter-side rejection of every invalid explicit source override
-- redaction completeness
 - indexing readiness
 - security/publication approval
+
+### Redaction/publication-safety proof surface
+
+`#4003` uses three bounded evidence classes:
+
+- allowed packet example:
+  - `#3472` exported packet README/manifest/SOR
+- refused example:
+  - `adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs`
+  - validator-side provenance/tracker refusal in `public_prompt_packet_validate_fails_closed_on_manifest_and_redaction_drift`
+- redacted reviewed projection example:
+  - [LOGGING_VALIDATION_REDACTION_PROOF_4000.md](../review/logging_observability/LOGGING_VALIDATION_REDACTION_PROOF_4000.md)
+  - tracked excerpt-plus-digest reviewer/public artifacts such as the OpenRouter matrix packet and `#3951` remediation evidence
+
+See [PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md).
 
 ## Determinism and Constraints
 
 - local `.adl` state remains the authoring surface
 - public packets are projections, not source-of-truth replacements
-- default-bundle export and accepted-packet provenance must remain reviewer-auditable
+- default-bundle export and accepted-packet provenance must remain
+  reviewer-auditable
+- public prompt packet export stays `refuse_not_rewrite` unless a later issue
+  explicitly changes and proves that behavior
 - later lanes may tighten enforcement, but they must not silently change this
-  issue's declared packet identity contract
+  issue's declared packet identity or publication-safety contract
 - later lanes must distinguish exporter-side guarantees from validator-side
   guarantees instead of collapsing them into one implied control
+- redacted reviewer/public projections must be explicit and reviewable rather
+  than silent source rewrites
 
 ## Integration Points
 
@@ -227,20 +320,22 @@ What this proof surface does not establish by itself:
 ## Validation
 
 This issue's proof is documentation/provenance proof, not runtime proof.
-Validation for `#4002` should confirm:
+Validation for `#4003` should confirm:
 
 - the feature doc defines one stable export shape
 - eligible and ineligible source classes are explicit as bridge policy
 - the doc distinguishes exporter-proven behavior from validator-proven behavior
 - tracker metadata and provenance requirements match the current accepted packet
   contract
-- non-exportable categories are explicit
-- a real selected-record export packet exists and matches the documented
-  happy-path shape
+- redaction/publication-safety classes and exception rules are explicit
+- non-publishable categories are explicit
+- the allowed, redacted, and refused example surfaces are linked to real repo
+  evidence
+- logging validation/redaction proof from WP-03 is consumed where relevant
 
-This issue does not prove all explicit-override rejection behavior. Redaction,
-public indexing, and security approval remain separately tracked and must not be
-claimed from `#4002` alone.
+This issue does not prove all explicit-override rejection behavior, public
+indexing, or security approval. Those remain separately tracked and must not be
+claimed from `#4003` alone.
 
 ## Acceptance Criteria
 
@@ -249,8 +344,11 @@ claimed from `#4002` alone.
   what is already proven by exporter or validator surfaces.
 - Required public metadata and provenance fields are documented truthfully for
   the current accepted packet shape.
-- Non-exportable categories are documented with truthful enforcement notes.
+- Redaction/publication-safety classes, exception rules, and non-publishable
+  categories are documented truthfully.
 - A real selected-record proof surface is linked for contract review.
+- Real allowed, redacted, and refused evidence surfaces are linked for
+  publication-safety review.
 - The doc states clearly that local `.adl` remains the authoring surface and
   public packets are projections.
 - The doc does not overclaim exporter-side rejection guarantees that are not yet
@@ -264,17 +362,21 @@ claimed from `#4002` alone.
   host-local assumptions.
 - If exporter-side and validator-side enforcement are conflated, reviewers may
   overtrust source-selection guarantees that are not yet fully hardened.
-- If redaction or security review is implied too early, reviewers may overtrust
-  publication readiness.
+- If redacted projections are allowed without explicit review-safe records,
+  public artifacts may quietly drift into raw prompt or provider-output
+  exposure.
+- If issue-body or packet-input paths drift from the current proof surfaces,
+  later docs may cite stale redaction evidence.
 
 ## Future Work
 
-- codify redaction/publication safety policy (`#4003`)
 - codify validation/public indexing contract (`#4004`)
 - codify security review/CAV routing (`#4005`)
 - prove bounded distribution and closeout (`#4006`)
 - harden exporter-side source-admission checks if later implementation work is
   needed to enforce the full bridge policy at export time
+- route stale issue-body proof-input paths for cleanup when they no longer match
+  the live milestone review packets
 
 ## Notes
 

--- a/docs/milestones/v0.91.6/review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md
+++ b/docs/milestones/v0.91.6/review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md
@@ -1,0 +1,136 @@
+# Public Prompt Records Redaction And Publication Safety Proof Note for #4003
+
+## Scope
+
+This note records the bounded proof surface used by `#4003` to define the
+current redaction and publication-safety posture for public prompt records.
+It is not an indexing proof, security signoff, CAV approval, or release
+clearance packet.
+
+## Source evidence
+
+- [PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md](../../features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md)
+- [PUBLIC_PROMPT_RECORDS_v0.91.5.md](../../../v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md)
+- [#3472 exported packet README](../../../v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/README.md)
+- [#3472 SOR](../../../v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md)
+- [PUBLIC_PROMPT_PACKET_PILOT_VALIDATION_3474.md](../../../v0.91.5/review/evidence/csdlc/issues/PUBLIC_PROMPT_PACKET_PILOT_VALIDATION_3474.md)
+- `adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs`
+- [LOGGING_VALIDATION_REDACTION_PROOF_4000.md](../logging_observability/LOGGING_VALIDATION_REDACTION_PROOF_4000.md)
+- [V0915_EXTERNAL_REVIEW_FINDINGS_2026-06-17.md](../../../v0.91.5/review/external_review/V0915_EXTERNAL_REVIEW_FINDINGS_2026-06-17.md)
+- [OPENROUTER_MATRIX_PROOF_2026-06-14.md](../../../v0.91.5/review/openrouter_matrix/OPENROUTER_MATRIX_PROOF_2026-06-14.md)
+- [openrouter_matrix_state_2026-06-14.json](../../../v0.91.5/review/openrouter_matrix/openrouter_matrix_state_2026-06-14.json)
+
+## Safety classes
+
+`#4003` uses three publication-safety classes.
+
+1. `allowed_verbatim_packet`
+2. `allowed_redacted_projection`
+3. `refused_public_record`
+
+These are policy and proof classes, not new runtime enums.
+
+## Evidence matrix
+
+| Safety class | Meaning | Representative evidence | What it proves |
+| --- | --- | --- | --- |
+| `allowed_verbatim_packet` | A bounded public prompt packet may be tracked verbatim after hygiene checks pass. | `#3472` exported packet README + SOR; `PUBLIC_PROMPT_PACKET_PILOT_VALIDATION_3474.md` | The current tracked packet shape is reviewable and public-safe after the pilot-validation metadata normalization repaired the earlier recovery-export provenance drift. |
+| `refused_public_record` | Unsafe packet candidates fail closed rather than being rewritten silently. | `public_prompt_packet_export_refuses_host_paths_and_secret_markers`; `public_prompt_packet_validate_fails_closed_on_manifest_and_redaction_drift` | Source cards with host paths or secret markers are refused, and accepted-packet validation also fails closed on invalid tracker/provenance drift. |
+| `allowed_redacted_projection` | A reviewer/public artifact may be tracked only in an explicitly redacted, review-safe form. | `#4000` logging proof; OpenRouter matrix proof and state packet; `#3951` external-review remediation evidence | Redacted excerpt-plus-digest or bounded metadata projections are acceptable when the artifact explicitly records the redaction posture instead of exposing raw prompts/output. |
+
+## Allowed case details
+
+The current tracked `#3472` packet is the canonical allowed packet example
+because it now proves:
+
+- packet `README.md`, `manifest.json`, and lifecycle cards exist in one bounded packet
+- source and public paths are repo-relative after the `#3474` metadata-normalization repair
+- packet text is scanned for host-local paths, secret-like values, private-key markers, local scratch markers, and unresolved template residue
+- the packet is a projection of `.adl` authoring state, not a replacement for it
+
+## Refused case details
+
+The current public prompt packet exporter and validator already prove fail-closed
+behavior for these refusal classes:
+
+- source-card host-local absolute paths
+- secret-like token markers
+- private-key markers through the shared safety check path
+- invalid packet tracker metadata such as a missing required GitHub issue URL
+- invalid public provenance such as absolute/worktree source paths in accepted packet metadata
+- temp-path and `.codex` scratch-path treatment remain bridge-policy expectations here, but `#4003` does not cite a dedicated refused example for those exact classes
+
+Current proof boundary:
+- `#4003` does not claim exporter-side refusal for every invalid explicit
+  `--source` override class before packet generation
+- it does claim that accepted public packets and obvious unsafe source-card
+  inputs already have fail-closed protection on the proven surfaces above
+
+## Redacted case details
+
+The current exporter mode remains `refuse_not_rewrite`. That means the redacted
+case is **not** “the exporter rewrites local source cards.”
+
+Instead, the redacted case is an explicit reviewer/public projection whose own
+artifact says that it contains only redacted excerpts, digests, counts, or
+bounded metadata. The current repository evidence for that class includes:
+
+- `#4000` logging proof, which explicitly treats redaction/path hygiene as part
+  of the proof surface for publication-facing artifacts
+- the OpenRouter matrix state packet and proof packet, which store
+  `prompt_excerpt` / `output_excerpt` markers with digest and length metadata
+  instead of raw provider content
+- `#3951` remediation evidence recorded in the external-review findings packet,
+  which verifies that raw prompt content was removed from tracked artifacts and
+  replaced with review-safe metadata
+
+Rule carried forward into the public prompt-record contract:
+- redacted publication is allowed only when the artifact itself makes the
+  transformation explicit and reviewable
+- silent source-card rewriting is not an acceptable substitute
+
+## Publication-safety rules established here
+
+The bounded rules `#4003` establishes are:
+
+- no durable public artifact may contain token bytes, private keys, or secret-like values
+- no durable public artifact may contain host-local absolute paths or worktree provenance on the currently proven public-packet surfaces
+- temp-path and `.codex` scratch-path provenance are also not acceptable by bridge policy, but `#4003` does not treat them as separately demonstrated refused examples yet
+- raw provider logs and raw provider payloads are not acceptable public prompt-record artifacts by default
+- raw prompt text and raw model output are not acceptable public prompt-record artifacts by default when a redacted reviewer/public projection is the correct surface
+- any exception must be recorded as an explicit review-safe projection, not hidden inside the exporter
+- local `.adl` authoring state remains private/local unless exported into an approved public packet or another explicit reviewed projection
+
+## Input drift captured for remediation
+
+The authored `#4003` issue body names `WP-03 logging validation/redaction
+outputs` and an older closeout-style expectation, but the current live WP-03
+redaction proof surface consumed here is:
+
+- [LOGGING_VALIDATION_REDACTION_PROOF_4000.md](../logging_observability/LOGGING_VALIDATION_REDACTION_PROOF_4000.md)
+
+This is not a blocker for `#4003`, because the live proof packet exists and is
+stronger than the stale issue-body path expectation. It should still be treated
+as issue-input drift to clean up in future authoring/remediation work.
+
+## What this proof note does not claim
+
+This note does not claim:
+
+- public indexing readiness
+- security-review completion
+- CAV approval
+- release readiness for public prompt record publication
+- exporter-side rejection of every invalid explicit override class
+
+Those remain owned by `#4004` through `#4006` and later tooling hardening.
+
+## Reviewer takeaway
+
+`#4003` is ready when reviewers can confirm that the repository now has one
+truthful publication-safety policy for public prompt records:
+
+- allowed packets are bounded and hygiene-checked
+- unsafe packets fail closed
+- redacted reviewer/public projections must be explicit and reviewable
+- local `.adl` source cards are not silently rewritten into public-safe output


### PR DESCRIPTION
Closes #4003

## Summary
Completed the `v0.91.6` redaction/publication-safety pass for `#4003` as a
stacked docs-only issue on top of `#4002`. The shared public prompt-records
feature doc now defines publication-safety classes, explicit exception rules,
and non-publishable categories while distinguishing packet-level refused proof,
review-safe redacted projection proof, and policy-level expectations that still
need later hardening. A companion proof note records the allowed, redacted, and
refused evidence surfaces and captures stale WP-03 input drift for remediation.

## Artifacts
- `docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md`
- `docs/milestones/v0.91.6/review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md`

## Validation
- Validation commands and their purpose:
  - `GITHUB_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 4003 --mode ready --json`
    Verified the issue remained bound and ready while the docs-only contract change was being prepared for PR publication; the open-wave preflight block was expected because `#4056` remains intentionally open.
  - `git diff --check`
    Verified whitespace hygiene in the touched docs.
  - `pattern=$'\x2fUsers\x2f|\bghp_[A-Za-z0-9]{8,}\b|\bgho_[A-Za-z0-9]{8,}\b|\bsk-[A-Za-z0-9]{8,}\b|BEGIN [A-Z ]*PRIVATE KEY'; rg -n "$pattern" docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md docs/milestones/v0.91.6/review/public_prompt_records/PUBLIC_PROMPT_RECORDS_REDACTION_PUBLICATION_SAFETY_4003.md`
    Verified the touched docs contain no obvious token values, private-key markers, or host-local absolute paths.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4003__v0-91-6-wp-04-public-records-p-01-complete-redaction-and-publication-safety/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4003__v0-91-6-wp-04-public-records-p-01-complete-redaction-and-publication-safety/sor.md
- Idempotency-Key: v0-91-6-wp-04-public-records-p-01-complete-redaction-and-publication-safety-adl-v0-91-6-tasks-issue-4003-v0-91-6-wp-04-public-records-p-01-complete-redaction-and-publication-safety-sip-md-adl-v0-91-6-tasks-issue-4003-v0-91-6-wp-04-public-records-p-01-complete-redaction-and-publication-safety-sor-md