### PR TITLE
[v0.91.6][runtime][tokio] Consolidate runtime bootstrap and supervision boundaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,13 +368,13 @@ jobs:
           bash adl/tools/check_coverage_impact.sh \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}" \
-            --print-risk-filters > adl/coverage-impact-filters.txt
-          if test -s adl/coverage-impact-filters.txt; then
+            --print-risk-nextest-expression > adl/coverage-impact-filter-expression.txt
+          if test -s adl/coverage-impact-filter-expression.txt; then
             echo "needs_fast_summary=true" >> "$GITHUB_OUTPUT"
-            echo "filters=$(paste -sd' ' adl/coverage-impact-filters.txt)" >> "$GITHUB_OUTPUT"
+            echo "filter_expression=$(cat adl/coverage-impact-filter-expression.txt)" >> "$GITHUB_OUTPUT"
           else
             echo "needs_fast_summary=false" >> "$GITHUB_OUTPUT"
-            echo "filters=" >> "$GITHUB_OUTPUT"
+            echo "filter_expression=" >> "$GITHUB_OUTPUT"
           fi
         working-directory: .
 
@@ -444,7 +444,7 @@ jobs:
       - name: PR fast coverage summary (json)
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'
         run: |
-          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -- ${{ steps.coverage-impact.outputs.filters }}
+          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E "${{ steps.coverage-impact.outputs.filter_expression }}"
           cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
 
       - name: Coverage-impact changed-source gate

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod run_artifacts_types;
 mod runtime_v2_cmd;
 #[cfg(test)]
 mod tests;
