### PR TITLE
[v0.91.6][tools][pr-finish] Harden output-card and card-path routing

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2098,9 +2098,7 @@ fn finish_local_issue_bundle_card_display(repo_root: &Path, path: &str) -> Optio
     if !relpath.starts_with(".adl/") {
         return None;
     }
-    if issue_bundle_issue_number_from_repo_relative(&relpath).is_none() {
-        return None;
-    }
+    issue_bundle_issue_number_from_repo_relative(&relpath)?;
     match Path::new(&relpath)
         .file_name()
         .and_then(|name| name.to_str())

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2037,6 +2037,7 @@ pub(super) fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<(
     if paths.is_empty() {
         bail!("finish: --paths resolved to empty");
     }
+    reject_local_issue_bundle_paths_in_finish_paths(repo_root, &paths)?;
     let mut stageable = Vec::new();
     for path in paths {
         if path.starts_with(".adl/") {
@@ -2064,6 +2065,49 @@ pub(super) fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<(
     args.extend(stageable);
     run_status("git", &args)?;
     Ok(())
+}
+
+fn reject_local_issue_bundle_paths_in_finish_paths(repo_root: &Path, paths: &[&str]) -> Result<()> {
+    let mut local_issue_surfaces = paths
+        .iter()
+        .filter_map(|path| finish_local_issue_bundle_card_display(repo_root, path))
+        .collect::<Vec<_>>();
+    if local_issue_surfaces.is_empty() {
+        return Ok(());
+    }
+
+    local_issue_surfaces.sort_unstable();
+    local_issue_surfaces.dedup();
+    bail!(
+        "finish: --paths includes local-only .adl task-bundle card paths: {}. Do not pass SIP/STP/SPP/SRP/SOR task-bundle files via --paths; use --output-card for the SOR truth surface and pass only tracked repo publication inputs such as docs/... or adl/src/.... Canonical .adl bundles are validated and synchronized separately and must remain local-only.",
+        local_issue_surfaces.join(", ")
+    )
+}
+
+fn finish_local_issue_bundle_card_display(repo_root: &Path, path: &str) -> Option<String> {
+    let path_value = Path::new(path);
+    let relpath = if path_value.is_absolute() {
+        path_value.strip_prefix(repo_root).ok()?.to_path_buf()
+    } else {
+        path_value
+            .components()
+            .filter(|component| !matches!(component, std::path::Component::CurDir))
+            .collect::<PathBuf>()
+    };
+    let relpath = relpath.to_string_lossy().replace('\\', "/");
+    if !relpath.starts_with(".adl/") {
+        return None;
+    }
+    if issue_bundle_issue_number_from_repo_relative(&relpath).is_none() {
+        return None;
+    }
+    match Path::new(&relpath)
+        .file_name()
+        .and_then(|name| name.to_str())
+    {
+        Some("sip.md" | "stp.md" | "spp.md" | "srp.md" | "sor.md") => Some(relpath),
+        _ => None,
+    }
 }
 
 pub(super) fn ensure_no_staged_issue_bundle_mutations(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -433,6 +433,36 @@ fn finish_helper_paths_cover_nonempty_and_staged_checks() {
     .expect("cached names");
     assert!(!staged_name_only.contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md"));
     assert!(staged_name_only.contains("tracked.txt"));
+
+    let err = stage_selected_paths_rust(
+        &repo,
+        "tracked.txt,.adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md",
+    )
+    .expect_err("task-bundle SOR in --paths should fail before staging");
+    let err_text = err.to_string();
+    assert!(err_text.contains("--paths includes local-only .adl task-bundle card paths"));
+    assert!(err_text.contains("issue-1153__rust-finish-test/sor.md"));
+    assert!(err_text.contains("use --output-card for the SOR truth surface"));
+    assert!(err_text.contains("tracked repo publication inputs"));
+
+    let dot_relative_err = stage_selected_paths_rust(
+        &repo,
+        "tracked.txt,./.adl/v0.86/tasks/issue-1153__rust-finish-test/srp.md",
+    )
+    .expect_err("dot-relative task-bundle SRP in --paths should fail");
+    assert!(dot_relative_err
+        .to_string()
+        .contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/srp.md"));
+
+    let absolute_sor = repo
+        .join(".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md")
+        .display()
+        .to_string();
+    let absolute_err = stage_selected_paths_rust(&repo, &format!("tracked.txt,{absolute_sor}"))
+        .expect_err("absolute task-bundle SOR in --paths should fail");
+    assert!(absolute_err
+        .to_string()
+        .contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md"));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2440,7 +2440,7 @@ Notes:
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
 - Runs Rust checks in adl/ by default (fmt, clippy -D warnings, test).
-- finish stages only the tracked repo-root paths selected by `--paths`; canonical `.adl` issue bundles remain local-only and must not be tracked or force-staged.
+- finish stages only the tracked repo-root paths selected by `--paths`; do not pass local `.adl` SIP/STP/SPP/SRP/SOR task-bundle files there. Use `--output-card` for the SOR truth surface; canonical `.adl` issue bundles remain local-only and must not be tracked or force-staged.
 - `--allow-gitignore` only permits staged `.gitignore` / `adl/.gitignore` changes during finish publication; it does not widen generic ignored-path staging.
 - C-SDLC prompt templates are stored in docs/templates/prompts/1.0.0/ (legacy SIP/SOR fallback: adl/templates/cards/ and .adl/templates/).
 - Cards are stored locally under cards_root and are not committed to git.
@@ -2610,6 +2610,7 @@ Usage:
 
 Notes:
 - By default, finish stages repo-root changes (`.`), which keeps docs and code changes together unless you narrow with `--paths`.
+- `--paths` is for tracked repo publication inputs only. Do not include local `.adl` SIP/STP/SPP/SRP/SOR task-bundle files; pass the SOR through `--output-card`.
 EOF
 }
 

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -270,7 +270,7 @@ Write a per-issue report under:
 - Dirty repo-local execution clone:
   - Commit/stash first, then re-run the relevant command from `.worktrees/adl-wp-<issue_num>`.
 - Wrong paths at `finish`:
-  - Ensure `--paths` only includes intended repo paths; do not include local `.adl` artifacts.
+  - Ensure `--paths` only includes intended tracked repo paths; do not include local `.adl` SIP/STP/SPP/SRP/SOR task-bundle artifacts. Use `--output-card` for the SOR truth surface.
 - Missing canonical STP:
   - Re-run `pr.sh init <issue_num> --slug <slug> --version <milestone_version>`.
 - Stale GitHub issue body:


### PR DESCRIPTION
Closes #4094

## Summary
Implemented a bounded `pr finish` publication guard for local `.adl` task-bundle card paths passed through `--paths`. The guard now fails before staging with actionable guidance to use `--output-card` for the SOR truth surface and tracked repo paths for publication inputs. Operator-facing help and workflow docs now state the same contract.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.6/tasks/issue-4094__v0-91-6-tools-harden-pr-finish-publication-truth-for-output-card-and-card-path-routing/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `adl/tools/pr.sh`
  - `docs/default_workflow.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for the touched Rust helper and regression test.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_cover_nonempty_and_staged_checks -- --nocapture`
    Verified focused path-staging behavior for tracked files, ignored `.adl` files, and fail-closed task-bundle card path inputs.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render -- --nocapture`
    Verified the full focused `pr finish` arg/render helper slice after the implementation and after rebasing on the merged #4086 main.
  - `bash -n adl/tools/pr.sh`
    Verified shell syntax after help text edits.
  - `git diff --check`
    Verified patch whitespace hygiene.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check && cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the hosted CI clippy failure was fixed locally.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4094__v0-91-6-tools-harden-pr-finish-publication-truth-for-output-card-and-card-path-routing/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4094__v0-91-6-tools-harden-pr-finish-publication-truth-for-output-card-and-card-path-routing/sor.md
- Idempotency-Key: v0-91-6-tools-pr-finish-harden-output-card-and-card-path-routing-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-pr-sh-docs-default-workflow-md-adl-v0-91-6-tasks-issue-4094-v0-91-6-tools-harden-pr-finish-publication-truth-for-output-card-and-card-path-routing-sip-md-adl-v0-91-6-tasks-issue-4094-v0-91-6-tools-harden-pr-finish-publication-truth-for-output-card-and-card-path-routing-sor-md