### PR TITLE
[v0.91.6][runtime][tokio] Prepare the ACIP-facing runtime substrate

### DIFF
--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -296,6 +296,69 @@ pub(super) fn enforce_delegation_policy_for_step_actions(
     Ok(())
 }
 
+pub(super) fn build_remote_execute_request(
+    step: &crate::resolve::ResolvedStep,
+    doc: &crate::adl::AdlDoc,
+    run_id: &str,
+    workflow_id: &str,
+    provider_id: &str,
+    prompt_text: &str,
+    inputs: &HashMap<String, String>,
+    saved_state: &HashMap<String, String>,
+    adl_base_dir: &Path,
+    spec: &crate::adl::ProviderSpec,
+    model_override: Option<&str>,
+) -> Result<remote_exec::ExecuteRequest> {
+    let remote = doc.run.remote.as_ref().ok_or_else(|| {
+        crate::remote_exec::RemoteExecuteClientError::new(
+            crate::remote_exec::RemoteExecuteClientErrorKind::SchemaViolation,
+            "REMOTE_SCHEMA_VIOLATION",
+            "run.remote.endpoint is required when placement=remote",
+        )
+    })?;
+    let timeout_ms = remote.timeout_ms.unwrap_or(30_000);
+    Ok(remote_exec::ExecuteRequest {
+        protocol_version: remote_exec::PROTOCOL_VERSION.to_string(),
+        run_id: run_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        step_id: step.id.clone(),
+        step: remote_exec::ExecuteStepPayload {
+            kind: "task".to_string(),
+            provider: provider_id.to_string(),
+            prompt: prompt_text.to_string(),
+            conversation: step.conversation.clone(),
+            tools: Vec::new(),
+            provider_spec: spec.clone(),
+            model_override: model_override.map(|v| v.to_string()),
+        },
+        inputs: remote_exec::ExecuteInputsPayload {
+            inputs: inputs.clone(),
+            state: saved_state.clone(),
+        },
+        timeout_ms,
+        security: Some(remote_exec::ExecuteSecurityEnvelope {
+            require_signature: remote.require_signed_requests,
+            require_key_id: remote.require_key_id,
+            signed: doc.signature.is_some(),
+            key_id: doc.signature.as_ref().map(|s| s.key_id.clone()),
+            signature_alg: doc.signature.as_ref().map(|s| s.alg.clone()),
+            key_source: doc
+                .signature
+                .as_ref()
+                .and_then(|s| s.public_key_b64.as_ref().map(|_| "embedded".to_string())),
+            request_signature: None,
+            allowed_algs: remote.verify_allowed_algs.clone(),
+            allowed_key_sources: remote.verify_allowed_key_sources.clone(),
+            sandbox_root: Some(adl_base_dir.display().to_string()),
+            requested_paths: step
+                .write_to
+                .as_ref()
+                .map(|w| vec![w.clone()])
+                .unwrap_or_default(),
+        }),
+    })
+}
+
 pub(super) fn execute_step_with_retry(
     step: &crate::resolve::ResolvedStep,
     doc: &crate::adl::AdlDoc,
@@ -422,44 +485,19 @@ where
                         )
                     })?;
                     let timeout_ms = remote.timeout_ms.unwrap_or(30_000);
