### PR TITLE
[v0.91.6][WP-02][resilience][R-04] Implement rate limiting policy

### DIFF
--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -489,6 +489,7 @@ pub fn provider_failure_classification_from_failure(
         summary: sanitize_resilience_summary(&failure.message),
         component_ref: None,
         http_status: failure.http_status,
+        retry_after_ms: None,
     }
 }
 

--- a/adl/src/resilience.rs
+++ b/adl/src/resilience.rs
@@ -20,11 +20,15 @@ pub const RESILIENCE_CIRCUIT_BREAKER_EXECUTION_TRACE_SCHEMA_V1: &str =
     "adl.resilience.circuit_breaker_execution_trace.v1";
 pub const RESILIENCE_CIRCUIT_BREAKER_STATE_SCHEMA_V1: &str =
     "adl.resilience.circuit_breaker_state.v1";
+pub const RESILIENCE_RATE_LIMIT_EXECUTION_TRACE_SCHEMA_V1: &str =
+    "adl.resilience.rate_limit_execution_trace.v1";
+pub const RESILIENCE_RATE_LIMIT_STATE_SCHEMA_V1: &str = "adl.resilience.rate_limit_state.v1";
 pub const RESILIENCE_POLICY_SCHEMA_V1: &str = "adl.resilience.policy.v1";
 pub const RESILIENCE_SUBSTRATE_SCHEMA_V1: &str = "adl.resilience.substrate_manifest.v1";
 
 static TIMEOUT_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CIRCUIT_BREAKER_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
