### PR TITLE
[v0.91.6][tools][pr-finish] Auto-declare non-closing lifecycle PRs

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -157,7 +157,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     let close_line = if parsed.no_close {
-        None
+        Some(non_closing_lifecycle_line(parsed.issue))
     } else {
         Some(format!("Closes #{}", parsed.issue))
     };
@@ -183,7 +183,10 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     )?;
     let pr_body_file = write_temp_markdown("pr_body", &pr_body)?;
 
-    let commit_msg = if let Some(close) = &close_line {
+    let commit_msg = if !parsed.no_close {
+        let close = close_line
+            .as_ref()
+            .expect("closing finish should have a close line");
         format!("{} ({close})", parsed.title)
     } else {
         parsed.title.clone()
@@ -2186,6 +2189,10 @@ pub(super) fn extra_pr_body_looks_like_issue_template(body: &str) -> bool {
         || lowered.contains("## goal")
         || lowered.contains("## deliverables")
         || lowered.contains("\n---\n")
+}
+
+pub(super) fn non_closing_lifecycle_line(issue: u32) -> String {
+    format!("Non-closing lifecycle PR: issue #{issue} remains open.")
 }
 
 pub(super) fn render_pr_body(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::cli::pr_cmd::finish_support::{
     ensure_finish_branch_not_behind_origin_main, ensure_finish_task_bundle_surfaces,
-    finish_declared_paths_for_validation, normalize_docs_only_sor_text, open_pr_url_nonblocking,
-    open_pr_url_nonblocking_with_timeout, real_pr_finish, resolve_finish_issue_scope_and_slug,
-    select_finish_validation_plan_for_finish, FinishValidationMode, FinishValidationPlan,
+    finish_declared_paths_for_validation, non_closing_lifecycle_line, normalize_docs_only_sor_text,
+    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, real_pr_finish,
+    resolve_finish_issue_scope_and_slug, select_finish_validation_plan_for_finish,
+    FinishValidationMode, FinishValidationPlan,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 
@@ -164,6 +165,35 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
     )
     .expect_err("issue template text should be rejected");
     assert!(err.to_string().contains("issue-template/prompt text"));
+}
+
+#[test]
+fn render_pr_body_can_declare_non_closing_lifecycle_pr() {
+    let temp = unique_temp_dir("adl-pr-render-body-no-close");
+    fs::create_dir_all(&temp).expect("temp dir");
+    let input = temp.join("input.md");
+    let output = temp.join("output.md");
+    fs::write(&input, "# input\n").expect("write input");
+    fs::write(
+        &output,
+        "# no-close\n\n## Summary\nsummary text\n\n## Artifacts produced\n- docs/example.md\n",
+    )
+    .expect("write output");
+
+    let body = render_pr_body(
+        Some(&non_closing_lifecycle_line(1153)),
+        &input,
+        &output,
+        None,
+        None,
+        "fp-123",
+        &temp,
+    )
+    .expect("render no-close body");
+
+    assert!(body.contains("Non-closing lifecycle PR"));
+    assert!(body.contains("issue #1153 remains open"));
+    assert!(!body.contains("Closes #1153"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -394,9 +394,13 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
     let closeout_path = bin_dir.join("closeout");
+    let pr_body_capture = temp.join("pr-body.md");
     write_executable(
         &gh_path,
-        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1160\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1154\\n'\n  else\n    printf 'Closes #1154\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = '--body-file' ]; then\n      cp \"$2\" '{}'\n      break\n    fi\n    shift\n  done\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1160\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1154\\n'\n  else\n    printf 'Closes #1154\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+            pr_body_capture.display()
+        ),
     );
     write_executable(
         &janitor_path,
@@ -465,6 +469,10 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     assert!(err
         .to_string()
         .contains("finish: PR janitor auto-attach failed"));
+    let captured_body = fs::read_to_string(&pr_body_capture).expect("captured PR body");
+    assert!(captured_body.contains("Non-closing lifecycle PR"));
+    assert!(captured_body.contains("issue #1154 remains open"));
+    assert!(!captured_body.contains("Closes #1154"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4085

## Summary
Implemented automatic non-closing lifecycle PR declaration for `pr finish
--no-close`. The finish PR body now includes the canonical
`Non-closing lifecycle PR` text while normal closing finish behavior continues
to emit the matching `Closes #N` line for the issue being finished.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for the touched code and test files.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::arg_render::render_pr_body -- --nocapture`
    Verified PR-body rendering for closing, docs-only validation, and non-closing lifecycle declaration cases.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::publication::linkage -- --nocapture`
    Verified finish publication linkage helper behavior remains intact.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::publication::flow::real_pr_finish_fails_when_pr_janitor_auto_attach_fails -- --nocapture`
    Verified the full `real_pr_finish --no-close` path writes a non-closing PR body to the PR creation body file.
  - `bash adl/tools/test_pr_closing_linkage.sh`
    Verified the shell guardrail accepts non-closing lifecycle PR declarations and still rejects missing linkage.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4085__v0-91-6-tools-pr-finish-auto-declare-non-closing-lifecycle-prs-when-finish-runs-with-no-close/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4085__v0-91-6-tools-pr-finish-auto-declare-non-closing-lifecycle-prs-when-finish-runs-with-no-close/sor.md
- Idempotency-Key: v0-91-6-tools-pr-finish-auto-declare-non-closing-lifecycle-prs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-src-cli-tests-pr-cmd-inline-finish-publication-flow-rs-adl-v0-91-6-tasks-issue-4085-v0-91-6-tools-pr-finish-auto-declare-non-closing-lifecycle-prs-when-finish-runs-with-no-close-sip-md-adl-v0-91-6-tasks-issue-4085-v0-91-6-tools-pr-finish-auto-declare-non-closing-lifecycle-prs-when-finish-runs-with-no-close-sor-md