### PR TITLE
[v0.91.6][WP-06][acip][C-04] Define external-agent citizen guild and capability-market routing

### DIFF
--- a/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md
@@ -325,6 +325,74 @@ decision is intentionally a bounded “JSON-shaped baseline now, protobuf and
 WebSocket deferred, downstream ownership preserved” record rather than a final
 transport architecture claim.
 
+## External-Agent / Citizen / Guild Routing Posture
+
+`v0.91.6` records the routing posture for external agents, citizens, guilds,
+providers, and capability-market concepts without claiming the full social or
+economic runtime already exists.
+
+| Surface | `v0.91.6` posture | Must remain distinct from |
+| --- | --- | --- |
+| External agent | a potential participant class that may later originate or receive allowed ACIP/A2A routes | provider profile, model identity, or institutional authority |
+| Citizen | a higher-layer identity/governance record that may later constrain what routes are legitimate | provider substrate, capability record, or guild policy by itself |
+| Guild | an MVP-scope policy/grouping input that may influence route classes, capability discovery, and membership-based restrictions | transport substrate, provider identity, or direct runtime execution authority |
+| Capability market | a planned routing/economic concept above capability and role-provider policy | current `v0.91.6` runtime behavior or low-level provider transport |
+| Provider communication | infrastructure-level invocation and substrate response path | citizen identity, guild membership, or capability-market semantics |
+
+## MVP Versus Post-MVP Boundary
+
+The MVP boundary for this lane is:
+
+- guilds may be represented as an input to capability/routing policy;
+- citizens and institutions remain distinct higher-layer identity surfaces;
+- capability-market concepts may be planned and named;
+- provider communication remains low-level substrate infrastructure;
+- no claim is made that market negotiation, citizen governance, or guild-state
+  runtime exists yet.
+
+Post-MVP or later-lane work includes:
+
+- first-class capability-market runtime behavior;
+- citizen/institution/guild persistent state and governance flows;
+- external-agent onboarding or trust protocols;
+- economic selection or bidding logic above capability routing;
+- autonomous multi-party route negotiation.
+
+## Routing Layer Dependencies
+
+The routing dependency order after this issue is:
+
+1. capability semantics remain primary
+2. access and authority boundaries remain fail-closed
+3. guild or citizen policy may narrow the route class
+4. role-provider policy may narrow acceptable provider/model families
+5. provider substrate selection happens only after the higher-layer checks pass
+
+This preserves the non-collapse rule: neither provider infrastructure nor
+market-style planning should become a disguised identity or authority layer.
+
+## Capability-Market Non-Claims
+
+- `v0.91.6` does not implement a live capability market.
+- `v0.91.6` does not claim pricing, bidding, auction, or settlement semantics.
+- `v0.91.6` does not claim guild membership is already a runtime-enforced
+  first-class object.
+- `v0.91.6` does not claim external agents are trusted by default.
+
+## `v0.91.7` / `v0.92` Handoff Notes
+
+- `v0.91.7` may refine residual routing boundaries where protobuf, WebSocket,
+  or security ownership affects external-agent posture.
+- `v0.92` may consume this posture as a planning and activation-bridge input,
+  but must not treat capability-market or citizen/guild runtime as already
+  implemented.
+- Any future identity/capability selector work must preserve the separation
+  between:
+  - citizen/institution identity;
+  - guild or role policy;
+  - capability need;
+  - provider/model substrate choice.
+
 ## Dependencies
 
 - Security bridge and CAV feature doc.


### PR DESCRIPTION
Closes #4017

## Summary
Extended the ACIP feature doc with the external-agent / citizen / guild / capability-market routing posture, MVP versus post-MVP boundary, routing dependency order, non-claims, and `v0.91.7` / `v0.92` handoff notes.

## Artifacts
- Updated tracked feature doc: `docs/milestones/v0.91.6/features/ACIP_A2A_PROVIDER_COMMUNICATIONS_v0.91.6.md`
- Updated review/output cards: `.adl/v0.91.6/tasks/issue-4017__v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing/srp.md`, `.adl/v0.91.6/tasks/issue-4017__v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 4017 --mode ready --json`
    Verified the issue bundle was structurally ready for execution, with no open PR and `ready_status: PASS`.
  - `bash adl/tools/pr.sh run 4017`
    Verified issue-mode binding to the correct branch and worktree before editing.
  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication during `pr finish` preflight.
  - `git diff --check`
    Verified whitespace and patch hygiene on the docs-only changed surfaces during `pr finish` preflight.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4017__v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4017__v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing/sor.md
- Idempotency-Key: v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing-docs-milestones-v0-91-6-features-acip-a2a-provider-communications-v0-91-6-md-adl-v0-91-6-tasks-issue-4017-v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing-sip-md-adl-v0-91-6-tasks-issue-4017-v0-91-6-wp-06-acip-c-04-define-external-agent-citizen-guild-and-capability-market-routing-sor-md