+mod tokio_runtime;
 mod tooling_cmd;
 mod usage;
 

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -10,6 +10,7 @@ use crate::cli::pr_cmd::github_client::{
 };
 use crate::cli::pr_cmd_args::IssueStateFilter;
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
+use crate::cli::tokio_runtime::with_current_thread_runtime;
 use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -520,22 +521,16 @@ fn with_octocrab<T>(
     operation: &str,
     f: impl FnOnce(&tokio::runtime::Runtime, octocrab::Octocrab) -> Result<T>,
 ) -> Result<T> {
-    let runtime = build_octocrab_runtime(operation)?;
-    let _runtime_guard = runtime.enter();
-    let client = github_client(operation)?;
-    let octo = client
-        .octocrab()
-        .map_err(|err| anyhow!("github_client.octocrab_build: {err}"))?;
-    f(&runtime, octo)
-}
-
-fn build_octocrab_runtime(operation: &str) -> Result<tokio::runtime::Runtime> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .with_context(|| {
-            format!("github_client.octocrab_runtime: failed to build runtime for {operation}")
-        })
+    with_current_thread_runtime(
+        &format!("github_client.octocrab_runtime: failed to build runtime for {operation}"),
+        |runtime| {
+            let client = github_client(operation)?;
+            let octo = client
+                .octocrab()
+                .map_err(|err| anyhow!("github_client.octocrab_build: {err}"))?;
+            f(runtime, octo)
+        },
+    )
 }
 
 fn run_octocrab_capture(operation: &str, args: &[&str]) -> Result<String> {

--- a/adl/src/cli/pr_cmd/github/tests.rs
+++ b/adl/src/cli/pr_cmd/github/tests.rs
@@ -80,11 +80,11 @@ fn restore_github_policy_env(saved: Vec<(&'static str, Option<String>)>) {
     }
 }
 
-fn reserve_local_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local port");
-    let port = listener.local_addr().expect("local addr").port();
-    drop(listener);
-    port
+fn bind_test_http_server(context: &str) -> (String, Server) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect(context);
+    let addr = listener.local_addr().expect("local addr");
+    let server = Server::from_listener(listener, None).expect("construct tiny_http server");
+    (format!("http://{addr}"), server)
 }
 
 fn json_response(body: impl Into<String>) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -232,9 +232,7 @@ fn issue_comment_fixture(issue: u32, body: &str) -> String {
 fn spawn_octocrab_test_server(
     expected_requests: usize,
 ) -> (String, thread::JoinHandle<Vec<String>>) {
-    let port = reserve_local_port();
-    let bind_addr = format!("127.0.0.1:{port}");
-    let server = Server::http(&bind_addr).expect("bind octocrab test server");
+    let (base_uri, server) = bind_test_http_server("bind octocrab test server");
     let handle = thread::spawn(move || {
         let mut seen = Vec::new();
         for _ in 0..expected_requests {
@@ -411,13 +409,11 @@ fn spawn_octocrab_test_server(
         }
         seen
     });
-    (format!("http://{bind_addr}"), handle)
+    (base_uri, handle)
 }
 
 fn spawn_transient_octocrab_test_server() -> (String, thread::JoinHandle<Vec<String>>) {
-    let port = reserve_local_port();
-    let bind_addr = format!("127.0.0.1:{port}");
-    let server = Server::http(&bind_addr).expect("bind transient octocrab test server");
+    let (base_uri, server) = bind_test_http_server("bind transient octocrab test server");
     let handle = thread::spawn(move || {
         let mut seen = Vec::new();
         for attempt in 1..=2 {
@@ -446,7 +442,7 @@ fn spawn_transient_octocrab_test_server() -> (String, thread::JoinHandle<Vec<Str
         }
         seen
     });
-    (format!("http://{bind_addr}"), handle)
+    (base_uri, handle)
 }
 
 fn pr_validation_graphql_response(
@@ -502,9 +498,7 @@ fn pr_validation_graphql_response_page(
 }
 
 fn spawn_validation_status_paginated_server() -> (String, thread::JoinHandle<Vec<String>>) {
-    let port = reserve_local_port();
-    let bind_addr = format!("127.0.0.1:{port}");
-    let server = Server::http(&bind_addr).expect("bind validation status pagination server");
+    let (base_uri, server) = bind_test_http_server("bind validation status pagination server");
     let handle = thread::spawn(move || {
         let mut seen = Vec::new();
         for page in 1..=2 {
@@ -540,7 +534,7 @@ fn spawn_validation_status_paginated_server() -> (String, thread::JoinHandle<Vec
         }
         seen
     });
-    (format!("http://{bind_addr}"), handle)
+    (base_uri, handle)
 }
 
 fn spawn_validation_status_once_server(
@@ -548,9 +542,7 @@ fn spawn_validation_status_once_server(
     conclusion: Option<&'static str>,
     check_name: &'static str,
 ) -> (String, thread::JoinHandle<Vec<String>>) {
-    let port = reserve_local_port();
-    let bind_addr = format!("127.0.0.1:{port}");
-    let server = Server::http(&bind_addr).expect("bind validation status single server");
+    let (base_uri, server) = bind_test_http_server("bind validation status single server");
     let handle = thread::spawn(move || {
         let mut seen = Vec::new();
         let Some(mut request) = server
@@ -569,13 +561,11 @@ fn spawn_validation_status_once_server(
         )));
         seen
     });
-    (format!("http://{bind_addr}"), handle)
+    (base_uri, handle)
 }
 
 fn spawn_validation_status_transient_server() -> (String, thread::JoinHandle<Vec<String>>) {
-    let port = reserve_local_port();
-    let bind_addr = format!("127.0.0.1:{port}");
-    let server = Server::http(&bind_addr).expect("bind validation status server");
+    let (base_uri, server) = bind_test_http_server("bind validation status server");
     let handle = thread::spawn(move || {
         let mut seen = Vec::new();
         for attempt in 1..=2 {
@@ -605,7 +595,7 @@ fn spawn_validation_status_transient_server() -> (String, thread::JoinHandle<Vec
         }
         seen
     });
-    (format!("http://{bind_addr}"), handle)
+    (base_uri, handle)
 }
 
 mod helpers;

--- a/adl/src/cli/tokio_runtime.rs
+++ b/adl/src/cli/tokio_runtime.rs
@@ -1,0 +1,17 @@
+use anyhow::{Context, Result};
+
+pub(crate) fn build_current_thread_runtime(context: &str) -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .with_context(|| context.to_string())
+}
+
+pub(crate) fn with_current_thread_runtime<T>(
+    context: &str,
+    f: impl FnOnce(&tokio::runtime::Runtime) -> Result<T>,
+) -> Result<T> {
+    let runtime = build_current_thread_runtime(context)?;
+    let _runtime_guard = runtime.enter();
+    f(&runtime)
+}

--- a/adl/src/cli/tooling_cmd/github_release.rs
+++ b/adl/src/cli/tooling_cmd/github_release.rs
@@ -1,4 +1,5 @@
 use crate::cli::pr_cmd::github_client::{AdlGithubClient, GithubClientBackend};
+use crate::cli::tokio_runtime::with_current_thread_runtime;
 use anyhow::{anyhow, bail, Context, Result};
 use octocrab::models::repos::Release;
 use std::fs;
@@ -119,88 +120,90 @@ fn run_release_action(args: &ReleaseArgs) -> Result<String> {
         .repo
         .split_once('/')
         .ok_or_else(|| anyhow!("github-release --repo must be owner/repo"))?;
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("github_release.octocrab_runtime: failed to build runtime")?;
-    let _guard = runtime.enter();
-    let octo = build_octocrab()?;
-    runtime.block_on(async move {
-        match args.action {
-            ReleaseAction::EnsureAbsent => {
-                if release_by_tag(&octo, owner, repo, &args.tag)
-                    .await?
-                    .is_some()
-                {
-                    bail!("GitHub release already exists for tag {}", args.tag);
+    with_current_thread_runtime(
+        "github_release.octocrab_runtime: failed to build runtime",
+        |runtime| {
+            let octo = build_octocrab()?;
+            runtime.block_on(async move {
+                match args.action {
+                    ReleaseAction::EnsureAbsent => {
+                        if release_by_tag(&octo, owner, repo, &args.tag)
+                            .await?
+                            .is_some()
+                        {
+                            bail!("GitHub release already exists for tag {}", args.tag);
+                        }
+                        Ok(format!("release_absent tag={}", args.tag))
+                    }
+                    ReleaseAction::EnsurePresent => {
+                        let release = release_by_tag(&octo, owner, repo, &args.tag).await?;
+                        if release.is_none() {
+                            bail!("GitHub release does not exist for tag {}", args.tag);
+                        }
+                        Ok(format!("release_present tag={}", args.tag))
+                    }
+                    ReleaseAction::Draft => {
+                        if release_by_tag(&octo, owner, repo, &args.tag)
+                            .await?
+                            .is_some()
+                        {
+                            bail!("GitHub release already exists for tag {}", args.tag);
+                        }
+                        let body = read_notes(args.notes_file.as_ref())?;
+                        let name = args.name.as_deref().unwrap_or(&args.tag);
+                        let repo_handler = octo.repos(owner, repo);
+                        let releases = repo_handler.releases();
+                        let mut builder = releases
+                            .create(&args.tag)
+                            .name(name)
+                            .body(&body)
+                            .draft(true)
+                            .prerelease(false);
+                        if let Some(target) = args.target.as_deref() {
+                            builder = builder.target_commitish(target);
+                        }
+                        let release = builder.send().await.with_context(|| {
+                            format!(
+                                "github_release.octocrab_transport: failed to draft {}",
+                                args.tag
+                            )
+                        })?;
+                        Ok(format!(
+                            "release_drafted tag={} url={}",
+                            release.tag_name, release.html_url
+                        ))
+                    }
+                    ReleaseAction::Publish => {
+                        let release = release_by_tag(&octo, owner, repo, &args.tag)
+                            .await?
+                            .ok_or_else(|| {
+                                anyhow!("GitHub release does not exist for tag {}", args.tag)
+                            })?;
+                        if !release.draft {
+                            bail!("GitHub release for tag {} is not a draft", args.tag);
+                        }
+                        let updated = octo
+                            .repos(owner, repo)
+                            .releases()
+                            .update(release_id_u64(&release)?)
+                            .draft(false)
+                            .send()
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "github_release.octocrab_transport: failed to publish {}",
+                                    args.tag
+                                )
+                            })?;
+                        Ok(format!(
+                            "release_published tag={} url={}",
+                            updated.tag_name, updated.html_url
+                        ))
+                    }
                 }
-                Ok(format!("release_absent tag={}", args.tag))
-            }
-            ReleaseAction::EnsurePresent => {
-                let release = release_by_tag(&octo, owner, repo, &args.tag).await?;
-                if release.is_none() {
-                    bail!("GitHub release does not exist for tag {}", args.tag);
-                }
-                Ok(format!("release_present tag={}", args.tag))
-            }
-            ReleaseAction::Draft => {
-                if release_by_tag(&octo, owner, repo, &args.tag)
-                    .await?
-                    .is_some()
-                {
-                    bail!("GitHub release already exists for tag {}", args.tag);
-                }
-                let body = read_notes(args.notes_file.as_ref())?;
-                let name = args.name.as_deref().unwrap_or(&args.tag);
-                let repo_handler = octo.repos(owner, repo);
-                let releases = repo_handler.releases();
-                let mut builder = releases
-                    .create(&args.tag)
-                    .name(name)
-                    .body(&body)
-                    .draft(true)
-                    .prerelease(false);
-                if let Some(target) = args.target.as_deref() {
-                    builder = builder.target_commitish(target);
-                }
-                let release = builder.send().await.with_context(|| {
-                    format!(
-                        "github_release.octocrab_transport: failed to draft {}",
-                        args.tag
-                    )
-                })?;
-                Ok(format!(
-                    "release_drafted tag={} url={}",
-                    release.tag_name, release.html_url
-                ))
-            }
-            ReleaseAction::Publish => {
-                let release = release_by_tag(&octo, owner, repo, &args.tag)
-                    .await?
-                    .ok_or_else(|| anyhow!("GitHub release does not exist for tag {}", args.tag))?;
-                if !release.draft {
-                    bail!("GitHub release for tag {} is not a draft", args.tag);
-                }
-                let updated = octo
-                    .repos(owner, repo)
-                    .releases()
-                    .update(release_id_u64(&release)?)
-                    .draft(false)
-                    .send()
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "github_release.octocrab_transport: failed to publish {}",
-                            args.tag
-                        )
-                    })?;
-                Ok(format!(
-                    "release_published tag={} url={}",
-                    updated.tag_name, updated.html_url
-                ))
-            }
-        }
-    })
+            })
+        },
+    )
 }
 
 async fn release_by_tag(

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -12,6 +12,7 @@ LARGE_FILE_LINES="${COVERAGE_IMPACT_LARGE_FILE_LINES:-200}"
 LARGE_FILE_DELTA="${COVERAGE_IMPACT_LARGE_FILE_DELTA:-80}"
 REQUIRE_SUMMARY_FOR_RISK=false
 PRINT_RISK_FILTERS=false
+PRINT_RISK_NEXTEST_EXPRESSION=false
 
 usage() {
   cat <<'USAGE'
@@ -29,6 +30,8 @@ Options:
   --require-summary-for-risk      Fail when risky changed Rust files lack summary evidence.
   --print-risk-filters            Print one candidate test filter per changed Rust file that
                                   may need summary evidence and exit.
+  --print-risk-nextest-expression Print one combined nextest filter expression for risky
+                                  changed Rust files and exit.
   -h, --help                      Show this help.
 
 This is a fast authoring-time guard. It does not replace the full GitHub
@@ -69,6 +72,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --print-risk-filters)
       PRINT_RISK_FILTERS=true
+      shift
+      ;;
+    --print-risk-nextest-expression)
+      PRINT_RISK_NEXTEST_EXPRESSION=true
       shift
       ;;
     -h|--help)
