### PR TITLE
[v0.91.6][provider] Sanitize private LAN endpoint fixtures before durable proof packets

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1108,6 +1108,24 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_private_endpoint_fixture_sanitation_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            commands
+                .push("bash adl/tools/test_demo_codex_ollama_operational_skills.sh".to_string());
+            commands.push("bash adl/tools/test_demo_codex_ollama_semantic_fallback.sh".to_string());
+            commands.push("bash adl/tools/test_demo_v089_gemma4_issue_clerk.sh".to_string());
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --lib provider_substrate_uses_http_transport_for_ollama_with_endpoint",
+            );
+            commands.push(
+                "python3 adl/tools/validate_v0915_remote_gemma_watcher_probe.py docs/milestones/v0.91.5/review/remote_gemma_watcher"
+                    .to_string(),
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_csdlc_owner_lane_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1294,6 +1312,15 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/cli/tooling_cmd/github_release.rs"
             | "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
             | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
+            | "adl/tools/demo_codex_ollama_operational_skills.sh"
+            | "adl/tools/demo_v089_gemma4_issue_clerk.sh"
+            | "adl/tools/test_demo_codex_ollama_operational_skills.sh"
+            | "adl/tools/test_demo_codex_ollama_semantic_fallback.sh"
+            | "adl/tools/test_demo_v089_gemma4_issue_clerk.sh"
+            | "adl/src/provider_substrate.rs"
+            | "adl/tools/validate_v0915_remote_gemma_watcher_probe.py"
+            | "demos/v0.87.1/codex_ollama_operational_skills_demo.md"
+            | "demos/v0.89/gemma4_issue_clerk_demo.md"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
@@ -1394,6 +1421,22 @@ fn finish_path_needs_repo_quality_staleness_validation(path: &str) -> bool {
         trimmed,
         "adl/tools/check_repo_quality_staleness.py"
             | "adl/tools/test_check_repo_quality_staleness.sh"
+    )
+}
+
+fn finish_path_needs_private_endpoint_fixture_sanitation_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/demo_codex_ollama_operational_skills.sh"
+            | "adl/tools/demo_v089_gemma4_issue_clerk.sh"
+            | "adl/tools/test_demo_codex_ollama_operational_skills.sh"
+            | "adl/tools/test_demo_codex_ollama_semantic_fallback.sh"
+            | "adl/tools/test_demo_v089_gemma4_issue_clerk.sh"
+            | "adl/src/provider_substrate.rs"
+            | "adl/tools/validate_v0915_remote_gemma_watcher_probe.py"
+            | "demos/v0.87.1/codex_ollama_operational_skills_demo.md"
+            | "demos/v0.89/gemma4_issue_clerk_demo.md"
     )
 }
 
