### PR TITLE
[v0.91.6][WP-05][provider][M-00] Define provider and capability profile catalog

### DIFF
--- a/docs/milestones/v0.91.6/features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md
@@ -4,11 +4,13 @@
 
 - Feature Name: Provider And Model Reliability
 - Milestone Target: `v0.91.6`
-- Status: planned
+- Status: `m_00_provider_capability_catalog_defined`
 - Owner: ADL maintainers
 - Doc Role: primary
 - Feature Types: policy, architecture
 - Proof Modes: tests, review, replay
+- Related issues: `#3970`, `#4007`
+- Catalog proof note: [PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md](../review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md)
 
 ## Purpose
 
@@ -20,6 +22,7 @@ Define model/provider suitability for reliable multi-agent operation before
 In scope:
 
 - hosted, local, remote, OpenRouter, and Gemma lanes;
+- provider-profile versus capability-profile catalog boundaries;
 - role suitability for planning, review, execution, and synthesis;
 - failure modes, timeouts, malformed outputs, and retry expectations;
 - multi-agent readiness and proof limits.
@@ -36,12 +39,143 @@ Out of scope:
 - Which models are useful with limits versus blocked?
 - What evidence makes Gemma reliable enough for multi-agent work?
 - How are provider failures surfaced and routed?
+- Which fields belong to provider infrastructure profiles versus capability profiles?
 
 ## Dependencies
 
 - Sprint 2 remediation proof packets.
 - Remote Gemma proof and multi-agent comparison remediation.
 - Tooling proof-loop reliability feature doc.
