### PR TITLE
[v0.91.6][tools][rust] Split issue and validation hot paths into small binaries

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -75,6 +75,10 @@ name = "adl-pr-validation"
 path = "src/bin/adl_pr_validation.rs"
 
 [[bin]]
+name = "adl-issue"
+path = "src/bin/adl_issue.rs"
+
+[[bin]]
 name = "adl-pr-closeout"
 path = "src/bin/adl_pr_closeout.rs"
 

--- a/adl/src/bin/adl_issue.rs
+++ b/adl/src/bin/adl_issue.rs
@@ -1,0 +1,79 @@
+extern crate adl;
+
+#[allow(dead_code)]
+#[path = "../cli/mod.rs"]
+mod cli;
+#[path = "../pr_dispatch_support.rs"]
+mod pr_dispatch_support;
+
+const USAGE: &str = "adl-issue - ADL direct issue operation binary\n\n\
+Usage:\n\
+  adl-issue list [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]\n\
+  adl-issue search --query \"<text>\" [-R owner/repo] [--state open|closed|all] [--limit <n>] [--json]\n\
+  adl-issue view <issue-number-or-url> [-R owner/repo] [--json]\n\
+  adl-issue create --title \"<title>\" [--body \"<markdown>\" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]\n\
+  adl-issue comment <issue-number-or-url> [--body \"<markdown>\" | --body-file <path>] [-R owner/repo] [--json]\n\
+  adl-issue edit <issue-number-or-url> [--title \"<title>\"] [--body \"<markdown>\" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]\n\
+  adl-issue --help\n\
+  adl-issue --version";
+
+fn run_with_dispatch(
+    args: &[String],
+    dispatch: fn(&[String]) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    pr_dispatch_support::run_pr_subcommand_args("issue", USAGE, args, dispatch)
+}
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    run_with_dispatch(args, cli::pr_cmd::real_pr)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run, run_with_dispatch};
+    use std::sync::{Mutex, OnceLock};
+
+    static CALLS: OnceLock<Mutex<Vec<Vec<String>>>> = OnceLock::new();
+
+    fn record_dispatch(args: &[String]) -> anyhow::Result<()> {
+        CALLS
+            .get_or_init(|| Mutex::new(Vec::new()))
+            .lock()
+            .expect("dispatch calls lock")
+            .push(args.to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn adl_issue_help_and_version_paths_succeed() {
+        for args in [vec!["--help".to_string()], vec!["--version".to_string()]] {
+            run(&args).expect("wrapper path should succeed");
+        }
+    }
+
+    #[test]
+    fn adl_issue_forwards_args_to_dispatch() {
+        let args = vec!["list".to_string(), "--json".to_string()];
+        run_with_dispatch(&args, record_dispatch).expect("dispatch should succeed");
+        let calls = CALLS
+            .get_or_init(|| Mutex::new(Vec::new()))
+            .lock()
+            .expect("dispatch calls lock");
+        assert_eq!(
+            calls.last().expect("recorded call"),
+            &vec![
+                "issue".to_string(),
+                "list".to_string(),
+                "--json".to_string()
+            ]
+        );
+    }
+}

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1480,6 +1480,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_tokio_manifest_runtime_validation(issue_number, changed_paths) {
         return Ok(build_tokio_manifest_runtime_validation_plan());
     }
+    if finish_issue_needs_issue_small_binary_validation(issue_number, changed_paths) {
+        return Ok(build_issue_small_binary_validation_plan());
+    }
     select_finish_validation_plan(&changed_paths.join(","))
 }
 
@@ -1782,6 +1785,27 @@ fn finish_issue_needs_tokio_manifest_runtime_validation(
         })
 }
 
