### PR TITLE
[v0.91.6][tools][pvf] Archive CI build logs to S3-backed evidence store

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1094,6 +1094,24 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_ci_log_archive_focused_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml ci_log_archive -- --nocapture",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture",
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_long_lived_agent_tokio_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1483,6 +1501,9 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/suitability_specs/deepseek_csdlc_panel_4096.json"
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
+            | "adl/src/cli/tooling_cmd.rs"
+            | "adl/src/cli/tooling_cmd/ci_log_archive.rs"
+            | "adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs"
             | "adl/src/cli/tooling_cmd/github_release.rs"
             | "adl/src/cli/tooling_cmd/public_prompt_packet.rs"
             | "adl/src/cli/tooling_cmd/tests/public_prompt_packet.rs"
@@ -1562,6 +1583,16 @@ fn finish_path_needs_scheduler_focused_validation(path: &str) -> bool {
 fn finish_path_needs_github_release_focused_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     trimmed == "adl/src/cli/tooling_cmd/github_release.rs"
+}
+
+fn finish_path_needs_ci_log_archive_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/src/cli/tooling_cmd.rs"
+            | "adl/src/cli/tooling_cmd/ci_log_archive.rs"
+            | "adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs"
+    )
 }
 
 fn finish_path_needs_long_lived_agent_tokio_validation(path: &str) -> bool {
@@ -1845,6 +1876,32 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl",
                             "github_release_",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml ci_log_archive -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "ci_log_archive",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint",
+                            "--",
+                            "--nocapture",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1136,6 +1136,24 @@ fn finish_validation_plan_classifies_github_release_tooling_slice() {
 }
 
 #[test]
+fn finish_validation_plan_classifies_ci_log_archive_tooling_slice() {
+    let plan = select_finish_validation_plan(
+        "adl/src/cli/tooling_cmd.rs,adl/src/cli/tooling_cmd/ci_log_archive.rs,adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs",
+    )
+    .expect("ci log archive tooling plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml ci_log_archive -- --nocapture".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture".to_string()
+    ));
+}
+
+#[test]
 fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request() {
     let docs_plan = select_finish_validation_plan_for_finish(
         1153,

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, Result};
 
 #[path = "tooling_cmd/card_prompt.rs"]
 mod card_prompt;
+#[path = "tooling_cmd/ci_log_archive.rs"]
+mod ci_log_archive;
 #[path = "tooling_cmd/code_review.rs"]
 mod code_review;
 #[path = "tooling_cmd/common.rs"]
@@ -30,6 +32,7 @@ mod structured_prompt;
 mod wp_issue_wave;
 
 use card_prompt::real_card_prompt;
+use ci_log_archive::real_ci_log_archive;
 use code_review::real_code_review;
 use csdlc_prompt_editor::real_csdlc_prompt_editor;
 use github_release::real_github_release;
@@ -66,12 +69,13 @@ use structured_prompt::{
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "tooling requires a subcommand: card-prompt | code-review | csdlc-prompt-editor | github-release | lint-prompt-spec | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
+            "tooling requires a subcommand: card-prompt | ci-log-archive | code-review | csdlc-prompt-editor | github-release | lint-prompt-spec | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
         ));
     };
 
     match subcommand {
         "card-prompt" => real_card_prompt(&args[1..]),
+        "ci-log-archive" => real_ci_log_archive(&args[1..]),
         "code-review" => real_code_review(&args[1..]),
         "csdlc-prompt-editor" => real_csdlc_prompt_editor(&args[1..]),
         "generate-wp-issue-wave" => real_generate_wp_issue_wave(&args[1..]),
@@ -91,7 +95,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | csdlc-prompt-editor | generate-wp-issue-wave | github-release | lint-prompt-spec | portable-project-doctor | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
+            "unknown tooling subcommand '{subcommand}' (expected card-prompt | ci-log-archive | code-review | csdlc-prompt-editor | generate-wp-issue-wave | github-release | lint-prompt-spec | portable-project-doctor | prompt-template | public-prompt-packet | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
         )),
     }
 }
