### PR TITLE
[v0.91.6][quality] Add repo-quality and documentation-staleness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.91.5 (Active bridge milestone)
+## v0.91.6 (Active bridge/readiness tranche)
+
+Status: Active. The `v0.91.6` package lives under `docs/milestones/v0.91.6/`
+and is the first execution bridge tranche before `v0.92`.
+
+Current state:
+- The planning package and feature-doc wave are landed.
+- WP-03 logging/tooling and WP-04 public-records umbrellas have merged.
+- Additional bridge-quality and reliability lanes remain in flight.
+- This is an active planning/execution milestone entry, not a release entry.
+
+Scope notes:
+- `v0.91.6` owns the first bridge tranche for resilience/persistence,
+  logging/tooling proof-loop reliability, public prompt records,
+  provider/model reliability, ACIP/A2A/provider communications, security
+  bridge readiness, and activation-adjacent accounting surfaces.
+- `v0.91.6` prepares `v0.92`; it does not claim first-birthday activation by
+  planning docs alone.
+
+## v0.91.5 (Previous bridge milestone)
 
 Status: Active Sprint 4 release-tail execution. The v0.91.5 package lives under
 `docs/milestones/v0.91.5/` and carries pre-v0.92 stabilization work that moved

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ packets, demos, and milestone evidence.
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.91.5%20bridge-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.91.6%20bridge-blue)
 
 ![ADL deterministic cognitive architecture overview](docs/assets/ADL-overview.png)
 
@@ -149,13 +149,28 @@ from issue
 
 ## Recent Milestones
 
-### v0.91.5 - Active Bridge Milestone
+### v0.91.6 - Active First Bridge Tranche
 
-v0.91.5 is the active bridge milestone between the C-SDLC rollout closeout and
-the v0.92 first-birthday milestone. It carries multi-agent stabilization,
-provider/model breadth, public prompt records, demo readiness, AEE completion
-routing, and activation testing so v0.92 can begin from a clean operational
-base.
+v0.91.6 is the active first pre-v0.92 bridge/readiness tranche. It carries the
+first execution wave for resilience/persistence, logging/tooling proof-loop
+reliability, public prompt records, provider/model reliability, ACIP/A2A
+communications, security bridge readiness, and bridge accounting needed before
+v0.92 activation can open from reviewed evidence.
+
+Start here:
+
+- [v0.91.6 README](docs/milestones/v0.91.6/README.md)
+- [v0.91.6 sprint plan](docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md)
+- [v0.91.6 issue wave](docs/milestones/v0.91.6/WP_ISSUE_WAVE_v0.91.6.yaml)
+- [v0.91.6 feature-doc index](docs/milestones/v0.91.6/FEATURE_DOCS_v0.91.6.md)
+
+### v0.91.5 - Previous Bridge Package And Release-Tail Input
+
+v0.91.5 remains the immediate upstream bridge package between the C-SDLC
+rollout closeout and the v0.92 first-birthday milestone. It carried
+multi-agent stabilization, provider/model breadth, public prompt records, demo
+readiness, AEE completion routing, and activation testing so v0.91.6 and
+v0.91.7 could open from a cleaner operational base.
 
 Start here:
 
@@ -275,12 +290,12 @@ production markets.
 
 ## Project Status
 
-- Active milestone: v0.91.5
+- Active milestone: v0.91.6
 - Current crate version: 0.91.5
 - Most recently completed milestone: v0.91.4