+fn finish_issue_needs_issue_small_binary_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4216 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            matches!(
+                path.trim().trim_matches('/'),
+                "adl/Cargo.toml"
+                    | "adl/src/bin/adl_issue.rs"
+                    | "adl/src/cli/pr_cmd/finish_support.rs"
+                    | "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
+                    | "adl/tools/pr.sh"
+                    | "adl/tools/test_pr_small_binary_delegation.sh"
+            )
+        })
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -1802,6 +1826,29 @@ fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     );
     FinishValidationPlan {
         mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
+}
+
+fn build_issue_small_binary_validation_plan() -> FinishValidationPlan {
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+    ];
+    push_finish_validation_command(
+        &mut commands,
+        "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml --bin adl-issue tests::adl_issue_forwards_args_to_dispatch -- --exact --nocapture",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "bash adl/tools/test_pr_small_binary_delegation.sh",
+    );
+    FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
         commands,
     }
 }
@@ -2277,6 +2324,22 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl-pr-finish",
                             "cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-issue tests::adl_issue_forwards_args_to_dispatch -- --exact --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-issue",
+                            "tests::adl_issue_forwards_args_to_dispatch",
+                            "--",
+                            "--exact",
+                            "--nocapture",
                         ],
                     )?;
                 }

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1845,6 +1845,10 @@ fn build_issue_small_binary_validation_plan() -> FinishValidationPlan {
     );
     push_finish_validation_command(
         &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_issue_small_binary_slice -- --exact --nocapture",
+    );
+    push_finish_validation_command(
+        &mut commands,
         "bash adl/tools/test_pr_small_binary_delegation.sh",
     );
     FinishValidationPlan {
@@ -2337,6 +2341,22 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl-issue",
                             "tests::adl_issue_forwards_args_to_dispatch",
+                            "--",
+                            "--exact",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_issue_small_binary_slice -- --exact --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-pr-finish",
+                            "cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_issue_small_binary_slice",
                             "--",
                             "--exact",
                             "--nocapture",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1801,6 +1801,7 @@ fn finish_issue_needs_issue_small_binary_validation(
                     | "adl/src/cli/pr_cmd/finish_support.rs"
                     | "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
                     | "adl/tools/pr.sh"
+                    | "adl/tools/test_ci_path_policy.sh"
                     | "adl/tools/test_pr_small_binary_delegation.sh"
             )
         })

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1732,6 +1732,10 @@ fn finish_validation_profile_classifies_issue_small_binary_slice() {
         &"cargo test --manifest-path adl/Cargo.toml --bin adl-issue tests::adl_issue_forwards_args_to_dispatch -- --exact --nocapture"
             .to_string()
     ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_issue_small_binary_slice -- --exact --nocapture"
+            .to_string()
+    ));
     assert!(plan
         .commands
         .contains(&"bash adl/tools/test_pr_small_binary_delegation.sh".to_string()));

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1719,6 +1719,7 @@ fn finish_validation_profile_classifies_issue_small_binary_slice() {
             "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
             "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
             "adl/tools/pr.sh".to_string(),
+            "adl/tools/test_ci_path_policy.sh".to_string(),
             "adl/tools/test_pr_small_binary_delegation.sh".to_string(),
         ],
     )
@@ -2599,6 +2600,7 @@ fn finish_issue_small_binary_paths_run_issue_focused_validation() {
             "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
             "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
             "adl/tools/pr.sh".to_string(),
+            "adl/tools/test_ci_path_policy.sh".to_string(),
             "adl/tools/test_pr_small_binary_delegation.sh".to_string(),
         ],
     )

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -580,6 +580,10 @@ fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
         &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
     );
