### PR TITLE
[v0.91.6][tools] Require goal creation for tracked issue sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,21 @@ These rules are mandatory for ADL issue work.
 3. Always work in a bound worktree on a specific branch.
    - Never do tracked issue work on `main`.
    - Use the repo-native issue-mode `pr run` flow to bind execution context.
-4. Always review work with a subagent before opening the PR.
+4. Always create an issue-bound session goal before implementation work starts.
+   - For tracked issue sessions, call `create_goal` after the issue is ready and
+     before bounded implementation begins in the issue worktree.
+   - The goal should minimally name the issue number and the concrete session
+     objective so token accounting, completion, and blocked-state reporting stay
+     tied to the tracked issue.
+   - Use `update_goal` only for truthful terminal state changes:
+     `complete` when the current session's bounded objective is actually
+     achieved, including a truthful handoff into review/wait state after
+     publication when that was the session goal, or `blocked` only when the
+     repeated blocking threshold is met and meaningful progress cannot continue.
+5. Always review work with a subagent before opening the PR.
    - Run a bounded review subagent over the changed work product.
    - Fix all actionable findings immediately before publication.
-5. Always perform closeout after the issue is closed.
+6. Always perform closeout after the issue is closed.
    - Use the normal closeout path so issue truth, cards, artifacts, and GitHub
      state all agree.
 
@@ -142,11 +153,14 @@ For a normal tracked issue:
 4. make sure `SIP`, `STP`, and `SPP` are issue-specific and design-time ready
 5. follow the conductor-selected lifecycle step
 6. if the issue is ready for execution binding, use `adl/tools/pr.sh run <issue>`
-7. make the bounded change in the issue worktree, never on `main`
-8. run the smallest meaningful validation for the touched surface
-9. run a pre-PR subagent review and fix findings
-10. verify PR base/stack topology, then publish through the normal PR workflow
-11. perform closeout after merge/closure
+7. call `create_goal` for the bound tracked issue session before implementation
+   starts
+8. make the bounded change in the issue worktree, never on `main`
+9. run the smallest meaningful validation for the touched surface
+10. run a pre-PR subagent review and fix findings
+11. verify PR base/stack topology, then publish through the normal PR workflow
+12. use `update_goal` for truthful terminal session state, then perform closeout
+   after merge/closure
 
 ## Validation Expectations
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1496,6 +1496,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_owner_validation_lane.sh"
             | "adl/tools/test_cli_wrapper_migration_contract.sh"
             | "adl/tools/test_pr_run_ambiguity_policy.sh"
