### PR TITLE
[v0.91.6][tools] Fix ADL issue metadata repair for existing issues

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -436,6 +437,31 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
     let repo_root = repo_root()?;
     let repo = default_repo(&repo_root)?;
     let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
+    if let Some((local_version, local_slug)) = local_identity.as_ref() {
+        if let Some(requested_slug) = parsed.slug.as_deref() {
+            let requested_slug = sanitize_slug(requested_slug);
+            if !requested_slug.is_empty() && requested_slug != *local_slug {
+                bail!(
+                    "repair-issue-body: slug/local identity change is not supported for issue #{}; current canonical local identity is {}:{} and requested slug is '{}'. Keep the canonical slug or migrate the local prompt/task bundle manually before rerunning.",
+                    parsed.issue,
+                    local_version,
+                    local_slug,
+                    requested_slug
+                );
+            }
+        }
+        if let Some(requested_version) = parsed.version.as_deref() {
+            if requested_version != local_version {
+                bail!(
+                    "repair-issue-body: version/local identity change is not supported for issue #{}; current canonical local identity is {}:{} and requested version is '{}'. Keep the canonical version or migrate the local prompt/task bundle manually before rerunning.",
+                    parsed.issue,
+                    local_version,
+                    local_slug,
+                    requested_version
+                );
+            }
+        }
+    }
     let raw_title = if let Some(title) = parsed.title_arg.clone() {
         title
     } else {
@@ -479,7 +505,16 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
         }
     });
     let normalized_labels = normalize_labels_csv(label_source, &version);
-    let body = resolve_issue_body(parsed.body.clone(), parsed.body_file.as_deref())?;
+    let body_requested = parsed.body.is_some() || parsed.body_file.is_some();
+    let body = if body_requested {
+        resolve_issue_body(parsed.body.clone(), parsed.body_file.as_deref())?
+    } else {
+        gh_issue_body(parsed.issue, &repo)?.ok_or_else(|| {
+            anyhow!(
+                "repair-issue-body: metadata-only repair requires the current GitHub issue body; pass --body or --body-file if the issue body is empty or cannot be fetched"
+            )
+        })?
+    };
     validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &body)?;
 
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
@@ -497,7 +532,33 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
     }
 
     let issue_url = format!("https://github.com/{repo}/issues/{}", parsed.issue);