+static RATE_LIMIT_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -81,6 +85,8 @@ pub struct ResilienceFaultClassificationV1 {
     pub component_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -407,6 +413,53 @@ pub struct RateLimitPolicyV1 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitFinalStatusV1 {
+    Allowed,
+    Throttled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitStateV1 {
+    pub schema_version: String,
+    pub policy_id: String,
+    pub window_started_at_ms: u64,
+    pub requests_in_window: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitExecutionTraceV1 {
+    pub schema_version: String,
+    pub policy_id: String,
+    pub surface: ResilienceSurfaceV1,
+    pub final_status: RateLimitFinalStatusV1,
+    pub window_started_at_ms: u64,
+    pub requests_in_window_before: u32,
+    pub requests_in_window_after: u32,
+    pub max_requests: u32,
+    pub window_ms: u64,
+    pub operation_executed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_ms: Option<u64>,
+    pub decision_summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fault: Option<ResilienceFaultClassificationV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_event: Option<ResilienceTelemetryEventV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_artifact: Option<RecoveryArtifactV1>,
+}
+
+#[derive(Debug)]
+pub struct RateLimitExecution<T, E> {
+    pub result: Result<T, E>,
+    pub state: RateLimitStateV1,
+    pub trace: RateLimitExecutionTraceV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BulkheadPolicyV1 {
     pub fault_domain: String,
@@ -559,6 +612,7 @@ impl ResilienceFaultClassificationV1 {
             summary: sanitize_resilience_summary(note),
             component_ref: None,
             http_status,
+            retry_after_ms: None,
         }
     }
 }
@@ -694,7 +748,9 @@ where
             }
             Err(error) => {
                 let classification = classify_error(&error);
-                let delay_ms = retry.next_delay_ms(&policy.policy_id, attempt_index);
+                let delay_ms = retry
+                    .next_delay_ms(&policy.policy_id, attempt_index)
+                    .max(classification.retry_after_ms.unwrap_or(0));
                 let elapsed_ms = started.elapsed().as_millis() as u64;
                 let retryable_fault = retry.permits_fault(&classification);
                 let within_attempt_budget = attempt_index < retry.max_attempts.max(1);
@@ -1392,6 +1448,150 @@ where
     }
 }
 
+pub fn rate_limit_initial_state(policy: &ResiliencePolicyV1, now_ms: u64) -> RateLimitStateV1 {
+    RateLimitStateV1 {
+        schema_version: RESILIENCE_RATE_LIMIT_STATE_SCHEMA_V1.to_string(),
+        policy_id: policy.policy_id.clone(),
+        window_started_at_ms: now_ms,
+        requests_in_window: 0,
+    }
+}
+
+pub fn execute_rate_limit_policy<T, E, F, R, C>(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    operation_ref: &str,
+    current_state: &RateLimitStateV1,
+    now_ms: u64,
+    operation: F,
+    mut rejection_error: R,
+    mut classify_error: C,
+) -> RateLimitExecution<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    R: FnMut(&RateLimitStateV1, u64) -> E,
+    C: FnMut(&E) -> ResilienceFaultClassificationV1,
+{
+    let state = rate_limit_state_for_policy(current_state, policy, now_ms);
+    let Some(rate_limit_policy) = policy.rate_limit.as_ref() else {
+        let result = operation();
+        let state = rate_limit_initial_state(policy, now_ms);
+        let decision_summary = format!("{operation_ref}: rate limit disabled; operation completed");
+        let telemetry_event = Some(rate_limit_decision_event(
+            policy,
+            surface.clone(),
+            operation_ref,
+            &decision_summary,
+            None,
+        ));
+        return RateLimitExecution {
+            result,
+            state: state.clone(),
+            trace: RateLimitExecutionTraceV1 {
+                schema_version: RESILIENCE_RATE_LIMIT_EXECUTION_TRACE_SCHEMA_V1.to_string(),
+                policy_id: policy.policy_id.clone(),
+                surface,
+                final_status: RateLimitFinalStatusV1::Allowed,
+                window_started_at_ms: state.window_started_at_ms,
+                requests_in_window_before: 0,
+                requests_in_window_after: 0,
+                max_requests: 0,
+                window_ms: 0,
+                operation_executed: true,
+                wait_ms: None,
+                decision_summary,
+                fault: None,
+                telemetry_event,
+                recovery_artifact: None,
+            },
+        };
+    };
+
+    let mut normalized_state = rate_limit_state_for_now(&state, rate_limit_policy, now_ms);
+    let requests_before = normalized_state.requests_in_window;
+    if normalized_state.requests_in_window < rate_limit_policy.max_requests {
+        normalized_state.requests_in_window = normalized_state.requests_in_window.saturating_add(1);
+        let result = operation();
+        let decision_summary = format!(
+            "{operation_ref}: rate limit allowed {}/{} in {}ms window",
+            normalized_state.requests_in_window,
+            rate_limit_policy.max_requests,
+            rate_limit_policy.window_ms
+        );
+        let telemetry_event = Some(rate_limit_decision_event(
+            policy,
+            surface.clone(),
+            operation_ref,
+            &decision_summary,
+            None,
+        ));
+        return RateLimitExecution {
+            result,
+            state: normalized_state.clone(),
+            trace: RateLimitExecutionTraceV1 {
+                schema_version: RESILIENCE_RATE_LIMIT_EXECUTION_TRACE_SCHEMA_V1.to_string(),
+                policy_id: policy.policy_id.clone(),
+                surface,
+                final_status: RateLimitFinalStatusV1::Allowed,
+                window_started_at_ms: normalized_state.window_started_at_ms,
+                requests_in_window_before: requests_before,
+                requests_in_window_after: normalized_state.requests_in_window,
+                max_requests: rate_limit_policy.max_requests,
+                window_ms: rate_limit_policy.window_ms,
+                operation_executed: true,
+                wait_ms: None,
+                decision_summary,
+                fault: None,
+                telemetry_event,
+                recovery_artifact: None,
+            },
+        };
+    }
+
+    let wait_ms = rate_limit_wait_ms(&normalized_state, rate_limit_policy, now_ms);
+    let error = rejection_error(&normalized_state, wait_ms);
+    let fault = classify_error(&error);
+    let decision_summary = format!(
+        "{operation_ref}: rate limited at {}/{} requests; wait {}ms for window refill",
+        normalized_state.requests_in_window, rate_limit_policy.max_requests, wait_ms
+    );
+    let telemetry_event = Some(rate_limit_decision_event(
+        policy,
+        surface.clone(),
+        operation_ref,
+        &decision_summary,
+        Some(fault.clone()),
+    ));
+    let recovery_artifact = Some(rate_limit_recovery_artifact(
+        policy,
+        surface.clone(),
+        operation_ref,
+        &fault,
+        wait_ms,
+    ));
+    RateLimitExecution {
+        result: Err(error),
+        state: normalized_state.clone(),
+        trace: RateLimitExecutionTraceV1 {
+            schema_version: RESILIENCE_RATE_LIMIT_EXECUTION_TRACE_SCHEMA_V1.to_string(),
+            policy_id: policy.policy_id.clone(),
+            surface,
+            final_status: RateLimitFinalStatusV1::Throttled,
+            window_started_at_ms: normalized_state.window_started_at_ms,
+            requests_in_window_before: requests_before,
+            requests_in_window_after: normalized_state.requests_in_window,
+            max_requests: rate_limit_policy.max_requests,
+            window_ms: rate_limit_policy.window_ms,
+            operation_executed: false,
+            wait_ms: Some(wait_ms),
+            decision_summary,
+            fault: Some(fault),
+            telemetry_event,
+            recovery_artifact,
+        },
+    }
+}
+
 pub fn resilience_schema_smoke() -> Value {
     serde_json::to_value(schema_for!(ResilienceSubstrateManifestV1))
         .expect("resilience substrate schema should serialize")
@@ -1567,6 +1767,7 @@ fn timeout_deadline_fault(
         ),
         component_ref: Some(operation_ref.to_string()),
         http_status: None,
+        retry_after_ms: None,
     }
 }
 