+
+## Provider/Capability Catalog Boundary
+
+WP-05 begins with one explicit split:
+
+- provider profiles answer what infrastructure-backed services are available
+- capability profiles answer what an entity or lane can do with those services
+
+This milestone must not collapse providers, models, capabilities, identities,
+citizens, or institutions into one profile object just because later routing
+consumes all of them.
+
+### Provider profile contract
+
+Provider profiles are infrastructure/service descriptors. They are not actor,
+identity, or authority records.
+
+Required provider-profile fields for WP-05:
+
+| Field | Meaning |
+| --- | --- |
+| `provider_family` | Stable provider family or substrate such as `openai`, `anthropic`, `google`, `ollama`, `openrouter`, `mock`, or bounded `http` profile families. |
+| `profile_id` | Deterministic profile identifier used by config and routing. |
+| `service_kind` | Runtime service substrate such as `http`, `ollama`, or `mock`. |
+| `default_model` | Default model or model family when the profile owns one. |
+| `endpoint_class` | Hosted HTTPS, local loopback, remote HTTPS, or placeholder/invalid until configured. |
+| `economics_class` | Qualitative economics bucket for later routing, such as premium hosted, commodity hosted, local compute, or aggregator lane. |
+| `latency_class` | Qualitative latency posture for later role/routing decisions. |
+| `cost_class` | Relative cost posture for bounded routing decisions. |
+| `tool_support_class` | Whether the provider surface is text-only, bounded tool-capable, or intentionally limited. |
+| `lane_class` | Reliability lane such as hosted first-party, local model, remote open-weight, aggregator, or test/mock lane. |
+| `locality_class` | `hosted`, `local`, or `remote` execution locality. |
+| `auth_surface` | Operator-managed credential or local endpoint expectation; not embedded secrets. |
+
+Provider profiles answer:
+
+- what services exist
+- how they are reached
+- what default model and endpoint expectations they carry
+- what qualitative latency/cost/tool/routing lane they belong to
+
+Provider profiles do not answer:
+
+- what one agent, citizen, or institution is allowed to do
+- what role authority a C-SDLC lane has
+- what identity continuity or civil record a system owns
+
+### Capability profile contract
+
+Capability profiles are provider-independent behavioral descriptors consumed by
+role routing and later provider/model matrices.
+
+Required capability-profile fields for WP-05:
+
+| Field | Meaning |
+| --- | --- |
+| `capability_id` | Stable capability identifier. |
+| `interaction_modes` | Chat, completion, tool use, review/synthesis, batch, or replay modes. |
+| `structured_output_posture` | Expected reliability for machine-readable output. |
+| `tool_orchestration_posture` | Whether the capability can safely act in tool-using or review-only lanes. |
+| `context_class` | Qualitative context-window class, independent of one provider. |
+| `reasoning_posture` | Qualitative reasoning/depth posture for later role suitability. |
+| `determinism_posture` | How safely the capability supports repeatable review or routing surfaces. |
+| `safety_limit_notes` | Named limitations or blocked cases that later matrices must preserve. |
+
+Capability profiles answer:
+
+- what a role or lane needs from a model surface
+- how later matrices can compare providers without confusing provider identity
+  with role authority
+
+Capability profiles do not answer:
+
+- which vendor hosts the model
+- where credentials live
+- which citizen/institution/identity record owns the action
+
+### Identity and authority non-claims
+
+The provider/capability catalog is intentionally not:
+
+- a civil identity registry
+- a citizen profile system
+- an institution directory
+- an authority or approval ledger
+- the final C-SDLC role-provider matrix
+
+Those layers may consume provider/capability catalogs later, but they are not
+represented as provider config in WP-05.
+
+## Current provider mapping notes
+
+WP-05 uses the current deterministic provider-profile sources in the repository
+to define the first catalog split.
+
+| Provider family / lane | Current profile shape | Catalog notes |
+| --- | --- | --- |
+| OpenAI | bounded `http` preset plus ChatGPT-facing profile family | Hosted HTTPS lane; premium-first provider family with distinct ChatGPT-facing profile names. |
+| Anthropic | bounded `http` preset plus Claude-facing profile family | Hosted HTTPS lane; provider family distinct from role authority. |
+| Google | bounded `http` preset for Gemini | Hosted HTTPS lane; profile catalog owns provider/service identity, not capability claims. |
+| Ollama | explicit local `ollama:*` presets | Local loopback or configured HTTP lane; locality matters independently of capability posture. |
+| OpenRouter | bounded `http` preset | Aggregator lane; provider family is not equivalent to the downstream model capability. |
+| DeepSeek remote | bounded `http` preset | Remote hosted lane; later reliability proof owns quality/resilience claims. |
+| Mock/test | `mock:echo-v1` | Test-only substrate; useful for deterministic harnesses, not general role authority. |
+| Local/remote open-weight lanes | represented through locality + endpoint class rather than identity objects | Locality and transport belong to provider profile; model-role suitability remains later matrix work. |
+
+## Current tracked source truth
+
+This issue was authored against `.adl/docs/TBD/ADL_PROFILES_PROVIDERS_V2.MD`,
+but that path is not present in the current tracked repository state.
+
+The live tracked sources consumed here are:
+
+- [ADR 0004 provider profiles](../../../adr/0004-provider-profiles.md)
+- `adl/src/provider/profiles.rs`
+
+Remediation note:
+
+- the stale issue-input path should be corrected or retired in future
+  authoring/remediation work rather than silently treated as canonical
+
+## Downstream consumption
+
+- WP-05 later issues consume this split for role suitability, Gemma/OpenRouter
+  proof, failure-mode/resilience integration, and closeout.
+- WP-06 should treat provider communication and access/catalog decisions as
+  consuming provider-profile and capability-profile boundaries rather than
+  collapsing them into one routing object.
+- WP-08 may consume capability evidence later, but identity/continuity remains
+  separate from provider config.
 
 ## Validation And Review
 
@@ -61,3 +195,4 @@ product benchmark status from this tranche.
 - No training claims.
 - No Aptitude Atlas baseline.
 - No unqualified "all models work" claim.
+- No provider catalog that doubles as identity, citizen, or institution state.

