### PR TITLE
[v0.91.6][tools][github-client] Inherit configured token context

### DIFF
--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -215,24 +215,47 @@ impl TokenReader for RealTokenReader {
 pub(crate) fn redact_for_github_token_diagnostics(input: &str) -> String {
     input
         .split_whitespace()
-        .map(|token| {
-            let lower = token.to_ascii_lowercase();
-            if lower.contains("token=")
-                || lower.contains("authorization:")
-                || lower.starts_with("ghp_")
-                || lower.starts_with("gho_")
-                || lower.starts_with("ghu_")
-                || lower.starts_with("ghs_")
-                || lower.starts_with("ghr_")
-                || lower.starts_with("github_pat_")
-            {
-                "<redacted>"
-            } else {
-                token
-            }
-        })
+        .map(redact_diagnostic_token)
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn redact_diagnostic_token(token: &str) -> String {
+    let lower = token.to_ascii_lowercase();
+    if lower.contains("authorization:") || lower.contains("token=") {
+        return "<redacted>".to_string();
+    }
+    let mut output = String::with_capacity(token.len());
+    let mut cursor = 0usize;
+    while cursor < token.len() {
+        let rest = &token[cursor..];
+        if let Some(prefix) = github_secret_prefix_at(rest) {
+            let secret_len = rest[prefix.len()..]
+                .char_indices()
+                .find_map(|(idx, ch)| (!is_github_secret_char(ch)).then_some(idx))
+                .unwrap_or(rest[prefix.len()..].len());
+            output.push_str("<redacted>");
+            cursor += prefix.len() + secret_len;
+        } else {
+            let ch = rest
+                .chars()
+                .next()
+                .expect("cursor remains on a char boundary");
+            output.push(ch);
+            cursor += ch.len_utf8();
+        }
+    }
+    output
+}
+
+fn github_secret_prefix_at(value: &str) -> Option<&'static str> {
+    ["github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_"]
+        .into_iter()
+        .find(|prefix| value.starts_with(prefix))
+}
+
+fn is_github_secret_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 #[cfg(test)]
@@ -374,11 +397,15 @@ mod tests {
     #[test]
     fn resolver_redacts_github_token_prefixes_in_diagnostics() {
         let text = redact_for_github_token_diagnostics(
-            "Authorization: token=ghp_secret ghp_secret github_pat_secret ghs_secret ordinary",
+            "Authorization: token=ghp_secret ghp_secret github_pat_secret ghs_secret {\"token\":\"ghp_json_secret\"} \"github_pat_quoted_secret\" ordinary",
         );
         assert!(!text.contains("ghp_secret"));
         assert!(!text.contains("github_pat_secret"));
         assert!(!text.contains("ghs_secret"));
+        assert!(!text.contains("ghp_json_secret"));
+        assert!(!text.contains("github_pat_quoted_secret"));
         assert!(text.contains("ordinary"));
+        assert!(text.contains("{\"token\":\"<redacted>\"}"));
+        assert!(text.contains("\"<redacted>\""));
     }
 }

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -5,8 +5,8 @@ use crate::cli::pr_cmd::github_client::GithubClientMode;
 use crate::cli::pr_cmd::github_client::{
     body_contains_closing_linkage, issue_labels_from_csv, issue_labels_from_csv_in_order,
     issue_metadata_drift, linked_issue_numbers_from_lines, linked_issue_numbers_include,
-    plan_issue_metadata_parity, pr_matches_main_version_wave, AdlGithubClient, GithubClientBackend,
-    IssueMetadataSnapshot, PullRequestMetadataSnapshot,
+    plan_issue_metadata_parity, pr_matches_main_version_wave, redact_for_diagnostics,
+    AdlGithubClient, GithubClientBackend, IssueMetadataSnapshot, PullRequestMetadataSnapshot,
 };
 use crate::cli::pr_cmd_args::IssueStateFilter;
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
@@ -889,7 +889,8 @@ pub(super) fn attach_pr_janitor(
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| helper_command_path(repo_root, "adl/tools/attach_pr_janitor.sh"));
-    let output = Command::new(&command_path)
+    let mut command = helper_command_with_github_context(&command_path);
+    let output = command
         .arg("--repo-root")
         .arg(repo_root)
         .arg("--repo")
@@ -905,8 +906,8 @@ pub(super) fn attach_pr_janitor(
         .output()
         .with_context(|| format!("finish: failed to spawn PR janitor command '{command_path}'"))?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&output.stderr));
