### PR TITLE
[v0.91.6][github][octocrab] Add typed issue mutation command surface

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -81,8 +81,9 @@ use self::git_support::{
     repo_root, run_capture, run_status, tracked_changes_status,
 };
 use self::github::{
-    ensure_issue_metadata_parity, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
-    gh_issue_title, issue_version, unresolved_milestone_pr_wave, IssueRecord,
+    ensure_issue_metadata_parity, format_open_pr_wave, gh_issue_comment, gh_issue_create,
+    gh_issue_edit_body, gh_issue_edit_title, gh_issue_set_labels, gh_issue_title, issue_version,
+    unresolved_milestone_pr_wave, IssueRecord,
 };
 
 const DEFAULT_VERSION: &str = "v0.86";
@@ -255,15 +256,7 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                 .repo
                 .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
                 .unwrap_or(default_repo(&repo_root)?);
-            let issue = if parsed.issue_ref.starts_with("http://")
-                || parsed.issue_ref.starts_with("https://")
-            {
-                parse_issue_number_from_url(&parsed.issue_ref)?
-            } else {
-                parsed.issue_ref.parse::<u32>().with_context(|| {
-                    format!("issue view: invalid issue number: {}", parsed.issue_ref)
-                })?
-            };
+            let issue = parse_issue_ref_number("issue view", &parsed.issue_ref)?;
             let record = github::gh_issue_view(&repo, issue)?;
             if parsed.json {
                 print_json(&record)?;
@@ -271,8 +264,80 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                 print_issue_view(&record);
             }
         }