@@ -122,12 +129,26 @@ changed_source_rows="$(
 )"
 
 if [ -z "$changed_source_rows" ]; then
-  if [ "$PRINT_RISK_FILTERS" = true ]; then
+  if [ "$PRINT_RISK_FILTERS" = true ] || [ "$PRINT_RISK_NEXTEST_EXPRESSION" = true ]; then
     exit 0
   fi
   echo "Coverage-impact preflight: no changed production adl/src Rust files."
   exit 0
 fi
+
+saw_tokio_bootstrap_related_surface=false
+while IFS=$'\t' read -r _status path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    adl/src/cli/tokio_runtime.rs|\
+    adl/src/cli/pr_cmd/github.rs|\
+    adl/src/cli/tooling_cmd/github_release.rs)
+      saw_tokio_bootstrap_related_surface=true
+      ;;
+  esac
+done <<EOF
+$changed_source_rows
+EOF
 
 line_count_for_path() {
   local path="$1"
@@ -169,8 +190,24 @@ candidate_filter_for_path() {
     adl/src/acc.rs|adl/src/acc/*.rs)
       printf 'acc'
       ;;
+    adl/src/cli/mod.rs)
+      if [ "$saw_tokio_bootstrap_related_surface" = true ]; then
+        printf 'tokio_bootstrap'
+      else
+        printf 'cli'
+      fi
+      ;;
+    adl/src/cli/tokio_runtime.rs)
+      printf 'tokio_bootstrap'
+      ;;
+    adl/src/cli/pr_cmd/github.rs)
+      printf 'pr_cmd'
+      ;;
     adl/src/cli/pr_cmd*|adl/src/cli/tests/pr_cmd*|adl/src/cli/pr_cmd/*|adl/src/cli/pr_cmd_cards.rs|adl/src/cli/pr_cmd_cards/*.rs|docs/default_workflow.md)
       printf 'pr_cmd'
+      ;;
+    adl/src/cli/tooling_cmd/github_release.rs)
+      printf 'github_release_'
       ;;
     adl/src/runtime_v2/cultivating_intelligence.rs|adl/src/runtime_v2/cultivating_intelligence_parts/*.rs)
       printf 'cultivating_intelligence'
@@ -187,7 +224,7 @@ candidate_filter_for_path() {
     adl/src/uts_acc_multi_model_benchmark.rs|adl/src/uts_acc_multi_model_benchmark/*.rs|adl/src/uts_acc_multi_model_benchmark/*/*.rs)
       printf 'uts_acc_multi_model_benchmark::'
       ;;
-    adl/src/cli/mod.rs|adl/src/cli/tests.rs)
+    adl/src/cli/tests.rs)
       printf 'cli'
       ;;
     adl/src/bin/adl_lint_prompt_spec.rs|adl/src/bin/adl_prompt_template.rs|adl/src/bin/adl_validate_structured_prompt.rs)
