### PR TITLE
[v0.91.6][runtime][tokio] Migrate long-lived agent cadence to Tokio timers and tasks

### DIFF
--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -5,10 +5,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
-use std::thread;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 mod inspection;
@@ -112,28 +109,32 @@ pub fn run(spec_path: &Path, options: RunOptions) -> Result<StatusRecord> {
         .or(loaded.spec.heartbeat.interval_secs)
         .unwrap_or(0);
 
-    let mut last_status = status(spec_path)?;
+    build_long_lived_runtime()?.block_on(run_with_tokio_cadence(
+        spec_path.to_path_buf(),
+        options,
+        loaded,
+        sleep_secs,
+    ))
+}
+
+async fn run_with_tokio_cadence(
+    spec_path: PathBuf,
+    options: RunOptions,
+    loaded: LoadedAgentSpec,
+    sleep_secs: u64,
+) -> Result<StatusRecord> {
+    let mut last_status = status(&spec_path)?;
     for index in 0..options.max_cycles {
         if read_stop(&loaded)?.is_some() {
-            last_status = tick(
-                spec_path,
-                TickOptions {
-                    recover_stale_lease: options.recover_stale_lease,
-                },
-            )?;
+            last_status = run_tick_blocking(spec_path.clone(), options.recover_stale_lease).await?;
             break;
         }
-        match tick(
-            spec_path,
-            TickOptions {
-                recover_stale_lease: options.recover_stale_lease,
-            },
-        ) {
+        match run_tick_blocking(spec_path.clone(), options.recover_stale_lease).await {
             Ok(status) => {
                 last_status = status;
             }
             Err(err) => {
-                last_status = status(spec_path)?;
+                last_status = status(&spec_path)?;
                 let failures = consecutive_failure_count(&loaded)?;
                 if failures >= max_consecutive_failures(&loaded) {
                     last_status = write_stop_record(
@@ -155,7 +156,7 @@ pub fn run(spec_path: &Path, options: RunOptions) -> Result<StatusRecord> {
             break;
         }
         if index + 1 < options.max_cycles && !options.no_sleep && sleep_secs > 0 {
-            thread::sleep(Duration::from_secs(sleep_secs));
+            tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
         }
     }
 
@@ -165,6 +166,26 @@ pub fn run(spec_path: &Path, options: RunOptions) -> Result<StatusRecord> {
         write_status(&loaded, &last_status)?;
     }
     Ok(last_status)
+}
+
+async fn run_tick_blocking(spec_path: PathBuf, recover_stale_lease: bool) -> Result<StatusRecord> {
+    tokio::task::spawn_blocking(move || {
+        tick(
+            &spec_path,
+            TickOptions {
+                recover_stale_lease,
+            },
+        )
+    })
+    .await
+    .map_err(|err| anyhow!("long-lived agent cadence task failed to join: {err}"))?
+}
+
+fn build_long_lived_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .context("failed building Tokio runtime for long-lived agent cadence")
 }
 
 pub fn status(spec_path: &Path) -> Result<StatusRecord> {

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1,6 +1,7 @@
 //! Integration tests for long-lived agent execution and artifact invariants.
 use super::*;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -268,6 +269,34 @@ fn run_max_cycles_no_sleep_writes_exactly_three_cycles_and_completed_status() {
     )
     .expect("parse manifest");
     assert_eq!(manifest["previous_cycle_id"], "cycle-000001");
+}
+
+#[test]
+fn run_with_interval_sleep_preserves_cycle_count_and_waits_between_cycles() {
+    let root = temp_dir("run-with-sleep");
+    let spec = write_spec(&root);
+    let started = Instant::now();
+
+    let status = run(
+        &spec,
+        RunOptions {
+            max_cycles: 2,
+            interval_secs: Some(1),
+            no_sleep: false,
+            recover_stale_lease: false,
+        },
+    )
+    .expect("run");
+
+    assert_eq!(status.state, AgentStatusState::Completed);
+    assert_eq!(status.completed_cycle_count, 2);
+    assert!(
+        started.elapsed() >= Duration::from_secs(1),
+        "expected Tokio-backed cadence wait between cycles"
+    );
+    let ledger =
+        fs::read_to_string(root.join("state/cycle_ledger.jsonl")).expect("read cycle ledger");
+    assert_eq!(ledger.lines().count(), 2);
 }
 
 #[test]

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -229,6 +229,10 @@ filter_token_for_path() {
       printf 'pr_cmd_finish'
       return 0
       ;;
+    adl/src/long_lived_agent.rs|adl/src/long_lived_agent/tests.rs)
+      printf 'long_lived_agent'
+      return 0
+      ;;
     adl/src/cli/tests/run_state/*.rs)
       printf 'run_state'
       return 0

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -265,6 +265,17 @@ assert_has "$finish_only_output" "reason=bounded_rust_surface_runs_focused_nexte
 assert_has "$finish_only_output" "filter_tokens=pr_cmd_finish"
 assert_has "$finish_only_output" "filter_expression=binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
 
+long_lived_agent_only="$TMP/long_lived_agent_only.txt"
+cat >"$long_lived_agent_only" <<'EOF'
+M	adl/src/long_lived_agent.rs
+M	adl/src/long_lived_agent/tests.rs
+EOF
+long_lived_agent_only_output="$(bash "$SCRIPT" --changed-files "$long_lived_agent_only" --print-plan)"
+assert_has "$long_lived_agent_only_output" "mode=focused"
+assert_has "$long_lived_agent_only_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$long_lived_agent_only_output" "filter_tokens=long_lived_agent"
+assert_has "$long_lived_agent_only_output" "filter_expression=binary_id(adl) and test(/^long_lived_agent::/)"
+
 too_many_families="$TMP/too_many_families.txt"
 cat >"$too_many_families" <<'EOF'
 M	adl/src/runtime_v2/subdir/nested.rs


### PR DESCRIPTION
Closes #4179

## Summary
Migrated long-lived agent cadence from blocking thread sleep to a Tokio-backed cadence loop that keeps the existing artifact and stop/failure behavior while using async sleep between cycles. Added focused proof that interval-driven runs still wait between cycles and complete with the expected cycle count.

## Artifacts
- Updated runtime implementation in `adl/src/long_lived_agent.rs`
- Focused cadence regression coverage in `adl/src/long_lived_agent/tests.rs`
- Tokio feature-floor expansion in `adl/Cargo.toml`
- Lockfile update in `adl/Cargo.lock`
- Issue-local review and execution record updates in `.adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/srp.md` and `.adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the changed Rust sources remain formatter-clean after the cadence refactor.
  - `cargo test --manifest-path adl/Cargo.toml long_lived_agent -- --nocapture`
    Verified the long-lived agent surface, including cycle execution, stop handling, stale-lease recovery, review packet inspection, and the new Tokio-backed cadence wait behavior.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/srp.md`
    Verified the updated SRP structure after recording review truth.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/sor.md`
    Verified the updated SOR structure after recording execution truth.
  - `bash adl/tools/pr.sh finish 4179 --title "[v0.91.6][runtime][tokio][T-01] Migrate long-lived agent cadence to Tokio timers and tasks" --no-checks`
    Verified publication is currently blocked because `pr finish` does not classify `adl/Cargo.toml`, `adl/Cargo.lock`, `adl/src/long_lived_agent.rs`, or `adl/src/long_lived_agent/tests.rs` into any supported validation lane.
- Results:
  - PASS
  - BLOCKED for publication

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4179__v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks/sor.md
- Idempotency-Key: v0-91-6-runtime-tokio-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-tests-rs-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-6-tasks-issue-4179-v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks-sip-md-adl-v0-91-6-tasks-issue-4179-v0-91-6-runtime-tokio-t-01-migrate-long-lived-agent-cadence-to-tokio-timers-and-tasks-sor-md