-                    let mut req = remote_exec::ExecuteRequest {
-                        protocol_version: remote_exec::PROTOCOL_VERSION.to_string(),
-                        run_id: run_id.to_string(),
-                        workflow_id: workflow_id.to_string(),
-                        step_id: step_id.clone(),
-                        step: remote_exec::ExecuteStepPayload {
-                            kind: "task".to_string(),
-                            provider: provider_id.to_string(),
-                            prompt: prompt_text.clone(),
-                            tools: Vec::new(),
-                            provider_spec: spec.clone(),
-                            model_override: model_override.map(|v| v.to_string()),
-                        },
-                        inputs: remote_exec::ExecuteInputsPayload {
-                            inputs: inputs.clone(),
-                            state: saved_state.clone(),
-                        },
-                        timeout_ms,
-                        security: Some(remote_exec::ExecuteSecurityEnvelope {
-                            require_signature: remote.require_signed_requests,
-                            require_key_id: remote.require_key_id,
-                            signed: doc.signature.is_some(),
-                            key_id: doc.signature.as_ref().map(|s| s.key_id.clone()),
-                            signature_alg: doc.signature.as_ref().map(|s| s.alg.clone()),
-                            key_source: doc.signature.as_ref().and_then(|s| {
-                                s.public_key_b64.as_ref().map(|_| "embedded".to_string())
-                            }),
-                            request_signature: None,
-                            allowed_algs: remote.verify_allowed_algs.clone(),
-                            allowed_key_sources: remote.verify_allowed_key_sources.clone(),
-                            sandbox_root: Some(adl_base_dir.display().to_string()),
-                            requested_paths: step
-                                .write_to
-                                .as_ref()
-                                .map(|w| vec![w.clone()])
-                                .unwrap_or_default(),
-                        }),
-                    };
+                    let mut req = build_remote_execute_request(
+                        step,
+                        doc,
+                        run_id,
+                        workflow_id,
+                        provider_id,
+                        &prompt_text,
+                        &inputs,
+                        saved_state,
+                        adl_base_dir,
+                        spec,
+                        model_override,
+                    )?;
                     remote_exec::maybe_attach_request_signature_from_env(&mut req).with_context(
                         || {
                             format!(

--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -296,20 +296,24 @@ pub(super) fn enforce_delegation_policy_for_step_actions(
     Ok(())
 }
 
+pub(super) struct RemoteExecuteRequestContext<'a> {
+    pub doc: &'a crate::adl::AdlDoc,
+    pub run_id: &'a str,
+    pub workflow_id: &'a str,
+    pub provider_id: &'a str,
+    pub prompt_text: &'a str,
+    pub inputs: &'a HashMap<String, String>,
+    pub saved_state: &'a HashMap<String, String>,
+    pub adl_base_dir: &'a Path,
+    pub spec: &'a crate::adl::ProviderSpec,
+    pub model_override: Option<&'a str>,
+}
+
 pub(super) fn build_remote_execute_request(
     step: &crate::resolve::ResolvedStep,
-    doc: &crate::adl::AdlDoc,
-    run_id: &str,
-    workflow_id: &str,
-    provider_id: &str,
-    prompt_text: &str,
-    inputs: &HashMap<String, String>,
-    saved_state: &HashMap<String, String>,
-    adl_base_dir: &Path,
-    spec: &crate::adl::ProviderSpec,
-    model_override: Option<&str>,
+    ctx: &RemoteExecuteRequestContext<'_>,
 ) -> Result<remote_exec::ExecuteRequest> {
-    let remote = doc.run.remote.as_ref().ok_or_else(|| {
+    let remote = ctx.doc.run.remote.as_ref().ok_or_else(|| {
         crate::remote_exec::RemoteExecuteClientError::new(
             crate::remote_exec::RemoteExecuteClientErrorKind::SchemaViolation,
             "REMOTE_SCHEMA_VIOLATION",
@@ -319,37 +323,38 @@ pub(super) fn build_remote_execute_request(
     let timeout_ms = remote.timeout_ms.unwrap_or(30_000);
     Ok(remote_exec::ExecuteRequest {
         protocol_version: remote_exec::PROTOCOL_VERSION.to_string(),
-        run_id: run_id.to_string(),
-        workflow_id: workflow_id.to_string(),
+        run_id: ctx.run_id.to_string(),
+        workflow_id: ctx.workflow_id.to_string(),
         step_id: step.id.clone(),
         step: remote_exec::ExecuteStepPayload {
             kind: "task".to_string(),
-            provider: provider_id.to_string(),
-            prompt: prompt_text.to_string(),
+            provider: ctx.provider_id.to_string(),
+            prompt: ctx.prompt_text.to_string(),
             conversation: step.conversation.clone(),
             tools: Vec::new(),
-            provider_spec: spec.clone(),
-            model_override: model_override.map(|v| v.to_string()),
+            provider_spec: ctx.spec.clone(),
+            model_override: ctx.model_override.map(|v| v.to_string()),
         },
         inputs: remote_exec::ExecuteInputsPayload {
-            inputs: inputs.clone(),
-            state: saved_state.clone(),
+            inputs: ctx.inputs.clone(),
+            state: ctx.saved_state.clone(),
         },
         timeout_ms,
         security: Some(remote_exec::ExecuteSecurityEnvelope {
             require_signature: remote.require_signed_requests,
             require_key_id: remote.require_key_id,
-            signed: doc.signature.is_some(),
-            key_id: doc.signature.as_ref().map(|s| s.key_id.clone()),
-            signature_alg: doc.signature.as_ref().map(|s| s.alg.clone()),
-            key_source: doc
+            signed: ctx.doc.signature.is_some(),
+            key_id: ctx.doc.signature.as_ref().map(|s| s.key_id.clone()),
+            signature_alg: ctx.doc.signature.as_ref().map(|s| s.alg.clone()),
+            key_source: ctx
+                .doc
                 .signature
                 .as_ref()
                 .and_then(|s| s.public_key_b64.as_ref().map(|_| "embedded".to_string())),
             request_signature: None,
             allowed_algs: remote.verify_allowed_algs.clone(),
             allowed_key_sources: remote.verify_allowed_key_sources.clone(),
-            sandbox_root: Some(adl_base_dir.display().to_string()),
+            sandbox_root: Some(ctx.adl_base_dir.display().to_string()),
             requested_paths: step
                 .write_to
                 .as_ref()
@@ -485,19 +490,19 @@ where
                         )
                     })?;
                     let timeout_ms = remote.timeout_ms.unwrap_or(30_000);
-                    let mut req = build_remote_execute_request(
-                        step,
+                    let request_context = RemoteExecuteRequestContext {
                         doc,
                         run_id,
                         workflow_id,
                         provider_id,
-                        &prompt_text,
-                        &inputs,
+                        prompt_text: &prompt_text,
+                        inputs: &inputs,
                         saved_state,
                         adl_base_dir,
                         spec,
                         model_override,
-                    )?;
+                    };
+                    let mut req = build_remote_execute_request(step, &request_context)?;
                     remote_exec::maybe_attach_request_signature_from_env(&mut req).with_context(
                         || {
                             format!(

--- a/adl/src/execute/tests.rs
+++ b/adl/src/execute/tests.rs
@@ -1,5 +1,5 @@
 use super::runner::{
-    effective_max_concurrency_with_source, effective_step_placement,
+    build_remote_execute_request, effective_max_concurrency_with_source, effective_step_placement,
     emit_delegation_lifecycle_finish, emit_delegation_lifecycle_start,
     enforce_delegation_policy_for_step_actions, resolve_call_binding,
 };
@@ -148,6 +148,17 @@ fn delegated_step(id: &str) -> crate::resolve::ResolvedStep {
         write_to: None,
         on_error: None,
         retry: None,
+    }
+}
+
+fn remote_provider_spec() -> crate::adl::ProviderSpec {
+    crate::adl::ProviderSpec {
+        id: None,
+        profile: None,
+        kind: "http".to_string(),
+        base_url: None,
+        default_model: None,
+        config: HashMap::new(),
     }
 }
 
@@ -585,6 +596,73 @@ fn execute_step_with_retry_does_not_retry_remote_schema_violation() {
         "unexpected error: {:#}",
         failure.err
     );
+}
+
+#[test]
+fn build_remote_execute_request_preserves_conversation_as_audit_metadata() {
+    let mut doc = minimal_resolved().doc;
+    doc.providers
+        .insert("p1".to_string(), remote_provider_spec());
+    doc.run.placement = Some(RunPlacementSpec::Mode(PlacementMode::Remote));
+    doc.run.remote = Some(crate::adl::RunRemoteSpec {
+        endpoint: "http://127.0.0.1:4100/v1/execute".to_string(),
+        timeout_ms: Some(45_000),
+        require_signed_requests: false,
+        require_key_id: false,
+        verify_allowed_algs: vec!["ed25519".to_string()],
+        verify_allowed_key_sources: vec!["embedded".to_string()],
+    });
+
+    let mut step = remote_retry_step(2);
+    step.write_to = Some("artifacts/reply.json".to_string());
+    step.conversation = Some(crate::adl::ConversationTurnSpec {
+        id: "turn_01".to_string(),
+        speaker: "agent.alpha".to_string(),
+        sequence: Some(1),
+        thread_id: Some("thread.local".to_string()),
+        responds_to: Some("turn_00".to_string()),
+    });
+
+    let mut inputs = HashMap::new();
+    inputs.insert("topic".to_string(), "acip".to_string());
+    let mut saved_state = HashMap::new();
+    saved_state.insert("history.latest".to_string(), "turn_00".to_string());
+
+    let req = build_remote_execute_request(
+        &step,
+        &doc,
+        "run-1",
+        "wf-1",
+        "p1",
+        "respond carefully",
+        &inputs,
+        &saved_state,
+        std::path::Path::new("."),
+        doc.providers.get("p1").expect("provider spec"),
+        Some("gpt-5.5"),
+    )
+    .expect("remote execute request");
+
+    assert_eq!(req.run_id, "run-1");
+    assert_eq!(req.workflow_id, "wf-1");
+    assert_eq!(req.step_id, step.id);
+    assert_eq!(req.timeout_ms, 45_000);
+    assert_eq!(req.step.provider, "p1");
+    assert_eq!(req.step.prompt, "respond carefully");
+    assert_eq!(req.step.model_override.as_deref(), Some("gpt-5.5"));
+    assert_eq!(req.step.conversation, step.conversation);
+    assert!(req.step.tools.is_empty());
+    assert_eq!(req.inputs.inputs, inputs);
+    assert_eq!(req.inputs.state, saved_state);
+
+    let security = req.security.expect("security envelope");
+    assert_eq!(security.sandbox_root.as_deref(), Some("."));
+    assert_eq!(
+        security.requested_paths,
+        vec!["artifacts/reply.json".to_string()]
+    );
+    assert_eq!(security.allowed_algs, vec!["ed25519".to_string()]);
+    assert_eq!(security.allowed_key_sources, vec!["embedded".to_string()]);
 }
 
 #[test]

--- a/adl/src/execute/tests.rs
+++ b/adl/src/execute/tests.rs
@@ -1,7 +1,7 @@
 use super::runner::{
     build_remote_execute_request, effective_max_concurrency_with_source, effective_step_placement,
     emit_delegation_lifecycle_finish, emit_delegation_lifecycle_start,
-    enforce_delegation_policy_for_step_actions, resolve_call_binding,
+    enforce_delegation_policy_for_step_actions, resolve_call_binding, RemoteExecuteRequestContext,
 };
 use super::*;
 use crate::adl::{
@@ -628,20 +628,19 @@ fn build_remote_execute_request_preserves_conversation_as_audit_metadata() {
     let mut saved_state = HashMap::new();
     saved_state.insert("history.latest".to_string(), "turn_00".to_string());
 
-    let req = build_remote_execute_request(
-        &step,
-        &doc,
-        "run-1",
-        "wf-1",
-        "p1",
-        "respond carefully",
-        &inputs,
-        &saved_state,
-        std::path::Path::new("."),
-        doc.providers.get("p1").expect("provider spec"),
-        Some("gpt-5.5"),
-    )
-    .expect("remote execute request");
+    let context = RemoteExecuteRequestContext {
+        doc: &doc,
+        run_id: "run-1",
+        workflow_id: "wf-1",
+        provider_id: "p1",
+        prompt_text: "respond carefully",
+        inputs: &inputs,
+        saved_state: &saved_state,
+        adl_base_dir: std::path::Path::new("."),
+        spec: doc.providers.get("p1").expect("provider spec"),
+        model_override: Some("gpt-5.5"),
+    };
+    let req = build_remote_execute_request(&step, &context).expect("remote execute request");
 
     assert_eq!(req.run_id, "run-1");
     assert_eq!(req.workflow_id, "wf-1");

--- a/adl/src/execute/tests.rs
+++ b/adl/src/execute/tests.rs
@@ -162,6 +162,25 @@ fn remote_provider_spec() -> crate::adl::ProviderSpec {
     }
 }
 
+fn mock_provider_spec() -> crate::adl::ProviderSpec {
+    crate::adl::ProviderSpec {
+        id: None,
+        profile: None,
+        kind: "mock".to_string(),
+        base_url: None,
+        default_model: Some("echo-v1".to_string()),
+        config: HashMap::new(),
+    }
+}
+
+fn unique_temp_path(label: &str) -> std::path::PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{label}-{now}-{}", std::process::id()))
+}
+
 fn steering_patch() -> SteeringPatch {
     let mut set_state = HashMap::new();
     set_state.insert("next.input".to_string(), "ready".to_string());
@@ -1278,4 +1297,582 @@ fn delegation_lifecycle_events_follow_remote_step_shape() {
             ..
         } if step_id == "remote-step" && outcome == "failure"
     )));
+}
+
+#[test]
+fn runner_executes_concurrent_mock_workflow_success_path() {
+    let mut resolved = minimal_resolved();
+    resolved
+        .doc
+        .providers
+        .insert("p1".to_string(), mock_provider_spec());
+
+    let branch_a = crate::resolve::ResolvedStep {
+        id: "fork.branch.a".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("BRANCH_A={{label}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::from([("label".to_string(), "alpha".to_string())]),
+        guards: vec![],
+        save_as: Some("branch_a".to_string()),
+        write_to: None,
+        on_error: None,
+        retry: None,
+    };
+    let branch_b = crate::resolve::ResolvedStep {
+        id: "fork.branch.b".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("BRANCH_B={{label}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::from([("label".to_string(), "beta".to_string())]),
+        guards: vec![],
+        save_as: Some("branch_b".to_string()),
+        write_to: None,
+        on_error: None,
+        retry: None,
+    };
+    let join = crate::resolve::ResolvedStep {
+        id: "fork.join".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("JOIN={{a}}+{{b}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::from([
+            ("a".to_string(), "@state:branch_a".to_string()),
+            ("b".to_string(), "@state:branch_b".to_string()),
+        ]),
+        guards: vec![],
+        save_as: Some("joined".to_string()),
+        write_to: Some("artifacts/join.txt".to_string()),
+        on_error: None,
+        retry: None,
+    };
+
+    resolved.steps = vec![branch_a, branch_b, join];
+    resolved.execution_plan = crate::execution_plan::ExecutionPlan {
+        workflow_kind: WorkflowKind::Concurrent,
+        nodes: vec![
+            crate::execution_plan::ExecutionNode {
+                step_id: "fork.branch.a".to_string(),
+                depends_on: vec![],
+                save_as: Some("branch_a".to_string()),
+                delegation: None,
+            },
+            crate::execution_plan::ExecutionNode {
+                step_id: "fork.branch.b".to_string(),
+                depends_on: vec![],
+                save_as: Some("branch_b".to_string()),
+                delegation: None,
+            },
+            crate::execution_plan::ExecutionNode {
+                step_id: "fork.join".to_string(),
+                depends_on: vec!["fork.branch.a".to_string(), "fork.branch.b".to_string()],
+                save_as: Some("joined".to_string()),
+                delegation: None,
+            },
+        ],
+    };
+
+    let base = unique_temp_path("adl-runner-concurrent");
+    let out_dir = base.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let mut tr = crate::trace::Trace::new("run", "wf", "0.3");
+    let result = execute_sequential(&resolved, &mut tr, false, false, &base, &out_dir)
+        .expect("concurrent mock workflow should succeed");
+
+    assert_eq!(result.outputs.len(), 3);
+    assert_eq!(result.records.len(), 3);
+    assert!(result.pause.is_none());
+    assert_eq!(result.artifacts.len(), 1);
+
+    let join_output = result
+        .outputs
+        .iter()
+        .find(|output| output.step_id == "fork.join")
+        .expect("join output");
+    assert!(join_output.model_output.contains("JOIN="));
+    assert!(join_output.model_output.contains("BRANCH_A=alpha"));
+    assert!(join_output.model_output.contains("BRANCH_B=beta"));
+    let join_artifact =
+        std::fs::read_to_string(out_dir.join("artifacts/join.txt")).expect("read join artifact");
+    assert_eq!(join_artifact, join_output.model_output);
+
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn runner_executes_called_workflow_success_path() {
+    let mut resolved = minimal_resolved();
+    resolved
+        .doc
+        .providers
+        .insert("p1".to_string(), mock_provider_spec());
+    resolved.doc.agents.insert(
+        "a1".to_string(),
+        crate::adl::AgentSpec {
+            id: None,
+            provider: "p1".to_string(),
+            model: "echo-v1".to_string(),
+            temperature: None,
+            top_k: None,
+            description: None,
+            prompt: None,
+            tools: vec![],
+        },
+    );
+    resolved.doc.tasks.insert(
+        "callee_task".to_string(),
+        crate::adl::TaskSpec {
+            id: None,
+            agent_ref: Some("a1".to_string()),
+            inputs: vec!["topic".to_string()],
+            tool_allowlist: vec![],
+            description: None,
+            prompt: PromptSpec {
+                user: Some("CALLEE={{topic}}".to_string()),
+                ..Default::default()
+            },
+        },
+    );
+    resolved.doc.workflows.insert(
+        "callee".to_string(),
+        WorkflowSpec {
+            id: Some("callee".to_string()),
+            kind: WorkflowKind::Sequential,
+            max_concurrency: None,
+            steps: vec![crate::adl::StepSpec {
+                id: Some("reply".to_string()),
+                task: Some("callee_task".to_string()),
+                save_as: Some("reply_text".to_string()),
+                write_to: Some("callee/reply.txt".to_string()),
+                inputs: HashMap::from([("topic".to_string(), "{{ topic }}".to_string())]),
+                ..crate::adl::StepSpec::default()
+            }],
+        },
+    );
+
+    resolved.steps = vec![crate::resolve::ResolvedStep {
+        id: "call.callee".to_string(),
+        agent: None,
+        provider: None,
+        placement: None,
+        task: None,
+        call: Some("callee".to_string()),
+        with: HashMap::from([("topic".to_string(), "acip".to_string())]),
+        as_ns: Some("nested".to_string()),
+        delegation: None,
+        conversation: None,
+        prompt: None,
+        inputs: HashMap::new(),
+        guards: vec![],
+        save_as: None,
+        write_to: None,
+        on_error: None,
+        retry: None,
+    }];
+    resolved.execution_plan = crate::execution_plan::ExecutionPlan {
+        workflow_kind: WorkflowKind::Sequential,
+        nodes: vec![crate::execution_plan::ExecutionNode {
+            step_id: "call.callee".to_string(),
+            depends_on: vec![],
+            save_as: None,
+            delegation: None,
+        }],
+    };
+
+    let base = unique_temp_path("adl-runner-call");
+    let out_dir = base.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let mut tr = crate::trace::Trace::new("run", "wf", "0.3");
+    let result = execute_sequential(&resolved, &mut tr, false, false, &base, &out_dir)
+        .expect("called workflow should succeed");
+
+    assert!(result.pause.is_none());
+    assert_eq!(result.outputs.len(), 1);
+    assert_eq!(result.artifacts.len(), 1);
+    assert!(result
+        .records
+        .iter()
+        .any(|record| record.step_id == "call.callee" && record.provider_id == "<call>"));
+    let output = &result.outputs[0];
+    assert!(output.step_id.contains("reply"));
+    assert!(!output.model_output.is_empty());
+    let artifact =
+        std::fs::read_to_string(out_dir.join("callee/reply.txt")).expect("read callee artifact");
+    assert_eq!(artifact, output.model_output);
+
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn runner_executes_nested_called_workflow_success_path() {
+    let mut resolved = minimal_resolved();
+    resolved
+        .doc
+        .providers
+        .insert("p1".to_string(), mock_provider_spec());
+    resolved.doc.agents.insert(
+        "a1".to_string(),
+        crate::adl::AgentSpec {
+            id: None,
+            provider: "p1".to_string(),
+            model: "echo-v1".to_string(),
+            temperature: None,
+            top_k: None,
+            description: None,
+            prompt: None,
+            tools: vec![],
+        },
+    );
+    resolved.doc.tasks.insert(
+        "leaf_task".to_string(),
+        crate::adl::TaskSpec {
+            id: None,
+            agent_ref: Some("a1".to_string()),
+            inputs: vec!["topic".to_string()],
+            tool_allowlist: vec![],
+            description: None,
+            prompt: PromptSpec {
+                user: Some("LEAF={{topic}}".to_string()),
+                ..Default::default()
+            },
+        },
+    );
+    resolved.doc.tasks.insert(
+        "summary_task".to_string(),
+        crate::adl::TaskSpec {
+            id: None,
+            agent_ref: Some("a1".to_string()),
+            inputs: vec!["reply".to_string()],
+            tool_allowlist: vec![],
+            description: None,
+            prompt: PromptSpec {
+                user: Some("SUMMARY={{reply}}".to_string()),
+                ..Default::default()
+            },
+        },
+    );
+    resolved.doc.workflows.insert(
+        "grandchild".to_string(),
+        WorkflowSpec {
+            id: Some("grandchild".to_string()),
+            kind: WorkflowKind::Sequential,
+            max_concurrency: None,
+            steps: vec![crate::adl::StepSpec {
+                id: Some("leaf".to_string()),
+                task: Some("leaf_task".to_string()),
+                save_as: Some("reply_text".to_string()),
+                inputs: HashMap::from([("topic".to_string(), "{{ topic }}".to_string())]),
+                ..crate::adl::StepSpec::default()
+            }],
+        },
+    );
+    resolved.doc.workflows.insert(
+        "callee".to_string(),
+        WorkflowSpec {
+            id: Some("callee".to_string()),
+            kind: WorkflowKind::Sequential,
+            max_concurrency: None,
+            steps: vec![
+                crate::adl::StepSpec {
+                    id: Some("call-grandchild".to_string()),
+                    call: Some("grandchild".to_string()),
+                    as_ns: Some("child".to_string()),
+                    with: HashMap::from([("topic".to_string(), "nested".to_string())]),
+                    ..crate::adl::StepSpec::default()
+                },
+                crate::adl::StepSpec {
+                    id: Some("summarize".to_string()),
+                    task: Some("summary_task".to_string()),
+                    save_as: Some("summary_text".to_string()),
+                    inputs: HashMap::from([(
+                        "reply".to_string(),
+                        "@state:child.reply_text".to_string(),
+                    )]),
+                    ..crate::adl::StepSpec::default()
+                },
+            ],
+        },
+    );
+
+    resolved.steps = vec![crate::resolve::ResolvedStep {
+        id: "call.callee".to_string(),
+        agent: None,
+        provider: None,
+        placement: None,
+        task: None,
+        call: Some("callee".to_string()),
+        with: HashMap::new(),
+        as_ns: Some("nested".to_string()),
+        delegation: None,
+        conversation: None,
+        prompt: None,
+        inputs: HashMap::new(),
+        guards: vec![],
+        save_as: None,
+        write_to: None,
+        on_error: None,
+        retry: None,
+    }];
+    resolved.execution_plan = crate::execution_plan::ExecutionPlan {
+        workflow_kind: WorkflowKind::Sequential,
+        nodes: vec![crate::execution_plan::ExecutionNode {
+            step_id: "call.callee".to_string(),
+            depends_on: vec![],
+            save_as: None,
+            delegation: None,
+        }],
+    };
+
+    let base = unique_temp_path("adl-runner-nested-call");
+    let out_dir = base.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let mut tr = crate::trace::Trace::new("run", "wf", "0.3");
+    let result = execute_sequential(&resolved, &mut tr, false, false, &base, &out_dir)
+        .expect("nested called workflow should succeed");
+
+    assert!(result.pause.is_none());
+    assert_eq!(result.outputs.len(), 2);
+    assert!(result.records.iter().any(|record| {
+        record.step_id == "call.callee::call-grandchild" && record.provider_id == "<call>"
+    }));
+    assert!(result
+        .records
+        .iter()
+        .any(|record| { record.step_id == "call.callee" && record.provider_id == "<call>" }));
+    assert!(result
+        .outputs
+        .iter()
+        .any(|output| output.step_id.ends_with("leaf")));
+    assert!(result
+        .outputs
+        .iter()
+        .any(|output| output.step_id.ends_with("summarize")));
+
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn runner_concurrent_failure_can_continue_when_step_is_marked_continue_on_error() {
+    let mut resolved = minimal_resolved();
+    resolved
+        .doc
+        .providers
+        .insert("p1".to_string(), mock_provider_spec());
+
+    let failing = crate::resolve::ResolvedStep {
+        id: "fork.fail".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("FAIL={{missing}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::new(),
+        guards: vec![],
+        save_as: None,
+        write_to: None,
+        on_error: Some(crate::adl::StepOnError::Continue),
+        retry: None,
+    };
+    let succeeding = crate::resolve::ResolvedStep {
+        id: "fork.ok".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("OK={{value}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::from([("value".to_string(), "present".to_string())]),
+        guards: vec![],
+        save_as: Some("ok".to_string()),
+        write_to: None,
+        on_error: None,
+        retry: None,
+    };
+
+    resolved.steps = vec![failing, succeeding];
+    resolved.execution_plan = crate::execution_plan::ExecutionPlan {
+        workflow_kind: WorkflowKind::Concurrent,
+        nodes: vec![
+            crate::execution_plan::ExecutionNode {
+                step_id: "fork.fail".to_string(),
+                depends_on: vec![],
+                save_as: None,
+                delegation: None,
+            },
+            crate::execution_plan::ExecutionNode {
+                step_id: "fork.ok".to_string(),
+                depends_on: vec![],
+                save_as: Some("ok".to_string()),
+                delegation: None,
+            },
+        ],
+    };
+
+    let base = unique_temp_path("adl-runner-continue");
+    let out_dir = base.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let mut tr = crate::trace::Trace::new("run", "wf", "0.3");
+    let result = execute_sequential(&resolved, &mut tr, false, false, &base, &out_dir)
+        .expect("continue_on_error branch should allow overall success");
+
+    assert!(result.pause.is_none());
+    assert_eq!(result.outputs.len(), 1);
+    assert!(result
+        .records
+        .iter()
+        .any(|record| record.step_id == "fork.fail" && record.status == "failure"));
+    assert!(result
+        .records
+        .iter()
+        .any(|record| record.step_id == "fork.ok" && record.status == "success"));
+
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn runner_concurrent_success_can_pause_after_completed_step() {
+    let mut resolved = minimal_resolved();
+    resolved
+        .doc
+        .providers
+        .insert("p1".to_string(), mock_provider_spec());
+
+    let paused = crate::resolve::ResolvedStep {
+        id: "pause.step".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("PAUSE={{value}}".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::from([("value".to_string(), "now".to_string())]),
+        guards: vec![crate::adl::GuardSpec {
+            kind: "pause".to_string(),
+            config: HashMap::from([(
+                "reason".to_string(),
+                serde_json::Value::String("operator checkpoint".to_string()),
+            )]),
+        }],
+        save_as: Some("paused".to_string()),
+        write_to: None,
+        on_error: None,
+        retry: None,
+    };
+
+    resolved.steps = vec![paused];
+    resolved.execution_plan = crate::execution_plan::ExecutionPlan {
+        workflow_kind: WorkflowKind::Concurrent,
+        nodes: vec![crate::execution_plan::ExecutionNode {
+            step_id: "pause.step".to_string(),
+            depends_on: vec![],
+            save_as: Some("paused".to_string()),
+            delegation: None,
+        }],
+    };
+
+    let base = unique_temp_path("adl-runner-pause");
+    let out_dir = base.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let mut tr = crate::trace::Trace::new("run", "wf", "0.3");
+    let result = execute_sequential(&resolved, &mut tr, false, false, &base, &out_dir)
+        .expect("pause branch should return paused result");
+
+    let pause = result.pause.expect("pause result");
+    assert_eq!(pause.paused_step_id, "pause.step");
+    assert_eq!(pause.reason.as_deref(), Some("operator checkpoint"));
+    assert_eq!(pause.completed_step_ids, vec!["pause.step".to_string()]);
+    assert!(pause.remaining_step_ids.is_empty());
+
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn runner_validation_covers_core_helper_paths() {
+    resolve_state_inputs_resolves_and_validates_state_bindings();
+    validate_steering_patch_rejects_invalid_shapes();
+    apply_steering_patch_updates_resume_state_and_records_sorted_keys();
+    effective_max_concurrency_precedence_and_validation();
+    effective_max_concurrency_supports_workflow_ref_overrides();
+    effective_step_placement_prefers_step_then_run_then_local_default();
+    pause_reason_for_step_detects_pause_guard_and_optional_reason();
+    pause_reason_for_step_ignores_non_pause_guards();
+    effective_max_concurrency_tracks_source_order();
+    scheduler_policy_for_run_returns_none_for_sequential_workflows();
+}
+
+#[test]
+fn runner_validation_covers_retry_and_remote_request_paths() {
+    execute_step_with_retry_does_not_retry_remote_schema_violation();
+    build_remote_execute_request_preserves_conversation_as_audit_metadata();
+    execute_step_with_retry_does_not_retry_missing_prompt_binding();
+    execute_step_with_retry_does_not_retry_unknown_provider_setup_failure();
+    execution_policy_error_code_covers_all_kinds();
+    execution_policy_error_display_covers_approval_required_branch();
+    execution_policy_error_display_handles_approval_without_rule_id();
+    execution_policy_error_display_includes_rule_id_for_denied();
+    stable_failure_kind_detects_only_policy_errors();
+}
+
+#[test]
+fn runner_validation_covers_called_workflow_and_delegation_paths() {
+    resolve_call_binding_requires_state_prefix_and_known_key();
+    execute_called_workflow_rejects_unknown_workflow();
+    execute_called_workflow_rejects_missing_state_binding_in_call_with();
+    execute_called_workflow_rejects_write_to_without_save_as();
+    execute_called_workflow_nested_call_failure_is_propagated();
+    enforce_delegation_policy_for_step_actions_denies_filesystem_write_targets();
+    enforce_delegation_policy_for_step_actions_requires_approval_for_remote_exec();
+    delegation_lifecycle_events_follow_remote_step_shape();
 }

--- a/adl/src/remote_exec.rs
+++ b/adl/src/remote_exec.rs
@@ -302,6 +302,7 @@ mod tests {
                 kind: "task".to_string(),
                 provider: "local".to_string(),
                 prompt: "hello".to_string(),
+                conversation: None,
                 tools: vec![],
                 provider_spec: adl::ProviderSpec {
                     id: None,
@@ -541,6 +542,47 @@ mod tests {
         assert_eq!(env_err.code(), "REMOTE_REQUEST_SIGNATURE_MISMATCH");
         let as_anyhow: anyhow::Error = env_err.into();
         assert_eq!(stable_failure_kind(&as_anyhow), Some("policy_denied"));
+    }
+
+    #[test]
+    fn security_envelope_rejects_tampered_signed_conversation_metadata() {
+        let mut req = base_request();
+        req.step.conversation = Some(adl::ConversationTurnSpec {
+            id: "turn_01".to_string(),
+            speaker: "agent.alpha".to_string(),
+            sequence: Some(1),
+            thread_id: Some("thread.local".to_string()),
+            responds_to: None,
+        });
+        req.security = Some(ExecuteSecurityEnvelope {
+            require_signature: true,
+            require_key_id: true,
+            signed: true,
+            key_id: Some("k1".to_string()),
+            signature_alg: Some("ed25519".to_string()),
+            key_source: Some("embedded".to_string()),
+            request_signature: None,
+            allowed_algs: vec!["ed25519".to_string()],
+            allowed_key_sources: vec!["embedded".to_string()],
+            sandbox_root: None,
+            requested_paths: vec![],
+        });
+        let sig = sign_execute_request_v1(&req, &fixed_private_key_b64(), Some("k1"))
+            .expect("sign request");
+        req.security.as_mut().expect("security").request_signature = Some(sig);
+        req.step
+            .conversation
+            .as_mut()
+            .expect("conversation")
+            .speaker = "agent.beta".to_string();
+
+        let response = execute_request(&req);
+        assert!(!response.ok);
+        let err = response.error.expect("error");
+        assert_eq!(err.code, "REMOTE_REQUEST_SIGNATURE_MISMATCH");
+        let env_err =
+            validate_security_envelope(&req).expect_err("tampered conversation must fail");
+        assert_eq!(env_err.code(), "REMOTE_REQUEST_SIGNATURE_MISMATCH");
     }
 
     #[test]
@@ -1004,6 +1046,37 @@ mod tests {
         value.as_object_mut().expect("object").remove("security");
         let decoded: ExecuteRequest = serde_json::from_value(value).expect("deserialize request");
         assert!(decoded.security.is_none());
+    }
+
+    #[test]
+    fn execute_request_deserializes_legacy_payload_without_conversation_field() {
+        let req = base_request();
+        let mut value = serde_json::to_value(req).expect("serialize request");
+        value
+            .as_object_mut()
+            .expect("object")
+            .get_mut("step")
+            .and_then(|step| step.as_object_mut())
+            .expect("step object")
+            .remove("conversation");
+        let decoded: ExecuteRequest = serde_json::from_value(value).expect("deserialize request");
+        assert!(decoded.step.conversation.is_none());
+    }
+
+    #[test]
+    fn execute_request_accepts_conversation_audit_metadata() {
+        let mut req = base_request();
+        req.step.conversation = Some(adl::ConversationTurnSpec {
+            id: "turn_01".to_string(),
+            speaker: "agent.alpha".to_string(),
+            sequence: Some(1),
+            thread_id: Some("thread.local".to_string()),
+            responds_to: None,
+        });
+        let response = execute_request(&req);
+        assert!(!response.ok);
+        let err = response.error.expect("error");
+        assert_eq!(err.code, "REMOTE_EXECUTION_ERROR");
     }
 
     #[test]

--- a/adl/src/remote_exec/signing_support.rs
+++ b/adl/src/remote_exec/signing_support.rs
@@ -216,6 +216,7 @@ mod tests {
                 kind: "agent".to_string(),
                 provider: "provider".to_string(),
                 prompt: "hello".to_string(),
+                conversation: None,
                 tools: vec!["web".to_string()],
                 provider_spec: ProviderSpec {
                     id: None,

--- a/adl/src/remote_exec/types.rs
+++ b/adl/src/remote_exec/types.rs
@@ -33,6 +33,10 @@ pub struct ExecuteStepPayload {
     pub kind: String,
     pub provider: String,
     pub prompt: String,
+    /// Optional conversation turn metadata preserved for ACIP-facing
+    /// invocation context without widening remote execution into scheduling.
+    #[serde(default)]
+    pub conversation: Option<adl::ConversationTurnSpec>,
     #[serde(default)]
     pub tools: Vec<String>,
     pub provider_spec: adl::ProviderSpec,


### PR DESCRIPTION
## Summary
- add an ACIP-facing conversation audit field to the single-step remote execute payload
- centralize remote request construction behind one helper seam in the execution runner
- add focused proof for request construction, signed-metadata tamper rejection, and legacy payload compatibility

## Testing
- cargo test --manifest-path adl/Cargo.toml build_remote_execute_request_preserves_conversation_as_audit_metadata -- --nocapture
- cargo test --manifest-path adl/Cargo.toml security_envelope_rejects_tampered_signed_conversation_metadata -- --nocapture
- cargo test --manifest-path adl/Cargo.toml execute_request_ -- --nocapture
- cargo fmt --manifest-path adl/Cargo.toml --check

Closes #4181.
