### PR TITLE
[v0.91.6][WP-09][observatory][O-05] Complete working Unity Observatory closeout proof

### DIFF
--- a/docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Observatory And Unity Consumption Classification
 - Milestone Target: `v0.91.6`
-- Status: planned
+- Status: closeout_proof_authored_with_open_wp09_residuals
 - Owner: ADL maintainers
 - Doc Role: primary
 - Feature Types: policy, artifact
@@ -73,3 +73,39 @@ surface marked rehearsal or substrate cannot prove activation by itself.
   ingestion security, and working Unity closeout remain open dependencies until
   the WP-09 issue set lands its own reviewed proof, and identity-safe
   inhabitant display also remains dependent on open WP-08 issue `#3973`.
+
+## Current WP-09 Closeout Posture
+
+WP-09 closeout proof is now authored, but WP-09 is not closeout-clean.
+
+Current live issue truth on the closeout date:
+
+| Surface | Owner | Current state | Closeout implication |
+| --- | --- | --- | --- |
+| Unity Observatory baseline definition | `#4030` | open | Working-baseline truth is still issue-owned rather than terminally closed |
+| Launchable Unity Observatory baseline | `#4031` | open | Governed launch surface is not yet closed |
+| Observatory evidence data contract | `#4032` | open | Ingestion contract remains an active dependency |
+| Inhabitant-readiness surfaces | `#4033` | open | Inhabitant-facing display/input remains open |
+| Logging/OTel/security consumption proof | `#4034` | open | Security/OTel consumption closure remains open |
+| Working Unity Observatory closeout proof | `#4035` | open | This issue records the closeout posture and residual truth rather than forcing false completion |
+| WP-09 umbrella | `#3974` | open | The sprint must remain open until the child issue set lands reviewed closure truth |
+
+The authoritative closeout packet for this posture is:
+
+- `docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md`
+
+## v0.92 Consumption Rule
+
+`v0.92` may consume this feature surface only as:
+
+- a classification and routing contract for Observatory/Unity proof posture;
+- a reference to bounded security-consumption inputs from WP-07;
+- a non-claim that WP-09 remains open until `#4030` through `#4035` reach
+  terminal reviewed truth.
+
+`v0.92` may not consume this feature surface as proof that:
+
+- the Unity Observatory is fully working and launch-ready;
+- inhabitant-facing display or input is security-cleared;
+- Observatory ingestion and logging/OTel consumption is fully closed;
+- WP-09 is ready for umbrella closure.