@@ -1608,6 +1651,40 @@ pub(super) fn run_finish_validation_rust(
                 "bash adl/tools/test_check_repo_quality_staleness.sh" => {
                     let script = repo_root.join("adl/tools/test_check_repo_quality_staleness.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_demo_codex_ollama_operational_skills.sh" => {
+                    let script = repo_root.join("adl/tools/test_demo_codex_ollama_operational_skills.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_demo_codex_ollama_semantic_fallback.sh" => {
+                    let script = repo_root.join("adl/tools/test_demo_codex_ollama_semantic_fallback.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_demo_v089_gemma4_issue_clerk.sh" => {
+                    let script = repo_root.join("adl/tools/test_demo_v089_gemma4_issue_clerk.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --lib provider_substrate_uses_http_transport_for_ollama_with_endpoint" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--lib",
+                            "provider_substrate_uses_http_transport_for_ollama_with_endpoint",
+                        ],
+                    )?;
+                }
+                "python3 adl/tools/validate_v0915_remote_gemma_watcher_probe.py docs/milestones/v0.91.5/review/remote_gemma_watcher" => {
+                    let script =
+                        repo_root.join("adl/tools/validate_v0915_remote_gemma_watcher_probe.py");
+                    let review_root =
+                        repo_root.join("docs/milestones/v0.91.5/review/remote_gemma_watcher");
+                    run_finish_validation_status(
+                        "python3",
+                        &[path_str(&script)?, path_str(&review_root)?],
+                    )?;
                 }
                 "bash adl/tools/run_owner_validation_lane.sh csdlc" => {
                     let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -851,6 +851,39 @@ fn finish_validation_plan_classifies_repo_quality_staleness_tooling() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_private_endpoint_fixture_sanitation_slice() {
+    let plan = select_finish_validation_plan(
+        "adl/tools/demo_codex_ollama_operational_skills.sh,adl/tools/demo_v089_gemma4_issue_clerk.sh,adl/tools/test_demo_codex_ollama_operational_skills.sh,adl/tools/test_demo_codex_ollama_semantic_fallback.sh,adl/tools/test_demo_v089_gemma4_issue_clerk.sh,adl/src/provider_substrate.rs,adl/tools/validate_v0915_remote_gemma_watcher_probe.py,demos/v0.87.1/codex_ollama_operational_skills_demo.md,demos/v0.89/gemma4_issue_clerk_demo.md",
+    )
+    .expect("private endpoint fixture sanitation plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_demo_codex_ollama_operational_skills.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_demo_codex_ollama_semantic_fallback.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_demo_v089_gemma4_issue_clerk.sh".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --lib provider_substrate_uses_http_transport_for_ollama_with_endpoint".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"python3 adl/tools/validate_v0915_remote_gemma_watcher_probe.py docs/milestones/v0.91.5/review/remote_gemma_watcher".to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
 fn finish_validation_plan_classifies_resilience_runtime_publication_paths() {
     let adapter_plan = select_finish_validation_plan("adl/src/provider_adapter.rs")
         .expect("provider adapter runtime plan");

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -670,7 +670,7 @@ mod tests {
     #[test]
     fn provider_substrate_uses_http_transport_for_ollama_with_endpoint() {
         let mut spec = provider_spec("ollama");
-        spec.base_url = Some("http://192.168.68.73:11434".to_string());
+        spec.base_url = Some("http://remote_ollama_private_lan:11434".to_string());
         spec.default_model = Some("phi4-mini".to_string());
 
         let substrate = provider_substrate_v1("remote_ollama", &spec).expect("substrate");

--- a/adl/tools/demo_codex_ollama_operational_skills.sh
+++ b/adl/tools/demo_codex_ollama_operational_skills.sh
@@ -33,7 +33,45 @@ normalize_ollama_host_url() {
   printf '%s\n' "${normalized%/}"
 }
 
+durable_ollama_host_ref() {
+  python3 - "$1" <<'PY'
+from __future__ import annotations
+
+import ipaddress
+import sys
+from urllib.parse import urlparse
+
+raw = sys.argv[1].strip().rstrip("/")
+parsed = urlparse(raw if "://" in raw else f"http://{raw}")
+host = parsed.hostname or ""
+
+if host in {"127.0.0.1", "localhost", "::1"}:
+    print(raw)
+    raise SystemExit(0)
+
+if host in {"remote_ollama_private_lan", "remote-ollama-private-lan"}:
+    print("remote_ollama_private_lan")
+    raise SystemExit(0)
+
+try:
+    addr = ipaddress.ip_address(host)
+except ValueError:
+    print(raw)
+    raise SystemExit(0)
+
+if addr.is_private and not addr.is_loopback:
+    print("remote_ollama_private_lan")
+else:
+    print(raw)
+PY
+}
+
 OLLAMA_HOST_URL="$(normalize_ollama_host_url "$RAW_OLLAMA_HOST_INPUT")"
+DURABLE_OLLAMA_HOST_REF="$(durable_ollama_host_ref "$OLLAMA_HOST_URL")"
+OLLAMA_HOST_ARTIFACT_POLICY="literal_runtime_url"
+if [[ "$DURABLE_OLLAMA_HOST_REF" != "$OLLAMA_HOST_URL" ]]; then
+  OLLAMA_HOST_ARTIFACT_POLICY="private_lan_redacted"
+fi
 
 usage() {
   cat <<'EOF'
@@ -50,7 +88,7 @@ Notes:
   - Default model: gpt-oss:latest
   - Default provider: ollama
   - Default Ollama API: http://127.0.0.1:11434
-  - Set OLLAMA_HOST=192.168.68.73 or OLLAMA_HOST_URL=http://192.168.68.73:11434 to target a remote Ollama host for this demo.
+  - Set OLLAMA_HOST=<private-lan-ollama-host> or OLLAMA_HOST_URL=http://<private-lan-ollama-host>:11434 to target a remote Ollama host for this demo.
   - Default semantic-fallback timeout: 90 seconds
   - Non-tool local models are routed through semantic tool fallback instead of native Codex tool calling.
   - --dry-run prepares the workspace, prompt, and manifest but does not invoke Codex.
@@ -367,7 +405,8 @@ cat >"$MANIFEST_FILE" <<EOF
   "codex_home": "$CODEX_HOME_DEMO",
   "install_mode": "$CODEX_INSTALL_MODE",
   "local_provider": "$LOCAL_PROVIDER",
-  "ollama_host_url": "$OLLAMA_HOST_URL",
+  "ollama_host_ref": "$DURABLE_OLLAMA_HOST_REF",
+  "ollama_host_runtime_input_policy": "$OLLAMA_HOST_ARTIFACT_POLICY",
   "model": "$MODEL",
   "capability_manifest": "$CAPABILITY_FILE",
   "capability_profile_id": "$CAPABILITY_PROFILE_ID",

--- a/adl/tools/demo_v089_gemma4_issue_clerk.sh
+++ b/adl/tools/demo_v089_gemma4_issue_clerk.sh
@@ -26,7 +26,45 @@ normalize_ollama_host_url() {
   printf '%s\n' "${normalized%/}"
 }
 
+durable_ollama_host_ref() {
+  python3 - "$1" <<'PY'
+from __future__ import annotations
+
+import ipaddress
+import sys
+from urllib.parse import urlparse
+
+raw = sys.argv[1].strip().rstrip("/")
+parsed = urlparse(raw if "://" in raw else f"http://{raw}")
+host = parsed.hostname or ""
+
+if host in {"127.0.0.1", "localhost", "::1"}:
+    print(raw)
+    raise SystemExit(0)
+
+if host in {"remote_ollama_private_lan", "remote-ollama-private-lan"}:
+    print("remote_ollama_private_lan")
+    raise SystemExit(0)
+
+try:
+    addr = ipaddress.ip_address(host)
+except ValueError:
+    print(raw)
+    raise SystemExit(0)
+
+if addr.is_private and not addr.is_loopback:
+    print("remote_ollama_private_lan")
+else:
+    print(raw)
+PY
+}
+
 OLLAMA_HOST_URL="$(normalize_ollama_host_url "$RAW_OLLAMA_HOST_INPUT")"
+DURABLE_OLLAMA_HOST_REF="$(durable_ollama_host_ref "$OLLAMA_HOST_URL")"
+OLLAMA_HOST_ARTIFACT_POLICY="literal_runtime_url"
+if [[ "$DURABLE_OLLAMA_HOST_REF" != "$OLLAMA_HOST_URL" ]]; then
+  OLLAMA_HOST_ARTIFACT_POLICY="private_lan_redacted"
+fi
 
 usage() {
   cat <<'EOF'
@@ -42,7 +80,7 @@ Purpose:
 Notes:
   - Default model: gemma4:latest
   - Default Ollama API: http://127.0.0.1:11434
-  - Set OLLAMA_HOST or OLLAMA_HOST_URL to target a remote Ollama host.
+  - Set OLLAMA_HOST=<private-lan-ollama-host> or OLLAMA_HOST_URL=http://<private-lan-ollama-host>:11434 to target a remote Ollama host.
   - Set ADL_GEMMA4_RESPONSE_FILE to replay a fixture instead of calling Ollama.
   - --dry-run prepares packet, prompt, and manifest without invoking a model.
 EOF
@@ -331,7 +369,7 @@ PY
 
 write_manifest() {
   local disposition="$1"
-  python3 - "$ROOT_DIR" "$MANIFEST_FILE" "$disposition" "$MODEL" "$OLLAMA_HOST_URL" "$DRY_RUN" "$PACKET_FILE" "$PROMPT_FILE" "$RAW_RESPONSE_FILE" "$VALIDATED_PROPOSAL_FILE" "$ISSUE_BODY_FILE" "$REJECTION_REASON_FILE" <<'PY'
+  python3 - "$ROOT_DIR" "$MANIFEST_FILE" "$disposition" "$MODEL" "$DURABLE_OLLAMA_HOST_REF" "$OLLAMA_HOST_ARTIFACT_POLICY" "$DRY_RUN" "$PACKET_FILE" "$PROMPT_FILE" "$RAW_RESPONSE_FILE" "$VALIDATED_PROPOSAL_FILE" "$ISSUE_BODY_FILE" "$REJECTION_REASON_FILE" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -341,7 +379,8 @@ from pathlib import Path
     manifest_path,
     disposition,
     model,
-    host,
+    host_ref,
+    host_policy,
     dry_run,
     packet_path,
     prompt_path,
@@ -366,7 +405,8 @@ manifest = {
     "demo": "gemma4_issue_clerk",
     "schema": "adl.demo_manifest.v1",
     "model": model,
-    "ollama_host_url": host,
+    "ollama_host_ref": host_ref,
+    "ollama_host_runtime_input_policy": host_policy,
     "dry_run": dry_run == "1",
     "disposition": disposition,
     "artifacts": {
@@ -408,7 +448,8 @@ write_summary() {
 
 - disposition: ${disposition}
 - model: ${MODEL}
-- ollama_host_url: ${OLLAMA_HOST_URL}
+- ollama_host_ref: ${DURABLE_OLLAMA_HOST_REF}
+- ollama_host_runtime_input_policy: ${OLLAMA_HOST_ARTIFACT_POLICY}
 - packet: ${packet_display}
 - prompt: ${prompt_display}
 - validated_proposal: ${validated_display}

--- a/adl/tools/test_demo_codex_ollama_operational_skills.sh
+++ b/adl/tools/test_demo_codex_ollama_operational_skills.sh
@@ -9,7 +9,7 @@ ARTIFACT_ROOT="$TMPDIR_ROOT/artifacts"
 
 (
   cd "$ROOT_DIR"
-  OLLAMA_HOST=192.168.68.73 \
+  OLLAMA_HOST=remote_ollama_private_lan \
   bash adl/tools/demo_codex_ollama_operational_skills.sh --dry-run --artifact-root "$ARTIFACT_ROOT" >/dev/null
 )
 
@@ -69,8 +69,12 @@ grep -Fq '"execution_mode": "native_tool_calling"' "$MANIFEST_FILE" || {
   echo "assertion failed: manifest does not record native tool execution mode" >&2
   exit 1
 }
-grep -Fq '"ollama_host_url": "http://192.168.68.73:11434"' "$MANIFEST_FILE" || {
-  echo "assertion failed: manifest did not normalize raw OLLAMA_HOST into the expected remote URL" >&2
+grep -Fq '"ollama_host_ref": "remote_ollama_private_lan"' "$MANIFEST_FILE" || {
+  echo "assertion failed: manifest did not sanitize the durable remote Ollama host reference" >&2
+  exit 1
+}
+grep -Fq '"ollama_host_runtime_input_policy": "private_lan_redacted"' "$MANIFEST_FILE" || {
+  echo "assertion failed: manifest did not record private-lan redaction policy" >&2
   exit 1
 }
 grep -Fq 'Do not use absolute host paths.' "$PROMPT_FILE" || {

--- a/adl/tools/test_demo_codex_ollama_semantic_fallback.sh
+++ b/adl/tools/test_demo_codex_ollama_semantic_fallback.sh
@@ -10,7 +10,7 @@ RESPONSE_FIXTURE="$ROOT_DIR/demos/fixtures/codex_ollama_operational_skills_demo/
 
 (
   cd "$ROOT_DIR"
-  OLLAMA_HOST_URL="http://192.168.68.73:11434" \
+  OLLAMA_HOST_URL="http://remote_ollama_private_lan:11434" \
   ADL_SEMANTIC_FALLBACK_RESPONSE_FILE="$RESPONSE_FIXTURE" \
   bash adl/tools/demo_codex_ollama_operational_skills.sh \
     --artifact-root "$ARTIFACT_ROOT" \
@@ -39,8 +39,12 @@ grep -Fq '"capability_profile_id": "ollama_deepseek_semantic_fallback"' "$MANIFE
   echo "assertion failed: manifest did not record deepseek fallback profile" >&2
   exit 1
 }
-grep -Fq '"ollama_host_url": "http://192.168.68.73:11434"' "$MANIFEST_FILE" || {
-  echo "assertion failed: manifest did not preserve explicit remote OLLAMA_HOST_URL" >&2
+grep -Fq '"ollama_host_ref": "remote_ollama_private_lan"' "$MANIFEST_FILE" || {
+  echo "assertion failed: manifest did not sanitize explicit remote OLLAMA_HOST_URL in durable artifacts" >&2
+  exit 1
+}
+grep -Fq '"ollama_host_runtime_input_policy": "private_lan_redacted"' "$MANIFEST_FILE" || {
+  echo "assertion failed: manifest did not record private-lan redaction policy" >&2
   exit 1
 }
 grep -Fq 'Branch: not bound yet' "$SIP_PATH" || {

--- a/adl/tools/test_demo_v089_gemma4_issue_clerk.sh
+++ b/adl/tools/test_demo_v089_gemma4_issue_clerk.sh
@@ -7,7 +7,8 @@ VALID_FIXTURE="$ROOT_DIR/demos/fixtures/gemma4_issue_clerk_demo/valid_response.j
 INVALID_FIXTURE="$ROOT_DIR/demos/fixtures/gemma4_issue_clerk_demo/invalid_response.json"
 
 rm -rf "$ARTIFACT_ROOT"
-bash "$ROOT_DIR/adl/tools/demo_v089_gemma4_issue_clerk.sh" --artifact-root "$ARTIFACT_ROOT" --dry-run >/dev/null
+OLLAMA_HOST=remote_ollama_private_lan \
+  bash "$ROOT_DIR/adl/tools/demo_v089_gemma4_issue_clerk.sh" --artifact-root "$ARTIFACT_ROOT" --dry-run >/dev/null
 python3 - "$ARTIFACT_ROOT/demo_manifest.json" <<'PY'
 import json
 import sys
@@ -15,6 +16,8 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     manifest = json.load(fh)
 assert manifest["disposition"] == "dry_run_prepared"
+assert manifest["ollama_host_ref"] == "remote_ollama_private_lan"
+assert manifest["ollama_host_runtime_input_policy"] == "private_lan_redacted"
 assert manifest["artifacts"]["issue_packet"]
 assert manifest["artifacts"]["model_prompt"]
 PY

--- a/adl/tools/validate_v0915_remote_gemma_watcher_probe.py
+++ b/adl/tools/validate_v0915_remote_gemma_watcher_probe.py
@@ -10,7 +10,7 @@ from pathlib import Path, PurePosixPath
 STATE_NAME = "v0915_remote_gemma_watcher_state_2026-06-15.json"
 PACKET_NAME = "REMOTE_GEMMA_WATCHER_PROOF_2026-06-15.md"
 EXPECTED_SCHEMA = "adl.remote_gemma_watcher_probe.v1"
-EXPECTED_ENDPOINT = "http://192.168.68.70:11434"
+EXPECTED_ENDPOINT = "remote_ollama_private_lan"
 REQUIRED_LANES = {
     "adapter_gemma4_31b": ("adl_provider_adapter", "gemma4:31b"),
     "raw_gemma4_26b": ("raw_ollama_http", "gemma4:26b"),

--- a/demos/v0.87.1/codex_ollama_operational_skills_demo.md
+++ b/demos/v0.87.1/codex_ollama_operational_skills_demo.md
@@ -62,14 +62,18 @@ If your Ollama API is not on the default host, set `OLLAMA_HOST` or
 Examples:
 
 ```bash
-OLLAMA_HOST=192.168.68.73 \
+OLLAMA_HOST=remote_ollama_private_lan \
 bash adl/tools/demo_codex_ollama_operational_skills.sh --dry-run
 ```
 
 ```bash
-OLLAMA_HOST_URL=http://192.168.68.73:11434 \
+OLLAMA_HOST_URL=http://remote_ollama_private_lan:11434 \
 bash adl/tools/demo_codex_ollama_operational_skills.sh
 ```
+
+When a private LAN Ollama host is configured, the durable demo manifest records
+the sanitized host reference `remote_ollama_private_lan` rather than publishing
+the runtime LAN coordinates.
 
 This support is intentionally bounded to the demo wrapper. It does **not**
 claim that the full ADL runtime `ollama` / `local_ollama` provider surfaces

--- a/demos/v0.89/gemma4_issue_clerk_demo.md
+++ b/demos/v0.89/gemma4_issue_clerk_demo.md
@@ -56,10 +56,14 @@ If your Ollama API is not on the default host, set `OLLAMA_HOST` or
 Example:
 
 ```bash
-OLLAMA_HOST=192.168.68.73 \
+OLLAMA_HOST=remote_ollama_private_lan \
 GEMMA4_OLLAMA_MODEL=gemma4:latest \
 bash adl/tools/demo_v089_gemma4_issue_clerk.sh
 ```
+
+When a private LAN Ollama host is configured, the durable demo manifest records
+the sanitized host reference `remote_ollama_private_lan` rather than the
+runtime LAN coordinates.
 
 If you want to replay a known response instead of calling a live model:
 


### PR DESCRIPTION
Closes #3946

## Summary
Sanitized the remaining durable private-LAN fixture surfaces named by `#3946` by redacting remote Ollama host details in tracked demo manifests/docs, replacing fixture expectations with the alias `remote_ollama_private_lan`, and aligning the existing provider-substrate and remote-gemma validator proofs to the same contract. The issue stayed bounded to durable artifact surfaces and did not change the broader loopback/local-harness allowance model.

## Artifacts
- `adl/tools/demo_codex_ollama_operational_skills.sh`
- `adl/tools/demo_v089_gemma4_issue_clerk.sh`
- `adl/tools/test_demo_codex_ollama_operational_skills.sh`
- `adl/tools/test_demo_codex_ollama_semantic_fallback.sh`
- `adl/tools/test_demo_v089_gemma4_issue_clerk.sh`
- `adl/src/provider_substrate.rs`
- `adl/tools/validate_v0915_remote_gemma_watcher_probe.py`
- `demos/v0.87.1/codex_ollama_operational_skills_demo.md`
- `demos/v0.89/gemma4_issue_clerk_demo.md`
- `.adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/srp.md`
- `.adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_demo_codex_ollama_operational_skills.sh`
    Verified durable redaction for the dry-run Codex/Ollama demo manifest and preserved bounded fixture behavior.
  - `bash adl/tools/test_demo_codex_ollama_semantic_fallback.sh`
    Verified durable redaction for the semantic-fallback Codex/Ollama manifest and preserved bounded fallback behavior.
  - `bash adl/tools/test_demo_v089_gemma4_issue_clerk.sh`
    Verified durable redaction for the Gemma issue-clerk manifest and preserved accept/reject fixture behavior.
  - `cargo test --manifest-path adl/Cargo.toml --lib provider_substrate_uses_http_transport_for_ollama_with_endpoint`
    Verified the provider-substrate HTTP Ollama transport proof still passes with the sanitized host alias fixture.
  - `python3 adl/tools/validate_v0915_remote_gemma_watcher_probe.py docs/milestones/v0.91.5/review/remote_gemma_watcher`
    Verified the tracked remote-gemma durable packet validator accepts the redacted endpoint contract.
  - `rg -n '192\\.168\\.68\\.73|192\\.168\\.68\\.70' adl/tools/demo_codex_ollama_operational_skills.sh adl/tools/test_demo_codex_ollama_operational_skills.sh adl/tools/test_demo_codex_ollama_semantic_fallback.sh adl/tools/demo_v089_gemma4_issue_clerk.sh adl/tools/test_demo_v089_gemma4_issue_clerk.sh adl/src/provider_substrate.rs adl/tools/validate_v0915_remote_gemma_watcher_probe.py demos/v0.87.1/codex_ollama_operational_skills_demo.md demos/v0.89/gemma4_issue_clerk_demo.md -S`
    Verified the previously tracked literal private-LAN coordinates are absent from the touched durable surfaces.
  - `git diff --check`
    Verified the scoped diff is free of patch-formatting defects.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase review --input .adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/srp.md`
    Verified the final SRP structure after recording the completed independent pre-PR review result.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase run --input .adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/sor.md`
    Verified this completed execution record against the run-phase SOR contract.
- Results:
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3946__v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets/sor.md
- Idempotency-Key: v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets-adl-tools-demo-codex-ollama-operational-skills-sh-adl-tools-demo-v089-gemma4-issue-clerk-sh-adl-tools-test-demo-codex-ollama-operational-skills-sh-adl-tools-test-demo-codex-ollama-semantic-fallback-sh-adl-tools-test-demo-v089-gemma4-issue-clerk-sh-adl-src-provider-substrate-rs-adl-tools-validate-v0915-remote-gemma-watcher-probe-py-demos-v0-87-1-codex-ollama-operational-skills-demo-md-demos-v0-89-gemma4-issue-clerk-demo-md-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-3946-v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets-sip-md-adl-v0-91-6-tasks-issue-3946-v0-91-6-provider-sanitize-private-lan-endpoint-fixtures-before-durable-proof-packets-sor-md