### PR TITLE
[v0.91.6][WP-02][resilience][R-01] Implement retry policy with backoff, jitter, and budgets

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1113,6 +1113,15 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             mode = FinishValidationMode::LargerBinaryFocused;
             if paths
                 .iter()
+                .any(|path| finish_path_needs_provider_adapter_focused_validation(path))
+            {
+                push_finish_validation_command(
+                    &mut commands,
+                    "cargo test --manifest-path adl/Cargo.toml --lib provider_adapter",
+                );
+            }
+            if paths
+                .iter()
                 .any(|path| finish_path_needs_provider_communication_focused_validation(path))
             {
                 push_finish_validation_command(
@@ -1233,6 +1242,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/cli/mod.rs"
             | "adl/src/cli/github_token.rs"
             | "adl/src/lib.rs"
+            | "adl/src/provider_adapter.rs"
             | "adl/src/provider_communication.rs"
             | "adl/src/resilience.rs"
             | "adl/src/cli/tests/pr_cmd_inline/basics.rs"
@@ -1378,9 +1388,15 @@ fn finish_path_needs_runtime_owner_lane_validation(path: &str) -> bool {
     matches!(
         trimmed,
         "adl/tools/test_adl_runtime_compatibility.sh"
+            | "adl/src/provider_adapter.rs"
             | "adl/src/provider_communication.rs"
             | "adl/src/resilience.rs"
     )
+}
+
+fn finish_path_needs_provider_adapter_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/provider_adapter.rs"
 }
 
 fn finish_path_needs_provider_communication_focused_validation(path: &str) -> bool {
@@ -1578,6 +1594,18 @@ pub(super) fn run_finish_validation_rust(
                             path_str(&manifest)?,
                             "--lib",
                             "provider_communication",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --lib provider_adapter" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--lib",
+                            "provider_adapter",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -831,6 +831,20 @@ fn finish_validation_plan_classifies_owner_validation_lanes() {
 
 #[test]
 fn finish_validation_plan_classifies_resilience_runtime_publication_paths() {
+    let adapter_plan = select_finish_validation_plan("adl/src/provider_adapter.rs")
+        .expect("provider adapter runtime plan");
+    assert_eq!(adapter_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(adapter_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --lib provider_adapter".to_string()));
+    assert!(adapter_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh runtime --build".to_string()));
+    assert!(!adapter_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+
     let provider_plan = select_finish_validation_plan("adl/src/provider_communication.rs")
         .expect("provider communication runtime plan");
     assert_eq!(
@@ -866,10 +880,13 @@ fn finish_validation_plan_classifies_resilience_runtime_publication_paths() {
         .any(|command| command.contains("cargo clippy")));
 
     let mixed_plan = select_finish_validation_plan(
-        "adl/src/lib.rs,adl/src/provider_communication.rs,adl/src/resilience.rs,docs/milestones/v0.91.6/features/RESILIENCE_PERSISTENCE_SLEEP_WAKE_v0.91.6.md",
+        "adl/src/lib.rs,adl/src/provider_adapter.rs,adl/src/provider_communication.rs,adl/src/resilience.rs,docs/milestones/v0.91.6/features/RESILIENCE_PERSISTENCE_SLEEP_WAKE_v0.91.6.md",
     )
     .expect("mixed resilience runtime plan");
     assert_eq!(mixed_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(mixed_plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --lib provider_adapter".to_string()));
     assert!(mixed_plan.commands.contains(
         &"cargo test --manifest-path adl/Cargo.toml --lib provider_communication".to_string()
     ));
@@ -1349,9 +1366,10 @@ fn finish_runtime_paths_run_module_focused_validation_and_runtime_lane() {
         env::set_var("FOCUSED_LOG", &focused_log);
     }
 
-    let plan =
-        select_finish_validation_plan("adl/src/provider_communication.rs,adl/src/resilience.rs")
-            .expect("runtime focused plan");
+    let plan = select_finish_validation_plan(
+        "adl/src/provider_adapter.rs,adl/src/provider_communication.rs,adl/src/resilience.rs",
+    )
+    .expect("runtime focused plan");
     assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     run_finish_validation_rust(&repo, &plan).expect("runtime focused validation");
 
@@ -1365,6 +1383,7 @@ fn finish_runtime_paths_run_module_focused_validation_and_runtime_lane() {
 
     let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
     assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--lib provider_adapter"));
     assert!(cargo_calls.contains("--lib provider_communication"));
     assert!(cargo_calls.contains("--lib resilience"));
     assert!(!cargo_calls.contains("clippy --manifest-path"));

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -1,16 +1,20 @@
-use crate::model_identity::observed_at_now_v1;
 use crate::provider_communication::{
-    hosted_model_identity, ollama_model_identity, provider_failure_from_note,
-    validate_provider_request, ProviderAttemptPolicyV1, ProviderAttemptStatusV1, ProviderAttemptV1,
-    ProviderFailureKindV1, ProviderFailureV1, ProviderInvocationFinalStatusV1,
-    ProviderInvocationRequestV1, ProviderInvocationResultV1, ProviderRunLogEventV1,
-    ProviderRunLoggerV1, RuntimeSurfaceV1, PROVIDER_COMMUNICATION_SCHEMA_VERSION,
+    hosted_model_identity, ollama_model_identity, provider_attempt_policy_as_resilience_policy,
+    provider_failure_classification_from_failure, provider_failure_from_classification,
+    provider_failure_from_note, validate_provider_request, ProviderAttemptPolicyV1,
+    ProviderAttemptStatusV1, ProviderAttemptV1, ProviderFailureKindV1, ProviderFailureV1,
+    ProviderInvocationFinalStatusV1, ProviderInvocationRequestV1, ProviderInvocationResultV1,
+    ProviderRunLogEventV1, ProviderRunLoggerV1, RuntimeSurfaceV1,
+    PROVIDER_COMMUNICATION_SCHEMA_VERSION,
+};
+use crate::resilience::{
+    execute_retry_policy, ResilienceFaultClassV1, ResilienceSurfaceV1, RetryAttemptRecordV1,
 };
 use anyhow::{anyhow, Result};
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
+use std::cell::RefCell;
 use std::env;
-use std::thread;
 use std::time::{Duration, Instant};
 
 const DEFAULT_OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
@@ -20,7 +24,6 @@ const DEFAULT_OPENROUTER_CHAT_COMPLETIONS_URL: &str =
     "https://openrouter.ai/api/v1/chat/completions";
 const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
-const DEFAULT_BACKOFF_MS: u64 = 1_000;
 
 pub fn execute_provider_invocation(
     mut request: ProviderInvocationRequestV1,
@@ -46,118 +49,94 @@ pub fn execute_provider_invocation(
 
     let _ = logger.event(event("run_start", &request).with_status("started"));
     let policy = request.attempt_policy.clone();
-    let mut attempts = Vec::new();
-    let mut final_failure = None;
-
-    for attempt_index in 1..=policy.max_attempts {
-        let attempt_started_at = observed_at_now_v1();
-        let attempt_started = Instant::now();
-        let _ = logger.event(event("attempt_start", &request).with_attempt(attempt_index));
-
-        let outcome = match request.route.runtime_surface {
-            RuntimeSurfaceV1::HostedApi => execute_hosted(&request, &policy),
-            RuntimeSurfaceV1::OllamaHttp => execute_ollama_http(&mut request, &policy),
-            RuntimeSurfaceV1::OllamaCli | RuntimeSurfaceV1::Mock | RuntimeSurfaceV1::Unknown => {
-                Err(provider_failure_from_note(
+    let resilience_policy =
+        provider_attempt_policy_as_resilience_policy("provider_adapter.execute", &policy);
+    let route = request.route.clone();
+    let lane_ref = request.lane_ref.clone();
+    let event_model_identity = request.model_identity.clone();
+    let logger_cell = RefCell::new(&mut *logger);
+    let execution = execute_retry_policy(
+        &resilience_policy,
+        ResilienceSurfaceV1::Provider,
+        "provider_adapter.execute",
+        |attempt_index| {
+            let _ = logger_cell.borrow_mut().event(
+                ProviderRunLogEventV1::new("attempt_start")
+                    .with_route(&route, &event_model_identity)
+                    .with_lane(&lane_ref)
+                    .with_attempt(attempt_index),
+            );
+            match request.route.runtime_surface {
+                RuntimeSurfaceV1::HostedApi => execute_hosted(&request, &policy),
+                RuntimeSurfaceV1::OllamaHttp => execute_ollama_http(&mut request, &policy),
+                RuntimeSurfaceV1::OllamaCli
+                | RuntimeSurfaceV1::Mock
+                | RuntimeSurfaceV1::Unknown => Err(provider_failure_from_note(
                     "unsupported provider runtime surface",
                     None,
-                ))
+                )),
             }
-        };
+        },
+        |failure| provider_failure_classification_from_failure(failure),
+        |delay_ms| std::thread::sleep(Duration::from_millis(delay_ms)),
+        |attempt| {
+            emit_retry_attempt_event(
+                &mut logger_cell.borrow_mut(),
+                &route,
+                &lane_ref,
+                &event_model_identity,
+                attempt,
+            )
+        },
+    );
+    let duration_ms = started.elapsed().as_millis() as u64;
 
-        let duration_ms = attempt_started.elapsed().as_millis() as u64;
-        match outcome {
-            Ok(provider_response) => {
-                let output_text = provider_response.output_text;
-                let mut model_identity = request.model_identity.clone();
-                if let Some(observed_provider_model_id) =
-                    provider_response.observed_provider_model_id
-                {
-                    if !observed_provider_model_id.trim().is_empty() {
-                        model_identity.provider_model_id = observed_provider_model_id;
-                    }
+    match execution.result {
+        Ok(provider_response) => {
+            let output_text = provider_response.output_text.clone();
+            let mut model_identity = request.model_identity.clone();
+            if let Some(ref observed_provider_model_id) =
+                provider_response.observed_provider_model_id
+            {
+                if !observed_provider_model_id.trim().is_empty() {
+                    model_identity.provider_model_id = observed_provider_model_id.clone();
                 }
-                attempts.push(ProviderAttemptV1 {
-                    attempt_index,
-                    started_at: attempt_started_at,
-                    duration_ms,
-                    status: ProviderAttemptStatusV1::Ok,
-                    retryable: false,
-                    http_status: Some(provider_response.http_status),
-                    failure: None,
-                    raw_response_excerpt: Some(redacted_response_marker(&output_text)),
-                });
-                let _ = logger.event(
-                    event("attempt_success", &request)
-                        .with_attempt(attempt_index)
-                        .with_status("ok"),
-                );
-                let _ = logger.event(event("run_finish", &request).with_status("ok"));
-                return ProviderInvocationResultV1 {
-                    schema_version: PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string(),
-                    route: request.route,
-                    model_identity,
-                    attempts,
-                    final_status: ProviderInvocationFinalStatusV1::Ok,
-                    duration_ms: started.elapsed().as_millis() as u64,
-                    request_id: request.request_id.clone(),
-                    output_text: Some(output_text.clone()),
-                    output_text_excerpt: Some(redacted_response_marker(&output_text)),
-                    failure: None,
-                    artifact_ref: None,
-                    trace_ref: None,
-                };
             }
-            Err(mut failure) => {
-                let retryable = failure.retryable && attempt_index < policy.max_attempts;
-                failure.retryable = retryable;
-                let status = if matches!(failure.kind, ProviderFailureKindV1::ProviderTimeout) {
-                    ProviderAttemptStatusV1::Timeout
-                } else {
-                    ProviderAttemptStatusV1::Error
-                };
-                attempts.push(ProviderAttemptV1 {
-                    attempt_index,
-                    started_at: attempt_started_at,
-                    duration_ms,
-                    status,
-                    retryable,
-                    http_status: failure.http_status,
-                    failure: Some(failure.clone()),
-                    raw_response_excerpt: None,
-                });
-                let _ = logger.event(
-                    event("attempt_failure", &request)
-                        .with_attempt(attempt_index)
-                        .with_failure(&failure)
-                        .with_status("failed"),
-                );
-                final_failure = Some(failure.clone());
-                if retryable {
-                    thread::sleep(Duration::from_millis(
-                        policy.retry_backoff_ms.unwrap_or(DEFAULT_BACKOFF_MS),
-                    ));
-                } else {
-                    break;
-                }
+            let attempts = provider_attempts_from_trace(
+                &execution.trace.attempts,
+                Some(&provider_response),
+                None,
+            );
+            let _ = logger_cell
+                .borrow_mut()
+                .event(event("run_finish", &request).with_status("ok"));
+            ProviderInvocationResultV1 {
+                schema_version: PROVIDER_COMMUNICATION_SCHEMA_VERSION.to_string(),
+                route: request.route,
+                model_identity,
+                attempts,
+                final_status: ProviderInvocationFinalStatusV1::Ok,
+                duration_ms,
+                request_id: request.request_id.clone(),
+                output_text: Some(output_text.clone()),
+                output_text_excerpt: Some(redacted_response_marker(&output_text)),
+                failure: None,
+                artifact_ref: None,
+                trace_ref: None,
             }
         }
+        Err(failure) => {
+            let failure = normalize_terminal_failure(&execution.trace.attempts, &failure);
+            let attempts =
+                provider_attempts_from_trace(&execution.trace.attempts, None, Some(&failure));
+            let _ = logger_cell.borrow_mut().event(
+                event("run_finish", &request)
+                    .with_failure(&failure)
+                    .with_status("failed"),
+            );
+            failed_result(request, attempts, failure, duration_ms)
+        }
     }
-
-    let failure = final_failure.unwrap_or_else(|| {
-        provider_failure_from_note("provider adapter ended without a result", None)
-    });
-    let _ = logger.event(
-        event("run_finish", &request)
-            .with_failure(&failure)
-            .with_status("failed"),
-    );
-    failed_result(
-        request,
-        attempts,
-        failure,
-        started.elapsed().as_millis() as u64,
-    )
 }
 
 fn failed_result(
@@ -179,6 +158,106 @@ fn failed_result(
         failure: Some(failure),
         artifact_ref: None,
         trace_ref: None,
+    }
+}
+
+fn provider_attempts_from_trace(
+    records: &[RetryAttemptRecordV1],
+    success: Option<&ProviderTextResponse>,
+    final_failure: Option<&ProviderFailureV1>,
+) -> Vec<ProviderAttemptV1> {
+    let success_attempt = success.map(|_| records.len() as u32);
+    records
+        .iter()
+        .map(|record| {
+            if let Some(classification) = &record.fault {
+                ProviderAttemptV1 {
+                    attempt_index: record.attempt_index,
+                    started_at: record.started_at.clone(),
+                    duration_ms: record.duration_ms,
+                    status: if matches!(
+                        classification.fault_class,
+                        ResilienceFaultClassV1::ProviderTimeout
+                    ) {
+                        ProviderAttemptStatusV1::Timeout
+                    } else {
+                        ProviderAttemptStatusV1::Error
+                    },
+                    retryable: record.retry_allowed,
+                    http_status: classification.http_status,
+                    failure: provider_failure_from_attempt_record(record),
+                    raw_response_excerpt: None,
+                }
+            } else {
+                let output_text = if success_attempt == Some(record.attempt_index) {
+                    success.map(|response| redacted_response_marker(&response.output_text))
+                } else {
+                    final_failure.map(|_| redacted_response_marker(""))
+                };
+                ProviderAttemptV1 {
+                    attempt_index: record.attempt_index,
+                    started_at: record.started_at.clone(),
+                    duration_ms: record.duration_ms,
+                    status: ProviderAttemptStatusV1::Ok,
+                    retryable: false,
+                    http_status: success.map(|response| response.http_status),
+                    failure: None,
+                    raw_response_excerpt: output_text,
+                }
+            }
+        })
+        .collect()
+}
+
+fn provider_failure_from_attempt_record(
+    record: &RetryAttemptRecordV1,
+) -> Option<ProviderFailureV1> {
+    let classification = record.fault.as_ref()?;
+    let mut failure = provider_failure_from_classification(classification);
+    failure.retryable = record.retry_allowed;
+    Some(failure)
+}
+
+fn normalize_terminal_failure(
+    records: &[RetryAttemptRecordV1],
+    failure: &ProviderFailureV1,
+) -> ProviderFailureV1 {
+    let mut normalized = failure.clone();
+    if let Some(record) = records.last() {
+        normalized.retryable = record.retry_allowed;
+    }
+    normalized
+}
+
+fn emit_retry_attempt_event(
+    logger: &mut ProviderRunLoggerV1,
+    route: &crate::provider_communication::ProviderRouteV1,
+    lane_ref: &str,
+    model_identity: &crate::model_identity::ModelIdentityV1,
+    attempt: &RetryAttemptRecordV1,
+) {
+    match &attempt.fault {
+        Some(_) => {
+            let failure = provider_failure_from_attempt_record(attempt)
+                .expect("attempt with fault must map to provider failure");
+            let _ = logger.event(
+                ProviderRunLogEventV1::new("attempt_failure")
+                    .with_route(route, model_identity)
+                    .with_lane(lane_ref)
+                    .with_attempt(attempt.attempt_index)
+                    .with_failure(&failure)
+                    .with_status("failed"),
+            );
+        }
+        None => {
+            let _ = logger.event(
+                ProviderRunLogEventV1::new("attempt_success")
+                    .with_route(route, model_identity)
+                    .with_lane(lane_ref)
+                    .with_attempt(attempt.attempt_index)
+                    .with_status("ok"),
+            );
+        }
     }
 }
 
@@ -1067,6 +1146,144 @@ mod tests {
         );
         let _ = fs::remove_file(path);
         env::remove_var("ADL_PROVIDER_ADAPTER_OPENAI_ARRAY_KEY");
+    }
+
+    #[test]
+    fn hosted_openai_retries_retryable_failure_then_succeeds() {
+        env::set_var("ADL_PROVIDER_ADAPTER_RETRY_KEY", "test-key");
+        let endpoint = scripted_server(vec![
+            (
+                r#"{"error":"rate limit exceeded"}"#,
+                "429 Too Many Requests",
+            ),
+            (r#"{"output_text":"retry success"}"#, "200 OK"),
+        ]);
+        let path = temp_log("retry-success");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_RETRY_KEY".to_string());
+        req.attempt_policy.max_attempts = 2;
+        req.attempt_policy.retry_backoff_ms = Some(1);
+
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("retry success"));
+        assert_eq!(result.attempts.len(), 2);
+        assert_eq!(
+            result.attempts[0]
+                .failure
+                .as_ref()
+                .map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderRateLimited)
+        );
+        assert!(result.attempts[0].retryable);
+        assert_eq!(
+            result.attempts[0]
+                .failure
+                .as_ref()
+                .map(|failure| failure.retryable),
+            Some(true)
+        );
+        assert_eq!(result.attempts[1].status, ProviderAttemptStatusV1::Ok);
+
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_RETRY_KEY");
+    }
+
+    #[test]
+    fn hosted_openai_stops_after_non_retryable_failure() {
+        env::set_var("ADL_PROVIDER_ADAPTER_NONRETRY_KEY", "test-key");
+        let endpoint = scripted_server(vec![
+            (r#"{"error":"unauthorized"}"#, "401 Unauthorized"),
+            (r#"{"output_text":"should not be reached"}"#, "200 OK"),
+        ]);
+        let path = temp_log("nonretryable");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_NONRETRY_KEY".to_string());
+        req.attempt_policy.max_attempts = 3;
+        req.attempt_policy.retry_backoff_ms = Some(1);
+
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(result.attempts.len(), 1);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderAuthError)
+        );
+        assert!(!result.attempts[0].retryable);
+        assert_eq!(
+            result.attempts[0]
+                .failure
+                .as_ref()
+                .map(|failure| failure.retryable),
+            Some(false)
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.retryable),
+            Some(false)
+        );
+
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_NONRETRY_KEY");
+    }
+
+    #[test]
+    fn hosted_openai_reports_retry_budget_exhaustion_after_last_retryable_failure() {
+        env::set_var("ADL_PROVIDER_ADAPTER_EXHAUST_KEY", "test-key");
+        let endpoint = scripted_server(vec![
+            (
+                r#"{"error":"server overloaded"}"#,
+                "503 Service Unavailable",
+            ),
+            (
+                r#"{"error":"server overloaded"}"#,
+                "503 Service Unavailable",
+            ),
+        ]);
+        let path = temp_log("retry-exhausted");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_EXHAUST_KEY".to_string());
+        req.attempt_policy.max_attempts = 2;
+        req.attempt_policy.retry_backoff_ms = Some(1);
+
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(result.attempts.len(), 2);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderTransientHttp)
+        );
+        assert!(result.attempts[0].retryable);
+        assert!(!result.attempts[1].retryable);
+        assert_eq!(
+            result.attempts[0]
+                .failure
+                .as_ref()
+                .map(|failure| failure.retryable),
+            Some(true)
+        );
+        assert_eq!(
+            result.attempts[1]
+                .failure
+                .as_ref()
+                .map(|failure| failure.retryable),
+            Some(false)
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.retryable),
+            Some(false)
+        );
+
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_EXHAUST_KEY");
     }
 
     #[test]

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -77,7 +77,7 @@ pub fn execute_provider_invocation(
                 )),
             }
         },
-        |failure| provider_failure_classification_from_failure(failure),
+        provider_failure_classification_from_failure,
         |delay_ms| std::thread::sleep(Duration::from_millis(delay_ms)),
         |attempt| {
             emit_retry_attempt_event(

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -829,6 +829,7 @@ pub fn validate_review_provider_result(result: &ReviewProviderResultV1) -> Resul
     Ok(())
 }
 
+#[cfg(test)]
 fn sanitize_provider_message(note: &str) -> String {
     sanitize_resilience_summary(note)
 }
@@ -841,10 +842,6 @@ fn scrub_log_event(event: &mut ProviderRunLogEventV1) {
         event.fields =
             Some(serde_json::json!({"redacted": "event fields omitted from provider run log"}));
     }
-}
-
-fn redacted_excerpt(note: &str) -> String {
-    format!("[redacted provider detail len={}]", note.len())
 }
 
 fn require_non_empty(field: &str, value: &str) -> Result<()> {

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -413,18 +413,7 @@ pub fn classify_provider_failure(note: &str, http_status: Option<u16>) -> Provid
 
 pub fn provider_failure_from_note(note: &str, http_status: Option<u16>) -> ProviderFailureV1 {
     let classification = provider_fault_classification(note, http_status);
-    let kind = provider_failure_kind_from_resilience(&classification);
-    let retryable = matches!(
-        classification.disposition,
-        ResilienceFaultDispositionV1::Retryable
-    );
-    ProviderFailureV1 {
-        kind,
-        retryable,
-        message: sanitize_provider_message(note),
-        provider_error_excerpt: Some(redacted_excerpt(note)),
-        http_status,
-    }
+    provider_failure_from_classification(&classification)
 }
 
 pub fn provider_fault_classification(
@@ -432,6 +421,90 @@ pub fn provider_fault_classification(
     http_status: Option<u16>,
 ) -> ResilienceFaultClassificationV1 {
     ResilienceFaultClassificationV1::provider(note, http_status)
+}
+
+pub fn provider_failure_classification_from_failure(
+    failure: &ProviderFailureV1,
+) -> ResilienceFaultClassificationV1 {
+    let (fault_class, disposition) = match failure.kind {
+        ProviderFailureKindV1::ProviderAuthMissing => (
+            ResilienceFaultClassV1::ProviderAuthMissing,
+            ResilienceFaultDispositionV1::OperatorGated,
+        ),
+        ProviderFailureKindV1::ProviderAuthError => (
+            ResilienceFaultClassV1::ProviderAuthError,
+            ResilienceFaultDispositionV1::OperatorGated,
+        ),
+        ProviderFailureKindV1::ProviderRateLimited => (
+            ResilienceFaultClassV1::ProviderRateLimited,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::ProviderTimeout => (
+            ResilienceFaultClassV1::ProviderTimeout,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::ProviderTransientHttp => (
+            ResilienceFaultClassV1::ProviderTransientHttp,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::ProviderEmptyTextOutput => (
+            ResilienceFaultClassV1::ProviderEmptyTextOutput,
+            ResilienceFaultDispositionV1::Terminal,
+        ),
+        ProviderFailureKindV1::ProviderModelUnavailable => (
+            ResilienceFaultClassV1::ProviderModelUnavailable,
+            ResilienceFaultDispositionV1::Terminal,
+        ),
+        ProviderFailureKindV1::ProviderBillingBlocked => (
+            ResilienceFaultClassV1::ProviderBillingBlocked,
+            ResilienceFaultDispositionV1::OperatorGated,
+        ),
+        ProviderFailureKindV1::LocalRuntimeUnavailable => (
+            ResilienceFaultClassV1::LocalRuntimeUnavailable,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::LocalRuntimeBusy => (
+            ResilienceFaultClassV1::LocalRuntimeBusy,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::LocalRuntimeHung => (
+            ResilienceFaultClassV1::LocalRuntimeHung,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+        ProviderFailureKindV1::ProviderError => (
+            ResilienceFaultClassV1::ProviderError,
+            ResilienceFaultDispositionV1::Terminal,
+        ),
+        ProviderFailureKindV1::Unknown => (
+            ResilienceFaultClassV1::Unknown,
+            ResilienceFaultDispositionV1::Retryable,
+        ),
+    };
+    ResilienceFaultClassificationV1 {
+        schema_version: crate::resilience::RESILIENCE_FAULT_CLASSIFICATION_SCHEMA_V1.to_string(),
+        surface: crate::resilience::ResilienceSurfaceV1::Provider,
+        fault_class,
+        disposition: disposition.clone(),
+        retryable: matches!(disposition, ResilienceFaultDispositionV1::Retryable),
+        summary: sanitize_resilience_summary(&failure.message),
+        component_ref: None,
+        http_status: failure.http_status,
+    }
+}
+
+pub fn provider_failure_from_classification(
+    classification: &ResilienceFaultClassificationV1,
+) -> ProviderFailureV1 {
+    ProviderFailureV1 {
+        kind: provider_failure_kind_from_resilience(classification),
+        retryable: matches!(
+            classification.disposition,
+            ResilienceFaultDispositionV1::Retryable
+        ),
+        message: classification.summary.clone(),
+        provider_error_excerpt: Some(classification.summary.clone()),
+        http_status: classification.http_status,
+    }
 }
 
 pub fn provider_attempt_policy_as_resilience_policy(
@@ -974,6 +1047,26 @@ mod tests {
             None,
         );
         assert_eq!(classification.summary, "redacted provider diagnostic");
+    }
+
+    #[test]
+    fn provider_failure_round_trips_through_shared_resilience_vocab() {
+        let failure = ProviderFailureV1 {
+            kind: ProviderFailureKindV1::ProviderRateLimited,
+            retryable: true,
+            message: "rate limit exceeded".to_string(),
+            provider_error_excerpt: Some("rate limit exceeded".to_string()),
+            http_status: Some(429),
+        };
+        let classification = provider_failure_classification_from_failure(&failure);
+        assert_eq!(
+            classification.fault_class,
+            ResilienceFaultClassV1::ProviderRateLimited
+        );
+        let remapped = provider_failure_from_classification(&classification);
+        assert_eq!(remapped.kind, ProviderFailureKindV1::ProviderRateLimited);
+        assert!(remapped.retryable);
+        assert_eq!(remapped.http_status, Some(429));
     }
 
     #[test]

--- a/adl/src/resilience.rs
+++ b/adl/src/resilience.rs
@@ -1,7 +1,9 @@
+use crate::model_identity::observed_at_now_v1;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 pub const RESILIENCE_FAULT_CLASSIFICATION_SCHEMA_V1: &str =
     "adl.resilience.fault_classification.v1";
@@ -9,6 +11,9 @@ pub const RESILIENCE_CITIZEN_HEALTH_SCHEMA_V1: &str = "adl.resilience.citizen_he
 pub const RESILIENCE_RECOVERY_ARTIFACT_SCHEMA_V1: &str = "adl.resilience.recovery_artifact.v1";
 pub const RESILIENCE_CHECKPOINT_SCHEMA_V1: &str = "adl.resilience.checkpoint.v1";
 pub const RESILIENCE_TELEMETRY_EVENT_SCHEMA_V1: &str = "adl.resilience.telemetry_event.v1";
+pub const RESILIENCE_RETRY_ATTEMPT_SCHEMA_V1: &str = "adl.resilience.retry_attempt.v1";
+pub const RESILIENCE_RETRY_EXECUTION_TRACE_SCHEMA_V1: &str =
+    "adl.resilience.retry_execution_trace.v1";
 pub const RESILIENCE_TIMEOUT_EXECUTION_TRACE_SCHEMA_V1: &str =
     "adl.resilience.timeout_execution_trace.v1";
 pub const RESILIENCE_POLICY_SCHEMA_V1: &str = "adl.resilience.policy.v1";
@@ -199,8 +204,64 @@ pub struct RetryPolicyV1 {
     pub backoff_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jitter_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_elapsed_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub retryable_fault_classes: Vec<ResilienceFaultClassV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryTerminalReasonV1 {
+    Succeeded,
+    NonRetryableFault,
+    RetryBudgetExhausted,
+    RetryTimeBudgetExhausted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RetryAttemptRecordV1 {
+    pub schema_version: String,
+    pub attempt_index: u32,
+    pub started_at: String,
+    pub duration_ms: u64,
+    pub retry_allowed: bool,
+    pub scheduled_backoff_ms: u64,
+    pub decision_summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<RetryTerminalReasonV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fault: Option<ResilienceFaultClassificationV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryExecutionFinalStatusV1 {
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RetryExecutionTraceV1 {
+    pub schema_version: String,
+    pub policy_id: String,
+    pub surface: ResilienceSurfaceV1,
+    pub final_status: RetryExecutionFinalStatusV1,
+    pub total_duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attempts: Vec<RetryAttemptRecordV1>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub telemetry_events: Vec<ResilienceTelemetryEventV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_artifact: Option<RecoveryArtifactV1>,
+}
+
+#[derive(Debug)]
+pub struct RetryExecution<T, E> {
+    pub result: Result<T, E>,
+    pub trace: RetryExecutionTraceV1,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -448,6 +509,7 @@ impl ResiliencePolicyV1 {
                 max_attempts,
                 backoff_ms: None,
                 jitter_ms: None,
+                max_elapsed_ms: None,
                 retryable_fault_classes: vec![
                     ResilienceFaultClassV1::ProviderRateLimited,
                     ResilienceFaultClassV1::ProviderTimeout,
@@ -470,6 +532,177 @@ impl ResiliencePolicyV1 {
             telemetry_required: true,
         }
     }
+}
+
+impl RetryPolicyV1 {
+    fn permits_fault(&self, classification: &ResilienceFaultClassificationV1) -> bool {
+        if !classification.retryable {
+            return false;
+        }
+        self.retryable_fault_classes.is_empty()
+            || self
+                .retryable_fault_classes
+                .contains(&classification.fault_class)
+    }
+
+    fn next_delay_ms(&self, policy_id: &str, attempt_index: u32) -> u64 {
+        let base = self.backoff_ms.unwrap_or(0);
+        let multiplier_shift = attempt_index.saturating_sub(1).min(20);
+        let multiplier = 1_u64 << multiplier_shift;
+        let backoff = base.saturating_mul(multiplier);
+        backoff.saturating_add(deterministic_jitter_ms(
+            policy_id,
+            attempt_index,
+            self.jitter_ms.unwrap_or(0),
+        ))
+    }
+}
+
+pub fn execute_retry_policy<T, E, F, C, S, O>(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    operation_ref: &str,
+    mut operation: F,
+    mut classify_error: C,
+    mut sleep_fn: S,
+    mut observe_attempt: O,
+) -> RetryExecution<T, E>
+where
+    E: Clone,
+    F: FnMut(u32) -> Result<T, E>,
+    C: FnMut(&E) -> ResilienceFaultClassificationV1,
+    S: FnMut(u64),
+    O: FnMut(&RetryAttemptRecordV1),
+{
+    let retry = policy.retry.clone().unwrap_or(RetryPolicyV1 {
+        max_attempts: 1,
+        backoff_ms: None,
+        jitter_ms: None,
+        max_elapsed_ms: None,
+        retryable_fault_classes: Vec::new(),
+    });
+    let started = Instant::now();
+    let mut attempts = Vec::new();
+    let mut telemetry_events = Vec::new();
+
+    for attempt_index in 1..=retry.max_attempts.max(1) {
+        let attempt_started_at = observed_at_now_v1();
+        let attempt_started = Instant::now();
+        match operation(attempt_index) {
+            Ok(value) => {
+                let record = RetryAttemptRecordV1 {
+                    schema_version: RESILIENCE_RETRY_ATTEMPT_SCHEMA_V1.to_string(),
+                    attempt_index,
+                    started_at: attempt_started_at.clone(),
+                    duration_ms: attempt_started.elapsed().as_millis() as u64,
+                    retry_allowed: false,
+                    scheduled_backoff_ms: 0,
+                    decision_summary: format!("attempt {attempt_index} succeeded"),
+                    terminal_reason: Some(RetryTerminalReasonV1::Succeeded),
+                    fault: None,
+                };
+                observe_attempt(&record);
+                telemetry_events.push(retry_decision_event(
+                    policy,
+                    surface.clone(),
+                    operation_ref,
+                    attempt_index,
+                    &record.decision_summary,
+                    None,
+                ));
+                attempts.push(record);
+                return RetryExecution {
+                    result: Ok(value),
+                    trace: RetryExecutionTraceV1 {
+                        schema_version: RESILIENCE_RETRY_EXECUTION_TRACE_SCHEMA_V1.to_string(),
+                        policy_id: policy.policy_id.clone(),
+                        surface,
+                        final_status: RetryExecutionFinalStatusV1::Succeeded,
+                        total_duration_ms: started.elapsed().as_millis() as u64,
+                        attempts,
+                        telemetry_events,
+                        recovery_artifact: None,
+                    },
+                };
+            }
+            Err(error) => {
+                let classification = classify_error(&error);
+                let delay_ms = retry.next_delay_ms(&policy.policy_id, attempt_index);
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                let retryable_fault = retry.permits_fault(&classification);
+                let within_attempt_budget = attempt_index < retry.max_attempts.max(1);
+                let within_time_budget = retry
+                    .max_elapsed_ms
+                    .map(|max_elapsed_ms| elapsed_ms.saturating_add(delay_ms) <= max_elapsed_ms)
+                    .unwrap_or(true);
+                let retry_allowed = retryable_fault && within_attempt_budget && within_time_budget;
+                let terminal_reason = if retry_allowed {
+                    None
+                } else if !retryable_fault {
+                    Some(RetryTerminalReasonV1::NonRetryableFault)
+                } else if !within_attempt_budget {
+                    Some(RetryTerminalReasonV1::RetryBudgetExhausted)
+                } else {
+                    Some(RetryTerminalReasonV1::RetryTimeBudgetExhausted)
+                };
+                let decision_summary = retry_decision_summary(
+                    attempt_index,
+                    &classification,
+                    retry_allowed,
+                    delay_ms,
+                    terminal_reason.as_ref(),
+                );
+                let record = RetryAttemptRecordV1 {
+                    schema_version: RESILIENCE_RETRY_ATTEMPT_SCHEMA_V1.to_string(),
+                    attempt_index,
+                    started_at: attempt_started_at,
+                    duration_ms: attempt_started.elapsed().as_millis() as u64,
+                    retry_allowed,
+                    scheduled_backoff_ms: if retry_allowed { delay_ms } else { 0 },
+                    decision_summary: decision_summary.clone(),
+                    terminal_reason: terminal_reason.clone(),
+                    fault: Some(classification.clone()),
+                };
+                observe_attempt(&record);
+                telemetry_events.push(retry_decision_event(
+                    policy,
+                    surface.clone(),
+                    operation_ref,
+                    attempt_index,
+                    &decision_summary,
+                    Some(classification.clone()),
+                ));
+                attempts.push(record);
+                if retry_allowed {
+                    sleep_fn(delay_ms);
+                    continue;
+                }
+
+                let recovery_artifact = Some(recovery_artifact_for_failure(
+                    policy,
+                    surface.clone(),
+                    attempt_index,
+                    &classification,
+                    terminal_reason.unwrap_or(RetryTerminalReasonV1::NonRetryableFault),
+                ));
+                return RetryExecution {
+                    result: Err(error),
+                    trace: RetryExecutionTraceV1 {
+                        schema_version: RESILIENCE_RETRY_EXECUTION_TRACE_SCHEMA_V1.to_string(),
+                        policy_id: policy.policy_id.clone(),
+                        surface,
+                        final_status: RetryExecutionFinalStatusV1::Failed,
+                        total_duration_ms: started.elapsed().as_millis() as u64,
+                        attempts,
+                        telemetry_events,
+                        recovery_artifact,
+                    },
+                };
+            }
+        }
+    }
+
+    unreachable!("retry execution should return inside the attempt loop")
 }
 
 impl ResilienceSubstrateManifestV1 {
@@ -748,6 +981,120 @@ pub(crate) fn sanitize_resilience_summary(note: &str) -> String {
         return "redacted provider diagnostic".to_string();
     }
     truncate_chars(&text, 180)
+}
+
+fn deterministic_jitter_ms(policy_id: &str, attempt_index: u32, max_jitter_ms: u64) -> u64 {
+    if max_jitter_ms == 0 {
+        return 0;
+    }
+    let mut hash = 1469598103934665603_u64;
+    for byte in policy_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    hash ^= u64::from(attempt_index);
+    hash = hash.wrapping_mul(1099511628211);
+    hash % max_jitter_ms.saturating_add(1)
+}
+
+fn retry_decision_summary(
+    attempt_index: u32,
+    classification: &ResilienceFaultClassificationV1,
+    retry_allowed: bool,
+    delay_ms: u64,
+    terminal_reason: Option<&RetryTerminalReasonV1>,
+) -> String {
+    if retry_allowed {
+        format!(
+            "attempt {attempt_index} classified {:?}; retry scheduled after {delay_ms}ms",
+            classification.fault_class
+        )
+    } else {
+        match terminal_reason {
+            Some(reason) => format!(
+                "attempt {attempt_index} classified {:?}; terminal reason {:?}",
+                classification.fault_class, reason
+            ),
+            None => format!(
+                "attempt {attempt_index} classified {:?}; retry not allowed",
+                classification.fault_class
+            ),
+        }
+    }
+}
+
+fn retry_decision_event(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    operation_ref: &str,
+    attempt_index: u32,
+    decision_summary: &str,
+    fault: Option<ResilienceFaultClassificationV1>,
+) -> ResilienceTelemetryEventV1 {
+    ResilienceTelemetryEventV1 {
+        schema_version: RESILIENCE_TELEMETRY_EVENT_SCHEMA_V1.to_string(),
+        event_id: format!("{}:retry:{attempt_index}", policy.policy_id),
+        event_kind: TelemetryEventKindV1::RetryDecision,
+        surface,
+        decision_summary: format!("{operation_ref}: {decision_summary}"),
+        run_id: None,
+        request_id: None,
+        policy_ref: Some(policy.policy_id.clone()),
+        fault,
+        artifact_ref: None,
+    }
+}
+
+fn recovery_artifact_for_failure(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    attempt_index: u32,
+    triggering_fault: &ResilienceFaultClassificationV1,
+    terminal_reason: RetryTerminalReasonV1,
+) -> RecoveryArtifactV1 {
+    let (disposition, next_action) = match terminal_reason {
+        RetryTerminalReasonV1::RetryBudgetExhausted => (
+            RecoveryDispositionV1::OperatorInterventionRequired,
+            format!(
+                "retry budget exhausted after attempt {attempt_index}; operator must decide whether to widen the retry budget"
+            ),
+        ),
+        RetryTerminalReasonV1::RetryTimeBudgetExhausted => (
+            RecoveryDispositionV1::OperatorInterventionRequired,
+            format!(
+                "retry time budget exhausted after attempt {attempt_index}; operator must decide whether to widen the elapsed budget"
+            ),
+        ),
+        RetryTerminalReasonV1::NonRetryableFault => match triggering_fault.disposition {
+            ResilienceFaultDispositionV1::DegradedAllowed => (
+                RecoveryDispositionV1::FallbackAllowed,
+                "fault is non-retryable here; route to a degraded or fallback path".to_string(),
+            ),
+            ResilienceFaultDispositionV1::QuarantineRequired => (
+                RecoveryDispositionV1::QuarantineRequired,
+                "fault requires quarantine before retrying the surface".to_string(),
+            ),
+            _ => (
+                RecoveryDispositionV1::OperatorInterventionRequired,
+                "fault is non-retryable; inspect the failure before attempting recovery".to_string(),
+            ),
+        },
+        RetryTerminalReasonV1::Succeeded => (
+            RecoveryDispositionV1::ResumeAllowed,
+            "operation completed successfully".to_string(),
+        ),
+    };
+    RecoveryArtifactV1 {
+        schema_version: RESILIENCE_RECOVERY_ARTIFACT_SCHEMA_V1.to_string(),
+        artifact_id: format!("{}:recovery:{attempt_index}", policy.policy_id),
+        surface,
+        triggering_fault: triggering_fault.clone(),
+        disposition,
+        next_action,
+        source_run_id: None,
+        checkpoint_ref: None,
+        evidence_refs: vec![policy.policy_id.clone()],
+    }
 }
 
 fn truncate_chars(text: &str, max_chars: usize) -> String {
@@ -1137,6 +1484,7 @@ mod tests {
     }
 
     #[test]
+<<<<<<< HEAD
     fn execute_timeout_policy_succeeds_before_deadline() {
         let policy = ResiliencePolicyV1::provider_attempt_policy("timeout.success", 1, 100);
         let execution = execute_timeout_policy(
@@ -1741,5 +2089,136 @@ mod tests {
         let provider_error =
             ResilienceFaultClassificationV1::provider("provider_internal_error", Some(500));
         assert!(!classification_represents_timeout(&provider_error));
+    }
+
+    #[test]
+    fn retry_policy_delay_is_deterministic_and_bounded_by_jitter() {
+        let retry = RetryPolicyV1 {
+            max_attempts: 3,
+            backoff_ms: Some(100),
+            jitter_ms: Some(25),
+            max_elapsed_ms: None,
+            retryable_fault_classes: vec![ResilienceFaultClassV1::ProviderTimeout],
+        };
+        let first = retry.next_delay_ms("policy.retry", 1);
+        let second = retry.next_delay_ms("policy.retry", 1);
+        let third_attempt = retry.next_delay_ms("policy.retry", 3);
+        assert_eq!(first, second);
+        assert!((100..=125).contains(&first));
+        assert!((400..=425).contains(&third_attempt));
+    }
+
+    #[test]
+    fn execute_retry_policy_retries_and_emits_trace() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "retry.trace".to_string(),
+            retry: Some(RetryPolicyV1 {
+                max_attempts: 3,
+                backoff_ms: Some(5),
+                jitter_ms: Some(0),
+                max_elapsed_ms: None,
+                retryable_fault_classes: vec![ResilienceFaultClassV1::ProviderTimeout],
+            }),
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: None,
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+        let mut attempts = Vec::new();
+        let mut sleeps = Vec::new();
+        let mut observed = Vec::new();
+        let execution = execute_retry_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.retry",
+            |attempt_index| {
+                attempts.push(attempt_index);
+                if attempt_index < 3 {
+                    Err(ResilienceFaultClassificationV1::provider(
+                        "provider timeout",
+                        Some(504),
+                    ))
+                } else {
+                    Ok("ok")
+                }
+            },
+            |error| error.clone(),
+            |delay_ms| sleeps.push(delay_ms),
+            |record| observed.push(record.clone()),
+        );
+        assert_eq!(execution.result.expect("final success"), "ok");
+        assert_eq!(attempts, vec![1, 2, 3]);
+        assert_eq!(sleeps, vec![5, 10]);
+        assert_eq!(observed.len(), 3);
+        assert_eq!(
+            execution.trace.schema_version,
+            RESILIENCE_RETRY_EXECUTION_TRACE_SCHEMA_V1
+        );
+        assert!(execution
+            .trace
+            .attempts
+            .iter()
+            .all(|attempt| attempt.schema_version == RESILIENCE_RETRY_ATTEMPT_SCHEMA_V1));
+        assert_eq!(execution.trace.telemetry_events.len(), 3);
+        assert_eq!(
+            execution.trace.final_status,
+            RetryExecutionFinalStatusV1::Succeeded
+        );
+        assert!(execution.trace.recovery_artifact.is_none());
+    }
+
+    #[test]
+    fn execute_retry_policy_emits_recovery_artifact_when_budget_exhausts() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "retry.exhausted".to_string(),
+            retry: Some(RetryPolicyV1 {
+                max_attempts: 2,
+                backoff_ms: Some(1),
+                jitter_ms: Some(0),
+                max_elapsed_ms: None,
+                retryable_fault_classes: vec![ResilienceFaultClassV1::ProviderTransientHttp],
+            }),
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: None,
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+        let execution: RetryExecution<(), ResilienceFaultClassificationV1> = execute_retry_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.retry.exhausted",
+            |_| {
+                Err(ResilienceFaultClassificationV1::provider(
+                    "server 503",
+                    Some(503),
+                ))
+            },
+            |error| error.clone(),
+            |_| {},
+            |_| {},
+        );
+        let failure = execution.result.expect_err("final failure");
+        assert_eq!(
+            failure.fault_class,
+            ResilienceFaultClassV1::ProviderTransientHttp
+        );
+        assert_eq!(execution.trace.attempts.len(), 2);
+        let recovery = execution
+            .trace
+            .recovery_artifact
+            .expect("recovery artifact");
+        assert_eq!(
+            recovery.disposition,
+            RecoveryDispositionV1::OperatorInterventionRequired
+        );
+        assert!(recovery.next_action.contains("retry budget exhausted"));
     }
 }

--- a/adl/src/resilience.rs
+++ b/adl/src/resilience.rs
@@ -1484,7 +1484,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
     fn execute_timeout_policy_succeeds_before_deadline() {
         let policy = ResiliencePolicyV1::provider_attempt_policy("timeout.success", 1, 100);
         let execution = execute_timeout_policy(


### PR DESCRIPTION
Closes #3987

## Summary
Implemented the shared retry execution substrate for WP-02 R-01 and wired provider invocation through it with deterministic backoff, bounded retry budgets, retry telemetry/recovery artifacts, and focused regression coverage.

During `pr finish`, publication exposed two bounded control-plane gaps for this runtime slice: `adl/src/provider_adapter.rs` was not classified into a finish validation lane, and the corresponding focused validation command was not accepted by the finish validation allowlist. Both were fixed in the same worktree so the issue can publish through the normal ADL control plane.

## Artifacts
- Updated shared resilience retry substrate in `adl/src/resilience.rs`
- Updated provider resilience classification bridge in `adl/src/provider_communication.rs`
- Updated provider invocation adapter to use shared retry execution in `adl/src/provider_adapter.rs`
- Updated finish validation lane classification and allowlist support in `adl/src/cli/pr_cmd/finish_support.rs`
- Updated finish validation focused tests in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated local ignored output record at `.adl/v0.91.6/tasks/issue-3987__v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --lib resilience::tests:: -- --nocapture`
    Verified deterministic retry delay bounds, retry trace emission, retry-budget recovery artifacts, and retry trace schema labeling.
  - `cargo test --manifest-path adl/Cargo.toml --lib provider_communication::tests:: -- --nocapture`
    Verified shared resilience/provider classification mapping, request validation, and provider run-log redaction boundaries.
  - `cargo test --manifest-path adl/Cargo.toml --lib provider_adapter::tests:: -- --nocapture`
    Verified hosted/local provider execution paths, retry success and exhaustion behavior, non-retryable stop behavior, and redacted provider logs.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_plan_classifies_resilience_runtime_publication_paths -- --nocapture`
    Verified `pr finish` classifies `provider_adapter.rs`, `provider_communication.rs`, and `resilience.rs` into the larger-binary runtime-focused validation lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_helper_paths_run_focused_local_ci_gated_validation -- --nocapture`
    Verified finish helper execution accepts and runs the focused runtime validation command set for this slice.
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build`
    Verified runtime owner binaries build and the runtime compatibility boundary passes for the runtime lane exercised by `pr finish`.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3987__v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3987__v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets/sor.md
- Idempotency-Key: v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets-adl-v0-91-6-tasks-issue-3987-v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets-sip-md-adl-v0-91-6-tasks-issue-3987-v0-91-6-wp-02-resilience-r-01-implement-retry-policy-with-backoff-jitter-and-budgets-sor-md