### PR TITLE
[v0.91.6][scheduler] Build Cognitive Scheduler v1

### DIFF
--- a/docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md
+++ b/docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md
@@ -1,0 +1,319 @@
+# Cognitive Scheduler v1 Plan
+
+## Status
+
+Planned for `v0.91.6` implementation.
+
+## Source Inputs
+
+- Operator-local source: `.adl/docs/TBD/ADL_COGNITIVE_ECONOMICS.md`
+- Operator-local source: `.adl/docs/TBD/ADL_COGNITIVE_SCHEDULER_v1.md`
+- Tracked review surface: this document
+- `#4105` scheduler umbrella
+- `#4106` scheduler economics input model
+- `#4107` Cognitive Scheduler v1 implementation
+
+## Executive Summary
+
+Cognitive Scheduler v1 is the first dedicated ADL scheduler plan for scarce cognitive resources.
+
+The scheduler exists because C-SDLC has compressed issue creation, lifecycle paperwork, and sprint coordination enough that the bottleneck has moved. The next constraint is no longer only human coordination. It is premium cognition availability, provider quota, context-window capacity, validation burden, and governor attention.
+
+The v1 goal is intentionally narrow:
+
+- define schedulable work items
+- define cognitive execution lanes
+- define economics inputs
+- rank or assign work to lanes deterministically
+- record the scheduling decision as an artifact
+- explain the decision
+- keep premium cognition visible and conserved
+
+It is not a market, bidding system, autonomous sprint conductor, or provider-purchasing agent.
+
+## Existing Scheduler-Adjacent Surfaces
+
+ADL does not currently have a dedicated `schedules.rs` module. Scheduler v1 should not pretend the repository is blank. It should coordinate with existing scheduler-adjacent surfaces:
+
+- `adl/src/execute/runner.rs` owns execution max-concurrency policy and emits scheduler policy trace events.
+- `adl/src/trace/mod.rs` and `adl/src/trace/store.rs` already represent `SchedulerPolicy` trace records.
+- `adl/src/runtime_v2/governed_episode/` has bounded resource-pressure scheduling-decision artifacts for Runtime v2 demos.
+- `adl/src/plan.rs` and `adl/src/execution_plan.rs` already define planning/execution-plan surfaces.
+
+Recommended v1 code shape remains a dedicated `adl/src/scheduler/` module, but it should treat those existing surfaces as integration boundaries rather than inventing a parallel scheduling vocabulary.
+
+## Core Thesis
+
+C-SDLC pushes ADL up the Amdahl curve by decomposing work and parallelizing execution. That success exposes the next serial fraction: scarce cognition and scarce governor attention.
+
+Cognitive Scheduler v1 is the mechanism that makes that new bottleneck explicit.
+
+```text
+C-SDLC = structured work demand
+SCR / providers / humans = cognitive labor supply
+Cognitive Scheduler = allocation mechanism
+```
+
+## v1 Completion Bar
+
+Scheduler v1 is complete when ADL has:
+
+1. A typed or schema-valid work-item input shape.
+2. A bounded economics input model.
+3. At least four execution lanes.
+4. A deterministic scheduler command or library surface.
+5. Fixture-driven proof covering serial blockers, parallelizable work, docs/review work, high-risk code work, and governor-only decisions.
+6. A scheduling decision artifact with explanation fields.
+7. Focused tests for deterministic ordering, dependency blocking, lane selection, and malformed input handling.
+8. A runbook explaining how to use the scheduler and what it does not claim.
+
+## Execution Lanes
+
+Scheduler v1 should support these lanes first:
+
+| Lane | Purpose | Typical work |
+| --- | --- | --- |
+| `LOCAL` | cheapest available cognition, quota-independent where possible | card checks, status summaries, routine docs, checklist support |
+| `CHEAP_REMOTE` | inexpensive cloud or commodity model work | first-pass review, decomposition, docs, test generation |
+| `PREMIUM` | scarce frontier/code execution | implementation, hard debugging, PR repair, security-sensitive code |
+| `GOVERNOR` | human/founder/architect judgment | irreversible choices, release authority, strategic direction |
+| `DELAYED` | wait for quota/capacity instead of wasting premium resources | low-urgency work during constrained windows |
+
+## Scheduler Inputs
+
+The first input shape should be boring and explicit.
+
+```yaml
+task_id: string
+task_type: issue_card | planning | documentation | review | test_generation | implementation | refactor | security_review | release_gate | architecture
+risk_level: low | medium | high | critical
+urgency: low | normal | high | immediate
+dependencies:
+  - task_id: string
+required_capabilities:
+  - string
+context_scope:
+  repo_paths: []
+  expected_files: []
+  max_context_budget: optional
+quality_bar: draft | reviewable | merge_ready | release_ready
+estimated_effort: small | medium | large
+estimated_validation_cost: low | medium | high
+estimated_coordination_cost: low | medium | high
+expected_value: low | medium | high | critical
+parallelism_potential: blocked | serial | parallelizable | highly_parallelizable
+human_required: false
+manual_override: optional
+```
+
+## Economics Inputs
+
+`#4106` should produce or validate the economics input model consumed by `#4107`.
+
+Minimum v1 fields:
+
+- estimated effort
+- estimated validation cost
+- estimated coordination cost
+- risk
+- expected value
+- urgency
+- dependency posture
+- parallelism potential
+- premium capacity pressure
+- governor attention pressure
+
+The key invariant is that cost means lifecycle cost, not just token cost.
+
+Cheap generation that creates expensive review is not cheap.
+
+## Scheduler Outputs
+
+Scheduler v1 should emit an auditable decision artifact.
+
+```yaml
+scheduler_decision:
+  schema: adl.scheduler.decision.v1
+  task_id: string
+  selected_lane: LOCAL | CHEAP_REMOTE | PREMIUM | GOVERNOR | DELAYED
+  selected_profile_ref: optional
+  alternatives_considered:
+    - lane: string
+      disposition: rejected | fallback | equivalent
+      reason: string
+  reason: string
+  score_breakdown:
+    effort: string
+    validation_cost: string
+    coordination_cost: string
+    risk: string
+    expected_value: string
+    urgency: string
+    premium_capacity_pressure: string
+    governor_attention_pressure: string
+  dependency_status: clear | blocked
+  manual_override:
+    present: boolean
+    reason: optional
+  confidence: low | medium | high
+```
+
+The artifact must answer:
+
+- why this route was selected
+- why alternatives were rejected
+- what policy was applied
+- whether the decision was automatic or overridden
+
+## Determinism Rules
+
+Scheduler v1 must be deterministic for the same inputs.
+
+Required tie-breakers:
+
+1. Dependency status.
+2. Risk and human-required gates.
+3. Urgency.
+4. Expected value.
+5. Validation burden.
+6. Premium capacity conservation.
+7. Stable task id ordering.
+
+The scheduler should not use ambient provider state, current open PRs, live quota telemetry, or local shell state unless the input explicitly provides that state.
+
+## PVF And Validation Awareness
+
+PVF matters because validation-tail latency is now one of the biggest scheduling costs.
+
+Scheduler v1 should model validation burden as a first-class input:
+
+- docs-only proof
+- focused tooling proof
+- runtime/code proof
+- release/full proof
+- security/adversarial proof
+
+A task with short implementation time and long validation time may be a poor candidate for late-sprint execution.
+
+## Governor Attention
+
+Governor attention is part of the economics model.
+
+Scheduler v1 should distinguish:
+
+- tasks that can auto-accept through contract proof
+- tasks that require review support
+- tasks that require explicit human decision
+- tasks that should wait rather than interrupt the governor
+
+This prevents the scheduler from optimizing tokens while increasing the true serial fraction.
+
+## Issue Wave
+
+### `#4105`: Umbrella And Planning Surface
+
+Purpose:
+
+- own this plan
+- keep the v0.91.6 scheduler issue wave coherent
+- close only after `#4106` and `#4107` have truthful closeout
+
+### `#4106`: Scheduler Economics Inputs
+
+Purpose:
+
+- implement the economics input shape
+- provide examples/fixtures
+- document included/deferred economics concepts
+- avoid claiming perfect cost prediction
+
+### `#4107`: Scheduler v1 Implementation
+
+Purpose:
+
+- implement scheduler v1 command or library surface
+- consume `#4106` inputs or compatible fixtures
+- emit deterministic decision artifacts
+- include tests and runbook
+
+## External Crate Note: `schedules`
+
+The Rust crate `schedules` should be evaluated, not assumed. It is a time-based callback scheduler for intervals, calendar schedules, manual execution, async execution, jitter, backoff, and persisted scheduler state. That is useful for recurring watchers, SEP cadence, delayed work, or retry-style execution loops.
+
+Cognitive Scheduler v1 is different: it assigns work to cognitive lanes based on economics, risk, validation burden, dependencies, and governor attention. That decision layer should remain ADL-owned. If `schedules` is adopted, it should support timed execution around the scheduler, not replace the scheduler's decision model.
+
+Initial recommendation: do not add `schedules` as a dependency in `#4106`. In `#4107`, evaluate it only if the implementation includes delayed execution, recurring watchers, or timed SEP checks. Otherwise keep v1 dependency-free and fixture-driven.
+
+## Recommended Implementation Shape
+
+Preferred small Rust surface:
+
+```text
+adl/src/scheduler/
+  mod.rs
+  economics.rs
+  work_item.rs
+  decision.rs
+  policy.rs
+  tests.rs
+```
+
+Possible command surface:
+
+```text
+adl tooling cognitive-scheduler plan --input fixtures/scheduler/work_items.yaml --policy fixtures/scheduler/policy.yaml --json
+```
+
+If the command routing is too large for v1, use a library plus focused fixture tests first, then add CLI in a follow-on.
+
+## Fixture Set
+
+Create fixtures for:
+
+1. Low-risk docs task routed to `LOCAL`.
+2. First-pass review task routed to `CHEAP_REMOTE`.
+3. High-risk implementation routed to `PREMIUM`.
+4. Architecture/release decision routed to `GOVERNOR`.
+5. Low-urgency task routed to `DELAYED` under capacity pressure.
+6. Blocked task held because dependency is not complete.
+
+## Validation Plan
+
+Focused proof is enough for `#4105`:
+
+- Markdown path/reference check for the plan and feature doc.
+- No broad Rust validation unless `#4105` touches code.
+
+For `#4106` and `#4107`:
+
+- `cargo fmt --manifest-path adl/Cargo.toml --all --check`
+- focused scheduler tests
+- fixture parse tests
+- malformed input tests
+- stdout/stderr contract proof if a CLI is added
+
+## Non-Claims
+
+Scheduler v1 does not claim:
+
+- autonomous sprint conduction
+- live provider quota introspection
+- model suitability proof
+- dynamic purchasing or overage decisions
+- market behavior
+- full PVF execution
+- measured speedup
+- measured cost reduction
+
+## Open Questions
+
+- Should the first CLI live under `adl tooling cognitive-scheduler` or a dedicated `adl scheduler` command?
+- Should economics inputs be YAML-only at first, or Rust structs plus JSON/YAML fixtures?
+- Should provider-profile refs be accepted in v1, or deferred until provider suitability work lands?
+- Should sprint-level summary output be part of v1 or the first follow-on?
+
+## Recommended Next Step
+
+Execute `#4106` first, then `#4107`.
+
+`#4105` should remain open as the umbrella until both children land and the scheduler feature doc is updated with the implemented truth.

