### PR TITLE
[v0.91.6][tools][validation] Split slow-proof validation families

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -90,7 +90,16 @@ path = "tools/adl_provider_adapter.rs"
 # Heavy runtime_v2 proof-materialization and CLI proof-smoke tests stay out of
 # ordinary `cargo test` but remain covered by authoritative `--all-features`
 # lanes such as cargo-llvm-cov.
-slow-proof-tests = []
+slow-proof-runtime = []
+slow-proof-private-state = []
+slow-proof-observatory = []
+slow-proof-security = []
+slow-proof-tests = [
+  "slow-proof-runtime",
+  "slow-proof-private-state",
+  "slow-proof-observatory",
+  "slow-proof-security",
+]
 # Heavy `pr finish` temp-repo publication and sync integration tests stay out
 # of ordinary `cargo test` but remain covered by authoritative `--all-features`
 # lanes such as cargo-llvm-cov.

--- a/adl/config/slow_proof_families.v0.91.6.json
+++ b/adl/config/slow_proof_families.v0.91.6.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "adl.slow_proof_families.v1",
+  "umbrella_feature": "slow-proof-tests",
+  "families": [
+    {
+      "id": "runtime",
+      "feature": "slow-proof-runtime",
+      "proof_role": "slow_proof",
+      "description": "Heavy runtime and governance proof materialization surfaces.",
+      "sample_tests": [
+        "runtime_v2_csm_governed_episode_writes_without_path_leakage",
+        "runtime_v2_theory_of_mind_foundation_write_to_root_materializes_fixture"
+      ]
+    },
+    {
+      "id": "private_state",
+      "feature": "slow-proof-private-state",
+      "proof_role": "slow_proof",
+      "description": "Private-state materialization, lineage, and sealed-state proof surfaces.",
+      "sample_tests": [
+        "runtime_v2_private_state_lineage_write_to_root_materializes_fixtures",
+        "runtime_v2_private_state_observatory_materialization_proof_is_stable"
+      ]
+    },
+    {
+      "id": "observatory",
+      "feature": "slow-proof-observatory",
+      "proof_role": "slow_proof",
+      "description": "Observatory-facing visibility and reporting proof surfaces.",
+      "sample_tests": [
+        "runtime_v2_csm_observatory_writes_without_path_leakage"
+      ]
+    },
+    {
+      "id": "security",
+      "feature": "slow-proof-security",
+      "proof_role": "slow_proof",
+      "description": "Security, access control, boundary refusal, and hardening proof surfaces.",
+      "sample_tests": [
+        "runtime_v2_security_boundary_proof_writes_without_path_leakage",
+        "runtime_v2_access_control_write_to_root_materializes_fixtures"
+      ]
+    }
+  ]
+}

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1291,6 +1291,12 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_validation_inventory_focused_validation(path))
+        {
+            commands.push("bash adl/tools/test_validation_inventory.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_small_binary_delegation_validation(path))
         {
             commands.push("bash adl/tools/test_pr_small_binary_delegation.sh".to_string());
@@ -1508,6 +1514,9 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
             | "adl/tools/validation_manager.py"
             | "adl/tools/validation_manager.sh"
             | "adl/tools/test_validation_manager.sh"
+            | "adl/tools/validation_inventory.py"
+            | "adl/tools/validation_inventory.sh"
+            | "adl/tools/test_validation_inventory.sh"
             | "adl/tools/test_install_adl_operational_skills.sh"
             | "adl/tools/test_sprint_conductor_helpers.sh"
     ) || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
@@ -1808,6 +1817,16 @@ fn finish_path_needs_validation_manager_focused_validation(path: &str) -> bool {
         "adl/tools/validation_manager.py"
             | "adl/tools/validation_manager.sh"
             | "adl/tools/test_validation_manager.sh"
+    )
+}
+
+fn finish_path_needs_validation_inventory_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/validation_inventory.py"
+            | "adl/tools/validation_inventory.sh"
+            | "adl/tools/test_validation_inventory.sh"
     )
 }
 