@@ -202,6 +239,50 @@ candidate_filter_for_path() {
   esac
 }
 
+nextest_expression_for_filter() {
+  local filter="$1"
+  case "$filter" in
+    tokio_bootstrap)
+      printf 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/)'
+      ;;
+    pr_cmd)
+      printf 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)'
+      ;;
+    pr_cmd::github)
+      printf 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/)'
+      ;;
+    github_release_)
+      printf 'test(/^cli::tooling_cmd::github_release::/)'
+      ;;
+    finish)
+      printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)'
+      ;;
+    tooling_cmd)
+      printf 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::/)'
+      ;;
+    cli)
+      printf 'test(cli)'
+      ;;
+    *)
+      printf 'test(%s)' "$filter"
+      ;;
+  esac
+}
+
+combined_nextest_expression_from_filters() {
+  local token expr joined=""
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    expr="$(nextest_expression_for_filter "$token")"
+    if [ -n "$joined" ]; then
+      joined="${joined} or "
+    fi
+    joined="${joined}${expr}"
+  done
+  [ -n "$joined" ] || return 1
+  printf '%s' "$joined"
+}
+
 extra_guidance_for_path() {
   local path="$1"
   case "$path" in
@@ -214,9 +295,17 @@ EOF
   esac
 }
 
+file_is_tokio_bootstrap_companion_surface() {
+  local path="$1"
+  [ "$saw_tokio_bootstrap_related_surface" = true ] || return 1
+  [ "$path" = "adl/src/cli/mod.rs" ]
+}
+
 focused_summary_command_for_filter() {
   local filter="$1"
-  printf 'cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- %s' "$filter"
+  local expression
+  expression="$(nextest_expression_for_filter "$filter")"
+  printf "cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E '%s' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" "$expression"
 }
 
 rerun_preflight_command() {
@@ -266,6 +355,9 @@ file_has_no_executable_surface() {
 risk_rows=""
 while IFS=$'\t' read -r status path; do
   [ -n "$path" ] || continue
+  if file_is_tokio_bootstrap_companion_surface "$path"; then
+    continue
+  fi
   lines="$(line_count_for_path "$path")"
   delta="$(changed_line_delta_for_path "$path")"
   reason=""
@@ -292,6 +384,9 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
   guidance=""
   while IFS=$'\t' read -r _status path; do
     [ -n "$path" ] || continue
+    if file_is_tokio_bootstrap_companion_surface "$path"; then
+      continue
+    fi
     row="$(jq -r --arg path "$path" '
       [
         .data[].files[]
@@ -321,7 +416,7 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
         end
     ' "$SUMMARY")"
     if [ -z "$row" ]; then
-      if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path"; then
+      if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path"; then
         continue
       fi
       missing="${missing}  - ${path} (no coverage row in ${SUMMARY})"$'\n'
@@ -363,13 +458,31 @@ if [ "$PRINT_RISK_FILTERS" = true ]; then
   printf '%s\n' "$changed_source_rows" \
     | while IFS=$'\t' read -r _status path; do
         [ -n "$path" ] || continue
-        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path"; then
+        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path"; then
           continue
         fi
         candidate_filter_for_path "$path"
         printf '\n'
       done \
     | awk 'NF && !seen[$0]++'
+  exit 0
+fi
+
+if [ "$PRINT_RISK_NEXTEST_EXPRESSION" = true ]; then
+  if ! printf '%s\n' "$changed_source_rows" \
+    | while IFS=$'\t' read -r _status path; do
+        [ -n "$path" ] || continue
+        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path"; then
+          continue
+        fi
+        candidate_filter_for_path "$path"
+        printf '\n'
+      done \
+    | awk 'NF && !seen[$0]++' \
+    | combined_nextest_expression_from_filters; then
+    exit 0
+  fi
+  printf '\n'
   exit 0
 fi
 

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -213,8 +213,20 @@ filter_token_for_path() {
       basename "$path" .rs
       return 0
       ;;
-    adl/src/cli/mod.rs|adl/src/cli/tests.rs)
+    adl/src/cli/mod.rs)
+      if [ "$saw_tokio_bootstrap_related_surface" = true ]; then
+        printf 'tokio_bootstrap'
+      else
+        printf 'cli'
+      fi
+      return 0
+      ;;
+    adl/src/cli/tests.rs)
       printf 'cli'
+      return 0
+      ;;
+    adl/src/cli/tokio_runtime.rs)
+      printf 'tokio_bootstrap'
       return 0
       ;;
     adl/src/csdlc_prompt_editor.rs|adl/src/csdlc_prompt_editor/*.rs)
@@ -231,6 +243,10 @@ filter_token_for_path() {
       ;;
     adl/src/cli/tests/artifact_builders/*.rs|adl/src/cli/tests/artifact_builders/*/*.rs)
       printf 'artifact_builders'