-    gh_issue_edit_body(&repo, parsed.issue, &body)?;
+    let current_title = gh_issue_title(parsed.issue, &repo)?.unwrap_or_default();
+    if title != current_title {
+        gh_issue_edit_title(&repo, parsed.issue, &title)?;
+    }
+    let current_labels = gh_issue_label_names(parsed.issue, &repo)?
+        .into_iter()
+        .map(|label| label.trim().to_string())
+        .filter(|label| !label.is_empty())
+        .collect::<BTreeSet<_>>();
+    let expected_labels = normalized_labels
+        .split(',')
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    if current_labels != expected_labels {
+        let ordered_labels = normalized_labels
+            .split(',')
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        gh_issue_set_labels(&repo, parsed.issue, &ordered_labels)?;
+    }
+    if body_requested {
+        gh_issue_edit_body(&repo, parsed.issue, &body)?;
+    }
     let source_path = write_source_issue_prompt(
         &repo_root,
         &issue_ref,
@@ -521,7 +582,7 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
     let (stp_path, bundle_input, bundle_output, bundle_dir) =
         bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
 
-    println!("• Repaired issue body/source prompt:");
+    println!("• Repaired issue metadata/source prompt:");
     println!("  ISSUE     #{}", parsed.issue);
     println!("  VERSION   {version}");
     println!("  SLUG      {slug}");

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -346,8 +346,16 @@ pub(crate) fn parse_repair_issue_body_args(args: &[String]) -> Result<RepairIssu
     if parsed.body.is_some() && parsed.body_file.is_some() {
         bail!("repair-issue-body: pass only one of --body or --body-file");
     }
-    if parsed.body.is_none() && parsed.body_file.is_none() {
-        bail!("repair-issue-body: --body or --body-file is required");
+    if parsed.body.is_none()
+        && parsed.body_file.is_none()
+        && parsed.title_arg.is_none()
+        && parsed.labels.is_none()
+        && parsed.slug.is_none()
+        && parsed.version.is_none()
+    {
+        bail!(
+            "repair-issue-body: pass at least one of --body, --body-file, --title, --labels, --slug, or --version"
+        );
     }
 
     Ok(parsed)

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -872,11 +872,30 @@ fn parse_repair_issue_body_args_accepts_body_and_force_flags() {
 }
 
 #[test]
-fn parse_repair_issue_body_args_requires_body_source() {
-    let err = parse_repair_issue_body_args(&["3779".to_string()]).expect_err("missing body");
+fn parse_repair_issue_body_args_accepts_metadata_only_repairs() {
+    let parsed = parse_repair_issue_body_args(&[
+        "3779".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Retitle only".to_string(),
+        "--labels".to_string(),
+        "area:tools,type:task".to_string(),
+    ])
+    .expect("metadata-only repair args");
+    assert_eq!(
+        parsed.title_arg.as_deref(),
+        Some("[v0.91.6][tools] Retitle only")
+    );
+    assert_eq!(parsed.labels.as_deref(), Some("area:tools,type:task"));
+    assert!(parsed.body.is_none());
+    assert!(parsed.body_file.is_none());
+}
+
+#[test]
+fn parse_repair_issue_body_args_requires_some_repair_input() {
+    let err = parse_repair_issue_body_args(&["3779".to_string()]).expect_err("missing input");
     assert!(err
         .to_string()
-        .contains("repair-issue-body: --body or --body-file is required"));
+        .contains("repair-issue-body: pass at least one of --body, --body-file, --title, --labels, --slug, or --version"));
 
     let err = parse_repair_issue_body_args(&[
         "3779".to_string(),
@@ -962,9 +981,75 @@ fn real_pr_repair_issue_body_updates_github_source_prompt_and_bundle() {
 }
 
 #[test]
-fn real_pr_repair_issue_body_blocks_duplicate_identity_before_github_edit() {
+fn real_pr_repair_issue_body_repairs_title_and_labels_without_body_mutation() {
     let _guard = env_lock();
-    let repo = unique_temp_dir("adl-pr-repair-duplicate-identity");
+    let repo = unique_temp_dir("adl-pr-repair-issue-metadata");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    let issue_body_log = repo.join("issue_body.log");
+    write_executable(
+        &fixture,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json body'; then\n    cat <<'EOF'\n{}\nEOF\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            authored_repair_body(),
+            issue_body_log.display()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let result = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1303".to_string(),
+        "--slug".to_string(),
+        "repair-body".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Repair metadata".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    result.expect("repair issue metadata");
+
+    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_calls.contains("issue view 1303"));
+    assert!(gh_calls.contains("--title [v0.91.6][tools] Repair metadata"));
+    assert!(gh_calls.contains("--add-label track:roadmap,type:task,area:tools,version:v0.91.6"));
+    assert!(
+        !gh_calls.contains("--body "),
+        "metadata-only repair should not mutate the live GitHub issue body"
+    );
+    assert!(
+        fs::read_to_string(&issue_body_log)
+            .unwrap_or_default()
+            .is_empty(),
+        "metadata-only repair should not emit a body edit payload"
+    );
+
+    let source = repo.join(".adl/v0.91.6/bodies/issue-1303-repair-body.md");
+    let prompt = fs::read_to_string(&source).expect("read source prompt");
+    assert!(prompt.contains("title: \"[v0.91.6][tools] Repair metadata\""));
+    assert!(prompt.contains("  - \"track:roadmap\""));
+    assert!(prompt.contains("  - \"type:task\""));
+    assert!(prompt.contains("  - \"area:tools\""));
+    assert!(prompt.contains("  - \"version:v0.91.6\""));
+    assert!(prompt.contains("## Required Outcome"));
+}
+
+#[test]
+fn real_pr_repair_issue_body_blocks_metadata_only_overwrite_of_authored_prompt_without_force() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-metadata-overwrite-blocked");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
 
@@ -974,38 +1059,145 @@ fn real_pr_repair_issue_body_blocks_duplicate_identity_before_github_edit() {
     write_executable(
         &fixture,
         &format!(
-            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
-            gh_log.display()
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json body'; then\n    cat <<'EOF'\n{}\nEOF\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            authored_repair_body()
         ),
     );
     let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
 
-    fs::create_dir_all(repo.join(".adl/v0.91.5/tasks/issue-1302__old-slug")).expect("old bundle");
-    let body_path = repo.join("repair-body.md");
-    fs::write(&body_path, authored_repair_body()).expect("write body");
+    let source = repo.join(".adl/v0.91.5/bodies/issue-1305-repair-body.md");
+    fs::create_dir_all(source.parent().expect("source parent")).expect("source dir");
+    fs::write(&source, authored_repair_body()).expect("write authored source");
+
     let prev_dir = env::current_dir().expect("cwd");
     env::set_current_dir(&repo).expect("chdir");
 
     let err = real_pr(&[
         "repair-issue-body".to_string(),
-        "1302".to_string(),
+        "1305".to_string(),
         "--slug".to_string(),
-        "new-slug".to_string(),
-        "--body-file".to_string(),
-        body_path.display().to_string(),
+        "repair-body".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Repair metadata".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
         "--version".to_string(),
         "v0.91.5".to_string(),
     ])
-    .expect_err("duplicate identity should block repair");
+    .expect_err("authored prompt overwrite should require force");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
     assert!(err
         .to_string()
-        .contains("duplicate local issue identities detected"));
-    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+        .contains("refusing to overwrite authored source prompt without --force"));
+    let gh_calls = fs::read_to_string(&gh_log).unwrap_or_default();
     assert!(
         !gh_calls.contains("issue edit"),
-        "duplicate guard should run before GitHub mutation"
+        "authored prompt overwrite guard should block before GitHub mutation"
+    );
+}
+
+#[test]
+fn real_pr_repair_issue_body_blocks_slug_change_for_existing_local_identity() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-slug-change-blocked");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &fixture,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json body'; then\n    cat <<'EOF'\n{}\nEOF\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            authored_repair_body()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    fs::create_dir_all(repo.join(".adl/v0.91.5/tasks/issue-1304__old-slug")).expect("old bundle");
+    let source_path = repo.join(".adl/v0.91.5/bodies/issue-1304-old-slug.md");
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source dir");
+    fs::write(&source_path, "placeholder").expect("write source placeholder");
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1304".to_string(),
+        "--slug".to_string(),
+        "new-slug".to_string(),
+        "--title".to_string(),
+        "[v0.91.5][tools] Repair body".to_string(),
+    ])
+    .expect_err("slug change should block repair");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    assert!(err
+        .to_string()
+        .contains("slug/local identity change is not supported"));
+    assert!(err
+        .to_string()
+        .contains("current canonical local identity is v0.91.5:old-slug"));
+    let gh_calls = fs::read_to_string(&gh_log).unwrap_or_default();
+    assert!(
+        !gh_calls.contains("issue edit"),
+        "slug-change guard should block before GitHub mutation"
+    );
+}
+
+#[test]
+fn real_pr_repair_issue_body_blocks_version_change_for_existing_local_identity() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-version-change-blocked");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &fixture,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.91.5][tools] Repair body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:backlog\\ntype:docs\\narea:docs\\nversion:v0.91.5\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json body'; then\n    cat <<'EOF'\n{}\nEOF\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            authored_repair_body()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    fs::create_dir_all(repo.join(".adl/v0.91.5/tasks/issue-1306__repair-body")).expect("bundle");
+    let source_path = repo.join(".adl/v0.91.5/bodies/issue-1306-repair-body.md");
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source dir");
+    fs::write(&source_path, "placeholder").expect("write source placeholder");
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1306".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+        "--title".to_string(),
+        "[v0.91.6][tools] Repair body".to_string(),
+    ])
+    .expect_err("version change should block");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    assert!(err
+        .to_string()
+        .contains("version/local identity change is not supported"));
+    assert!(err
+        .to_string()
+        .contains("current canonical local identity is v0.91.5:repair-body"));
+    let gh_calls = fs::read_to_string(&gh_log).unwrap_or_default();
+    assert!(
+        !gh_calls.contains("issue edit"),
+        "version-change guard should block before GitHub mutation"
     );
 }
 


