### PR TITLE
[v0.91.6][runtime][tokio][T-04] Define bounded CAV cadence integration on the shared runtime

### DIFF
--- a/adl/src/cli/identity_cmd/tests/adversarial_contracts.rs
+++ b/adl/src/cli/identity_cmd/tests/adversarial_contracts.rs
@@ -317,6 +317,14 @@ fn identity_continuous_verification_writes_contract_json() {
         .expect("array")
         .iter()
         .any(|value| value == "continuous_bounded"));
+    assert!(json["runtime_integration"]["cadence_requirements"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value
+            .as_str()
+            .expect("string")
+            .contains("shared Tokio runtime")));
     assert!(json["lifecycle"]
         .as_array()
         .expect("array")

--- a/adl/src/continuous_verification_self_attack.rs
+++ b/adl/src/continuous_verification_self_attack.rs
@@ -12,6 +12,13 @@ pub struct ContinuousVerificationCadenceContract {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContinuousVerificationRuntimeIntegrationContract {
+    pub shared_runtime_surfaces: Vec<String>,
+    pub cadence_requirements: Vec<String>,
+    pub bounded_execution_guards: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VerificationSurfaceSelectionContract {
     pub eligible_surface_types: Vec<String>,
     pub selection_requirements: Vec<String>,
@@ -69,6 +76,7 @@ pub struct ContinuousVerificationSelfAttackContract {
     pub runtime_condition: String,
     pub upstream_contracts: Vec<String>,
     pub cadence: ContinuousVerificationCadenceContract,
+    pub runtime_integration: ContinuousVerificationRuntimeIntegrationContract,
     pub surface_selection: VerificationSurfaceSelectionContract,
     pub lifecycle: Vec<ContinuousVerificationStageContract>,
     pub self_attack_layers: Vec<SelfAttackLayerContract>,
@@ -127,6 +135,23 @@ impl ContinuousVerificationSelfAttackContract {
                     "hypothesis generation must be prioritized by posture, target criticality, and prior evidence",
                     "duplicate findings link to prior exploit knowledge instead of creating uncorrelated churn",
                     "low-confidence speculation remains a hypothesis artifact rather than proof",
+                ]),
+            },
+            runtime_integration: ContinuousVerificationRuntimeIntegrationContract {
+                shared_runtime_surfaces: strings(&[
+                    "Tokio shared runtime substrate",
+                    "long-lived agent cadence and supervision loop",
+                    "ordinary ADL runtime control plane",
+                ]),
+                cadence_requirements: strings(&[
+                    "future scheduled and continuous_bounded verification cadence must run on the shared Tokio runtime rather than a parallel security daemon",
+                    "future continuous verification cadence must reuse runtime stop, lease, and status boundaries before the next bounded iteration proceeds",
+                    "bounded verification tasks remain review-visible and artifact-linked inside the ordinary runtime control plane",
+                ]),
+                bounded_execution_guards: strings(&[
+                    "shared cadence never grants additional target, mutation, or scheduling authority",
+                    "this contract does not claim always-on autonomous red/blue runtime execution",
+                    "CAV cadence consumes the same shared runtime substrate as ACIP-facing runtime work while preserving separate issue-owned execution logic",
                 ]),
             },
             surface_selection: VerificationSurfaceSelectionContract {
@@ -527,6 +552,16 @@ mod tests {
                 "continuous_bounded"
             ]
         );
+        assert!(contract
+            .runtime_integration
+            .shared_runtime_surfaces
+            .iter()
+            .any(|surface| surface == "Tokio shared runtime substrate"));
+        assert!(contract
+            .runtime_integration
+            .cadence_requirements
+            .iter()
+            .any(|rule| rule.contains("shared Tokio runtime")));
         assert_eq!(
             contract
                 .lifecycle
@@ -609,6 +644,12 @@ mod tests {
             .downstream_boundaries
             .iter()
             .any(|boundary| boundary.contains("WP-07")));
+        assert!(contract
+            .runtime_integration
+            .bounded_execution_guards
+            .iter()
+            .any(|guard| guard
+                .contains("does not claim always-on autonomous red/blue runtime execution")));
         assert!(contract
             .scope_boundary
             .contains("future executable tooling"));


### PR DESCRIPTION
Closes #4182

## Summary
- make the continuous-verification contract name the shared Tokio runtime integration path explicitly
- preserve the bounded non-claim guard against always-on autonomous red/blue runtime execution
- extend the identity continuous-verification proof surface to assert the new shared-runtime cadence requirement

## Validation
- cargo test --manifest-path adl/Cargo.toml continuous_verification_self_attack -- --nocapture
- cargo test --manifest-path adl/Cargo.toml identity_continuous_verification -- --nocapture