### PR TITLE
[v0.91.6][tools][validation] Build test inventory and attribution report

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1214,6 +1214,12 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_validation_inventory_focused_validation(path))
+        {
+            commands.push("bash adl/tools/test_validation_inventory.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_small_binary_delegation_validation(path))
         {
             commands.push("bash adl/tools/test_pr_small_binary_delegation.sh".to_string());
@@ -1401,6 +1407,9 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
         trimmed,
         "adl/tools/pr.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
+            | "adl/tools/validation_inventory.py"
+            | "adl/tools/validation_inventory.sh"
+            | "adl/tools/test_validation_inventory.sh"
             | "adl/tools/test_install_adl_operational_skills.sh"
             | "adl/tools/test_sprint_conductor_helpers.sh"
     ) || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
@@ -1677,6 +1686,16 @@ fn finish_path_needs_validation_selector_focused_validation(path: &str) -> bool 
             | "adl/tools/select_validation_lanes.py"
             | "adl/tools/select_validation_lanes.sh"
             | "adl/tools/test_select_validation_lanes.sh"
+    )
+}
+
+fn finish_path_needs_validation_inventory_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/validation_inventory.py"
+            | "adl/tools/validation_inventory.sh"
+            | "adl/tools/test_validation_inventory.sh"
     )
 }
 
@@ -2064,6 +2083,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_select_validation_lanes.sh" => {
                     let script = repo_root.join("adl/tools/test_select_validation_lanes.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_validation_inventory.sh" => {
+                    let script = repo_root.join("adl/tools/test_validation_inventory.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1564,6 +1564,29 @@ fn finish_validation_profile_keeps_small_binary_delegation_proof_focused() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_validation_inventory_slice_as_small_binary_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        4213,
+        ".",
+        &[
+            "adl/tools/validation_inventory.py".to_string(),
+            "adl/tools/validation_inventory.sh".to_string(),
+            "adl/tools/test_validation_inventory.sh".to_string(),
+        ],
+    )
+    .expect("validation inventory plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_inventory.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo test --manifest-path adl/Cargo.toml --bin adl")));
+}
+
+#[test]
 fn finish_restores_missing_canonical_cards_from_slug_drifted_issue_bundle() {
     let repo = unique_temp_dir("adl-pr-finish-slug-drift");
     let issue_ref = IssueRef::new(
@@ -1820,6 +1843,69 @@ fn finish_helper_paths_run_validation_selector_validation() {
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("selector"));
+}
+
+#[test]
+fn finish_helper_paths_run_validation_inventory_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-validation-inventory-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_validation_inventory.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' validation-inventory >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/tools/validation_inventory.py,adl/tools/validation_inventory.sh,adl/tools/test_validation_inventory.sh",
+    )
+    .expect("validation inventory plan");
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("validation inventory validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "validation inventory focused validation should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("validation-inventory"));
 }
 
 #[test]