### PR DESCRIPTION
Closes #3985

## Summary
Completed the bounded `#3985` tooling fix by making `adl pr repair-issue-body`
support metadata-only repairs, preserving the existing authored-source
overwrite safety guard for those repairs, and failing closed when the requested
slug or version would diverge from an existing local identity bundle. The issue
stops at branch-local implementation and proof capture; draft-PR publication is
the next lifecycle step.

## Artifacts
- Updated tracked CLI implementation: `adl/src/cli/pr_cmd.rs`
- Updated tracked CLI parser: `adl/src/cli/pr_cmd_args.rs`
- Updated tracked focused tests: `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-3985__v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues/srp.md`
  - `.adl/v0.91.6/tasks/issue-3985__v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues/sor.md`

## Validation
- Validation commands and their purpose:
  - `GITHUB_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 3985 --mode ready --json`
    Verified publication readiness and confirmed the bound issue/worktree state.
  - `cargo test --manifest-path adl/Cargo.toml parse_repair_issue_body_args -- --nocapture`
    Verified parser behavior for metadata-only repair inputs.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_repair_issue_body -- --nocapture`
    Verified the repaired metadata/body synchronization path and the new fail-closed diagnostics.
  - `git diff --check`
    Verified the tracked branch diff was clean and publishable.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-3985__v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues/sip.md
- Output card: .adl/v0.91.6/tasks/issue-3985__v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues/sor.md
- Idempotency-Key: v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-v0-91-6-tasks-issue-3985-v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues-sip-md-adl-v0-91-6-tasks-issue-3985-v0-91-6-tools-fix-adl-issue-metadata-repair-for-existing-issues-sor-md