### PR TITLE
[v0.91.6][tools] Add sprint-review skill for sprint and mini-sprint reviews

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1205,10 +1205,16 @@ fn finish_path_is_docs_only(path: &str) -> bool {
     if trimmed.starts_with("adl/tools/skills/docs/") {
         return finish_path_has_docs_artifact_extension(trimmed);
     }
+    if trimmed.starts_with("adl/tools/skills/") && trimmed.contains("/docs/") {
+        return finish_path_has_docs_artifact_extension(trimmed);
+    }
     if trimmed.starts_with("adl/tools/skills/")
         && (trimmed.ends_with("/SKILL.md") || trimmed.contains("/references/"))
     {
         return finish_path_has_docs_artifact_extension(trimmed);
+    }
+    if trimmed.starts_with("adl/tools/skills/") && trimmed.ends_with("/agents/openai.yaml") {
+        return true;
     }
     if trimmed.starts_with("adl/tools/skills/")
         && (trimmed.ends_with("/adl-skill.yaml") || trimmed.contains("/scripts/"))

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1025,6 +1025,27 @@ fn finish_validation_profile_treats_issue_records_and_skill_docs_as_docs_only() 
 }
 
 #[test]
+fn finish_validation_profile_treats_skill_schema_and_agent_manifest_as_docs_only() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &[
+            "adl/tools/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md".to_string(),
+            "adl/tools/skills/sprint-review/agents/openai.yaml".to_string(),
+        ],
+    )
+    .expect("docs-only skill metadata plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::DocsOnly);
+    assert_eq!(
+        plan.commands,
+        vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
     let plan = select_finish_validation_plan_for_finish(
         ".",

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -61,6 +61,7 @@ The tracked skill set is:
 - `sip-editor`
 - `sor-editor`
 - `sprint-conductor`
+- `sprint-review`
 - `stp-editor`
 - `test-generator`
 - `use-case-writer`
@@ -146,7 +147,8 @@ values-rendered card path is available.
 `sprint-conductor` is a bounded orchestration helper rather than an editor
 skill. It coordinates one sprint issue across an explicit child issue wave
 using the existing lifecycle/editor stack, then assembles sprint review and
-sprint closeout evidence. Sprint umbrellas should carry a Sprint Execution
+sprint closeout evidence.
+`sprint-review` is a bounded findings-first review composition skill for one completed sprint, mini-sprint, issue wave, or release-tail bundle. It composes existing review, gap-analysis, evidence, and synthesis skills without approving merge, approving closure, or performing remediation. Sprint umbrellas should carry a Sprint Execution
 Packet from `docs/templates/sprints/1.0.0/sprint_execution_packet.md` or equivalent
 issue-body sections that name execution mode, dependency order, safe parallel
 lanes, serial gates, PVF notes, review bar, closeout bar, and residual routing.

--- a/adl/tools/skills/sprint-review/SKILL.md
+++ b/adl/tools/skills/sprint-review/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: sprint-review
+description: Findings-first review orchestrator for one completed sprint, mini-sprint, issue wave, or release-tail bundle. Use when umbrella issue truth, child issue closure truth, PR state, lifecycle cards, validation evidence, closeout artifacts, and follow-up routing need one consistent review packet composed from the existing ADL review skills rather than a hand-assembled process.
+---
+
+# Sprint Review
+
+Review one completed sprint, mini-sprint, issue wave, or release-tail bundle with a findings-first packet that preserves scope, evidence, lifecycle truth, validation status, closeout truth, and follow-up routing.
+This is a findings-first review orchestrator for sprint-scoped review work, not a new execution engine or approval surface.
+
+This skill composes the existing review capabilities. It is not a new execution engine, not a merge/close authority, and not a replacement for issue-level lifecycle or specialist review skills.
+
+## Quick Start
+
+1. Confirm the review scope: `sprint`, `mini_sprint`, `issue_wave`, or `release_tail`.
+2. Gather the umbrella issue, ordered child issues, PR list, changed paths, validation evidence, lifecycle cards, review docs, and closeout artifacts.
+3. Build or refresh the bounded review packet first.
+4. Run the required review lanes for the actual changed surface.
+5. Synthesize findings first, preserve residual risk and skipped lanes, and stop before remediation, merge approval, or sprint closure.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- `mode`
+- `target.scope`
+- `target.umbrella_issue`
+- `target.child_issues`
+- `target.pr_urls`
+- `target.changed_paths`
+- `target.lifecycle_cards`
+- `target.validation_evidence`
+- `target.closeout_artifacts`
+- `policy`
+
+Useful additional inputs:
+
+- `target.review_docs`
+- `target.execution_packet_path`
+- `target.activity_log_path`
+- `target.release_or_milestone`
+- `target.follow_up_issues`
+- `policy.required_lanes`
+- `policy.require_code_review_when_code_changed`
+- `policy.require_closeout_truth`
+- `policy.allow_review_subagent_exception`
+- `output_root`
+- `run_id`
+
+If the umbrella issue, child issue list, or evidence bundle is materially incomplete, stop and report `blocked`.
+
+## Supported Scopes
+
+- `sprint`: one full sprint umbrella and its child wave
+- `mini_sprint`: one bounded mini-sprint umbrella and its child wave
+- `issue_wave`: one explicit non-sprint issue bundle reviewed as a set
+- `release_tail`: one release-facing bundle where closeout and residual risk matter more than implementation sequencing
+
+## Review Lanes
+
+Always treat findings as the primary output. Select lanes according to the changed surface and declared review policy.
+
+Required lane families:
+
+- `gap_analysis`
+  - Compare intended sprint scope against observed implementation, docs, validation, review, and closeout evidence.
+- `code`
+  - Required when sprint work includes code changes.
+  - Use `repo-review-code` or `repo-code-review` according to scope.
+- `docs`
+  - Review reviewer-facing docs, packets, milestone truth, runbooks, demos, and public records touched by the sprint.
+- `tests`
+  - Review validation adequacy, missing proof, fragile assertions, path-policy misuse, and unreviewed test surfaces.
+- `evidence_and_closeout`
+  - Check umbrella closure truth, child issue closure truth, PR state, lifecycle-card truth, validation evidence, closeout packets, ignored/local-only evidence, and legacy tooling residue.
+- `synthesis`
+  - Merge the lane artifacts into one findings-first sprint review.
+- `review_quality`
+  - Evaluate whether the final packet is honest, evidence-bound, and usable.
+
+Optional lane families when the sprint surface warrants them:
+
+- `security`
+- `architecture`
+- `dependency`
+- `release_evidence`
+
+## Recommended Composition
+
+Preferred composition order:
+
+1. `repo-packet-builder`
+2. `gap-analysis`
+3. `repo-review-code` or `repo-code-review` when code changed
+4. `repo-review-docs`
+5. `repo-review-tests`
+6. `redaction-and-evidence-auditor` when publication or public records are involved
+7. `repo-review-synthesis`
+8. `review-quality-evaluator`
+9. `finding-to-issue-planner` only after review findings exist and only when explicit follow-up issue planning is wanted
+
+Use `release-evidence` when the sprint review is also serving a milestone or release proof surface.
+
+## Required Checks
+
+The review must explicitly check:
+
+- umbrella issue state and whether it is truthfully still open or safely closable
+- child issue state and whether each child is actually closed or only appears complete locally
+- PR state for each child where applicable
+- lifecycle cards, especially stale `SRP`/`SOR` truth and missing closeout normalization
+- validation evidence and what it actually proves
+- closeout artifacts and whether they are retained, truthful, and on tracked paths
+- ignored or local-only artifacts that would make the sprint look more complete than `main`
+- legacy or superseded tooling evidence presented as if it were canonical
+- unreviewed code, test, or docs surfaces that changed during the sprint
+
+## Follow-up Routing
+
+Keep the review packet findings-first. Only create or propose follow-up issues when the review policy or operator explicitly wants issue planning.
+
+Use follow-up issues when:
+
+- the fix is out of scope for the reviewed sprint
+- the finding is real but should land later
+- the sprint can close with explicit residual risk and routed cleanup
+
+Keep findings in the review packet without issue creation when:
+
+- the purpose is review truth rather than planning
+- the finding still needs operator judgment
+- the remediation should happen immediately in the active issue/PR instead of via backlog routing
+
+## Output Expectations
+
+Default output should include:
+
+- findings first, ordered by severity
+- scope and evidence summary
+- coverage matrix for the review lanes used and skipped
+- lifecycle and closeout truth summary
+- validation adequacy summary
+- residual risk and non-goals
+- recommended follow-up routing
+- non-claims covering merge, closure, and remediation authority boundaries
+
+Use the detailed output shape in `references/output-contract.md`.
+
+## Example Invocation
+
+Use this skill after a mini-sprint has merged and closeout evidence exists:
+
+```yaml
+skill_input_schema: sprint_review.v1
+mode: review_completed_bundle
+repo_root: /absolute/path/to/repo
+target:
+  scope: mini_sprint
+  umbrella_issue: 4069
+  child_issues: [4076, 4077, 3927, 4074]
+  pr_urls:
+    - https://github.com/danielbaustin/agent-design-language/pull/4104
+    - https://github.com/danielbaustin/agent-design-language/pull/4112
+  changed_paths:
+    - docs/milestones/v0.91.6/review/sprint_execution_packets/
+    - adl/tools/skills/sprint-conductor/
+  lifecycle_cards:
+    - .adl/v0.91.6/tasks/issue-4076__v0-91-6-sep-sprints-automate-sprint-readiness-sweep/
+    - .adl/v0.91.6/tasks/issue-4077__v0-91-6-sep-sprints-add-deterministic-sprint-closeout-mode/
+  validation_evidence:
+    - adl/tools/test_sprint_conductor_helpers.sh
+    - adl/tools/test_install_adl_operational_skills.sh
+  closeout_artifacts:
+    - docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_SEP_LOCAL_AGENT_ACCELERATION_MINI_SPRINT_4069.md
+policy:
+  required_lanes: [gap_analysis, code, docs, tests, evidence_and_closeout, synthesis, review_quality]
+  require_code_review_when_code_changed: true
+  require_closeout_truth: true
+  stop_before_remediation: true
+  stop_before_publication: true
+```
+
+## Stop Boundary
+
+This skill must not:
+
+- execute sprint work
+- mutate implementation code as part of review
+- claim merge approval or sprint closure approval
+- hide stale cards, missing closeout truth, or missing validation
+- silently create follow-up issues without explicit policy or operator approval
+
+Handoff candidates:
+
+- `repo-packet-builder`
+- `gap-analysis`
+- `repo-review-code`
+- `repo-review-docs`
+- `repo-review-tests`
+- `repo-review-synthesis`
+- `review-quality-evaluator`
+- `finding-to-issue-planner`
+- `release-evidence`

--- a/adl/tools/skills/sprint-review/adl-skill.yaml
+++ b/adl/tools/skills/sprint-review/adl-skill.yaml
@@ -1,0 +1,118 @@
+version: "0.1"
+kind: "adl-skill"
+id: "sprint-review"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "sprint_review.v1"
+    reference_doc: "docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_completed_bundle"
+      - "refresh_existing_review"
+    policy_fields:
+      - "required_lanes"
+      - "require_code_review_when_code_changed"
+      - "require_closeout_truth"
+      - "allow_review_subagent_exception"
+      - "stop_before_remediation"
+      - "stop_before_publication"
+      - "write_review_artifact"
+  intent:
+    - "sprint_review"
+    - "mini_sprint_review"
+    - "issue_wave_review"
+    - "release_tail_review"
+  required_inputs:
+    - "repo_root"
+    - "target.scope"
+    - "target.umbrella_issue"
+    - "target.child_issues"
+    - "target.pr_urls"
+    - "target.changed_paths"
+    - "target.lifecycle_cards"
+    - "target.validation_evidence"
+    - "target.closeout_artifacts"
+    - "policy"
+  optional_inputs:
+    - "target.review_docs"
+    - "target.execution_packet_path"
+    - "target.activity_log_path"
+    - "target.follow_up_issues"
+    - "output_root"
+    - "run_id"
+  stop_if_missing:
+    - "repo_root"
+    - "target.scope"
+    - "target.umbrella_issue"
+    - "target.child_issues"
+    - "target.pr_urls"
+    - "target.changed_paths"
+    - "target.lifecycle_cards"
+    - "target.validation_evidence"
+    - "target.closeout_artifacts"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_sprint_review.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "target.scope_must_match_supported_scope_enum"
+    - "target.child_issues_must_not_be_empty"
+    - "policy.stop_before_remediation_must_be_true"
+    - "policy.stop_before_publication_must_be_true"
+execution:
+  mode: "compose_existing_review_skills"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: true
+  preferred_read_order:
+    - "umbrella issue prompt or review brief"
+    - "execution packet"
+    - "child issue closure truth"
+    - "lifecycle cards"
+    - "validation evidence"
+    - "closeout artifacts"
+    - "review artifacts"
+  preferred_skill_stack:
+    - "repo-packet-builder"
+    - "gap-analysis"
+    - "repo-review-code"
+    - "repo-review-docs"
+    - "repo-review-tests"
+    - "redaction-and-evidence-auditor"
+    - "repo-review-synthesis"
+    - "review-quality-evaluator"
+    - "finding-to-issue-planner"
+  invocation_guidance: "prefer findings-first composition; do not collapse into a monolithic approval pass"
+boundaries:
+  must_not_run:
+    - "implementation_execution"
+    - "silent_remediation"
+    - "merge_or_close_authority"
+    - "undisclosed_issue_creation"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-sprint-review.md"
+  required_sections:
+    - "findings"
+    - "scope_summary"
+    - "lane_coverage"
+    - "lifecycle_and_closeout_truth"
+    - "validation_summary"
+    - "residual_risk"
+    - "follow_up_routing"
+    - "non_claims"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_approval_claims: true

--- a/adl/tools/skills/sprint-review/agents/openai.yaml
+++ b/adl/tools/skills/sprint-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sprint Review"
+  short_description: "Review completed sprint bundles with findings first"
+  default_prompt: "Use $sprint-review to review one completed sprint, mini-sprint, issue wave, or release-tail bundle with findings first, lifecycle-card truth checks, and follow-up routing."

--- a/adl/tools/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,53 @@
+# Sprint Review Skill Input Schema
+
+## Purpose
+
+Define the structured input for `sprint-review`, which reviews one completed sprint, mini-sprint, issue wave, or release-tail bundle by composing the existing ADL review skills.
+
+## Shape
+
+```yaml
+skill_input_schema: sprint_review.v1
+mode: review_completed_bundle | refresh_existing_review
+repo_root: /absolute/path
+target:
+  scope: sprint | mini_sprint | issue_wave | release_tail
+  umbrella_issue: <u32>
+  child_issues:
+    - <u32>
+  pr_urls:
+    - <url>
+  changed_paths:
+    - <path>
+  review_docs:
+    - <path>
+  validation_evidence:
+    - <path or command>
+  lifecycle_cards:
+    - <path>
+  closeout_artifacts:
+    - <path>
+  execution_packet_path: <path or null>
+  activity_log_path: <path or null>
+  follow_up_issues:
+    - <u32>
+policy:
+  required_lanes:
+    - gap_analysis | code | docs | tests | evidence_and_closeout | synthesis | review_quality | security | architecture | dependency | release_evidence
+  require_code_review_when_code_changed: true | false
+  require_closeout_truth: true | false
+  allow_review_subagent_exception: true | false
+  stop_before_remediation: true
+  stop_before_publication: true
+  write_review_artifact: true | false
+output_root: <path or null>
+run_id: <string or null>
+```
+
+## Notes
+
+- `scope` determines the review framing, not the implementation workflow.
+- For `review_completed_bundle`, `pr_urls`, `changed_paths`, `validation_evidence`, `lifecycle_cards`, and `closeout_artifacts` are required parts of the evidence bundle, not optional enrichments.
+- `child_issues` must be explicit and ordered enough that missing closeout truth can be detected.
+- `required_lanes` should reflect the actual changed surfaces; code review is mandatory when code changed.
+- This skill stops at review truth and follow-up routing. It is not an approval or remediation skill.

--- a/adl/tools/skills/sprint-review/references/output-contract.md
+++ b/adl/tools/skills/sprint-review/references/output-contract.md
@@ -1,0 +1,54 @@
+# Sprint Review Output Contract
+
+Required default sections:
+
+## Findings
+- Findings first, ordered by severity.
+- Each finding should include:
+  - priority
+  - title
+  - umbrella or child issue context
+  - file or artifact reference when available
+  - scenario or trigger
+  - impact
+  - evidence
+
+## Scope Summary
+- reviewed scope type: sprint | mini_sprint | issue_wave | release_tail
+- umbrella issue
+- child issue list
+- PR list reviewed
+- changed surfaces reviewed
+- skipped surfaces and why
+
+## Lane Coverage
+- lane: gap_analysis | code | docs | tests | evidence_and_closeout | synthesis | review_quality | security | architecture | dependency | release_evidence
+- status: run | skipped | blocked
+- artifact path or reason
+
+## Lifecycle And Closeout Truth
+- umbrella issue state
+- child issue closure truth summary
+- PR state summary
+- lifecycle-card truth summary
+- closeout artifact summary
+- local-only or ignored evidence notes
+
+## Validation Summary
+- commands or artifacts reviewed
+- what each validation surface actually proved
+- missing proof or residual validation gaps
+
+## Residual Risk
+- what the review did not inspect or could not prove
+- what must be fixed before closure versus what can route as follow-up
+
+## Follow-up Routing
+- findings retained in packet only
+- recommended follow-up issues
+- must-land-before-close vs post-sprint-follow-on distinctions
+
+## Non-Claims
+- no merge approval
+- no sprint closure approval
+- no remediation completion claim

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor srp-editor sprint-conductor stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor srp-editor sprint-conductor sprint-review stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -63,6 +63,11 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/adl-skill.yaml" ]]
   [[ -f "${root}/skills/sprint-conductor/references/output-contract.md" ]]
+  [[ -f "${root}/skills/sprint-review/SKILL.md" ]]
+  [[ -f "${root}/skills/sprint-review/adl-skill.yaml" ]]
+  [[ -f "${root}/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md" ]]
+  [[ -f "${root}/skills/sprint-review/agents/openai.yaml" ]]
+  [[ -f "${root}/skills/sprint-review/references/output-contract.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_readiness.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_installed_skill_parity.py" ]]
@@ -108,6 +113,7 @@ assert_skill_bundle() {
   grep -Fq "planning artifact rather than an execution log" "${root}/skills/spp-editor/SKILL.md"
   grep -Fq "Structured Review Prompt" "${root}/skills/srp-editor/SKILL.md"
   grep -Fq "one issue at a time, fully closed out before the next" "${root}/skills/sprint-conductor/SKILL.md"
+  grep -Fq "findings-first review orchestrator" "${root}/skills/sprint-review/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -143,6 +149,7 @@ assert_skill_bundle() {
     "${root}/skills/spp-editor/SKILL.md" \
     "${root}/skills/srp-editor/SKILL.md" \
     "${root}/skills/sprint-conductor/SKILL.md" \
+    "${root}/skills/sprint-review/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"
@@ -166,6 +173,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/repo-diagram-planner" ]]
 [[ -L "${CODEX_HOME}/skills/architecture-diagram-reviewer" ]]
 [[ -L "${CODEX_HOME}/skills/review-to-test-planner" ]]
+[[ -L "${CODEX_HOME}/skills/sprint-review" ]]
 [[ -L "${CODEX_HOME}/skills/adr-curator" ]]
 [[ -L "${CODEX_HOME}/skills/architecture-fitness-function-author" ]]
 [[ -L "${CODEX_HOME}/skills/finding-to-issue-planner" ]]


### PR DESCRIPTION
Closes #3927

## Summary
Added a new `sprint-review` operational skill bundle for findings-first review of completed sprint and mini-sprint issue waves, documented its structured input and output contracts, wired it into the operational skills guide, and extended the install regression suite so the bundle is validated in copy and symlink install modes.

## Artifacts
- `adl/tools/skills/sprint-review/SKILL.md`
- `adl/tools/skills/sprint-review/adl-skill.yaml`
- `adl/tools/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md`
- `adl/tools/skills/sprint-review/references/output-contract.md`
- `adl/tools/skills/sprint-review/agents/openai.yaml`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/test_install_adl_operational_skills.sh`
- Updated issue-local review and output cards for issue `#3927`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified the sprint-review bundle installs correctly in copy and symlink modes and that the new schema doc, `agents/openai.yaml`, and required packaging surfaces are present.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/sprint-review/SKILL.md`
    Verified the new skill frontmatter remains structurally valid.
  - `ruby -e 'require "yaml"; YAML.load_file("adl/tools/skills/sprint-review/adl-skill.yaml"); YAML.load_file("adl/tools/skills/sprint-review/agents/openai.yaml"); puts "PASS yaml parse"'`
    Verified the machine-readable skill contract and OpenAI agent manifest parse cleanly.
  - `git diff --check`
    Verified the tracked diff is whitespace-clean after the contract and packaging updates.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3927__v0-91-6-tools-add-sprint-review-skill/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3927__v0-91-6-tools-add-sprint-review-skill/sor.md
- Idempotency-Key: v0-91-6-tools-add-sprint-review-skill-for-sprint-and-mini-sprint-reviews-adl-v0-91-6-tasks-issue-3927-v0-91-6-tools-add-sprint-review-skill-sip-md-adl-v0-91-6-tasks-issue-3927-v0-91-6-tools-add-sprint-review-skill-sor-md