### PR TITLE
[v0.91.6][tools][validation] Create validation surface manifest

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -1,9 +1,96 @@
 {
   "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    },
+    "tooling": {
+      "owner": "tools",
+      "resource_class": "small",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "none"
+    },
+    "runtime": {
+      "owner": "runtime",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    },
+    "provider": {
+      "owner": "provider",
+      "resource_class": "high",
+      "determinism_posture": "credential_or_network_bound",
+      "proof_role": "provider_regression",
+      "risk_class": "high",
+      "escalation_rule": "manual_provider_gate"
+    },
+    "security": {
+      "owner": "security",
+      "resource_class": "high",
+      "determinism_posture": "deterministic",
+      "proof_role": "security_regression",
+      "risk_class": "high",
+      "escalation_rule": "manual_security_gate"
+    },
+    "ci_policy": {
+      "owner": "tools",
+      "resource_class": "small",
+      "determinism_posture": "deterministic",
+      "proof_role": "ci_contract",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    },
+    "slow_proof": {
+      "owner": "runtime",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "slow_proof",
+      "risk_class": "high",
+      "escalation_rule": "manual_slow_proof_gate"
+    },
+    "release_gate": {
+      "owner": "tools",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "release_gate",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    },
+    "shared_rust": {
+      "owner": "shared",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    }
+  },
   "lanes": [
     {
       "id": "prompt_template_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "csdlc",
+      "proof_role": "prompt_template_contract",
+      "requirement_ids": [
+        "prompt_template_contracts"
+      ],
+      "path_selectors": [
+        "docs/templates/prompts/**",
+        "adl/src/bin/adl_prompt_template.rs",
+        "adl/src/bin/adl_validate_structured_prompt.rs",
+        "adl/src/csdlc_prompt_editor/**",
+        "adl/src/csdlc_prompt_editor.rs"
+      ],
       "path_hints": [
         "docs/templates/prompts/**",
         "adl/src/bin/adl_prompt_template.rs",
@@ -18,6 +105,19 @@
     {
       "id": "pvf_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "pvf_contract",
+      "requirement_ids": [
+        "pvf_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/run_pvf_validation_lane.sh",
+        "adl/tools/validate_pvf_manifest.py",
+        "adl/tools/test_run_pvf_validation_lane.sh",
+        "adl/tools/test_pvf_ci_release_policy.sh",
+        "adl/tools/run_pvf_ci_release_policy_fixture.sh"
+      ],
       "path_hints": [
         "adl/tools/run_pvf_validation_lane.sh",
         "adl/tools/validate_pvf_manifest.py",
@@ -32,6 +132,16 @@
     {
       "id": "ci_path_policy_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "ci_policy",
+      "owner": "tools",
+      "requirement_ids": [
+        "ci_path_policy_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh",
+        ".github/workflows/**"
+      ],
       "path_hints": [
         "adl/tools/ci_path_policy.sh",
         "adl/tools/test_ci_path_policy.sh",
@@ -44,6 +154,16 @@
     {
       "id": "coverage_impact_contracts",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "coverage_contract",
+      "requirement_ids": [
+        "coverage_impact_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/check_coverage_impact.sh",
+        "adl/tools/test_check_coverage_impact.sh"
+      ],
       "path_hints": [
         "adl/tools/check_coverage_impact.sh",
         "adl/tools/test_check_coverage_impact.sh"
@@ -55,6 +175,20 @@
     {
       "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "csdlc",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "csdlc_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/cli/pr_cmd.rs",
+        "adl/src/cli/pr_cmd/**",
+        "adl/src/cli/pr_cmd_cards.rs",
+        "adl/src/cli/pr_cmd_cards/**",
+        "adl/tools/pr.sh",
+        "adl/tools/run_owner_validation_lane.sh"
+      ],
       "path_hints": [
         "adl/src/cli/pr_cmd.rs",
         "adl/src/cli/pr_cmd/**",
@@ -70,6 +204,16 @@
     {
       "id": "runtime_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "runtime",
+      "owner": "runtime",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "runtime_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/bin/adl_runtime.rs",
+        "adl/tools/test_adl_runtime_compatibility.sh"
+      ],
       "path_hints": [
         "adl/src/bin/adl_runtime.rs",
         "adl/tools/test_adl_runtime_compatibility.sh"
@@ -81,6 +225,17 @@
     {
       "id": "review_owner_lane",
       "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "owner_lane",
+      "requirement_ids": [
+        "review_owner_lane"
+      ],
+      "path_selectors": [
+        "adl/src/bin/adl_review.rs",
+        "adl/src/review*.rs",
+        "adl/tools/test_adl_review_compatibility.sh"
+      ],
       "path_hints": [
         "adl/src/bin/adl_review.rs",
         "adl/src/review*.rs",
@@ -93,6 +248,15 @@
     {
       "id": "docs_diff_check",
       "lane_class": "docs",
+      "default_surface": "docs",
+      "owner": "docs",
+      "requirement_ids": [
+        "docs_diff_check"
+      ],
+      "path_selectors": [
+        "docs/**",
+        "*.md"
+      ],
       "path_hints": [
         "docs/**",
         "*.md"
@@ -102,6 +266,57 @@
       "reason": "docs_only_surface_requires_diff_hygiene"
     }
   ],
+  "special_surfaces": {
+    "release_gate_review": {
+      "id": "release_gate_review",
+      "lane_class": "release_gate",
+      "default_surface": "release_gate",
+      "owner": "tools",
+      "path_selectors": [
+        ".github/workflows/**",
+        "docs/milestones/**/release/**",
+        "docs/milestones/**/RELEASE_PLAN*.md",
+        "docs/milestones/**/MILESTONE_CHECKLIST*.md"
+      ],
+      "path_hints": [
+        ".github/workflows/**",
+        "docs/milestones/**/release/**",
+        "docs/milestones/**/RELEASE_PLAN*.md",
+        "docs/milestones/**/MILESTONE_CHECKLIST*.md"
+      ],
+      "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+      "run_command": "",
+      "reason": "changed_surface_requires_release_or_ci_policy_review",
+      "requirement_ids": [
+        "release_gate_disposition_required"
+      ],
+      "broad_lane_reason": "release and CI-policy surfaces remain distinct from ordinary PR proof"
+    },
+    "rust_pr_fast": {
+      "id": "rust_pr_fast",
+      "lane_class": "fast_unit",
+      "escalated_lane_class": "release_gate",
+      "default_surface": "shared_rust",
+      "owner": "shared",
+      "path_selectors": [
+        "adl/build.rs",
+        "adl/src/**",
+        "adl/tests/**"
+      ],
+      "path_hints": [
+        "adl/build.rs",
+        "adl/src/**",
+        "adl/tests/**"
+      ],
+      "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "reason": "delegate_rust_changed_surface_to_pr_fast_lane_selector",
+      "requirement_ids": [
+        "rust_changed_surface"
+      ],
+      "broad_lane_reason": "shared Rust changes escalate when PR-fast cannot prove a bounded slice"
+    }
+  },
   "release_gate_hints": [
     ".github/workflows/**",
     "docs/milestones/**/release/**",

--- a/adl/tools/select_validation_lanes.py
+++ b/adl/tools/select_validation_lanes.py
@@ -91,27 +91,119 @@ def matches(path: str, hints: list[str]) -> bool:
     return any(path == hint or fnmatch.fnmatch(path, hint) for hint in hints)
 
 
+def selectors_for(entry: dict[str, Any]) -> list[str]:
+    selectors = entry.get("path_selectors") or entry.get("path_hints")
+    if not isinstance(selectors, list) or not selectors:
+        fail(f"manifest entry {entry.get('id', '<unknown>')} selectors must be a non-empty array")
+    return selectors
+
+
+REQUIRED_SURFACE_METADATA = (
+    "owner",
+    "resource_class",
+    "determinism_posture",
+    "proof_role",
+    "risk_class",
+    "escalation_rule",
+)
+
+
+def merge_surface_defaults(manifest: dict[str, Any], entry: dict[str, Any], *, entry_id: str) -> dict[str, Any]:
+    default_surface = entry.get("default_surface")
+    if not isinstance(default_surface, str) or not default_surface:
+        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required key: default_surface")
+    surface_defaults = manifest["surface_defaults"].get(default_surface)
+    if not isinstance(surface_defaults, dict):
+        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} references unknown default_surface: {default_surface}")
+    merged = dict(surface_defaults)
+    merged.update(entry)
+    merged["path_selectors"] = selectors_for(entry)
+    for key in REQUIRED_SURFACE_METADATA:
+        if not isinstance(merged.get(key), str) or not merged[key]:
+            fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required surface metadata: {key}")
+    return merged
+
+
+def plan_entry(
+    manifest: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    status: str,
+    matched_paths: list[str],
+    command: str | None = None,
+    run_command: str | None = None,
+    lane_class: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized = merge_surface_defaults(manifest, entry, entry_id=entry["id"])
+    result = {
+        "lane_class": lane_class or normalized["lane_class"],
+        "status": status,
+        "reason": normalized["reason"],
+        "command": command if command is not None else normalized["command"],
+        "run_command": run_command if run_command is not None else normalized.get("run_command", normalized["command"]),
+        "matched_paths": matched_paths,
+        "owner": normalized["owner"],
+        "resource_class": normalized["resource_class"],
+        "determinism_posture": normalized["determinism_posture"],
+        "proof_role": normalized["proof_role"],
+        "risk_class": normalized["risk_class"],
+        "escalation_rule": normalized["escalation_rule"],
+        "default_surface": normalized["default_surface"],
+        "path_selectors": normalized["path_selectors"],
+        "requirement_ids": normalized.get("requirement_ids", []),
+    }
+    broad_lane_reason = normalized.get("broad_lane_reason")
+    if broad_lane_reason:
+        result["broad_lane_reason"] = broad_lane_reason
+    if extra:
+        result.update(extra)
+    return result
+
+
+def manifest_entry_for(manifest: dict[str, Any], surface_id: str, fallback: dict[str, Any]) -> dict[str, Any]:
+    special_surfaces = manifest.get("special_surfaces", {})
+    entry = special_surfaces.get(surface_id, fallback)
+    if not isinstance(entry, dict):
+        fail(f"{DEFAULT_MANIFEST}: special_surfaces.{surface_id} must be an object")
+    return entry
+
+
 def load_manifest(path: Path) -> dict[str, Any]:
     manifest = json.loads(path.read_text())
     if manifest.get("schema_version") != "adl.validation_lane_selector.v1":
         fail(f"{path}: unsupported schema_version")
-    for key in ("lanes", "release_gate_hints", "rust_path_hints"):
+    for key in ("surface_defaults", "lanes", "release_gate_hints", "rust_path_hints"):
         if key not in manifest:
             fail(f"{path}: missing required key: {key}")
+    if not isinstance(manifest["surface_defaults"], dict) or not manifest["surface_defaults"]:
+        fail(f"{path}: surface_defaults must be a non-empty object")
     lane_ids: set[str] = set()
     for index, lane in enumerate(manifest["lanes"]):
         if not isinstance(lane, dict):
             fail(f"{path}: lanes[{index}] must be an object")
-        for key in ("id", "lane_class", "path_hints", "command", "reason"):
+        for key in ("id", "lane_class", "command", "reason", "default_surface"):
             if key not in lane:
                 fail(f"{path}: lanes[{index}] missing required key: {key}")
         if lane["id"] in lane_ids:
             fail(f"{path}: duplicate lane id: {lane['id']}")
         lane_ids.add(lane["id"])
-        if not isinstance(lane["path_hints"], list) or not lane["path_hints"]:
-            fail(f"{path}: lane {lane['id']} path_hints must be a non-empty array")
+        selectors_for(lane)
         if "run_command" in lane and not isinstance(lane["run_command"], str):
             fail(f"{path}: lane {lane['id']} run_command must be a string")
+        merge_surface_defaults(manifest, lane, entry_id=lane["id"])
+    special_surfaces = manifest.get("special_surfaces", {})
+    if special_surfaces:
+        if not isinstance(special_surfaces, dict):
+            fail(f"{path}: special_surfaces must be an object")
+        for surface_id, surface in special_surfaces.items():
+            if not isinstance(surface, dict):
+                fail(f"{path}: special_surfaces.{surface_id} must be an object")
+            for key in ("id", "lane_class", "command", "reason", "default_surface"):
+                if key not in surface:
+                    fail(f"{path}: special_surfaces.{surface_id} missing required key: {key}")
+            selectors_for(surface)
+            merge_surface_defaults(manifest, surface, entry_id=surface_id)
     for key in ("release_gate_hints", "rust_path_hints"):
         if not isinstance(manifest[key], list):
             fail(f"{path}: {key} must be an array")
@@ -145,33 +237,52 @@ def select_lanes(
     head: str,
 ) -> dict[str, Any]:
     selected: dict[str, dict[str, Any]] = {}
+    release_gate_entry = manifest_entry_for(
+        manifest,
+        "release_gate_review",
+        {
+            "id": "release_gate_review",
+            "lane_class": "release_gate",
+            "default_surface": "release_gate",
+            "owner": "tools",
+            "path_selectors": manifest["release_gate_hints"],
+            "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+            "run_command": "",
+            "reason": "changed_surface_requires_release_or_ci_policy_review",
+        },
+    )
+    rust_entry = manifest_entry_for(
+        manifest,
+        "rust_pr_fast",
+        {
+            "id": "rust_pr_fast",
+            "lane_class": "fast_unit",
+            "escalated_lane_class": "release_gate",
+            "default_surface": "shared_rust",
+            "owner": "shared",
+            "path_selectors": manifest["rust_path_hints"],
+            "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+            "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+            "reason": "delegate_rust_changed_surface_to_pr_fast_lane_selector",
+        },
+    )
 
     release_gate_paths = [
-        path for path in paths if matches(path, manifest["release_gate_hints"])
+        path for path in paths if matches(path, selectors_for(release_gate_entry))
     ]
 
     for path in paths:
         for lane in manifest["lanes"]:
-            if matches(path, lane["path_hints"]):
+            if matches(path, selectors_for(lane)):
                 lane_id = lane["id"]
-                entry = selected.setdefault(
-                    lane_id,
-                    {
-                        "lane_class": lane["lane_class"],
-                        "status": "selected",
-                        "reason": lane["reason"],
-                        "command": lane["command"],
-                        "run_command": lane.get("run_command", lane["command"]),
-                        "matched_paths": [],
-                    },
-                )
+                entry = selected.setdefault(lane_id, plan_entry(manifest, lane, status="selected", matched_paths=[]))
                 entry["matched_paths"].append(path)
                 break
 
     rust_paths = [
         path
         for path in paths
-        if matches(path, manifest["rust_path_hints"])
+        if matches(path, selectors_for(rust_entry))
         and not path.endswith("/README.md")
         and not path.endswith(".md")
     ]
@@ -185,27 +296,30 @@ def select_lanes(
             command += f" --changed-files {shlex.quote(str(changed_files))}"
         else:
             command += f" --base {shlex.quote(base)} --head {shlex.quote(head)}"
-        selected["rust_pr_fast"] = {
-            "lane_class": "fast_unit" if status == "selected" else "release_gate",
-            "status": status,
-            "reason": reason,
-            "command": command,
-            "run_command": command,
-            "matched_paths": rust_paths,
-            "mode": mode,
-            "filter_tokens": fast_plan.get("filter_tokens", ""),
-            "filter_expression": fast_plan.get("filter_expression", ""),
-        }
+        selected["rust_pr_fast"] = plan_entry(
+            manifest,
+            rust_entry,
+            status=status,
+            matched_paths=rust_paths,
+            command=command,
+            run_command=command,
+            lane_class=rust_entry.get("escalated_lane_class") if status == "escalated" else rust_entry["lane_class"],
+            extra={
+                "reason": reason,
+                "mode": mode,
+                "filter_tokens": fast_plan.get("filter_tokens", ""),
+                "filter_expression": fast_plan.get("filter_expression", ""),
+            },
+        )
+        selected["rust_pr_fast"]["reason"] = reason
 
     if release_gate_paths:
-        selected["release_gate_review"] = {
-            "lane_class": "release_gate",
-            "status": "release_gate_required",
-            "reason": "changed_surface_requires_release_or_ci_policy_review",
-            "command": "record release-gate disposition; do not treat focused PR validation as release proof",
-            "run_command": "",
-            "matched_paths": release_gate_paths,
-        }
+        selected["release_gate_review"] = plan_entry(
+            manifest,
+            release_gate_entry,
+            status="release_gate_required",
+            matched_paths=release_gate_paths,
+        )
 
     aggregate = "skipped"
     for lane in selected.values():

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -76,6 +76,19 @@ assert_has "$TMP/release.out" "aggregate_status=release_gate_required"
 assert_has "$TMP/release.out" "release_gate_review status=release_gate_required"
 assert_has "$TMP/release.out" "ci_path_policy_contracts status=selected"
 
+bash "$SCRIPT" --changed-files "$docs_only" --json >"$TMP/docs.json"
+python3 - <<'PY' "$TMP/docs.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+docs_lane = plan["lanes"]["docs_diff_check"]
+assert docs_lane["owner"] == "docs"
+assert docs_lane["default_surface"] == "docs"
+assert docs_lane["resource_class"] == "tiny"
+assert docs_lane["proof_role"] == "diff_hygiene"
+PY
+
 bash "$SCRIPT" --changed-files "$focused_rust" --json >"$TMP/focused.json"
 python3 - <<'PY' "$TMP/focused.json"
 import json
@@ -84,7 +97,25 @@ import sys
 plan = json.load(open(sys.argv[1]))
 assert plan["schema_version"] == "adl.validation_lane_plan.v1"
 assert plan["lanes"]["rust_pr_fast"]["mode"] == "focused"
+assert plan["lanes"]["rust_pr_fast"]["owner"] == "shared"
+assert plan["lanes"]["rust_pr_fast"]["resource_class"] == "medium"
+assert plan["lanes"]["rust_pr_fast"]["escalation_rule"] == "delegate_or_escalate"
 assert plan["pr_publication_sufficient"] is True
+PY
+
+bash "$SCRIPT" --changed-files "$release_gate" --json >"$TMP/release.json"
+python3 - <<'PY' "$TMP/release.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+release_gate_lane = plan["lanes"]["release_gate_review"]
+ci_policy_lane = plan["lanes"]["ci_path_policy_contracts"]
+assert release_gate_lane["proof_role"] == "release_gate"
+assert release_gate_lane["resource_class"] == "high"
+assert release_gate_lane["escalation_rule"] == "require_release_gate_disposition"
+assert ci_policy_lane["proof_role"] == "ci_contract"
+assert ci_policy_lane["default_surface"] == "ci_policy"
 PY
 
 report="$TMP/report.json"
@@ -118,5 +149,172 @@ plan = json.load(open(sys.argv[1]))
 assert plan["run_status"] == "passed"
 assert plan["lanes"]["docs_diff_check"]["run_status"] == "passed"
 PY
+
+invalid_manifest="$TMP/invalid-manifest.json"
+cat >"$invalid_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "broken_lane",
+      "lane_class": "docs",
+      "default_surface": "missing_surface",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "reason": "broken"
+    }
+  ],
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$invalid_manifest" --changed-files "$docs_only" >"$TMP/invalid.out" 2>"$TMP/invalid.err"; then
+  echo "expected invalid manifest to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/invalid.err" "references unknown default_surface: missing_surface"
+
+special_surface_manifest="$TMP/special-surface-manifest.json"
+cat >"$special_surface_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    },
+    "shared_rust": {
+      "owner": "shared",
+      "resource_class": "medium",
+      "determinism_posture": "deterministic",
+      "proof_role": "regression",
+      "risk_class": "medium",
+      "escalation_rule": "delegate_or_escalate"
+    },
+    "release_gate": {
+      "owner": "tools",
+      "resource_class": "high",
+      "determinism_posture": "evidence_bound",
+      "proof_role": "release_gate",
+      "risk_class": "high",
+      "escalation_rule": "require_release_gate_disposition"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "special_surfaces": {
+    "release_gate_review": {
+      "id": "release_gate_review",
+      "lane_class": "release_gate",
+      "default_surface": "release_gate",
+      "path_selectors": [
+        "special/release/**"
+      ],
+      "command": "record release-gate disposition; do not treat focused PR validation as release proof",
+      "run_command": "",
+      "reason": "special_release_gate_surface"
+    },
+    "rust_pr_fast": {
+      "id": "rust_pr_fast",
+      "lane_class": "fast_unit",
+      "escalated_lane_class": "release_gate",
+      "default_surface": "shared_rust",
+      "path_selectors": [
+        "special/rust/**"
+      ],
+      "command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
+      "reason": "special_rust_surface"
+    }
+  },
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+special_release="$TMP/special-release.txt"
+printf 'M\tspecial/release/packet.md\n' >"$special_release"
+bash "$SCRIPT" --manifest "$special_surface_manifest" --changed-files "$special_release" --json >"$TMP/special-release.json"
+python3 - <<'PY' "$TMP/special-release.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["aggregate_status"] == "release_gate_required"
+assert plan["lanes"]["release_gate_review"]["matched_paths"] == ["special/release/packet.md"]
+PY
+
+special_rust="$TMP/special-rust.txt"
+printf 'M\tspecial/rust/module.rs\n' >"$special_rust"
+bash "$SCRIPT" --manifest "$special_surface_manifest" --changed-files "$special_rust" --json >"$TMP/special-rust.json"
+python3 - <<'PY' "$TMP/special-rust.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["lanes"]["rust_pr_fast"]["matched_paths"] == ["special/rust/module.rs"]
+PY
+
+missing_metadata_manifest="$TMP/missing-metadata-manifest.json"
+cat >"$missing_metadata_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$missing_metadata_manifest" --changed-files "$docs_only" >"$TMP/missing-metadata.out" 2>"$TMP/missing-metadata.err"; then
+  echo "expected missing surface metadata to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/missing-metadata.err" "missing required surface metadata: proof_role"
 
 echo "PASS test_select_validation_lanes"

--- a/docs/architecture/VALIDATION_LANE_SELECTOR.md
+++ b/docs/architecture/VALIDATION_LANE_SELECTOR.md
@@ -28,6 +28,33 @@ of C-SDLC truth. It gives local and PR tooling a deterministic answer for which
 focused validation commands are sufficient, which release gates remain required,
 and which ambiguous Rust surfaces must escalate.
 
+The manifest is now the tracked authority for validation-surface metadata, not
+just path matching. Each lane entry carries:
+
+- owner
+- lane class
+- command and run command
+- path selectors
+- requirement IDs
+- resource class
+- determinism posture
+- proof role
+- risk class
+- escalation rule
+
+Top-level `surface_defaults` provide durable defaults for docs, tooling,
+runtime, provider, security, CI policy, slow-proof, release-gate, and shared
+Rust surfaces. Lane entries may override those defaults, but the selector
+validates the references so metadata drift fails closed instead of silently
+falling back.
+
+Compatibility note:
+
+- `path_hints` remains accepted as a compatibility alias.
+- `path_selectors` is the authoritative field for new manifest work.
+- `release_gate_hints` and `rust_path_hints` still exist for backward
+  compatibility, but their durable metadata now lives in `special_surfaces`.
+
 To write machine-readable proof:
 
 ```bash
@@ -61,7 +88,6 @@ The first slice is intentionally small:
 - release/CI-policy paths report `release_gate_required`
 - credential and live-provider lanes remain outside ordinary PR validation
 
-Future work should add a validation manager agent on top of this selector. That
-agent should create a tailored test profile whenever an issue is sent to PR,
-handling each issue case separately while consuming this selector as policy
-input. The selector itself should stay deterministic and boring.
+The selector remains the deterministic surface classifier. Validation-manager
+style profile builders should consume the selector's emitted metadata instead of
+re-inventing owner, risk, or escalation inference in a second code path.


### PR DESCRIPTION
Closes #4214

## Summary
Completed `#4214` by turning the selector manifest into the tracked authority
for validation-surface metadata instead of leaving owner, resource, proof-role,
and escalation semantics scattered across code branches and docs. The selector
now merges durable `surface_defaults` into each lane, emits that metadata in
its plan output, treats `special_surfaces` as the authoritative selector home
for release-gate and shared-Rust boundary surfaces, and fails closed when
manifest defaults are malformed. The focused contract test now proves both the
normal in-repo manifest behavior and custom-manifest fail-closed behavior so
future drift is caught immediately.

## Artifacts
- Updated tracked code and docs:
  - `adl/config/validation_lane_selector.v0.91.6.json`
  - `adl/tools/select_validation_lanes.py`
  - `adl/tools/test_select_validation_lanes.sh`
  - `docs/architecture/VALIDATION_LANE_SELECTOR.md`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4214__v0-91-6-tools-validation-create-validation-surface-manifest/spp.md`
  - `.adl/v0.91.6/tasks/issue-4214__v0-91-6-tools-validation-create-validation-surface-manifest/srp.md`
  - `.adl/v0.91.6/tasks/issue-4214__v0-91-6-tools-validation-create-validation-surface-manifest/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified the focused selector contract, including emitted metadata, custom
    `special_surfaces` matching, and fail-closed manifest validation.
  - `python3 -m py_compile adl/tools/select_validation_lanes.py`
    Verified the Python source parses successfully.
  - `git diff --check`
    Verified there are no whitespace or patch-format defects.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4214__v0-91-6-tools-validation-create-validation-surface-manifest/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4214__v0-91-6-tools-validation-create-validation-surface-manifest/sor.md
- Idempotency-Key: v0-91-6-tools-validation-create-validation-surface-manifest-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-select-validation-lanes-py-adl-tools-test-select-validation-lanes-sh-docs-architecture-validation-lane-selector-md-adl-v0-91-6-tasks-issue-4214-v0-91-6-tools-validation-create-validation-surface-manifest-sip-md-adl-v0-91-6-tasks-issue-4214-v0-91-6-tools-validation-create-validation-surface-manifest-sor-md