### PR TITLE
[v0.91.6][runtime][tokio] Unblock finish classification for Tokio child issues

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -121,8 +121,11 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         issue_ref.scope(),
         &validation_changed_paths,
     )?;
-    let finish_validation_plan =
-        select_finish_validation_plan_for_finish(&parsed.paths, &validation_changed_paths)?;
+    let finish_validation_plan = select_finish_validation_plan_for_finish(
+        parsed.issue,
+        &parsed.paths,
+        &validation_changed_paths,
+    )?;
     if !parsed.no_checks {
         run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
         record_docs_only_validation_evidence_for_finish(&output_path, &finish_validation_plan)?;
@@ -1077,6 +1080,90 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_long_lived_agent_tokio_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml long_lived_agent",
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_tokio_bootstrap_helper_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml pr_cmd::github",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl github_release_",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl octocrab_transport_",
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_remote_exec_tokio_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml build_remote_execute_request_preserves_conversation_as_audit_metadata",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml execute_step_with_retry_does_not_retry_remote_schema_violation",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml security_envelope_rejects_tampered_signed_conversation_metadata",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml remote_exec::",
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_cav_tokio_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml continuous_verification_contract_covers_cadence_lifecycle_and_artifacts",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml self_attack_contract_is_policy_bounded_and_reviewable",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml identity_continuous_verification_writes_contract_json",
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_public_prompt_packet_focused_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1216,6 +1303,7 @@ fn push_finish_validation_command(commands: &mut Vec<String>, command: &str) {
 }
 
 pub(super) fn select_finish_validation_plan_for_finish(
+    issue_number: u32,
     requested_paths_csv: &str,
     changed_paths: &[String],
 ) -> Result<FinishValidationPlan> {
@@ -1229,6 +1317,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     }
     if changed_paths.is_empty() {
         bail!("finish: no changed tracked paths available for validation profile selection");
+    }
+    if finish_issue_needs_tokio_manifest_runtime_validation(issue_number, changed_paths) {
+        return Ok(build_tokio_manifest_runtime_validation_plan());
     }
     select_finish_validation_plan(&changed_paths.join(","))
 }
@@ -1307,12 +1398,22 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/cli/pr_cmd.rs"
             | "adl/src/cli/pr_cmd_args.rs"
             | "adl/src/cli/mod.rs"
+            | "adl/src/cli/tokio_runtime.rs"
             | "adl/src/cli/github_token.rs"
             | "adl/src/lib.rs"
             | "adl/src/scheduler.rs"
             | "adl/src/provider_adapter.rs"
             | "adl/src/provider_communication.rs"
             | "adl/src/resilience.rs"
+            | "adl/src/long_lived_agent.rs"
+            | "adl/src/long_lived_agent/tests.rs"
+            | "adl/src/execute/runner.rs"
+            | "adl/src/execute/tests.rs"
+            | "adl/src/remote_exec.rs"
+            | "adl/src/remote_exec/signing_support.rs"
+            | "adl/src/remote_exec/types.rs"
+            | "adl/src/continuous_verification_self_attack.rs"
+            | "adl/src/cli/identity_cmd/tests/adversarial_contracts.rs"
             | "adl/src/cli/tests/pr_cmd_inline/basics.rs"
             | "adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs"
             | "adl/src/cli/tests/pr_cmd_inline/support.rs"