+        IssueArgs::Create(parsed) => {
+            let repo = parsed.repo.unwrap_or(default_repo(&repo_root)?);
+            let body = resolve_issue_body(parsed.body, parsed.body_file.as_deref())?;
+            let labels_csv = parsed.labels.join(",");
+            let url = gh_issue_create(&repo, &parsed.title, &body, &labels_csv)?;
+            if parsed.json {
+                print_json(&IssueMutationResult {
+                    status: "created",
+                    issue: parse_issue_number_from_url(&url).ok(),
+                    url: Some(url),
+                })?;
+            } else {
+                println!("{url}");
+            }
+        }
+        IssueArgs::Comment(parsed) => {
+            let repo = parsed
+                .repo
+                .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+                .unwrap_or(default_repo(&repo_root)?);
+            let issue = parse_issue_ref_number("issue comment", &parsed.issue_ref)?;
+            let body = resolve_issue_body(parsed.body, parsed.body_file.as_deref())?;
+            gh_issue_comment(&repo, issue, &body)?;
+            if parsed.json {
+                print_json(&IssueMutationResult {
+                    status: "commented",
+                    issue: Some(issue),
+                    url: None,
+                })?;
+            }
+        }
+        IssueArgs::Edit(parsed) => {
+            let repo = parsed
+                .repo
+                .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+                .unwrap_or(default_repo(&repo_root)?);
+            let issue = parse_issue_ref_number("issue edit", &parsed.issue_ref)?;
+            if let Some(title) = parsed.title {
+                gh_issue_edit_title(&repo, issue, &title)?;
+            }
+            if parsed.body.is_some() || parsed.body_file.is_some() {
+                let body = resolve_issue_body(parsed.body, parsed.body_file.as_deref())?;
+                gh_issue_edit_body(&repo, issue, &body)?;
+            }
+            if !parsed.labels.is_empty() {
+                gh_issue_set_labels(&repo, issue, &parsed.labels)?;
+            }
+            if parsed.json {
+                print_json(&IssueMutationResult {
+                    status: "edited",
+                    issue: Some(issue),
+                    url: None,
+                })?;
+            }
+        }
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+struct IssueMutationResult {
+    status: &'static str,
+    issue: Option<u32>,
+    url: Option<String>,
+}
+
+fn parse_issue_ref_number(command: &str, issue_ref: &str) -> Result<u32> {
+    if issue_ref.starts_with("http://") || issue_ref.starts_with("https://") {
+        parse_issue_number_from_url(issue_ref)
+    } else {
+        issue_ref
+            .parse::<u32>()
+            .with_context(|| format!("{command}: invalid issue number: {issue_ref}"))
+    }
 }
 
 fn repo_from_pr_ref(pr_ref: &str) -> Option<String> {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1230,6 +1230,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "docs/milestones/v0.91.4/DEMO_MATRIX_v0.91.4.md"
             | "docs/milestones/v0.91.4/FEATURE_PROOF_COVERAGE_v0.91.4.md"
             | "adl/src/cli/pr_cmd.rs"
+            | "adl/src/cli/pr_cmd_args.rs"
             | "adl/src/cli/mod.rs"
             | "adl/src/cli/github_token.rs"
             | "adl/src/lib.rs"
@@ -1283,6 +1284,7 @@ fn finish_path_needs_pr_finish_rust_focused_validation(path: &str) -> bool {
 fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     trimmed == "adl/src/cli/pr_cmd.rs"
+        || trimmed == "adl/src/cli/pr_cmd_args.rs"
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/basics.rs"
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/support.rs"
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1009,6 +1009,13 @@ pub(super) fn gh_issue_create(
     body: &str,
     labels_csv: &str,
 ) -> Result<String> {
+    #[derive(Serialize)]
+    struct IssueCreatePayload<'a> {
+        title: &'a str,
+        body: &'a str,
+        labels: Vec<String>,
+    }
+
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed("issue.create")? {
         return run_gh_capture_shell(
@@ -1025,15 +1032,21 @@ pub(super) fn gh_issue_create(
     with_octocrab("issue.create", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        let issue = block_on_octocrab(runtime, "issue.create", || async {
-            octo.issues(&owner, &name)
-                .create(title)
-                .body(body.to_string())
-                .labels(labels.clone())
-                .send()
-                .await
+        let route = format!("/repos/{owner}/{name}/issues");
+        let payload = IssueCreatePayload {
+            title,
+            body,
+            labels: labels.clone(),
+        };
+        let issue: RestIssueRecord = block_on_octocrab(runtime, "issue.create", || async {
+            octo.post(route.as_str(), Some(&payload)).await
         })?;
-        Ok(issue.html_url.to_string())
+        issue
+            .into_issue_record()
+            .map(|issue| issue.url)
+            .ok_or_else(|| {
+                anyhow!("issue create: GitHub returned a pull request or malformed issue")
+            })
     })
 }
 
@@ -1194,7 +1207,12 @@ pub(crate) fn gh_issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>
     })
 }
 
-fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {
+pub(super) fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {
+    #[derive(Serialize)]
+    struct IssueTitlePayload<'a> {
+        title: &'a str,
+    }
+
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed("issue.edit.title")? {
         return run_gh_status_shell(
@@ -1215,12 +1233,10 @@ fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {
     with_octocrab("issue.edit.title", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        block_on_octocrab(runtime, "issue.edit.title", || async {
-            octo.issues(&owner, &name)
-                .update(issue as u64)
-                .title(title)
-                .send()
-                .await
+        let route = format!("/repos/{owner}/{name}/issues/{issue}");
+        let payload = IssueTitlePayload { title };
+        let _: RestIssueRecord = block_on_octocrab(runtime, "issue.edit.title", || async {
+            octo.patch(route.as_str(), Some(&payload)).await
         })?;
         Ok(())
     })
@@ -1278,6 +1294,11 @@ pub(super) fn ensure_issue_metadata_parity(
 }
 
 pub(super) fn gh_issue_edit_body(repo: &str, issue: u32, body: &str) -> Result<()> {
+    #[derive(Serialize)]
+    struct IssueBodyPayload<'a> {
+        body: &'a str,
+    }
+
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed("issue.edit.body")? {
         return run_gh_status_shell(
@@ -1298,12 +1319,10 @@ pub(super) fn gh_issue_edit_body(repo: &str, issue: u32, body: &str) -> Result<(
     with_octocrab("issue.edit.body", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        block_on_octocrab(runtime, "issue.edit.body", || async {
-            octo.issues(&owner, &name)
-                .update(issue as u64)
-                .body(body)
-                .send()
-                .await
+        let route = format!("/repos/{owner}/{name}/issues/{issue}");
+        let payload = IssueBodyPayload { body };
+        let _: RestIssueRecord = block_on_octocrab(runtime, "issue.edit.body", || async {
+            octo.patch(route.as_str(), Some(&payload)).await
         })?;
         Ok(())
     })
@@ -1416,7 +1435,12 @@ pub(crate) fn gh_issue_is_closed_completed(issue: u32, repo: &str) -> Result<boo
     })
 }
 
-fn gh_issue_set_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> {
+pub(super) fn gh_issue_set_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> {
+    #[derive(Serialize)]
+    struct IssueLabelsPayload<'a> {
+        labels: &'a [String],
+    }
+
     #[cfg(test)]
     if test_gh_fixture_fallback_allowed("issue.edit.labels")? {
         return run_gh_status_shell(
@@ -1439,16 +1463,34 @@ fn gh_issue_set_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> 
     with_octocrab("issue.edit.labels", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        block_on_octocrab(runtime, "issue.edit.labels", || async {
-            octo.issues(&owner, &name)
-                .update(issue as u64)
-                .labels(labels)
-                .send()
-                .await
+        let route = format!("/repos/{owner}/{name}/issues/{issue}");
+        let payload = IssueLabelsPayload { labels };
+        let _: RestIssueRecord = block_on_octocrab(runtime, "issue.edit.labels", || async {
+            octo.patch(route.as_str(), Some(&payload)).await
         })?;
         Ok(())
     })
     .with_context(|| format!("create: octocrab issue label update failed for issue #{issue}"))
+}
+
+pub(super) fn gh_issue_comment(repo: &str, issue: u32, body: &str) -> Result<()> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("issue.comment")? {
+        return run_gh_status_shell(
+            "issue.comment",
+            &[
+                "issue",
+                "comment",
+                &issue.to_string(),
+                "-R",
+                repo,
+                "--body",
+                body,
+            ],
+        )
+        .with_context(|| format!("issue comment: gh fixture comment failed for issue #{issue}"));
+    }
+    issue_comment_octocrab(repo, issue, body)
 }
 
 #[cfg(test)]

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -6,7 +6,7 @@ use super::{
 use super::{run_gh_status_shell, test_gh_fixture_fallback_allowed};
 use crate::cli::observability;
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -233,14 +233,19 @@ pub(super) fn pr_body_octocrab(repo: &str, pr_ref: &str) -> Result<String> {
 }
 
 pub(super) fn issue_comment_octocrab(repo: &str, issue: u32, body: &str) -> Result<()> {
+    #[derive(Serialize)]
+    struct IssueCommentPayload<'a> {
+        body: &'a str,
+    }
+
     let repo_parts = parse_repo(repo)?;
     with_octocrab("issue.comment", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        block_on_octocrab(runtime, "issue.comment", || async {
-            octo.issues(&owner, &name)
-                .create_comment(issue as u64, body.to_string())
-                .await
+        let route = format!("/repos/{owner}/{name}/issues/{issue}/comments");
+        let payload = IssueCommentPayload { body };
+        let _: serde_json::Value = block_on_octocrab(runtime, "issue.comment", || async {
+            octo.post(route.as_str(), Some(&payload)).await
         })?;
         Ok(())
     })

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -153,10 +153,43 @@ pub(crate) struct IssueViewArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueCreateArgs {
+    pub(crate) title: String,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<PathBuf>,
+    pub(crate) labels: Vec<String>,
+    pub(crate) repo: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueCommentArgs {
+    pub(crate) issue_ref: String,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<PathBuf>,
+    pub(crate) repo: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueEditArgs {
+    pub(crate) issue_ref: String,
+    pub(crate) title: Option<String>,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<PathBuf>,
+    pub(crate) labels: Vec<String>,
+    pub(crate) repo: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IssueArgs {
     List(IssueListArgs),
     Search(IssueSearchArgs),
     View(IssueViewArgs),
+    Create(IssueCreateArgs),
+    Comment(IssueCommentArgs),
+    Edit(IssueEditArgs),
 }
 
 pub(crate) fn parse_init_args(args: &[String]) -> Result<InitArgs> {
@@ -641,13 +674,16 @@ pub(crate) fn parse_closeout_args(args: &[String]) -> Result<CloseoutArgs> {
 
 pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
     let Some(subcommand) = args.first().map(|value| value.as_str()) else {
-        bail!("issue: missing subcommand (list | search | view)");
+        bail!("issue: missing subcommand (list | search | view | create | comment | edit)");
     };
 
     match subcommand {
         "list" => parse_issue_list_args(&args[1..]).map(IssueArgs::List),
         "search" => parse_issue_search_args(&args[1..]).map(IssueArgs::Search),
         "view" => parse_issue_view_args(&args[1..]).map(IssueArgs::View),
+        "create" => parse_issue_create_args(&args[1..]).map(IssueArgs::Create),
+        "comment" => parse_issue_comment_args(&args[1..]).map(IssueArgs::Comment),
+        "edit" => parse_issue_edit_args(&args[1..]).map(IssueArgs::Edit),
         other => bail!("issue: unknown subcommand: {other}"),
     }
 }
@@ -756,6 +792,195 @@ fn parse_issue_view_args(args: &[String]) -> Result<IssueViewArgs> {
         i += 1;
     }
     Ok(parsed)
+}
+
+fn parse_issue_create_args(args: &[String]) -> Result<IssueCreateArgs> {
+    let mut parsed = IssueCreateArgs {
+        title: String::new(),
+        body: None,
+        body_file: None,
+        labels: Vec::new(),
+        repo: None,
+        json: false,
+    };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--title" => {
+                parsed.title = require_value(args, i, "issue create", "--title")?;
+                i += 1;
+            }
+            "--body" => {
+                parsed.body = Some(require_value(args, i, "issue create", "--body")?);
+                i += 1;
+            }
+            "--body-file" => {
+                parsed.body_file = Some(PathBuf::from(require_value(
+                    args,
+                    i,
+                    "issue create",
+                    "--body-file",
+                )?));
+                i += 1;
+            }
+            "--label" => {
+                parsed
+                    .labels
+                    .push(require_value(args, i, "issue create", "--label")?);
+                i += 1;
+            }
+            "--labels" => {
+                parsed.labels.extend(split_labels(&require_value(
+                    args,
+                    i,
+                    "issue create",
+                    "--labels",
+                )?));
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue create", args[i].as_str())?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue create: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    if parsed.title.trim().is_empty() {
+        bail!("issue create: --title is required");
+    }
+    if parsed.body.is_some() && parsed.body_file.is_some() {
+        bail!("issue create: pass only one of --body or --body-file");
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_comment_args(args: &[String]) -> Result<IssueCommentArgs> {
+    let issue_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("issue comment: missing <issue-number-or-url>"))?
+        .clone();
+    let mut parsed = IssueCommentArgs {
+        issue_ref,
+        body: None,
+        body_file: None,
+        repo: None,
+        json: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--body" => {
+                parsed.body = Some(require_value(args, i, "issue comment", "--body")?);
+                i += 1;
+            }
+            "--body-file" => {
+                parsed.body_file = Some(PathBuf::from(require_value(
+                    args,
+                    i,
+                    "issue comment",
+                    "--body-file",
+                )?));
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue comment", args[i].as_str())?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue comment: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    if parsed.body.is_some() && parsed.body_file.is_some() {
+        bail!("issue comment: pass only one of --body or --body-file");
+    }
+    if parsed.body.is_none() && parsed.body_file.is_none() {
+        bail!("issue comment: --body or --body-file is required");
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_edit_args(args: &[String]) -> Result<IssueEditArgs> {
+    let issue_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("issue edit: missing <issue-number-or-url>"))?
+        .clone();
+    let mut parsed = IssueEditArgs {
+        issue_ref,
+        title: None,
+        body: None,
+        body_file: None,
+        labels: Vec::new(),
+        repo: None,
+        json: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--title" => {
+                parsed.title = Some(require_value(args, i, "issue edit", "--title")?);
+                i += 1;
+            }
+            "--body" => {
+                parsed.body = Some(require_value(args, i, "issue edit", "--body")?);
+                i += 1;
+            }
+            "--body-file" => {
+                parsed.body_file = Some(PathBuf::from(require_value(
+                    args,
+                    i,
+                    "issue edit",
+                    "--body-file",
+                )?));
+                i += 1;
+            }
+            "--label" => {
+                parsed
+                    .labels
+                    .push(require_value(args, i, "issue edit", "--label")?);
+                i += 1;
+            }
+            "--labels" => {
+                parsed.labels.extend(split_labels(&require_value(
+                    args,
+                    i,
+                    "issue edit",
+                    "--labels",
+                )?));
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue edit", args[i].as_str())?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue edit: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    if parsed.body.is_some() && parsed.body_file.is_some() {
+        bail!("issue edit: pass only one of --body or --body-file");
+    }
+    if parsed.title.is_none()
+        && parsed.body.is_none()
+        && parsed.body_file.is_none()
+        && parsed.labels.is_empty()
+    {
+        bail!(
+            "issue edit: pass at least one of --title, --body, --body-file, --label, or --labels"
+        );
+    }
+    Ok(parsed)
+}
+
+fn split_labels(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 fn parse_issue_state_filter(cmd: &str, value: &str) -> Result<IssueStateFilter> {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -52,6 +52,23 @@ fn spawn_issue_octocrab_test_server(
                     "\"milestone\":{\"title\":\"v0.91.5\"}}"
                 )
                 .to_string(),
+                ("POST", "/repos/owner/repo/issues") => concat!(
+                    "{\"number\":101,\"title\":\"[v0.91.6][tools] Typed create\",",
+                    "\"state\":\"open\",\"html_url\":\"https://github.com/owner/repo/issues/101\",",
+                    "\"closed_at\":null,\"body\":\"Created body\",\"labels\":[],\"milestone\":null}"
+                )
+                .to_string(),
+                ("POST", "/repos/owner/repo/issues/77/comments") => {
+                    "{\"html_url\":\"https://github.com/owner/repo/issues/77#issuecomment-1\"}"
+                        .to_string()
+                }
+                ("PATCH", "/repos/owner/repo/issues/77") => concat!(
+                    "{\"number\":77,\"title\":\"[v0.91.6][tools] Edited\",",
+                    "\"state\":\"open\",\"html_url\":\"https://github.com/owner/repo/issues/77\",",
+                    "\"closed_at\":null,\"body\":\"Issue body\",\"labels\":[{\"name\":\"area:tools\"}],",
+                    "\"milestone\":{\"title\":\"v0.91.6\"}}"
+                )
+                .to_string(),
                 _ => {
                     panic!("unexpected request: {method} {url}");
                 }
@@ -233,6 +250,65 @@ fn parse_issue_args_accepts_list_search_and_view_modes() {
     assert!(err
         .to_string()
         .contains("issue search: --limit must be 1000 or less"));
+
+    let parsed = parse_issue_args(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Typed create".to_string(),
+        "--body-file".to_string(),
+        "body.md".to_string(),
+        "--label".to_string(),
+        "area:tools".to_string(),
+        "--labels".to_string(),
+        "type:task,version:v0.91.6".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse issue create");
+    match parsed {
+        IssueArgs::Create(parsed) => {
+            assert_eq!(parsed.title, "[v0.91.6][tools] Typed create");
+            assert_eq!(parsed.body_file, Some(PathBuf::from("body.md")));
+            assert_eq!(
+                parsed.labels,
+                vec!["area:tools", "type:task", "version:v0.91.6"]
+            );
+            assert!(parsed.json);
+        }
+        other => panic!("expected create args, got {other:?}"),
+    }
+
+    let parsed = parse_issue_args(&[
+        "comment".to_string(),
+        "77".to_string(),
+        "--body".to_string(),
+        "comment body".to_string(),
+    ])
+    .expect("parse issue comment");
+    match parsed {
+        IssueArgs::Comment(parsed) => {
+            assert_eq!(parsed.issue_ref, "77");
+            assert_eq!(parsed.body.as_deref(), Some("comment body"));
+        }
+        other => panic!("expected comment args, got {other:?}"),
+    }
+
+    let parsed = parse_issue_args(&[
+        "edit".to_string(),
+        "77".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Edited".to_string(),
+        "--label".to_string(),
+        "area:tools".to_string(),
+    ])
+    .expect("parse issue edit");
+    match parsed {
+        IssueArgs::Edit(parsed) => {
+            assert_eq!(parsed.issue_ref, "77");
+            assert_eq!(parsed.title.as_deref(), Some("[v0.91.6][tools] Edited"));
+            assert_eq!(parsed.labels, vec!["area:tools"]);
+        }
+        other => panic!("expected edit args, got {other:?}"),
+    }
 }
 
 #[test]
@@ -338,7 +414,7 @@ fn format_issue_view_renders_empty_labels_without_optional_fields() {
 }
 
 #[test]
-fn real_pr_issue_covers_list_search_and_url_view_against_mock_github() {
+fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     let _guard = env_lock();
     let _transport_env = force_gh_cli_transport_env();
     let temp = unique_temp_dir("adl-pr-issue-inline");
@@ -363,7 +439,11 @@ fn real_pr_issue_covers_list_search_and_url_view_against_mock_github() {
         .status()
         .expect("git commit")
         .success());
-    let (base_uri, server) = spawn_issue_octocrab_test_server(3);
+    let body_path = repo.join("issue-body.md");
+    std::fs::write(&body_path, "Created body\n").expect("write body");
+    let comment_path = repo.join("comment.md");
+    std::fs::write(&comment_path, "Comment body\n").expect("write comment");
+    let (base_uri, server) = spawn_issue_octocrab_test_server(6);
     unsafe {
         std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
         std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
@@ -385,13 +465,43 @@ fn real_pr_issue_covers_list_search_and_url_view_against_mock_github() {
         "https://github.com/owner/repo/issues/77".to_string(),
     ])
     .expect("issue view");
+    real_pr_issue(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Typed create".to_string(),
+        "--body-file".to_string(),
+        body_path.to_string_lossy().to_string(),
+        "--label".to_string(),
+        "area:tools".to_string(),
+    ])
+    .expect("issue create");
+    real_pr_issue(&[
+        "comment".to_string(),
+        "77".to_string(),
+        "--body-file".to_string(),
+        comment_path.to_string_lossy().to_string(),
+    ])
+    .expect("issue comment");
+    real_pr_issue(&[
+        "edit".to_string(),
+        "77".to_string(),
+        "--label".to_string(),
+        "area:tools".to_string(),
+    ])
+    .expect("issue edit");
 
     std::env::set_current_dir(prev_dir).expect("restore cwd");
     let seen = server.join().expect("server join");
-    assert_eq!(seen.len(), 3);
+    assert_eq!(seen.len(), 6);
     assert!(seen[0].starts_with("GET /repos/owner/repo/issues?"));
     assert!(seen[1].contains("/search/issues?"));
     assert!(seen[2].starts_with("GET /repos/owner/repo/issues/77"));
+    assert!(seen[3].starts_with("POST /repos/owner/repo/issues "));
+    assert!(seen[3].contains("[v0.91.6][tools] Typed create"));
+    assert!(seen[4].starts_with("POST /repos/owner/repo/issues/77/comments "));
+    assert!(seen[4].contains("Comment body"));
+    assert!(seen[5].starts_with("PATCH /repos/owner/repo/issues/77 "));
+    assert!(seen[5].contains("area:tools"));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2634,12 +2634,13 @@ Usage:
   adl/tools/pr.sh issue list [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]
   adl/tools/pr.sh issue search --query "<text>" [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]
   adl/tools/pr.sh issue view <issue-number-or-url> [-R owner/repo] [--json]
+  adl/tools/pr.sh issue create --title "<title>" [--body "<markdown>" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]
+  adl/tools/pr.sh issue comment <issue-number-or-url> [--body "<markdown>" | --body-file <path>] [-R owner/repo] [--json]
+  adl/tools/pr.sh issue edit <issue-number-or-url> [--title "<title>"] [--body "<markdown>" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]
 
 Behavior:
-- delegates to the Rust-owned issue inspection surface
-- uses the typed GitHub transport rather than raw `gh issue list/view`
-- issue mutation commands (`create`, `comment`, `edit`) are not exposed here yet;
-  #4078 owns adding those typed octocrab-backed paths
+- delegates to the Rust-owned issue inspection and mutation surface
+- uses the typed GitHub transport rather than raw `gh issue` commands for covered paths
 - requires a shared GitHub token source for live GitHub operations. Supported
   sources are GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or
   ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE. The keychain source uses macOS

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2638,6 +2638,8 @@ Usage:
 Behavior:
 - delegates to the Rust-owned issue inspection surface
 - uses the typed GitHub transport rather than raw `gh issue list/view`
+- issue mutation commands (`create`, `comment`, `edit`) are not exposed here yet;
+  #4078 owns adding those typed octocrab-backed paths
 - requires a shared GitHub token source for live GitHub operations. Supported
   sources are GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or
   ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE. The keychain source uses macOS

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -231,13 +231,14 @@ Preferred commands:
 bash adl/tools/pr.sh issue view <issue-number-or-url> --json
 bash adl/tools/pr.sh issue list --state open|closed|all --limit <n> --json
 bash adl/tools/pr.sh issue search --query "<text>" --state open|closed|all --json
+bash adl/tools/pr.sh issue create --title "<title>" --body-file <path> --label track:roadmap --json
+bash adl/tools/pr.sh issue comment <issue-number-or-url> --body-file <path> --json
+bash adl/tools/pr.sh issue edit <issue-number-or-url> --title "<title>" --body-file <path> --label area:tools --json
 ```
 
-Typed issue mutation commands are scheduled but not yet exposed. `#4078` owns
-adding `issue create`, `issue comment`, and `issue edit` or an equivalent
-title/body/label update path. Until that lands, any direct `gh issue
-create/comment/edit` use must be recorded as a temporary transport gap rather
-than treated as the normal ADL sprint setup path.
+Use typed issue mutation commands for covered issue setup and repair paths.
+Direct `gh issue create/comment/edit` use should be treated as helper migration
+debt, not as the normal ADL sprint setup path.
 
 Use this surface when:
 
@@ -246,6 +247,8 @@ Use this surface when:
   or closeout
 - reproducing milestone queue or closeout checks that previously depended on
   `gh issue list` or `gh issue view`
+- creating, commenting on, or updating issue metadata during bounded sprint
+  setup and tooling work
 
 Pair it with:
 

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -233,6 +233,12 @@ bash adl/tools/pr.sh issue list --state open|closed|all --limit <n> --json
 bash adl/tools/pr.sh issue search --query "<text>" --state open|closed|all --json
 ```
 
+Typed issue mutation commands are scheduled but not yet exposed. `#4078` owns
+adding `issue create`, `issue comment`, and `issue edit` or an equivalent
+title/body/label update path. Until that lands, any direct `gh issue
+create/comment/edit` use must be recorded as a temporary transport gap rather
+than treated as the normal ADL sprint setup path.
+
 Use this surface when:
 
 - confirming that an issue exists before `pr-init` or `pr-run`

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -66,6 +66,14 @@ Preferred structured-prompt preflight helper:
 Preferred missing-sprint-issue helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>`
 
+Known transport gap:
+- until `#4078` lands, the missing-sprint-issue helper still shells through
+  `gh issue create` for live issue creation
+- record that as a temporary transport gap in sprint artifacts when the helper
+  is used
+- after `#4078`, update the helper to call the typed `pr.sh issue create` path
+  instead of direct `gh`
+
 Preferred live-truth helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match`
 

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -66,13 +66,12 @@ Preferred structured-prompt preflight helper:
 Preferred missing-sprint-issue helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>`
 
-Known transport gap:
-- until `#4078` lands, the missing-sprint-issue helper still shells through
-  `gh issue create` for live issue creation
-- record that as a temporary transport gap in sprint artifacts when the helper
-  is used
-- after `#4078`, update the helper to call the typed `pr.sh issue create` path
-  instead of direct `gh`
+Known helper migration note:
+- the typed issue mutation command surface exists as `pr.sh issue
+  create/comment/edit`
+- if the missing-sprint-issue helper still shells through direct `gh issue
+  create`, route that helper as migration debt and prefer the typed command
+  surface for new sprint setup automation
 
 Preferred live-truth helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match`

--- a/adl/tools/test_slow_proof_lane_contract.sh
+++ b/adl/tools/test_slow_proof_lane_contract.sh
@@ -19,8 +19,8 @@ slow_tests=(
 
 (
   cd "$ADL_DIR"
-  cargo nextest list runtime_v2_ > "$default_list"
-  cargo nextest list --features slow-proof-tests runtime_v2_ > "$slow_list"
+  cargo nextest list --lib runtime_v2_ > "$default_list"
+  cargo nextest list --lib --features slow-proof-tests runtime_v2_ > "$slow_list"
 )
 
 for test_name in "${slow_tests[@]}"; do

--- a/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
+++ b/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
@@ -33,6 +33,25 @@ The shared layer owns:
 - PR wave filtering.
 - PR closing-linkage interpretation.
 
+## Current Command Surface
+
+The typed issue inspection surface is currently exposed through:
+
+- `adl/tools/pr.sh issue list`
+- `adl/tools/pr.sh issue search`
+- `adl/tools/pr.sh issue view`
+
+Issue mutation is intentionally not documented as complete at this boundary yet.
+The missing typed command surface is tracked by `#4078`, which owns adding:
+
+- `adl/tools/pr.sh issue create`
+- `adl/tools/pr.sh issue comment`
+- `adl/tools/pr.sh issue edit` or an equivalent title/body/label update path
+
+Until `#4078` lands, direct `gh issue create/comment/edit` use is a known
+workflow gap and should be recorded in issue artifacts when it is unavoidable.
+It is not the desired steady-state sprint setup path.
+
 ## Migration Rules
 
 - Do not duplicate GitHub issue or PR metadata interpretation in `adl-csdlc`.

--- a/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
+++ b/docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md
@@ -41,16 +41,15 @@ The typed issue inspection surface is currently exposed through:
 - `adl/tools/pr.sh issue search`
 - `adl/tools/pr.sh issue view`
 
-Issue mutation is intentionally not documented as complete at this boundary yet.
-The missing typed command surface is tracked by `#4078`, which owns adding:
+The typed issue mutation surface is currently exposed through:
 
 - `adl/tools/pr.sh issue create`
 - `adl/tools/pr.sh issue comment`
 - `adl/tools/pr.sh issue edit` or an equivalent title/body/label update path
 
-Until `#4078` lands, direct `gh issue create/comment/edit` use is a known
-workflow gap and should be recorded in issue artifacts when it is unavoidable.
-It is not the desired steady-state sprint setup path.
+Direct `gh issue create/comment/edit` use is not the desired sprint setup path
+for covered operations. If a future helper still shells out directly, treat that
+as helper migration debt rather than a new command-boundary gap.
 
 ## Migration Rules
 

--- a/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
+++ b/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
@@ -55,6 +55,7 @@ The stable failure code for disabled shell fallback is
 The following workflow helper operations now route through octocrab:
 
 - issue inspection through `adl/tools/pr.sh issue list/search/view`
+- issue mutation through `adl/tools/pr.sh issue create/comment/edit`
 - issue metadata reads used by workflow guardrails
 - PR creation, body updates, readiness changes, and merge operations
 - live PR list/view calls used by workflow guardrails
@@ -66,26 +67,26 @@ The helper function names still contain `gh` in a few places for compatibility
 with the existing PR control-plane call graph, but those helpers no longer
 spawn the GitHub CLI for covered operations.
 
-## Known Issue Mutation Gap
+## Remaining Issue Mutation Migration Notes
 
-The public issue command surface does not yet expose typed issue mutation:
+The public issue command surface exposes typed issue mutation:
 
 - `adl/tools/pr.sh issue create`
 - `adl/tools/pr.sh issue comment`
 - `adl/tools/pr.sh issue edit`
 
-That gap is tracked by `#4078`. Until it lands, sprint setup paths that must
-create or comment on issues may still require an explicitly recorded temporary
-`gh` use. That temporary path must not be described as the desired ADL
-transport model and must not be hidden in sprint automation claims.
+Some older helper scripts may still need to be migrated from direct `gh issue`
+usage onto these commands. Treat remaining direct helper use as explicit helper
+migration debt, not as the normal ADL transport model.
 
 ## Follow-On Routes
 
 The next octocrab follow-ons should stay behavior-preserving and separately
 reviewable:
 
-- add typed issue mutation commands for create/comment/edit (`#4078`)
 - rename legacy `gh_*` helper functions once the transport behavior has settled
+- migrate older helper scripts that still call direct `gh issue` onto the typed
+  issue mutation commands
 - add richer observability for fallback selection, slow GitHub calls, and
   command timeouts beyond the current per-operation Octocrab events
 - add an optional release-gate smoke check for token-backed octocrab auth

--- a/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
+++ b/docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md
@@ -54,8 +54,8 @@ The stable failure code for disabled shell fallback is
 
 The following workflow helper operations now route through octocrab:
 
-- issue creation and issue body updates
-- issue title and version-label updates
+- issue inspection through `adl/tools/pr.sh issue list/search/view`
+- issue metadata reads used by workflow guardrails
 - PR creation, body updates, readiness changes, and merge operations
 - live PR list/view calls used by workflow guardrails
 - live issue and PR linkage checks where the current code calls `gh`
@@ -66,11 +66,25 @@ The helper function names still contain `gh` in a few places for compatibility
 with the existing PR control-plane call graph, but those helpers no longer
 spawn the GitHub CLI for covered operations.
 
+## Known Issue Mutation Gap
+
+The public issue command surface does not yet expose typed issue mutation:
+
+- `adl/tools/pr.sh issue create`
+- `adl/tools/pr.sh issue comment`
+- `adl/tools/pr.sh issue edit`
+
+That gap is tracked by `#4078`. Until it lands, sprint setup paths that must
+create or comment on issues may still require an explicitly recorded temporary
+`gh` use. That temporary path must not be described as the desired ADL
+transport model and must not be hidden in sprint automation claims.
+
 ## Follow-On Routes
 
 The next octocrab follow-ons should stay behavior-preserving and separately
 reviewable:
 
+- add typed issue mutation commands for create/comment/edit (`#4078`)
 - rename legacy `gh_*` helper functions once the transport behavior has settled
 - add richer observability for fallback selection, slow GitHub calls, and
   command timeouts beyond the current per-operation Octocrab events


### PR DESCRIPTION
Closes #4078

## Summary
Implemented the missing typed issue mutation command surface for `adl/tools/pr.sh issue create`, `issue comment`, and `issue edit`, backed by the Rust/octocrab path for covered operations. Updated docs and sprint-conductor guidance so sprint setup can use the typed issue mutation surface instead of direct `gh`.

## Artifacts
- GitHub issue: #4078
- SEP sprint link comment on #4069
- `adl/tools/pr.sh`
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/pr_cmd_args.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/github/transport.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `docs/tooling/ADL_CSDLC_GITHUB_CLIENT_BOUNDARY.md`
- `docs/tooling/ADL_OCTOCRAB_MIGRATION_REVIEW.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Rust formatting check.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl parse_issue_args_accepts_list_search_and_view_modes -- --nocapture`
    Focused parser regression test.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_issue_covers_list_search_view_and_mutation_against_mock_github -- --nocapture`
    Focused octocrab issue command transport regression test.
  - `git diff --check`
    Diff hygiene check.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation -- --nocapture`
    Focused finish-validation classification tests.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4078__v0-91-6-github-octocrab-add-typed-issue-mutation-command-surface/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4078__v0-91-6-github-octocrab-add-typed-issue-mutation-command-surface/sor.md
- Idempotency-Key: v0-91-6-github-octocrab-add-typed-issue-mutation-command-surface-adl-tools-pr-sh-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-docs-tooling-adl-csdlc-github-client-boundary-md-docs-tooling-adl-octocrab-migration-review-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-sprint-conductor-references-conductor-playbook-md-adl-v0-91-6-tasks-issue-4078-v0-91-6-github-octocrab-add-typed-issue-mutation-command-surface-sip-md-adl-v0-91-6-tasks-issue-4078-v0-91-6-github-octocrab-add-typed-issue-mutation-command-surface-sor-md