@@ -99,6 +103,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
 fn tooling_usage() -> &'static str {
     "adl tooling card-prompt --issue <number> [--out <path>]\n\
 adl tooling card-prompt --input <path> [--out <path>]\n\
+adl tooling ci-log-archive summarize --logs-dir <dir> --out <manifest.json> --s3-prefix s3://bucket/prefix [--repo owner/repo] [--pr <n>] [--run-id <id>] [--commit <sha>] [--raw-zip <logs.zip>] [--upload] [--threshold-seconds 60] [--redaction-status <status>]\n\
 adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--timeout-secs <n>] [--include-working-tree] [--file <path> ...] [--fixture-case clean|blocked]\n\
 adl tooling csdlc-prompt-editor [--repo-root <path>] [--emit-model-js <path>] [--render-samples <dir>]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\

--- a/adl/src/cli/tooling_cmd/ci_log_archive.rs
+++ b/adl/src/cli/tooling_cmd/ci_log_archive.rs
@@ -1,0 +1,495 @@
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ArchiveAction {
+    Summarize,
+}
+
+#[derive(Debug, Clone)]
+struct ArchiveArgs {
+    action: ArchiveAction,
+    logs_dir: PathBuf,
+    out: PathBuf,
+    s3_prefix: String,
+    repo: Option<String>,
+    pr_number: Option<u64>,
+    run_id: Option<String>,
+    commit: Option<String>,
+    raw_zip: Option<PathBuf>,
+    upload: bool,
+    threshold_seconds: f64,
+    redaction_status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TimingEntry {
+    kind: String,
+    name: String,
+    duration_seconds: f64,
+    lane_class: String,
+    source_ref: String,
+}
+
+pub(super) fn real_ci_log_archive(args: &[String]) -> Result<()> {
+    let args = parse_args(args)?;
+    let manifest = run_archive(&args)?;
+    if let Some(parent) = args.out.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output dir '{}'", parent.display()))?;
+    }
+    fs::write(&args.out, serde_json::to_string_pretty(&manifest)? + "\n")
+        .with_context(|| format!("failed to write manifest '{}'", args.out.display()))?;
+    println!("ci_log_archive_manifest={}", args.out.display());
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<ArchiveArgs> {
+    let Some(action) = args.first().map(String::as_str) else {
+        bail!("{}", usage());
+    };
+    let action = match action {
+        "summarize" => ArchiveAction::Summarize,
+        "--help" | "-h" | "help" => {
+            println!("{}", usage());
+            return Err(anyhow!("help requested"));
+        }
+        other => bail!("unknown ci-log-archive action '{other}'\n{}", usage()),
+    };
+
+    let mut logs_dir = None;
+    let mut out = None;
+    let mut s3_prefix = None;
+    let mut repo = None;
+    let mut pr_number = None;
+    let mut run_id = None;
+    let mut commit = None;
+    let mut raw_zip = None;
+    let mut upload = false;
+    let mut threshold_seconds = 60.0;
+    let mut redaction_status = "not_redacted_private_archive_manifest_only".to_string();
+
+    let mut i = 1usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--logs-dir" => {
+                logs_dir = Some(PathBuf::from(require_value(args, &mut i, "--logs-dir")?))
+            }
+            "--out" => out = Some(PathBuf::from(require_value(args, &mut i, "--out")?)),
+            "--s3-prefix" => s3_prefix = Some(require_value(args, &mut i, "--s3-prefix")?),
+            "--repo" => repo = Some(require_value(args, &mut i, "--repo")?),
+            "--pr" => {
+                let value = require_value(args, &mut i, "--pr")?;
+                pr_number = Some(
+                    value
+                        .parse::<u64>()
+                        .with_context(|| format!("invalid --pr '{value}'"))?,
+                );
+            }
+            "--run-id" => run_id = Some(require_value(args, &mut i, "--run-id")?),
+            "--commit" => commit = Some(require_value(args, &mut i, "--commit")?),
+            "--raw-zip" => raw_zip = Some(PathBuf::from(require_value(args, &mut i, "--raw-zip")?)),
+            "--upload" => upload = true,
+            "--threshold-seconds" => {
+                let value = require_value(args, &mut i, "--threshold-seconds")?;
+                threshold_seconds = value
+                    .parse::<f64>()
+                    .with_context(|| format!("invalid --threshold-seconds '{value}'"))?;
+                if threshold_seconds <= 0.0 {
+                    bail!("--threshold-seconds must be positive");
+                }
+            }
+            "--redaction-status" => {
+                redaction_status = require_value(args, &mut i, "--redaction-status")?;
+                validate_redaction_status(&redaction_status)?;
+            }
+            other => bail!("unknown ci-log-archive argument '{other}'"),
+        }
+        i += 1;
+    }
+
+    let logs_dir =
+        logs_dir.ok_or_else(|| anyhow!("ci-log-archive summarize requires --logs-dir"))?;
+    let out = out.ok_or_else(|| anyhow!("ci-log-archive summarize requires --out"))?;
+    let s3_prefix = s3_prefix.ok_or_else(|| {
+        anyhow!("ci-log-archive summarize requires --s3-prefix s3://bucket/prefix")
+    })?;
+    if !s3_prefix.starts_with("s3://") {
+        bail!("--s3-prefix must start with s3://");
+    }
+    if !logs_dir.is_dir() {
+        bail!("--logs-dir is not a directory: {}", logs_dir.display());
+    }
+    if let Some(raw_zip) = raw_zip.as_ref() {
+        if !raw_zip.is_file() {
+            bail!("--raw-zip is not a file: {}", raw_zip.display());
+        }
+    }
+
+    validate_redaction_status(&redaction_status)?;
+
+    Ok(ArchiveArgs {
+        action,
+        logs_dir,
+        out,
+        s3_prefix,
+        repo,
+        pr_number,
+        run_id,
+        commit,
+        raw_zip,
+        upload,
+        threshold_seconds,
+        redaction_status,
+    })
+}
+
+fn require_value(args: &[String], i: &mut usize, flag: &str) -> Result<String> {
+    *i += 1;
+    args.get(*i)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| anyhow!("{flag} requires a non-empty value"))
+}
+
+fn validate_redaction_status(value: &str) -> Result<()> {
+    match value {
+        "not_redacted_private_archive_manifest_only"
+        | "redacted_private_archive"
+        | "redacted_review_safe_summary" => Ok(()),
+        other => bail!(
+            "unsupported --redaction-status '{other}' (expected not_redacted_private_archive_manifest_only | redacted_private_archive | redacted_review_safe_summary)"
+        ),
+    }
+}
+
+fn usage() -> &'static str {
+    "adl tooling ci-log-archive summarize --logs-dir <dir> --out <manifest.json> --s3-prefix s3://bucket/prefix [--repo owner/repo] [--pr <n>] [--run-id <id>] [--commit <sha>] [--raw-zip <logs.zip>] [--upload] [--threshold-seconds 60] [--redaction-status <status>]"
+}
+
+fn run_archive(args: &ArchiveArgs) -> Result<serde_json::Value> {
+    match args.action {
+        ArchiveAction::Summarize => {}
+    }
+    let mut entries = analyze_logs(&args.logs_dir, args.threshold_seconds)?;
+    entries.sort_by(|a, b| {
+        b.duration_seconds
+            .partial_cmp(&a.duration_seconds)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.source_ref.cmp(&b.source_ref))
+    });
+    let over_threshold = entries
+        .iter()
+        .filter(|entry| entry.duration_seconds > args.threshold_seconds)
+        .count();
+    let raw_log_ref = raw_log_s3_ref(args);
+    let upload_status = if args.upload {
+        upload_raw_logs(args, &raw_log_ref)?
+    } else {
+        "upload_not_run".to_string()
+    };
+
+    Ok(json!({
+        "schema_version": "adl.ci_log_archive_manifest.v1",
+        "generated_at": Utc::now().to_rfc3339(),
+        "source": {
+            "repo": args.repo,
+            "pr_number": args.pr_number,
+            "run_id": args.run_id,
+            "commit": args.commit
+        },
+        "archive": {
+            "backend": "s3",
+            "raw_log_ref": raw_log_ref,
+            "upload_status": upload_status,
+            "redaction_status": args.redaction_status,
+            "local_retention": "temporary_input_only"
+        },
+        "timing_summary": {
+            "threshold_seconds": args.threshold_seconds,
+            "entry_count": entries.len(),
+            "over_threshold_count": over_threshold,
+            "a_small_count": entries.len().saturating_sub(over_threshold),
+            "b_large_count": over_threshold
+        },
+        "timing_entries": entries,
+        "consumption_policy": {
+            "raw_logs_are_evidence": true,
+            "manifest_and_summaries_are_memory": true,
+            "obsmem_ingests_raw_logs": false,
+            "obsmem_ingests_manifest": true,
+            "validation_lane_index_consumes_timing_summary": true,
+            "fail_closed_on_upload_or_redaction_error": true
+        }
+    }))
+}
+
+fn analyze_logs(logs_dir: &Path, threshold_seconds: f64) -> Result<Vec<TimingEntry>> {
+    let mut files = Vec::new();
+    collect_files(logs_dir, logs_dir, &mut files)?;
+    let mut entries = Vec::new();
+    for (path, rel) in files {
+        let text = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read log '{}'", path.display()))?;
+        if let Some(duration) = github_timestamp_duration_seconds(&text) {
+            entries.push(TimingEntry {
+                kind: "github_step_log".to_string(),
+                name: rel.clone(),
+                duration_seconds: round3(duration),
+                lane_class: lane_class(duration, threshold_seconds),
+                source_ref: rel.clone(),
+            });
+        }
+        for (idx, duration) in rust_finished_durations(&text).into_iter().enumerate() {
+            entries.push(TimingEntry {
+                kind: "rust_test_summary".to_string(),
+                name: format!("{rel}#finished_in_{}", idx + 1),
+                duration_seconds: round3(duration),
+                lane_class: lane_class(duration, threshold_seconds),
+                source_ref: rel.clone(),
+            });
+        }
+    }
+    Ok(entries)
+}
+
+fn collect_files(root: &Path, dir: &Path, files: &mut Vec<(PathBuf, String)>) -> Result<()> {
+    for entry in
+        fs::read_dir(dir).with_context(|| format!("failed to read dir '{}'", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, files)?;
+        } else if path.is_file() && is_log_file(&path) {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((path, rel));
+        }
+    }
+    Ok(())
+}
+
+fn is_log_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| matches!(ext, "txt" | "log" | "jsonl"))
+}
+
+fn github_timestamp_duration_seconds(text: &str) -> Option<f64> {
+    let mut first: Option<DateTime<Utc>> = None;
+    let mut last: Option<DateTime<Utc>> = None;
+    for line in text.lines() {
+        let Some(stamp) = line.get(..30).and_then(extract_rfc3339_prefix) else {
+            continue;
+        };
+        first.get_or_insert(stamp);
+        last = Some(stamp);
+    }
+    match (first, last) {
+        (Some(first), Some(last)) if last >= first => {
+            Some((last - first).num_milliseconds() as f64 / 1000.0)
+        }
+        _ => None,
+    }
+}
+
+fn extract_rfc3339_prefix(line_prefix: &str) -> Option<DateTime<Utc>> {
+    let end = line_prefix.find(' ')?;
+    let candidate = &line_prefix[..end];
+    DateTime::parse_from_rfc3339(candidate)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn rust_finished_durations(text: &str) -> Vec<f64> {
+    let mut durations = Vec::new();
+    for line in text.lines() {
+        let Some(idx) = line.find("finished in ") else {
+            continue;
+        };
+        let rest = &line[idx + "finished in ".len()..];
+        if let Some(duration) = parse_duration_token(rest.split_whitespace().next().unwrap_or("")) {
+            durations.push(duration);
+        }
+    }
+    durations
+}
+
+fn parse_duration_token(token: &str) -> Option<f64> {
+    if let Some(raw) = token.strip_suffix("ms") {
+        raw.parse::<f64>().ok().map(|value| value / 1000.0)
+    } else if let Some(raw) = token.strip_suffix('s') {
+        raw.parse::<f64>().ok()
+    } else if let Some(raw) = token.strip_suffix('m') {
+        raw.parse::<f64>().ok().map(|value| value * 60.0)
+    } else {
+        None
+    }
+}
+
+fn lane_class(duration: f64, threshold_seconds: f64) -> String {
+    if duration > threshold_seconds {
+        "B_large".to_string()
+    } else {
+        "A_small".to_string()
+    }
+}
+
+fn round3(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
+}
+
+fn raw_log_s3_ref(args: &ArchiveArgs) -> String {
+    let mut prefix = args.s3_prefix.trim_end_matches('/').to_string();
+    if let Some(repo) = args.repo.as_deref() {
+        prefix.push('/');
+        prefix.push_str(&sanitize_key_component(repo));
+    }
+    if let Some(pr) = args.pr_number {
+        prefix.push_str(&format!("/pr-{pr}"));
+    }
+    if let Some(run_id) = args.run_id.as_deref() {
+        prefix.push_str("/run-");
+        prefix.push_str(&sanitize_key_component(run_id));
+    }
+    prefix.push_str("/github-actions-logs.zip");
+    prefix
+}
+
+fn sanitize_key_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '-',
+        })
+        .collect()
+}
+
+fn upload_raw_logs(args: &ArchiveArgs, raw_log_ref: &str) -> Result<String> {
+    let Some(raw_zip) = args.raw_zip.as_ref() else {
+        bail!("--upload requires --raw-zip so the uploaded payload is explicit");
+    };
+    let status = Command::new("aws")
+        .args(["s3", "cp"])
+        .arg(raw_zip)
+        .arg(raw_log_ref)
+        .status()
+        .context("failed to invoke aws s3 cp for ci-log-archive upload")?;
+    if !status.success() {
+        bail!("aws s3 cp failed for ci-log-archive upload");
+    }
+    Ok("uploaded".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("repo root")
+            .join(".tmp/ci_log_archive_tests")
+            .join(format!("{label}-{stamp}"));
+        fs::create_dir_all(&path).expect("temp dir");
+        path
+    }
+
+    #[test]
+    fn summarize_classifies_github_step_and_rust_finished_durations() {
+        let root = temp_dir("summary");
+        let logs = root.join("logs");
+        fs::create_dir_all(&logs).expect("logs");
+        fs::write(
+            logs.join("slow-step.txt"),
+            "2026-06-19T18:00:00.0000000Z start\n2026-06-19T18:02:10.0000000Z end\n",
+        )
+        .expect("slow log");
+        fs::write(
+            logs.join("rust.txt"),
+            "test result: ok. 12 passed; finished in 0.05s\ntest result: ok. 1 passed; finished in 61.2s\n",
+        )
+        .expect("rust log");
+        let out = root.join("manifest.json");
+        let args = ArchiveArgs {
+            action: ArchiveAction::Summarize,
+            logs_dir: logs,
+            out,
+            s3_prefix: "s3://adl-ci-logs/v0.91.6".to_string(),
+            repo: Some("danielbaustin/agent-design-language".to_string()),
+            pr_number: Some(4152),
+            run_id: Some("27840922589".to_string()),
+            commit: Some("abc123".to_string()),
+            raw_zip: None,
+            upload: false,
+            threshold_seconds: 60.0,
+            redaction_status: "not_redacted_private_archive_manifest_only".to_string(),
+        };
+        let manifest = run_archive(&args).expect("manifest");
+        assert_eq!(manifest["schema_version"], "adl.ci_log_archive_manifest.v1");
+        assert_eq!(manifest["timing_summary"]["over_threshold_count"], 2);
+        assert_eq!(manifest["timing_summary"]["a_small_count"], 1);
+        assert_eq!(manifest["archive"]["upload_status"], "upload_not_run");
+        assert_eq!(
+            manifest["archive"]["raw_log_ref"],
+            "s3://adl-ci-logs/v0.91.6/danielbaustin-agent-design-language/pr-4152/run-27840922589/github-actions-logs.zip"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_unrecognized_redaction_status() {
+        let args = vec![
+            "summarize".to_string(),
+            "--logs-dir".to_string(),
+            ".".to_string(),
+            "--out".to_string(),
+            "manifest.json".to_string(),
+            "--s3-prefix".to_string(),
+            "s3://adl-ci-logs/v0.91.6".to_string(),
+            "--redaction-status".to_string(),
+            "public_safe_trust_me".to_string(),
+        ];
+        let err = parse_args(&args).expect_err("unknown redaction status must fail");
+        assert!(err.to_string().contains("unsupported --redaction-status"));
+    }
+
+    #[test]
+    fn upload_requires_explicit_raw_zip() {
+        let root = temp_dir("upload-requires-zip");
+        let logs = root.join("logs");
+        fs::create_dir_all(&logs).expect("logs");
+        let args = ArchiveArgs {
+            action: ArchiveAction::Summarize,
+            logs_dir: logs,
+            out: root.join("manifest.json"),
+            s3_prefix: "s3://adl-ci-logs/v0.91.6".to_string(),
+            repo: None,
+            pr_number: None,
+            run_id: None,
+            commit: None,
+            raw_zip: None,
+            upload: true,
+            threshold_seconds: 60.0,
+            redaction_status: "not_redacted_private_archive_manifest_only".to_string(),
+        };
+        let err = run_archive(&args).expect_err("upload without zip must fail");
+        assert!(err.to_string().contains("--upload requires --raw-zip"));
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+++ b/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
@@ -25,11 +25,46 @@ fn tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint() {
 
     assert!(real_tooling(&[]).is_err());
     real_tooling(&["help".to_string()]).expect("help should succeed");
-    assert!(real_tooling(&["unknown".to_string()]).is_err());
+    let unknown_err = real_tooling(&["unknown".to_string()]).expect_err("unknown command");
+    assert!(unknown_err.to_string().contains("ci-log-archive"));
     real_tooling(&["code-review".to_string(), "--help".to_string()])
         .expect("code-review help should succeed without --out");
     real_tooling(&["portable-project-doctor".to_string(), "--help".to_string()])
         .expect("portable-project-doctor help should succeed");
+
+    let ci_logs = repo.path().join("ci-logs");
+    fs::create_dir_all(&ci_logs).expect("ci log dir");
+    fs::write(
+        ci_logs.join("step.txt"),
+        "2026-06-19T18:00:00.0000000Z start\n2026-06-19T18:01:10.0000000Z end\n",
+    )
+    .expect("ci log");
+    let ci_manifest = repo.path().join("ci-log-manifest.json");
+    real_tooling(&[
+        "ci-log-archive".to_string(),
+        "summarize".to_string(),
+        "--logs-dir".to_string(),
+        ci_logs.to_string_lossy().to_string(),
+        "--out".to_string(),
+        ci_manifest.to_string_lossy().to_string(),
+        "--s3-prefix".to_string(),
+        "s3://adl-ci-logs/v0.91.6".to_string(),
+        "--repo".to_string(),
+        "danielbaustin/agent-design-language".to_string(),
+        "--pr".to_string(),
+        "4152".to_string(),
+        "--run-id".to_string(),
+        "27840922589".to_string(),
+    ])
+    .expect("ci-log-archive dispatch should succeed");
+    let ci_manifest_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&ci_manifest).expect("ci log archive manifest"))
+            .expect("ci manifest json");
+    assert_eq!(
+        ci_manifest_json["schema_version"],
+        "adl.ci_log_archive_manifest.v1"
+    );
+    assert_eq!(ci_manifest_json["timing_summary"]["b_large_count"], 1);
 
     real_tooling(&[
         "card-prompt".to_string(),

--- a/docs/milestones/v0.91.6/review/ci_log_archive/CI_LOG_ARCHIVE_S3_CONTRACT_4225.md
+++ b/docs/milestones/v0.91.6/review/ci_log_archive/CI_LOG_ARCHIVE_S3_CONTRACT_4225.md
@@ -1,0 +1,150 @@
+# CI Log Archive S3 Contract (#4225)
+
+## Summary
+
+ADL now has a bounded CI/build-log archive surface for preserving verbose GitHub Actions logs without storing raw logs in Git or leaving permanent local piles behind.
+
+The contract is deliberately split:
+
+- raw CI/build logs are evidence and belong in S3-compatible object storage
+- small manifests and timing summaries are memory and can be tracked, reviewed, indexed, and consumed by ObsMem/community-memory surfaces
+
+## Command
+
+```bash
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- \
+  tooling ci-log-archive summarize \
+  --logs-dir <extracted-github-actions-logs> \
+  --out <manifest.json> \
+  --s3-prefix s3://<bucket>/<prefix> \
+  --repo danielbaustin/agent-design-language \
+  --pr <pr-number> \
+  --run-id <github-actions-run-id> \
+  --commit <sha>
+```
+
+Optional live upload requires an explicit raw log zip and configured AWS-compatible CLI credentials:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- \
+  tooling ci-log-archive summarize \
+  --logs-dir <extracted-github-actions-logs> \
+  --raw-zip <github-actions-logs.zip> \
+  --upload \
+  --out <manifest.json> \
+  --s3-prefix s3://<bucket>/<prefix>
+```
+
+If `--upload` is not set, the manifest records `upload_not_run`. If `--upload` is set without `--raw-zip`, the command fails closed.
+
+## Manifest Shape
+
+The command writes `adl.ci_log_archive_manifest.v1` JSON with:
+
+- `source.repo`
+- `source.pr_number`
+- `source.run_id`
+- `source.commit`
+- `archive.backend`
+- `archive.raw_log_ref`
+- `archive.upload_status`
+- `archive.redaction_status`
+- `archive.local_retention`
+- `timing_summary.threshold_seconds`
+- `timing_summary.entry_count`
+- `timing_summary.over_threshold_count`
+- `timing_summary.a_small_count`
+- `timing_summary.b_large_count`
+- `timing_entries[]`
+- `consumption_policy`
+
+## S3 Object Convention
+
+Given:
+
+- prefix: `s3://adl-ci-logs/v0.91.6`
+- repo: `danielbaustin/agent-design-language`
+- PR: `4152`
+- run id: `27840922589`
+
+The raw log object ref becomes:
+
+```text
+s3://adl-ci-logs/v0.91.6/danielbaustin-agent-design-language/pr-4152/run-27840922589/github-actions-logs.zip
+```
+
+This makes build logs addressable by project, PR, and GitHub Actions run without encoding local machine paths.
+
+## A/B Validation-Lane Consumption
+
+Every manifest classifies observed durations against the threshold, defaulting to `60` seconds:
+
+- `A_small`: timing entry is at or below the threshold
+- `B_large`: timing entry is greater than the threshold
+
+#4223 should consume these manifests to update the validation-lane index. It should not require extracted logs or raw zip files to remain local after the manifest and S3 object are durable.
+
+## Runtime And Memory Boundary
+
+For runtime, ObsMem, and community memory:
+
+- raw logs remain evidence
+- manifests and summaries are memory
+- raw logs are not ingested into ObsMem by default
+- memory records preserve provenance to `archive.raw_log_ref`
+- community-memory surfaces consume redacted summaries, not raw logs
+
+## Redaction And Security Posture
+
+The default manifest status is:
+
+```text
+not_redacted_private_archive_manifest_only
+```
+
+Allowed statuses are intentionally narrow:
+
+- `not_redacted_private_archive_manifest_only`
+- `redacted_private_archive`
+- `redacted_review_safe_summary`
+
+That means the raw object is intended for private evidence storage unless a later redaction lane certifies it for broader review or community-memory publication.
+
+The command does not claim to redact raw logs. It records a validated redaction posture so later surfaces cannot mistake private evidence for publishable memory. Unknown redaction statuses fail closed instead of being copied into durable manifests.
+
+## Local Retention Policy
+
+Local logs are temporary input only. The durable surfaces are:
+
+- S3 raw log object
+- tracked manifest/summary
+
+Local extracted logs and local zip files should be deleted by the caller once archive/upload and manifest production are complete.
+
+## Failure Behavior
+
+- Missing `--logs-dir`: fail.
+- Non-S3 `--s3-prefix`: fail.
+- `--upload` without `--raw-zip`: fail.
+- Missing or failed `aws s3 cp`: fail.
+- No upload requested: succeed with `upload_not_run`.
+
+## Validation Performed
+
+Focused Rust tests cover:
+
+- GitHub step log duration extraction.
+- Rust `finished in ...` summary extraction.
+- `A_small` / `B_large` threshold classification.
+- S3 object-ref construction.
+- Fail-closed upload behavior when `--upload` lacks `--raw-zip`.
+
+## Non-claims
+
+This issue does not claim:
+
+- automatic download of GitHub Actions logs
+- automatic attachment to every PR closeout
+- raw-log redaction
+- ObsMem ingestion implementation
+- a complete artifact lake


### PR DESCRIPTION
Closes #4225

## Summary
Implemented a bounded `ci-log-archive` tooling command that analyzes extracted GitHub Actions/build logs, classifies timing entries into `A_small` and `B_large` using a default `60s` threshold, writes a small durable manifest, and points raw log storage at S3-compatible object storage instead of Git or permanent local disk.

This issue establishes the immediate CI-log archive/analyze surface needed by #4223 and the future runtime/ObsMem/community-memory trace strategy. It does not claim automatic download of every GitHub Actions run yet, and it does not claim live S3 upload was exercised in this run.

## Artifacts
- `adl/src/cli/tooling_cmd/ci_log_archive.rs`
- `adl/src/cli/tooling_cmd.rs`
- `adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs`
- `docs/milestones/v0.91.6/review/ci_log_archive/CI_LOG_ARCHIVE_S3_CONTRACT_4225.md`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `.adl/v0.91.6/tasks/issue-4225__v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Applied Rust formatting after adding the new tooling module and dispatch test.
  - `cargo test --manifest-path adl/Cargo.toml ci_log_archive -- --nocapture`
    Verified timestamp duration extraction, Rust summary parsing, A/B threshold classification, S3 object-ref construction, and fail-closed upload preconditions.
  - `cargo test --manifest-path adl/Cargo.toml tooling_cmd_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture`
    Verified the public tooling dispatcher path can invoke `ci-log-archive summarize` and produce a manifest.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4225__v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4225__v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store/sor.md
- Idempotency-Key: v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store-adl-v0-91-6-tasks-issue-4225-v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store-sip-md-adl-v0-91-6-tasks-issue-4225-v0-91-6-tools-pvf-archive-ci-build-logs-to-s3-backed-evidence-store-sor-md