### PR TITLE
[v0.91.6][WP-04][docs] Normalize final closeout truth

### DIFF
--- a/docs/milestones/v0.91.6/README.md
+++ b/docs/milestones/v0.91.6/README.md
@@ -12,16 +12,15 @@
 ## Status
 
 Current status: first pre-`v0.92` bridge tranche executing with WP-03 complete
-and WP-04 complete through its merged child wave; umbrella closeout is the
-remaining tracked step.
+and WP-04 complete and closed through its merged umbrella.
 
 - Planning: created by `#3800`
 - Documentation completion: `#3824`
 - Issue wave: WP-03 logging/tooling umbrella `#3968` and WP-04 public-records
   umbrella `#3969` were opened with child lanes `#3995`-`#4001` and
   `#4002`-`#4006`
-- Execution: WP-03 merged; WP-04 child lanes `#4002`-`#4006` merged in order;
-  umbrella `#3969` is in final closeout
+- Execution: WP-03 merged; WP-04 umbrella `#3969` and child lanes
+  `#4002`-`#4006` merged and closed
 - Validation: docs-readiness validation plus focused issue/PR proof for the
   merged WP-03 and WP-04 waves
 - Release readiness: not applicable until `v0.91.6` executes

--- a/docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md
+++ b/docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md
@@ -7,14 +7,13 @@
 - Start date: not scheduled
 - End date: not scheduled
 - Owner: ADL maintainers
-- Status: issue waves opened; WP-03 merged; WP-04 child wave merged; umbrella closeout pending merge
+- Status: issue waves opened; WP-03 merged; WP-04 merged and closed
 
 ## Status
 
-Issue opening has completed for the WP-03/WP-04 tranche. WP-04 is no longer
-just executing at the umbrella truth layer: child implementation issues
-`#4002` through `#4006` are merged, and only the final umbrella closeout
-remains.
+Issue opening has completed for the WP-03/WP-04 tranche. WP-04 is complete
+through umbrella `#3969` and child implementation issues `#4002` through
+`#4006`.
 
 ## Sprint Overview
 
@@ -37,7 +36,7 @@ turns planning docs and feature docs into issue-ready work with review gates.
 | 2 | Open/promote first-tranche implementation issues | `#3968`, `#3969`, `#3995`-`#4006` opened for the WP-03/WP-04 tranche | ADL maintainers | in progress |
 | 3 | Resilience, persistence, sleep/wake execution route | not opened | ADL maintainers | planned |
 | 4 | Tooling proof-loop reliability route | `#3968`, `#3995`-`#4001` | ADL maintainers | merged |
-| 5 | Public prompt records export route | `#3969`, `#4002`-`#4006` | ADL maintainers | child lanes merged through `#4006`; umbrella closeout pending |
+| 5 | Public prompt records export route | `#3969`, `#4002`-`#4006` | ADL maintainers | merged and closed through umbrella `#3969` |
 | 6 | Provider/model reliability route | not opened | ADL maintainers | planned |
 | 7 | ACIP/A2A/provider communications route | not opened | ADL maintainers | planned |
 | 8 | Security bridge and CAV route | not opened | ADL maintainers | planned |

--- a/docs/milestones/v0.91.6/WBS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/WBS_v0.91.6.md
@@ -24,7 +24,7 @@ Current live state:
 
 - WP-03 has merged through `#4001`
 - WP-04 child issues `#4002`-`#4006` have merged through `#4006`
-- WP-04 umbrella `#3969` is in final closeout after the merged child wave
+- WP-04 umbrella `#3969` has merged and closed after the merged child wave
 
 ## WBS Summary
 

--- a/docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md
@@ -6,7 +6,7 @@
 - Version: `v0.91.6`
 - Date: `2026-06-18`
 - Owner: ADL maintainers
-- Status: `wp_04_closeout_ready_pending_review`
+- Status: `wp_04_complete_wp07_residuals_routed`
 - Related issues: `#3969`, `#4002`, `#4003`, `#4004`, `#4005`, `#4006`
 - Prior baseline: [PUBLIC_PROMPT_RECORDS_v0.91.5.md](../../v0.91.5/features/PUBLIC_PROMPT_RECORDS_v0.91.5.md)
 - Export contract proof note: [PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md](../review/public_prompt_records/PUBLIC_PROMPT_RECORDS_EXPORT_CONTRACT_4002.md)
@@ -137,8 +137,8 @@ Closeout result for this feature lane:
 
 Truth boundary carried forward:
 
-- WP-04 becomes closeout-ready for review once the stacked `#4002`-`#4006`
-  proof set is present
+- WP-04 is complete through umbrella closeout once the stacked `#4002`-`#4006`
+  proof set and umbrella `#3969` closeout are present
 - broader activation-path security residuals remain routed to WP-07
 - this feature doc does not claim unrestricted release approval or that later
   security work has already finished


### PR DESCRIPTION
Closes #3969

## Summary
Normalize the final WP-04 milestone and feature-doc status strings after umbrella PR #4054 merged and closed the issue. This follow-up removes stale "pending merge" / "closeout ready" wording that survived the first umbrella merge.

## Artifacts
- `docs/milestones/v0.91.6/README.md`
- `docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md`
- `docs/milestones/v0.91.6/WBS_v0.91.6.md`
- `docs/milestones/v0.91.6/features/PUBLIC_PROMPT_RECORDS_EXPORT_v0.91.6.md`

## Validation
- `git diff --check`
  Verified whitespace and patch hygiene on the docs-only truth-fix surface.
- Results:
  - PASS