### PR TITLE
[v0.91.6][WP-06][acip][C-00] Define communication schema catalog and profile boundaries

### DIFF
--- a/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
@@ -4,7 +4,7 @@
 
 - Feature Name: ACIP, A2A, And Provider Communications
 - Milestone Target: `v0.91.6`
-- Status: planned
+- Status: in_progress
 - Owner: ADL maintainers
 - Doc Role: primary
 - Feature Types: architecture, policy, schema
@@ -39,6 +39,63 @@ Out of scope:
 - Which messages can cross provider or polis boundaries?
 - Is protobuf required before `v0.92`, or is JSON projection sufficient?
 - Which access-control failures are terminal?
+
+## Canonical Schema Catalog For `v0.91.6`
+
+The first ACIP boundary decision in `v0.91.6` is a schema-catalog decision,
+not a transport implementation claim.
+
+| Schema family | Role in `v0.91.6` | Canonical owner | May cross provider boundary? | May cross polis or external-agent boundary? | Notes |
+| --- | --- | --- | --- | --- | --- |
+| ACIP envelope metadata | Top-level message framing, schema family, version, sender class, and routing posture | ACIP contract layer | No | Yes, only after later access-rule review | This is the minimal catalog entry every later message family must inherit. |
+| ACIP capability delegation request | Requests work by named capability, constraints, and required proof posture | ACIP delegation layer | No | Not yet approved by this issue | Capability routing must stay distinct from provider/model selection. |
+| ACIP capability delegation result | Returns outcome, refusal, failure class, and proof handles | ACIP delegation layer | No | Not yet approved by this issue | Output posture is capability-shaped, not provider-shaped. |
+| A2A inter-agent route message | Agent-to-agent request/response contract above provider transport | A2A route layer | No | Deferred to the explicit A2A/access-rule issues | A2A remains a policy/documentation boundary in `v0.91.6`. |
+| Provider execution request | Low-level provider invocation payload sent to model/runtime substrates | Provider substrate layer | Yes, internally | No | Provider messages are infrastructure records, not citizen or institution records. |
+| Provider execution response | Low-level provider completion/result payload | Provider substrate layer | Yes, internally | No | Provider output stays behind the provider boundary unless explicitly projected upward. |
+| Capability profile record | Provider-independent description of what a lane or role needs | Capability profile layer | No | Yes, as reviewed policy metadata | Capability profiles may inform delegation and routing without carrying vendor/endpoint state. |
+| Provider profile record | Deterministic infrastructure descriptor for service family, endpoint, and model defaults | Provider profile layer | No | No | Provider profiles remain low-level substrate descriptors. |
+| Role-provider policy record | Higher-level C-SDLC routing policy that references provider and capability layers | C-SDLC policy layer | No | No | This is advisory policy, not direct transport authority. |
+| Identity, citizen, institution, or guild records | Civil/governance identity surfaces | Identity/governance layers | No | Not part of this lane | These remain explicitly out of provider/profile transport scope. |
+
+## Layer Boundary Table
+
+| Layer | Canonical responsibility | Must not be collapsed into |
+| --- | --- | --- |
+| Provider profile | Infrastructure-backed service identity, endpoint family, model default, and substrate validation | capability semantics, actor identity, or role authority |
+| Capability profile | Provider-independent statement of required behavior or ability | vendor, endpoint, credential, or transport identity |
+| Role-provider policy | C-SDLC routing preference or suitability policy referencing provider/capability layers | autonomous provider authority or civil identity |
+| ACIP message layer | Capability-shaped communication semantics and versioned message families | raw provider transport payloads |
+| A2A message layer | Agent-to-agent protocol posture and cross-agent route semantics | provider execution metadata or identity registries |
+| Identity/citizen/institution/guild layer | Civil, institutional, continuity, or governance records | provider profiles, capability policy, or runtime routing metadata |
+
+## Message Ownership And Versioning Notes
+
+- `v0.91.6` adopts deterministic JSON as the only canonical projection proved by
+  this issue.
+- Each message family must declare a schema family name, message kind, and
+  version identifier before later transport or wire-format work is accepted.
+- Provider execution payloads may reference provider-profile identifiers and
+  model names, but they must not become the canonical identity of a capability
+  request.
+- Capability-facing ACIP or A2A records may reference provider suitability or
+  role-provider policy, but they must not inline provider endpoint contracts as
+  if those were the user-facing protocol.
+- The historical authored input path `.adl/docs/TBD/ADL_PROFILES_PROVIDERS_V2.MD`
+  is not present in the tracked repository state. For provider/profile boundary
+  truth, `v0.91.6` now depends on the merged WP-05 provider artifacts and the
+  reconciliation packet for `#4111`, not on the missing TBD file.
+
+## `v0.92` Consumption Rules
+
+- `v0.92` may consume the schema catalog and boundary vocabulary from this file
+  as the required baseline for later ACIP/A2A decisions.
+- `v0.92` may not assume protobuf, WebSocket transport, or cross-boundary A2A
+  execution authority is settled by this issue.
+- `v0.92` must continue to route delegation requests by capability semantics
+  first and only resolve provider/model choices through bounded lower layers.
+- `v0.92` must preserve the separation between provider profiles, capability
+  profiles, role-provider policy, and civil identity surfaces.
 
 ## Dependencies
 


### PR DESCRIPTION
Closes #4013

## Summary
Updated the ACIP feature doc with the first WP-06 schema catalog, layer boundary table, message ownership/versioning notes, and `v0.92` consumption rules for the communication boundary.

## Artifacts
- Updated tracked feature doc: `docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md`
- Updated review/output cards: `.adl/v0.91.6/tasks/issue-4013__v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries/srp.md`, `.adl/v0.91.6/tasks/issue-4013__v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 4013 --mode ready --json`
    Verified the issue bundle was structurally ready for execution, with no open PR and `ready_status: PASS`.
  - `bash adl/tools/pr.sh run 4013`
    Verified issue-mode binding to the correct branch and worktree before editing.
  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication during `pr finish` preflight.
  - `git diff --check`
    Verified whitespace and patch hygiene on the docs-only changed surfaces during `pr finish` preflight.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4013__v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4013__v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries/sor.md
- Idempotency-Key: v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries-docs-milestones-v0-91-6-features-acip-a2a-provider-communications-v0-91-6-md-adl-v0-91-6-tasks-issue-4013-v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries-sip-md-adl-v0-91-6-tasks-issue-4013-v0-91-6-wp-06-acip-c-00-define-communication-schema-catalog-and-profile-boundaries-sor-md