### PR TITLE
[v0.91.6][SEP][sprints] Automate sprint readiness sweep

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1238,7 +1238,10 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     matches!(
         trimmed,
-        "adl/tools/pr.sh" | "adl/tools/test_pr_small_binary_delegation.sh"
+        "adl/tools/pr.sh"
+            | "adl/tools/test_pr_small_binary_delegation.sh"
+            | "adl/tools/test_install_adl_operational_skills.sh"
+            | "adl/tools/test_sprint_conductor_helpers.sh"
     ) || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1039,6 +1039,27 @@ fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/tools/test_install_adl_operational_skills.sh".to_string(),
+            "adl/tools/test_sprint_conductor_helpers.sh".to_string(),
+        ],
+    )
+    .expect("sprint shell helper plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(
+        plan.commands,
+        vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
     let plan = select_finish_validation_plan_for_finish(
         ".",

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -43,6 +43,8 @@ sprint:
   blocked_issue_number: <u32 or null>
   review_paths:
     - /absolute/or/repo-relative/path
+  activity_log_paths:
+    - /absolute/or/repo-relative/path
   closeout_paths:
     - /absolute/or/repo-relative/path
   issue_records:
@@ -93,6 +95,28 @@ sprint:
       - <path>
     diff_files:
       - <path>
+  readiness_sweep:
+    status: not_run | ready | needs_repair | blocked
+    execution_packet:
+      status: not_required | present | needs_repair | blocked
+      path: /absolute/or/repo-relative/path | null
+      missing_sections:
+        - <heading>
+    review_paths:
+      status: declared | needs_repair
+      paths:
+        - /absolute/or/repo-relative/path
+    activity_log_paths:
+      status: declared | needs_repair
+      paths:
+        - /absolute/or/repo-relative/path
+    issue_repairs:
+      - issue_number: <u32>
+        status: ready | needs_editor_repair | blocked
+        bundle_path: /absolute/or/repo-relative/path | null
+        next_skills:
+          - pr-init | workflow-conductor | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor
+        rationale: <bounded text>
   issue_closed: true | false
 policy:
   require_declared_execution_mode: true
@@ -129,3 +153,9 @@ Notes:
 - The current sprint-state helper remains single-current-issue. SEP records
   safe parallel intent and routing evidence; it does not by itself prove
   automated multi-active sprint execution.
+- `readiness_sweep` is the aggregate pre-execution gate. It is expected to
+  consume installed-skill parity, structured-prompt preflight, execution-packet
+  presence, review-path declaration, and activity-log declaration before the
+  first child issue runs.
+- Review and activity-log paths are declaration surfaces for future sprint
+  artifacts; readiness does not require those files to exist yet.

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -70,6 +70,7 @@ At the moment, the key repo references are:
 Within this bundle, the operational details live in:
 - `references/conductor-playbook.md`
 - `references/output-contract.md`
+- `scripts/check_sprint_readiness.py`
 - `scripts/check_installed_skill_parity.py`
 - `scripts/check_sprint_truth.py`
 - `scripts/record_child_issue_closeout.py`
@@ -134,42 +135,53 @@ missing sprint-management issue first.
    `hybrid`, require safe lanes, serial gates, and PVF notes before execution
    is routed to separate issue workers or sessions.
 3. Create or load the sprint-state artifact.
-4. When live execution is about to begin, run the installed-skill parity/readiness gate first.
-5. Run sprint-wide structured prompt review before issue execution begins.
-5. If any child issue cards are not ready, repair them through the editor skills first.
+4. When live execution is about to begin, run the sprint readiness sweep first.
+   Use `check_sprint_readiness.py` to aggregate installed-skill parity,
+   structured-prompt preflight, execution-packet presence, review-path
+   declaration, and activity-log declaration into one readiness result.
+   Review and activity-log paths are declaration surfaces here; they do not
+   need to exist on disk yet to satisfy readiness.
+5. If the readiness sweep reports `needs_repair`, fix the flagged issue-local
+   or sprint-local defects before starting child execution.
+6. Run sprint-wide structured prompt review before issue execution begins when
+   the readiness sweep or policy requires a fresh pass.
+7. If any child issue cards are not ready, repair them through the editor skills first.
    When the child issue needs new or fully re-rendered cards, prefer the
    prompt-template values renderer and `validate-structure` before routing
    issue-local lifecycle truth through the matching editor skill.
-6. Select the next child issue or operator-approved lane handoff according to
+8. Select the next child issue or operator-approved lane handoff according to
    the declared execution mode and serial gates. Current helper state remains
    single-current-issue; parallel execution is achieved by separate issue
    workers/sessions using the SEP as the coordination contract.
-7. Route the selected child issue or lane handoff through `workflow-conductor`.
-8. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
-9. Run only the selected downstream lifecycle or editor skill.
-10. Re-check issue truth. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
-11. If the issue is healthy but waiting on review, checks, or merge, route it into the bounded watch/janitor path rather than surfacing that healthy waiting state as a default sprint stop.
-12. If the issue is merged or otherwise closed but not locally closeouted yet, immediately route `pr-closeout` and finish the child-closeout gate.
-13. If the issue is fully closed out, use the deterministic child-closeout helper path to advance sprint state.
-14. If the issue is still active after the fresh truth check, repeat the routing loop for the same issue.
-15. In `sequential` mode, only after child-closeout truth is satisfied may the
+9. Route the selected child issue or lane handoff through `workflow-conductor`.
+10. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
+11. Run only the selected downstream lifecycle or editor skill.
+12. Re-check issue truth. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
+13. If the issue is healthy but waiting on review, checks, or merge, route it into the bounded watch/janitor path rather than surfacing that healthy waiting state as a default sprint stop.
+14. If the issue is merged or otherwise closed but not locally closeouted yet, immediately route `pr-closeout` and finish the child-closeout gate.
+15. If the issue is fully closed out, use the deterministic child-closeout helper path to advance sprint state.
+16. If the issue is still active after the fresh truth check, repeat the routing loop for the same issue.
+17. In `sequential` mode, only after child-closeout truth is satisfied may the
     sprint advance to the next ordered issue. In `parallel` or `hybrid` mode,
     do not treat a lane as clear unless its SEP-defined dependencies, serial
     gates, and issue-local closeout truth are satisfied.
-16. After the final issue closes, assemble sprint review evidence.
-17. Record sprint closeout metrics including coverage and Rust tracker counts.
-18. Write the bounded sprint closeout artifact before closing the sprint-management issue.
-19. Stop with one bounded sprint review/closeout result.
+18. After the final issue closes, assemble sprint review evidence.
+19. Record sprint closeout metrics including coverage and Rust tracker counts.
+20. Write the bounded sprint closeout artifact before closing the sprint-management issue.
+21. Stop with one bounded sprint review/closeout result.
 
 ## Execution Model
 
 This skill enforces:
+- one issue at a time, fully closed out before the next in `sequential` mode
 - exactly one active child issue in this helper's local sprint state
 - SEP-declared active lanes for `parallel` and `hybrid` sprints as
   coordination evidence for separate workers/sessions
 - no child issue execution before the whole sprint batch passes structured prompt review
 - no child issue execution before the whole sprint batch passes design-time
   card-completion review for `SIP`, `STP`, `SPP`, and `SRP`
+- no live sprint execution before the readiness sweep records execution-packet,
+  review-path, and activity-log declaration truth
 - no issue `N+1` work before issue `N` is fully closed out in `sequential`
   mode
 - no intentional parallel lane work unless the SEP names the lane, write-set
@@ -206,6 +218,9 @@ This skill enforces:
   completion claims.
 
 Preferred per-issue routing model:
+- sprint readiness not run or stale ->
+  `check_sprint_readiness.py`, then repair the flagged sprint-local or
+  issue-local defects before child execution
 - sprint-wide structured prompt preflight not ready ->
   `check_sprint_structured_prompt_readiness.py`, then route flagged child issues
   through the matching editor skills before starting issue execution

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -72,6 +72,7 @@ admission:
     - "sprint.blocked_issue_number"
     - "resume_from_state_path"
     - "sprint.review_paths"
+    - "sprint.activity_log_paths"
     - "sprint.closeout_paths"
     - "sprint.issue_records"
     - "sprint.execution_packet_path"
@@ -83,7 +84,7 @@ admission:
     - "sprint.structured_prompt_preflight"
     - "sprint.truth_check"
     - "sprint.installed_skill_parity"
-    - "sprint.closeout_gate"
+    - "sprint.readiness_sweep"
     - "review_subagent_ids"
   stop_if_missing:
     - "repo_root"
@@ -110,6 +111,7 @@ execution:
   allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
+    - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py --repo-root <repo> --ordered-issues <csv> --execution-mode <sequential|parallel|hybrid> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py --repo-root <repo> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root <repo> --ordered-issues <csv> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>"
@@ -144,10 +146,14 @@ outputs:
     - "sprint"
     - "sequence"
     - "installed_skill_parity"
+    - "readiness_sweep"
+    - "structured_prompt_preflight"
     - "truth_check"
     - "current_state"
     - "review"
     - "closeout"
+    - "actions_taken"
+    - "next_handoff"
     - "artifact"
 security:
   trusted_root_required: true

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -88,6 +88,37 @@ installed_skill_parity:
     - <path>
   notes:
     - <bounded text>
+readiness_sweep:
+  status: not_run | ready | needs_repair | blocked
+  ordered_issue_numbers:
+    - <u32>
+  execution_mode: sequential | parallel | hybrid
+  execution_packet:
+    status: not_required | present | needs_repair | blocked
+    path: <path or null>
+    missing_sections:
+      - <heading>
+  review_paths:
+    status: declared | needs_repair
+    paths:
+      - <path>
+    missing_paths:
+      - <path>
+  activity_log_paths:
+    status: declared | needs_repair
+    paths:
+      - <path>
+    missing_paths:
+      - <path>
+  issue_repairs:
+    - issue_number: <u32>
+      status: ready | needs_editor_repair | blocked
+      bundle_path: <path or null>
+      next_skills:
+        - pr-init | workflow-conductor | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor
+      rationale: <bounded text>
+  notes:
+    - <bounded text>
 truth_check:
   status: not_run | matched | drift_detected | blocked
   source: github_live | sprint_state_only | mixed

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    values: list[int] = []
+    for part in raw.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        values.append(int(part))
+    return values
+
+
+def run_json(cmd: list[str]) -> Any:
+    completed = subprocess.run(cmd, capture_output=True, text=True)
+    stdout = completed.stdout.strip()
+    stderr = completed.stderr.strip()
+    if completed.returncode not in {0, 2}:
+        detail = stderr or stdout or 'no output'
+        raise RuntimeError(f'command failed ({completed.returncode}): {" ".join(cmd)} :: {detail}')
+    if not stdout:
+        detail = stderr or 'no output'
+        raise RuntimeError(f'command returned no JSON: {" ".join(cmd)} :: {detail}')
+    return json.loads(stdout)
+
+
+def resolve_optional_path(repo_root: Path, raw: str | None) -> Path | None:
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    return repo_root / candidate
+
+
+def resolve_paths(repo_root: Path, raw_paths: list[str]) -> list[Path]:
+    return [resolve_optional_path(repo_root, raw) for raw in raw_paths if raw]
+
+
+def inspect_execution_packet(repo_root: Path, execution_mode: str, raw_path: str | None) -> dict[str, Any]:
+    packet_path = resolve_optional_path(repo_root, raw_path)
+    if execution_mode == 'sequential':
+        if packet_path is None:
+            return {
+                'status': 'not_required',
+                'path': None,
+                'missing_sections': [],
+                'notes': ['execution packet is optional for sequential mode'],
+            }
+    else:
+        if packet_path is None:
+            return {
+                'status': 'blocked',
+                'path': None,
+                'missing_sections': [],
+                'notes': [f'execution packet path is required for {execution_mode} mode'],
+            }
+
+    assert packet_path is not None
+    if not packet_path.exists():
+        return {
+            'status': 'blocked',
+            'path': str(packet_path),
+            'missing_sections': [],
+            'notes': [f'execution packet missing: {packet_path}'],
+        }
+
+    text = packet_path.read_text()
+    required_sections = ['## Child Issue Wave', '## Recommended Execution Order', '## Watcher Policy']
+    if execution_mode in {'parallel', 'hybrid'}:
+        required_sections.extend(['## Safe Parallel Lanes', '## Serial Gates'])
+    missing_sections = [heading for heading in required_sections if heading not in text]
+    notes = [f'execution packet present: {packet_path}']
+    if missing_sections:
+        notes.append('execution packet is missing one or more required readiness sections')
+        return {
+            'status': 'needs_repair',
+            'path': str(packet_path),
+            'missing_sections': missing_sections,
+            'notes': notes,
+        }
+    return {
+        'status': 'present',
+        'path': str(packet_path),
+        'missing_sections': [],
+        'notes': notes,
+    }
+
+
+def inspect_declared_paths(kind: str, paths: list[Path]) -> dict[str, Any]:
+    if not paths:
+        return {
+            'status': 'needs_repair',
+            'paths': [],
+            'missing_paths': [],
+            'notes': [f'no {kind} path declared'],
+        }
+    missing = [str(path) for path in paths if not path.exists()]
+    return {
+        'status': 'declared',
+        'paths': [str(path) for path in paths],
+        'missing_paths': missing,
+        'notes': (
+            [f'{kind} path(s) declared']
+            + [f'{kind} path declared but not created yet: {path}' for path in missing]
+        ),
+    }
+
+
+def next_skills_for_issue(result: dict[str, Any]) -> list[str]:
+    required_editor_skills = [
+        skill for skill in result.get('required_editor_skills', []) if isinstance(skill, str)
+    ]
+    if required_editor_skills:
+        return required_editor_skills
+    notes = [note for note in result.get('notes', []) if isinstance(note, str)]
+    if any(note.startswith('No local task bundle found') for note in notes):
+        return ['pr-init']
+    if any(note.startswith('Ambiguous local task bundles') for note in notes):
+        return ['workflow-conductor']
+    return []
+
+
+def build_issue_repairs(preflight: dict[str, Any]) -> list[dict[str, Any]]:
+    repairs: list[dict[str, Any]] = []
+    for result in preflight.get('issue_results', []):
+        status = result.get('status')
+        if status == 'ready':
+            continue
+        next_skills = next_skills_for_issue(result)
+        repairs.append(
+            {
+                'issue_number': result.get('issue_number'),
+                'status': status,
+                'bundle_path': result.get('bundle_path'),
+                'next_skills': next_skills,
+                'rationale': '; '.join(result.get('notes', [])) or 'issue readiness repair required',
+            }
+        )
+    return repairs
+
+
+def overall_status(
+    parity: dict[str, Any],
+    preflight: dict[str, Any],
+    packet: dict[str, Any],
+    review_paths: dict[str, Any],
+    activity_log_paths: dict[str, Any],
+) -> str:
+    component_statuses = [
+        parity.get('status'),
+        preflight.get('status'),
+        packet.get('status'),
+        review_paths.get('status'),
+        activity_log_paths.get('status'),
+    ]
+    if 'blocked' in component_statuses:
+        return 'blocked'
+    if any(status in {'drift_detected', 'needs_editor_repair', 'needs_repair'} for status in component_statuses):
+        return 'needs_repair'
+    return 'ready'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo-root', required=True)
+    parser.add_argument('--ordered-issues', required=True)
+    parser.add_argument('--execution-mode', required=True, choices=['sequential', 'parallel', 'hybrid'])
+    parser.add_argument('--execution-packet-path')
+    parser.add_argument('--activity-log-path', action='append', default=[])
+    parser.add_argument('--review-path', action='append', default=[])
+    parser.add_argument('--state')
+    parser.add_argument('--tracked-skill-dir')
+    parser.add_argument('--installed-skill-dir')
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    ordered_issues = parse_csv_ints(args.ordered_issues)
+    state: dict[str, Any] = {}
+    if args.state:
+        state_path = Path(args.state)
+        if state_path.exists():
+            state = json.loads(state_path.read_text())
+    else:
+        state_path = None
+
+    parity_cmd = [
+        'python3',
+        str(SCRIPT_DIR / 'check_installed_skill_parity.py'),
+        '--repo-root',
+        str(repo_root),
+        '--print-json',
+    ]
+    if args.tracked_skill_dir:
+        parity_cmd.extend(['--tracked-skill-dir', args.tracked_skill_dir])
+    if args.installed_skill_dir:
+        parity_cmd.extend(['--installed-skill-dir', args.installed_skill_dir])
+    parity = run_json(parity_cmd)
+
+    preflight = run_json(
+        [
+            'python3',
+            str(SCRIPT_DIR / 'check_sprint_structured_prompt_readiness.py'),
+            '--repo-root',
+            str(repo_root),
+            '--ordered-issues',
+            ','.join(str(issue) for issue in ordered_issues),
+            '--print-json',
+        ]
+    )
+
+    packet = inspect_execution_packet(repo_root, args.execution_mode, args.execution_packet_path)
+    review_paths = inspect_declared_paths('review', resolve_paths(repo_root, args.review_path))
+    activity_log_paths = inspect_declared_paths('activity log', resolve_paths(repo_root, args.activity_log_path))
+    issue_repairs = build_issue_repairs(preflight)
+
+    readiness = {
+        'status': overall_status(parity, preflight, packet, review_paths, activity_log_paths),
+        'ordered_issue_numbers': ordered_issues,
+        'execution_mode': args.execution_mode,
+        'execution_packet': packet,
+        'review_paths': review_paths,
+        'activity_log_paths': activity_log_paths,
+        'issue_repairs': issue_repairs,
+        'notes': (
+            parity.get('notes', [])
+            + preflight.get('notes', [])
+            + packet.get('notes', [])
+            + review_paths.get('notes', [])
+            + activity_log_paths.get('notes', [])
+        ),
+    }
+
+    state['installed_skill_parity'] = parity
+    state['structured_prompt_preflight'] = preflight
+    state['readiness_sweep'] = readiness
+
+    if state_path is not None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+
+    payload = json.dumps(readiness, indent=2, sort_keys=True)
+    if args.print_json or state_path is None:
+        print(payload)
+    else:
+        print(state_path)
+
+    return 0 if readiness['status'] == 'ready' else 2 if readiness['status'] == 'needs_repair' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -62,6 +62,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/srp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_readiness.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_installed_skill_parity.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/close_sprint_issue.py" ]]

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -207,6 +207,42 @@ issue: 2828
 - Not run yet.
 EOF2
 
+readiness_packet="${tmpdir}/trial-sep.md"
+cat >"${readiness_packet}" <<'EOF2'
+# Trial Sprint Execution Packet
+
+## Child Issue Wave
+
+- `#2827`
+- `#2828`
+
+## Recommended Execution Order
+
+1. `#2827`
+2. `#2828`
+
+## Safe Parallel Lanes
+
+- none for this trial
+
+## Serial Gates
+
+- `#2827` must close out before `#2828`
+
+## Watcher Policy
+
+- every wait state has a watcher
+EOF2
+
+readiness_review="${tmpdir}/trial-review.md"
+readiness_activity="${tmpdir}/trial-activity.md"
+touch "${readiness_review}" "${readiness_activity}"
+readiness_tracked_skill_dir="${tmpdir}/tracked-readiness-skill"
+readiness_installed_skill_dir="${tmpdir}/installed-readiness-skill"
+mkdir -p "${readiness_tracked_skill_dir}" "${readiness_installed_skill_dir}"
+printf 'alpha\n' > "${readiness_tracked_skill_dir}/SKILL.md"
+printf 'alpha\n' > "${readiness_installed_skill_dir}/SKILL.md"
+
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
   --repo-root "${fake_repo}" \
   --ordered-issues "2827,2828" \
@@ -267,6 +303,59 @@ assert all(result["status"] == "ready" for result in preflight["issue_results"])
 assert all(result["canonical_slug"] for result in preflight["issue_results"])
 PY
 
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --execution-mode hybrid \
+  --execution-packet-path "${readiness_packet}" \
+  --review-path "${readiness_review}" \
+  --activity-log-path "${readiness_activity}" \
+  --tracked-skill-dir "${readiness_tracked_skill_dir}" \
+  --installed-skill-dir "${readiness_installed_skill_dir}" \
+  --state "${state_path}" >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+readiness = state["readiness_sweep"]
+assert readiness["status"] == "ready"
+assert readiness["execution_mode"] == "hybrid"
+assert readiness["execution_packet"]["status"] == "present"
+assert readiness["review_paths"]["status"] == "declared"
+assert readiness["activity_log_paths"]["status"] == "declared"
+assert readiness["issue_repairs"] == []
+assert state["installed_skill_parity"]["status"] == "matched"
+assert state["structured_prompt_preflight"]["status"] == "ready"
+PY
+
+blocked_readiness_state_path="${tmpdir}/sprint-state-readiness-blocked.json"
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --execution-mode hybrid \
+  --review-path "${readiness_review}" \
+  --activity-log-path "${readiness_activity}" \
+  --tracked-skill-dir "${readiness_tracked_skill_dir}" \
+  --installed-skill-dir "${readiness_installed_skill_dir}" \
+  --state "${blocked_readiness_state_path}" >/dev/null 2>&1; then
+  echo "expected check_sprint_readiness.py to fail when a hybrid sprint omits the execution packet path" >&2
+  exit 1
+fi
+
+python3 - "${blocked_readiness_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+readiness = state["readiness_sweep"]
+assert readiness["status"] == "blocked"
+assert readiness["execution_packet"]["status"] == "blocked"
+PY
+
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'
 ---
 issue: 2828
@@ -295,6 +384,34 @@ assert preflight["status"] == "needs_editor_repair"
 wp06 = [result for result in preflight["issue_results"] if result["issue_number"] == 2828][0]
 assert "srp-editor" in wp06["required_editor_skills"]
 assert any("srp.md" in defect for defect in wp06["design_time_defects"])
+PY
+
+repair_readiness_state_path="${tmpdir}/sprint-state-readiness-repair.json"
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --execution-mode hybrid \
+  --execution-packet-path "${readiness_packet}" \
+  --review-path "${readiness_review}" \
+  --activity-log-path "${readiness_activity}" \
+  --tracked-skill-dir "${readiness_tracked_skill_dir}" \
+  --installed-skill-dir "${readiness_installed_skill_dir}" \
+  --state "${repair_readiness_state_path}" >/dev/null 2>&1; then
+  echo "expected check_sprint_readiness.py to fail with needs_repair when child issue cards need editor work" >&2
+  exit 1
+fi
+
+python3 - "${repair_readiness_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+readiness = state["readiness_sweep"]
+assert readiness["status"] == "needs_repair"
+repair = next(item for item in readiness["issue_repairs"] if item["issue_number"] == 2828)
+assert "srp-editor" in repair["next_skills"]
+assert repair["status"] == "needs_editor_repair"
 PY
 
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'


### PR DESCRIPTION
Closes #4076

## Summary
Implemented a sprint-readiness sweep helper for the sprint-conductor bundle, wired the new readiness surface into the sprint-conductor skill/docs/manifest contracts, expanded the helper tests to cover `ready`, `needs_repair`, and `blocked` readiness outcomes, repaired the source issue bootstrap contract so `#4076` could bind cleanly, and fixed `pr finish` path classification so the sprint shell-helper tests publish through the focused small-binary lane instead of blocking closeout.

## Artifacts
- `adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/skills/sprint-conductor/references/output-contract.md`
- `adl/tools/skills/sprint-conductor/adl-skill.yaml`
- `adl/tools/test_sprint_conductor_helpers.sh`
- `adl/tools/test_install_adl_operational_skills.sh`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated local review/output cards for issue `#4076`

## Validation
- Validation commands and their purpose:
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" adl/tools/pr.sh issue edit 4076 --body-file <temporary normalized issue body file> --json`
    Verified the source issue body could be normalized through the typed ADL GitHub surface.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" adl/tools/pr.sh run 4076 --version v0.91.6`
    Verified the issue bootstrapped and bound successfully after the source-body repair.
  - bounded pre-PR review subagent over the tracked diff
    Verified the change set for contract mismatches and fixed the reported findings.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified the readiness helper contract and per-child routing outputs across `ready`, `needs_repair`, and `blocked` cases.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified the installed-skill bundle assertions after the readiness helper was added to the sprint-conductor bundle.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation`
    Verified the focused finish-path classifier behavior, including the new sprint shell-helper regression.
  - `git diff --check`
    Verified the tracked diff is whitespace-clean after the helper, contract, and classifier updates.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4076__v0-91-6-sep-sprints-automate-sprint-readiness-sweep/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4076__v0-91-6-sep-sprints-automate-sprint-readiness-sweep/sor.md
- Idempotency-Key: v0-91-6-sep-sprints-automate-sprint-readiness-sweep-adl-tools-skills-sprint-conductor-scripts-check-sprint-readiness-py-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-docs-sprint-conductor-skill-input-schema-md-adl-tools-skills-sprint-conductor-references-output-contract-md-adl-tools-skills-sprint-conductor-adl-skill-yaml-adl-tools-test-sprint-conductor-helpers-sh-adl-tools-test-install-adl-operational-skills-sh-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4076-v0-91-6-sep-sprints-automate-sprint-readiness-sweep-sip-md-adl-v0-91-6-tasks-issue-4076-v0-91-6-sep-sprints-automate-sprint-readiness-sweep-sor-md