### PR TITLE
[v0.91.6][WP-06][acip][C-03] Decide JSON protobuf and WebSocket projection boundaries

### DIFF
--- a/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
@@ -265,6 +265,66 @@ These residuals route to the `v0.91.6` security bridge lane and, where
 transport or projection shape is still unsettled, to the later WP-06
 transport/closeout issues rather than being silently absorbed into `v0.92`.
 
+## JSON / Protobuf / WebSocket Decision Table
+
+`v0.91.6` records the first projection/transport posture and the required
+downstream ownership as follows:
+
+| Surface | `v0.91.6` decision | Status | Owner / next lane | Rationale |
+| --- | --- | --- | --- | --- |
+| Deterministic JSON projection | current documented baseline for message shape; final downstream consumption stays explicitly owned later | documented_baseline_only | `v0.91.7` residual clarification and `v0.92` projection/carrier work | JSON is the only projection this milestone can describe without inventing unproven transport, signing, fixture, or runtime claims, but downstream implementation/proof ownership remains tracked later. |
+| Protobuf wire format | not required for `v0.91.6`; explicit residual for later decision | deferred | `v0.91.7` ACIP/A2A protobuf residuals | Protobuf must not ship without schema-version, compatibility, and security ownership that this milestone does not yet prove. |
+| WebSocket transport | not part of the reviewed `v0.91.6` activation baseline | deferred | `v0.91.7` residual clarification and `v0.92` transport work | WebSocket remains transport productization until access, integrity, carrier, and projection rules are explicit enough to consume safely. |
+| Mock or internal carrier posture | may exist only as bounded internal/testing carriage; not a settled protocol decision here | documented_non_claim | `v0.92` carrier/fixture work | Internal carriage may exist, but `v0.91.6` does not claim that mock or loopback transport has already been accepted as the protocol route. |
+| Cross-boundary external-agent transport | blocked from implied approval in `v0.91.6` | rejected_for_now | later ACIP/A2A residual and security lanes | Activation cannot infer external-agent trust or transport closure from schema-only decisions. |
+
+## Projection Boundary Decision Notes
+
+- Deterministic JSON is the only projection this milestone can describe as the
+  current documented message-shape baseline.
+- That baseline does not take away later tracked ownership for projection,
+  carrier, fixture, or runtime proof work in `v0.91.7` and `v0.92`.
+- Protobuf is neither silently approved nor vaguely “future”; it is explicitly
+  routed to the tracked `v0.91.7` residual surface.
+- WebSocket is not rejected forever, but it is outside the `v0.91.6` reviewed
+  communication baseline and must remain a residual until transport and
+  security ownership are stronger.
+
+## Versioning And Compatibility Posture
+
+- Every projection must preserve the schema family, message kind, and version
+  identifier already required by the earlier schema-catalog decision.
+- JSON projection is required to remain deterministic for identical message
+  content and ordering assumptions.
+- Protobuf cannot be accepted until field numbering, compatibility posture, and
+  downgrade/upgrade rules are explicitly tracked.
+- WebSocket cannot be accepted until it is clear whether it carries JSON,
+  protobuf, or another bounded framed payload, and what integrity/access rules
+  apply at that boundary.
+
+## Validation And Projection Expectations
+
+- `v0.91.6` may claim schema/documentation truth for the current JSON-shaped
+  message baseline only.
+- No claim in this milestone should imply that protobuf serialization,
+  WebSocket carriage, or external-agent interop has already been runtime-proven.
+- No claim in this milestone should imply that later tracked `v0.91.7` or
+  `v0.92` ownership for projection/carrier proof has been silently collapsed
+  into `v0.91.6`.
+- Any later acceptance of protobuf or WebSocket must also consume the access
+  and authority boundaries from `#4015` and the security-bridge residuals
+  already routed above.
+
+## ADR Candidate Routing
+
+No transport ADR is accepted in `v0.91.6` from this issue alone.
+
+If a later tranche accepts protobuf, WebSocket, or a concrete carrier contract,
+that acceptance should be captured as an ADR candidate then. The current
+decision is intentionally a bounded “JSON-shaped baseline now, protobuf and
+WebSocket deferred, downstream ownership preserved” record rather than a final
+transport architecture claim.
+
 ## Dependencies
 
 - Security bridge and CAV feature doc.


### PR DESCRIPTION
Closes #4016

## Summary
Extended the ACIP feature doc with the JSON/protobuf/WebSocket decision table, projection-boundary notes, versioning/compatibility posture, validation expectations, and explicit ADR/non-ADR routing for the first transport decision tranche.

## Artifacts
- Updated tracked feature doc: `docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md`
- Updated review/output cards: `.adl/v0.91.6/tasks/issue-4016__v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries/srp.md`, `.adl/v0.91.6/tasks/issue-4016__v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 4016 --mode ready --json`
    Verified the issue bundle was structurally ready for execution, with no open PR and `ready_status: PASS`.
  - `bash adl/tools/pr.sh run 4016`
    Verified issue-mode binding to the correct branch and worktree before editing.
  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication during `pr finish` preflight.
  - `git diff --check`
    Verified whitespace and patch hygiene on the docs-only changed surfaces during `pr finish` preflight.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4016__v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4016__v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries/sor.md
- Idempotency-Key: v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries-docs-milestones-v0-91-6-features-acip-a2a-provider-communications-v0-91-6-md-adl-v0-91-6-tasks-issue-4016-v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries-sip-md-adl-v0-91-6-tasks-issue-4016-v0-91-6-wp-06-acip-c-03-decide-json-protobuf-and-websocket-projection-boundaries-sor-md