+        let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
         bail!(
             "finish: PR janitor auto-attach failed for issue #{} and PR '{}': {}{}",
             issue,
@@ -952,7 +953,8 @@ pub(super) fn attach_post_merge_closeout(
         );
         return Ok(());
     };
-    let output = Command::new(&command_path)
+    let mut command = helper_command_with_github_context(&command_path);
+    let output = command
         .arg("--repo-root")
         .arg(repo_root)
         .arg("--repo")
@@ -968,8 +970,8 @@ pub(super) fn attach_post_merge_closeout(
             format!("finish: failed to spawn post-merge closeout command '{command_path}'")
         })?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&output.stderr));
+        let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
         bail!(
             "finish: post-merge closeout auto-attach failed for issue #{} and PR '{}': {}{}",
             issue,
@@ -983,6 +985,30 @@ pub(super) fn attach_post_merge_closeout(
         );
     }
     Ok(())
+}
+
+const GITHUB_CONTEXT_ENVS: &[&str] = &[
+    "ADL_GITHUB_CLIENT",
+    "ADL_GITHUB_DISABLE_GH_FALLBACK",
+    "ADL_GITHUB_OCTOCRAB_BASE_URI",
+    "ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "ADL_GITHUB_TOKEN_FILE",
+    "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE",
+    "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT",
+];
+
+fn helper_command_with_github_context(command_path: &str) -> Command {
+    let mut command = Command::new(command_path);
+    for key in GITHUB_CONTEXT_ENVS {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        } else {
+            command.env_remove(key);
+        }
+    }
+    command
 }
 
 fn helper_command_path(repo_root: &Path, relative: &str) -> String {

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -129,14 +129,16 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     write_executable(
         &tools_dir.join("attach_pr_janitor.sh"),
         &format!(
-            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nprintf 'ctx ADL_GITHUB_CLIENT=%s GH_TOKEN_PRESENT=%s\\n' \"${{ADL_GITHUB_CLIENT:-missing}}\" \"${{GH_TOKEN:+present}}\" >> '{}'\n",
+            janitor_success.display(),
             janitor_success.display()
         ),
     );
     write_executable(
         &tools_dir.join("attach_post_merge_closeout.sh"),
         &format!(
-            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nprintf 'ctx ADL_GITHUB_CLIENT=%s GH_TOKEN_PRESENT=%s\\n' \"${{ADL_GITHUB_CLIENT:-missing}}\" \"${{GH_TOKEN:+present}}\" >> '{}'\n",
+            closeout_success.display(),
             closeout_success.display()
         ),
     );
@@ -150,8 +152,12 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     let old_janitor_cmd = std::env::var("ADL_PR_JANITOR_CMD").ok();
     let old_closeout_disable = std::env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let old_closeout_cmd = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_github_client = std::env::var("ADL_GITHUB_CLIENT").ok();
+    let old_gh_token = std::env::var("GH_TOKEN").ok();
 
     unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GH_TOKEN", "gh-token-from-parent");
         std::env::set_var("ADL_PR_JANITOR_DISABLE", "1");
         std::env::remove_var("ADL_PR_JANITOR_CMD");
     }
@@ -274,9 +280,82 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     let janitor_calls = fs::read_to_string(&janitor_success).expect("janitor success log");
     assert!(janitor_calls.contains("--expected-pr-state draft"));
     assert!(janitor_calls.contains("--expected-pr-state ready"));