--- a/docs/milestones/v0.91.6/review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md
+++ b/docs/milestones/v0.91.6/review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md
@@ -1,0 +1,115 @@
+# Provider And Capability Profile Catalog Proof Note for #4007
+
+## Scope
+
+This note records the bounded proof surface for `#4007`. It defines the first
+WP-05 provider/capability profile catalog boundary and does not claim role
+suitability completion, Gemma/OpenRouter reliability proof, failure-mode
+closure, or final provider/model closeout.
+
+## Source evidence
+
+- [PROVIDER_MODEL_RELIABILITY_v0.91.6.md](../../features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md)
+- [ADR 0004 provider profiles](../../../adr/0004-provider-profiles.md)
+- `adl/src/provider/profiles.rs`
+
+## Catalog split established here
+
+`#4007` establishes one explicit split:
+
+1. provider profiles
+2. capability profiles
+
+This split is the guardrail that prevents later role-provider work from
+confusing:
+
+- vendor/service infrastructure
+- model capability
+- role authority
+- identity/citizen/institution state
+
+## Provider profile boundary
+
+Provider profiles are infrastructure/service descriptors.
+
+They own:
+
+- provider family
+- deterministic profile id
+- service substrate
+- default model binding
+- endpoint/locality class
+- qualitative economics, latency, cost, tool-support, and lane class
+- operator-managed auth surface expectations
+
+They do not own:
+
+- role authority
+- actor identity
+- citizen records
+- institution records
+
+## Capability profile boundary
+
+Capability profiles are provider-independent behavioral descriptors.
+
+They own:
+
+- interaction modes
+- structured-output posture
+- tool-orchestration posture
+- context class
+- reasoning posture
+- determinism posture
+- safety-limit notes
+
+They do not own:
+
+- vendor identity
+- endpoint configuration
+- credential location
+- civil or institutional identity
+
+## Current mapping evidence
+
+The current tracked provider-profile sources already prove deterministic
+provider families for:
+
+- OpenAI/ChatGPT-facing HTTP profiles
+- Anthropic/Claude-facing HTTP profiles
+- Google/Gemini-facing HTTP profiles
+- Ollama local profiles
+- OpenRouter aggregator profile
+- DeepSeek hosted profile
+- mock/test profile
+
+This issue uses that live registry evidence to define the first catalog
+boundary rather than inventing a new untracked profile source.
+
+## Input drift captured for remediation
+
+The authored issue input references:
+
+- `.adl/docs/TBD/ADL_PROFILES_PROVIDERS_V2.MD`
+
+That path is not present in the current tracked repository state.
+
+The live tracked inputs used instead are:
+
+- `docs/adr/0004-provider-profiles.md`
+- `adl/src/provider/profiles.rs`
+
+This is not a blocker for `#4007`, but it is authoring/input drift that should
+be corrected in follow-on remediation rather than copied forward silently.
+
+## What this proof note does not claim
+
+This note does not claim:
+
+- final role-provider suitability decisions
+- Gemma or OpenRouter reliability proof
+- provider failure-mode closure
+- provider/model closeout matrix completion
+- identity/citizen/institution design completion
+
+Those remain owned by `#4008`, `#4009`, `#4010`, `#4012`, and later work.


### PR DESCRIPTION
Closes #4007

## Summary
Defined the first WP-05 provider/capability profile catalog boundary by
splitting provider infrastructure profiles from provider-independent capability
profiles in the milestone feature doc and by recording one bounded proof note
for the split. The issue also captured stale authored-input drift: the named
`.adl/docs/TBD/ADL_PROFILES_PROVIDERS_V2.MD` source is not present in the
current tracked repository state, so this issue consumed the live ADR and Rust
registry sources instead and routed the stale path for remediation.

## Artifacts
- Updated tracked feature doc: `docs/milestones/v0.91.6/features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md`
- New tracked proof note: `docs/milestones/v0.91.6/review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4007__v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog/spp.md`
  - `.adl/v0.91.6/tasks/issue-4007__v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog/srp.md`
  - `.adl/v0.91.6/tasks/issue-4007__v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the touched branch diff was clean and publishable.
  - `pattern=$'\\x2fUsers\\x2f|\\bghp_[A-Za-z0-9]{8,}\\b|\\bgho_[A-Za-z0-9]{8,}\\b|\\bsk-[A-Za-z0-9]{8,}\\b|BEGIN [A-Z ]*PRIVATE KEY'; rg -n "$pattern" docs/milestones/v0.91.6/features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md docs/milestones/v0.91.6/review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md`
    Verified the updated and new docs stayed free of obvious secrets and private host-path leakage.
  - `test -f docs/adr/0004-provider-profiles.md && test -f docs/milestones/v0.91.6/review/provider/PROVIDER_CAPABILITY_PROFILE_CATALOG_4007.md && test -f docs/milestones/v0.91.6/features/PROVIDER_MODEL_RELIABILITY_v0.91.6.md`
    Verified the live tracked provider-profile source and the new proof output exist.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4007__v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4007__v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog/sor.md
- Idempotency-Key: v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog-adl-v0-91-6-tasks-issue-4007-v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog-sip-md-adl-v0-91-6-tasks-issue-4007-v0-91-6-wp-05-provider-m-00-define-provider-and-capability-profile-catalog-sor-md