--- a/docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md
@@ -1,0 +1,183 @@
+# Cognitive Scheduler v1
+
+## Status
+
+Planned implementation for `v0.91.6`.
+
+## Feature Role
+
+Cognitive Scheduler v1 is the first dedicated ADL scheduler substrate planned for scarce cognitive resources.
+
+It turns the cognitive economics and scheduler concept drafts into a bounded implementation path for deciding which lane should handle a unit of work:
+
+- local cognition
+- cheap remote cognition
+- premium cognition
+- governor cognition
+- delayed execution
+
+The feature exists because Current ADL execution evidence suggests C-SDLC is moving from issue-centric execution toward sprint-centric execution. Once issue creation, card generation, review support, and workflow paperwork become faster, the bottleneck shifts to premium model capacity, validation-tail latency, and human governor attention.
+
+## Source Inputs
+
+- Operator-local input consumed into the tracked plan: `.adl/docs/TBD/ADL_COGNITIVE_ECONOMICS.md`
+- Operator-local input consumed into the tracked plan: `.adl/docs/TBD/ADL_COGNITIVE_SCHEDULER_v1.md`
+- Tracked TBD plan: `docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md`
+- `#4105` scheduler umbrella
+- `#4106` scheduler economics inputs
+- `#4107` scheduler implementation
+
+## Existing Scheduler-Adjacent Surfaces
+
+ADL already has scheduler-adjacent code, but not a dedicated Cognitive Scheduler v1 implementation. The implementation issue should coordinate with:
+
+- `adl/src/execute/runner.rs` for execution max-concurrency policy.
+- `adl/src/trace/mod.rs` and `adl/src/trace/store.rs` for scheduler policy trace events.
+- `adl/src/runtime_v2/governed_episode/` for existing bounded scheduling-decision artifacts.
+- `adl/src/plan.rs` and `adl/src/execution_plan.rs` for planning/execution-plan concepts.
+
+The preferred v1 home is a dedicated `adl/src/scheduler/` module, unless implementation review finds that extending an existing module is simpler and cleaner.
+
+## Problem Statement
+
+ADL can now generate more useful work than a single premium cognition lane should execute.
+
+That is a good problem. It means the lifecycle is compressing. But it also means scheduling must become explicit.
+
+Without a scheduler, ADL risks:
+
+- wasting premium model windows on low-risk paperwork
+- hiding validation-tail cost until too late
+- overloading the human governor with avoidable decisions
+- treating cheap generation as cheap even when review cost is high
+- leaving provider and local-model capacity invisible
+
+Scheduler v1 addresses this by turning work allocation into an auditable decision artifact.
+
+## v1 Scope
+
+In scope:
+
+- schedulable work-item input model
+- economics input model
+- deterministic lane selection
+- scheduling decision artifact
+- explanation fields
+- fixture-driven proof
+- focused tests
+- runbook/documentation
+
+Out of scope:
+
+- autonomous sprint conductor
+- live GitHub mutation
+- live provider/model calls
+- automatic purchasing or overage
+- market/bidding behavior
+- full PVF execution
+- measured speedup or cost-reduction claims
+
+## Execution Lanes
+
+| Lane | Purpose | Typical Work |
+| --- | --- | --- |
+| `LOCAL` | Cheapest available cognition, usually quota-independent | card checks, status summaries, routine docs, checklist support |
+| `CHEAP_REMOTE` | Inexpensive cloud or commodity model work | first-pass review, decomposition, docs, test generation |
+| `PREMIUM` | Scarce frontier/code execution | implementation, hard debugging, PR repair, security-sensitive code |
+| `GOVERNOR` | Human/founder/architect judgment | irreversible choices, release authority, strategic direction |
+| `DELAYED` | Wait for quota/capacity instead of wasting premium resources | low-urgency work during constrained windows |
+
+## Decision Inputs
+
+Scheduler v1 should account for:
+
+- task type
+- dependencies
+- urgency
+- risk
+- expected value
+- estimated effort
+- validation burden
+- coordination cost
+- parallelism potential
+- premium capacity pressure
+- governor attention pressure
+- manual override
+
+## Decision Output
+
+Scheduler v1 should emit a first-class artifact that records:
+
+- selected lane
+- alternatives considered
+- rejection reasons
+- score/explanation breakdown
+- dependency status
+- manual override status
+- confidence
+
+The output must be deterministic for identical inputs.
+
+## Relationship To PVF
+
+PVF is part of scheduling because validation-tail latency can dominate the actual cost of a task.
+
+Scheduler v1 should not only ask whether a task is easy to implement. It should ask whether the task is cheap to prove, cheap to review, and safe to schedule at the current point in the sprint.
+
+## Relationship To Provider Work
+
+Scheduler v1 should not directly choose live providers by hidden heuristics.
+
+Provider/profile and model-suitability work can supply future inputs, but v1 should remain fixture-driven and deterministic unless provider state is explicitly passed in.
+
+## Dependency Note: `schedules` Crate
+
+The `schedules` crate is a candidate dependency for timed execution, recurring watchers, delayed work, or SEP cadence. It is not a substitute for Cognitive Scheduler v1's lane-selection and economics decision model.
+
+The v1 implementation should evaluate `schedules` only if timed execution is part of the accepted `#4107` scope. The default should remain a deterministic, fixture-driven ADL scheduler with no live timing dependency.
+
+## Relationship To SEP And Sprint Conduction
+
+Scheduler v1 is a planning primitive for future SEP and sprint-conductor work.
+
+It does not conduct the sprint by itself. It helps explain how a sprint should allocate work across lanes.
+
+## Issue Plan
+
+| Issue | Role |
+| --- | --- |
+| `#4105` | Umbrella and planning surface |
+| `#4106` | Scheduler economics input model |
+| `#4107` | Scheduler v1 implementation and proof |
+
+Recommended order:
+
+1. Execute `#4106` to define the economics input model.
+2. Execute `#4107` to build Scheduler v1 and prove deterministic scheduling.
+3. Close `#4105` only after both children land and this feature doc reflects implementation truth.
+
+## Acceptance Bar
+
+The feature is ready when:
+
+- Scheduler v1 can load explicit work-item inputs.
+- Scheduler v1 can produce deterministic lane decisions.
+- Decisions include explanation fields.
+- Fixtures cover local, cheap remote, premium, governor, delayed, and blocked/dependency cases.
+- Focused tests prove ordering and failure behavior.
+- Documentation states how to use the scheduler and what it does not claim.
+
+## Non-Claims
+
+This feature does not claim:
+
+- measured sprint acceleration
+- measured cost reduction
+- automatic agent orchestration
+- replacement of human review
+- live provider capacity visibility
+- complete cognitive economics
+
+## Review Notes
+
+The design deliberately starts small. The point of v1 is to make scheduling explicit and inspectable, not to invent a hidden optimizer.