--- a/adl/tools/test_validation_inventory.sh
+++ b/adl/tools/test_validation_inventory.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/validation_inventory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+json_one="$TMP/inventory-1.json"
+json_two="$TMP/inventory-2.json"
+md_one="$TMP/inventory-1.md"
+md_two="$TMP/inventory-2.md"
+
+bash "$SCRIPT" --format json >"$json_one"
+bash "$SCRIPT" --format json >"$json_two"
+diff -u "$json_one" "$json_two" >/dev/null
+
+bash "$SCRIPT" --format markdown >"$md_one"
+bash "$SCRIPT" --format markdown >"$md_two"
+diff -u "$md_one" "$md_two" >/dev/null
+
+portable_dir="$TMP/portable"
+mkdir -p "$portable_dir"
+(
+  cd "$portable_dir"
+  bash "$SCRIPT" --format json --json-out "$TMP/portable.json" --markdown-out "$TMP/portable.md" >/dev/null
+)
+[[ -s "$TMP/portable.json" ]]
+[[ -s "$TMP/portable.md" ]]
+
+python3 - <<'PY' "$json_one" "$md_one"
+import json
+import sys
+from pathlib import Path
+
+inventory = json.loads(Path(sys.argv[1]).read_text())
+markdown = Path(sys.argv[2]).read_text()
+
+assert inventory["schema_version"] == "adl.validation_inventory.v1"
+assert inventory["manifest_path"] == "adl/config/validation_lane_selector.v0.91.6.json"
+assert inventory["repo_root"] == "."
+assert inventory["tracked_file_count"] > 0
+
+rust = inventory["rust"]
+assert rust["rust_lib_unit_tests"]["file_count"] > 0
+assert rust["rust_integration_tests"]["file_count"] > 0
+assert "slow-proof-tests" in inventory["feature_inventory"]
+assert len(inventory["release_gate_surfaces"]) > 0
+assert len(inventory["coverage_only_surfaces"]) > 0
+assert len(inventory["manifest_backed_surfaces"]) > 0
+assert isinstance(inventory["unknown_or_unclassified_surfaces"], list)
+assert len(inventory["shell_validators"]) > 0
+assert len(inventory["python_validators"]) > 0
+assert len(inventory["demo_proof_surfaces"]) > 0
+assert "## Shell validators" in markdown
+assert "## Python validators" in markdown
+assert "## Demo proof surfaces" in markdown
+
+pr_finish_records = [
+    record for record in inventory["all_surface_records"]
+    if record["path"] == "adl/src/bin/adl_pr_finish.rs"
+]
+assert any(record["owner"] == "csdlc" for record in pr_finish_records)
+csdlc_records = [
+    record for record in inventory["all_surface_records"]
+    if record["path"] == "adl/src/bin/adl_csdlc.rs"
+]
+assert any(record["owner"] == "csdlc" for record in csdlc_records)
+
+demo_paths = {record["path"] for record in inventory["demo_proof_surfaces"]}
+assert "adl/tools/demo_smoke_v07_story.sh" in demo_paths
+assert all(
+    record["path"] != "adl/tools/demo_smoke_v07_story.sh"
+    for record in inventory["unknown_or_unclassified_surfaces"]
+)
+python_validator_paths = {record["path"] for record in inventory["python_validators"]}
+assert "adl/tools/test_prompt_template_structure_schemas.py" in python_validator_paths
+assert any(
+    record["path"] == "adl/tools/test_prompt_template_structure_schemas.py"
+    and record["classification_status"] == "partial"
+    for record in inventory["unknown_or_unclassified_surfaces"]
+)
+assert any(
+    record["path"] == "adl/Cargo.toml" and record["owner"] == "runtime"
+    for record in inventory["slow_proof_surfaces"]
+)
+
+assert "## Rust test-bearing surfaces" in markdown
+assert "## Unknown or unclassified surfaces" in markdown
+assert "status=partial" in markdown
+PY
+
+echo "PASS test_validation_inventory"