@@ -1418,6 +1519,80 @@ fn finish_path_needs_scheduler_focused_validation(path: &str) -> bool {
 fn finish_path_needs_github_release_focused_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     trimmed == "adl/src/cli/tooling_cmd/github_release.rs"
+}
+
+fn finish_path_needs_long_lived_agent_tokio_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/long_lived_agent.rs" | "adl/src/long_lived_agent/tests.rs"
+    )
+}
+
+fn finish_path_needs_tokio_bootstrap_helper_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/cli/tokio_runtime.rs"
+}
+
+fn finish_path_needs_remote_exec_tokio_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/execute/runner.rs"
+            | "adl/src/execute/tests.rs"
+            | "adl/src/remote_exec.rs"
+            | "adl/src/remote_exec/signing_support.rs"
+            | "adl/src/remote_exec/types.rs"
+    )
+}
+
+fn finish_path_needs_cav_tokio_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/continuous_verification_self_attack.rs"
+            | "adl/src/cli/identity_cmd/tests/adversarial_contracts.rs"
+    )
+}
+
+fn finish_issue_needs_tokio_manifest_runtime_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4178 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            matches!(
+                path.trim().trim_matches('/'),
+                "adl/Cargo.toml" | "adl/Cargo.lock"
+            )
+        })
+}
+
+fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
+    let mut commands = Vec::new();
+    push_finish_validation_command(
+        &mut commands,
+        "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml pr_cmd::github",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml --bin adl github_release_",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml long_lived_agent",
+    );
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
 }
 
 fn finish_path_needs_coverage_tooling_focused_validation(path: &str) -> bool {
@@ -1617,6 +1792,31 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml pr_cmd::github" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &["test", "--manifest-path", path_str(&manifest)?, "pr_cmd::github"],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml long_lived_agent" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &["test", "--manifest-path", path_str(&manifest)?, "long_lived_agent"],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl octocrab_transport_" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "octocrab_transport_",
+                        ],
+                    )?;
+                }
                 "cargo test --manifest-path adl/Cargo.toml --bin adl github_token" => {
                     run_finish_validation_status(
                         "cargo",
@@ -1656,6 +1856,45 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml build_remote_execute_request_preserves_conversation_as_audit_metadata" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "build_remote_execute_request_preserves_conversation_as_audit_metadata",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml execute_step_with_retry_does_not_retry_remote_schema_violation" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "execute_step_with_retry_does_not_retry_remote_schema_violation",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml security_envelope_rejects_tampered_signed_conversation_metadata" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "security_envelope_rejects_tampered_signed_conversation_metadata",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml remote_exec::" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &["test", "--manifest-path", path_str(&manifest)?, "remote_exec::"],
+                    )?;
+                }
                 "cargo test --manifest-path adl/Cargo.toml scheduler_economics" => {
                     run_finish_validation_status(
                         "cargo",
@@ -1664,6 +1903,39 @@ pub(super) fn run_finish_validation_rust(
                             "--manifest-path",
                             path_str(&manifest)?,
                             "scheduler_economics",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml continuous_verification_contract_covers_cadence_lifecycle_and_artifacts" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "continuous_verification_contract_covers_cadence_lifecycle_and_artifacts",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml self_attack_contract_is_policy_bounded_and_reviewable" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "self_attack_contract_is_policy_bounded_and_reviewable",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml identity_continuous_verification_writes_contract_json" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "identity_continuous_verification_writes_contract_json",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1092,6 +1092,7 @@ fn finish_validation_plan_classifies_github_release_tooling_slice() {
 #[test]
 fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request() {
     let docs_plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &["docs/milestones/v0.91.3/review/example.md".to_string()],
     )
@@ -1103,6 +1104,7 @@ fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request()
         .any(|command: &String| command.contains("cargo nextest")));
 
     let focused_plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &["adl/src/cli/pr_cmd/doctor.rs".to_string()],
     )
@@ -1120,6 +1122,7 @@ fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request()
 #[test]
 fn finish_validation_profile_treats_issue_records_and_skill_docs_as_docs_only() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md".to_string(),
@@ -1141,6 +1144,7 @@ fn finish_validation_profile_treats_issue_records_and_skill_docs_as_docs_only() 
 #[test]
 fn finish_validation_profile_treats_skill_schema_and_agent_manifest_as_docs_only() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/tools/skills/sprint-review/docs/SPRINT_REVIEW_SKILL_INPUT_SCHEMA.md".to_string(),
@@ -1162,6 +1166,7 @@ fn finish_validation_profile_treats_skill_schema_and_agent_manifest_as_docs_only
 #[test]
 fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/tools/pr.sh".to_string(),
@@ -1176,6 +1181,7 @@ fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
 #[test]
 fn finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/tools/test_install_adl_operational_skills.sh".to_string(),
@@ -1197,6 +1203,7 @@ fn finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binar
 #[test]
 fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/src/cli/tooling_cmd/public_prompt_packet.rs".to_string(),
@@ -1231,6 +1238,7 @@ fn finish_validation_profile_keeps_public_prompt_packet_changes_focused() {
 #[test]
 fn finish_validation_profile_classifies_github_token_loading_surfaces() {
     let plan = select_finish_validation_plan_for_finish(
+        4001,
         ".",
         &[
             "adl/src/cli/github_token.rs".to_string(),
@@ -1265,8 +1273,138 @@ fn finish_validation_profile_classifies_github_token_loading_surfaces() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_tokio_manifest_runtime_wave_paths() {
+    let plan = select_finish_validation_plan_for_finish(
+        4178,
+        ".",
+        &["adl/Cargo.toml".to_string(), "adl/Cargo.lock".to_string()],
+    )
+    .expect("tokio manifest plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml pr_cmd::github".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl github_release_".to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml long_lived_agent".to_string()));
+}
+
+#[test]
+fn finish_validation_profile_classifies_long_lived_agent_tokio_paths() {
+    let plan = select_finish_validation_plan_for_finish(
+        4179,
+        ".",
+        &[
+            "adl/src/long_lived_agent.rs".to_string(),
+            "adl/src/long_lived_agent/tests.rs".to_string(),
+        ],
+    )
+    .expect("long-lived tokio plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml long_lived_agent".to_string()));
+}
+
+#[test]
+fn finish_validation_profile_classifies_tokio_bootstrap_helper_paths() {
+    let plan = select_finish_validation_plan_for_finish(
+        4180,
+        ".",
+        &[
+            "adl/src/cli/tokio_runtime.rs".to_string(),
+            "docs/default_workflow.md".to_string(),
+        ],
+    )
+    .expect("tokio bootstrap helper plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml pr_cmd::github".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl github_release_".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl octocrab_transport_".to_string()
+    ));
+}
+
+#[test]
+fn finish_validation_profile_classifies_remote_exec_tokio_paths() {
+    let plan = select_finish_validation_plan_for_finish(
+        4181,
+        ".",
+        &[
+            "adl/src/execute/runner.rs".to_string(),
+            "adl/src/execute/tests.rs".to_string(),
+            "adl/src/remote_exec.rs".to_string(),
+            "adl/src/remote_exec/signing_support.rs".to_string(),
+            "adl/src/remote_exec/types.rs".to_string(),
+        ],
+    )
+    .expect("remote exec tokio plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml build_remote_execute_request_preserves_conversation_as_audit_metadata"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml execute_step_with_retry_does_not_retry_remote_schema_violation"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml security_envelope_rejects_tampered_signed_conversation_metadata"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"cargo test --manifest-path adl/Cargo.toml remote_exec::".to_string()));
+}
+
+#[test]
+fn finish_validation_profile_classifies_bounded_cav_tokio_paths() {
+    let plan = select_finish_validation_plan_for_finish(
+        4182,
+        ".",
+        &[
+            "adl/src/continuous_verification_self_attack.rs".to_string(),
+            "adl/src/cli/identity_cmd/tests/adversarial_contracts.rs".to_string(),
+        ],
+    )
+    .expect("bounded cav tokio plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml continuous_verification_contract_covers_cadence_lifecycle_and_artifacts"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml self_attack_contract_is_policy_bounded_and_reviewable"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml identity_continuous_verification_writes_contract_json"
+            .to_string()
+    ));
+}
+
+#[test]
 fn finish_validation_profile_keeps_finish_support_changes_narrow() {
     let plan = select_finish_validation_plan_for_finish(
+        4177,
         ".",
         &[
             "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
@@ -1304,6 +1442,7 @@ fn finish_validation_profile_keeps_finish_support_changes_narrow() {
 #[test]
 fn finish_validation_profile_classifies_lifecycle_inline_tests() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &["adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs".to_string()],
     )
@@ -1321,6 +1460,7 @@ fn finish_validation_profile_classifies_lifecycle_inline_tests() {
 #[test]
 fn finish_validation_profile_keeps_small_binary_delegation_proof_focused() {
     let plan = select_finish_validation_plan_for_finish(
+        1153,
         ".",
         &[
             "adl/tools/test_pr_small_binary_delegation.sh".to_string(),
@@ -1584,6 +1724,72 @@ fn finish_runtime_paths_run_module_focused_validation_and_runtime_lane() {
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("runtime --build"));
+}
+
+#[test]
+fn finish_tokio_wave_paths_run_new_focused_validation_commands() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-tokio-wave-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let plan = select_finish_validation_plan_for_finish(
+        4178,
+        ".",
+        &["adl/Cargo.toml".to_string(), "adl/Cargo.lock".to_string()],
+    )
+    .expect("tokio wave focused plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("tokio wave focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("fmt --manifest-path"));
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("pr_cmd::github"));
+    assert!(cargo_calls.contains("github_release_"));
+    assert!(cargo_calls.contains("long_lived_agent"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
+}
+
+#[test]
+fn finish_validation_profile_does_not_special_case_tokio_manifest_paths_for_other_issues() {
+    let err = select_finish_validation_plan_for_finish(
+        5000,
+        ".",
+        &["adl/Cargo.toml".to_string(), "adl/Cargo.lock".to_string()],
+    )
+    .expect_err("non-Tokio manifest-only issues should stay unclassified");
+
+    assert!(err.to_string().contains("changed paths are not classified"));
 }
 
 #[test]


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4177 remains open.

## Summary
Implemented the `#4177` shared unblocker for the Tokio runtime wave by teaching `pr finish` to classify and validate issues `#4178` through `#4182` without widening manifest-only handling to unrelated `Cargo.toml` work. The final classifier is issue-aware for `#4178`, keeps non-Tokio manifest-only issues fail-closed, and records the targeted validation commands needed for the Tokio child issues.

## Artifacts
- Updated finish-path classifier logic in `adl/src/cli/pr_cmd/finish_support.rs`
- Added and revised finish-path regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated review and execution truth in:
  - `.adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/srp.md`
  - `.adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Normalized the touched Rust source and test files after the classifier changes.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation -- --nocapture`
    Verified the focused finish-path classifier cases, including the new Tokio-wave routing assertions and fail-closed manifest behavior.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render -- --nocapture`
    Verified the broader `adl-pr-finish` finish-path suite still passes with the issue-aware Tokio classifier in place.
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 4177 --json`
    Verified worktree binding, queue state, and remaining publication blockers after implementation and review.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/srp.md`
    Verified the updated SRP review record remains structurally valid.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/sor.md`
    Verified this updated SOR execution record remains structurally valid.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4177__v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2/sor.md
- Idempotency-Key: v0-91-6-runtime-tokio-unblock-finish-classification-for-tokio-child-issues-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4177-v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2-sip-md-adl-v0-91-6-tasks-issue-4177-v0-91-6-runtime-tokio-prepare-the-tokio-runtime-substrate-before-acip-2-sor-md