### PR TITLE
[v0.91.6][tools][workflow] Prove fresh worktree task-bundle materialization

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1351,6 +1351,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "demos/v0.89/gemma4_issue_clerk_demo.md"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
+        || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/lifecycle/")
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
         || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
         || trimmed.starts_with("adl/tests/fixtures/scheduler/")
@@ -1371,6 +1372,7 @@ fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/basics.rs"
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs"
         || trimmed == "adl/src/cli/tests/pr_cmd_inline/support.rs"
+        || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/lifecycle/")
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
         || (trimmed.starts_with("adl/src/cli/pr_cmd/")
             && trimmed != "adl/src/cli/pr_cmd/finish_support.rs")

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1251,6 +1251,23 @@ fn finish_validation_profile_keeps_finish_support_changes_narrow() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_lifecycle_inline_tests() {
+    let plan = select_finish_validation_plan_for_finish(
+        ".",
+        &["adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs".to_string()],
+    )
+    .expect("lifecycle inline test plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()));
+}
+
+#[test]
 fn finish_validation_profile_keeps_small_binary_delegation_proof_focused() {
     let plan = select_finish_validation_plan_for_finish(
         ".",

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+fn assert_nonempty_materialized_file(path: impl AsRef<std::path::Path>) {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path).unwrap_or_else(|err| {
+        panic!(
+            "expected materialized nonempty file at {}: {err}",
+            path.display()
+        )
+    });
+    assert!(
+        metadata.is_file() && metadata.len() > 0,
+        "expected materialized nonempty file at {}",
+        path.display()
+    );
+}
+
 #[test]
 fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
     let _guard = env_lock();
@@ -234,14 +249,12 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     assert!(issue_ref.task_bundle_output_path(&repo).is_file());
     assert!(issue_ref.task_bundle_plan_path(&repo).is_file());
     assert!(issue_ref.task_bundle_review_policy_path(&repo).is_file());
-    assert!(issue_ref.issue_prompt_path(&worktree).is_file());
-    assert!(issue_ref.task_bundle_stp_path(&worktree).is_file());
-    assert!(issue_ref.task_bundle_input_path(&worktree).is_file());
-    assert!(issue_ref.task_bundle_output_path(&worktree).is_file());
-    assert!(issue_ref.task_bundle_plan_path(&worktree).is_file());
-    assert!(issue_ref
-        .task_bundle_review_policy_path(&worktree)
-        .is_file());
+    assert_nonempty_materialized_file(issue_ref.issue_prompt_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.task_bundle_stp_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.task_bundle_input_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.task_bundle_output_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.task_bundle_plan_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.task_bundle_review_policy_path(&worktree));
     assert_eq!(
         fs::read_to_string(worktree.join("docs/templates/README_TEMPLATE.md"))
             .expect("read mirrored template"),
@@ -508,20 +521,12 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
 
     env::set_current_dir(prev_dir).expect("restore cwd");
 
-    assert!(issue_ref.issue_prompt_path(&worktree).is_file());
-    assert!(issue_ref.worktree_task_bundle_stp_path(&worktree).is_file());
-    assert!(issue_ref
-        .worktree_task_bundle_input_path(&worktree)
-        .is_file());
-    assert!(issue_ref
-        .worktree_task_bundle_output_path(&worktree)
-        .is_file());
-    assert!(issue_ref
-        .worktree_task_bundle_plan_path(&worktree)
-        .is_file());
-    assert!(issue_ref
-        .worktree_task_bundle_review_policy_path(&worktree)
-        .is_file());
+    assert_nonempty_materialized_file(issue_ref.issue_prompt_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_stp_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_input_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_output_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_plan_path(&worktree));
+    assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_review_policy_path(&worktree));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4088

## Summary
Execution confirmed that the fresh issue-worktree task-bundle behavior already exists in the current workflow start path and tightened the focused regression coverage so the materialized worktree issue prompt and SIP/STP/SPP/SRP/SOR files must be nonempty, not merely present. Publication also exposed a narrow finish validation classifier omission for lifecycle inline test paths; that omission was fixed with a focused classifier regression so the #4088 proof can publish through the normal validation lane.

## Artifacts
- Tracked updates:
  - `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Local ignored output card: `.adl/v0.91.6/tasks/issue-4088__v0-91-6-tools-workflow-materialize-the-expected-issue-local-task-bundle-in-fresh-issue-worktrees/sor.md`
- Pull request: not yet opened at this record revision

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting for the touched Rust test.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::lifecycle::start_ready::real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
    Proved fresh worktree bundle materialization remains functional and nonempty for the expected local issue prompt plus cards.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::lifecycle::start_ready::real_pr_start_repairs_preexisting_worktree_missing_task_bundle -- --nocapture`
    Proved rebinding an existing clean worktree repairs missing local task-bundle surfaces with nonempty files.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl start_ready -- --nocapture`
    Proved the broader start/ready lifecycle test selector remains green.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_lifecycle_inline_tests -- --nocapture`
    Proved the finish validation selector accepts lifecycle inline test paths and selects the lifecycle-focused validation command.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile -- --nocapture`
    Proved the broader finish validation profile selector suite remains green.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4088__v0-91-6-tools-workflow-materialize-the-expected-issue-local-task-bundle-in-fresh-issue-worktrees/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4088__v0-91-6-tools-workflow-materialize-the-expected-issue-local-task-bundle-in-fresh-issue-worktrees/sor.md
- Idempotency-Key: v0-91-6-tools-workflow-prove-fresh-worktree-task-bundle-materialization-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4088-v0-91-6-tools-workflow-materialize-the-expected-issue-local-task-bundle-in-fresh-issue-worktrees-sip-md-adl-v0-91-6-tasks-issue-4088-v0-91-6-tools-workflow-materialize-the-expected-issue-local-task-bundle-in-fresh-issue-worktrees-sor-md