@@ -2225,6 +2244,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_validation_manager.sh" => {
                     let script = repo_root.join("adl/tools/test_validation_manager.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_validation_inventory.sh" => {
+                    let script = repo_root.join("adl/tools/test_validation_inventory.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1285,6 +1285,17 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_slow_proof_family_focused_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            commands.push("bash adl/tools/test_slow_proof_lane_contract.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_validation_manager_focused_validation(path))
         {
             commands.push("bash adl/tools/test_validation_manager.sh".to_string());
@@ -1590,6 +1601,9 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_control_plane_observability.sh"
             | "adl/tools/test_adl_runtime_compatibility.sh"
             | "adl/tools/test_adl_review_compatibility.sh"
+            | "adl/tools/run_slow_proof_family.sh"
+            | "adl/tools/test_slow_proof_lane_contract.sh"
+            | "adl/config/slow_proof_families.v0.91.6.json"
             | "adl/tools/check_repo_quality_staleness.py"
             | "adl/tools/test_check_repo_quality_staleness.sh"
             | "adl/tools/run_v0916_agent_suitability_panel.py"
@@ -1615,11 +1629,14 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/validate_v0915_remote_gemma_watcher_probe.py"
             | "demos/v0.87.1/codex_ollama_operational_skills_demo.md"
             | "demos/v0.89/gemma4_issue_clerk_demo.md"
+            | "adl/Cargo.toml"
     ) || trimmed.starts_with("adl/src/cli/pr_cmd/")
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
         || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/lifecycle/")
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
         || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
+        || trimmed == "adl/src/runtime_v2/tests.rs"
+        || trimmed.starts_with("adl/src/runtime_v2/tests/")
         || trimmed.starts_with("adl/tests/fixtures/scheduler/")
         || trimmed.starts_with("docs/milestones/v0.91.4/review/merge_readiness/")
         || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
@@ -1808,6 +1825,18 @@ fn finish_path_needs_validation_selector_focused_validation(path: &str) -> bool 
             | "adl/tools/select_validation_lanes.sh"
             | "adl/tools/test_select_validation_lanes.sh"
     )
+}
+
+fn finish_path_needs_slow_proof_family_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/Cargo.toml"
+            | "adl/config/slow_proof_families.v0.91.6.json"
+            | "adl/tools/run_slow_proof_family.sh"
+            | "adl/tools/test_slow_proof_lane_contract.sh"
+    ) || trimmed == "adl/src/runtime_v2/tests.rs"
+        || trimmed.starts_with("adl/src/runtime_v2/tests/")
 }
 
 fn finish_path_needs_validation_manager_focused_validation(path: &str) -> bool {
@@ -2248,6 +2277,10 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_validation_inventory.sh" => {
                     let script = repo_root.join("adl/tools/test_validation_inventory.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_slow_proof_lane_contract.sh" => {
+                    let script = repo_root.join("adl/tools/test_slow_proof_lane_contract.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1667,11 +1667,34 @@ fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary
         ],
     )
     .expect("validation manager plan");
-
+ 
     assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
     assert!(plan
         .commands
         .contains(&"bash adl/tools/test_validation_manager.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo test --manifest-path adl/Cargo.toml --bin adl")));
+}
+
+#[test]
+fn finish_validation_profile_classifies_validation_inventory_slice_as_small_binary_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        4213,
+        ".",
+        &[
+            "adl/tools/validation_inventory.py".to_string(),
+            "adl/tools/validation_inventory.sh".to_string(),
+            "adl/tools/test_validation_inventory.sh".to_string(),
+        ],
+    )
+    .expect("validation inventory plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_inventory.sh".to_string()));
     assert!(!plan
         .commands
         .iter()
@@ -1941,6 +1964,7 @@ fn finish_helper_paths_run_validation_selector_validation() {
 fn finish_helper_paths_run_validation_manager_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-validation-manager-validation");
+
     let repo = temp.join("repo");
     fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
     fs::write(
@@ -1998,6 +2022,69 @@ fn finish_helper_paths_run_validation_manager_validation() {
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("validation-manager"));
+}
+
+#[test]
+fn finish_helper_paths_run_validation_inventory_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-validation-inventory-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_validation_inventory.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' validation-inventory >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/tools/validation_inventory.py,adl/tools/validation_inventory.sh,adl/tools/test_validation_inventory.sh",
+    )
+    .expect("validation inventory plan");
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    run_finish_validation_rust(&repo, &plan).expect("validation inventory validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "validation inventory focused validation should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("validation-inventory"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1667,7 +1667,7 @@ fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary
         ],
     )
     .expect("validation manager plan");
- 
+
     assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
     assert!(plan
         .commands

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1702,6 +1702,45 @@ fn finish_validation_profile_classifies_validation_inventory_slice_as_small_bina
 }
 
 #[test]
+fn finish_validation_profile_classifies_slow_proof_family_split_slice() {
+    let plan = select_finish_validation_plan_for_finish(
+        4219,
+        ".",
+        &[
+            "adl/Cargo.toml".to_string(),
+            "adl/config/slow_proof_families.v0.91.6.json".to_string(),
+            "adl/src/runtime_v2/tests.rs".to_string(),
+            "adl/src/runtime_v2/tests/private_state_observatory.rs".to_string(),
+            "adl/tools/run_slow_proof_family.sh".to_string(),
+            "adl/tools/test_slow_proof_lane_contract.sh".to_string(),
+            "adl/tools/validation_inventory.py".to_string(),
+            "adl/tools/test_validation_inventory.sh".to_string(),
+            "adl/tools/validation_manager.py".to_string(),
+            "adl/tools/test_validation_manager.sh".to_string(),
+            "adl/tools/ci_path_policy.sh".to_string(),
+        ],
+    )
+    .expect("slow-proof family split plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_slow_proof_lane_contract.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_inventory.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_manager.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh".to_string()));
+}
+
+#[test]
 fn finish_restores_missing_canonical_cards_from_slug_drifted_issue_bundle() {
     let repo = unique_temp_dir("adl-pr-finish-slug-drift");
     let issue_ref = IssueRef::new(

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -1,31 +1,31 @@
 use super::*;
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod a2a_adapter_boundary;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 mod access_control;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 mod acip_hardening;
 mod affect_reasoning_control;
 mod agent_lifecycle_state;
 mod anti_harm_trajectory_constraints;
 mod bid_schema;
 mod boot_admission;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod challenge;
 mod citizen_lifecycle;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
 mod common;
 mod contract_lifecycle_state;
 mod contract_market_demo;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod contract_registry_accessors;
 mod contract_schema;
 mod csm_run_packet;
 mod cultivating_intelligence;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod delegation_subcontract;
 mod evaluation_selection;
 mod external_counterparty;

--- a/adl/src/runtime_v2/tests/access_control.rs
+++ b/adl/src/runtime_v2/tests/access_control.rs
@@ -20,7 +20,7 @@ fn runtime_v2_access_control_contract_is_stable() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 fn runtime_v2_access_control_serializes_and_matches_golden_fixtures() {
     let artifacts = runtime_v2_access_control_contract().expect("access artifacts");
     let matrix_json = String::from_utf8(
@@ -174,7 +174,7 @@ fn runtime_v2_access_control_rejects_unsafe_event_mutations() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 fn runtime_v2_access_control_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_access_control_contract().expect("access artifacts");
     let root = common::unique_temp_path("access-control-write");

--- a/adl/src/runtime_v2/tests/bid_schema.rs
+++ b/adl/src/runtime_v2/tests/bid_schema.rs
@@ -138,7 +138,7 @@ fn runtime_v2_bid_schema_requires_named_negative_case_membership() {
         .contains("must contain the required case-id set"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_bid_schema_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_bid_schema_contract().expect("bid schema artifacts");

--- a/adl/src/runtime_v2/tests/boot_admission.rs
+++ b/adl/src/runtime_v2/tests/boot_admission.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use std::fs;
 
 #[test]
@@ -84,7 +84,7 @@ fn runtime_v2_csm_boot_admission_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 #[test]
 fn runtime_v2_csm_boot_admission_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-boot-admission");

--- a/adl/src/runtime_v2/tests/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/tests/citizen_state_substrate.rs
@@ -310,7 +310,7 @@ fn runtime_v2_citizen_state_substrate_write_to_path_materializes_fixture() {
     std::fs::remove_dir_all(root).expect("cleanup citizen-state substrate temp root");
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_citizen_state_substrate_write_to_root_materializes_fixture() {
     let packet =

--- a/adl/src/runtime_v2/tests/contract_lifecycle_state.rs
+++ b/adl/src/runtime_v2/tests/contract_lifecycle_state.rs
@@ -20,7 +20,7 @@ fn runtime_v2_contract_lifecycle_state_machine_is_stable() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_contract_lifecycle_state_machine_matches_golden_fixture() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");
@@ -42,7 +42,7 @@ fn runtime_v2_contract_lifecycle_state_machine_matches_golden_fixture() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_contract_lifecycle_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");
@@ -136,7 +136,7 @@ fn runtime_v2_contract_lifecycle_negative_cases_require_full_terminal_reopen_mat
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_contract_lifecycle_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");

--- a/adl/src/runtime_v2/tests/contract_schema.rs
+++ b/adl/src/runtime_v2/tests/contract_schema.rs
@@ -118,7 +118,7 @@ fn runtime_v2_contract_schema_requires_named_negative_case_membership() {
         .contains("must contain the required case-id set"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_contract_schema_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_contract_schema_contract().expect("contract schema artifacts");

--- a/adl/src/runtime_v2/tests/csm_run_packet.rs
+++ b/adl/src/runtime_v2/tests/csm_run_packet.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -88,7 +88,7 @@ fn runtime_v2_csm_run_packet_contract_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_run_packet_contract_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-run-contract");

--- a/adl/src/runtime_v2/tests/delegation_subcontract.rs
+++ b/adl/src/runtime_v2/tests/delegation_subcontract.rs
@@ -16,7 +16,7 @@ fn runtime_v2_delegation_subcontract_negative_matrix_rejects_drift() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_delegation_subcontract_golden_surfaces_are_stable() {
     delegation_subcontract_matches_golden_fixture();
     delegated_output_matches_golden_fixture();
@@ -25,7 +25,7 @@ fn runtime_v2_delegation_subcontract_golden_surfaces_are_stable() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_delegation_subcontract_materialization_proof_is_stable() {
     delegation_subcontract_write_to_root_materializes_fixtures();
 }
@@ -48,7 +48,7 @@ fn delegation_subcontract_artifacts_are_stable() {
     assert_eq!(artifacts.negative_cases.required_negative_cases.len(), 5);
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn delegation_subcontract_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -69,7 +69,7 @@ fn delegation_subcontract_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn delegated_output_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -88,7 +88,7 @@ fn delegated_output_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn parent_integration_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -107,7 +107,7 @@ fn parent_integration_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn delegation_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -348,7 +348,7 @@ fn delegation_subcontract_rejects_subcontractor_outside_runner_up_basis() {
         .contains("subcontractor must match the runner-up bid counterparty selected by subcontractor_selection_basis_ref"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn delegation_subcontract_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");

--- a/adl/src/runtime_v2/tests/evaluation_selection.rs
+++ b/adl/src/runtime_v2/tests/evaluation_selection.rs
@@ -29,7 +29,7 @@ fn runtime_v2_evaluation_selection_contract_is_stable() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_evaluation_selection_matches_golden_fixture() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");
@@ -51,7 +51,7 @@ fn runtime_v2_evaluation_selection_matches_golden_fixture() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_selection_negative_cases_match_golden_fixture() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");
@@ -133,7 +133,7 @@ fn runtime_v2_evaluation_selection_does_not_treat_tool_availability_as_authority
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_evaluation_selection_write_to_root_materializes_fixtures() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");

--- a/adl/src/runtime_v2/tests/external_counterparty.rs
+++ b/adl/src/runtime_v2/tests/external_counterparty.rs
@@ -21,7 +21,7 @@ fn runtime_v2_external_counterparty_validation_matrix_rejects_drift() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 fn runtime_v2_external_counterparty_golden_and_materialization_proofs_are_stable() {
     runtime_v2_external_counterparty_model_matches_golden_fixture();
     runtime_v2_external_counterparty_write_to_root_materializes_fixtures();
@@ -638,7 +638,7 @@ fn runtime_v2_external_counterparty_helper_validators_cover_remaining_variants()
         .contains("requested_tool_capability must not be empty"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 fn runtime_v2_external_counterparty_model_matches_golden_fixture() {
     let artifacts =
         runtime_v2_external_counterparty_model().expect("external counterparty artifacts");
@@ -674,7 +674,7 @@ fn runtime_v2_external_counterparty_negative_cases_match_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 fn runtime_v2_external_counterparty_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_external_counterparty_model().expect("external counterparty artifacts");

--- a/adl/src/runtime_v2/tests/freedom_gate_mediation.rs
+++ b/adl/src/runtime_v2/tests/freedom_gate_mediation.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -69,7 +69,7 @@ fn runtime_v2_csm_freedom_gate_mediation_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_freedom_gate_mediation_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-freedom-gate-mediation");

--- a/adl/src/runtime_v2/tests/governed_episode.rs
+++ b/adl/src/runtime_v2/tests/governed_episode.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -75,7 +75,7 @@ fn runtime_v2_csm_governed_episode_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_governed_episode_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-governed-episode");

--- a/adl/src/runtime_v2/tests/governed_learning_substrate.rs
+++ b/adl/src/runtime_v2/tests/governed_learning_substrate.rs
@@ -466,7 +466,7 @@ fn runtime_v2_governed_learning_substrate_write_to_path_materializes_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_governed_learning_substrate_write_to_root_materializes_fixture() {
     let packet =

--- a/adl/src/runtime_v2/tests/hardening.rs
+++ b/adl/src/runtime_v2/tests/hardening.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use std::fs;
 
 #[test]
@@ -109,7 +109,7 @@ fn runtime_v2_csm_hardening_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 #[test]
 fn runtime_v2_csm_hardening_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-hardening");

--- a/adl/src/runtime_v2/tests/integrated_csm_run.rs
+++ b/adl/src/runtime_v2/tests/integrated_csm_run.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -62,7 +62,7 @@ fn runtime_v2_csm_integrated_run_contract_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_integrated_run_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-integrated-run");

--- a/adl/src/runtime_v2/tests/intelligence_metric_architecture.rs
+++ b/adl/src/runtime_v2/tests/intelligence_metric_architecture.rs
@@ -147,7 +147,7 @@ fn runtime_v2_intelligence_metric_architecture_write_to_path_materializes_fixtur
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_intelligence_metric_architecture_write_to_root_materializes_fixture() {
     let packet = runtime_v2_intelligence_metric_architecture_contract()

--- a/adl/src/runtime_v2/tests/invalid_action_rejection.rs
+++ b/adl/src/runtime_v2/tests/invalid_action_rejection.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use std::fs;
 
 #[test]
@@ -75,7 +75,7 @@ fn runtime_v2_csm_invalid_action_rejection_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 #[test]
 fn runtime_v2_csm_invalid_action_rejection_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-invalid-action-rejection");

--- a/adl/src/runtime_v2/tests/invariant_contract.rs
+++ b/adl/src/runtime_v2/tests/invariant_contract.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -76,7 +76,7 @@ fn runtime_v2_invariant_and_violation_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_invariant_and_violation_contract_writes_without_path_leakage() {
     let temp_root = unique_temp_path("wp04-contract");

--- a/adl/src/runtime_v2/tests/memory_identity_architecture.rs
+++ b/adl/src/runtime_v2/tests/memory_identity_architecture.rs
@@ -225,7 +225,7 @@ fn runtime_v2_memory_identity_architecture_proof_route_paths_exist() {
     std::fs::remove_dir_all(temp_root).expect("cleanup memory-identity proof-route temp root");
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_memory_identity_architecture_write_to_root_materializes_fixture() {
     let packet = runtime_v2_memory_identity_architecture_contract()

--- a/adl/src/runtime_v2/tests/observatory.rs
+++ b/adl/src/runtime_v2/tests/observatory.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-observatory"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-observatory"))]
 use std::fs;
 
 #[test]
@@ -56,7 +56,7 @@ fn runtime_v2_csm_observatory_contract_is_stable() {
         .contains("runtime_v2/agent_lifecycle/state_contract.json"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-observatory"))]
 #[test]
 fn runtime_v2_csm_observatory_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-observatory");

--- a/adl/src/runtime_v2/tests/operator_control.rs
+++ b/adl/src/runtime_v2/tests/operator_control.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -55,7 +55,7 @@ fn runtime_v2_operator_control_report_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_operator_control_report_writes_without_path_leakage() {
     let temp_root = unique_temp_path("operator-controls");

--- a/adl/src/runtime_v2/tests/private_state.rs
+++ b/adl/src/runtime_v2/tests/private_state.rs
@@ -137,7 +137,7 @@ fn runtime_v2_private_state_validation_rejects_missing_required_boundaries() {
         .contains("non-authority"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_write_to_root_materializes_authority_and_projection() {
     let artifacts = runtime_v2_private_state_contract().expect("private-state artifacts");

--- a/adl/src/runtime_v2/tests/private_state_envelope.rs
+++ b/adl/src/runtime_v2/tests/private_state_envelope.rs
@@ -176,7 +176,7 @@ fn runtime_v2_private_state_envelope_rejects_signature_and_trust_policy_drift() 
         .contains("missing negative case"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_envelope_write_to_root_materializes_fixtures() {
     let artifacts =

--- a/adl/src/runtime_v2/tests/private_state_equivocation.rs
+++ b/adl/src/runtime_v2/tests/private_state_equivocation.rs
@@ -186,7 +186,7 @@ fn runtime_v2_private_state_anti_equivocation_rejects_non_conflicting_claims() {
         .contains("must contain conflicting signed successors"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_anti_equivocation_write_to_root_materializes_fixtures() {
     let artifacts =

--- a/adl/src/runtime_v2/tests/private_state_lineage.rs
+++ b/adl/src/runtime_v2/tests/private_state_lineage.rs
@@ -205,7 +205,7 @@ fn runtime_v2_private_state_lineage_head_disagreement_enters_recovery_or_quarant
         .contains("reconstruct_from_ledger_or_quarantine"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_lineage_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_lineage_contract().expect("lineage artifacts");

--- a/adl/src/runtime_v2/tests/private_state_observatory.rs
+++ b/adl/src/runtime_v2/tests/private_state_observatory.rs
@@ -20,7 +20,7 @@ fn runtime_v2_private_state_observatory_validation_matrix_rejects_leakage() {
     runtime_v2_private_state_observatory_rejects_public_overexposure_and_report_drift();
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_observatory_materialization_proof_is_stable() {
     runtime_v2_private_state_observatory_write_to_root_materializes_fixtures();
@@ -227,7 +227,7 @@ fn runtime_v2_private_state_observatory_rejects_public_overexposure_and_report_d
     .contains("must not claim raw private-state inspection"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 fn runtime_v2_private_state_observatory_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_observatory_contract().expect("observatory artifacts");
     let root = common::unique_temp_path("private-state-observatory-write");

--- a/adl/src/runtime_v2/tests/private_state_witness.rs
+++ b/adl/src/runtime_v2/tests/private_state_witness.rs
@@ -201,7 +201,7 @@ fn runtime_v2_private_state_receipts_reject_leakage_and_missing_explanation() {
         .contains("must explain valid continuation"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-private-state"))]
 #[test]
 fn runtime_v2_private_state_witness_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_witness_contract().expect("witness artifacts");

--- a/adl/src/runtime_v2/tests/quarantine.rs
+++ b/adl/src/runtime_v2/tests/quarantine.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use std::fs;
 
 #[test]
@@ -86,7 +86,7 @@ fn runtime_v2_csm_quarantine_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 #[test]
 fn runtime_v2_csm_quarantine_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-quarantine");

--- a/adl/src/runtime_v2/tests/recovery_eligibility.rs
+++ b/adl/src/runtime_v2/tests/recovery_eligibility.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -95,7 +95,7 @@ fn runtime_v2_csm_recovery_eligibility_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_recovery_eligibility_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-recovery-eligibility");

--- a/adl/src/runtime_v2/tests/resource_stewardship_bridge.rs
+++ b/adl/src/runtime_v2/tests/resource_stewardship_bridge.rs
@@ -21,7 +21,7 @@ fn runtime_v2_resource_stewardship_bridge_negative_matrix_rejects_drift() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_resource_stewardship_bridge_golden_and_materialization_proofs_are_stable() {
     resource_stewardship_bridge_matches_golden_fixture();
     resource_stewardship_bridge_write_to_root_materializes_fixture();
@@ -43,7 +43,7 @@ fn resource_stewardship_bridge_is_stable() {
     assert_eq!(artifact.bid_resource_estimates.len(), 2);
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn resource_stewardship_bridge_matches_golden_fixture() {
     let artifact = resource_stewardship_bridge_artifact();
     let json = String::from_utf8(
@@ -174,7 +174,7 @@ fn resource_stewardship_bridge_rejects_policy_and_authority_drift() {
         .contains("must preserve overlapping bid resource claim"));
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn resource_stewardship_bridge_write_to_root_materializes_fixture() {
     let artifact = resource_stewardship_bridge_artifact();
     let fixture_refresh_root = std::env::var("ADL_RUNTIME_V2_WRITE_ROOT").ok();

--- a/adl/src/runtime_v2/tests/security_boundary.rs
+++ b/adl/src/runtime_v2/tests/security_boundary.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 use std::fs;
 
 #[test]
@@ -47,7 +47,7 @@ fn runtime_v2_security_boundary_proof_matches_golden_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-security"))]
 #[test]
 fn runtime_v2_security_boundary_proof_writes_without_path_leakage() {
     let temp_root = unique_temp_path("security-boundary");

--- a/adl/src/runtime_v2/tests/theory_of_mind_foundation.rs
+++ b/adl/src/runtime_v2/tests/theory_of_mind_foundation.rs
@@ -217,7 +217,7 @@ fn runtime_v2_theory_of_mind_foundation_write_to_path_materializes_fixture() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_theory_of_mind_foundation_write_to_root_materializes_fixture() {
     let packet =

--- a/adl/src/runtime_v2/tests/transition_authority.rs
+++ b/adl/src/runtime_v2/tests/transition_authority.rs
@@ -16,7 +16,7 @@ fn runtime_v2_transition_authority_contract_is_stable() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_transition_authority_matrix_matches_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -33,7 +33,7 @@ fn runtime_v2_transition_authority_matrix_matches_golden_fixture() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_transition_authority_basis_matches_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -55,7 +55,7 @@ fn runtime_v2_transition_authority_basis_matches_golden_fixture() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_transition_authority_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -144,7 +144,7 @@ fn runtime_v2_transition_authority_records_governed_tool_boundary() {
 }
 
 #[test]
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 fn runtime_v2_transition_authority_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");

--- a/adl/src/runtime_v2/tests/wake_continuity.rs
+++ b/adl/src/runtime_v2/tests/wake_continuity.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use super::common::unique_temp_path;
 use super::*;
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 use std::fs;
 
 #[test]
@@ -80,7 +80,7 @@ fn runtime_v2_csm_wake_continuity_contract_matches_golden_fixtures() {
     );
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_wake_continuity_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-wake-continuity");
@@ -114,7 +114,7 @@ fn runtime_v2_csm_wake_continuity_writes_without_path_leakage() {
     fs::remove_dir_all(temp_root).ok();
 }
 
-#[cfg(feature = "slow-proof-tests")]
+#[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 #[test]
 fn runtime_v2_csm_wake_continuity_proof_standalone_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-wake-proof-standalone");

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -352,7 +352,7 @@ is_pvf_slow_proof_workflow_change() {
   local diff_text
   diff_text="$(git_pr_patch "$path")"
   [ -n "$diff_text" ] || return 1
-  grep -E 'adl-slow-proof|test_slow_proof_lane_contract|slow-proof-tests|EXCLUDE_FROM_FILE_FLOOR_REGEX' <<<"$diff_text" >/dev/null 2>&1
+  grep -E 'adl-slow-proof|test_slow_proof_lane_contract|run_slow_proof_family|slow-proof-tests|slow-proof-runtime|slow-proof-private-state|slow-proof-observatory|slow-proof-security|EXCLUDE_FROM_FILE_FLOOR_REGEX' <<<"$diff_text" >/dev/null 2>&1
 }
 
 is_pvf_slow_proof_runtime_manifest_change() {
@@ -361,7 +361,7 @@ is_pvf_slow_proof_runtime_manifest_change() {
   local diff_text
   diff_text="$(git_pr_patch "$path")"
   [ -n "$diff_text" ] || return 1
-  grep -E 'slow-proof-tests|a2a_adapter_boundary|access_control|acip_hardening|challenge|citizen_state_substrate|contract_registry_accessors|delegation_subcontract' <<<"$diff_text" >/dev/null 2>&1
+  grep -E 'slow-proof-tests|slow-proof-runtime|slow-proof-private-state|slow-proof-observatory|slow-proof-security|a2a_adapter_boundary|access_control|acip_hardening|challenge|citizen_state_substrate|contract_registry_accessors|delegation_subcontract' <<<"$diff_text" >/dev/null 2>&1
 }
 
 is_pvf_slow_proof_policy_surface() {
@@ -371,6 +371,7 @@ is_pvf_slow_proof_policy_surface() {
     adl/src/runtime_v2/tests.rs|\
     adl/tools/ci_path_policy.sh|\
     adl/tools/run_authoritative_coverage_lane.sh|\
+    adl/tools/run_slow_proof_family.sh|\
     adl/tools/run_pr_fast_test_lane.sh|\
     adl/tools/test_ci_path_policy.sh|\
     adl/tools/test_ci_runtime_contracts.sh|\
@@ -413,6 +414,7 @@ is_pvf_slow_proof_policy_change() {
         ;;
       adl/tools/ci_path_policy.sh|\
       adl/tools/run_authoritative_coverage_lane.sh|\
+      adl/tools/run_slow_proof_family.sh|\
       adl/tools/run_pr_fast_test_lane.sh|\
       adl/tools/test_ci_path_policy.sh|\
       adl/tools/test_ci_runtime_contracts.sh|\

--- a/adl/tools/run_slow_proof_family.sh
+++ b/adl/tools/run_slow_proof_family.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ADL_DIR="$ROOT_DIR/adl"
+FAMILY_CONFIG="$ADL_DIR/config/slow_proof_families.v0.91.6.json"
+
+family=""
+mode="run"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/run_slow_proof_family.sh --family <id> [--list|--run|--print-plan|--json]
+
+Modes:
+  --list        Run `cargo nextest list` for the selected family feature.
+  --run         Run `cargo nextest run` for the selected family feature. Default.
+  --print-plan  Print key=value plan lines and exit.
+  --json        Print the selected family plan as JSON and exit.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --family)
+      family="${2:-}"
+      shift 2
+      ;;
+    --list)
+      mode="list"
+      shift
+      ;;
+    --run)
+      mode="run"
+      shift
+      ;;
+    --print-plan)
+      mode="print-plan"
+      shift
+      ;;
+    --json)
+      mode="json"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$family" ]; then
+  echo "run_slow_proof_family: --family is required" >&2
+  usage >&2
+  exit 2
+fi
+
+family_payload="$(
+  python3 - "$FAMILY_CONFIG" "$family" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config = json.loads(Path(sys.argv[1]).read_text())
+if config.get("schema_version") != "adl.slow_proof_families.v1":
+    raise SystemExit("unsupported slow-proof family config schema")
+family_id = sys.argv[2]
+for family in config.get("families", []):
+    if family.get("id") == family_id:
+        print(json.dumps({
+            "id": family["id"],
+            "feature": family["feature"],
+            "proof_role": family.get("proof_role", "slow_proof"),
+            "description": family.get("description", ""),
+            "sample_tests": family.get("sample_tests", []),
+            "umbrella_feature": config.get("umbrella_feature", "slow-proof-tests"),
+        }))
+        break
+else:
+    raise SystemExit(f"unknown slow-proof family: {family_id}")
+PY
+)" || {
+  echo "run_slow_proof_family: failed to resolve family '$family'" >&2
+  exit 2
+}
+
+feature="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["feature"])' <<<"$family_payload")"
+description="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["description"])' <<<"$family_payload")"
+
+command_list=(cargo nextest list --lib --features "$feature" runtime_v2_)
+command_run=(cargo nextest run --lib --features "$feature" runtime_v2_ --status-level all --final-status-level slow)
+
+case "$mode" in
+  print-plan)
+    printf 'family=%s\n' "$family"
+    printf 'feature=%s\n' "$feature"
+    printf 'description=%s\n' "$description"
+    printf 'list_command=%q ' "${command_list[@]}"
+    printf '\n'
+    printf 'run_command=%q ' "${command_run[@]}"
+    printf '\n'
+    ;;
+  json)
+    python3 - <<'PY' "$family_payload"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+payload["list_command"] = [
+    "cargo", "nextest", "list", "--lib", "--features", payload["feature"], "runtime_v2_"
+]
+payload["run_command"] = [
+    "cargo", "nextest", "run", "--lib", "--features", payload["feature"],
+    "runtime_v2_",
+    "--status-level", "all", "--final-status-level", "slow",
+]
+print(json.dumps(payload, indent=2, sort_keys=True))
+PY
+    ;;
+  list)
+    (
+      cd "$ADL_DIR"
+      "${command_list[@]}"
+    )
+    ;;
+  run)
+    (
+      cd "$ADL_DIR"
+      "${command_run[@]}"
+    )
+    ;;
+esac

--- a/adl/tools/test_slow_proof_lane_contract.sh
+++ b/adl/tools/test_slow_proof_lane_contract.sh
@@ -3,35 +3,78 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ADL_DIR="$ROOT_DIR/adl"
+FAMILY_CONFIG="$ADL_DIR/config/slow_proof_families.v0.91.6.json"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 default_list="$tmpdir/default-nextest-list.txt"
-slow_list="$tmpdir/slow-proof-nextest-list.txt"
+full_list="$tmpdir/full-nextest-list.txt"
+family_matrix="$tmpdir/families.tsv"
 
-slow_tests=(
-  "runtime_v2_a2a_adapter_boundary_contract_is_stable"
-  "runtime_v2_acip_hardening_contract_is_stable"
-  "runtime_v2_citizen_state_substrate_contract_is_stable"
-  "runtime_v2_continuity_challenge_contract_is_stable"
-  "runtime_v2_delegation_subcontract_contract_and_authority_matrix_is_stable"
-)
+python3 - "$FAMILY_CONFIG" >"$family_matrix" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+for family in payload["families"]:
+    for sample in family.get("sample_tests", []):
+        print(f"{family['id']}\t{family['feature']}\t{sample}")
+PY
+
+runtime_plan="$tmpdir/runtime-plan.json"
+bash "$ROOT_DIR/adl/tools/run_slow_proof_family.sh" --family runtime --json >"$runtime_plan"
+python3 - "$runtime_plan" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+assert payload["run_command"][:6] == [
+    "cargo",
+    "nextest",
+    "run",
+    "--lib",
+    "--features",
+    "slow-proof-runtime",
+]
+assert "runtime_v2_" in payload["run_command"]
+PY
 
 (
   cd "$ADL_DIR"
   cargo nextest list --lib runtime_v2_ > "$default_list"
-  cargo nextest list --lib --features slow-proof-tests runtime_v2_ > "$slow_list"
+  cargo nextest list --lib --features slow-proof-tests runtime_v2_ > "$full_list"
 )
 
-for test_name in "${slow_tests[@]}"; do
-  if grep -Fq "$test_name" "$default_list"; then
-    echo "slow proof test leaked into default PR lane: $test_name" >&2
+while IFS=$'\t' read -r family feature sample_test; do
+  [ -n "$family" ] || continue
+  family_list="$tmpdir/${family}-nextest-list.txt"
+  bash "$ROOT_DIR/adl/tools/run_slow_proof_family.sh" --family "$family" --list >"$family_list"
+
+  if grep -Fq "$sample_test" "$default_list"; then
+    echo "slow proof test leaked into default PR lane: $sample_test" >&2
     exit 1
   fi
-  if ! grep -Fq "$test_name" "$slow_list"; then
-    echo "slow proof test missing from explicit slow-proof lane: $test_name" >&2
+  if ! grep -Fq "$sample_test" "$family_list"; then
+    echo "family '$family' missing expected slow-proof test: $sample_test" >&2
     exit 1
   fi
-done
+  if ! grep -Fq "$sample_test" "$full_list"; then
+    echo "umbrella slow-proof lane missing family sample test: $sample_test" >&2
+    exit 1
+  fi
+
+  while IFS=$'\t' read -r other_family _other_feature other_sample; do
+    [ -n "$other_family" ] || continue
+    if [ "$other_family" = "$family" ]; then
+      continue
+    fi
+    if grep -Fq "$other_sample" "$family_list"; then
+      echo "family '$family' leaked unrelated slow-proof test from '$other_family': $other_sample" >&2
+      exit 1
+    fi
+  done <"$family_matrix"
+done <"$family_matrix"
 
 echo "PASS test_slow_proof_lane_contract"

--- a/adl/tools/test_validation_inventory.sh
+++ b/adl/tools/test_validation_inventory.sh
@@ -45,6 +45,7 @@ rust = inventory["rust"]
 assert rust["rust_lib_unit_tests"]["file_count"] > 0
 assert rust["rust_integration_tests"]["file_count"] > 0
 assert "slow-proof-tests" in inventory["feature_inventory"]
+assert "slow-proof-runtime" in inventory["feature_inventory"]
 assert len(inventory["release_gate_surfaces"]) > 0
 assert len(inventory["coverage_only_surfaces"]) > 0
 assert len(inventory["manifest_backed_surfaces"]) > 0
@@ -75,6 +76,8 @@ assert all(
 )
 python_validator_paths = {record["path"] for record in inventory["python_validators"]}
 assert "adl/tools/test_prompt_template_structure_schemas.py" in python_validator_paths
+shell_validator_paths = {record["path"] for record in inventory["shell_validators"]}
+assert "adl/tools/run_slow_proof_family.sh" in shell_validator_paths
 assert any(
     record["path"] == "adl/tools/test_prompt_template_structure_schemas.py"
     and record["classification_status"] == "partial"
@@ -84,10 +87,37 @@ assert any(
     record["path"] == "adl/Cargo.toml" and record["owner"] == "runtime"
     for record in inventory["slow_proof_surfaces"]
 )
+assert [family["id"] for family in inventory["slow_proof_family_inventory"]] == [
+    "runtime",
+    "private_state",
+    "observatory",
+    "security",
+]
+assert any(
+    record["path"] == "adl/src/runtime_v2/tests/private_state_observatory.rs"
+    and record["slow_proof_families"] == ["private_state"]
+    for record in inventory["slow_proof_surfaces"]
+)
+assert any(
+    record["path"] == "adl/src/runtime_v2/tests/a2a_adapter_boundary.rs"
+    and record["slow_proof_families"] == ["runtime"]
+    and record["feature_requirements"] == ["slow-proof-runtime", "slow-proof-tests"]
+    for record in inventory["slow_proof_surfaces"]
+)
+assert any(
+    record["path"] == "adl/Cargo.toml"
+    and "runtime" in record["slow_proof_families"]
+    and "security" in record["slow_proof_families"]
+    and "slow-proof-runtime" in record["feature_requirements"]
+    and "slow-proof-security" in record["feature_requirements"]
+    for record in inventory["slow_proof_surfaces"]
+)
 
 assert "## Rust test-bearing surfaces" in markdown
+assert "## Slow-proof families" in markdown
 assert "## Unknown or unclassified surfaces" in markdown
 assert "status=partial" in markdown
+assert "`private_state` feature=`slow-proof-private-state`" in markdown
 PY
 
 echo "PASS test_validation_inventory"

--- a/adl/tools/test_validation_inventory.sh
+++ b/adl/tools/test_validation_inventory.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/validation_inventory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+json_one="$TMP/inventory-1.json"
+json_two="$TMP/inventory-2.json"
+md_one="$TMP/inventory-1.md"
+md_two="$TMP/inventory-2.md"
+
+bash "$SCRIPT" --format json >"$json_one"
+bash "$SCRIPT" --format json >"$json_two"
+diff -u "$json_one" "$json_two" >/dev/null
+
+bash "$SCRIPT" --format markdown >"$md_one"
+bash "$SCRIPT" --format markdown >"$md_two"
+diff -u "$md_one" "$md_two" >/dev/null
+
+portable_dir="$TMP/portable"
+mkdir -p "$portable_dir"
+(
+  cd "$portable_dir"
+  bash "$SCRIPT" --format json --json-out "$TMP/portable.json" --markdown-out "$TMP/portable.md" >/dev/null
+)
+[[ -s "$TMP/portable.json" ]]
+[[ -s "$TMP/portable.md" ]]
+
+python3 - <<'PY' "$json_one" "$md_one"
+import json
+import sys
+from pathlib import Path
+
+inventory = json.loads(Path(sys.argv[1]).read_text())
+markdown = Path(sys.argv[2]).read_text()
+
+assert inventory["schema_version"] == "adl.validation_inventory.v1"
+assert inventory["manifest_path"] == "adl/config/validation_lane_selector.v0.91.6.json"
+assert inventory["repo_root"] == "."
+assert inventory["tracked_file_count"] > 0
+
+rust = inventory["rust"]
+assert rust["rust_lib_unit_tests"]["file_count"] > 0
+assert rust["rust_integration_tests"]["file_count"] > 0
+assert "slow-proof-tests" in inventory["feature_inventory"]
+assert len(inventory["release_gate_surfaces"]) > 0
+assert len(inventory["coverage_only_surfaces"]) > 0
+assert len(inventory["manifest_backed_surfaces"]) > 0
+assert isinstance(inventory["unknown_or_unclassified_surfaces"], list)
+assert len(inventory["shell_validators"]) > 0
+assert len(inventory["python_validators"]) > 0
+assert len(inventory["demo_proof_surfaces"]) > 0
+assert "## Shell validators" in markdown
+assert "## Python validators" in markdown
+assert "## Demo proof surfaces" in markdown
+
+pr_finish_records = [
+    record for record in inventory["all_surface_records"]
+    if record["path"] == "adl/src/bin/adl_pr_finish.rs"
+]
+assert any(record["owner"] == "csdlc" for record in pr_finish_records)
+csdlc_records = [
+    record for record in inventory["all_surface_records"]
+    if record["path"] == "adl/src/bin/adl_csdlc.rs"
+]
+assert any(record["owner"] == "csdlc" for record in csdlc_records)
+
+demo_paths = {record["path"] for record in inventory["demo_proof_surfaces"]}
+assert "adl/tools/demo_smoke_v07_story.sh" in demo_paths
+assert all(
+    record["path"] != "adl/tools/demo_smoke_v07_story.sh"
+    for record in inventory["unknown_or_unclassified_surfaces"]
+)
+python_validator_paths = {record["path"] for record in inventory["python_validators"]}
+assert "adl/tools/test_prompt_template_structure_schemas.py" in python_validator_paths
+assert any(
+    record["path"] == "adl/tools/test_prompt_template_structure_schemas.py"
+    and record["classification_status"] == "partial"
+    for record in inventory["unknown_or_unclassified_surfaces"]
+)
+assert any(
+    record["path"] == "adl/Cargo.toml" and record["owner"] == "runtime"
+    for record in inventory["slow_proof_surfaces"]
+)
+
+assert "## Rust test-bearing surfaces" in markdown
+assert "## Unknown or unclassified surfaces" in markdown
+assert "status=partial" in markdown
+PY
+
+echo "PASS test_validation_inventory"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -74,6 +74,13 @@ profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
 assert profile["status"] == "ready_to_run"
 assert [item["lane_id"] for item in profile["run"]] == ["rust_pr_fast"]
+assert [family["id"] for family in profile["slow_proof_families"]] == [
+    "runtime",
+    "private_state",
+    "observatory",
+    "security",
+]
+assert profile["slow_proof_families"][0]["feature"] == "slow-proof-runtime"
 surface = profile["behavior_surfaces"][0]
 assert surface["id"] == "rust_focused_behavior"
 assert surface["owner"] == "shared"
@@ -118,6 +125,7 @@ profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
 assert profile["status"] == "escalation_required"
 assert profile["escalation"]["required"] is True
+assert any(item["surface"] == "slow_proof/runtime" for item in profile["not_run"])
 assert any(
     reason["lane_id"] == "release_gate_review"
     for reason in profile["escalation"]["reasons"]

--- a/adl/tools/validation_inventory.py
+++ b/adl/tools/validation_inventory.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Build a deterministic local inventory of ADL validation surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
+DEFAULT_CARGO = ROOT / "adl/Cargo.toml"
+
+TEST_ATTRIBUTE_RE = re.compile(
+    r"#\[\s*(?:tokio::test|test|rstest|quickcheck|proptest)\b"
+)
+DOC_FENCE_RE = re.compile(
+    r"^\s*(?:(?://[/!])|(?:/\*\*)|(?:\*))?.*```(?:rust|ignore|no_run|should_panic|compile_fail|edition\d{4})\b",
+    re.MULTILINE,
+)
+
+SLOW_PROOF_PATTERNS = (
+    "adl/Cargo.toml",
+    "adl/tools/test_slow_proof_lane_contract.sh",
+    "adl/src/runtime_v2/tests/**",
+    ".github/workflows/ci.yaml",
+)
+RELEASE_GATE_EXTRA_PATTERNS = (
+    "adl/tools/run_authoritative_coverage_lane.sh",
+    "adl/tools/run_local_authoritative_coverage_gate.sh",
+    "adl/tools/test_slow_proof_lane_contract.sh",
+)
+COVERAGE_ONLY_PATTERNS = (
+    ".github/workflows/nightly-coverage-ratchet.yaml",
+    "adl/tools/check_coverage_impact.sh",
+    "adl/tools/test_check_coverage_impact.sh",
+    "adl/tools/run_authoritative_coverage_lane.sh",
+    "adl/tools/run_local_authoritative_coverage_gate.sh",
+)
+
+
+def fail(message: str) -> None:
+    print(f"validation_inventory: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def git_files(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        fail(f"git ls-files failed: {result.stderr.strip()}")
+    return sorted(line for line in result.stdout.splitlines() if line.strip())
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = json.loads(path.read_text())
+    if manifest.get("schema_version") != "adl.validation_lane_selector.v1":
+        fail(f"{path}: unsupported schema_version")
+    return manifest
+
+
+def load_features(path: Path) -> dict[str, list[str]]:
+    cargo = tomllib.loads(path.read_text())
+    features = cargo.get("features", {})
+    return {
+        name: sorted(value) if isinstance(value, list) else []
+        for name, value in sorted(features.items())
+    }
+
+
+def matches(path: str, patterns: tuple[str, ...] | list[str]) -> bool:
+    return any(path == pattern or fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def classify_owner(path: str) -> str | None:
+    if path in {"adl/Cargo.toml", "adl/Cargo.lock"}:
+        return "runtime"
+    if path.startswith("docs/") or path.endswith(".md"):
+        return "docs"
+    if path.startswith(".github/workflows/"):
+        return "github"
+    if path.startswith("adl/src/bin/adl_issue"):
+        return "github"
+    if path.startswith("adl/src/bin/adl_pr_"):
+        return "csdlc"
+    if path in {
+        "adl/src/bin/adl_csdlc.rs",
+        "adl/src/bin/adl_prompt_template.rs",
+        "adl/src/bin/adl_validate_structured_prompt.rs",
+        "adl/src/bin/adl_lint_prompt_spec.rs",
+    }:
+        return "csdlc"
+    if path.startswith("adl/src/runtime_v2/") or path.startswith("adl/src/bin/adl_runtime"):
+        return "runtime"
+    if path.startswith("adl/src/provider") or path.startswith("adl/src/bin/adl_provider"):
+        return "provider"
+    if path.startswith("adl/src/review") or path.startswith("adl/src/bin/adl_review"):
+        return "review"
+    if path.startswith("adl/src/bin/"):
+        return "tools"
+    if path.startswith("adl/src/cli/pr_cmd") or path == "adl/tools/pr.sh":
+        return "csdlc"
+    if path.startswith("adl/src/cli/"):
+        return "tools"
+    if path.startswith("adl/tools/"):
+        return "tools"
+    if path.startswith("adl/src/"):
+        return "runtime"
+    if path.startswith("adl/tests/"):
+        return "runtime"
+    return None
+
+
+def resource_class_for_lane(lane_class: str | None) -> str | None:
+    if lane_class == "docs":
+        return "tiny"
+    if lane_class in {"cli_workflow", "contract_schema_card", "fast_unit"}:
+        return "normal"
+    if lane_class == "integration_worktree":
+        return "expensive"
+    if lane_class in {"release_gate", "provider_live"}:
+        return "external" if lane_class == "provider_live" else "expensive"
+    return None
+
+
+def doc_test_block_count(text: str) -> int:
+    return len(DOC_FENCE_RE.findall(text))
+
+
+def rust_category_for_path(path: str) -> str | None:
+    if not path.endswith(".rs"):
+        return None
+    if path.startswith("adl/src/bin/"):
+        return "rust_bin_tests"
+    if path.startswith("adl/tests/"):
+        return "rust_integration_tests"
+    if path.startswith("adl/src/"):
+        return "rust_lib_unit_tests"
+    return None
+
+
+def build_rust_inventory(files: list[str]) -> dict[str, Any]:
+    categories: dict[str, dict[str, Any]] = {
+        "rust_lib_unit_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+        "rust_bin_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+        "rust_integration_tests": {"files": [], "test_count": 0, "doc_test_blocks": 0},
+    }
+    doc_test_paths: list[str] = []
+    owner_counts: Counter[str] = Counter()
+
+    for rel in files:
+        category = rust_category_for_path(rel)
+        if category is None:
+            continue
+        abs_path = ROOT / rel
+        text = abs_path.read_text(encoding="utf-8")
+        test_count = len(TEST_ATTRIBUTE_RE.findall(text))
+        doc_blocks = doc_test_block_count(text)
+        if test_count == 0 and doc_blocks == 0:
+            continue
+        categories[category]["files"].append(rel)
+        categories[category]["test_count"] += test_count
+        categories[category]["doc_test_blocks"] += doc_blocks
+        owner = classify_owner(rel)
+        if owner:
+            owner_counts[owner] += 1
+        if doc_blocks:
+            doc_test_paths.append(rel)
+
+    rust = {
+        key: {
+            "file_count": len(value["files"]),
+            "test_entry_count": value["test_count"],
+            "doc_test_block_count": value["doc_test_blocks"],
+            "sample_paths": value["files"][:12],
+        }
+        for key, value in categories.items()
+    }
+    rust["rust_doc_tests"] = {
+        "file_count": len(doc_test_paths),
+        "doc_test_block_count": sum(categories[key]["doc_test_blocks"] for key in categories),
+        "sample_paths": sorted(doc_test_paths)[:12],
+    }
+    rust["owner_summary"] = dict(sorted(owner_counts.items()))
+    rust["candidate_paths"] = sorted(
+        {
+            *categories["rust_lib_unit_tests"]["files"],
+            *categories["rust_bin_tests"]["files"],
+            *categories["rust_integration_tests"]["files"],
+            *doc_test_paths,
+        }
+    )
+    return rust
+
+
+def add_surface_record(
+    records: list[dict[str, Any]],
+    path: str,
+    *,
+    surface_kind: str,
+    lane_class: str | None,
+    owner: str | None,
+    resource_class: str | None,
+    proof_role: str,
+    feature_requirements: list[str] | None = None,
+) -> None:
+    records.append(
+        {
+            "path": path,
+            "surface_kind": surface_kind,
+            "lane_class": lane_class,
+            "owner": owner,
+            "resource_class": resource_class,
+            "proof_role": proof_role,
+            "feature_requirements": sorted(feature_requirements or []),
+        }
+    )
+
+
+def build_surface_inventory(
+    files: list[str],
+    manifest: dict[str, Any],
+    rust_candidate_paths: list[str],
+) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    known_paths: set[str] = set()
+
+    for lane in manifest.get("lanes", []):
+        lane_class = lane["lane_class"]
+        resource_class = resource_class_for_lane(lane_class)
+        for path in files:
+            if matches(path, lane["path_hints"]):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="manifest_surface",
+                    lane_class=lane_class,
+                    owner=classify_owner(path),
+                    resource_class=resource_class,
+                    proof_role="ordinary_pr",
+                )
+                known_paths.add(path)
+
+    rust_hints = tuple(manifest.get("rust_path_hints", []))
+    for path in rust_candidate_paths:
+        if matches(path, rust_hints):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="rust_validation_surface",
+                lane_class="fast_unit",
+                owner=classify_owner(path),
+                resource_class="normal",
+                proof_role="ordinary_pr",
+            )
+            known_paths.add(path)
+
+    for path in files:
+        if path.startswith("adl/tools/") and path not in known_paths:
+            name = Path(path).name
+            if name.startswith("demo_") and (path.endswith(".sh") or path.endswith(".py")):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="demo_proof_surface",
+                    lane_class="integration_worktree",
+                    owner=classify_owner(path),
+                    resource_class="expensive",
+                    proof_role="integration_demo",
+                )
+            if path.endswith(".sh") and (
+                name.startswith("test_")
+                or name.startswith("check_")
+                or name.startswith("validate_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                    )
+                )
+            ):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="shell_validator",
+                    lane_class=None,
+                    owner=classify_owner(path),
+                    resource_class="normal",
+                    proof_role="ordinary_pr",
+                )
+            if path.endswith(".py") and (
+                name.startswith("test_")
+                or
+                name.startswith("validate_")
+                or name.startswith("check_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "benchmark")
+                    )
+                )
+            ):
+                add_surface_record(
+                    records,
+                    path,
+                    surface_kind="python_validator",
+                    lane_class=None,
+                    owner=classify_owner(path),
+                    resource_class="normal",
+                    proof_role="ordinary_pr",
+                )
+
+    for path in files:
+        if matches(path, SLOW_PROOF_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="slow_proof_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="slow_proof",
+                feature_requirements=["slow-proof-tests"],
+            )
+        if matches(path, COVERAGE_ONLY_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="coverage_only_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="coverage_only",
+            )
+        if matches(path, tuple(manifest.get("release_gate_hints", [])) + RELEASE_GATE_EXTRA_PATTERNS):
+            add_surface_record(
+                records,
+                path,
+                surface_kind="release_gate_surface",
+                lane_class="release_gate",
+                owner=classify_owner(path),
+                resource_class="expensive",
+                proof_role="release_gate",
+                feature_requirements=["slow-proof-tests"] if path in {"adl/Cargo.toml"} else [],
+            )
+
+    unique_records = {
+        (
+            record["path"],
+            record["surface_kind"],
+            record["lane_class"],
+            record["proof_role"],
+        ): record
+        for record in records
+    }
+    deduped = [unique_records[key] for key in sorted(unique_records)]
+    return {
+        "records": deduped,
+        "known_paths": sorted({record["path"] for record in deduped}),
+    }
+
+
+def candidate_validation_paths(files: list[str], rust_candidate_paths: list[str]) -> list[str]:
+    candidates = set(rust_candidate_paths)
+    for path in files:
+        if path.startswith("adl/tools/"):
+            name = Path(path).name
+            if path.endswith((".sh", ".py")) and (
+                name.startswith("test_")
+                or name.startswith("check_")
+                or name.startswith("validate_")
+                or name.startswith("demo_")
+                or (
+                    name.startswith("run_")
+                    and any(
+                        token in name
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                    )
+                )
+            ):
+                candidates.add(path)
+        if path.startswith(".github/workflows/"):
+            candidates.add(path)
+    return sorted(candidates)
+
+
+def feature_inventory(features: dict[str, list[str]]) -> dict[str, Any]:
+    interesting = {}
+    for name, members in features.items():
+        if "slow-proof" in name or "proof" in name or "coverage" in name:
+            interesting[name] = {
+                "member_count": len(members),
+                "members": members,
+            }
+    return interesting
+
+
+def build_inventory(files: list[str], manifest: dict[str, Any], features: dict[str, list[str]]) -> dict[str, Any]:
+    rust = build_rust_inventory(files)
+    surfaces = build_surface_inventory(files, manifest, rust["candidate_paths"])
+    candidates = candidate_validation_paths(files, rust["candidate_paths"])
+    unmatched_paths = sorted(set(candidates) - set(surfaces["known_paths"]))
+
+    partial_records = []
+    for record in surfaces["records"]:
+        missing_fields = [
+            field
+            for field in ("lane_class", "owner", "resource_class")
+            if record[field] is None
+        ]
+        if missing_fields:
+            partial_records.append(
+                {
+                    "path": record["path"],
+                    "classification_status": "partial",
+                    "missing_fields": missing_fields,
+                    "surface_kind": record["surface_kind"],
+                }
+            )
+
+    unknown_records = [
+        {
+            "path": path,
+            "classification_status": "unmatched",
+            "missing_fields": ["lane_class", "owner", "resource_class"],
+            "surface_kind": "unmatched_candidate",
+        }
+        for path in unmatched_paths
+    ]
+    remediation_index = {
+        (record["path"], record["classification_status"]): record
+        for record in [*unknown_records, *partial_records]
+    }
+    remediation_records = [
+        remediation_index[key]
+        for key in sorted(remediation_index, key=lambda item: (item[0], item[1]))
+    ]
+
+    lane_summary: Counter[str] = Counter()
+    owner_summary: Counter[str] = Counter()
+    resource_summary: Counter[str] = Counter()
+    proof_role_summary: Counter[str] = Counter()
+    kind_summary: Counter[str] = Counter()
+    for record in surfaces["records"]:
+        if record["lane_class"]:
+            lane_summary[record["lane_class"]] += 1
+        if record["owner"]:
+            owner_summary[record["owner"]] += 1
+        if record["resource_class"]:
+            resource_summary[record["resource_class"]] += 1
+        proof_role_summary[record["proof_role"]] += 1
+        kind_summary[record["surface_kind"]] += 1
+
+    return {
+        "schema_version": "adl.validation_inventory.v1",
+        "repo_root": ".",
+        "repo_name": ROOT.name,
+        "manifest_path": str(DEFAULT_MANIFEST.relative_to(ROOT)),
+        "tracked_file_count": len(files),
+        "rust": {
+            "rust_lib_unit_tests": rust["rust_lib_unit_tests"],
+            "rust_bin_tests": rust["rust_bin_tests"],
+            "rust_integration_tests": rust["rust_integration_tests"],
+            "rust_doc_tests": rust["rust_doc_tests"],
+            "owner_summary": rust["owner_summary"],
+        },
+        "surface_summary": {
+            "by_surface_kind": dict(sorted(kind_summary.items())),
+            "by_lane_class": dict(sorted(lane_summary.items())),
+            "by_owner": dict(sorted(owner_summary.items())),
+            "by_resource_class": dict(sorted(resource_summary.items())),
+            "by_proof_role": dict(sorted(proof_role_summary.items())),
+        },
+        "feature_inventory": feature_inventory(features),
+        "all_surface_records": surfaces["records"],
+        "shell_validators": [
+            record for record in surfaces["records"] if record["surface_kind"] == "shell_validator"
+        ],
+        "python_validators": [
+            record for record in surfaces["records"] if record["surface_kind"] == "python_validator"
+        ],
+        "demo_proof_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "demo_proof_surface"
+        ],
+        "slow_proof_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "slow_proof_surface"
+        ],
+        "coverage_only_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "coverage_only_surface"
+        ],
+        "release_gate_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "release_gate_surface"
+        ],
+        "manifest_backed_surfaces": [
+            record for record in surfaces["records"] if record["surface_kind"] == "manifest_surface"
+        ],
+        "unknown_or_unclassified_surfaces": remediation_records,
+    }
+
+
+def markdown_table_row(label: str, values: dict[str, Any]) -> str:
+    return (
+        f"| {label} | {values['file_count']} | {values.get('test_entry_count', 0)} | "
+        f"{values.get('doc_test_block_count', 0)} |"
+    )
+
+
+def render_markdown(inventory: dict[str, Any]) -> str:
+    rust = inventory["rust"]
+    lines = [
+        "# Validation Inventory",
+        "",
+        "## Rust test-bearing surfaces",
+        "",
+        "| Category | Files | Test entries | Doc-test blocks |",
+        "| --- | ---: | ---: | ---: |",
+        markdown_table_row("Rust lib unit tests", rust["rust_lib_unit_tests"]),
+        markdown_table_row("Rust bin tests", rust["rust_bin_tests"]),
+        markdown_table_row("Rust integration tests", rust["rust_integration_tests"]),
+        markdown_table_row("Rust doc tests", rust["rust_doc_tests"]),
+        "",
+        "## Surface summaries",
+        "",
+    ]
+
+    for heading, values in (
+        ("Lane class", inventory["surface_summary"]["by_lane_class"]),
+        ("Owner", inventory["surface_summary"]["by_owner"]),
+        ("Resource class", inventory["surface_summary"]["by_resource_class"]),
+        ("Proof role", inventory["surface_summary"]["by_proof_role"]),
+        ("Surface kind", inventory["surface_summary"]["by_surface_kind"]),
+    ):
+        lines.extend([f"### {heading}", ""])
+        if not values:
+            lines.append("- none")
+        else:
+            for key, count in values.items():
+                lines.append(f"- `{key}`: {count}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Feature expansions",
+            "",
+        ]
+    )
+    if not inventory["feature_inventory"]:
+        lines.append("- none")
+    else:
+        for name, details in inventory["feature_inventory"].items():
+            lines.append(
+                f"- `{name}`: members={details['member_count']} "
+                f"({', '.join(details['members']) if details['members'] else 'none'})"
+            )
+    lines.append("")
+
+    for heading, records in (
+        ("Shell validators", inventory["shell_validators"]),
+        ("Python validators", inventory["python_validators"]),
+        ("Demo proof surfaces", inventory["demo_proof_surfaces"]),
+    ):
+        lines.extend([f"## {heading}", ""])
+        if not records:
+            lines.append("- none")
+        else:
+            lines.append(f"- count: {len(records)}")
+            for record in records[:20]:
+                lines.append(
+                    f"- `{record['path']}` owner={record['owner'] or 'unknown'} "
+                    f"lane={record['lane_class'] or 'unknown'} "
+                    f"resource={record['resource_class'] or 'unknown'}"
+                )
+        lines.append("")
+
+    for heading, records in (
+        ("Slow-proof surfaces", inventory["slow_proof_surfaces"]),
+        ("Coverage-only surfaces", inventory["coverage_only_surfaces"]),
+        ("Release-gate surfaces", inventory["release_gate_surfaces"]),
+    ):
+        lines.extend([f"## {heading}", ""])
+        if not records:
+            lines.append("- none")
+        else:
+            for record in records[:20]:
+                lines.append(
+                    f"- `{record['path']}` owner={record['owner'] or 'unknown'} "
+                    f"lane={record['lane_class'] or 'unknown'} "
+                    f"resource={record['resource_class'] or 'unknown'}"
+                )
+        lines.append("")
+
+    lines.extend(["## Unknown or unclassified surfaces", ""])
+    if not inventory["unknown_or_unclassified_surfaces"]:
+        lines.append("- none")
+    else:
+        for record in inventory["unknown_or_unclassified_surfaces"][:40]:
+            lines.append(
+                f"- `{record['path']}` status={record['classification_status']} "
+                f"missing={','.join(record['missing_fields'])}"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown", "both"),
+        default="both",
+    )
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    files = git_files(ROOT)
+    manifest = load_manifest(DEFAULT_MANIFEST)
+    features = load_features(DEFAULT_CARGO)
+    inventory = build_inventory(files, manifest, features)
+    markdown = render_markdown(inventory)
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(inventory, indent=2, sort_keys=True) + "\n")
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown + "\n")
+
+    if args.format == "json":
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(markdown)
+    else:
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+        print()
+        print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/adl/tools/validation_inventory.py
+++ b/adl/tools/validation_inventory.py
@@ -18,6 +18,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
 DEFAULT_CARGO = ROOT / "adl/Cargo.toml"
+SLOW_PROOF_FAMILIES = ROOT / "adl/config/slow_proof_families.v0.91.6.json"
 
 TEST_ATTRIBUTE_RE = re.compile(
     r"#\[\s*(?:tokio::test|test|rstest|quickcheck|proptest)\b"
@@ -26,9 +27,12 @@ DOC_FENCE_RE = re.compile(
     r"^\s*(?:(?://[/!])|(?:/\*\*)|(?:\*))?.*```(?:rust|ignore|no_run|should_panic|compile_fail|edition\d{4})\b",
     re.MULTILINE,
 )
+RUNTIME_TEST_MODULE_RE = re.compile(r"^mod\s+([A-Za-z0-9_]+);$")
 
 SLOW_PROOF_PATTERNS = (
     "adl/Cargo.toml",
+    "adl/config/slow_proof_families.v0.91.6.json",
+    "adl/tools/run_slow_proof_family.sh",
     "adl/tools/test_slow_proof_lane_contract.sh",
     "adl/src/runtime_v2/tests/**",
     ".github/workflows/ci.yaml",
@@ -36,6 +40,7 @@ SLOW_PROOF_PATTERNS = (
 RELEASE_GATE_EXTRA_PATTERNS = (
     "adl/tools/run_authoritative_coverage_lane.sh",
     "adl/tools/run_local_authoritative_coverage_gate.sh",
+    "adl/tools/run_slow_proof_family.sh",
     "adl/tools/test_slow_proof_lane_contract.sh",
 )
 COVERAGE_ONLY_PATTERNS = (
@@ -79,6 +84,16 @@ def load_features(path: Path) -> dict[str, list[str]]:
         name: sorted(value) if isinstance(value, list) else []
         for name, value in sorted(features.items())
     }
+
+
+def load_slow_proof_families(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text())
+    if payload.get("schema_version") != "adl.slow_proof_families.v1":
+        fail(f"{path}: unsupported schema_version")
+    families = payload.get("families")
+    if not isinstance(families, list):
+        fail(f"{path}: slow-proof families config must expose a families array")
+    return families
 
 
 def matches(path: str, patterns: tuple[str, ...] | list[str]) -> bool:
@@ -216,6 +231,7 @@ def add_surface_record(
     resource_class: str | None,
     proof_role: str,
     feature_requirements: list[str] | None = None,
+    slow_proof_families: list[str] | None = None,
 ) -> None:
     records.append(
         {
@@ -226,17 +242,81 @@ def add_surface_record(
             "resource_class": resource_class,
             "proof_role": proof_role,
             "feature_requirements": sorted(feature_requirements or []),
+            "slow_proof_families": sorted(slow_proof_families or []),
         }
     )
+
+
+def classify_slow_proof_families(
+    path: str,
+    family_feature_map: dict[str, str],
+    runtime_module_family_map: dict[str, list[str]],
+) -> list[str]:
+    family_ids = sorted(family_feature_map)
+    shared_surfaces = {
+        "adl/Cargo.toml",
+        "adl/config/slow_proof_families.v0.91.6.json",
+        "adl/tools/run_slow_proof_family.sh",
+        "adl/tools/test_slow_proof_lane_contract.sh",
+        ".github/workflows/ci.yaml",
+    }
+    if path in shared_surfaces:
+        return family_ids
+    if not path.startswith("adl/src/runtime_v2/tests"):
+        return []
+    text = (ROOT / path).read_text(encoding="utf-8")
+    memberships = {
+        family_id
+        for family_id, feature in sorted(family_feature_map.items())
+        if feature in text
+    }
+    module_name = Path(path).stem
+    memberships.update(runtime_module_family_map.get(module_name, []))
+    return sorted(memberships)
+
+
+def load_runtime_module_family_map(
+    family_feature_map: dict[str, str],
+) -> dict[str, list[str]]:
+    tests_root = ROOT / "adl/src/runtime_v2/tests.rs"
+    cfg_line = ""
+    mapping: dict[str, list[str]] = {}
+    for raw_line in tests_root.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("#[cfg("):
+            cfg_line = line
+            continue
+        match = RUNTIME_TEST_MODULE_RE.match(line)
+        if match:
+            module_name = match.group(1)
+            memberships = [
+                family_id
+                for family_id, feature in sorted(family_feature_map.items())
+                if feature in cfg_line
+            ]
+            if memberships:
+                mapping[module_name] = memberships
+            cfg_line = ""
+            continue
+        if line and not line.startswith("#["):
+            cfg_line = ""
+    return mapping
 
 
 def build_surface_inventory(
     files: list[str],
     manifest: dict[str, Any],
     rust_candidate_paths: list[str],
+    slow_proof_families: list[dict[str, Any]],
 ) -> dict[str, Any]:
     records: list[dict[str, Any]] = []
     known_paths: set[str] = set()
+    family_feature_map = {
+        family["id"]: family["feature"]
+        for family in slow_proof_families
+        if isinstance(family.get("id"), str) and isinstance(family.get("feature"), str)
+    }
+    runtime_module_family_map = load_runtime_module_family_map(family_feature_map)
 
     for lane in manifest.get("lanes", []):
         lane_class = lane["lane_class"]
@@ -289,7 +369,7 @@ def build_surface_inventory(
                     name.startswith("run_")
                     and any(
                         token in name
-                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark", "family")
                     )
                 )
             ):
@@ -311,7 +391,7 @@ def build_surface_inventory(
                     name.startswith("run_")
                     and any(
                         token in name
-                        for token in ("validation", "coverage", "proof", "benchmark")
+                        for token in ("validation", "coverage", "proof", "benchmark", "family")
                     )
                 )
             ):
@@ -327,6 +407,11 @@ def build_surface_inventory(
 
     for path in files:
         if matches(path, SLOW_PROOF_PATTERNS):
+            slow_proof_memberships = classify_slow_proof_families(
+                path,
+                family_feature_map,
+                runtime_module_family_map,
+            )
             add_surface_record(
                 records,
                 path,
@@ -335,7 +420,15 @@ def build_surface_inventory(
                 owner=classify_owner(path),
                 resource_class="expensive",
                 proof_role="slow_proof",
-                feature_requirements=["slow-proof-tests"],
+                feature_requirements=[
+                    "slow-proof-tests",
+                    *[
+                        family_feature_map[family_id]
+                        for family_id in slow_proof_memberships
+                        if family_id in family_feature_map
+                    ],
+                ],
+                slow_proof_families=slow_proof_memberships,
             )
         if matches(path, COVERAGE_ONLY_PATTERNS):
             add_surface_record(
@@ -389,7 +482,7 @@ def candidate_validation_paths(files: list[str], rust_candidate_paths: list[str]
                     name.startswith("run_")
                     and any(
                         token in name
-                        for token in ("validation", "coverage", "proof", "lane", "benchmark")
+                        for token in ("validation", "coverage", "proof", "lane", "benchmark", "family")
                     )
                 )
             ):
@@ -411,8 +504,9 @@ def feature_inventory(features: dict[str, list[str]]) -> dict[str, Any]:
 
 
 def build_inventory(files: list[str], manifest: dict[str, Any], features: dict[str, list[str]]) -> dict[str, Any]:
+    slow_proof_families = load_slow_proof_families(SLOW_PROOF_FAMILIES)
     rust = build_rust_inventory(files)
-    surfaces = build_surface_inventory(files, manifest, rust["candidate_paths"])
+    surfaces = build_surface_inventory(files, manifest, rust["candidate_paths"], slow_proof_families)
     candidates = candidate_validation_paths(files, rust["candidate_paths"])
     unmatched_paths = sorted(set(candidates) - set(surfaces["known_paths"]))
 
@@ -487,6 +581,14 @@ def build_inventory(files: list[str], manifest: dict[str, Any], features: dict[s
             "by_proof_role": dict(sorted(proof_role_summary.items())),
         },
         "feature_inventory": feature_inventory(features),
+        "slow_proof_family_inventory": [
+            {
+                "id": family["id"],
+                "feature": family["feature"],
+                "sample_tests": family.get("sample_tests", []),
+            }
+            for family in slow_proof_families
+        ],
         "all_surface_records": surfaces["records"],
         "shell_validators": [
             record for record in surfaces["records"] if record["surface_kind"] == "shell_validator"
@@ -569,6 +671,17 @@ def render_markdown(inventory: dict[str, Any]) -> str:
             )
     lines.append("")
 
+    lines.extend(["## Slow-proof families", ""])
+    if not inventory["slow_proof_family_inventory"]:
+        lines.append("- none")
+    else:
+        for family in inventory["slow_proof_family_inventory"]:
+            lines.append(
+                f"- `{family['id']}` feature=`{family['feature']}` "
+                f"samples={', '.join(family['sample_tests']) if family['sample_tests'] else 'none'}"
+            )
+    lines.append("")
+
     for heading, records in (
         ("Shell validators", inventory["shell_validators"]),
         ("Python validators", inventory["python_validators"]),
@@ -583,7 +696,8 @@ def render_markdown(inventory: dict[str, Any]) -> str:
                 lines.append(
                     f"- `{record['path']}` owner={record['owner'] or 'unknown'} "
                     f"lane={record['lane_class'] or 'unknown'} "
-                    f"resource={record['resource_class'] or 'unknown'}"
+                    f"resource={record['resource_class'] or 'unknown'} "
+                    f"families={','.join(record['slow_proof_families']) if record['slow_proof_families'] else 'none'}"
                 )
         lines.append("")
 

--- a/adl/tools/validation_inventory.sh
+++ b/adl/tools/validation_inventory.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "$ROOT/adl/tools/validation_inventory.py" "$@"

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -13,11 +13,21 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 SELECTOR = ROOT / "adl/tools/select_validation_lanes.sh"
+SLOW_PROOF_FAMILIES = ROOT / "adl/config/slow_proof_families.v0.91.6.json"
 
 
 def fail(message: str) -> None:
     print(f"validation_manager: {message}", file=sys.stderr)
     raise SystemExit(2)
+
+
+def load_slow_proof_families() -> dict[str, Any]:
+    payload = json.loads(SLOW_PROOF_FAMILIES.read_text())
+    if payload.get("schema_version") != "adl.slow_proof_families.v1":
+        fail("slow-proof families config returned unsupported schema_version")
+    if not isinstance(payload.get("families"), list):
+        fail("slow-proof families config must expose a families array")
+    return payload
 
 
 def selector_plan(args: argparse.Namespace) -> dict[str, Any]:
@@ -142,6 +152,8 @@ def estimate_cost(selected: list[tuple[str, dict[str, Any]]], blocked: list[tupl
 
 
 def build_profile(plan: dict[str, Any], max_selected_lanes: int) -> dict[str, Any]:
+    slow_proof_config = load_slow_proof_families()
+    slow_proof_families = slow_proof_config.get("families", [])
     lanes = plan.get("lanes", {})
     changed_paths = plan.get("changed_paths", [])
     covered_paths = {
@@ -197,6 +209,14 @@ def build_profile(plan: dict[str, Any], max_selected_lanes: int) -> dict[str, An
             "reason": "reserved for coverage or release policy selection",
         },
     ]
+    not_run.extend(
+        {
+            "surface": f"slow_proof/{family['id']}",
+            "reason": "reserved for explicit proof-family selection",
+            "feature": family["feature"],
+        }
+        for family in slow_proof_families
+    )
 
     unmapped_change_gap = bool(uncovered_paths)
 
@@ -263,6 +283,18 @@ def build_profile(plan: dict[str, Any], max_selected_lanes: int) -> dict[str, An
             "edges": [],
             "compression_note": "profile validates behavior surfaces rather than enumerating every test-bearing module",
         },
+        "slow_proof_families": [
+            {
+                "id": family["id"],
+                "feature": family["feature"],
+                "proof_role": family.get("proof_role", "slow_proof"),
+                "description": family.get("description", ""),
+                "selection_mode": "manual_only",
+                "command": f"bash adl/tools/run_slow_proof_family.sh --family {family['id']} --run",
+                "sample_tests": family.get("sample_tests", []),
+            }
+            for family in slow_proof_families
+        ],
         "estimated_cost": estimate_cost(selected, blocked),
         "escalation": {
             "required": escalation_required,
@@ -296,6 +328,12 @@ def print_text(profile: dict[str, Any]) -> None:
         for behavior in profile["behavior_surfaces"]:
             print(
                 f"    - id={behavior['id']} risk={behavior['risk_class']} source={behavior['source']}"
+            )
+    if profile.get("slow_proof_families"):
+        print("  slow_proof_families:")
+        for family in profile["slow_proof_families"]:
+            print(
+                f"    - id={family['id']} feature={family['feature']} selection_mode={family['selection_mode']}"
             )
     print(
         "  estimated_cost="


### PR DESCRIPTION
Closes #4219

## Summary
Completed `#4219` by splitting slow-proof validation into named runtime,
private-state, observatory, and security families, adding a tracked family
config and dedicated family runner, and teaching both the validation manager
and validation inventory to report per-family proof membership. The
runtime-v2 slow-proof tests are now selectively gated so a chosen family does
not pull unrelated slow-proof families into the focused proof lane, while the
umbrella `slow-proof-tests` feature still preserves full release-gate proof.
Review found three correctness defects during the slice: the family runner
initially widened `--run` beyond the selected proof family, inventory family
membership initially missed module-gated runtime-v2 tests, and inventory
feature requirements initially overclaimed all family features for isolated
surfaces. All three findings were fixed before the final no-findings review
pass, and the focused proof set was rerun after each correction.

## Artifacts
- Updated tracked code:
  - `adl/Cargo.toml`
  - `adl/config/slow_proof_families.v0.91.6.json`
  - `adl/src/runtime_v2/tests.rs`
  - `adl/src/runtime_v2/tests/access_control.rs`
  - `adl/src/runtime_v2/tests/bid_schema.rs`
  - `adl/src/runtime_v2/tests/boot_admission.rs`
  - `adl/src/runtime_v2/tests/citizen_state_substrate.rs`
  - `adl/src/runtime_v2/tests/contract_lifecycle_state.rs`
  - `adl/src/runtime_v2/tests/contract_schema.rs`
  - `adl/src/runtime_v2/tests/csm_run_packet.rs`
  - `adl/src/runtime_v2/tests/delegation_subcontract.rs`
  - `adl/src/runtime_v2/tests/evaluation_selection.rs`
  - `adl/src/runtime_v2/tests/external_counterparty.rs`
  - `adl/src/runtime_v2/tests/freedom_gate_mediation.rs`
  - `adl/src/runtime_v2/tests/governed_episode.rs`
  - `adl/src/runtime_v2/tests/governed_learning_substrate.rs`
  - `adl/src/runtime_v2/tests/hardening.rs`
  - `adl/src/runtime_v2/tests/integrated_csm_run.rs`
  - `adl/src/runtime_v2/tests/intelligence_metric_architecture.rs`
  - `adl/src/runtime_v2/tests/invalid_action_rejection.rs`
  - `adl/src/runtime_v2/tests/invariant_contract.rs`
  - `adl/src/runtime_v2/tests/memory_identity_architecture.rs`
  - `adl/src/runtime_v2/tests/observatory.rs`
  - `adl/src/runtime_v2/tests/operator_control.rs`
  - `adl/src/runtime_v2/tests/private_state.rs`
  - `adl/src/runtime_v2/tests/private_state_envelope.rs`
  - `adl/src/runtime_v2/tests/private_state_equivocation.rs`
  - `adl/src/runtime_v2/tests/private_state_lineage.rs`
  - `adl/src/runtime_v2/tests/private_state_observatory.rs`
  - `adl/src/runtime_v2/tests/private_state_witness.rs`
  - `adl/src/runtime_v2/tests/quarantine.rs`
  - `adl/src/runtime_v2/tests/recovery_eligibility.rs`
  - `adl/src/runtime_v2/tests/resource_stewardship_bridge.rs`
  - `adl/src/runtime_v2/tests/security_boundary.rs`
  - `adl/src/runtime_v2/tests/theory_of_mind_foundation.rs`
  - `adl/src/runtime_v2/tests/transition_authority.rs`
  - `adl/src/runtime_v2/tests/wake_continuity.rs`
  - `adl/tools/ci_path_policy.sh`
  - `adl/tools/run_slow_proof_family.sh`
  - `adl/tools/test_slow_proof_lane_contract.sh`
  - `adl/tools/test_validation_inventory.sh`
  - `adl/tools/test_validation_manager.sh`
  - `adl/tools/validation_inventory.py`
  - `adl/tools/validation_manager.py`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4219__v0-91-6-tools-validation-split-slow-proof-validation-families/srp.md`
  - `.adl/v0.91.6/tasks/issue-4219__v0-91-6-tools-validation-split-slow-proof-validation-families/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_inventory.sh`
    Verified the focused family-aware validation-inventory contract suite and
    deterministic output shape.
  - `bash adl/tools/test_validation_manager.sh`
    Verified the focused validation-manager contract suite for family metadata,
    reserved proof-family visibility, and family run-command emission.
  - `bash adl/tools/test_slow_proof_lane_contract.sh`
    Verified per-family proof isolation and umbrella coverage for the selected
    runtime-v2 slow-proof families.
  - `python3 -m py_compile adl/tools/validation_inventory.py adl/tools/validation_manager.py`
    Verified the Python sources parse successfully.
  - `git diff --check`
    Verified there are no whitespace or patch-format defects.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4219__v0-91-6-tools-validation-split-slow-proof-validation-families/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4219__v0-91-6-tools-validation-split-slow-proof-validation-families/sor.md
- Idempotency-Key: v0-91-6-tools-validation-split-slow-proof-validation-families-adl-v0-91-6-tasks-issue-4219-v0-91-6-tools-validation-split-slow-proof-validation-families-sip-md-adl-v0-91-6-tasks-issue-4219-v0-91-6-tools-validation-split-slow-proof-validation-families-sor-md