--- a/docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md
+++ b/docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md
@@ -1,0 +1,107 @@
+# WP-09 Working Unity Observatory Closeout Proof for #4035
+
+## Scope
+
+This packet records the truthful closeout posture for WP-09 Observatory/Unity
+consumption work at issue `#4035`.
+
+It is a closeout-proof and residual-routing packet, not evidence that WP-09 is
+complete today.
+
+## Source evidence
+
+- `docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md`
+- `docs/milestones/v0.91.6/review/security/UNITY_OBSERVATORY_INHABITANT_READINESS_SECURITY_REVIEW_4023.md`
+- `docs/milestones/v0.91.6/review/logging_observability/OTEL_OBSERVATORY_CONSUMPTION_PROOF_3999.md`
+- `docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_ACTIVE_SPRINT_EXECUTION_PACKETS_2026-06-18.md`
+- live issue state for `#3974` and `#4030` through `#4035`
+
+## Review goal
+
+Determine whether WP-09 can honestly close in `v0.91.6`, and if not, leave a
+reviewable closeout record that identifies what is already consumable, what
+remains open, and how later milestone work must treat those residuals.
+
+## Live issue state
+
+| Issue | Role | Live state | Closeout meaning |
+| --- | --- | --- | --- |
+| `#4030` | Unity Observatory baseline definition | open | Working baseline remains an open implementation truth surface |
+| `#4031` | Launchable Unity Observatory baseline | open | Launch-ready baseline has not reached terminal reviewed closure |
+| `#4032` | ADL evidence data contract for Observatory | open | Observatory ingestion contract remains open |
+| `#4033` | Inhabitant-readiness surfaces | open | Inhabitant-facing readiness remains open |
+| `#4034` | Logging/OTel/security consumption proof | open | Observatory consumption proof remains open |
+| `#4035` | Working Unity Observatory closeout proof | open | This issue records the residual posture |
+| `#3974` | WP-09 umbrella | open | Umbrella closure is not yet justified |
+
+## What is already proved enough to consume
+
+- WP-07 security review `#4023` provides a bounded security-consumption floor
+  for Unity Observatory and Observatory-ingestion posture.
+- The event-stream and logging-redaction proof surfaces consumed by `#4023`
+  establish a limited vocabulary/redaction floor for later consumers.
+- The Observatory/Unity feature doc now explicitly records that WP-09 remains
+  open and that rehearsal/planning/security-input evidence must not be mistaken
+  for implementation closure.
+
+## What is not proved
+
+The current repository and live issue state do not prove:
+
+- complete WP-09 Unity Observatory implementation;
+- launch-ready working Unity Observatory behavior;
+- closed Observatory evidence-ingestion contract;
+- closed inhabitant-facing readiness and input/output safety;
+- closed logging/OTel/security consumption posture for Observatory;
+- readiness to close umbrella `#3974`.
+
+## Closeout classification
+
+Current decision:
+
+- `wp09_closeout_not_ready_residuals_explicit`
+
+This means:
+
+- `#4035` may close only as a truthful proof-and-routing issue if reviewers
+  accept that its deliverable is the closeout packet rather than fake sprint
+  completion;
+- umbrella `#3974` must remain open until the child issue set lands real
+  reviewed completion or explicit deferred routing through the normal sprint
+  process.
+
+## Residual ownership
+
+| Residual surface | Owner | Required truth before WP-09 umbrella closeout |
+| --- | --- | --- |
+| Working baseline definition | `#4030` | Baseline scope and proof must be terminally reviewed |
+| Launchable Unity baseline | `#4031` | Launch surface must be evidenced and reviewed |
+| Observatory ingestion contract | `#4032` | Data contract and evidence-ingestion limits must be explicit |
+| Inhabitant-facing readiness | `#4033` | Display/input surfaces must be reviewable and bounded |
+| Logging/OTel/security consumption | `#4034` | Observatory consumption proof must land with explicit security posture |
+| Identity-safe inhabitant display dependency | `#3973` | WP-08 identity boundary must not be silently assumed complete |
+
+## v0.92 consumption rule
+
+Later milestone work may consume this packet as proof that:
+
+- WP-09 closeout truth has been authored for review with explicit residual
+  ownership;
+- the current state is explicitly open rather than ambiguous;
+- residual ownership is named and retained.
+
+Later milestone work may not consume this packet as proof that:
+
+- the Unity Observatory is complete;
+- the observatory sprint is closed;
+- inhabitant-facing or ingestion-facing security work is fully landed.
+
+## Reviewer takeaway
+
+`#4035` is successful if reviewers can confirm that:
+
+- the packet truthfully shows WP-09 as still open;
+- the feature doc no longer leaves closeout posture implicit;
+- the packet names the open owners instead of smearing partial proof into false
+  closure;
+- umbrella `#3974` remains open pending real downstream closure truth.


### PR DESCRIPTION
## Summary
- add the WP-09 closeout-proof packet for the Unity Observatory wave
- update the Observatory/Unity feature doc with explicit live closeout posture and v0.92 consumption limits
- preserve truthful open residual routing so WP-09 and umbrella #3974 are not overclaimed as complete

## Validation
- `git diff --check`
- `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.6/tasks/issue-4035__v0-91-6-wp-09-observatory-o-05-complete-working-unity-observatory-closeout-proof/srp.md`
- `bash adl/tools/validate_structured_prompt.sh --type sor --phase closeout --input .adl/v0.91.6/tasks/issue-4035__v0-91-6-wp-09-observatory-o-05-complete-working-unity-observatory-closeout-proof/sor.md`

Closes #4035