### PR TITLE
[v0.91.6][tools][finish] Fix native merge path stalling on green draft PR validation

### DIFF
--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -601,6 +601,7 @@ pub(crate) fn parse_finish_args(args: &[String]) -> Result<FinishArgs> {
             }
             "--merge" | "--auto-merge" => {
                 parsed.merge_mode = true;
+                parsed.ready = true;
                 i += 1;
             }
             "--idempotent" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -40,6 +40,32 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
     assert!(parsed.ready);
     assert!(parsed.allow_gitignore);
     assert!(parsed.no_open);
+
+    let merge_parsed = parse_finish_args(&[
+        "1153".to_string(),
+        "--title".to_string(),
+        "Example".to_string(),
+        "--merge".to_string(),
+    ])
+    .expect("parse finish merge");
+    assert!(merge_parsed.merge_mode);
+    assert!(
+        merge_parsed.ready,
+        "--merge should imply ready so native finish merge does not stall on draft-only state"
+    );
+
+    let auto_merge_parsed = parse_finish_args(&[
+        "1153".to_string(),
+        "--title".to_string(),
+        "Example".to_string(),
+        "--auto-merge".to_string(),
+    ])
+    .expect("parse finish auto-merge");
+    assert!(auto_merge_parsed.merge_mode);
+    assert!(
+        auto_merge_parsed.ready,
+        "--auto-merge should imply ready so native finish merge does not stall on draft-only state"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #4190

## Summary
Implemented the bounded `#4190` native-finish fix by making merge-mode finish
arguments imply ready-state before validation waiting, then added focused parser
coverage for both `--merge` and `--auto-merge`. The issue is ready to publish;
the first native `pr finish` rerun proved the draft-state stall is gone and
surfaced the remaining lifecycle blocker as stale bootstrap SOR truth rather
than a silent validation wait.

## Artifacts
- Updated tracked code:
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4190__v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::arg_render::parse_finish_args_requires_title_and_accepts_finish_flags -- --exact --nocapture`
    Verified the targeted finish parser regression path and the new alias
    coverage.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::finish::publication:: -- --nocapture`
    Verified existing native finish publication behavior stayed green.
  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only issue-record residue would leak into
    publication.
  - `git diff --check`
    Verified the patch was format-clean.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" ./adl/tools/pr.sh finish 4190 --title "[v0.91.6][tools][finish] Fix native merge path stalling on green draft PR validation" --paths "adl/src/cli/pr_cmd_args.rs,adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs" --no-open`
    Verified the native finish path no longer stalls on the draft-state bug and
    now reports the remaining output-card truth blocker explicitly.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4190__v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4190__v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation/sor.md
- Idempotency-Key: v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4190-v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation-sip-md-adl-v0-91-6-tasks-issue-4190-v0-91-6-tools-finish-fix-native-merge-path-stalling-on-green-draft-pr-validation-sor-md