--- a/adl/tools/validation_inventory.py
+++ b/adl/tools/validation_inventory.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Build a deterministic local inventory of ADL validation surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
+DEFAULT_CARGO = ROOT / "adl/Cargo.toml"
+
+TEST_ATTRIBUTE_RE = re.compile(
+    r"#\[\s*(?:tokio::test|test|rstest|quickcheck|proptest)\b"
+)
+DOC_FENCE_RE = re.compile(
+    r"^\s*(?:(?://[/!])|(?:/\*\*)|(?:\*))?.*```(?:rust|ignore|no_run|should_panic|compile_fail|edition\d{4})\b",
+    re.MULTILINE,
+)
+
+SLOW_PROOF_PATTERNS = (
+    "adl/Cargo.toml",
+    "adl/tools/test_slow_proof_lane_contract.sh",
+    "adl/src/runtime_v2/tests/**",
+    ".github/workflows/ci.yaml",
+)
+RELEASE_GATE_EXTRA_PATTERNS = (
+    "adl/tools/run_authoritative_coverage_lane.sh",
+    "adl/tools/run_local_authoritative_coverage_gate.sh",
+    "adl/tools/test_slow_proof_lane_contract.sh",
+)
+COVERAGE_ONLY_PATTERNS = (
+    ".github/workflows/nightly-coverage-ratchet.yaml",
+    "adl/tools/check_coverage_impact.sh",
+    "adl/tools/test_check_coverage_impact.sh",
+    "adl/tools/run_authoritative_coverage_lane.sh",
+    "adl/tools/run_local_authoritative_coverage_gate.sh",
+)
+
+
+def fail(message: str) -> None:
+    print(f"validation_inventory: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def git_files(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        fail(f"git ls-files failed: {result.stderr.strip()}")
+    return sorted(line for line in result.stdout.splitlines() if line.strip())
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = json.loads(path.read_text())
+    if manifest.get("schema_version") != "adl.validation_lane_selector.v1":
+        fail(f"{path}: unsupported schema_version")
+    return manifest
+
+
+def load_features(path: Path) -> dict[str, list[str]]:
+    cargo = tomllib.loads(path.read_text())
+    features = cargo.get("features", {})
+    return {
+        name: sorted(value) if isinstance(value, list) else []
+        for name, value in sorted(features.items())
+    }
+
+
+def matches(path: str, patterns: tuple[str, ...] | list[str]) -> bool:
+    return any(path == pattern or fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def classify_owner(path: str) -> str | None:
+    if path in {"adl/Cargo.toml", "adl/Cargo.lock"}:
+        return "runtime"
+    if path.startswith("docs/") or path.endswith(".md"):
+        return "docs"
+    if path.startswith(".github/workflows/"):
+        return "github"
+    if path.startswith("adl/src/bin/adl_issue"):
+        return "github"
+    if path.startswith("adl/src/bin/adl_pr_"):
+        return "csdlc"
+    if path in {
+        "adl/src/bin/adl_csdlc.rs",
+        "adl/src/bin/adl_prompt_template.rs",
+        "adl/src/bin/adl_validate_structured_prompt.rs",
+        "adl/src/bin/adl_lint_prompt_spec.rs",
+    }:
+        return "csdlc"
+    if path.startswith("adl/src/runtime_v2/") or path.startswith("adl/src/bin/adl_runtime"):
+        return "runtime"
+    if path.startswith("adl/src/provider") or path.startswith("adl/src/bin/adl_provider"):
+        return "provider"
+    if path.startswith("adl/src/review") or path.startswith("adl/src/bin/adl_review"):
+        return "review"
+    if path.startswith("adl/src/bin/"):
+        return "tools"
+    if path.startswith("adl/src/cli/pr_cmd") or path == "adl/tools/pr.sh":
+        return "csdlc"
+    if path.startswith("adl/src/cli/"):
+        return "tools"
+    if path.startswith("adl/tools/"):
+        return "tools"
+    if path.startswith("adl/src/"):
+        return "runtime"
+    if path.startswith("adl/tests/"):
+        return "runtime"
+    return None
+
+
+def resource_class_for_lane(lane_class: str | None) -> str | None:
+    if lane_class == "docs":
+        return "tiny"
+    if lane_class in {"cli_workflow", "contract_schema_card", "fast_unit"}:
+        return "normal"
+    if lane_class == "integration_worktree":
+        return "expensive"
+    if lane_class in {"release_gate", "provider_live"}:
+        return "external" if lane_class == "provider_live" else "expensive"
+    return None
+
+
+def doc_test_block_count(text: str) -> int:
+    return len(DOC_FENCE_RE.findall(text))
+
+
+def rust_category_for_path(path: str) -> str | None:
+    if not path.endswith(".rs"):
+        return None
+    if path.startswith("adl/src/bin/"):
+        return "rust_bin_tests"
+    if path.startswith("adl/tests/"):
+        return "rust_integration_tests"
+    if path.startswith("adl/src/"):
+        return "rust_lib_unit_tests"
+    return None
+
+
+def build_rust_inventory(files: list[str]) -> dict[str, Any]:
+    categories: dict[str, dict[str, Any]] = {
+        "rust_lib_unit_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+        "rust_bin_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+        "rust_integration_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+    }
+    doc_test_paths: list[str] = []
+    owner_counts: Counter[str] = Counter()
+
+    for rel in files:
+        category = rust_category_for_path(rel)
+        if category is None:
+            continue
+        abs_path = ROOT / rel
+        text = abs_path.read_text(encoding="utf-8")
+        test_count = len(TEST_ATTRIBUTE_RE.findall(text))
+        doc_blocks = doc_test_block_count(text)
+        if test_count == 0 and doc_blocks == 0:
+            continue
+        categories[category]["files"].append(rel)
+        categories[category]["test_count"] += test_count
+        categories[category]["doc_test_blocks"] += doc_blocks
+        owner = classify_owner(rel)
+        if owner:
+            owner_counts[owner] += 1
+        if doc_blocks:
+            doc_test_paths.append(rel)
+
+    rust = {
+        key: {
+            "file_count": len(value["files"]),
+            "test_entry_count": value["test_count"],
+            "doc_test_block_count": value["doc_test_blocks"],
+            "sample_paths": value["files"][:12],
+        }
+        for key, value in categories.items()
+    }
+    rust["rust_doc_tests"] = {
+        "file_count": len(doc_test_paths),
+        "doc_test_block_count": sum(categories[key]["doc_test_blocks"] for key in categories),
+        "sample_paths": sorted(doc_test_paths)[:12],
+    }
+    rust["owner_summary"] = dict(sorted(owner_counts.items()))
+    rust["candidate_paths"] = sorted(
+        {
+            *categories["rust_lib_unit_tests"]["files"],
+            *categories["rust_bin_tests"]["files"],
+            *categories["rust_integration_tests"]["files"],
+            *doc_test_paths,
+        }
+    )
+    return rust
+
+
+def add_surface_record(
+    records: list[dict[str, Any]],
+    path: str,
+    *,
+    surface_kind: str,
+    lane_class: str | None,
+    owner: str | None,
+    resource_class: str | None,
+    proof_role: str,
+    feature_requirements: list[str] | None = None,
+) -> None:
+    records.append(
+        {
+            "path": path,
+            "surface_kind": surface_kind,
+            "lane_class": lane_class,
+            "owner": owner,
+            "resource_class": resource_class,
+            "proof_role": proof_role,
+            "feature_requirements": sorted(feature_requirements or []),
+        }
+    )
+
+
+def build_surface_inventory(
+    files: list[str],
+    manifest: dict[str, Any],
+    rust_candidate_paths: list[str],
+) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    known_paths: set[str] = set()
+
+    for lane in manifest.get("lanes", []):
+        lane_class = lane["lane_class"]
+        resource_class = resource_class_for_lane(lane_class)
+        for path in files:
+            if matches(path, lane["path_hints"]):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="manifest_surface",
+                    lane_class=lane_class,
+                    owner=classify_owner(path),
+                    resource_class=resource_class,
+                    proof_role="ordinary_pr",
+                )
+                known_paths.add(path)
+
+    rust_hints = tuple(manifest.get("rust_path_hints", []))
+    for path in rust_candidate_paths:
+        if matches(path, rust_hints):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="rust_validation_surface",
+                lane_class="fast_unit",
+                owner=classify_owner(path),
+                resource_class="normal",
+                proof_role="ordinary_pr",
+            )
+            known_paths.add(path)
+
+    for path in files:
+        if path.startswith("adl/tools/") and path not in known_paths:
+            name = Path(path).name
+            if name.startswith("demo_") and (path.endswith(".sh") or path.endswith(".py")):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="demo_proof_surface",
+                    lane_class="integration_worktree",
+                    owner=classify_owner(path),
+                    resource_class="expensive",
+                    proof_role="integration_demo",
+                )
+            if path.endswith(".sh") and (
+                name.startswith("test_")
+                or name.startswith("check_")
+                or name.startswith("validate_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                    )
+                )
+            ):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="shell_validator",
+                    lane_class=None,
+                    owner=classify_owner(path),
+                    resource_class="normal",
+                    proof_role="ordinary_pr",
+                )
+            if path.endswith(".py") and (
+                name.startswith("test_")
+                or
+                name.startswith("validate_")
+                or name.startswith("check_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "benchmark")
+                    )
+                )
+            ):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="python_validator",
+                    lane_class=None,
+                    owner=classify_owner(path),
+                    resource_class="normal",
+                    proof_role="ordinary_pr",
+                )
+
+    for path in files:
+        if matches(path, SLOW_PROOF_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="slow_proof_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="slow_proof",
+                feature_requirements=["slow-proof-tests"],
+            )
+        if matches(path, COVERAGE_ONLY_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="coverage_only_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="coverage_only",
+            )
+        if matches(path, tuple(manifest.get("release_gate_hints", [])) + RELEASE_GATE_EXTRA_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="release_gate_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="release_gate",
+                feature_requirements=["slow-proof-tests"] if path in {"adl/Cargo.toml"} else [],
+            )
+
+    unique_records = {
+        (
+            record["path"],
+            record["surface_kind"],
+            record["lane_class"],
+            record["proof_role"],
+        ): record
+        for record in records
+    }
+    deduped = [unique_records[key] for key in sorted(unique_records)]
+    return {
+        "records": deduped,
+        "known_paths": sorted({record["path"] for record in deduped}),
+    }
+
+
+def candidate_validation_paths(files: list[str], rust_candidate_paths: list[str]) -> list[str]:
+    candidates = set(rust_candidate_paths)
+    for path in files:
+        if path.startswith("adl/tools/"):
+            name = Path(path).name
+            if path.endswith((".sh", ".py")) and (
+                name.startswith("test_")
+                or name.startswith("check_")
+                or name.startswith("validate_")
+                or name.startswith("demo_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                    )
+                )
+            ):
+                candidates.add(path)
+        if path.startswith(".github/workflows/"):
+            candidates.add(path)
+    return sorted(candidates)
+
+
+def feature_inventory(features: dict[str, list[str]]) -> dict[str, Any]:
+    interesting = {}
+    for name, members in features.items():
+        if "slow-proof" in name or "proof" in name or "coverage" in name:
+            interesting[name] = {
+                "member_count": len(members),
+                "members": members,
+            }
+    return interesting
+
+
+def build_inventory(files: list[str], manifest: dict[str, Any], features: dict[str, list[str]]) -> dict[str, Any]:
+    rust = build_rust_inventory(files)
+    surfaces = build_surface_inventory(files, manifest, rust["candidate_paths"])
+    candidates = candidate_validation_paths(files, rust["candidate_paths"])
+    unmatched_paths = sorted(set(candidates) - set(surfaces["known_paths"]))
+
+    partial_records = []
+    for record in surfaces["records"]:
+        missing_fields = [
+            field
+            for field in ("lane_class", "owner", "resource_class")
+            if record[field] is None
+        ]
+        if missing_fields:
+            partial_records.append(
+                {
+                    "path": record["path"],
+                    "classification_status": "partial",
+                    "missing_fields": missing_fields,
+                    "surface_kind": record["surface_kind"],
+                }
+            )
+
+    unknown_records = [
+        {
+            "path": path,
+            "classification_status": "unmatched",
+            "missing_fields": ["lane_class", "owner", "resource_class"],
+            "surface_kind": "unmatched_candidate",
+        }
+        for path in unmatched_paths
+    ]
+    remediation_index = {
+        (record["path"], record["classification_status"]): record
+        for record in [*unknown_records, *partial_records]
+    }
+    remediation_records = [
+        remediation_index[key]
+        for key in sorted(remediation_index, key=lambda item: (item[0], item[1]))
+    ]
+
+    lane_summary: Counter[str] = Counter()
+    owner_summary: Counter[str] = Counter()
+    resource_summary: Counter[str] = Counter()
+    proof_role_summary: Counter[str] = Counter()
+    kind_summary: Counter[str] = Counter()
+    for record in surfaces["records"]:
+        if record["lane_class"]:
+            lane_summary[record["lane_class"]] += 1
+        if record["owner"]:
+            owner_summary[record["owner"]] += 1
+        if record["resource_class"]:
+            resource_summary[record["resource_class"]] += 1
+        proof_role_summary[record["proof_role"]] += 1
+        kind_summary[record["surface_kind"]] += 1
+
+    return {
+        "schema_version": "adl.validation_inventory.v1",
+        "repo_root": ".",
+        "repo_name": ROOT.name,
+        "manifest_path": str(DEFAULT_MANIFEST.relative_to(ROOT)),
+        "tracked_file_count": len(files),
+        "rust": {
+            "rust_lib_unit_tests": rust["rust_lib_unit_tests"],
+            "rust_bin_tests": rust["rust_bin_tests"],
+            "rust_integration_tests": rust["rust_integration_tests"],
+            "rust_doc_tests": rust["rust_doc_tests"],
+            "owner_summary": rust["owner_summary"],
+        },
+        "surface_summary": {
+            "by_surface_kind": dict(sorted(kind_summary.items())),
+            "by_lane_class": dict(sorted(lane_summary.items())),
+            "by_owner": dict(sorted(owner_summary.items())),
+            "by_resource_class": dict(sorted(resource_summary.items())),
+            "by_proof_role": dict(sorted(proof_role_summary.items())),
+        },
+        "feature_inventory": feature_inventory(features),
+        "all_surface_records": surfaces["records"],
+        "shell_validators": [
+            record for record in surfaces["records"] if record["surface_kind"] == "shell_validator"
+        ],
+        "python_validators": [
+            record for record in surfaces["records"] if record["surface_kind"] == "python_validator"
+        ],
+        "demo_proof_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "demo_proof_surface"
+        ],
+        "slow_proof_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "slow_proof_surface"
+        ],
+        "coverage_only_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "coverage_only_surface"
+        ],
+        "release_gate_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "release_gate_surface"
+        ],
+        "manifest_backed_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "manifest_surface"
+        ],
+        "unknown_or_unclassified_surfaces": remediation_records,
+    }
+
+
+def markdown_table_row(label: str, values: dict[str, Any]) -> str:
+    return (
+        f"| {label} | {values['file_count']} | {values.get('test_entry_count', 0)} | "
+        f"{values.get('doc_test_block_count', 0)} |"
+    )
+
+
+def render_markdown(inventory: dict[str, Any]) -> str:
+    rust = inventory["rust"]
+    lines = [
+        "# Validation Inventory",
+        "",
+        "## Rust test-bearing surfaces",
+        "",
+        "| Category | Files | Test entries | Doc-test blocks |",
+        "| --- | ---: | ---: | ---: |",
+        markdown_table_row("Rust lib unit tests", rust["rust_lib_unit_tests"]),
+        markdown_table_row("Rust bin tests", rust["rust_bin_tests"]),
+        markdown_table_row("Rust integration tests", rust["rust_integration_tests"]),
+        markdown_table_row("Rust doc tests", rust["rust_doc_tests"]),
+        "",
+        "## Surface summaries",
+        "",
+    ]
+
+    for heading, values in (
+        ("Lane class", inventory["surface_summary"]["by_lane_class"]),
+        ("Owner", inventory["surface_summary"]["by_owner"]),
+        ("Resource class", inventory["surface_summary"]["by_resource_class"]),
+        ("Proof role", inventory["surface_summary"]["by_proof_role"]),
+        ("Surface kind", inventory["surface_summary"]["by_surface_kind"]),
+    ):
+        lines.extend([f"### {heading}", ""])
+        if not values:
+            lines.append("- none")
+        else:
+            for key, count in values.items():
+                lines.append(f"- `{key}`: {count}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Feature expansions",
+            "",
+        ]
+    )
+    if not inventory["feature_inventory"]:
+        lines.append("- none")
+    else:
+        for name, details in inventory["feature_inventory"].items():
+            lines.append(
+                f"- `{name}`: members={details['member_count']} "
+                f"({', '.join(details['members']) if details['members'] else 'none'})"
+            )
+    lines.append("")
+
+    for heading, records in (
+        ("Shell validators", inventory["shell_validators"]),
+        ("Python validators", inventory["python_validators"]),
+        ("Demo proof surfaces", inventory["demo_proof_surfaces"]),
+    ):
+        lines.extend([f"## {heading}", ""])
+        if not records:
+            lines.append("- none")
+        else:
+            lines.append(f"- count: {len(records)}")
+            for record in records[:20]:
+                lines.append(
+                    f"- `{record['path']}` owner={record['owner'] or 'unknown'} "
+                    f"lane={record['lane_class'] or 'unknown'} "
+                    f"resource={record['resource_class'] or 'unknown'}"
+                )
+        lines.append("")
+
+    for heading, records in (
+        ("Slow-proof surfaces", inventory["slow_proof_surfaces"]),
+        ("Coverage-only surfaces", inventory["coverage_only_surfaces"]),
+        ("Release-gate surfaces", inventory["release_gate_surfaces"]),
+    ):
+        lines.extend([f"## {heading}", ""])
+        if not records:
+            lines.append("- none")
+        else:
+            for record in records[:20]:
+                lines.append(
+                    f"- `{record['path']}` owner={record['owner'] or 'unknown'} "
+                    f"lane={record['lane_class'] or 'unknown'} "
+                    f"resource={record['resource_class'] or 'unknown'}"
+                )
+        lines.append("")
+
+    lines.extend(["## Unknown or unclassified surfaces", ""])
+    if not inventory["unknown_or_unclassified_surfaces"]:
+        lines.append("- none")
+    else:
+        for record in inventory["unknown_or_unclassified_surfaces"][:40]:
+            lines.append(
+                f"- `{record['path']}` status={record['classification_status']} "
+                f"missing={','.join(record['missing_fields'])}"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown", "both"),
+        default="both",
+    )
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    files = git_files(ROOT)
+    manifest = load_manifest(DEFAULT_MANIFEST)
+    features = load_features(DEFAULT_CARGO)
+    inventory = build_inventory(files, manifest, features)
+    markdown = render_markdown(inventory)
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(inventory, indent=2, sort_keys=True) + "\n")
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown + "\n")
+
+    if args.format == "json":
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(markdown)
+    else:
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+        print()
+        print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/adl/tools/validation_inventory.sh
+++ b/adl/tools/validation_inventory.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "$ROOT/adl/tools/validation_inventory.py" "$@"


