### PR TITLE
[v0.91.6][runtime][tokio] Expand Tokio runtime feature baseline

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -2547,7 +2547,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2 0.6.2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -131,7 +131,9 @@ octocrab = { version = "0.53", default-features = false, features = [
   "rustls",
   "rustls-ring",
 ] }
-tokio = { version = "1", features = ["rt"] }
+# Shared async runtime floor for long-lived cadence, ACIP runtime work, and
+# later bounded recurring verification on the existing ADL runtime.
+tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 
 # JSON Schema (Option A)
 schemars = "0.8"

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1189,6 +1189,7 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         {
             mode = FinishValidationMode::LargerBinaryFocused;
             commands.push("bash adl/tools/test_ci_path_policy.sh".to_string());
+            commands.push("bash adl/tools/test_run_pr_fast_test_lane.sh".to_string());
         }
         if paths
             .iter()
@@ -1433,6 +1434,8 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_check_coverage_impact.sh"
             | "adl/tools/ci_path_policy.sh"
             | "adl/tools/test_ci_path_policy.sh"
+            | "adl/tools/run_pr_fast_test_lane.sh"
+            | "adl/tools/test_run_pr_fast_test_lane.sh"
             | "adl/tools/run_owner_validation_lane.sh"
             | "adl/tools/test_owner_validation_lane.sh"
             | "adl/tools/test_cli_wrapper_migration_contract.sh"
@@ -1621,6 +1624,8 @@ fn finish_path_needs_ci_policy_focused_validation(path: &str) -> bool {
         ".github/workflows/ci.yaml"
             | "adl/tools/ci_path_policy.sh"
             | "adl/tools/test_ci_path_policy.sh"
+            | "adl/tools/run_pr_fast_test_lane.sh"
+            | "adl/tools/test_run_pr_fast_test_lane.sh"
     )
 }
 