+      return 0
+      ;;
+    adl/src/cli/pr_cmd/github.rs|adl/src/cli/pr_cmd/github/*.rs)
+      printf 'pr_cmd::github'
       return 0
       ;;
     adl/src/cli/pr_cmd/finish_support.rs|adl/src/cli/tests/pr_cmd_inline/finish/*)
@@ -255,6 +271,10 @@ filter_token_for_path() {
       ;;
     adl/src/cli/pr_cmd_cards.rs|adl/src/cli/pr_cmd_cards/*.rs)
       printf 'pr_cmd'
+      return 0
+      ;;
+    adl/src/cli/tooling_cmd/github_release.rs)
+      printf 'github_release_'
       return 0
       ;;
     adl/src/cli/tests/tooling_cmd*|adl/src/cli/tooling_cmd*|adl/src/cli/tests/tooling_cmd/*)
@@ -361,12 +381,13 @@ build_filter_expression() {
 import sys
 
 TOKEN_MAP = {
+    "tokio_bootstrap": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/)',
     "pr_cmd": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)',
     "pr_cmd_finish": 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)',
-    "pr_cmd::github": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)',
-    "github_release_": 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)',
-    "long_lived_agent": 'binary_id(adl) and test(/^long_lived_agent::/)',
-    "manifest_support": '(binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)) or (binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)) or (binary_id(adl) and test(/^long_lived_agent::/))',
+    "pr_cmd::github": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/)',
+    "github_release_": 'test(/^cli::tooling_cmd::github_release::/)',
+    "long_lived_agent": 'test(/^long_lived_agent::/)',
+    "manifest_support": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/)',
 }
 
 clauses = []
@@ -412,6 +433,7 @@ all_paths_have_precise_token=true
 all_paths_have_family_token=true
 classification_locked=false
 saw_slow_proof_contract_surface=false
+saw_tokio_bootstrap_related_surface=false
 
 declare -a tokens=()
 declare -a family_tokens=()
@@ -425,6 +447,11 @@ while IFS= read -r path; do
     docs/milestones/v0.91.4/features/PVF_INITIAL_LANE_INVENTORY_v0.91.4.md|\
     docs/milestones/v0.91.4/features/PVF_CI_RELEASE_POLICY_v0.91.4.md)
       saw_slow_proof_contract_surface=true
+      ;;
+    adl/src/cli/tokio_runtime.rs|\
+    adl/src/cli/pr_cmd/github.rs|\
+    adl/src/cli/tooling_cmd/github_release.rs)
+      saw_tokio_bootstrap_related_surface=true
       ;;
   esac
 done <<EOF

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -134,7 +134,7 @@ fi
 grep -F "Coverage-impact preflight needs coverage evidence" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "candidate filter: new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base origin/main --changed-files $changed --summary adl/target/coverage-impact-summary.json --require-summary-for-risk" /tmp/coverage-impact-missing.out >/dev/null
 
 if bash "$SCRIPT" --changed-files "$finish_helper_changed" --require-summary-for-risk >/tmp/coverage-impact-finish-helper-missing.out 2>&1; then
@@ -142,7 +142,7 @@ if bash "$SCRIPT" --changed-files "$finish_helper_changed" --require-summary-for
   exit 1
 fi
 grep -F "candidate filter: finish" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- finish" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
 
 if bash "$SCRIPT" --changed-files "$mixed_pr_cmd_helper_changed" --require-summary-for-risk >/tmp/coverage-impact-mixed-helper-missing.out 2>&1; then
   echo "expected mixed pr_cmd helper guidance to fail without summary" >&2
@@ -175,6 +175,31 @@ grep -Fx "pr_cmd" "$mixed_fast_lane_filters" >/dev/null
 grep -Fx "structured_prompt" "$mixed_fast_lane_filters" >/dev/null
 grep -Fx "markdown" "$mixed_fast_lane_filters" >/dev/null
 
+tokio_bootstrap_wave="$TMP/tokio-bootstrap-wave.txt"
+cat >"$tokio_bootstrap_wave" <<'EOF'
+M	adl/src/cli/mod.rs
+M	adl/src/cli/pr_cmd/github.rs
+M	adl/src/cli/tokio_runtime.rs
+M	adl/src/cli/tooling_cmd/github_release.rs
+EOF
+tokio_bootstrap_filters="$TMP/tokio-bootstrap-filters.txt"
+bash "$SCRIPT" --changed-files "$tokio_bootstrap_wave" --print-risk-filters >"$tokio_bootstrap_filters"
+grep -Fx "tokio_bootstrap" "$tokio_bootstrap_filters" >/dev/null
+grep -Fx "pr_cmd" "$tokio_bootstrap_filters" >/dev/null
+grep -Fx "github_release_" "$tokio_bootstrap_filters" >/dev/null
+if grep -Fx "cli" "$tokio_bootstrap_filters" >/dev/null; then
+  echo "did not expect broad cli filter for tokio bootstrap wave" >&2
+  exit 1
+fi
+tokio_bootstrap_expression="$(bash "$SCRIPT" --changed-files "$tokio_bootstrap_wave" --print-risk-nextest-expression)"
+grep -F "test(/^cli::pr_cmd::github::/)" <<<"$tokio_bootstrap_expression" >/dev/null
+grep -F "test(/^cli::pr_cmd::github_client::/)" <<<"$tokio_bootstrap_expression" >/dev/null
+grep -F "test(/^cli::tooling_cmd::github_release::/)" <<<"$tokio_bootstrap_expression" >/dev/null
+if grep -F "test(cli)" <<<"$tokio_bootstrap_expression" >/dev/null; then
+  echo "did not expect broad cli nextest expression for tokio bootstrap wave" >&2
+  exit 1
+fi
+
 low_summary="$TMP/low-summary.json"
 make_summary "adl/src/runtime_v2/new_large_surface.rs" 77 100 "$low_summary"
 if bash "$SCRIPT" --changed-files "$changed" --summary "$low_summary" >/tmp/coverage-impact-low.out 2>&1; then
@@ -183,7 +208,7 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$low_summary" >/tmp/cove
 fi
 grep -F "77.00% < 80%" /tmp/coverage-impact-low.out >/dev/null
 grep -F "Actionable next steps:" /tmp/coverage-impact-low.out >/dev/null
-grep -F "refresh focused summary after adding or expanding tests: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-low.out >/dev/null
+grep -F "refresh focused summary after adding or expanding tests: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-low.out >/dev/null
 grep -F "Common failure modes:" /tmp/coverage-impact-low.out >/dev/null
 
 missing_summary="$TMP/missing-row-summary.json"
@@ -193,7 +218,7 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$missing_summary" >/tmp/
   exit 1
 fi
 grep -F "no coverage row" /tmp/coverage-impact-missing-row.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-missing-row.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-missing-row.out >/dev/null
 
 mkdir -p "$BARREL_DIR"
 cat >"$BARREL_DIR/mod.rs" <<'EOF'

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -116,6 +116,19 @@ assert_has "$cli_family_output" "mode=focused"
 assert_has "$cli_family_output" "filter_tokens=cli"
 assert_has "$cli_family_output" "filter_expression=test(cli)"
 
+tokio_bootstrap_wave="$TMP/tokio_bootstrap_wave.txt"
+cat >"$tokio_bootstrap_wave" <<'EOF'
+M	adl/src/cli/mod.rs
+M	adl/src/cli/pr_cmd/github.rs
+M	adl/src/cli/tokio_runtime.rs
+M	adl/src/cli/tooling_cmd/github_release.rs
+EOF
+tokio_bootstrap_wave_output="$(bash "$SCRIPT" --changed-files "$tokio_bootstrap_wave" --print-plan)"
+assert_has "$tokio_bootstrap_wave_output" "mode=focused"
+assert_has "$tokio_bootstrap_wave_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$tokio_bootstrap_wave_output" "filter_tokens=tokio_bootstrap,pr_cmd::github,github_release_"
+assert_has "$tokio_bootstrap_wave_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/)"
+
 direct_tooling_binaries="$TMP/direct_tooling_binaries.txt"
 cat >"$direct_tooling_binaries" <<'EOF'
 M	adl/src/bin/adl_lint_prompt_spec.rs
@@ -244,7 +257,7 @@ manifest_plus_finish_output="$(bash "$SCRIPT" --changed-files "$manifest_plus_fi
 assert_has "$manifest_plus_finish_output" "mode=focused"
 assert_has "$manifest_plus_finish_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$manifest_plus_finish_output" "filter_tokens=manifest_support,pr_cmd_finish"
-assert_has "$manifest_plus_finish_output" "filter_expression=(binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/)) or (binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/)) or (binary_id(adl) and test(/^long_lived_agent::/)) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
+assert_has "$manifest_plus_finish_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
 
 manifest_only_pair="$TMP/manifest_only_pair.txt"
 cat >"$manifest_only_pair" <<'EOF'
@@ -255,7 +268,7 @@ manifest_only_pair_output="$(bash "$SCRIPT" --changed-files "$manifest_only_pair
 assert_has "$manifest_only_pair_output" "mode=focused"
 assert_has "$manifest_only_pair_output" "reason=manifest_only_rust_wave_runs_focused_nextest"
 assert_has "$manifest_only_pair_output" "filter_tokens=pr_cmd::github,github_release_,long_lived_agent"
-assert_has "$manifest_only_pair_output" "filter_expression=binary_id(adl::bin/adl) and test(/^cli::pr_cmd::github::/) or binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::github_release::/) or binary_id(adl) and test(/^long_lived_agent::/)"
+assert_has "$manifest_only_pair_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/)"
 
 manifest_only_single="$TMP/manifest_only_single.txt"
 printf 'M\tadl/Cargo.toml\n' >"$manifest_only_single"
@@ -284,7 +297,7 @@ long_lived_agent_only_output="$(bash "$SCRIPT" --changed-files "$long_lived_agen
 assert_has "$long_lived_agent_only_output" "mode=focused"
 assert_has "$long_lived_agent_only_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$long_lived_agent_only_output" "filter_tokens=long_lived_agent"
-assert_has "$long_lived_agent_only_output" "filter_expression=binary_id(adl) and test(/^long_lived_agent::/)"
+assert_has "$long_lived_agent_only_output" "filter_expression=test(/^long_lived_agent::/)"
 
 too_many_families="$TMP/too_many_families.txt"
 cat >"$too_many_families" <<'EOF'


### PR DESCRIPTION
Closes #4180

## Summary
Consolidated duplicated current-thread Tokio runtime bootstrap into one shared CLI helper and routed the GitHub transport and GitHub release surfaces through it. The refactor keeps the existing runtime behavior, retry policy, and observability semantics while reducing duplicated bootstrap glue on the touched runtime-facing helpers.

## Artifacts
- New shared runtime helper at `adl/src/cli/tokio_runtime.rs`
- Updated runtime-facing helper call sites in `adl/src/cli/pr_cmd/github.rs` and `adl/src/cli/tooling_cmd/github_release.rs`
- CLI module wiring update in `adl/src/cli/mod.rs`
- Updated issue-local review and execution records in `.adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/srp.md` and `.adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter-clean Rust sources after extracting the shared runtime helper.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd::github -- --nocapture`
    Verified the GitHub transport runtime bootstrap and observability behavior on the touched helper surface.
  - `cargo test --manifest-path adl/Cargo.toml github_release_ -- --nocapture`
    Verified the GitHub release runtime bootstrap and release-path behavior on the touched helper surface.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl octocrab_transport_ -- --nocapture`
    Verified the exact focused octocrab transport lane cited by the reviewer.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/srp.md`
    Verified the updated SRP structure after recording review truth.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/sor.md`
    Verified the updated SOR structure after recording execution truth.
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh finish 4180 --title "[v0.91.6][runtime][tokio][T-02] Consolidate runtime bootstrap and supervision boundaries" --no-checks`
    Verified publication is currently blocked because `pr finish` does not classify `adl/src/cli/tokio_runtime.rs` into a supported validation lane.
- Results:
  - PASS
  - BLOCKED for publication

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4180__v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries/sor.md
- Idempotency-Key: v0-91-6-runtime-tokio-consolidate-runtime-bootstrap-and-supervision-boundaries-adl-src-cli-mod-rs-adl-src-cli-tokio-runtime-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-rs-adl-src-cli-tooling-cmd-github-release-rs-adl-v0-91-6-tasks-issue-4180-v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries-sip-md-adl-v0-91-6-tasks-issue-4180-v0-91-6-runtime-tokio-t-02-consolidate-runtime-bootstrap-and-supervision-boundaries-sor-md