@@ -1583,6 +1784,7 @@ fn timeout_cancellation_fault(
         summary: format!("{operation_ref} cancelled before completion"),
         component_ref: Some(operation_ref.to_string()),
         http_status: None,
+        retry_after_ms: None,
     }
 }
 
@@ -1793,10 +1995,102 @@ fn circuit_breaker_execution_correlation_suffix() -> String {
         .to_string()
 }
 
+fn rate_limit_state_for_policy(
+    state: &RateLimitStateV1,
+    policy: &ResiliencePolicyV1,
+    now_ms: u64,
+) -> RateLimitStateV1 {
+    if state.policy_id == policy.policy_id {
+        state.clone()
+    } else {
+        rate_limit_initial_state(policy, now_ms)
+    }
+}
+
+fn rate_limit_state_for_now(
+    state: &RateLimitStateV1,
+    policy: &RateLimitPolicyV1,
+    now_ms: u64,
+) -> RateLimitStateV1 {
+    if now_ms.saturating_sub(state.window_started_at_ms) < policy.window_ms {
+        return state.clone();
+    }
+    RateLimitStateV1 {
+        schema_version: state.schema_version.clone(),
+        policy_id: state.policy_id.clone(),
+        window_started_at_ms: now_ms,
+        requests_in_window: 0,
+    }
+}
+
+fn rate_limit_wait_ms(state: &RateLimitStateV1, policy: &RateLimitPolicyV1, now_ms: u64) -> u64 {
+    policy
+        .window_ms
+        .saturating_sub(now_ms.saturating_sub(state.window_started_at_ms))
+}
+
+fn rate_limit_decision_event(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    operation_ref: &str,
+    decision_summary: &str,
+    fault: Option<ResilienceFaultClassificationV1>,
+) -> ResilienceTelemetryEventV1 {
+    let correlation_suffix = rate_limit_execution_correlation_suffix();
+    ResilienceTelemetryEventV1 {
+        schema_version: RESILIENCE_TELEMETRY_EVENT_SCHEMA_V1.to_string(),
+        event_id: format!(
+            "{}:rate-limit:{operation_ref}:{correlation_suffix}",
+            policy.policy_id
+        ),
+        event_kind: TelemetryEventKindV1::RateLimitDecision,
+        surface,
+        decision_summary: decision_summary.to_string(),
+        run_id: None,
+        request_id: None,
+        policy_ref: Some(policy.policy_id.clone()),
+        fault,
+        artifact_ref: None,
+    }
+}
+
+fn rate_limit_recovery_artifact(
+    policy: &ResiliencePolicyV1,
+    surface: ResilienceSurfaceV1,
+    operation_ref: &str,
+    fault: &ResilienceFaultClassificationV1,
+    wait_ms: u64,
+) -> RecoveryArtifactV1 {
+    let correlation_suffix = rate_limit_execution_correlation_suffix();
+    RecoveryArtifactV1 {
+        schema_version: RESILIENCE_RECOVERY_ARTIFACT_SCHEMA_V1.to_string(),
+        artifact_id: format!(
+            "{}:rate-limit:{operation_ref}:{correlation_suffix}",
+            policy.policy_id
+        ),
+        surface,
+        triggering_fault: fault.clone(),
+        disposition: RecoveryDispositionV1::RetryAllowed,
+        next_action: format!(
+            "respect rate limit throttle by waiting at least {wait_ms}ms before retrying"
+        ),
+        source_run_id: None,
+        checkpoint_ref: None,
+        evidence_refs: vec![policy.policy_id.clone()],
+    }
+}
+
+fn rate_limit_execution_correlation_suffix() -> String {
+    RATE_LIMIT_EXECUTION_COUNTER
+        .fetch_add(1, Ordering::Relaxed)
+        .saturating_add(1)
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     fn clone_fault_classification(
         error: &ResilienceFaultClassificationV1,
@@ -1821,6 +2115,7 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1841,6 +2136,7 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1861,6 +2157,7 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1881,6 +2178,7 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1894,6 +2192,7 @@ mod tests {
             summary: format!("cancelled at {elapsed_ms}"),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1907,6 +2206,7 @@ mod tests {
             summary: format!("cancelled at {elapsed_ms}"),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1920,6 +2220,7 @@ mod tests {
             summary: format!("cancelled at {elapsed_ms}"),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1933,6 +2234,7 @@ mod tests {
             summary: format!("cancelled at {elapsed_ms}"),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1952,6 +2254,7 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         }
     }
 
@@ -1971,6 +2274,27 @@ mod tests {
             ),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
+        }
+    }
+
+    fn provider_rate_limit_rejection(
+        state: &RateLimitStateV1,
+        wait_ms: u64,
+    ) -> ResilienceFaultClassificationV1 {
+        ResilienceFaultClassificationV1 {
+            schema_version: RESILIENCE_FAULT_CLASSIFICATION_SCHEMA_V1.to_string(),
+            surface: ResilienceSurfaceV1::Provider,
+            fault_class: ResilienceFaultClassV1::ProviderRateLimited,
+            disposition: ResilienceFaultDispositionV1::Retryable,
+            retryable: true,
+            summary: format!(
+                "rate limited after {} request(s); wait {}ms",
+                state.requests_in_window, wait_ms
+            ),
+            component_ref: None,
+            http_status: Some(429),
+            retry_after_ms: Some(wait_ms),
         }
     }
 
@@ -2469,6 +2793,7 @@ mod tests {
                     summary: "tool timeout while waiting for child process".to_string(),
                     component_ref: None,
                     http_status: None,
+                    retry_after_ms: None,
                 }),
                 elapsed_ms: 105,
                 cancelled: false,
@@ -2519,6 +2844,7 @@ mod tests {
                     summary: "operation timed out without explicit timeout budget".to_string(),
                     component_ref: None,
                     http_status: None,
+                    retry_after_ms: None,
                 }),
                 elapsed_ms: 45,
                 cancelled: false,
