### PR TITLE
[v0.91.6][tools][quality] Add manifest-driven validation lane selector

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "lanes": [
+    {
+      "id": "prompt_template_contracts",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "docs/templates/prompts/**",
+        "adl/src/bin/adl_prompt_template.rs",
+        "adl/src/bin/adl_validate_structured_prompt.rs",
+        "adl/src/csdlc_prompt_editor/**",
+        "adl/src/csdlc_prompt_editor.rs"
+      ],
+      "command": "bash adl/tools/test_prompt_template_workflow_integration.sh",
+      "run_command": "bash adl/tools/test_prompt_template_workflow_integration.sh",
+      "reason": "prompt_template_or_editor_surface_requires_template_contract_checks"
+    },
+    {
+      "id": "pvf_contracts",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/tools/run_pvf_validation_lane.sh",
+        "adl/tools/validate_pvf_manifest.py",
+        "adl/tools/test_run_pvf_validation_lane.sh",
+        "adl/tools/test_pvf_ci_release_policy.sh",
+        "adl/tools/run_pvf_ci_release_policy_fixture.sh"
+      ],
+      "command": "bash adl/tools/test_run_pvf_validation_lane.sh && bash adl/tools/test_pvf_ci_release_policy.sh",
+      "run_command": "bash adl/tools/test_run_pvf_validation_lane.sh && bash adl/tools/test_pvf_ci_release_policy.sh",
+      "reason": "pvf_lane_surface_requires_pvf_contract_checks"
+    },
+    {
+      "id": "ci_path_policy_contracts",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh",
+        ".github/workflows/**"
+      ],
+      "command": "bash adl/tools/test_ci_path_policy.sh",
+      "run_command": "bash adl/tools/test_ci_path_policy.sh",
+      "reason": "ci_policy_surface_requires_path_policy_contract_checks"
+    },
+    {
+      "id": "coverage_impact_contracts",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/tools/check_coverage_impact.sh",
+        "adl/tools/test_check_coverage_impact.sh"
+      ],
+      "command": "bash adl/tools/test_check_coverage_impact.sh",
+      "run_command": "bash adl/tools/test_check_coverage_impact.sh",
+      "reason": "coverage_impact_surface_requires_coverage_impact_contract_checks"
+    },
+    {
+      "id": "csdlc_owner_lane",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/src/cli/pr_cmd.rs",
+        "adl/src/cli/pr_cmd/**",
+        "adl/src/cli/pr_cmd_cards.rs",
+        "adl/src/cli/pr_cmd_cards/**",
+        "adl/tools/pr.sh",
+        "adl/tools/run_owner_validation_lane.sh"
+      ],
+      "command": "bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan",
+      "run_command": "bash adl/tools/run_owner_validation_lane.sh csdlc",
+      "reason": "csdlc_owner_surface_requires_csdlc_owner_lane"
+    },
+    {
+      "id": "runtime_owner_lane",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/src/bin/adl_runtime.rs",
+        "adl/tools/test_adl_runtime_compatibility.sh"
+      ],
+      "command": "bash adl/tools/run_owner_validation_lane.sh runtime --print-plan",
+      "run_command": "bash adl/tools/run_owner_validation_lane.sh runtime",
+      "reason": "runtime_owner_surface_requires_runtime_owner_lane"
+    },
+    {
+      "id": "review_owner_lane",
+      "lane_class": "cli_workflow",
+      "path_hints": [
+        "adl/src/bin/adl_review.rs",
+        "adl/src/review*.rs",
+        "adl/tools/test_adl_review_compatibility.sh"
+      ],
+      "command": "bash adl/tools/run_owner_validation_lane.sh review --print-plan",
+      "run_command": "bash adl/tools/run_owner_validation_lane.sh review",
+      "reason": "review_owner_surface_requires_review_owner_lane"
+    },
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "path_hints": [
+        "docs/**",
+        "*.md"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "release_gate_hints": [
+    ".github/workflows/**",
+    "docs/milestones/**/release/**",
+    "docs/milestones/**/RELEASE_PLAN*.md",
+    "docs/milestones/**/MILESTONE_CHECKLIST*.md"
+  ],
+  "rust_path_hints": [
+    "adl/build.rs",
+    "adl/src/**",
+    "adl/tests/**"
+  ]
+}

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1193,6 +1193,13 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_validation_selector_focused_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            commands.push("bash adl/tools/test_select_validation_lanes.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_small_binary_delegation_validation(path))
         {
             commands.push("bash adl/tools/test_pr_small_binary_delegation.sh".to_string());
@@ -1436,6 +1443,10 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_ci_path_policy.sh"
             | "adl/tools/run_pr_fast_test_lane.sh"
             | "adl/tools/test_run_pr_fast_test_lane.sh"
+            | "adl/config/validation_lane_selector.v0.91.6.json"
+            | "adl/tools/select_validation_lanes.py"
+            | "adl/tools/select_validation_lanes.sh"
+            | "adl/tools/test_select_validation_lanes.sh"
             | "adl/tools/run_owner_validation_lane.sh"
             | "adl/tools/test_owner_validation_lane.sh"
             | "adl/tools/test_cli_wrapper_migration_contract.sh"
@@ -1626,6 +1637,17 @@ fn finish_path_needs_ci_policy_focused_validation(path: &str) -> bool {
             | "adl/tools/test_ci_path_policy.sh"
             | "adl/tools/run_pr_fast_test_lane.sh"
             | "adl/tools/test_run_pr_fast_test_lane.sh"
+    )
+}
+
+fn finish_path_needs_validation_selector_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/config/validation_lane_selector.v0.91.6.json"
+            | "adl/tools/select_validation_lanes.py"
+            | "adl/tools/select_validation_lanes.sh"
+            | "adl/tools/test_select_validation_lanes.sh"
     )
 }
 