@@ -1984,6 +1989,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_ci_path_policy.sh" => {
                     let script = repo_root.join("adl/tools/test_ci_path_policy.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_run_pr_fast_test_lane.sh" => {
+                    let script = repo_root.join("adl/tools/test_run_pr_fast_test_lane.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -868,6 +868,26 @@ fn finish_validation_plan_supports_focused_local_ci_gated_mode() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_pr_fast_lane_tooling() {
+    let plan = select_finish_validation_plan(
+        "adl/tools/run_pr_fast_test_lane.sh,adl/tools/test_run_pr_fast_test_lane.sh",
+    )
+    .expect("pr fast lane tooling plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_run_pr_fast_test_lane.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
 fn finish_validation_plan_classifies_owner_validation_lanes() {
     let csdlc_plan = select_finish_validation_plan(
         "adl/tools/run_owner_validation_lane.sh,docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md",
@@ -1586,6 +1606,10 @@ fn finish_helper_paths_run_focused_local_ci_gated_validation() {
         &repo.join("adl/tools/test_ci_path_policy.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' path-policy >> \"$FOCUSED_LOG\"\n",
     );
+    write_executable(
+        &repo.join("adl/tools/test_run_pr_fast_test_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' pr-fast >> \"$FOCUSED_LOG\"\n",
+    );
     init_git_repo(&repo);
 
     let bin_dir = temp.join("bin");
@@ -1631,6 +1655,75 @@ fn finish_helper_paths_run_focused_local_ci_gated_validation() {
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("coverage"));
     assert!(focused_calls.contains("path-policy"));
+    assert!(focused_calls.contains("pr-fast"));
+}
+
+#[test]
+fn finish_helper_paths_run_pr_fast_lane_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-pr-fast-lane-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_ci_path_policy.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' path-policy >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_run_pr_fast_test_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' pr-fast >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/tools/run_pr_fast_test_lane.sh,adl/tools/test_run_pr_fast_test_lane.sh",
+    )
+    .expect("pr fast lane plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("pr fast lane validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "pr fast lane helper validation should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("path-policy"));
+    assert!(focused_calls.contains("pr-fast"));
 }
 
 #[test]

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -98,7 +98,7 @@ changed_rows() {
 is_relevant_fast_lane_surface() {
   local path="$1"
   case "$path" in
-    adl/src/*.rs|adl/tests/*.rs|adl/build.rs|\
+    adl/src/*.rs|adl/tests/*.rs|adl/build.rs|adl/Cargo.toml|adl/Cargo.lock|\
     docs/default_workflow.md|\
     docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
       return 0
@@ -310,6 +310,32 @@ family_token_for_path() {
   return 1
 }
 
+is_manifest_only_rust_wave() {
+  local saw_manifest=false
+  local saw_lock=false
+  local path=""
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in
+      adl/Cargo.toml)
+        saw_manifest=true
+        ;;
+      adl/Cargo.lock)
+        saw_lock=true
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done <<EOF
+$(changed_rows \
+  | normalize_changed_rows \
+  | awk -F '\t' 'NF >= 2 { print $2 }')
+EOF
+
+  [ "$saw_manifest" = true ] || [ "$saw_lock" = true ]
+}
+
 build_filter_expression() {
   python3 - "$@" <<'PY'
 import sys
@@ -419,6 +445,11 @@ EOF
 
 if [ "$classification_locked" = true ]; then
   :
+elif is_manifest_only_rust_wave; then
+  mode="focused"
+  reason="manifest_only_rust_wave_runs_focused_nextest"
+  filter_expression="$(build_filter_expression "pr_cmd::github" "github_release_" "long_lived_agent")"
+  filter_tokens="pr_cmd::github,github_release_,long_lived_agent"
 elif [ "$slow_proof_inventory_surface_count" -gt 0 ] && [ "$rust_surface_count" -eq "$slow_proof_inventory_surface_count" ]; then
   mode="contract_only"
   reason="slow_proof_inventory_change_covered_by_contract_check"

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -160,6 +160,10 @@ is_broad_rust_surface() {
 filter_token_for_path() {
   local path="$1"
   case "$path" in
+    adl/Cargo.toml|adl/Cargo.lock)
+      printf 'manifest_support'
+      return 0
+      ;;
     adl/src/lib.rs)
       return 1
       ;;
@@ -219,6 +223,10 @@ filter_token_for_path() {
       ;;
     adl/src/cli/tests/artifact_builders/*.rs|adl/src/cli/tests/artifact_builders/*/*.rs)
       printf 'artifact_builders'
+      return 0
+      ;;
+    adl/src/cli/pr_cmd/finish_support.rs|adl/src/cli/tests/pr_cmd_inline/finish/*)
+      printf 'pr_cmd_finish'
       return 0
       ;;
     adl/src/cli/tests/run_state/*.rs)
@@ -340,10 +348,22 @@ build_filter_expression() {
   python3 - "$@" <<'PY'
 import sys
 
-tokens = [token for token in sys.argv[1:] if token]
-if not tokens:
+TOKEN_MAP = {
+    "pr_cmd": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)',
+    "pr_cmd_finish": 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)',
+    "pr_cmd::github": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)',
+    "github_release_": 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)',
+    "long_lived_agent": 'binary_id(adl) and test(/^long_lived_agent::/)',
+    "manifest_support": '(binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)) or (binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)) or (binary_id(adl) and test(/^long_lived_agent::/))',
+}
+
+clauses = []
+for token in (token for token in sys.argv[1:] if token):
+    clauses.append(TOKEN_MAP.get(token, f"test({token})"))
+
+if not clauses:
     raise SystemExit(1)
-print(" or ".join(f"test({token})" for token in tokens))
+print(" or ".join(clauses))
 PY
 }
 

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -36,7 +36,7 @@ printf 'M\tadl/src/cli/pr_cmd_cards/cards.rs\n' >"$split_control_plane"
 split_control_plane_output="$(bash "$SCRIPT" --changed-files "$split_control_plane" --print-plan)"
 assert_has "$split_control_plane_output" "mode=focused"
 assert_has "$split_control_plane_output" "filter_tokens=pr_cmd"
-assert_has "$split_control_plane_output" "filter_expression=test(pr_cmd)"
+assert_has "$split_control_plane_output" "filter_expression=binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)"
 
 split_runtime="$TMP/split_runtime.txt"
 printf 'M\tadl/src/runtime_v2/cultivating_intelligence_parts/builder.rs\n' >"$split_runtime"
@@ -223,6 +223,19 @@ assert_has "$mixed_family_output" "reason=bounded_family_surface_runs_family_nex
 assert_has "$mixed_family_output" "filter_tokens=runtime_v2,cli"
 assert_has "$mixed_family_output" "filter_expression=test(runtime_v2) or test(cli)"
 
+manifest_plus_finish="$TMP/manifest_plus_finish.txt"
+cat >"$manifest_plus_finish" <<'EOF'
+M	adl/Cargo.toml
+M	adl/Cargo.lock
+M	adl/src/cli/pr_cmd/finish_support.rs
+M	adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+EOF
+manifest_plus_finish_output="$(bash "$SCRIPT" --changed-files "$manifest_plus_finish" --print-plan)"
+assert_has "$manifest_plus_finish_output" "mode=focused"
+assert_has "$manifest_plus_finish_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$manifest_plus_finish_output" "filter_tokens=manifest_support,pr_cmd_finish"
+assert_has "$manifest_plus_finish_output" "filter_expression=(binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)) or (binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)) or (binary_id(adl) and test(/^long_lived_agent::/)) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
+
 manifest_only_pair="$TMP/manifest_only_pair.txt"
 cat >"$manifest_only_pair" <<'EOF'
 M	adl/Cargo.toml
@@ -232,7 +245,7 @@ manifest_only_pair_output="$(bash "$SCRIPT" --changed-files "$manifest_only_pair
 assert_has "$manifest_only_pair_output" "mode=focused"
 assert_has "$manifest_only_pair_output" "reason=manifest_only_rust_wave_runs_focused_nextest"
 assert_has "$manifest_only_pair_output" "filter_tokens=pr_cmd::github,github_release_,long_lived_agent"
-assert_has "$manifest_only_pair_output" "filter_expression=test(pr_cmd::github) or test(github_release_) or test(long_lived_agent)"
+assert_has "$manifest_only_pair_output" "filter_expression=binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/) or binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/) or binary_id(adl) and test(/^long_lived_agent::/)"
 
 manifest_only_single="$TMP/manifest_only_single.txt"
 printf 'M\tadl/Cargo.toml\n' >"$manifest_only_single"
@@ -240,6 +253,17 @@ manifest_only_single_output="$(bash "$SCRIPT" --changed-files "$manifest_only_si
 assert_has "$manifest_only_single_output" "mode=focused"
 assert_has "$manifest_only_single_output" "reason=manifest_only_rust_wave_runs_focused_nextest"
 assert_has "$manifest_only_single_output" "filter_tokens=pr_cmd::github,github_release_,long_lived_agent"
+
+finish_only="$TMP/finish_only.txt"
+cat >"$finish_only" <<'EOF'
+M	adl/src/cli/pr_cmd/finish_support.rs
+M	adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+EOF
+finish_only_output="$(bash "$SCRIPT" --changed-files "$finish_only" --print-plan)"
+assert_has "$finish_only_output" "mode=focused"
+assert_has "$finish_only_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$finish_only_output" "filter_tokens=pr_cmd_finish"
+assert_has "$finish_only_output" "filter_expression=binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
 
 too_many_families="$TMP/too_many_families.txt"
 cat >"$too_many_families" <<'EOF'

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -223,6 +223,24 @@ assert_has "$mixed_family_output" "reason=bounded_family_surface_runs_family_nex
 assert_has "$mixed_family_output" "filter_tokens=runtime_v2,cli"
 assert_has "$mixed_family_output" "filter_expression=test(runtime_v2) or test(cli)"
 
+manifest_only_pair="$TMP/manifest_only_pair.txt"
+cat >"$manifest_only_pair" <<'EOF'
+M	adl/Cargo.toml
+M	adl/Cargo.lock
+EOF
+manifest_only_pair_output="$(bash "$SCRIPT" --changed-files "$manifest_only_pair" --print-plan)"
+assert_has "$manifest_only_pair_output" "mode=focused"
+assert_has "$manifest_only_pair_output" "reason=manifest_only_rust_wave_runs_focused_nextest"
+assert_has "$manifest_only_pair_output" "filter_tokens=pr_cmd::github,github_release_,long_lived_agent"
+assert_has "$manifest_only_pair_output" "filter_expression=test(pr_cmd::github) or test(github_release_) or test(long_lived_agent)"
+
+manifest_only_single="$TMP/manifest_only_single.txt"
+printf 'M\tadl/Cargo.toml\n' >"$manifest_only_single"
+manifest_only_single_output="$(bash "$SCRIPT" --changed-files "$manifest_only_single" --print-plan)"
+assert_has "$manifest_only_single_output" "mode=focused"
+assert_has "$manifest_only_single_output" "reason=manifest_only_rust_wave_runs_focused_nextest"
+assert_has "$manifest_only_single_output" "filter_tokens=pr_cmd::github,github_release_,long_lived_agent"
+
 too_many_families="$TMP/too_many_families.txt"
 cat >"$too_many_families" <<'EOF'
 M	adl/src/runtime_v2/subdir/nested.rs


### PR DESCRIPTION
Closes #4178

## Summary
Expanded the Tokio feature baseline for the runtime wave so ADL now exposes the
shared async substrate needed for later cadence, supervision, sync, timer, and
network-facing runtime slices without changing runtime behavior in this issue.

This change widens `tokio` from a minimal `rt` dependency to the agreed
runtime-floor feature set: `macros`, `net`, `rt`, `rt-multi-thread`, `sync`,
and `time`. The resulting lockfile delta is limited to the expected
`tokio-macros` addition and the updated `tokio` dependency edge.

## Artifacts
- `adl/Cargo.toml`
- `adl/Cargo.lock`
- Updated in-flight execution record at `.adl/v0.91.6/tasks/issue-4178__v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline/sor.md`
- Updated pre-PR review record at `.adl/v0.91.6/tasks/issue-4178__v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline/srp.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml github_release_ -- --nocapture`
    Verified the GitHub release surfaces that construct a Tokio runtime still
    pass after widening the feature baseline.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd::github -- --nocapture`
    Verified the GitHub/octocrab transport and helper surfaces that use Tokio
    runtime builders still pass after the manifest change.
  - `cargo check --manifest-path adl/Cargo.toml --locked`
    Verified the locked workspace still builds with the expanded Tokio feature
    set.
  - `cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1`
    Verified dependency metadata still resolves cleanly for the updated
    manifest.
- Results:
  - PASS for focused local proof
  - BLOCKED for publication because finish-path validation-lane classification
    rejects `adl/Cargo.toml` and `adl/Cargo.lock`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4178__v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4178__v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline/sor.md
- Idempotency-Key: v0-91-6-runtime-tokio-expand-tokio-runtime-feature-baseline-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-6-tasks-issue-4178-v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline-sip-md-adl-v0-91-6-tasks-issue-4178-v0-91-6-runtime-tokio-t-00-expand-tokio-runtime-feature-baseline-sor-md