--- a/docs/milestones/v0.91.6/features/README.md
+++ b/docs/milestones/v0.91.6/features/README.md
@@ -17,6 +17,8 @@ They are planning and bridge documents, not runtime implementation proof.
 - [Observatory And Unity Consumption Classification](OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md)
 - [AEE, Memory/ObsMem, And ACP Bridge Accounting](AEE_MEMORY_ACP_BRIDGE_ACCOUNTING_v0.91.6.md)
 
+- [Cognitive Scheduler v1](COGNITIVE_SCHEDULER_v0.91.6.md)
+
 ## Guardrails
 
 - Do not claim runtime feature completion from this index.


### PR DESCRIPTION
Closes #4105

## Summary
Recast the cognitive economics and cognitive scheduler work from review-only routing into a concrete v0.91.6 Scheduler v1 build plan. Produced a tracked TBD plan, a milestone feature doc, and feature-index linkage. The actual economics input implementation and scheduler implementation remain assigned to child issues `#4106` and `#4107`.

## Artifacts
- `docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md`
- `docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md`
- `docs/milestones/v0.91.6/features/README.md`
- Local mirror for operator TBD context: `.adl/docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md`

## Validation
- Validation commands and their purpose:
  - `test -f docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md && test -f docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md && rg -n "Existing Scheduler-Adjacent Surfaces|adl/src/execute/runner.rs|docs/TBD/cognitive_scheduler|#4105|#4106|#4107" docs/TBD/cognitive_scheduler/COGNITIVE_SCHEDULER_V1_PLAN.md docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md docs/milestones/v0.91.6/features/README.md`
    Verified tracked plan, feature doc, feature-index linkage, issue references, and existing scheduler-adjacent surface notes.
  - `git diff --check`
    Verified no whitespace errors in tracked changes.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4105__v0-91-6-scheduler-build-cognitive-scheduler-v1/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4105__v0-91-6-scheduler-build-cognitive-scheduler-v1/sor.md
- Idempotency-Key: v0-91-6-scheduler-build-cognitive-scheduler-v1-docs-tbd-cognitive-scheduler-cognitive-scheduler-v1-plan-md-docs-milestones-v0-91-6-features-cognitive-scheduler-v0-91-6-md-docs-milestones-v0-91-6-features-readme-md-adl-v0-91-6-tasks-issue-4105-v0-91-6-scheduler-build-cognitive-scheduler-v1-sip-md-adl-v0-91-6-tasks-issue-4105-v0-91-6-scheduler-build-cognitive-scheduler-v1-sor-md