@@ -2558,6 +2884,7 @@ mod tests {
                     summary: "cancelled".to_string(),
                     component_ref: None,
                     http_status: None,
+                    retry_after_ms: None,
                 }),
                 elapsed_ms: 15,
                 cancelled: true,
@@ -2660,6 +2987,7 @@ mod tests {
             summary: "deadline elapsed while waiting".to_string(),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         };
         assert!(classification_represents_timeout(&runtime_deadline));
 
@@ -2672,6 +3000,7 @@ mod tests {
             summary: "worker exited with code 2".to_string(),
             component_ref: None,
             http_status: None,
+            retry_after_ms: None,
         };
         assert!(!classification_represents_timeout(&runtime_non_timeout));
 
@@ -3423,5 +3752,226 @@ mod tests {
         );
         assert_ne!(first_event.event_id, second_event.event_id);
         assert_ne!(first_artifact.artifact_id, second_artifact.artifact_id);
+    }
+
+    #[test]
+    fn rate_limit_allows_calls_within_window_budget() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "rate-limit.allow".to_string(),
+            retry: None,
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: Some(RateLimitPolicyV1 {
+                max_requests: 2,
+                window_ms: 100,
+            }),
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+        let state = rate_limit_initial_state(&policy, 0);
+        let first = execute_rate_limit_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.rate-limit.allow",
+            &state,
+            10,
+            || Ok::<_, ResilienceFaultClassificationV1>("first"),
+            provider_rate_limit_rejection,
+            clone_fault_classification,
+        );
+        assert_eq!(first.result.expect("allowed"), "first");
+        assert_eq!(first.state.requests_in_window, 1);
+        assert_eq!(first.trace.final_status, RateLimitFinalStatusV1::Allowed);
+        assert_eq!(
+            first
+                .trace
+                .telemetry_event
+                .as_ref()
+                .map(|event| event.event_kind.clone()),
+            Some(TelemetryEventKindV1::RateLimitDecision)
+        );
+
+        let second = execute_rate_limit_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.rate-limit.allow",
+            &first.state,
+            20,
+            || Ok::<_, ResilienceFaultClassificationV1>("second"),
+            provider_rate_limit_rejection,
+            clone_fault_classification,
+        );
+        assert_eq!(second.result.expect("allowed"), "second");
+        assert_eq!(second.state.requests_in_window, 2);
+        assert_eq!(second.trace.requests_in_window_before, 1);
+        assert_eq!(second.trace.requests_in_window_after, 2);
+    }
+
+    #[test]
+    fn rate_limit_throttles_calls_after_budget_is_exhausted() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "rate-limit.throttle".to_string(),
+            retry: None,
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: Some(RateLimitPolicyV1 {
+                max_requests: 1,
+                window_ms: 100,
+            }),
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+        let state = RateLimitStateV1 {
+            schema_version: RESILIENCE_RATE_LIMIT_STATE_SCHEMA_V1.to_string(),
+            policy_id: policy.policy_id.clone(),
+            window_started_at_ms: 10,
+            requests_in_window: 1,
+        };
+        let called = Cell::new(0);
+        let execution = execute_rate_limit_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.rate-limit.throttle",
+            &state,
+            40,
+            || {
+                called.set(called.get() + 1);
+                Ok::<_, ResilienceFaultClassificationV1>("should-not-run")
+            },
+            provider_rate_limit_rejection,
+            clone_fault_classification,
+        );
+
+        assert_eq!(called.get(), 0);
+        let failure = execution.result.expect_err("throttled");
+        assert_eq!(
+            failure.fault_class,
+            ResilienceFaultClassV1::ProviderRateLimited
+        );
+        assert_eq!(
+            execution.trace.final_status,
+            RateLimitFinalStatusV1::Throttled
+        );
+        assert_eq!(execution.trace.wait_ms, Some(70));
+        assert!(execution.trace.recovery_artifact.is_some());
+        assert!(execution
+            .trace
+            .decision_summary
+            .contains("wait 70ms for window refill"));
+    }
+
+    #[test]
+    fn rate_limit_resets_window_after_budget_refills() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "rate-limit.reset".to_string(),
+            retry: None,
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: Some(RateLimitPolicyV1 {
+                max_requests: 1,
+                window_ms: 50,
+            }),
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+        let stale_state = RateLimitStateV1 {
+            schema_version: RESILIENCE_RATE_LIMIT_STATE_SCHEMA_V1.to_string(),
+            policy_id: policy.policy_id.clone(),
+            window_started_at_ms: 10,
+            requests_in_window: 1,
+        };
+        let execution = execute_rate_limit_policy(
+            &policy,
+            ResilienceSurfaceV1::Workflow,
+            "test.rate-limit.reset",
+            &stale_state,
+            70,
+            || Ok::<_, ResilienceFaultClassificationV1>("ok"),
+            provider_rate_limit_rejection,
+            clone_fault_classification,
+        );
+        assert_eq!(execution.result.expect("allowed"), "ok");
+        assert_eq!(execution.state.window_started_at_ms, 70);
+        assert_eq!(execution.state.requests_in_window, 1);
+        assert_eq!(execution.trace.requests_in_window_before, 0);
+    }
+
+    #[test]
+    fn retry_policy_can_respect_rate_limit_waits_without_retry_storms() {
+        let policy = ResiliencePolicyV1 {
+            schema_version: RESILIENCE_POLICY_SCHEMA_V1.to_string(),
+            policy_id: "rate-limit.retry".to_string(),
+            retry: Some(RetryPolicyV1 {
+                max_attempts: 2,
+                backoff_ms: Some(5),
+                jitter_ms: Some(0),
+                max_elapsed_ms: None,
+                retryable_fault_classes: vec![ResilienceFaultClassV1::ProviderRateLimited],
+            }),
+            timeout: None,
+            circuit_breaker: None,
+            rate_limit: Some(RateLimitPolicyV1 {
+                max_requests: 1,
+                window_ms: 50,
+            }),
+            bulkhead: None,
+            fallback: None,
+            checkpoint_required: false,
+            telemetry_required: true,
+        };
+
+        let rate_state = RefCell::new(RateLimitStateV1 {
+            schema_version: RESILIENCE_RATE_LIMIT_STATE_SCHEMA_V1.to_string(),
+            policy_id: policy.policy_id.clone(),
+            window_started_at_ms: 0,
+            requests_in_window: 1,
+        });
+        let now_ms = Cell::new(10_u64);
+        let mut sleeps = Vec::new();
+
+        let execution = execute_retry_policy(
+            &policy,
+            ResilienceSurfaceV1::Provider,
+            "test.rate-limit.retry",
+            |_| {
+                let current_state = rate_state.borrow().clone();
+                let limited = execute_rate_limit_policy(
+                    &policy,
+                    ResilienceSurfaceV1::Provider,
+                    "test.rate-limit.retry",
+                    &current_state,
+                    now_ms.get(),
+                    || Ok::<_, ResilienceFaultClassificationV1>("ok"),
+                    provider_rate_limit_rejection,
+                    clone_fault_classification,
+                );
+                *rate_state.borrow_mut() = limited.state.clone();
+                match limited.result {
+                    Ok(value) => Ok(value),
+                    Err(error) => Err(error),
+                }
+            },
+            clone_fault_classification,
+            |delay_ms| {
+                sleeps.push(delay_ms);
+                now_ms.set(now_ms.get().saturating_add(delay_ms.max(50)));
+            },
+            |_| {},
+        );
+
+        assert_eq!(execution.result.expect("second attempt succeeds"), "ok");
+        assert_eq!(execution.trace.attempts.len(), 2);
+        assert_eq!(sleeps, vec![40]);
+        assert_eq!(rate_state.borrow().requests_in_window, 1);
+        assert_eq!(rate_state.borrow().window_started_at_ms, 60);
     }
 }