### PR DESCRIPTION
Closes #4213

## Summary
Completed `#4213` by adding a deterministic local validation-inventory command
and wrapper that emit both JSON and Markdown from tracked repository state
without network access. The inventory now reports Rust lib/bin/integration/doc
test-bearing surfaces, shell validators, Python validators, slow-proof
surfaces, coverage-only surfaces, release-gate surfaces, feature-expansion
metadata, and a normalized surface-record list suitable for later manifest
work. The slice also teaches native `pr finish` to keep this inventory-only
change set in a small-binary focused lane instead of falling back to a broad
classifier. Review found owner-attribution drift for control-plane binaries,
misclassified demo and `test_*.py` validation surfaces, and missing focused
assertions; all findings were fixed before publication, including the final
`adl/Cargo.toml` owner-attribution gap on slow-proof and release-gate surfaces.

## Artifacts
- Updated tracked code:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `adl/tools/validation_inventory.py`
  - `adl/tools/validation_inventory.sh`
  - `adl/tools/test_validation_inventory.sh`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4213__v0-91-6-tools-validation-build-test-inventory-and-attribution-report/sor.md`
  - `.adl/v0.91.6/tasks/issue-4213__v0-91-6-tools-validation-build-test-inventory-and-attribution-report/srp.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_inventory.sh`
    Verified the focused validation-inventory contract suite and deterministic
    output shape.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_validation_inventory_slice_as_small_binary_focused -- --exact --nocapture`
    Verified the finish classifier for the `#4213` publication slice.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_validation_inventory_validation -- --exact --nocapture`
    Verified the finish validation runner executes the narrow inventory shell
    proof for the `#4213` file set.
  - `python3 -m py_compile adl/tools/validation_inventory.py`
    Verified the Python source parses successfully.
  - `git diff --check`
    Verified there are no whitespace or patch-format defects.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4213__v0-91-6-tools-validation-build-test-inventory-and-attribution-report/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4213__v0-91-6-tools-validation-build-test-inventory-and-attribution-report/sor.md
- Idempotency-Key: v0-91-6-tools-validation-build-test-inventory-and-attribution-report-adl-v0-91-6-tasks-issue-4213-v0-91-6-tools-validation-build-test-inventory-and-attribution-report-sip-md-adl-v0-91-6-tasks-issue-4213-v0-91-6-tools-validation-build-test-inventory-and-attribution-report-sor-md