-- Current milestone state: v0.91.5 is in the Sprint 4 review/remediation/
-  release tail after substantial bridge delivery, first internal review, and a
-  completed first remediation tranche.
+- Current milestone state: v0.91.6 is executing as the first pre-v0.92 bridge
+  tranche, with WP-03 and WP-04 merged and later bridge/reliability lanes still
+  active.
 - Previous completed milestone before v0.91.2: v0.91.1
 - Primary implementation language: Rust
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1101,6 +1101,13 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_repo_quality_staleness_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            commands.push("bash adl/tools/test_check_repo_quality_staleness.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_csdlc_owner_lane_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1188,6 +1195,9 @@ fn finish_path_is_docs_only(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     if trimmed.is_empty() {
         return false;
+    }
+    if trimmed == "adl/tools/README.md" {
+        return true;
     }
     if trimmed == "docs" || trimmed.starts_with("docs/") {
         return true;
@@ -1277,6 +1287,8 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_control_plane_observability.sh"
             | "adl/tools/test_adl_runtime_compatibility.sh"
             | "adl/tools/test_adl_review_compatibility.sh"
+            | "adl/tools/check_repo_quality_staleness.py"
+            | "adl/tools/test_check_repo_quality_staleness.sh"
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
             | "adl/src/cli/tooling_cmd/github_release.rs"
@@ -1373,6 +1385,15 @@ fn finish_path_needs_owner_lane_contract_validation(path: &str) -> bool {
             | "adl/tools/test_owner_validation_lane.sh"
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
+    )
+}
+
+fn finish_path_needs_repo_quality_staleness_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/check_repo_quality_staleness.py"
+            | "adl/tools/test_check_repo_quality_staleness.sh"
     )
 }
 
