### PR TITLE
[v0.91.6][tools][workflow] Refine doctor open-wave queue pressure

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -91,15 +91,12 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
         }
     };
     let mode = doctor_mode_name(&parsed.mode);
+    let ready_status = ready.as_ref().map(|x| x.status);
     let doctor_status = match parsed.mode {
         DoctorMode::Preflight => preflight.status,
-        DoctorMode::Ready => ready.as_ref().map(|x| x.status).unwrap_or("BLOCK"),
+        DoctorMode::Ready => ready_status.unwrap_or("BLOCK"),
         DoctorMode::Full => {
-            if preflight.status == "PASS" && ready.as_ref().map(|x| x.status) == Some("PASS") {
-                "PASS"
-            } else {
-                "BLOCK"
-            }
+            doctor_full_status(preflight.status, preflight.block_kind, ready_status)
         }
     };
 
@@ -114,10 +111,12 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
             target_queue: preflight.target_queue.clone(),
             target_queue_source: preflight.target_queue_source,
             preflight_status: preflight.status,
+            preflight_block_kind: preflight.block_kind,
+            preflight_guidance: preflight.guidance,
             open_pr_count: preflight.open_pr_count,
             open_prs: preflight.open_prs,
             lifecycle_state: ready.as_ref().map(|x| x.lifecycle_state),
-            ready_status: ready.as_ref().map(|x| x.status),
+            ready_status,
             worktree: ready.as_ref().and_then(|x| x.worktree.clone()),
             source: ready.as_ref().map(|x| x.source.clone()),
             root_stp: ready.as_ref().map(|x| x.root_stp.clone()),
@@ -145,6 +144,18 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
         println!("DOCTOR_STATUS={doctor_status}");
     }
     Ok(())
+}
+
+fn doctor_full_status(
+    preflight_status: &'static str,
+    preflight_block_kind: &'static str,
+    ready_status: Option<&'static str>,
+) -> &'static str {
+    match (preflight_status, preflight_block_kind, ready_status) {
+        ("PASS", _, Some("PASS")) => "PASS",
+        ("BLOCK", "open_pr_wave", Some("PASS")) => "WARN",
+        _ => "BLOCK",
+    }
 }
 
 fn resolve_doctor_scope_and_slug(

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -24,13 +24,17 @@ pub(super) fn run_doctor_preflight(
         })
         .collect::<Vec<_>>();
     let card_run_readiness = preflight_card_run_readiness(repo_root, issue_ref);
+    let (status, block_kind, guidance) =
+        doctor_preflight_status(open_prs.is_empty(), card_run_readiness);
     if open_prs.is_empty() && card_run_readiness != Some("blocked") {
         Ok(DoctorPreflightResult {
             target_queue: target_queue.queue,
             target_queue_source: target_queue.source,
             open_pr_count: 0,
             open_prs,
-            status: "PASS",
+            status,
+            block_kind,
+            guidance,
         })
     } else {
         Ok(DoctorPreflightResult {
@@ -38,8 +42,39 @@ pub(super) fn run_doctor_preflight(
             target_queue_source: target_queue.source,
             open_pr_count: open_prs.len(),
             open_prs,
-            status: "BLOCK",
+            status,
+            block_kind,
+            guidance,
         })
+    }
+}
+
+pub(super) fn doctor_preflight_status(
+    open_pr_wave_empty: bool,
+    card_run_readiness: Option<&'static str>,
+) -> (&'static str, &'static str, &'static str) {
+    let card_blocked = card_run_readiness == Some("blocked");
+    match (open_pr_wave_empty, card_blocked) {
+        (true, false) => (
+            "PASS",
+            "none",
+            "No preflight queue or card-readiness blockers detected.",
+        ),
+        (false, false) => (
+            "BLOCK",
+            "open_pr_wave",
+            "Issue-local readiness may proceed only under an explicit queue override such as --allow-open-pr-wave after recording why the open PR wave is unrelated or intentionally sequenced.",
+        ),
+        (true, true) => (
+            "BLOCK",
+            "card_run_readiness",
+            "Repair issue-local SIP/STP/SPP/SRP/SOR readiness before execution; do not override this as queue pressure.",
+        ),
+        (false, true) => (
+            "BLOCK",
+            "open_pr_wave_and_card_run_readiness",
+            "Repair issue-local card readiness before execution; open PR queue pressure remains a separate scheduling gate.",
+        ),
     }
 }
 

--- a/adl/src/cli/pr_cmd/doctor/printing.rs
+++ b/adl/src/cli/pr_cmd/doctor/printing.rs
@@ -13,6 +13,8 @@ pub(super) fn print_doctor_preflight_text(preflight: &DoctorPreflightResult) {
         );
     }
     println!("PREFLIGHT={}", preflight.status);