@@ -1993,6 +2015,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_run_pr_fast_test_lane.sh" => {
                     let script = repo_root.join("adl/tools/test_run_pr_fast_test_lane.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_select_validation_lanes.sh" => {
+                    let script = repo_root.join("adl/tools/test_select_validation_lanes.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1727,6 +1727,69 @@ fn finish_helper_paths_run_pr_fast_lane_validation() {
 }
 
 #[test]
+fn finish_helper_paths_run_validation_selector_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-validation-selector-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_select_validation_lanes.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' selector >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/config/validation_lane_selector.v0.91.6.json,adl/tools/select_validation_lanes.py,adl/tools/select_validation_lanes.sh,adl/tools/test_select_validation_lanes.sh",
+    )
+    .expect("validation selector plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("validation selector validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "validation selector focused validation should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("selector"));
+}
+
+#[test]
 fn finish_helper_paths_run_narrow_finish_focused_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-narrow-focused-validation");

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -7,6 +7,7 @@ HEAD_SHA=""
 CHANGED_FILES_FILE=""
 GITHUB_OUTPUT_PATH=""
 PRINT_PLAN=false
+JSON_OUTPUT=false
 
 usage() {
   cat <<'USAGE'
@@ -20,6 +21,7 @@ Options:
                                "path" or "STATUS<TAB>path".
   --github-output <path>       Emit key=value outputs for GitHub Actions.
   --print-plan                 Print the computed plan and exit.
+  --json                       Emit the computed plan as JSON and exit.
   -h, --help                   Show this help.
 
 This script selects the ordinary PR-fast non-coverage Rust test lane.
@@ -52,6 +54,10 @@ while [ "$#" -gt 0 ]; do
       PRINT_PLAN=true
       shift
       ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -67,7 +73,9 @@ done
 emit() {
   local key="$1"
   local value="$2"
-  printf '%s=%s\n' "$key" "$value"
+  if [ "$JSON_OUTPUT" != true ]; then
+    printf '%s=%s\n' "$key" "$value"
+  fi
   if [ -n "$GITHUB_OUTPUT_PATH" ]; then
     printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT_PATH"
   fi
@@ -513,6 +521,46 @@ emit "structural_surface_count" "$structural_surface_count"
 emit "slow_proof_inventory_surface_count" "$slow_proof_inventory_surface_count"
 emit "filter_tokens" "$filter_tokens"
 emit "filter_expression" "$filter_expression"
+
+if [ "$JSON_OUTPUT" = true ]; then
+  python3 - <<'PY' \
+    "$mode" \
+    "$reason" \
+    "$rust_surface_count" \
+    "$structural_surface_count" \
+    "$slow_proof_inventory_surface_count" \
+    "$filter_tokens" \
+    "$filter_expression"
+import json
+import sys
+
+(
+    mode,
+    reason,
+    rust_surface_count,
+    structural_surface_count,
+    slow_proof_inventory_surface_count,
+    filter_tokens,
+    filter_expression,
+) = sys.argv[1:]
+
+print(json.dumps(
+    {
+        "schema_version": "adl.pr_fast_lane_plan.v1",
+        "mode": mode,
+        "reason": reason,
+        "rust_surface_count": int(rust_surface_count),
+        "structural_surface_count": int(structural_surface_count),
+        "slow_proof_inventory_surface_count": int(slow_proof_inventory_surface_count),
+        "filter_tokens": filter_tokens,
+        "filter_expression": filter_expression,
+    },
+    indent=2,
+    sort_keys=True,
+))
+PY
+  exit 0
+fi
 
 if [ "$PRINT_PLAN" = true ]; then
   exit 0

--- a/adl/tools/select_validation_lanes.py
+++ b/adl/tools/select_validation_lanes.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Select the smallest ADL validation lane plan for a changed-file set."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
+
+
+def fail(message: str) -> None:
+    print(f"select_validation_lanes: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def normalize_row(row: str) -> str | None:
+    row = row.strip()
+    if not row:
+        return None
+    parts = row.split("\t")
+    if len(parts) == 1:
+        return parts[0]
+    if parts[0].startswith("R") and len(parts) >= 3:
+        return parts[2]
+    if len(parts) >= 2:
+        return parts[1]
+    return None
+
+
+def changed_paths_from_file(path: Path) -> list[str]:
+    return [
+        normalized
+        for line in path.read_text().splitlines()
+        if (normalized := normalize_row(line))
+    ]
+
+
+def changed_paths_from_git(base: str, head: str, include_worktree: bool) -> list[str]:
+    if include_worktree:
+        cmd = ["git", "-C", str(ROOT), "diff", "--name-status", "--diff-filter=ACMR", base, "--"]
+        result = subprocess.run(cmd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        untracked = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "--others", "--exclude-standard"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        rows = result.stdout.splitlines() + untracked.stdout.splitlines()
+        return [
+            normalized
+            for line in rows
+            if (normalized := normalize_row(line))
+        ]
+    else:
+        cmd = [
+            "git",
+            "-C",
+            str(ROOT),
+            "diff",
+            "--name-status",
+            "--diff-filter=ACMR",
+            f"{base}...{head}",
+        ]
+    result = subprocess.run(cmd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    if result.returncode != 0 and not include_worktree:
+        result = subprocess.run(
+            ["git", "-C", str(ROOT), "diff", "--name-status", "--diff-filter=ACMR", base, head],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    return [
+        normalized
+        for line in result.stdout.splitlines()
+        if (normalized := normalize_row(line))
+    ]
+
+
+def matches(path: str, hints: list[str]) -> bool:
+    return any(path == hint or fnmatch.fnmatch(path, hint) for hint in hints)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = json.loads(path.read_text())
+    if manifest.get("schema_version") != "adl.validation_lane_selector.v1":
+        fail(f"{path}: unsupported schema_version")
+    for key in ("lanes", "release_gate_hints", "rust_path_hints"):
+        if key not in manifest:
+            fail(f"{path}: missing required key: {key}")
+    lane_ids: set[str] = set()
+    for index, lane in enumerate(manifest["lanes"]):
+        if not isinstance(lane, dict):
+            fail(f"{path}: lanes[{index}] must be an object")
+        for key in ("id", "lane_class", "path_hints", "command", "reason"):
+            if key not in lane:
+                fail(f"{path}: lanes[{index}] missing required key: {key}")
+        if lane["id"] in lane_ids:
+            fail(f"{path}: duplicate lane id: {lane['id']}")
+        lane_ids.add(lane["id"])
+        if not isinstance(lane["path_hints"], list) or not lane["path_hints"]:
+            fail(f"{path}: lane {lane['id']} path_hints must be a non-empty array")
+        if "run_command" in lane and not isinstance(lane["run_command"], str):
+            fail(f"{path}: lane {lane['id']} run_command must be a string")
+    for key in ("release_gate_hints", "rust_path_hints"):
+        if not isinstance(manifest[key], list):
+            fail(f"{path}: {key} must be an array")
+    return manifest
+
+
+def pr_fast_plan(changed_files: Path | None, base: str, head: str) -> dict[str, str]:
+    cmd = ["bash", "adl/tools/run_pr_fast_test_lane.sh", "--print-plan", "--json"]
+    if changed_files is not None:
+        cmd.extend(["--changed-files", str(changed_files)])
+    else:
+        cmd.extend(["--base", base, "--head", head])
+    result = subprocess.run(cmd, cwd=ROOT, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        fail(f"run_pr_fast_test_lane failed while planning Rust validation: {result.stderr.strip()}")
+    try:
+        plan = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        fail(f"run_pr_fast_test_lane returned invalid JSON: {exc}")
+    if plan.get("schema_version") != "adl.pr_fast_lane_plan.v1":
+        fail("run_pr_fast_test_lane returned unsupported JSON schema")
+    return plan
+
+
+def select_lanes(
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    paths: list[str],
+    changed_files: Path | None,
+    base: str,
+    head: str,
+) -> dict[str, Any]:
+    selected: dict[str, dict[str, Any]] = {}
+
+    release_gate_paths = [
+        path for path in paths if matches(path, manifest["release_gate_hints"])
+    ]
+
+    for path in paths:
+        for lane in manifest["lanes"]:
+            if matches(path, lane["path_hints"]):
+                lane_id = lane["id"]
+                entry = selected.setdefault(
+                    lane_id,
+                    {
+                        "lane_class": lane["lane_class"],
+                        "status": "selected",
+                        "reason": lane["reason"],
+                        "command": lane["command"],
+                        "run_command": lane.get("run_command", lane["command"]),
+                        "matched_paths": [],
+                    },
+                )
+                entry["matched_paths"].append(path)
+                break
+
+    rust_paths = [
+        path
+        for path in paths
+        if matches(path, manifest["rust_path_hints"])
+        and not path.endswith("/README.md")
+        and not path.endswith(".md")
+    ]
+    if rust_paths:
+        fast_plan = pr_fast_plan(changed_files, base, head)
+        mode = fast_plan.get("mode", "full")
+        reason = fast_plan.get("reason", "missing_pr_fast_reason")
+        status = "selected" if mode in {"focused", "family", "contract_only"} else "escalated"
+        command = "bash adl/tools/run_pr_fast_test_lane.sh"
+        if changed_files is not None:
+            command += f" --changed-files {shlex.quote(str(changed_files))}"
+        else:
+            command += f" --base {shlex.quote(base)} --head {shlex.quote(head)}"
+        selected["rust_pr_fast"] = {
+            "lane_class": "fast_unit" if status == "selected" else "release_gate",
+            "status": status,
+            "reason": reason,
+            "command": command,
+            "run_command": command,
+            "matched_paths": rust_paths,
+            "mode": mode,
+            "filter_tokens": fast_plan.get("filter_tokens", ""),
+            "filter_expression": fast_plan.get("filter_expression", ""),
+        }
+
+    if release_gate_paths:
+        selected["release_gate_review"] = {
+            "lane_class": "release_gate",
+            "status": "release_gate_required",
+            "reason": "changed_surface_requires_release_or_ci_policy_review",
+            "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+            "run_command": "",
+            "matched_paths": release_gate_paths,
+        }
+
+    aggregate = "skipped"
+    for lane in selected.values():
+        if lane["status"] == "escalated":
+            aggregate = "escalated"
+            break
+        if lane["status"] == "release_gate_required":
+            aggregate = "release_gate_required"
+        elif aggregate == "skipped" and lane["status"] == "selected":
+            aggregate = "selected"
+
+    sufficient = aggregate == "selected"
+    return {
+        "schema_version": "adl.validation_lane_plan.v1",
+        "manifest_path": str(manifest_path.relative_to(ROOT)) if manifest_path.is_relative_to(ROOT) else str(manifest_path),
+        "changed_paths": paths,
+        "aggregate_status": aggregate,
+        "pr_publication_sufficient": sufficient,
+        "lanes": selected,
+    }
+
+
+def print_text(plan: dict[str, Any]) -> None:
+    print("Validation lane plan")
+    print(f"  aggregate_status={plan['aggregate_status']}")
+    print(f"  pr_publication_sufficient={str(plan['pr_publication_sufficient']).lower()}")
+    if not plan["lanes"]:
+        print("  - no lanes selected")
+        return
+    for lane_id, lane in plan["lanes"].items():
+        print(
+            f"  - {lane_id} status={lane['status']} class={lane['lane_class']} reason={lane['reason']}"
+        )
+        if lane.get("mode"):
+            print(f"    mode={lane['mode']}")
+        if lane.get("filter_expression"):
+            print(f"    filter_expression={lane['filter_expression']}")
+        print(f"    command={lane['command']}")
+        if lane.get("run_command") and lane.get("run_command") != lane.get("command"):
+            print(f"    run_command={lane['run_command']}")
+        for path in lane["matched_paths"]:
+            print(f"    path={path}")
+
+
+def write_report(path: Path, plan: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+
+
+def run_selected_lanes(plan: dict[str, Any]) -> int:
+    if plan["aggregate_status"] != "selected":
+        print_text(plan)
+        print(
+            "select_validation_lanes: refusing --run because the plan is not fully selected",
+            file=sys.stderr,
+        )
+        return 1
+
+    failed = False
+    for lane_id, lane in plan["lanes"].items():
+        command = lane.get("run_command") or lane.get("command")
+        if not command:
+            lane["run_status"] = "skipped"
+            lane["run_reason"] = "no_run_command"
+            continue
+        print(f"==> {lane_id}: {command}", file=sys.stderr)
+        result = subprocess.run(command, cwd=ROOT, shell=True)
+        if result.returncode == 0:
+            lane["run_status"] = "passed"
+            lane["run_reason"] = "command_succeeded"
+        else:
+            lane["run_status"] = "failed"
+            lane["run_reason"] = f"exit_code_{result.returncode}"
+            failed = True
+
+    plan["run_status"] = "failed" if failed else "passed"
+    return 1 if failed else 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--changed-files")
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--include-working-tree", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--run", action="store_true")
+    parser.add_argument("--report-out")
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = ROOT / manifest_path
+    manifest = load_manifest(manifest_path)
+
+    changed_file_path = Path(args.changed_files).resolve() if args.changed_files else None
+    if changed_file_path is not None:
+        paths = changed_paths_from_file(changed_file_path)
+    else:
+        paths = changed_paths_from_git(args.base, args.head, args.include_working_tree)
+
+    plan = select_lanes(manifest_path, manifest, paths, changed_file_path, args.base, args.head)
+    exit_code = 0
+    if args.run:
+        exit_code = run_selected_lanes(plan)
+    if args.report_out:
+        write_report(Path(args.report_out), plan)
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        print_text(plan)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/adl/tools/select_validation_lanes.sh
+++ b/adl/tools/select_validation_lanes.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+python3 "$ROOT/adl/tools/select_validation_lanes.py" "$@"

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -24,6 +24,16 @@ assert_has "$focused_runtime_output" "mode=focused"
 assert_has "$focused_runtime_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$focused_runtime_output" "filter_tokens=contract_schema"
 assert_has "$focused_runtime_output" "filter_expression=test(contract_schema)"
+bash "$SCRIPT" --changed-files "$focused_runtime" --print-plan --json >"$TMP/focused-runtime.json"
+python3 - <<'PY' "$TMP/focused-runtime.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["schema_version"] == "adl.pr_fast_lane_plan.v1"
+assert plan["mode"] == "focused"
+assert plan["filter_expression"] == "test(contract_schema)"
+PY
 
 focused_control_plane="$TMP/focused_control_plane.txt"
 printf 'M\tdocs/default_workflow.md\n' >"$focused_control_plane"

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/select_validation_lanes.sh"
+TMP="$(mktemp -d)"
+UNTRACKED_FIXTURE="$ROOT/docs/architecture/__selector_untracked_fixture__.md"
+trap 'rm -rf "$TMP" "$UNTRACKED_FIXTURE"' EXIT
+
+assert_has() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -- "$needle" "$file" >/dev/null; then
+    echo "expected $file to contain: $needle" >&2
+    echo "actual output:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_has() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -- "$needle" "$file" >/dev/null; then
+    echo "expected $file not to contain: $needle" >&2
+    echo "actual output:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+docs_only="$TMP/docs-only.txt"
+printf 'M\tdocs/milestones/v0.91.6/README.md\n' >"$docs_only"
+bash "$SCRIPT" --changed-files "$docs_only" >"$TMP/docs.out"
+assert_has "$TMP/docs.out" "aggregate_status=selected"
+assert_has "$TMP/docs.out" "docs_diff_check status=selected"
+assert_not_has "$TMP/docs.out" "rust_pr_fast"
+
+prompt_template="$TMP/prompt-template.txt"
+printf 'M\tdocs/templates/prompts/current.json\n' >"$prompt_template"
+bash "$SCRIPT" --changed-files "$prompt_template" >"$TMP/prompt.out"
+assert_has "$TMP/prompt.out" "prompt_template_contracts status=selected"
+assert_not_has "$TMP/prompt.out" "docs_diff_check status=selected"
+
+focused_rust="$TMP/focused-rust.txt"
+printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$focused_rust"
+bash "$SCRIPT" --changed-files "$focused_rust" >"$TMP/focused.out"
+assert_has "$TMP/focused.out" "rust_pr_fast status=selected"
+assert_has "$TMP/focused.out" "mode=focused"
+assert_has "$TMP/focused.out" "filter_expression=test(contract_schema)"
+assert_not_has "$TMP/focused.out" "runtime_owner_lane status=selected"
+
+focused_rust_with_space="$TMP/focused rust paths.txt"
+printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$focused_rust_with_space"
+focused_rust_with_space_resolved="$(python3 - <<'PY' "$focused_rust_with_space"
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve())
+PY
+)"
+bash "$SCRIPT" --changed-files "$focused_rust_with_space" >"$TMP/focused-space.out"
+assert_has "$TMP/focused-space.out" "rust_pr_fast status=selected"
+assert_has "$TMP/focused-space.out" "--changed-files '$focused_rust_with_space_resolved'"
+
+shared_rust="$TMP/shared-rust.txt"
+printf 'M\tadl/src/lib.rs\n' >"$shared_rust"
+bash "$SCRIPT" --changed-files "$shared_rust" >"$TMP/shared.out"
+assert_has "$TMP/shared.out" "aggregate_status=escalated"
+assert_has "$TMP/shared.out" "rust_pr_fast status=escalated"
+
+release_gate="$TMP/release-gate.txt"
+printf 'M\t.github/workflows/ci.yaml\n' >"$release_gate"
+bash "$SCRIPT" --changed-files "$release_gate" >"$TMP/release.out"
+assert_has "$TMP/release.out" "aggregate_status=release_gate_required"
+assert_has "$TMP/release.out" "release_gate_review status=release_gate_required"
+assert_has "$TMP/release.out" "ci_path_policy_contracts status=selected"
+
+bash "$SCRIPT" --changed-files "$focused_rust" --json >"$TMP/focused.json"
+python3 - <<'PY' "$TMP/focused.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["schema_version"] == "adl.validation_lane_plan.v1"
+assert plan["lanes"]["rust_pr_fast"]["mode"] == "focused"
+assert plan["pr_publication_sufficient"] is True
+PY
+
+report="$TMP/report.json"
+bash "$SCRIPT" --changed-files "$focused_rust" --json --report-out "$report" >/dev/null
+python3 - <<'PY' "$report"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["lanes"]["rust_pr_fast"]["status"] == "selected"
+PY
+
+if bash "$SCRIPT" --changed-files "$shared_rust" --run >"$TMP/refuse.out" 2>"$TMP/refuse.err"; then
+  echo "expected --run to refuse an escalated plan" >&2
+  exit 1
+fi
+assert_has "$TMP/refuse.err" "refusing --run because the plan is not fully selected"
+
+printf '# selector untracked fixture\n' >"$UNTRACKED_FIXTURE"
+bash "$SCRIPT" --include-working-tree >"$TMP/include-working-tree.out"
+assert_has "$TMP/include-working-tree.out" "path=docs/architecture/__selector_untracked_fixture__.md"
+
+run_docs="$TMP/run-docs.txt"
+printf 'M\tdocs/architecture/VALIDATION_LANE_SELECTOR.md\n' >"$run_docs"
+bash "$SCRIPT" --changed-files "$run_docs" --run --report-out "$TMP/run-docs-report.json" >/dev/null
+python3 - <<'PY' "$TMP/run-docs-report.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["run_status"] == "passed"
+assert plan["lanes"]["docs_diff_check"]["run_status"] == "passed"
+PY
+
+echo "PASS test_select_validation_lanes"

--- a/docs/architecture/VALIDATION_LANE_SELECTOR.md
+++ b/docs/architecture/VALIDATION_LANE_SELECTOR.md
@@ -1,0 +1,67 @@
+# Validation Lane Selector
+
+ADL keeps the full validation surface available, but normal PR work should run
+the smallest proving lane for the changed surface.
+
+Use:
+
+```bash
+bash adl/tools/select_validation_lanes.sh --changed-files /path/to/changed-files
+```
+
+or, for a branch diff:
+
+```bash
+bash adl/tools/select_validation_lanes.sh --base origin/main --head HEAD
+```
+
+During local authoring, include tracked working-tree changes and untracked new
+files with:
+
+```bash
+bash adl/tools/select_validation_lanes.sh --include-working-tree
+```
+
+The selector reads `adl/config/validation_lane_selector.v0.91.6.json`, classifies
+changed paths, and prints a lane plan. It does not make GitHub or CI the source
+of C-SDLC truth. It gives local and PR tooling a deterministic answer for which
+focused validation commands are sufficient, which release gates remain required,
+and which ambiguous Rust surfaces must escalate.
+
+To write machine-readable proof:
+
+```bash
+bash adl/tools/select_validation_lanes.sh \
+  --changed-files /path/to/changed-files \
+  --json \
+  --report-out /path/to/validation-lane-plan.json
+```
+
+To run only the selected lanes:
+
+```bash
+bash adl/tools/select_validation_lanes.sh --changed-files /path/to/changed-files --run
+```
+
+`--run` refuses plans with `escalated` or `release_gate_required` aggregate
+status. That keeps the selector from turning a focused proof into a false green
+when the change actually needs broader validation or release-gate handling.
+
+For Rust source paths, the selector delegates filter computation to
+`adl/tools/run_pr_fast_test_lane.sh --print-plan` so the existing focused
+nextest mapping remains the single implementation of Rust test-filter policy.
+
+The first slice is intentionally small:
+
+- docs paths select diff hygiene unless the path belongs to prompt/template or
+  validation-policy surfaces
+- ordinary Rust paths select the existing PR-fast focused or family lane
+- owner-binary and owner-compatibility paths select owner lanes
+- shared Rust paths escalate instead of pretending a small filter is enough
+- release/CI-policy paths report `release_gate_required`
+- credential and live-provider lanes remain outside ordinary PR validation
+
+Future work should add a validation manager agent on top of this selector. That
+agent should create a tailored test profile whenever an issue is sent to PR,
+handling each issue case separately while consuming this selector as policy
+input. The selector itself should stay deterministic and boring.


### PR DESCRIPTION
Closes #4199

## Summary
Implemented a deterministic validation lane selector for `v0.91.6` tooling work.
The selector reads a tracked manifest, classifies changed paths, delegates Rust
filter computation to structured PR-fast JSON, emits text or JSON lane plans,
optionally writes a report, and refuses `--run` for escalated or release-gated
plans. The later validation-manager agent remains follow-on work and was not
implemented in this issue.

## Artifacts
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/tools/select_validation_lanes.py`
- `adl/tools/select_validation_lanes.sh`
- `adl/tools/test_select_validation_lanes.sh`
- `docs/architecture/VALIDATION_LANE_SELECTOR.md`
- Updated `adl/tools/run_pr_fast_test_lane.sh` with `adl.pr_fast_lane_plan.v1`
  JSON plan output.
- Updated `adl/tools/test_run_pr_fast_test_lane.sh` with JSON contract coverage.
- Updated `adl/src/cli/pr_cmd/finish_support.rs` and
  `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` so `pr finish`
  recognizes selector-path changes and runs the selector-focused validation
  lane instead of failing as unclassified.

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace/diff hygiene.
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`
    Verified selector manifest JSON syntax.
  - `python3 -m py_compile adl/tools/select_validation_lanes.py`
    Verified selector Python syntax.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector classification, fail-closed behavior, structured report
    output, optional execution behavior, shell quoting, and untracked-file
    handling.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified PR-fast lane behavior and the new structured JSON contract.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_helper_paths_run_validation_selector_validation`
    Verified the finish classifier regression for selector-path changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Implements a manifest-driven validation lane selector for focused PR validation.\n\nCloses #4199

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4199__v0-91-6-tools-quality-add-manifest-driven-validation-lane-selector-and-test-shepherd/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4199__v0-91-6-tools-quality-add-manifest-driven-validation-lane-selector-and-test-shepherd/sor.md
- Idempotency-Key: v0-91-6-tools-quality-add-manifest-driven-validation-lane-selector-adl-v0-91-6-tasks-issue-4199-v0-91-6-tools-quality-add-manifest-driven-validation-lane-selector-and-test-shepherd-sip-md-adl-v0-91-6-tasks-issue-4199-v0-91-6-tools-quality-add-manifest-driven-validation-lane-selector-and-test-shepherd-sor-md