+    write_executable(
+        &repo.join("adl/tools/test_pr_small_binary_delegation.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -836,6 +840,10 @@ fn finish_validation_sanitizes_live_github_transport_env() {
     .expect("cargo toml");
     write_executable(
         &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_pr_small_binary_delegation.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
     );
     init_git_repo(&repo);
@@ -1701,6 +1709,43 @@ fn finish_validation_profile_keeps_small_binary_delegation_proof_focused() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_issue_small_binary_slice() {
+    let plan = select_finish_validation_plan_for_finish(
+        4216,
+        ".",
+        &[
+            "adl/Cargo.toml".to_string(),
+            "adl/src/bin/adl_issue.rs".to_string(),
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+            "adl/tools/pr.sh".to_string(),
+            "adl/tools/test_pr_small_binary_delegation.sh".to_string(),
+        ],
+    )
+    .expect("issue small binary focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-issue tests::adl_issue_forwards_args_to_dispatch -- --exact --nocapture"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_pr_small_binary_delegation.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo nextest")));
+}
+
+#[test]
 fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4215,
@@ -2502,6 +2547,70 @@ fn finish_owner_binary_paths_run_owner_binary_focused_validation() {
     assert!(cargo_calls.contains("--bin adl"));
     assert!(!cargo_calls.contains("github_token"));
     assert!(!cargo_calls.contains(" cli::pr_cmd"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
+}
+
+#[test]
+fn finish_issue_small_binary_paths_run_issue_focused_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-issue-small-binary-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_pr_small_binary_delegation.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let plan = select_finish_validation_plan_for_finish(
+        4216,
+        ".",
+        &[
+            "adl/Cargo.toml".to_string(),
+            "adl/src/bin/adl_issue.rs".to_string(),
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+            "adl/tools/pr.sh".to_string(),
+            "adl/tools/test_pr_small_binary_delegation.sh".to_string(),
+        ],
+    )
+    .expect("issue small binary plan");
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("issue small binary focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("fmt --manifest-path"));
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--bin adl-issue"));
+    assert!(cargo_calls.contains("tests::adl_issue_forwards_args_to_dispatch"));
     assert!(!cargo_calls.contains("clippy --manifest-path"));
 }
 

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -262,6 +262,7 @@ rust_pr_subcommand_binary_name() {
     preflight) printf 'adl-pr-preflight\n' ;;
     finish) printf 'adl-pr-finish\n' ;;
     validation) printf 'adl-pr-validation\n' ;;
+    issue) printf 'adl-issue\n' ;;
     closeout) printf 'adl-pr-closeout\n' ;;
     *) return 1 ;;
   esac
@@ -278,6 +279,7 @@ rust_pr_subcommand_override_var_name() {
     preflight) printf 'ADL_PR_PREFLIGHT_BIN\n' ;;
     finish) printf 'ADL_PR_FINISH_BIN\n' ;;
     validation) printf 'ADL_PR_VALIDATION_BIN\n' ;;
+    issue) printf 'ADL_ISSUE_BIN\n' ;;
     closeout) printf 'ADL_PR_CLOSEOUT_BIN\n' ;;
     *) return 1 ;;
   esac
@@ -2330,7 +2332,7 @@ cmd_issue() {
     return 0
   fi
   adl_obs_event "pr.sh" "issue" "started" "issue_query" "${1:-}"
-  require_rust_pr_delegate
+  require_rust_pr_delegate issue
   delegate_pr_command_to_rust issue "$@"
 }
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -46,6 +46,34 @@ EOF
 jobs:
   adl-coverage:
     steps:
+      - name: Determine PR fast coverage filters
+        id: coverage-impact
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        run: |
+          set -euo pipefail
+          bash adl/tools/check_coverage_impact.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --print-risk-nextest-expression > adl/coverage-impact-filter-expression.txt
+          if test -s adl/coverage-impact-filter-expression.txt; then
+            echo "needs_fast_summary=true" >> "$GITHUB_OUTPUT"
+            echo "filter_expression=$(cat adl/coverage-impact-filter-expression.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_fast_summary=false" >> "$GITHUB_OUTPUT"
+            echo "filter_expression=" >> "$GITHUB_OUTPUT"
+          fi
+        working-directory: .
+      - name: PR fast coverage summary (json)
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'
+        run: |
+          rm -rf target/debug target/llvm-cov-target
+          COVERAGE_BUILD_ROOT="${RUNNER_TEMP:-/tmp}/adl-pr-fast-coverage"
+          mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/llvm-cov-target"
+          export CARGO_TARGET_DIR="$COVERAGE_BUILD_ROOT/target"
+          export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/llvm-cov-target"
+          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E "${{ steps.coverage-impact.outputs.filter_expression }}"
+          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
+        working-directory: .
       - name: Coverage run and summary (json)
         run: bash tools/run_authoritative_coverage_lane.sh
       - name: Coverage summary (text)
