### PR TITLE
[v0.91.6][tools][pr-closeout] Quarantine stale dirty worktrees during closeout

### DIFF
--- a/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+++ b/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
@@ -485,12 +485,17 @@ fn classify_sor_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let result = line_value_after_prefix(&text, "- Result:").unwrap_or_default();
     let worktree_only =
         line_value_after_prefix(&text, "- Worktree-only paths remaining:").unwrap_or_default();
+    let worktree_prune_result =
+        line_value_after_prefix(&text, "- Worktree prune result:").unwrap_or_default();
+    let terminal_worktree_truth = worktree_only == "none"
+        || (worktree_only.starts_with("issue worktree retained: ")
+            && worktree_prune_result.starts_with("retained_with_reason: "));
     let terminal_closeout = ["merged", "closed_no_pr"].contains(&integration_state.as_str())
         && matches!(
             (status.as_str(), result.as_str()),
             ("DONE", "PASS") | ("FAILED", "FAIL")
         )
-        && worktree_only == "none"
+        && terminal_worktree_truth
         && text.contains("## Validation");
     if card_status_value(&text).as_deref() == Some("completed") && !terminal_closeout {
         return card_stage(

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -614,6 +614,30 @@ fn card_lifecycle_reports_final_review_and_output_truth() {
 }
 
 #[test]
+fn card_lifecycle_accepts_terminal_sor_with_retained_dirty_worktree_truth() {
+    let repo = lifecycle_temp_repo("retained-dirty-worktree-final-sor");
+    let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: complete_stp_fixture(),
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
+                sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: issue worktree retained: adl-wp-3065\n- Worktree prune result: retained_with_reason: dirty stale worktree retained: adl-wp-3065\n- Integration state: merged\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
+            },
+        );
+
+    let lifecycle = build_doctor_card_lifecycle(
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+    );
+
+    assert_eq!(lifecycle.active_stage, "SOR");
+    assert_eq!(lifecycle.next_required_stage, None);
+    assert_eq!(lifecycle.pr_finish_readiness, "ready");
+    assert_stage(&lifecycle, "SOR", "final", true, true);
+}
+
+#[test]
 fn card_lifecycle_blocks_final_sor_with_contradictory_status_and_result() {
     let repo = lifecycle_temp_repo("contradictory-sor-status-result");
     let paths = write_lifecycle_fixture(

--- a/adl/src/cli/pr_cmd/lifecycle/cleanup.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/cleanup.rs
@@ -58,6 +58,7 @@ pub(crate) fn same_filesystem_target(left: &Path, right: &Path) -> Result<bool> 
 pub(crate) enum IssueWorktreePruneResult {
     Missing(String),
     Pruned(String),
+    RetainedWithReason(String),
 }
 
 impl IssueWorktreePruneResult {
@@ -65,6 +66,9 @@ impl IssueWorktreePruneResult {
         match self {
             Self::Missing(name) => format!("skipped_missing: {name}"),
             Self::Pruned(name) => format!("pruned: {name}"),
+            Self::RetainedWithReason(name) => {
+                format!("retained_with_reason: dirty stale worktree retained: {name}")
+            }
         }
     }
 }

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -130,30 +130,65 @@ pub(crate) fn closeout_closed_completed_issue_bundle(
             .map(PathBuf::from)
             .as_deref(),
     );
-    let recovery_bundles = [issue_ref.task_bundle_dir_path(&worktree_path)];
-    reconcile_closed_completed_issue_bundle_with_recovery_sources(
+    let worktree_is_dirty =
+        worktree_path.is_dir() && has_uncommitted_or_untracked_changes(&worktree_path)?;
+    let recovery_bundles = if worktree_is_dirty {
+        Vec::new()
+    } else {
+        vec![issue_ref.task_bundle_dir_path(&worktree_path)]
+    };
+    if let Err(error) = reconcile_closed_completed_issue_bundle_with_recovery_sources(
         primary_root,
         issue_ref,
         canonical_output,
         &recovery_bundles,
-    )?;
+    ) {
+        if worktree_is_dirty {
+            if canonical_output.is_file() {
+                let name = super::cleanup::worktree_display_name(&worktree_path);
+                super::cleanup::record_worktree_prune_result(
+                    canonical_output,
+                    &format!("blocked_dirty: retained {name}"),
+                )?;
+                super::cleanup::replace_worktree_only_paths_remaining(
+                    canonical_output,
+                    &format!("issue worktree retained: {name}"),
+                )?;
+            }
+            return Err(error).with_context(|| {
+                format!(
+                    "closeout: dirty worktree '{}' was retained and was not used as a recovery source",
+                    worktree_path.display()
+                )
+            });
+        }
+        return Err(error);
+    }
     if worktree_path.is_dir() {
         super::cleanup::scrub_noncanonical_issue_bundle_residue(&worktree_path, issue_ref)?;
     }
-    if worktree_path.is_dir() && has_uncommitted_or_untracked_changes(&worktree_path)? {
-        let name = super::cleanup::worktree_display_name(&worktree_path);
+    if worktree_is_dirty {
+        let retained_result = super::cleanup::IssueWorktreePruneResult::RetainedWithReason(
+            super::cleanup::worktree_display_name(&worktree_path),
+        );
         super::cleanup::record_worktree_prune_result(
             canonical_output,
-            &format!("blocked_dirty: retained {name}"),
+            &retained_result.card_value(),
         )?;
         super::cleanup::replace_worktree_only_paths_remaining(
             canonical_output,
-            &format!("issue worktree retained: {name}"),
+            &format!(
+                "issue worktree retained: {}",
+                super::cleanup::worktree_display_name(&worktree_path)
+            ),
         )?;
-        bail!(
-            "closeout: refusing to prune dirty worktree '{}' because it contains staged, unstaged, or untracked changes",
-            worktree_path.display()
-        );
+        return ensure_closed_completed_issue_bundle_truth(primary_root, issue_ref, canonical_output)
+            .with_context(|| {
+                format!(
+                    "closeout: canonical closed-issue sor truth drift remains for issue #{} after retaining dirty stale worktree",
+                    issue_ref.issue_number()
+                )
+            });
     }
     let prune_result = super::cleanup::prune_issue_worktree(repo_root, primary_root, issue_ref)?;
     super::cleanup::record_worktree_prune_result(canonical_output, &prune_result.card_value())?;
@@ -186,6 +221,9 @@ pub(crate) fn ensure_closed_completed_issue_bundle_truth(
     } else {
         let text = fs::read_to_string(canonical_output)?;
         sor_integration_state = line_value_after_prefix(&text, "- Integration state:");
+        let worktree_only_paths =
+            line_value_after_prefix(&text, "- Worktree-only paths remaining:");
+        let worktree_prune_result = line_value_after_prefix(&text, "- Worktree prune result:");
         let branch = line_value_after_prefix(&text, "Branch:");
         let retrospective_no_branch = branch.as_deref() == Some("retrospective-no-branch");
         check_required_field(&text, "Status:", "DONE", "SOR Status", &mut mismatches);
@@ -219,13 +257,24 @@ pub(crate) fn ensure_closed_completed_issue_bundle_truth(
             )),
             None => mismatches.push("SOR Integration state is missing".to_string()),
         }
-        check_required_field(
-            &text,
-            "- Worktree-only paths remaining:",
-            "none",
-            "SOR Worktree-only paths remaining",
-            &mut mismatches,
-        );
+        match worktree_only_paths.as_deref() {
+            Some("none") => {}
+            Some(value) if value.starts_with("issue worktree retained: ") => {
+                match worktree_prune_result.as_deref() {
+                    Some(result) if result.starts_with("retained_with_reason: ") => {}
+                    Some(result) => mismatches.push(format!(
+                        "SOR Worktree prune result expected retained_with_reason for retained worktree but found '{result}'"
+                    )),
+                    None => mismatches.push(
+                        "SOR Worktree prune result is missing for retained worktree".to_string(),
+                    ),
+                }
+            }
+            Some(value) => mismatches.push(format!(
+                "SOR Worktree-only paths remaining expected 'none' or retained issue worktree but found '{value}'"
+            )),
+            None => mismatches.push("SOR Worktree-only paths remaining is missing".to_string()),
+        }
     }
 
     let stp_path = issue_ref.task_bundle_stp_path(repo_root);

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -501,8 +501,9 @@ fn ensure_closed_completed_issue_bundle_truth_rejects_stale_fields() {
     assert!(rendered
         .contains("SOR Integration state expected 'merged' or 'closed_no_pr' but found 'pr_open'"));
     assert!(rendered.contains("SOR Verification scope expected 'main_repo' but found 'worktree'"));
-    assert!(rendered
-        .contains("SOR Worktree-only paths remaining expected 'none' but found 'adl/src/foo.rs'"));
+    assert!(rendered.contains(
+        "SOR Worktree-only paths remaining expected 'none' or retained issue worktree but found 'adl/src/foo.rs'"
+    ));
     assert!(rendered.contains("STP status expected '\"complete\"' but found '\"draft\"'"));
     assert!(rendered.contains("SIP Branch expected 'codex/1410-canonical-slug'"));
     assert!(rendered.contains("SIP still contains pre-run lifecycle wording"));
@@ -997,7 +998,7 @@ fn closeout_recovers_missing_primary_cards_from_bound_worktree_bundle() {
 }
 
 #[test]
-fn closeout_records_blocked_dirty_worktree_and_refuses_prune() {
+fn closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete() {
     let _guard = env_lock();
     let _manifest_guard = set_tooling_manifest_root_to_workspace();
     let temp = temp_dir("adl-pr-lifecycle-closeout-dirty-worktree");
@@ -1060,14 +1061,108 @@ fn closeout_records_blocked_dirty_worktree_and_refuses_prune() {
         .success());
     fs::write(worktree.join("DIRTY.txt"), "dirty\n").expect("dirty marker");
 
-    let err = closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
-        .expect_err("dirty worktree should block pruning");
+    closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
+        .expect("dirty stale worktree should be retained when root closeout truth is complete");
 
-    assert!(err.to_string().contains("refusing to prune dirty worktree"));
     assert!(worktree.is_dir(), "dirty worktree should be retained");
     let text = fs::read_to_string(&output).expect("read sor");
-    assert!(text.contains("- Worktree prune result: blocked_dirty: retained adl-wp-1410"));
+    assert!(text.contains(
+        "- Worktree prune result: retained_with_reason: dirty stale worktree retained: adl-wp-1410"
+    ));
     assert!(text.contains("- Worktree-only paths remaining: issue worktree retained: adl-wp-1410"));
+    ensure_closed_completed_issue_bundle_truth(&repo, &issue_ref, &output)
+        .expect("canonical truth accepts retained stale worktree");
+}
+
+#[test]
+fn closeout_refuses_dirty_worktree_when_canonical_truth_needs_recovery() {
+    let _guard = env_lock();
+    let _manifest_guard = set_tooling_manifest_root_to_workspace();
+    let temp = temp_dir("adl-pr-lifecycle-closeout-dirty-worktree-only-source");
+    let repo = temp.join("repo");
+    let origin = temp.join("origin.git");
+    init_repo_with_origin(&repo, &origin);
+    copy_prompt_templates(&repo);
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "add",
+            ".gitignore"
+        ])
+        .status()
+        .expect("git add gitignore")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "commit",
+            "-q",
+            "-m",
+            "ignore local adl state",
+        ])
+        .status()
+        .expect("git commit gitignore")
+        .success());
+
+    let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+    let title = "PR Command Dirty Recovery Closeout";
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source parent");
+    fs::write(
+        &source_path,
+        "## Summary\n\nDirty worktree recovery fixture.\n\n## Goal\n\nDo not recover closeout truth from a dirty worktree.\n\n## Required Outcome\n\n- closeout fails when dirty worktree cards are the only recovery source\n\n## Deliverables\n\n- focused lifecycle regression test\n\n## Acceptance Criteria\n\n- dirty worktree is retained\n- root cards are not recovered from dirty worktree residue\n\n## Repo Inputs\n\n- `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- no broader closeout redesign\n\n## Issue-Graph Notes\n\n- regression fixture\n\n## Notes\n\n- local `.adl` state is ignored\n\n## Tooling Notes\n\n- focused lifecycle test\n",
+    )
+    .expect("write source");
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "worktree",
+            "add",
+            path_str(&worktree).expect("worktree path"),
+            "-b",
+            "codex/1410-canonical-slug",
+            "main",
+        ])
+        .status()
+        .expect("git worktree add")
+        .success());
+    let worktree_bundle = issue_ref.task_bundle_dir_path(&worktree);
+    fs::create_dir_all(&worktree_bundle).expect("worktree bundle");
+    for relative in ["stp.md", "sip.md", "spp.md", "srp.md", "sor.md"] {
+        fs::copy(canonical_dir.join(relative), worktree_bundle.join(relative))
+            .expect("copy card to dirty worktree");
+    }
+    for relative in ["stp.md", "sip.md", "spp.md", "srp.md"] {
+        fs::remove_file(canonical_dir.join(relative)).expect("remove root card");
+    }
+    fs::write(worktree.join("DIRTY.txt"), "dirty\n").expect("dirty marker");
+
+    let err = closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
+        .expect_err("dirty worktree should not be used as a recovery source");
+
+    assert!(
+        err.to_string().contains("dirty worktree")
+            || err.to_string().contains("failed to create")
+            || err.to_string().contains("missing canonical")
+            || err.to_string().contains("failed closed"),
+        "unexpected closeout error: {err}"
+    );
+    assert!(worktree.is_dir(), "dirty worktree should be retained");
+    assert!(
+        !canonical_dir.join("stp.md").exists(),
+        "root cards should not be recovered from dirty worktree residue"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #4086

## Summary
Implemented bounded closeout handling for stale dirty issue worktrees. Closeout no longer uses a dirty worktree as a recovery source; if canonical/root closeout truth is already sufficient, it records the dirty worktree as `retained_with_reason` residue and succeeds without pruning local changes. If canonical truth would require recovery from the dirty worktree, closeout fails closed with explicit context.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.6/tasks/issue-4086__v0-91-6-tools-pr-closeout-ignore-or-quarantine-stale-broken-worktrees-when-a-clean-issue-closeout-surface-exists/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/lifecycle/cleanup.rs`
  - `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`
  - `adl/src/cli/pr_cmd/lifecycle/tests.rs`
  - `adl/src/cli/pr_cmd/doctor/card_lifecycle.rs`
  - `adl/src/cli/pr_cmd/doctor/tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting before tests; initially reported a wrap-only rustfmt diff.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Applied the required formatting.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check && cargo test --manifest-path adl/Cargo.toml closeout_ -- --nocapture`
    Verified final formatting and focused closeout behavior, including retained stale dirty worktree success and dirty-worktree recovery refusal.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check && cargo test --manifest-path adl/Cargo.toml --bin adl ensure_closed_completed_issue_bundle_truth -- --nocapture && cargo test --manifest-path adl/Cargo.toml --bin adl card_lifecycle_accepts_terminal_sor_with_retained_dirty_worktree_truth -- --nocapture`
    Verified review-found truth validation and doctor lifecycle classifier coverage.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_ -- --nocapture`
    Reverified the closeout-focused lane after fixing review findings.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4086__v0-91-6-tools-pr-closeout-ignore-or-quarantine-stale-broken-worktrees-when-a-clean-issue-closeout-surface-exists/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4086__v0-91-6-tools-pr-closeout-ignore-or-quarantine-stale-broken-worktrees-when-a-clean-issue-closeout-surface-exists/sor.md
- Idempotency-Key: v0-91-6-tools-pr-closeout-quarantine-stale-dirty-worktrees-during-closeout-adl-src-cli-pr-cmd-lifecycle-cleanup-rs-adl-src-cli-pr-cmd-lifecycle-reconciliation-rs-adl-src-cli-pr-cmd-lifecycle-tests-rs-adl-src-cli-pr-cmd-doctor-card-lifecycle-rs-adl-src-cli-pr-cmd-doctor-tests-rs-adl-v0-91-6-tasks-issue-4086-v0-91-6-tools-pr-closeout-ignore-or-quarantine-stale-broken-worktrees-when-a-clean-issue-closeout-surface-exists-sip-md-adl-v0-91-6-tasks-issue-4086-v0-91-6-tools-pr-closeout-ignore-or-quarantine-stale-broken-worktrees-when-a-clean-issue-closeout-surface-exists-sor-md