+            | "adl/tools/test_pr_run_issue_mode.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
             | "adl/tools/test_control_plane_observability.sh"
             | "adl/tools/test_adl_runtime_compatibility.sh"

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1250,6 +1250,7 @@ fn finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binar
         &[
             "adl/tools/test_install_adl_operational_skills.sh".to_string(),
             "adl/tools/test_sprint_conductor_helpers.sh".to_string(),
+            "adl/tools/test_pr_run_issue_mode.sh".to_string(),
         ],
     )
     .expect("sprint shell helper plan");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1796,6 +1796,7 @@ cmd_run() {
     require_rust_pr_delegate start
     adl_obs_event "pr.sh" "issue_bind" "started" "issue" "$1"
     note "Issue-mode run: binding execution context for issue $1"
+    note "Goal guardrail: call create_goal for issue $1 after bind succeeds and before implementation starts; treat update_goal as a truthful session-terminal record only."
     ADL_PR_SUPPRESS_START_COMPAT_NOTE=1 delegate_pr_command_to_rust start "$@"
     return 0
   fi

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -76,10 +76,11 @@ The normal workflow is:
 2. qualitative card review
 3. `pr-ready`
 4. `pr-run`
-5. `pr-finish`
-6. `pr-janitor`
+5. create the issue-bound session goal for the tracked session before implementation begins
+6. `pr-finish`
+7. `pr-janitor`
    - the repo finish path should auto-attach the janitor hook after PR publication so in-flight monitoring starts without an extra manual step
-7. `pr-closeout` after the PR outcome or explicit non-PR closure disposition is settled
+8. truthful `update_goal` terminal state, then `pr-closeout` after the PR outcome or explicit non-PR closure disposition is settled
 
 `repo-code-review` is cross-cutting rather than phase-specific.
 `test-generator` is a bounded helper skill for focused tests for a concrete issue, diff, file, or worktree.
@@ -103,6 +104,17 @@ that the current helper scripts automate multi-active issue execution.
 `review-readiness-cleanup` is a bounded review-cycle preflight helper for classifying safe cleanup, blockers, skipped surfaces, and follow-on needs before formal review starts.
 `planning-doc-editor` is a bounded planning-document editor for milestone/project docs that need placeholder cleanup, required-section repair, status-truth normalization, template-contract alignment, or portable-path cleanup without editing lifecycle cards.
 `portable-contract-normalizer` is a bounded portability helper for detecting machine-local assumptions and applying only explicitly approved safe mechanical normalization.
+
+Tracked issue sessions should create an explicit issue-bound session goal after
+readiness/bind succeeds and before implementation starts. The minimum goal
+surface is the issue number plus the bounded session objective. Current repo
+workflow guidance treats this as a Codex/session discipline rather than a
+proven ADL runtime-enforced contract, so helper scripts may warn about the
+requirement but must not claim they can verify live goal state unless a later
+issue proves that integration. A truthful `complete` update may represent a
+session handoff into normal review/wait state after PR publication when that
+handoff was the declared bounded session objective; it does not imply the whole
+issue is merged or closed.
 
 The PR lifecycle skills share the CI runtime interpretation policy in
 `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`. Stable PR check names

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -106,11 +106,12 @@ If there is no concrete target, stop and report `blocked`.
 3. Use compatibility readiness/preflight aliases only if the canonical doctor surface is unavailable.
 4. Bind or confirm the issue branch and worktree using repo-native `run` behavior.
 5. Verify that the worktree-local STP, SIP, and SOR execution bundle now exists.
-6. Read the source prompt, STP, SIP, and current output card.
-7. Perform only the bounded work required for the issue.
-8. Run the smallest truthful validation set.
-9. Update the output card or execution record truthfully.
-10. Stop before janitor/closeout.
+6. Create the issue-bound session goal after bind/readiness succeeds and before implementation starts.
+7. Read the source prompt, STP, SIP, and current output card.
+8. Perform only the bounded work required for the issue.
+9. Run the smallest truthful validation set.
+10. Update the output card or execution record truthfully, including goal-creation truth when relevant.
+11. Stop before janitor/closeout.
 
 ## Workflow
 
@@ -186,6 +187,13 @@ If those execution surfaces are missing after the repo-native run/bind step:
 - otherwise stop as `blocked` or `failed`
 - do not continue into implementation while pretending the execution bundle is complete
 
+After bind/readiness succeeds and before implementation starts:
+- create the issue-bound session goal for the current Codex session
+- make the goal include at minimum the issue number and the bounded session objective this run is expected to advance
+- treat goal creation as mandatory workflow state for tracked issue execution, not a nice-to-have reminder
+- if the current environment cannot create the session goal, stop and report that blocked state truthfully instead of proceeding as though the requirement was satisfied
+- reserve `update_goal status=complete` and `update_goal status=blocked` for truthful session-terminal states only
+
 ### 4. Execute The Issue
 
 Read the relevant issue surfaces:
@@ -199,6 +207,10 @@ Then perform only the work required by the issue:
 - docs changes
 - tests
 - templates or validation artifacts
+
+Execution-order rule:
+- do not begin implementation edits before the issue-bound session goal has been created for the bound run
+- if execution resumes in an already-bound worktree, confirm or create the current session goal before continuing implementation
 
 Boundaries:
 - stay within the issue's required outcome and acceptance criteria
@@ -248,6 +260,7 @@ Update the output card or execution record truthfully:
 - actions taken
 - main repo integration status
 - validation
+- whether the issue-bound session goal was created for this execution session, or why execution was blocked before implementation
 - determinism/security notes where relevant
 - follow-ups or deferred work
 

--- a/adl/tools/skills/pr-run/references/run-playbook.md
+++ b/adl/tools/skills/pr-run/references/run-playbook.md
@@ -17,6 +17,7 @@ This step is automatable but writes real repo state.
 It may:
 - inspect and confirm readiness
 - bind or confirm branch/worktree execution context
+- create the issue-bound session goal for the bound execution session
 - edit issue-scoped code/docs/tests/artifacts
 - run bounded validation
 - update the output record
@@ -78,6 +79,13 @@ Post-bind materialization rule:
 - if any are missing, treat that as a run failure or blocked execution state rather than a soft warning
 - do not continue into implementation on root-only bundle state once the worktree has been bound
 
+Session-goal rule:
+- after bind/readiness succeeds and before implementation starts, create the issue-bound session goal
+- make the goal include at minimum the issue number and the bounded session objective for the current run
+- if the environment cannot create the goal, stop and report the blocked state truthfully instead of silently proceeding
+- treat `update_goal status=complete` and `update_goal status=blocked` as session-terminal truth only
+- do not claim shell tooling can introspect live Codex goal state unless the active tool surface actually proves that capability
+
 ## Execution Checklist
 
 Read and use:
@@ -87,6 +95,7 @@ Read and use:
 - current SOR/output card
 
 Then:
+- create or confirm the current session's issue-bound goal before editing if that has not already happened
 - perform only the work required by the issue
 - keep edits bounded to the issue's acceptance criteria
 - record follow-on discoveries instead of silently expanding scope
@@ -102,6 +111,7 @@ Always report:
 - what ran
 - what it verified
 - what was intentionally not run
+- whether the issue-bound session goal was created for the execution session, or why it was blocked
 
 ## Output Card Rules
 
@@ -118,6 +128,7 @@ For `pr_open` state:
 
 For execution binding:
 - record explicitly whether worktree-local `stp.md`, `sip.md`, and `sor.md` were present after binding
+- record whether the issue-bound session goal was created after bind and before implementation
 - if materialization was missing or had to be repaired, surface that in findings and handoff guidance
 
 ## Failure Handling
@@ -125,5 +136,6 @@ For execution binding:
 If execution fails:
 - report which target was attempted
 - report which checks were actually performed
+- report whether session-goal creation succeeded before the failure
 - record partial outputs truthfully
 - stop without widening scope

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -110,9 +110,14 @@ If there is no concrete target, stop and report `blocked`.
    - blocked/no-op reporting
 4. Apply the declared skill/subagent policy.
 5. Select the next skill.
-6. Record the workflow-compliance result and write the routing artifact.
-7. When explicit dispatch mode is enabled, dispatch one bounded downstream skill subtask.
-8. Stop without absorbing the selected skill's logic.
+6. If the selected route binds or resumes tracked issue execution, record the
+   issue-bound session-goal requirement in the routing result or handoff note:
+   create the goal after bind/readiness succeeds and before implementation
+   starts; treat `complete` or `blocked` as truthful session-terminal states
+   only.
+7. Record the workflow-compliance result and write the routing artifact.
+8. When explicit dispatch mode is enabled, dispatch one bounded downstream skill subtask.
+9. Stop without absorbing the selected skill's logic.
 
 ## Observability Expectations
 
@@ -178,6 +183,9 @@ Important rule:
 - when values-rendered prompt-card support exists for the target, do not route
   broad card generation to direct Markdown edits; use the renderer/schema path
   first, then card-editor skills only for issue-local lifecycle truth
+- when routing to `pr-run` or resuming bound execution, include the issue-bound
+  session-goal requirement in the handoff: create the goal after bind/readiness
+  succeeds and before implementation starts
 
 ## Policy Model
 

--- a/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
@@ -55,6 +55,22 @@ Examples:
 - if cards are clean and execution is already bound, do not route back to `pr-ready`
 - if the PR exists and is failing CI, do not route to `pr-finish`; route to `pr-janitor`
 
+## Goal Handoff Rule
+
+When the selected route binds or resumes tracked issue execution, the conductor
+should record one explicit handoff note: create the issue-bound session goal
+after readiness/bind succeeds and before implementation starts.
+
+The handoff should treat goal state as session-scoped:
+
+- `complete` is truthful when the bounded session objective is done, including
+  a handoff into normal review/wait state after publication when that was the
+  declared session objective
+- `blocked` is truthful only when the repeated blocking threshold is met
+
+Do not claim the conductor or helper scripts can verify live goal state unless
+the relevant integration has been separately proved.
+
 ## Editor Rule
 
 If the blocker is card-local and the matching editor skill exists, route to the matching editor skill instead of allowing ad hoc card edits.

--- a/adl/tools/test_pr_run_issue_mode.sh
+++ b/adl/tools/test_pr_run_issue_mode.sh
@@ -50,6 +50,7 @@ run_out="$(
 
 captured="$(cat "$capture_file")"
 assert_contains 'Issue-mode run: binding execution context for issue 1303' "$run_out" "issue-mode note"
+assert_contains 'Goal guardrail: call create_goal for issue 1303 after bind succeeds and before implementation starts; treat update_goal as a truthful session-terminal record only.' "$run_out" "goal guardrail note"
 assert_contains 'pr start 1303 --slug example-slug --version v0.86' "$captured" "delegates to start binder"
 
 echo "pr.sh run issue-mode delegation: ok"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -121,11 +121,39 @@ Structured Card Templates v2 (required sections):
 These sections are designed to support deterministic replay/security verification and
 machine-parsable prompt automation.
 
-## 4) Implement
+## 4) Create The Issue-Bound Session Goal
+
+After the issue is ready and the execution worktree is bound, create a session
+goal before implementation starts.
+
+Minimum goal content:
+
+- the tracked issue number
+- the concrete session objective
+
+Preferred pattern:
+
+```text
+create_goal objective="#<issue_num> <bounded objective>"
+```
+
+The repository workflow currently treats this as an agent-session requirement,
+not as an ADL runtime-enforced object. `pr.sh` can remind, but it does not
+claim to introspect Codex goal state.
+
+Use `update_goal` only for truthful terminal state:
+
+- `complete` when the current session objective is actually achieved, including
+  publication-to-review handoff when opening or updating the PR was the bounded
+  session objective
+- `blocked` only when the repeated blocking threshold is met and meaningful
+  progress cannot continue without user input or an external state change
+
+## 5) Implement
 
 Read the active issue cards, stay inside the issue edit fence, and make the tracked repo changes.
 
-## 5) Run (when the issue requires a bounded runtime proof surface)
+## 6) Run (when the issue requires a bounded runtime proof surface)
 
 ```bash
 bash ./adl/tools/pr.sh run <adl-file> [run arguments...]
@@ -134,7 +162,7 @@ bash ./adl/tools/pr.sh run <adl-file> [run arguments...]
 Use `pr run` when the issue's proof surface requires emitted run artifacts, replay, or bounded runtime execution.
 For docs-only or non-runtime issues, skip `pr run` truthfully and record that in the SOR or report rather than inventing a hidden step.
 
-## 6) Validate
+## 7) Validate
 
 Typical local preflight:
 
@@ -242,7 +270,7 @@ Always record:
 Do not use full local validation as a reflex. Use it because the changed
 surface needs it.
 
-## 7) Finish PR
+## 8) Finish PR
 
 ```bash
 bash ./adl/tools/pr.sh finish <issue_num> \
@@ -259,7 +287,11 @@ should be synced to the canonical task bundle under:
 Do not treat legacy `.adl/cards/<issue_num>/...` paths as the canonical finish
 surface for new issue work.
 
-## 8) Report
+After publication and terminal issue-session disposition, update the active
+goal truthfully before closeout rather than leaving the session without a final
+completion or blocked record.
+
+## 9) Report
 
 Write a per-issue report under:
 


### PR DESCRIPTION
Closes #4231

## Summary
Added repository-side session-goal workflow requirements for tracked issue
sessions in `v0.91.6`, updated the required conductor/front-door guidance to
carry the same rule, and added a narrow `pr.sh run` guardrail plus focused
shell coverage.

## Artifacts
- Updated `AGENTS.md` with a tracked issue session-goal requirement and
  truthful `update_goal` terminal-state guidance.
- Updated `docs/default_workflow.md` with the canonical issue-bound
  session-goal step and session-terminal semantics.
- Updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md` with the normal
  workflow insertion point and non-overclaim guidance.
- Updated `adl/tools/skills/workflow-conductor/SKILL.md` and
  `adl/tools/skills/workflow-conductor/references/conductor-playbook.md` so the
  required front door carries the same handoff rule.
- Updated `adl/tools/pr.sh` and `adl/tools/test_pr_run_issue_mode.sh` with a
  bounded issue-mode goal guardrail reminder and regression coverage.
- Updated `adl/src/cli/pr_cmd/finish_support.rs` and
  `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` so `pr finish`
  classifies the issue-mode shell proof helper into the existing small-binary
  focused lane instead of failing closed during publication.

## Validation
- Validation commands and their purpose:
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 4231 --slug require-goal-creation-for-tracked-issue-sessions --version v0.91.6 --json`
    Verified the issue is still correctly bound and identified the stale SOR
    scaffold as the finish-readiness blocker before this normalization pass.
  - `bash adl/tools/test_pr_run_issue_mode.sh`
    Verified the issue-mode guardrail reminder and delegate contract.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused -- --nocapture`
    Verified the finish-path classifier recognizes the issue-mode shell proof
    helper as small-binary focused.
  - `git diff --check -- AGENTS.md docs/default_workflow.md adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/workflow-conductor/SKILL.md adl/tools/skills/workflow-conductor/references/conductor-playbook.md adl/tools/pr.sh adl/tools/test_pr_run_issue_mode.sh`
    Verified the touched workflow and shell surfaces are whitespace-clean.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.6/tasks/issue-4231__require-goal-creation-for-tracked-issue-sessions/srp.md`
    Verified the finalized SRP review record is structurally valid.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.6/tasks/issue-4231__require-goal-creation-for-tracked-issue-sessions/sor.md`
    Verified this SOR is structurally valid as a finish-ready execution record.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4231__require-goal-creation-for-tracked-issue-sessions/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4231__require-goal-creation-for-tracked-issue-sessions/sor.md
- Idempotency-Key: v0-91-6-tools-require-goal-creation-for-tracked-issue-sessions-adl-v0-91-6-tasks-issue-4231-require-goal-creation-for-tracked-issue-sessions-sip-md-adl-v0-91-6-tasks-issue-4231-require-goal-creation-for-tracked-issue-sessions-sor-md