-    assert!(fs::read_to_string(&closeout_success)
-        .expect("closeout success log")
-        .contains("--pr-url https://github.com/owner/repo/pull/1159"));
+    assert!(janitor_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));
+    let closeout_calls = fs::read_to_string(&closeout_success).expect("closeout success log");
+    assert!(closeout_calls.contains("--pr-url https://github.com/owner/repo/pull/1159"));
+    assert!(closeout_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));
+
+    restore_env("ADL_GITHUB_CLIENT", old_github_client);
+    restore_env("GH_TOKEN", old_gh_token);
+}
+
+#[test]
+fn helper_attach_failures_redact_token_like_output() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-github-helper-redaction");
+    let failing = temp.join("failing-helper.sh");
+    write_executable(
+            &failing,
+            "#!/usr/bin/env bash\nset -euo pipefail\necho 'stdout ghp_stdout_secret {\"token\":\"ghp_json_secret\"}'\necho 'stderr token=ghp_stderr_secret github_pat_secret \"github_pat_quoted_secret\"' >&2\nexit 9\n",
+        );
+
+    let old_janitor_disable = std::env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_janitor_cmd = std::env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_closeout_disable = std::env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
+    let old_closeout_cmd = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_gh_token = std::env::var("GH_TOKEN").ok();
+
+    unsafe {
+        std::env::set_var("GH_TOKEN", "ghp_parent_secret");
+        std::env::set_var("ADL_PR_JANITOR_CMD", &failing);
+        std::env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+    }
+    let err = attach_pr_janitor(
+        temp.as_path(),
+        "owner/repo",
+        1153,
+        "codex/1153-branch",
+        "https://github.com/owner/repo/pull/1159",
+        "draft",
+    )
+    .expect_err("failing janitor should bubble");
+    let err = err.to_string();
+    assert!(err.contains("<redacted>"));
+    assert!(!err.contains("ghp_stdout_secret"));
+    assert!(!err.contains("ghp_stderr_secret"));
+    assert!(!err.contains("ghp_json_secret"));
+    assert!(!err.contains("github_pat_secret"));
+    assert!(!err.contains("github_pat_quoted_secret"));
+    assert!(!err.contains("ghp_parent_secret"));
+
+    unsafe {
+        std::env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &failing);
+        std::env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+    }
+    let err = attach_post_merge_closeout(
+        temp.as_path(),
+        "owner/repo",
+        1153,
+        "codex/1153-branch",
+        "https://github.com/owner/repo/pull/1159",
+    )
+    .expect_err("failing closeout should bubble");
+    let err = err.to_string();
+    assert!(err.contains("<redacted>"));
+    assert!(!err.contains("ghp_stdout_secret"));
+    assert!(!err.contains("ghp_stderr_secret"));
+    assert!(!err.contains("ghp_json_secret"));
+    assert!(!err.contains("github_pat_secret"));
+    assert!(!err.contains("github_pat_quoted_secret"));
+    assert!(!err.contains("ghp_parent_secret"));
+
+    restore_env("ADL_PR_JANITOR_DISABLE", old_janitor_disable);
+    restore_env("ADL_PR_JANITOR_CMD", old_janitor_cmd);
+    restore_env("ADL_POST_MERGE_CLOSEOUT_DISABLE", old_closeout_disable);
+    restore_env("ADL_POST_MERGE_CLOSEOUT_CMD", old_closeout_cmd);
+    restore_env("GH_TOKEN", old_gh_token);
+    restore_github_policy_env(policy_env);
 }
 
 #[test]


### PR DESCRIPTION
Closes #4087

## Summary
Implemented the bounded `#4087` GitHub helper context hardening. PR janitor and
post-merge closeout helper spawns now explicitly carry the configured ADL
GitHub client/token context into the helper process. Helper failure diagnostics
redact token-like stdout/stderr before surfacing errors, including
punctuation-wrapped and JSON/quoted GitHub token shapes.

## Artifacts
- `adl/src/cli/github_token.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/github/tests/helpers.rs`
- Local ignored output-card record at `.adl/v0.91.6/tasks/issue-4087__v0-91-6-tools-github-client-inherit-configured-token-context-for-repo-native-closeout-and-other-live-github-operations/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests::helpers::helper_attach_commands_cover_disabled_success_failure_and_fallback_paths -- --nocapture`
    Verified helper attach behavior and context propagation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests::helpers::helper_attach_failures_redact_token_like_output -- --nocapture`
    Verified redaction for token-like helper output.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_token::tests::resolver_redacts_github_token_prefixes_in_diagnostics -- --nocapture`
    Verified the shared redactor covers JSON-shaped and quoted GitHub token-like values.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture`
    Verified the broader GitHub helper/policy/transport lane.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4087__v0-91-6-tools-github-client-inherit-configured-token-context-for-repo-native-closeout-and-other-live-github-operations/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4087__v0-91-6-tools-github-client-inherit-configured-token-context-for-repo-native-closeout-and-other-live-github-operations/sor.md
- Idempotency-Key: v0-91-6-tools-github-client-inherit-configured-token-context-adl-src-cli-github-token-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-helpers-rs-adl-v0-91-6-tasks-issue-4087-v0-91-6-tools-github-client-inherit-configured-token-context-for-repo-native-closeout-and-other-live-github-operations-sip-md-adl-v0-91-6-tasks-issue-4087-v0-91-6-tools-github-client-inherit-configured-token-context-for-repo-native-closeout-and-other-live-github-operations-sor-md