### PR TITLE
[v0.91.6][tools][validation] Implement validation manager profiles

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -1,9 +1,96 @@
 {
   "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    },
+    "tooling": {
+      "owner": "tools",
+      "resource_class": "small",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "none"
+    },
+    "runtime": {
+      "owner": "runtime",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    },
+    "provider": {
+      "owner": "provider",
+      "resource_class": "high",
+      "determinism_posture": "credential_or_network_bound",
+      "proof_role": "provider_regression",
+      "risk_class": "high",
+      "escalation_rule": "manual_provider_gate"
+    },
+    "security": {
+      "owner": "security",
+      "resource_class": "high",
+      "determinism_posture": "deterministic",
+      "proof_role": "security_regression",
+      "risk_class": "high",
+      "escalation_rule": "manual_security_gate"
+    },
+    "ci_policy": {
+      "owner": "tools",
+      "resource_class": "small",
+      "determinism_posture": "deterministic",
+      "proof_role": "ci_contract",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    },
+    "slow_proof": {
+      "owner": "runtime",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "slow_proof",
+      "risk_class": "high",
+      "escalation_rule": "manual_slow_proof_gate"
+    },
+    "release_gate": {
+      "owner": "tools",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "release_gate",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    },
+    "shared_rust": {
+      "owner": "shared",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    }
+  },
   "lanes": [
     {
       "id": "prompt_template_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "csdlc",
+      "proof_role": "prompt_template_contract",
+      "requirement_ids": [
+        "prompt_template_contracts"
+      ],
+      "path_selectors": [
+        "docs/templates/prompts/**",
+        "adl/src/bin/adl_prompt_template.rs",
+        "adl/src/bin/adl_validate_structured_prompt.rs",
+        "adl/src/csdlc_prompt_editor/**",
+        "adl/src/csdlc_prompt_editor.rs"
+      ],
       "path_hints": [
         "docs/templates/prompts/**",
         "adl/src/bin/adl_prompt_template.rs",
@@ -18,6 +105,19 @@
     {
       "id": "pvf_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "pvf_contract",
+      "requirement_ids": [
+        "pvf_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/run_pvf_validation_lane.sh",
+        "adl/tools/validate_pvf_manifest.py",
+        "adl/tools/test_run_pvf_validation_lane.sh",
+        "adl/tools/test_pvf_ci_release_policy.sh",
+        "adl/tools/run_pvf_ci_release_policy_fixture.sh"
+      ],
       "path_hints": [
         "adl/tools/run_pvf_validation_lane.sh",
         "adl/tools/validate_pvf_manifest.py",
@@ -32,6 +132,16 @@
     {
       "id": "ci_path_policy_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "ci_policy",
+      "owner": "tools",
+      "requirement_ids": [
+        "ci_path_policy_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh",
+        ".github/workflows/**"
+      ],
       "path_hints": [
         "adl/tools/ci_path_policy.sh",
         "adl/tools/test_ci_path_policy.sh",
@@ -44,6 +154,16 @@
     {
       "id": "coverage_impact_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "coverage_contract",
+      "requirement_ids": [
+        "coverage_impact_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/check_coverage_impact.sh",
+        "adl/tools/test_check_coverage_impact.sh"
+      ],
       "path_hints": [
         "adl/tools/check_coverage_impact.sh",
         "adl/tools/test_check_coverage_impact.sh"
@@ -55,6 +175,20 @@
     {
       "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "csdlc",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "csdlc_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/cli/pr_cmd.rs",
+        "adl/src/cli/pr_cmd/**",
+        "adl/src/cli/pr_cmd_cards.rs",
+        "adl/src/cli/pr_cmd_cards/**",
+        "adl/tools/pr.sh",
+        "adl/tools/run_owner_validation_lane.sh"
+      ],
       "path_hints": [
         "adl/src/cli/pr_cmd.rs",
         "adl/src/cli/pr_cmd/**",
@@ -70,6 +204,16 @@
     {
       "id": "runtime_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "runtime",
+      "owner": "runtime",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "runtime_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/bin/adl_runtime.rs",
+        "adl/tools/test_adl_runtime_compatibility.sh"
+      ],
       "path_hints": [
         "adl/src/bin/adl_runtime.rs",
         "adl/tools/test_adl_runtime_compatibility.sh"
@@ -81,6 +225,17 @@
     {
       "id": "review_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "review_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/bin/adl_review.rs",
+        "adl/src/review*.rs",
+        "adl/tools/test_adl_review_compatibility.sh"
+      ],
       "path_hints": [
         "adl/src/bin/adl_review.rs",
         "adl/src/review*.rs",
@@ -93,6 +248,15 @@
     {
       "id": "docs_diff_check",
       "lane_class": "docs",
+      "default_surface": "docs",
+      "owner": "docs",
+      "requirement_ids": [
+        "docs_diff_check"
+      ],
+      "path_selectors": [
+        "docs/**",
+        "*.md"
+      ],
       "path_hints": [
         "docs/**",
         "*.md"
@@ -102,6 +266,57 @@
       "reason": "docs_only_surface_requires_diff_hygiene"
     }
   ],
+  "special_surfaces": {
+    "release_gate_review": {
+      "id": "release_gate_review",
+      "lane_class": "release_gate",
+      "default_surface": "release_gate",
+      "owner": "tools",
+      "path_selectors": [
+        ".github/workflows/**",
+        "docs/milestones/**/release/**",
+        "docs/milestones/**/RELEASE_PLAN*.md",
+        "docs/milestones/**/MILESTONE_CHECKLIST*.md"
+      ],
+      "path_hints": [
+        ".github/workflows/**",
+        "docs/milestones/**/release/**",
+        "docs/milestones/**/RELEASE_PLAN*.md",
+        "docs/milestones/**/MILESTONE_CHECKLIST*.md"
+      ],
+      "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+      "run_command": "",
+      "reason": "changed_surface_requires_release_or_ci_policy_review",
+      "requirement_ids": [
+        "release_gate_disposition_required"
+      ],
+      "broad_lane_reason": "release and CI-policy surfaces remain distinct from ordinary PR proof"
+    },
+    "rust_pr_fast": {
+      "id": "rust_pr_fast",
+      "lane_class": "fast_unit",
+      "escalated_lane_class": "release_gate",
+      "default_surface": "shared_rust",
+      "owner": "shared",
+      "path_selectors": [
+        "adl/build.rs",
+        "adl/src/**",
+        "adl/tests/**"
+      ],
+      "path_hints": [
+        "adl/build.rs",
+        "adl/src/**",
+        "adl/tests/**"
+      ],
+      "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "reason": "delegate_rust_changed_surface_to_pr_fast_lane_selector",
+      "requirement_ids": [
+        "rust_changed_surface"
+      ],
+      "broad_lane_reason": "shared Rust changes escalate when PR-fast cannot prove a bounded slice"
+    }
+  },
   "release_gate_hints": [
     ".github/workflows/**",
     "docs/milestones/**/release/**",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1214,6 +1214,12 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_validation_manager_focused_validation(path))
+        {
+            commands.push("bash adl/tools/test_validation_manager.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_small_binary_delegation_validation(path))
         {
             commands.push("bash adl/tools/test_pr_small_binary_delegation.sh".to_string());
@@ -1401,6 +1407,9 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
         trimmed,
         "adl/tools/pr.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
+            | "adl/tools/validation_manager.py"
+            | "adl/tools/validation_manager.sh"
+            | "adl/tools/test_validation_manager.sh"
             | "adl/tools/test_install_adl_operational_skills.sh"
             | "adl/tools/test_sprint_conductor_helpers.sh"
     ) || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
@@ -1677,6 +1686,16 @@ fn finish_path_needs_validation_selector_focused_validation(path: &str) -> bool 
             | "adl/tools/select_validation_lanes.py"
             | "adl/tools/select_validation_lanes.sh"
             | "adl/tools/test_select_validation_lanes.sh"
+    )
+}
+
+fn finish_path_needs_validation_manager_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/validation_manager.py"
+            | "adl/tools/validation_manager.sh"
+            | "adl/tools/test_validation_manager.sh"
     )
 }
 
@@ -2064,6 +2083,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_select_validation_lanes.sh" => {
                     let script = repo_root.join("adl/tools/test_select_validation_lanes.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_validation_manager.sh" => {
+                    let script = repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1564,6 +1564,29 @@ fn finish_validation_profile_keeps_small_binary_delegation_proof_focused() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        4215,
+        ".",
+        &[
+            "adl/tools/validation_manager.py".to_string(),
+            "adl/tools/validation_manager.sh".to_string(),
+            "adl/tools/test_validation_manager.sh".to_string(),
+        ],
+    )
+    .expect("validation manager plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_manager.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo test --manifest-path adl/Cargo.toml --bin adl")));
+}
+
+#[test]
 fn finish_restores_missing_canonical_cards_from_slug_drifted_issue_bundle() {
     let repo = unique_temp_dir("adl-pr-finish-slug-drift");
     let issue_ref = IssueRef::new(
@@ -1820,6 +1843,69 @@ fn finish_helper_paths_run_validation_selector_validation() {
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("selector"));
+}
+
+#[test]
+fn finish_helper_paths_run_validation_manager_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-validation-manager-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_validation_manager.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' validation-manager >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/tools/validation_manager.py,adl/tools/validation_manager.sh,adl/tools/test_validation_manager.sh",
+    )
+    .expect("validation manager plan");
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("validation manager validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "validation manager focused validation should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("validation-manager"));
 }
 
 #[test]

--- a/adl/tools/select_validation_lanes.py
+++ b/adl/tools/select_validation_lanes.py
@@ -91,27 +91,119 @@ def matches(path: str, hints: list[str]) -> bool:
     return any(path == hint or fnmatch.fnmatch(path, hint) for hint in hints)
 
 
+def selectors_for(entry: dict[str, Any]) -> list[str]:
+    selectors = entry.get("path_selectors") or entry.get("path_hints")
+    if not isinstance(selectors, list) or not selectors:
+        fail(f"manifest entry {entry.get('id', '<unknown>')} selectors must be a non-empty array")
+    return selectors
+
+
+REQUIRED_SURFACE_METADATA = (
+    "owner",
+    "resource_class",
+    "determinism_posture",
+    "proof_role",
+    "risk_class",
+    "escalation_rule",
+)
+
+
+def merge_surface_defaults(manifest: dict[str, Any], entry: dict[str, Any], *, entry_id: str) -> dict[str, Any]:
+    default_surface = entry.get("default_surface")
+    if not isinstance(default_surface, str) or not default_surface:
+        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required key: default_surface")
+    surface_defaults = manifest["surface_defaults"].get(default_surface)
+    if not isinstance(surface_defaults, dict):
+        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} references unknown default_surface: {default_surface}")
+    merged = dict(surface_defaults)
+    merged.update(entry)
+    merged["path_selectors"] = selectors_for(entry)
+    for key in REQUIRED_SURFACE_METADATA:
+        if not isinstance(merged.get(key), str) or not merged[key]:
+            fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required surface metadata: {key}")
+    return merged
+
+
+def plan_entry(
+    manifest: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    status: str,
+    matched_paths: list[str],
+    command: str | None = None,
+    run_command: str | None = None,
+    lane_class: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized = merge_surface_defaults(manifest, entry, entry_id=entry["id"])
+    result = {
+        "lane_class": lane_class or normalized["lane_class"],
+        "status": status,
+        "reason": normalized["reason"],
+        "command": command if command is not None else normalized["command"],
+        "run_command": run_command if run_command is not None else normalized.get("run_command", normalized["command"]),
+        "matched_paths": matched_paths,
+        "owner": normalized["owner"],
+        "resource_class": normalized["resource_class"],
+        "determinism_posture": normalized["determinism_posture"],
+        "proof_role": normalized["proof_role"],
+        "risk_class": normalized["risk_class"],
+        "escalation_rule": normalized["escalation_rule"],
+        "default_surface": normalized["default_surface"],
+        "path_selectors": normalized["path_selectors"],
+        "requirement_ids": normalized.get("requirement_ids", []),
+    }
+    broad_lane_reason = normalized.get("broad_lane_reason")
+    if broad_lane_reason:
+        result["broad_lane_reason"] = broad_lane_reason
+    if extra:
+        result.update(extra)
+    return result
+
+
+def manifest_entry_for(manifest: dict[str, Any], surface_id: str, fallback: dict[str, Any]) -> dict[str, Any]:
+    special_surfaces = manifest.get("special_surfaces", {})
+    entry = special_surfaces.get(surface_id, fallback)
+    if not isinstance(entry, dict):
+        fail(f"{DEFAULT_MANIFEST}: special_surfaces.{surface_id} must be an object")
+    return entry
+
+
 def load_manifest(path: Path) -> dict[str, Any]:
     manifest = json.loads(path.read_text())
     if manifest.get("schema_version") != "adl.validation_lane_selector.v1":
         fail(f"{path}: unsupported schema_version")
-    for key in ("lanes", "release_gate_hints", "rust_path_hints"):
+    for key in ("surface_defaults", "lanes", "release_gate_hints", "rust_path_hints"):
         if key not in manifest:
             fail(f"{path}: missing required key: {key}")
+    if not isinstance(manifest["surface_defaults"], dict) or not manifest["surface_defaults"]:
+        fail(f"{path}: surface_defaults must be a non-empty object")
     lane_ids: set[str] = set()
     for index, lane in enumerate(manifest["lanes"]):
         if not isinstance(lane, dict):
             fail(f"{path}: lanes[{index}] must be an object")
-        for key in ("id", "lane_class", "path_hints", "command", "reason"):
+        for key in ("id", "lane_class", "command", "reason", "default_surface"):
             if key not in lane:
                 fail(f"{path}: lanes[{index}] missing required key: {key}")
         if lane["id"] in lane_ids:
             fail(f"{path}: duplicate lane id: {lane['id']}")
         lane_ids.add(lane["id"])
-        if not isinstance(lane["path_hints"], list) or not lane["path_hints"]:
-            fail(f"{path}: lane {lane['id']} path_hints must be a non-empty array")
+        selectors_for(lane)
         if "run_command" in lane and not isinstance(lane["run_command"], str):
             fail(f"{path}: lane {lane['id']} run_command must be a string")
+        merge_surface_defaults(manifest, lane, entry_id=lane["id"])
+    special_surfaces = manifest.get("special_surfaces", {})
+    if special_surfaces:
+        if not isinstance(special_surfaces, dict):
+            fail(f"{path}: special_surfaces must be an object")
+        for surface_id, surface in special_surfaces.items():
+            if not isinstance(surface, dict):
+                fail(f"{path}: special_surfaces.{surface_id} must be an object")
+            for key in ("id", "lane_class", "command", "reason", "default_surface"):
+                if key not in surface:
+                    fail(f"{path}: special_surfaces.{surface_id} missing required key: {key}")
+            selectors_for(surface)
+            merge_surface_defaults(manifest, surface, entry_id=surface_id)
     for key in ("release_gate_hints", "rust_path_hints"):
         if not isinstance(manifest[key], list):
             fail(f"{path}: {key} must be an array")
@@ -145,33 +237,52 @@ def select_lanes(
     head: str,
 ) -> dict[str, Any]:
     selected: dict[str, dict[str, Any]] = {}
+    release_gate_entry = manifest_entry_for(
+        manifest,
+        "release_gate_review",
+        {
+            "id": "release_gate_review",
+            "lane_class": "release_gate",
+            "default_surface": "release_gate",
+            "owner": "tools",
+            "path_selectors": manifest["release_gate_hints"],
+            "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+            "run_command": "",
+            "reason": "changed_surface_requires_release_or_ci_policy_review",
+        },
+    )
+    rust_entry = manifest_entry_for(
+        manifest,
+        "rust_pr_fast",
+        {
+            "id": "rust_pr_fast",
+            "lane_class": "fast_unit",
+            "escalated_lane_class": "release_gate",
+            "default_surface": "shared_rust",
+            "owner": "shared",
+            "path_selectors": manifest["rust_path_hints"],
+            "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+            "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+            "reason": "delegate_rust_changed_surface_to_pr_fast_lane_selector",
+        },
+    )
 
     release_gate_paths = [
-        path for path in paths if matches(path, manifest["release_gate_hints"])
+        path for path in paths if matches(path, selectors_for(release_gate_entry))
     ]
 
     for path in paths:
         for lane in manifest["lanes"]:
-            if matches(path, lane["path_hints"]):
+            if matches(path, selectors_for(lane)):
                 lane_id = lane["id"]
-                entry = selected.setdefault(
-                    lane_id,
-                    {
-                        "lane_class": lane["lane_class"],
-                        "status": "selected",
-                        "reason": lane["reason"],
-                        "command": lane["command"],
-                        "run_command": lane.get("run_command", lane["command"]),
-                        "matched_paths": [],
-                    },
-                )
+                entry = selected.setdefault(lane_id, plan_entry(manifest, lane, status="selected", matched_paths=[]))
                 entry["matched_paths"].append(path)
                 break
 
     rust_paths = [
         path
         for path in paths
-        if matches(path, manifest["rust_path_hints"])
+        if matches(path, selectors_for(rust_entry))
         and not path.endswith("/README.md")
         and not path.endswith(".md")
     ]
@@ -185,27 +296,30 @@ def select_lanes(
             command += f" --changed-files {shlex.quote(str(changed_files))}"
         else:
             command += f" --base {shlex.quote(base)} --head {shlex.quote(head)}"
-        selected["rust_pr_fast"] = {
-            "lane_class": "fast_unit" if status == "selected" else "release_gate",
-            "status": status,
-            "reason": reason,
-            "command": command,
-            "run_command": command,
-            "matched_paths": rust_paths,
-            "mode": mode,
-            "filter_tokens": fast_plan.get("filter_tokens", ""),
-            "filter_expression": fast_plan.get("filter_expression", ""),
-        }
+        selected["rust_pr_fast"] = plan_entry(
+            manifest,
+            rust_entry,
+            status=status,
+            matched_paths=rust_paths,
+            command=command,
+            run_command=command,
+            lane_class=rust_entry.get("escalated_lane_class") if status == "escalated" else rust_entry["lane_class"],
+            extra={
+                "reason": reason,
+                "mode": mode,
+                "filter_tokens": fast_plan.get("filter_tokens", ""),
+                "filter_expression": fast_plan.get("filter_expression", ""),
+            },
+        )
+        selected["rust_pr_fast"]["reason"] = reason
 
     if release_gate_paths:
-        selected["release_gate_review"] = {
-            "lane_class": "release_gate",
-            "status": "release_gate_required",
-            "reason": "changed_surface_requires_release_or_ci_policy_review",
-            "command": "record release-gate disposition; do not treat focused PR validation as release proof",
-            "run_command": "",
-            "matched_paths": release_gate_paths,
-        }
+        selected["release_gate_review"] = plan_entry(
+            manifest,
+            release_gate_entry,
+            status="release_gate_required",
+            matched_paths=release_gate_paths,
+        )
 
     aggregate = "skipped"
     for lane in selected.values():

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -76,6 +76,19 @@ assert_has "$TMP/release.out" "aggregate_status=release_gate_required"
 assert_has "$TMP/release.out" "release_gate_review status=release_gate_required"
 assert_has "$TMP/release.out" "ci_path_policy_contracts status=selected"
 
+bash "$SCRIPT" --changed-files "$docs_only" --json >"$TMP/docs.json"
+python3 - <<'PY' "$TMP/docs.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+docs_lane = plan["lanes"]["docs_diff_check"]
+assert docs_lane["owner"] == "docs"
+assert docs_lane["default_surface"] == "docs"
+assert docs_lane["resource_class"] == "tiny"
+assert docs_lane["proof_role"] == "diff_hygiene"
+PY
+
 bash "$SCRIPT" --changed-files "$focused_rust" --json >"$TMP/focused.json"
 python3 - <<'PY' "$TMP/focused.json"
 import json
@@ -84,7 +97,25 @@ import sys
 plan = json.load(open(sys.argv[1]))
 assert plan["schema_version"] == "adl.validation_lane_plan.v1"
 assert plan["lanes"]["rust_pr_fast"]["mode"] == "focused"
+assert plan["lanes"]["rust_pr_fast"]["owner"] == "shared"
+assert plan["lanes"]["rust_pr_fast"]["resource_class"] == "medium"
+assert plan["lanes"]["rust_pr_fast"]["escalation_rule"] == "delegate_or_escalate"
 assert plan["pr_publication_sufficient"] is True
+PY
+
+bash "$SCRIPT" --changed-files "$release_gate" --json >"$TMP/release.json"
+python3 - <<'PY' "$TMP/release.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+release_gate_lane = plan["lanes"]["release_gate_review"]
+ci_policy_lane = plan["lanes"]["ci_path_policy_contracts"]
+assert release_gate_lane["proof_role"] == "release_gate"
+assert release_gate_lane["resource_class"] == "high"
+assert release_gate_lane["escalation_rule"] == "require_release_gate_disposition"
+assert ci_policy_lane["proof_role"] == "ci_contract"
+assert ci_policy_lane["default_surface"] == "ci_policy"
 PY
 
 report="$TMP/report.json"
@@ -118,5 +149,172 @@ plan = json.load(open(sys.argv[1]))
 assert plan["run_status"] == "passed"
 assert plan["lanes"]["docs_diff_check"]["run_status"] == "passed"
 PY
+
+invalid_manifest="$TMP/invalid-manifest.json"
+cat >"$invalid_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "broken_lane",
+      "lane_class": "docs",
+      "default_surface": "missing_surface",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "reason": "broken"
+    }
+  ],
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$invalid_manifest" --changed-files "$docs_only" >"$TMP/invalid.out" 2>"$TMP/invalid.err"; then
+  echo "expected invalid manifest to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/invalid.err" "references unknown default_surface: missing_surface"
+
+special_surface_manifest="$TMP/special-surface-manifest.json"
+cat >"$special_surface_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    },
+    "shared_rust": {
+      "owner": "shared",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    },
+    "release_gate": {
+      "owner": "tools",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "release_gate",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "special_surfaces": {
+    "release_gate_review": {
+      "id": "release_gate_review",
+      "lane_class": "release_gate",
+      "default_surface": "release_gate",
+      "path_selectors": [
+        "special/release/**"
+      ],
+      "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+      "run_command": "",
+      "reason": "special_release_gate_surface"
+    },
+    "rust_pr_fast": {
+      "id": "rust_pr_fast",
+      "lane_class": "fast_unit",
+      "escalated_lane_class": "release_gate",
+      "default_surface": "shared_rust",
+      "path_selectors": [
+        "special/rust/**"
+      ],
+      "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "reason": "special_rust_surface"
+    }
+  },
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+special_release="$TMP/special-release.txt"
+printf 'M\tspecial/release/packet.md\n' >"$special_release"
+bash "$SCRIPT" --manifest "$special_surface_manifest" --changed-files "$special_release" --json >"$TMP/special-release.json"
+python3 - <<'PY' "$TMP/special-release.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["aggregate_status"] == "release_gate_required"
+assert plan["lanes"]["release_gate_review"]["matched_paths"] == ["special/release/packet.md"]
+PY
+
+special_rust="$TMP/special-rust.txt"
+printf 'M\tspecial/rust/module.rs\n' >"$special_rust"
+bash "$SCRIPT" --manifest "$special_surface_manifest" --changed-files "$special_rust" --json >"$TMP/special-rust.json"
+python3 - <<'PY' "$TMP/special-rust.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["lanes"]["rust_pr_fast"]["matched_paths"] == ["special/rust/module.rs"]
+PY
+
+missing_metadata_manifest="$TMP/missing-metadata-manifest.json"
+cat >"$missing_metadata_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$missing_metadata_manifest" --changed-files "$docs_only" >"$TMP/missing-metadata.out" 2>"$TMP/missing-metadata.err"; then
+  echo "expected missing surface metadata to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/missing-metadata.err" "missing required surface metadata: proof_role"
 
 echo "PASS test_select_validation_lanes"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/validation_manager.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_has() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -- "$needle" "$file" >/dev/null; then
+    echo "expected $file to contain: $needle" >&2
+    echo "actual output:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+docs_only="$TMP/docs-only.txt"
+printf 'M\tdocs/milestones/v0.91.6/README.md\n' >"$docs_only"
+bash "$SCRIPT" --changed-files "$docs_only" >"$TMP/docs.out"
+assert_has "$TMP/docs.out" "selected_profile=docs_diff_check_profile"
+assert_has "$TMP/docs.out" "status=ready_to_run"
+assert_has "$TMP/docs.out" "lane=docs_diff_check"
+assert_has "$TMP/docs.out" "behavior_surfaces:"
+assert_has "$TMP/docs.out" "id=documentation_contract"
+assert_has "$TMP/docs.out" "estimated_cost=tiny"
+
+bash "$SCRIPT" --changed-files "$docs_only" --json >"$TMP/docs.json"
+python3 - <<'PY' "$TMP/docs.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["behavior_surfaces"][0]["id"] == "documentation_contract"
+assert profile["validation_dag"]["nodes"][0]["status"] == "runnable"
+assert profile["estimated_cost"]["runtime_class"] == "tiny"
+assert profile["validation_dag"]["compression_note"].startswith("profile validates behavior surfaces")
+PY
+
+release_gate="$TMP/release-gate.txt"
+printf 'M\t.github/workflows/ci.yaml\n' >"$release_gate"
+bash "$SCRIPT" --changed-files "$release_gate" --json >"$TMP/release.json"
+python3 - <<'PY' "$TMP/release.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "escalation_required"
+assert profile["escalation"]["required"] is True
+assert any(
+    reason["lane_id"] == "release_gate_review"
+    for reason in profile["escalation"]["reasons"]
+)
+assert any(item["lane_id"] == "ci_path_policy_contracts" for item in profile["run"])
+assert any(
+    behavior["id"] == "release_or_ci_policy_boundary"
+    for behavior in profile["behavior_surfaces"]
+)
+assert profile["estimated_cost"]["runtime_class"] == "escalated"
+PY
+
+if bash "$SCRIPT" --changed-files "$release_gate" --run >"$TMP/refuse.out" 2>"$TMP/refuse.err"; then
+  echo "expected validation manager to refuse escalated --run" >&2
+  exit 1
+fi
+assert_has "$TMP/refuse.err" "refusing --run for non-runnable profile"
+
+unmapped="$TMP/unmapped.txt"
+printf 'M\ttotally/unmapped/path.txt\n' >"$unmapped"
+bash "$SCRIPT" --changed-files "$unmapped" --json >"$TMP/unmapped.json"
+python3 - <<'PY' "$TMP/unmapped.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "validation_none"
+assert profile["status"] == "escalation_required"
+assert profile["pr_publication_sufficient"] is False
+assert profile["run"] == []
+assert profile["escalation"]["required"] is True
+assert profile["escalation"]["reasons"] == [
+    {
+        "lane_id": "unmapped_change_surface",
+        "matched_paths": ["totally/unmapped/path.txt"],
+        "reason": "selector left changed paths without validation-lane coverage",
+        "status": "escalated",
+    }
+]
+PY
+
+if bash "$SCRIPT" --changed-files "$unmapped" --run >"$TMP/unmapped-run.out" 2>"$TMP/unmapped-run.err"; then
+  echo "expected validation manager to refuse unmapped-path --run" >&2
+  exit 1
+fi
+assert_has "$TMP/unmapped-run.err" "refusing --run for non-runnable profile"
+
+mixed="$TMP/mixed.txt"
+printf 'M\tdocs/milestones/v0.91.6/README.md\nM\ttotally/unmapped/path.txt\n' >"$mixed"
+bash "$SCRIPT" --changed-files "$mixed" --json >"$TMP/mixed.json"
+python3 - <<'PY' "$TMP/mixed.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "escalation_required"
+assert profile["pr_publication_sufficient"] is False
+assert [item["lane_id"] for item in profile["run"]] == ["docs_diff_check"]
+assert profile["escalation"]["required"] is True
+assert any(
+    reason == {
+        "lane_id": "unmapped_change_surface",
+        "matched_paths": ["totally/unmapped/path.txt"],
+        "reason": "selector left changed paths without validation-lane coverage",
+        "status": "escalated",
+    }
+    for reason in profile["escalation"]["reasons"]
+)
+PY
+
+if bash "$SCRIPT" --changed-files "$mixed" --run >"$TMP/mixed-run.out" 2>"$TMP/mixed-run.err"; then
+  echo "expected validation manager to refuse mixed unmapped-path --run" >&2
+  exit 1
+fi
+assert_has "$TMP/mixed-run.err" "refusing --run for non-runnable profile"
+
+portable_dir="$TMP/portable"
+mkdir -p "$portable_dir"
+portable_changed="$portable_dir/changed.txt"
+printf 'M\tdocs/milestones/v0.91.6/README.md\n' >"$portable_changed"
+(
+  cd "$portable_dir"
+  bash "$SCRIPT" --changed-files "changed.txt" --json >"$TMP/portable.json"
+)
+python3 - <<'PY' "$TMP/portable.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "docs_diff_check_profile"
+assert profile["status"] == "ready_to_run"
+assert [item["lane_id"] for item in profile["run"]] == ["docs_diff_check"]
+PY
+
+echo "PASS test_validation_manager"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -24,7 +24,7 @@ assert_has "$TMP/docs.out" "selected_profile=docs_diff_check_profile"
 assert_has "$TMP/docs.out" "status=ready_to_run"
 assert_has "$TMP/docs.out" "lane=docs_diff_check"
 assert_has "$TMP/docs.out" "behavior_surfaces:"
-assert_has "$TMP/docs.out" "id=documentation_contract"
+assert_has "$TMP/docs.out" "id=diff_hygiene_docs_diff_check"
 assert_has "$TMP/docs.out" "estimated_cost=tiny"
 
 bash "$SCRIPT" --changed-files "$docs_only" --json >"$TMP/docs.json"
@@ -34,10 +34,55 @@ import sys
 
 profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
-assert profile["behavior_surfaces"][0]["id"] == "documentation_contract"
+assert profile["behavior_surfaces"][0]["id"] == "diff_hygiene_docs_diff_check"
+assert profile["behavior_surfaces"][0]["owner"] == "docs"
+assert profile["behavior_surfaces"][0]["proof_role"] == "diff_hygiene"
+assert profile["behavior_surfaces"][0]["resource_class"] == "tiny"
 assert profile["validation_dag"]["nodes"][0]["status"] == "runnable"
+assert profile["validation_dag"]["nodes"][0]["proof_role"] == "diff_hygiene"
 assert profile["estimated_cost"]["runtime_class"] == "tiny"
 assert profile["validation_dag"]["compression_note"].startswith("profile validates behavior surfaces")
+PY
+
+tooling="$TMP/tooling.txt"
+printf 'M\tadl/tools/ci_path_policy.sh\n' >"$tooling"
+bash "$SCRIPT" --changed-files "$tooling" --json >"$TMP/tooling.json"
+python3 - <<'PY' "$TMP/tooling.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert [item["lane_id"] for item in profile["run"]] == ["ci_path_policy_contracts"]
+surface = profile["behavior_surfaces"][0]
+assert surface["id"] == "ci_contract_ci_path_policy_contracts"
+assert surface["owner"] == "tools"
+assert surface["proof_role"] == "ci_contract"
+assert surface["resource_class"] == "small"
+assert profile["validation_dag"]["nodes"][0]["proof_role"] == "ci_contract"
+PY
+
+runtime="$TMP/runtime.txt"
+printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$runtime"
+bash "$SCRIPT" --changed-files "$runtime" --json >"$TMP/runtime.json"
+python3 - <<'PY' "$TMP/runtime.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert [item["lane_id"] for item in profile["run"]] == ["rust_pr_fast"]
+surface = profile["behavior_surfaces"][0]
+assert surface["id"] == "rust_focused_behavior"
+assert surface["owner"] == "shared"
+assert surface["default_surface"] == "shared_rust"
+assert surface["proof_role"] == "regression"
+assert "contract_schema" in surface["requirement_ids"]
+node = profile["validation_dag"]["nodes"][0]
+assert node["proof_role"] == "regression"
+assert node["resource_class"] == "medium"
 PY
 
 release_gate="$TMP/release-gate.txt"
@@ -57,7 +102,12 @@ assert any(
 )
 assert any(item["lane_id"] == "ci_path_policy_contracts" for item in profile["run"])
 assert any(
-    behavior["id"] == "release_or_ci_policy_boundary"
+    behavior["id"] == "release_gate_release_gate_review"
+    for behavior in profile["behavior_surfaces"]
+)
+assert any(
+    behavior["proof_role"] == "release_gate"
+    and behavior["owner"] == "tools"
     for behavior in profile["behavior_surfaces"]
 )
 assert profile["estimated_cost"]["runtime_class"] == "escalated"
@@ -128,6 +178,22 @@ if bash "$SCRIPT" --changed-files "$mixed" --run >"$TMP/mixed-run.out" 2>"$TMP/m
   exit 1
 fi
 assert_has "$TMP/mixed-run.err" "refusing --run for non-runnable profile"
+
+owner_mix="$TMP/owner-mix.txt"
+printf 'M\tadl/tools/pr.sh\nM\tadl/src/bin/adl_runtime.rs\n' >"$owner_mix"
+bash "$SCRIPT" --changed-files "$owner_mix" --json >"$TMP/owner-mix.json"
+python3 - <<'PY' "$TMP/owner-mix.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+surface_ids = [surface["id"] for surface in profile["behavior_surfaces"]]
+assert "owner_lane_csdlc_owner_lane" in surface_ids
+assert "owner_lane_runtime_owner_lane" in surface_ids
+assert len(surface_ids) == len(set(surface_ids))
+node_ids = [node["behavior_surface"] for node in profile["validation_dag"]["nodes"]]
+assert len(node_ids) == len(set(node_ids))
+PY
 
 portable_dir="$TMP/portable"
 mkdir -p "$portable_dir"

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Build and optionally run an ADL validation profile for a change set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SELECTOR = ROOT / "adl/tools/select_validation_lanes.sh"
+
+
+def fail(message: str) -> None:
+    print(f"validation_manager: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def selector_plan(args: argparse.Namespace) -> dict[str, Any]:
+    cmd = ["bash", str(SELECTOR), "--json"]
+    if args.changed_files:
+        cmd.extend(["--changed-files", str(args.changed_files.resolve())])
+    else:
+        cmd.extend(["--base", args.base, "--head", args.head])
+    if args.include_working_tree:
+        cmd.append("--include-working-tree")
+    result = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        fail(f"selector failed: {result.stderr.strip()}")
+    try:
+        plan = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        fail(f"selector returned invalid JSON: {exc}")
+    if plan.get("schema_version") != "adl.validation_lane_plan.v1":
+        fail("selector returned unsupported schema_version")
+    return plan
+
+
+def profile_id(plan: dict[str, Any]) -> str:
+    aggregate = plan.get("aggregate_status", "unknown")
+    lanes = sorted(plan.get("lanes", {}).keys())
+    if not lanes:
+        return "validation_none"
+    if aggregate == "selected" and len(lanes) == 1:
+        return f"{lanes[0]}_profile"
+    return f"{aggregate}_{len(lanes)}_lane_profile"
+
+
+def lane_behavior_surface(lane_id: str, lane: dict[str, Any]) -> dict[str, Any]:
+    matched_paths = lane.get("matched_paths", [])
+    if lane_id == "rust_pr_fast":
+        mode = lane.get("mode", "unknown")
+        filter_tokens = lane.get("filter_tokens", "")
+        return {
+            "id": f"rust_{mode}_behavior",
+            "source": "selector_pr_fast_plan",
+            "requirement_ids": [token for token in filter_tokens.split("|") if token],
+            "matched_paths": matched_paths,
+            "risk_class": "medium" if lane.get("status") == "selected" else "high",
+        }
+    if lane_id == "release_gate_review":
+        return {
+            "id": "release_or_ci_policy_boundary",
+            "source": "release_gate_hints",
+            "requirement_ids": ["release_gate_disposition_required"],
+            "matched_paths": matched_paths,
+            "risk_class": "high",
+        }
+    if "docs" in lane_id:
+        behavior_id = "documentation_contract"
+    elif "prompt" in lane_id:
+        behavior_id = "prompt_template_contract"
+    elif "ci" in lane_id:
+        behavior_id = "ci_validation_policy"
+    elif "owner" in lane_id:
+        behavior_id = "owner_binary_contract"
+    else:
+        behavior_id = lane_id.replace("_lane", "").replace("_contracts", "_contract")
+    return {
+        "id": behavior_id,
+        "source": "validation_lane_selector",
+        "requirement_ids": [lane_id],
+        "matched_paths": matched_paths,
+        "risk_class": "low" if lane.get("status") == "selected" else "medium",
+    }
+
+
+def validation_dag_node(lane_id: str, lane: dict[str, Any], behavior_id: str) -> dict[str, Any]:
+    status = lane.get("status", "unknown")
+    if status == "selected":
+        node_status = "runnable"
+    elif status in {"escalated", "release_gate_required"}:
+        node_status = "blocked_for_escalation"
+    else:
+        node_status = "not_selected"
+    return {
+        "id": f"node_{lane_id}",
+        "lane_id": lane_id,
+        "behavior_surface": behavior_id,
+        "status": node_status,
+        "proof_role": "release_gate" if status == "release_gate_required" else "regression",
+        "command": lane.get("run_command") or lane.get("command", ""),
+        "depends_on": [],
+    }
+
+
+def estimate_cost(selected: list[tuple[str, dict[str, Any]]], blocked: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    if blocked:
+        runtime_class = "escalated"
+    elif not selected:
+        runtime_class = "none"
+    elif len(selected) == 1:
+        lane_id = selected[0][0]
+        runtime_class = "tiny" if "docs" in lane_id else "normal"
+    else:
+        runtime_class = "normal"
+    return {
+        "runtime_class": runtime_class,
+        "selected_lane_count": len(selected),
+        "blocked_lane_count": len(blocked),
+        "expected_test_scope": "focused_or_family" if not blocked else "requires_human_or_release_gate_decision",
+        "token_review_cost": "low" if runtime_class in {"none", "tiny"} else "medium",
+    }
+
+
+def build_profile(plan: dict[str, Any], max_selected_lanes: int) -> dict[str, Any]:
+    lanes = plan.get("lanes", {})
+    changed_paths = plan.get("changed_paths", [])
+    covered_paths = {
+        path
+        for lane in lanes.values()
+        for path in lane.get("matched_paths", [])
+    }
+    uncovered_paths = [path for path in changed_paths if path not in covered_paths]
+    selected = [
+        (lane_id, lane)
+        for lane_id, lane in lanes.items()
+        if lane.get("status") == "selected"
+    ]
+    blocked = [
+        (lane_id, lane)
+        for lane_id, lane in lanes.items()
+        if lane.get("status") in {"escalated", "release_gate_required"}
+    ]
+
+    run = []
+    behavior_surfaces = []
+    dag_nodes = []
+    for lane_id, lane in selected:
+        behavior = lane_behavior_surface(lane_id, lane)
+        behavior_surfaces.append(behavior)
+        dag_nodes.append(validation_dag_node(lane_id, lane, behavior["id"]))
+        command = lane.get("run_command") or lane.get("command")
+        if command:
+            run.append(
+                {
+                    "lane_id": lane_id,
+                    "command": command,
+                    "reason": lane.get("reason", "selector_selected_lane"),
+                    "matched_paths": lane.get("matched_paths", []),
+                }
+            )
+
+    not_run = [
+        {
+            "surface": "full_workspace_nextest",
+            "reason": "not selected by validation profile",
+        },
+        {
+            "surface": "cargo_clippy_all_targets",
+            "reason": "reserved for broad shared changes or release gates",
+        },
+        {
+            "surface": "slow_proof",
+            "reason": "reserved for explicit proof-family selection",
+        },
+        {
+            "surface": "coverage_release_gate",
+            "reason": "reserved for coverage or release policy selection",
+        },
+    ]
+
+    unmapped_change_gap = bool(uncovered_paths)
+
+    escalation_required = (
+        bool(blocked)
+        or len(selected) > max_selected_lanes
+        or unmapped_change_gap
+    )
+    escalation_reasons = []
+    for lane_id, lane in blocked:
+        behavior = lane_behavior_surface(lane_id, lane)
+        behavior_surfaces.append(behavior)
+        dag_nodes.append(validation_dag_node(lane_id, lane, behavior["id"]))
+        escalation_reasons.append(
+            {
+                "lane_id": lane_id,
+                "status": lane.get("status"),
+                "reason": lane.get("reason", "selector_requires_escalation"),
+                "matched_paths": lane.get("matched_paths", []),
+            }
+        )
+    if len(selected) > max_selected_lanes:
+        escalation_reasons.append(
+            {
+                "lane_id": "selected_lane_threshold",
+                "status": "escalated",
+                "reason": f"selected lane count {len(selected)} exceeds limit {max_selected_lanes}",
+                "matched_paths": plan.get("changed_paths", []),
+            }
+        )
+    if unmapped_change_gap:
+        escalation_reasons.append(
+            {
+                "lane_id": "unmapped_change_surface",
+                "status": "escalated",
+                "reason": "selector left changed paths without validation-lane coverage",
+                "matched_paths": uncovered_paths,
+            }
+        )
+
+    status = "ready_to_run"
+    if not changed_paths:
+        status = "no_validation_needed"
+    elif escalation_required:
+        status = "escalation_required"
+    elif plan.get("aggregate_status") != "selected":
+        status = "not_runnable"
+
+    return {
+        "schema_version": "adl.validation_profile.v1",
+        "selected_profile": profile_id(plan),
+        "status": status,
+        "selector_aggregate_status": plan.get("aggregate_status"),
+        "pr_publication_sufficient": (
+            bool(plan.get("pr_publication_sufficient")) and not unmapped_change_gap
+        ),
+        "changed_paths": changed_paths,
+        "run": run,
+        "not_run": not_run,
+        "deferred": [],
+        "behavior_surfaces": behavior_surfaces,
+        "validation_dag": {
+            "nodes": dag_nodes,
+            "edges": [],
+            "compression_note": "profile validates behavior surfaces rather than enumerating every test-bearing module",
+        },
+        "estimated_cost": estimate_cost(selected, blocked),
+        "escalation": {
+            "required": escalation_required,
+            "reasons": escalation_reasons,
+        },
+        "selector_plan": plan,
+    }
+
+
+def print_text(profile: dict[str, Any]) -> None:
+    print("Validation profile")
+    print(f"  selected_profile={profile['selected_profile']}")
+    print(f"  status={profile['status']}")
+    print(f"  selector_aggregate_status={profile['selector_aggregate_status']}")
+    print(f"  pr_publication_sufficient={str(profile['pr_publication_sufficient']).lower()}")
+    if profile["run"]:
+        print("  run:")
+        for item in profile["run"]:
+            print(f"    - lane={item['lane_id']} reason={item['reason']}")
+            print(f"      command={item['command']}")
+    else:
+        print("  run: []")
+    if profile["escalation"]["required"]:
+        print("  escalation:")
+        for reason in profile["escalation"]["reasons"]:
+            print(
+                f"    - lane={reason['lane_id']} status={reason['status']} reason={reason['reason']}"
+            )
+    if profile["behavior_surfaces"]:
+        print("  behavior_surfaces:")
+        for behavior in profile["behavior_surfaces"]:
+            print(
+                f"    - id={behavior['id']} risk={behavior['risk_class']} source={behavior['source']}"
+            )
+    print(
+        "  estimated_cost="
+        f"{profile['estimated_cost']['runtime_class']} "
+        f"lanes={profile['estimated_cost']['selected_lane_count']}"
+    )
+
+
+def write_report(path: Path, profile: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+
+def run_profile(profile: dict[str, Any]) -> int:
+    if profile["status"] not in {"ready_to_run", "no_validation_needed"}:
+        print_text(profile)
+        print("validation_manager: refusing --run for non-runnable profile", file=sys.stderr)
+        return 1
+    failed = False
+    for item in profile["run"]:
+        print(f"==> {item['lane_id']}: {item['command']}", file=sys.stderr)
+        result = subprocess.run(item["command"], cwd=ROOT, shell=True)
+        item["run_status"] = "passed" if result.returncode == 0 else "failed"
+        if result.returncode != 0:
+            failed = True
+    profile["run_status"] = "failed" if failed else "passed"
+    return 1 if failed else 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--changed-files", type=Path)
+    source.add_argument("--include-working-tree", action="store_true")
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--max-selected-lanes", type=int, default=8)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--report-out", type=Path)
+    parser.add_argument("--run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    plan = selector_plan(args)
+    profile = build_profile(plan, args.max_selected_lanes)
+    exit_code = 0
+    if args.run:
+        exit_code = run_profile(profile)
+    if args.report_out:
+        write_report(args.report_out, profile)
+    if args.json:
+        print(json.dumps(profile, indent=2, sort_keys=True))
+    else:
+        print_text(profile)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -57,42 +57,46 @@ def profile_id(plan: dict[str, Any]) -> str:
     return f"{aggregate}_{len(lanes)}_lane_profile"
 
 
+def lane_requirement_ids(lane: dict[str, Any]) -> list[str]:
+    requirement_ids = lane.get("requirement_ids", [])
+    if not isinstance(requirement_ids, list):
+        return []
+    return [item for item in requirement_ids if isinstance(item, str) and item]
+
+
+def lane_behavior_id(lane_id: str, lane: dict[str, Any]) -> str:
+    proof_role = str(lane.get("proof_role", "")).strip()
+    default_surface = str(lane.get("default_surface", "")).strip()
+    mode = str(lane.get("mode", "")).strip()
+    if lane_id == "rust_pr_fast":
+        suffix = mode or "unknown"
+        return f"rust_{suffix}_behavior"
+    if proof_role:
+        return f"{proof_role}_{lane_id}"
+    if default_surface:
+        return f"{default_surface}_behavior"
+    return lane_id
+
+
 def lane_behavior_surface(lane_id: str, lane: dict[str, Any]) -> dict[str, Any]:
     matched_paths = lane.get("matched_paths", [])
+    requirement_ids = lane_requirement_ids(lane)
     if lane_id == "rust_pr_fast":
-        mode = lane.get("mode", "unknown")
-        filter_tokens = lane.get("filter_tokens", "")
-        return {
-            "id": f"rust_{mode}_behavior",
-            "source": "selector_pr_fast_plan",
-            "requirement_ids": [token for token in filter_tokens.split("|") if token],
-            "matched_paths": matched_paths,
-            "risk_class": "medium" if lane.get("status") == "selected" else "high",
-        }
-    if lane_id == "release_gate_review":
-        return {
-            "id": "release_or_ci_policy_boundary",
-            "source": "release_gate_hints",
-            "requirement_ids": ["release_gate_disposition_required"],
-            "matched_paths": matched_paths,
-            "risk_class": "high",
-        }
-    if "docs" in lane_id:
-        behavior_id = "documentation_contract"
-    elif "prompt" in lane_id:
-        behavior_id = "prompt_template_contract"
-    elif "ci" in lane_id:
-        behavior_id = "ci_validation_policy"
-    elif "owner" in lane_id:
-        behavior_id = "owner_binary_contract"
-    else:
-        behavior_id = lane_id.replace("_lane", "").replace("_contracts", "_contract")
+        filter_tokens = str(lane.get("filter_tokens", ""))
+        requirement_ids.extend(token for token in filter_tokens.split("|") if token)
     return {
-        "id": behavior_id,
+        "id": lane_behavior_id(lane_id, lane),
         "source": "validation_lane_selector",
-        "requirement_ids": [lane_id],
+        "lane_id": lane_id,
+        "owner": lane.get("owner", "unknown"),
+        "default_surface": lane.get("default_surface", "unknown"),
+        "proof_role": lane.get("proof_role", "unknown"),
+        "resource_class": lane.get("resource_class", "unknown"),
+        "determinism_posture": lane.get("determinism_posture", "unknown"),
+        "escalation_rule": lane.get("escalation_rule", "unknown"),
+        "requirement_ids": requirement_ids or [lane_id],
         "matched_paths": matched_paths,
-        "risk_class": "low" if lane.get("status") == "selected" else "medium",
+        "risk_class": lane.get("risk_class", "unknown"),
     }
 
 
@@ -109,7 +113,10 @@ def validation_dag_node(lane_id: str, lane: dict[str, Any], behavior_id: str) ->
         "lane_id": lane_id,
         "behavior_surface": behavior_id,
         "status": node_status,
-        "proof_role": "release_gate" if status == "release_gate_required" else "regression",
+        "proof_role": lane.get("proof_role", "unknown"),
+        "owner": lane.get("owner", "unknown"),
+        "resource_class": lane.get("resource_class", "unknown"),
+        "determinism_posture": lane.get("determinism_posture", "unknown"),
         "command": lane.get("run_command") or lane.get("command", ""),
         "depends_on": [],
     }

--- a/adl/tools/validation_manager.sh
+++ b/adl/tools/validation_manager.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "$ROOT/adl/tools/validation_manager.py" "$@"

--- a/docs/architecture/VALIDATION_LANE_SELECTOR.md
+++ b/docs/architecture/VALIDATION_LANE_SELECTOR.md
@@ -28,6 +28,33 @@ of C-SDLC truth. It gives local and PR tooling a deterministic answer for which
 focused validation commands are sufficient, which release gates remain required,
 and which ambiguous Rust surfaces must escalate.
 
+The manifest is now the tracked authority for validation-surface metadata, not
+just path matching. Each lane entry carries:
+
+- owner
+- lane class
+- command and run command
+- path selectors
+- requirement IDs
+- resource class
+- determinism posture
+- proof role
+- risk class
+- escalation rule
+
+Top-level `surface_defaults` provide durable defaults for docs, tooling,
+runtime, provider, security, CI policy, slow-proof, release-gate, and shared
+Rust surfaces. Lane entries may override those defaults, but the selector
+validates the references so metadata drift fails closed instead of silently
+falling back.
+
+Compatibility note:
+
+- `path_hints` remains accepted as a compatibility alias.
+- `path_selectors` is the authoritative field for new manifest work.
+- `release_gate_hints` and `rust_path_hints` still exist for backward
+  compatibility, but their durable metadata now lives in `special_surfaces`.
+
 To write machine-readable proof:
 
 ```bash
@@ -61,7 +88,6 @@ The first slice is intentionally small:
 - release/CI-policy paths report `release_gate_required`
 - credential and live-provider lanes remain outside ordinary PR validation
 
-Future work should add a validation manager agent on top of this selector. That
-agent should create a tailored test profile whenever an issue is sent to PR,
-handling each issue case separately while consuming this selector as policy
-input. The selector itself should stay deterministic and boring.
+The selector remains the deterministic surface classifier. Validation-manager
+style profile builders should consume the selector's emitted metadata instead of
+re-inventing owner, risk, or escalation inference in a second code path.


### PR DESCRIPTION
Closes #4215

## Summary
Reopened and advanced `#4215` after the first validation-manager slice because
`#4214` established a richer selector/manifest contract underneath it. The
manager now consumes selector-emitted owner, resource, determinism, proof-role,
and escalation metadata instead of preserving a parallel heuristic model for
behavior surfaces and DAG nodes. Review on the reopened slice found one new
integration regression: non-Rust behavior-surface IDs were derived from
`proof_role`, which made multi-owner profiles ambiguous because several owner
lanes reuse `proof_role: owner_lane`. That defect was fixed by lane-qualifying
non-Rust behavior IDs, and focused proof now covers docs, tooling, runtime,
release-gate, unmapped, mixed mapped/unmapped, portable relative-path inputs,
and mixed-owner multi-lane profiles.

## Artifacts
- Existing tracked code carried by the issue branch:
  - `adl/tools/validation_manager.py`
  - `adl/tools/validation_manager.sh`
  - `adl/tools/test_validation_manager.sh`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Dependent selector/manifest contract currently stacked beneath this branch:
  - `adl/config/validation_lane_selector.v0.91.6.json`
  - `adl/tools/select_validation_lanes.py`
  - `adl/tools/test_select_validation_lanes.sh`
  - `docs/architecture/VALIDATION_LANE_SELECTOR.md`
- Updated local issue records during the reopen pass:
  - `.adl/v0.91.6/tasks/issue-4215__v0-91-6-tools-validation-implement-validation-manager-profiles/spp.md`
  - `.adl/v0.91.6/tasks/issue-4215__v0-91-6-tools-validation-implement-validation-manager-profiles/srp.md`
  - `.adl/v0.91.6/tasks/issue-4215__v0-91-6-tools-validation-implement-validation-manager-profiles/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_manager.sh`
    Verified the focused validation-manager regression matrix on the reopened
    branch state, including docs, tooling, runtime, release-gate, unmapped,
    mixed mapped/unmapped, portable relative-path, and multi-owner uniqueness
    cases.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified the dependent selector/manifest contract still passes on the
    stacked branch state.
  - `python3 -m py_compile adl/tools/validation_manager.py`
    Verified the Python source parses successfully.
  - `python3 -m py_compile adl/tools/select_validation_lanes.py`
    Verified the stacked selector Python source parses successfully.
  - `git diff --check`
    Verified there are no whitespace or patch-format defects.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4215__v0-91-6-tools-validation-implement-validation-manager-profiles/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4215__v0-91-6-tools-validation-implement-validation-manager-profiles/sor.md
- Idempotency-Key: v0-91-6-tools-validation-implement-validation-manager-profiles-adl-tools-validation-manager-py-adl-tools-test-validation-manager-sh-adl-v0-91-6-tasks-issue-4215-v0-91-6-tools-validation-implement-validation-manager-profiles-sip-md-adl-v0-91-6-tasks-issue-4215-v0-91-6-tools-validation-implement-validation-manager-profiles-sor-md