@@ -505,17 +533,25 @@ EOF
   python3 - <<'PY'
 from pathlib import Path
 
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    if old not in text:
+        raise SystemExit(f"expected workflow snippet missing for {label}")
+    return text.replace(old, new, 1)
+
 workflow = Path(".github/workflows/ci.yaml")
 text = workflow.read_text()
-text = text.replace(
-    '            echo "filters=$(paste -sd\' \' adl/coverage-impact-filters.txt)" >> "$GITHUB_OUTPUT"\n',
-    '            echo "filters=$(paste -sd\' \' adl/coverage-impact-filters.txt)" >> "$GITHUB_OUTPUT"\n            echo "run_cli_smoke_process_status=true" >> "$GITHUB_OUTPUT"\n            echo "run_cli_smoke_basics=true" >> "$GITHUB_OUTPUT"\n',
-    1,
+text = replace_once(
+    text,
+    '            echo "filter_expression=$(cat adl/coverage-impact-filter-expression.txt)" >> "$GITHUB_OUTPUT"\n',
+    '            echo "filter_expression=$(cat adl/coverage-impact-filter-expression.txt)" >> "$GITHUB_OUTPUT"\n            echo "run_cli_smoke_process_status=true" >> "$GITHUB_OUTPUT"\n            echo "run_cli_smoke_basics=true" >> "$GITHUB_OUTPUT"\n',
+    "coverage-impact output augmentation",
 )
-text = text.replace(
+text = replace_once(
+    text,
     "          rm -rf target/debug target/llvm-cov-target\n          COVERAGE_BUILD_ROOT=\"${RUNNER_TEMP:-/tmp}/adl-pr-fast-coverage\"\n          mkdir -p \"$COVERAGE_BUILD_ROOT/target\" \"$COVERAGE_BUILD_ROOT/llvm-cov-target\"\n          export CARGO_TARGET_DIR=\"$COVERAGE_BUILD_ROOT/target\"\n          export CARGO_LLVM_COV_TARGET_DIR=\"$COVERAGE_BUILD_ROOT/llvm-cov-target\"\n          CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E \"${{ steps.coverage-impact.outputs.filter_expression }}\"\n          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json\n",
     "          rm -rf target/debug target/llvm-cov-target\n          COVERAGE_BUILD_ROOT=\"${RUNNER_TEMP:-/tmp}/adl-pr-fast-coverage\"\n          mkdir -p \"$COVERAGE_BUILD_ROOT/target\" \"$COVERAGE_BUILD_ROOT/llvm-cov-target\"\n          export CARGO_TARGET_DIR=\"$COVERAGE_BUILD_ROOT/target\"\n          export CARGO_LLVM_COV_TARGET_DIR=\"$COVERAGE_BUILD_ROOT/llvm-cov-target\"\n          summary_files=()\n          if [ \"${{ steps.coverage-impact.outputs.run_cli_smoke_process_status }}\" = \"true\" ]; then\n            CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --test cli_smoke process_status --no-report\n            cargo llvm-cov report --json --summary-only --output-path coverage-summary-process-status.json\n            summary_files+=(coverage-summary-process-status.json)\n          fi\n          if [ \"${{ steps.coverage-impact.outputs.run_cli_smoke_basics }}\" = \"true\" ]; then\n            CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --test cli_smoke basics --no-report\n            cargo llvm-cov report --json --summary-only --output-path coverage-summary-cli-basics.json\n            summary_files+=(coverage-summary-cli-basics.json)\n          fi\n          cp \"${summary_files[0]}\" coverage-summary.json\n",
-    1,
+    "coverage summary command split",
 )
 workflow.write_text(text)
 

--- a/adl/tools/test_pr_small_binary_delegation.sh
+++ b/adl/tools/test_pr_small_binary_delegation.sh
@@ -16,7 +16,6 @@ cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
 cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
 cp "$OBS_SRC" "$repo/adl/tools/observability.sh"
 chmod +x "$repo/adl/tools/pr.sh"
-touch "$repo/adl/Cargo.toml"
 
 (
   cd "$repo"
@@ -60,6 +59,14 @@ set -euo pipefail
 printf 'validation:%s\n' "$*" >"${ADL_TEST_LOG}"
 EOF
 chmod +x "$validation_bin"
+
+issue_bin="$repo/bin/adl-issue"
+cat >"$issue_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'issue:%s\n' "$*" >"${ADL_TEST_LOG}"
+EOF
+chmod +x "$issue_bin"
 
 closeout_bin="$repo/bin/adl-pr-closeout"
 cat >"$closeout_bin" <<'EOF'
@@ -122,6 +129,18 @@ validation_log="$tmpdir/validation.log"
 )
 grep -Fqx 'validation:3888 --json' "$validation_log" || {
   echo "assertion failed: validation should delegate directly to adl-pr-validation without broad 'pr validation' argv" >&2
+  exit 1
+}
+
+issue_log="$tmpdir/issue.log"
+(
+  cd "$repo"
+  ADL_TEST_LOG="$issue_log" \
+    ADL_ISSUE_BIN="$issue_bin" \
+    "$BASH_BIN" adl/tools/pr.sh issue search --query "validation manager" --state open --json >/dev/null
+)
+grep -Fqx 'issue:search --query validation manager --state open --json' "$issue_log" || {
+  echo "assertion failed: issue operations should delegate directly to adl-issue without broad 'pr issue' argv" >&2
   exit 1
 }
 


### PR DESCRIPTION
Closes #4216

## Summary
Completed the first small-binary decomposition slice for `#4216` by adding a
direct `adl-issue` Rust binary, wiring `adl/tools/pr.sh issue` to delegate to
that binary, and extending the small-binary delegation proof to cover the issue
path. The initial pre-publication review findings around the direct delegate
gate and fake-manifest proof were fixed before publication. A later bounded
review of the published branch found one remaining proof gap: the issue-specific
focused finish profile did not run the classifier regression that proves this
slice is routed into the intended `SmallBinaryFocused` validation plan. That
gap is now fixed in scope on the same branch.

## Artifacts
- Updated tracked code:
  - `adl/Cargo.toml`
  - `adl/src/bin/adl_issue.rs`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_small_binary_delegation.sh`
- Updated local issue record:
  - `.adl/v0.91.6/tasks/issue-4216__v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries/sor.md`
  - `.adl/v0.91.6/tasks/issue-4216__v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries/spp.md`
  - `.adl/v0.91.6/tasks/issue-4216__v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries/srp.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified the compatibility shell wrapper delegates directly to role-specific
    binaries, including the new issue path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-issue tests::adl_issue_forwards_args_to_dispatch -- --exact --nocapture`
    Verified the exact direct-binary forwarding path for `adl-issue`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_issue_small_binary_slice -- --exact --nocapture`
    Verified the native finish classifier for the `#4216` focused profile and
    closed the review-reported proof gap in the issue-specific finish plan.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_issue_small_binary_paths_run_issue_focused_validation -- --exact --nocapture`
    Verified the native finish runner executes the repaired focused
    issue-small-binary validation plan end to end.
  - `git diff --check`
    Verified there are no whitespace or patch-format defects.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4216__v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4216__v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries/sor.md
- Idempotency-Key: v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries-adl-v0-91-6-tasks-issue-4216-v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries-sip-md-adl-v0-91-6-tasks-issue-4216-v0-91-6-tools-rust-split-issue-and-validation-hot-paths-into-small-binaries-sor-md