@@ -1582,6 +1603,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_owner_validation_lane.sh" => {
                     let script = repo_root.join("adl/tools/test_owner_validation_lane.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_check_repo_quality_staleness.sh" => {
+                    let script = repo_root.join("adl/tools/test_check_repo_quality_staleness.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/run_owner_validation_lane.sh csdlc" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -830,6 +830,27 @@ fn finish_validation_plan_classifies_owner_validation_lanes() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_repo_quality_staleness_tooling() {
+    let plan = select_finish_validation_plan(
+        "adl/tools/check_repo_quality_staleness.py,adl/tools/test_check_repo_quality_staleness.sh,adl/tools/README.md,README.md,CHANGELOG.md,docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md,docs/milestones/v0.91.6/REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md",
+    )
+    .expect("repo-quality staleness plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_check_repo_quality_staleness.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
 fn finish_validation_plan_classifies_resilience_runtime_publication_paths() {
     let adapter_plan = select_finish_validation_plan("adl/src/provider_adapter.rs")
         .expect("provider adapter runtime plan");

--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -23,6 +23,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
 - `check_issue_metadata_parity.sh`: canonical metadata parity audit for GitHub issue title/labels plus local `.adl` body/STP metadata identity.
+- `check_repo_quality_staleness.py`: focused reviewer-facing docs and tracked-junk audit for the current milestone package and root repo status surfaces.
 - `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync; `--dry-run` or `--report-only` emits the merged-needs-closeout candidate set without mutation.
 - `check_milestone_closed_issue_sor_truth.sh`: milestone closed-issue bundle truth gate for local-only `.adl` task bundles; verifies canonical `stp.md`, `sip.md`, and final `sor.md` truth for closed/completed issues.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
@@ -119,6 +120,9 @@ bash adl/tools/demo_v089_quality_gate.sh
 
 # audit GitHub/local issue metadata parity for one milestone package
 ./adl/tools/check_issue_metadata_parity.sh --version v0.88
+
+# audit root + milestone reviewer-facing docs for current-milestone staleness
+python3 ./adl/tools/check_repo_quality_staleness.py --milestone v0.91.6
 
 # enforce coverage thresholds from coverage-summary.json
 cd ./adl/ && bash tools/enforce_coverage_gates.sh coverage-summary.json

--- a/adl/tools/check_repo_quality_staleness.py
+++ b/adl/tools/check_repo_quality_staleness.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check reviewer-facing repo and milestone surfaces for obvious "
+            "current-milestone staleness and tracked junk."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parents[2],
+        type=Path,
+        help="Repository root to inspect.",
+    )
+    parser.add_argument(
+        "--milestone",
+        required=True,
+        help="Current reviewer-facing milestone, for example v0.91.6.",
+    )
+    return parser.parse_args()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def add_result(ok: bool, message: str, failures: list[str]) -> None:
+    prefix = "PASS" if ok else "FAIL"
+    print(f"{prefix} repo-quality-staleness {message}")
+    if not ok:
+        failures.append(message)
+
+
+def expect_contains(path: Path, needle: str, label: str, failures: list[str]) -> None:
+    add_result(needle in read_text(path), f"{label} in {path}: {needle}", failures)
+
+
+def expect_exists(path: Path, label: str, failures: list[str]) -> None:
+    add_result(path.exists(), f"{label} exists: {path}", failures)
+
+
+def extract_markdown_links(text: str) -> list[str]:
+    return re.findall(r"\[[^\]]+\]\(([^)]+)\)", text)
+
+
+def section_body(text: str, title: str) -> str:
+    pattern = re.compile(rf"^## {re.escape(title)}\n(.*?)(?=^## |\Z)", re.M | re.S)
+    match = pattern.search(text)
+    return match.group(1) if match else ""
+
+
+def feature_links_from_index(text: str) -> list[str]:
+    return re.findall(r"\(\s*(features/[^)]+\.md)\s*\)", text)
+
+
+def tracked_junk(repo_root: Path) -> list[str]:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    tracked = [Path(item) for item in proc.stdout.decode("utf-8").split("\0") if item]
+    return [
+        str(path)
+        for path in tracked
+        if any(part == "__pycache__" for part in path.parts)
+        or path.name.endswith((".pyc", ".pyo"))
+        or path.name == ".DS_Store"
+    ]
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    milestone = args.milestone
+    failures: list[str] = []
+
+    root_readme = repo_root / "README.md"
+    changelog = repo_root / "CHANGELOG.md"
+    milestone_dir = repo_root / "docs" / "milestones" / milestone
+    milestone_readme = milestone_dir / "README.md"
+    release_plan = milestone_dir / f"RELEASE_PLAN_{milestone}.md"
+    release_notes = milestone_dir / f"RELEASE_NOTES_{milestone}.md"
+    checklist = milestone_dir / f"MILESTONE_CHECKLIST_{milestone}.md"
+    feature_index = milestone_dir / f"FEATURE_DOCS_{milestone}.md"
+    feature_dir_index = milestone_dir / "features" / "README.md"
+
+    expect_exists(root_readme, "root README", failures)
+    expect_exists(changelog, "CHANGELOG", failures)
+    expect_exists(milestone_dir, "milestone directory", failures)
+    for path, label in [
+        (milestone_readme, "milestone README"),
+        (release_plan, "milestone release plan"),
+        (release_notes, "milestone release notes"),
+        (checklist, "milestone checklist"),
+        (feature_index, "milestone feature index"),
+        (feature_dir_index, "milestone feature directory index"),
+    ]:
+        expect_exists(path, label, failures)
+
+    if failures:
+        return 1
+
+    expect_contains(
+        root_readme,
+        f"- Active milestone: {milestone}",
+        "root README active milestone line",
+        failures,
+    )
+    expect_contains(
+        root_readme,
+        f"docs/milestones/{milestone}/README.md",
+        "root README current milestone link",
+        failures,
+    )
+    expect_contains(
+        changelog,
+        f"## {milestone} (",
+        "CHANGELOG current milestone heading",
+        failures,
+    )
+
+    for path in [milestone_readme, release_plan, release_notes, checklist, feature_index]:
+        expect_contains(path, f"`{milestone}`", f"milestone marker", failures)
+
+    readme_text = read_text(milestone_readme)
+    document_map = section_body(readme_text, "Document Map")
+    required_doc_map_links = [
+        f"RELEASE_PLAN_{milestone}.md",
+        f"RELEASE_NOTES_{milestone}.md",
+        f"MILESTONE_CHECKLIST_{milestone}.md",
+        f"FEATURE_DOCS_{milestone}.md",
+        "features/README.md",
+    ]
+    for rel in required_doc_map_links:
+        add_result(rel in document_map, f"document-map link present: {rel}", failures)
+
+    for link in extract_markdown_links(document_map):
+        target = (milestone_dir / link).resolve()
+        add_result(target.exists(), f"document-map target exists: {link}", failures)
+
+    feature_index_text = read_text(feature_index)
+    feature_dir_text = read_text(feature_dir_index)
+    feature_index_links = sorted(set(feature_links_from_index(feature_index_text)))
+    feature_dir_links = sorted(set(extract_markdown_links(feature_dir_text)))
+    feature_dir_md_links = sorted(link for link in feature_dir_links if link.endswith(".md"))
+    feature_index_names = sorted(Path(link).name for link in feature_index_links)
+    feature_dir_names = sorted(Path(link).name for link in feature_dir_md_links)
+
+    add_result(
+        feature_index_names == feature_dir_names,
+        "feature index and feature directory links match",
+        failures,
+    )
+    for rel in feature_index_links:
+        add_result((milestone_dir / rel).exists(), f"feature doc exists: {rel}", failures)
+
+    junk = tracked_junk(repo_root)
+    add_result(not junk, "tracked junk absent (__pycache__/.pyc/.pyo/.DS_Store)", failures)
+    if junk:
+        for path in junk:
+            print(f"DETAIL tracked-junk {path}")
+
+    if failures:
+        print("repo-quality-staleness summary: FAIL", file=sys.stderr)
+        return 1
+
+    print(f"repo-quality-staleness summary: PASS milestone={milestone}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_check_repo_quality_staleness.sh
+++ b/adl/tools/test_check_repo_quality_staleness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO/docs/milestones/v0.91.6/features"
+
+cat >"$REPO/README.md" <<'EOF'
+# Repo
+
+- [v0.91.6 README](docs/milestones/v0.91.6/README.md)
+
+- Active milestone: v0.91.6
+EOF
+
+cat >"$REPO/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## v0.91.6 (Active bridge/readiness tranche)
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/README.md" <<'EOF'
+# v0.91.6 Milestone README
+
+## Metadata
+
+- Milestone: `v0.91.6`
+
+## Document Map
+
+- [Feature-doc index](FEATURE_DOCS_v0.91.6.md)
+- [Checklist](MILESTONE_CHECKLIST_v0.91.6.md)
+- [Release plan](RELEASE_PLAN_v0.91.6.md)
+- [Release notes](RELEASE_NOTES_v0.91.6.md)
+- [Feature directory index](features/README.md)
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/FEATURE_DOCS_v0.91.6.md" <<'EOF'
+# Feature index
+
+- Milestone: `v0.91.6`
+
+| Feature doc |
+| --- |
+| [One](features/ONE_v0.91.6.md) |
+| [Two](features/TWO_v0.91.6.md) |
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/features/README.md" <<'EOF'
+# Feature directory
+
+- [One](ONE_v0.91.6.md)
+- [Two](TWO_v0.91.6.md)
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md" <<'EOF'
+# Release plan
+
+- Version: `v0.91.6`
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/RELEASE_NOTES_v0.91.6.md" <<'EOF'
+# Release notes
+
+- Version: `v0.91.6`
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/MILESTONE_CHECKLIST_v0.91.6.md" <<'EOF'
+# Checklist
+
+- Version: `v0.91.6`
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/features/ONE_v0.91.6.md" <<'EOF'
+# One
+EOF
+
+cat >"$REPO/docs/milestones/v0.91.6/features/TWO_v0.91.6.md" <<'EOF'
+# Two
+EOF
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" add .
+git -C "$REPO" commit -q -m "fixture"
+
+python3 "$ROOT/adl/tools/check_repo_quality_staleness.py" --repo-root "$REPO" --milestone v0.91.6 >/dev/null
+
+python3 - "$REPO/README.md" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace("Active milestone: v0.91.6", "Active milestone: v0.91.5"))
+PY
+
+if python3 "$ROOT/adl/tools/check_repo_quality_staleness.py" --repo-root "$REPO" --milestone v0.91.6 >/dev/null 2>&1; then
+  echo "expected stale README milestone check to fail" >&2
+  exit 1
+fi
+
+git -C "$REPO" checkout -- README.md
+mkdir -p "$REPO/docs/__pycache__"
+touch "$REPO/docs/__pycache__/bad.pyc"
+git -C "$REPO" add docs/__pycache__/bad.pyc
+git -C "$REPO" commit -q -m "tracked junk"
+
+if python3 "$ROOT/adl/tools/check_repo_quality_staleness.py" --repo-root "$REPO" --milestone v0.91.6 >/dev/null 2>&1; then
+  echo "expected tracked junk check to fail" >&2
+  exit 1
+fi
+
+echo "PASS test_check_repo_quality_staleness"

--- a/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
+++ b/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
@@ -49,7 +49,9 @@ planning package does not publish a release by itself.
 
 ## 4. Verification
 
-- [ ] Focused docs validation recorded.
+- [ ] Focused docs validation recorded, including
+  `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
+  when reviewer-facing repo or milestone docs changed.
 - [ ] CI status checked for merged PRs.
 - [ ] Release links tested.
 - [ ] Immediate regressions triaged and tracked.

--- a/docs/milestones/v0.91.6/REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md
+++ b/docs/milestones/v0.91.6/REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md
@@ -16,6 +16,7 @@ Candidate review checklist for docs/planning and first-tranche bridge work.
 For planning-doc-only changes:
 
 - `git diff --check`
+- `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
 - required-file check for `README.md`, `WBS_v0.91.6.md`,
   `FEATURE_DOCS_v0.91.6.md`, `MILESTONE_CHECKLIST_v0.91.6.md`,
   `REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md`, and
@@ -30,6 +31,9 @@ For planning-doc-only changes:
 For runtime or tooling changes opened from this milestone:
 
 - use the focused owner lane or exact validation command named by the issue
+- if reviewer-facing repo or milestone docs changed, run
+  `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
+  before broader owner-lane proof
 - record local proof separately from deferred CI proof
 - state whether slow proof is skipped, expected, or required
 

--- a/docs/milestones/v0.91.6/review/REPO_QUALITY_STALENESS_REMEDIATION_3925.md
+++ b/docs/milestones/v0.91.6/review/REPO_QUALITY_STALENESS_REMEDIATION_3925.md
@@ -1,0 +1,36 @@
+# `#3925` Publication Friction And Remediation Capture
+
+## Summary
+
+This note records the concrete problems encountered while implementing and
+publishing `#3925` so they remain available for follow-on tooling remediation.
+It separates issues that were fixed in-branch from issues that still deserve a
+tracked follow-up.
+
+## Problems Encountered
+
+| Problem | Impact | Status | Remediation |
+| --- | --- | --- | --- |
+| `pr finish` did not classify `adl/tools/check_repo_quality_staleness.py`, `adl/tools/test_check_repo_quality_staleness.sh`, or `adl/tools/README.md` into an allowed validation lane. | Normal publication failed closed even though the issue-local proof was already green. | Fixed in `#3925`. | Added focused finish-lane routing in `adl/src/cli/pr_cmd/finish_support.rs` plus regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`. |
+| `pr finish` failed when `--output-card` pointed at the ignored cards-root path `.adl/cards/3925/output_3925.md`. | Finish completed validation, then failed while trying to re-stage an ignored output card. | Not fixed in `#3925`; worked around. | Use the task-bundle `SOR` path `.adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/sor.md` for publication until finish learns to skip restaging ignored cards-root outputs. |
+| Including worktree task-bundle `SRP`/`SOR` paths in `--paths` caused `git add` pathspec failures. | First finish attempt failed before validation because local bundle files are not tracked repo publication paths. | Not fixed in `#3925`; operator/workflow knowledge workaround only. | Improve `pr finish` diagnostics so it explicitly warns that task-bundle cards are local truth surfaces and must not be passed in `--paths`. |
+| The branch became one commit behind `origin/main` before publication. | Finish stopped before validation and required a rebase. | Healthy guard, not a defect. | Keep the stale-base guard; improve operator/runbook guidance or watcher automation so rebases happen before the final finish pass. |
+| The broader owner-lane attempt `bash adl/tools/run_owner_validation_lane.sh csdlc` exposed an unrelated failure in `adl/tools/test_control_plane_observability.sh`. | Broader owner-lane proof was not trustworthy for this issue and had to be excluded from issue proof. | Unresolved outside `#3925`. | Route separately as owner-lane/observability remediation; do not treat it as a blocker for the bounded repo-quality checker issue. |
+| Local PR URL opening failed after publication with `kLSExecutableIncorrectFormat`. | PR publication succeeded, but local auto-open did not. | Environment-specific and non-blocking. | Low-priority workstation/tool-launcher follow-up only if repeated. |
+
+## Most Important Follow-Ups
+
+1. Make `pr finish` tolerant of ignored cards-root output cards, or standardize
+   the command to always publish against the task-bundle `SOR`.
+2. Improve `pr finish` error text for accidental task-bundle paths in
+   `--paths`.
+3. Route the unrelated `adl/tools/test_control_plane_observability.sh` owner-lane
+   failure into its own remediation issue so broader C-SDLC owner-lane trust
+   does not depend on operator memory.
+
+## Non-Claims
+
+- This note does not claim every tooling rough edge in the repo was exercised by
+  `#3925`.
+- This note does not treat the stale-base guard as a bug; it is recorded here
+  because it affected cycle time during publication.


### PR DESCRIPTION
Closes #3925

## Summary
Implemented a focused repo-quality/documentation-staleness gate for `v0.91.6`, corrected stale reviewer-facing root surfaces that the gate would flag, and wired the new proof lane into the milestone validation guidance. The issue stayed bounded to reviewer-facing repository and milestone truth rather than widening into generic docs linting or unrelated runtime policy.

## Artifacts
- `adl/tools/check_repo_quality_staleness.py`
- `adl/tools/test_check_repo_quality_staleness.sh`
- `README.md`
- `CHANGELOG.md`
- `adl/tools/README.md`
- `docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md`
- `docs/milestones/v0.91.6/REVIEW_AND_VALIDATION_CHECKLIST_v0.91.6.md`
- `.adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/srp.md`
- `.adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/sor.md`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
    Verified the active reviewer-facing milestone surface, required milestone documents, feature index linkage, and tracked-junk absence for the real repository state after the docs updates.
  - `bash adl/tools/test_check_repo_quality_staleness.sh`
    Verified deterministic clean/fail fixture behavior for the new checker, including stale milestone wording and tracked-junk rejection.
  - `git diff --check`
    Verified the scoped diff is free of patch-formatting defects.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase review --input .adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/srp.md`
    Verified the final SRP structure after recording the completed independent pre-PR review result.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase run --input .adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/sor.md`
    Verified this completed execution record against the run-phase SOR contract.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Attempted broader owner-lane validation; this exposed an unrelated pre-existing failure in `adl/tools/test_control_plane_observability.sh` and is not used as issue proof.
- Results:
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS
  - PARTIAL: broader owner-lane attempt failed outside the touched surface and is recorded for truth only, not as issue-blocking proof

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3925__v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks/sor.md
- Idempotency-Key: v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-check-repo-quality-staleness-py-adl-tools-test-check-repo-quality-staleness-sh-readme-md-changelog-md-adl-tools-readme-md-docs-milestones-v0-91-6-release-plan-v0-91-6-md-docs-milestones-v0-91-6-review-and-validation-checklist-v0-91-6-md-adl-v0-91-6-tasks-issue-3925-v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks-sip-md-adl-v0-91-6-tasks-issue-3925-v0-91-6-quality-add-repo-quality-and-documentation-staleness-checks-sor-md