--- a/adl/src/resilience.rs
+++ b/adl/src/resilience.rs
@@ -1457,6 +1457,7 @@ pub fn rate_limit_initial_state(policy: &ResiliencePolicyV1, now_ms: u64) -> Rat
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_rate_limit_policy<T, E, F, R, C>(
     policy: &ResiliencePolicyV1,
     surface: ResilienceSurfaceV1,


### PR DESCRIPTION
Closes #3990

## Summary
Implemented the shared rate-limiting substrate in `adl/src/resilience.rs`, added the minimal provider fault-classification bridge needed to carry bounded throttle waits through retries, and proved allowed, throttled, refill, and retry-storm-prevention behavior with focused resilience tests.

## Artifacts
- Updated shared resilience substrate in `adl/src/resilience.rs`
- Updated provider failure classification bridge in `adl/src/provider_communication.rs`
- Updated local ignored output record at `.adl/v0.91.6/tasks/issue-3990__v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Normalized Rust formatting for the touched resilience and provider communication surfaces.
  - `cargo test --manifest-path adl/Cargo.toml resilience::tests:: -- --nocapture`
    Verified the focused rate-limit acceptance surface and the surrounding resilience regressions.
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 3990 --json`
    Verified the issue remained bound and structurally ready while identifying the scaffolded SOR as the only publication blocker before this update.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3990__v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3990__v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy/sor.md
- Idempotency-Key: v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy-adl-v0-91-6-tasks-issue-3990-v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy-sip-md-adl-v0-91-6-tasks-issue-3990-v0-91-6-wp-02-resilience-r-04-implement-rate-limiting-policy-sor-md