+    println!("PREFLIGHT_BLOCK_KIND={}", preflight.block_kind);
+    println!("PREFLIGHT_GUIDANCE={}", preflight.guidance);
 }
 
 pub(super) fn print_doctor_ready_text(ready: &DoctorReadyResult) {

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -1,4 +1,4 @@
-use super::preflight::preflight_card_run_readiness;
+use super::preflight::{doctor_preflight_status, preflight_card_run_readiness};
 use super::*;
 use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -22,6 +22,45 @@ fn doctor_issue_prompt_resolution_falls_back_to_bound_worktree_prompt() {
         resolve_doctor_issue_prompt_path(&repo, &issue_ref).expect("doctor source prompt");
 
     assert_eq!(resolved, source_path);
+}
+
+#[test]
+fn doctor_full_warns_when_only_open_wave_blocks_ready_issue() {
+    let (preflight_status, block_kind, guidance) = doctor_preflight_status(false, Some("ready"));
+
+    assert_eq!(preflight_status, "BLOCK");
+    assert_eq!(block_kind, "open_pr_wave");
+    assert!(guidance.contains("--allow-open-pr-wave"));
+    assert_eq!(
+        doctor_full_status(preflight_status, block_kind, Some("PASS")),
+        "WARN"
+    );
+}
+
+#[test]
+fn doctor_full_stays_blocked_for_issue_local_card_readiness() {
+    let (preflight_status, block_kind, guidance) = doctor_preflight_status(true, Some("blocked"));
+
+    assert_eq!(preflight_status, "BLOCK");
+    assert_eq!(block_kind, "card_run_readiness");
+    assert!(guidance.contains("SIP/STP/SPP/SRP/SOR"));
+    assert_eq!(
+        doctor_full_status(preflight_status, block_kind, Some("PASS")),
+        "BLOCK"
+    );
+}
+
+#[test]
+fn doctor_full_stays_blocked_for_combined_open_wave_and_card_readiness() {
+    let (preflight_status, block_kind, guidance) = doctor_preflight_status(false, Some("blocked"));
+
+    assert_eq!(preflight_status, "BLOCK");
+    assert_eq!(block_kind, "open_pr_wave_and_card_run_readiness");
+    assert!(guidance.contains("card readiness"));
+    assert_eq!(
+        doctor_full_status(preflight_status, block_kind, Some("PASS")),
+        "BLOCK"
+    );
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd/doctor/types.rs
+++ b/adl/src/cli/pr_cmd/doctor/types.rs
@@ -16,6 +16,8 @@ pub(crate) struct DoctorPreflightResult {
     pub(crate) open_pr_count: usize,
     pub(crate) open_prs: Vec<DoctorPreflightJsonPullRequest>,
     pub(crate) status: &'static str,
+    pub(crate) block_kind: &'static str,
+    pub(crate) guidance: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,6 +68,8 @@ pub(crate) struct DoctorJsonOutput {
     pub(crate) target_queue: String,
     pub(crate) target_queue_source: &'static str,
     pub(crate) preflight_status: &'static str,
+    pub(crate) preflight_block_kind: &'static str,
+    pub(crate) preflight_guidance: &'static str,
     pub(crate) open_pr_count: usize,
     pub(crate) open_prs: Vec<DoctorPreflightJsonPullRequest>,
     pub(crate) lifecycle_state: Option<&'static str>,


### PR DESCRIPTION
Closes #4083

## Summary
Implemented a bounded `pr doctor` queue-pressure refinement. Full doctor now preserves `preflight_status: "BLOCK"` for an unresolved same-queue open PR wave, but returns `doctor_status: "WARN"` when issue-local readiness is `PASS` and the only preflight blocker is open-wave pressure. JSON and text output now include the machine-readable `preflight_block_kind` plus actionable `preflight_guidance`, so mini-sprint conductors can distinguish unrelated queue pressure from issue-local card or worktree blockers.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.6/tasks/issue-4083__v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/doctor.rs`
  - `adl/src/cli/pr_cmd/doctor/preflight.rs`
  - `adl/src/cli/pr_cmd/doctor/printing.rs`
  - `adl/src/cli/pr_cmd/doctor/types.rs`
  - `adl/src/cli/pr_cmd/doctor/tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all && cargo test --manifest-path adl/Cargo.toml doctor_full_ -- --nocapture`
    Applied formatting and verified the focused doctor status refinement tests, including open-wave-only, card-readiness-only, and combined blocker branches.
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 4083 --json`
    Verified the changed machine-readable doctor surface on the live `#4083` issue against current unrelated open-wave pressure.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check && git diff --check`
    Verified formatting and whitespace hygiene after code edits.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified clippy cleanliness for all Rust targets.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase execution --input .adl/v0.91.6/tasks/issue-4083__v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure/sor.md`
    Verified the SOR contract after execution-record updates.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4083__v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4083__v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure/sor.md
- Idempotency-Key: v0-91-6-tools-workflow-refine-doctor-open-wave-queue-pressure-adl-src-cli-pr-cmd-doctor-rs-adl-src-cli-pr-cmd-doctor-preflight-rs-adl-src-cli-pr-cmd-doctor-printing-rs-adl-src-cli-pr-cmd-doctor-tests-rs-adl-src-cli-pr-cmd-doctor-types-rs-adl-v0-91-6-tasks-issue-4083-v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure-sip-md-adl-v0-91-6-tasks-issue-4083-v0-91-6-tools-workflow-doctor-blocks-new-wp-execution-on-unrelated-open-wave-pr-pressure-sor-md