### PR TITLE
[v0.91.6][tools] Auto-create session goals for Sprint Execution Packet work

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -95,6 +95,11 @@ issue while coordinating broader sprint intent through a declared Sprint
 Execution Packet, then finishes with sprint review and closeout. SEP can record
 safe parallel lanes for separate workers or sessions; it is not itself a claim
 that the current helper scripts automate multi-active issue execution.
+When SEP routing starts or resumes a live child issue session, the sprint
+handoff should carry the same issue-bound session-goal requirement directly
+instead of relying on a separate manual reminder. For SEP-routed child work,
+the minimum goal surface is the sprint issue number when present, the child
+issue number, and the bounded session objective.
 `adl-milestone-creator` is a bounded milestone setup helper for creating full milestone packages, bridge milestones, issue-routing truth, feature/proof coverage, and downstream handoff docs without relying on session memory.
 `issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
 `issue-splitter` is a bounded issue-scope helper for deciding whether one issue should stay intact, split now, defer splitting, or stop for operator review.
@@ -115,6 +120,9 @@ issue proves that integration. A truthful `complete` update may represent a
 session handoff into normal review/wait state after PR publication when that
 handoff was the declared bounded session objective; it does not imply the whole
 issue is merged or closed.
+When the session is started through sprint orchestration, keep the same timing
+rule and make the goal content SEP-aware: include sprint issue context when
+present, the child issue number, and the bounded child-session objective.
 
 The PR lifecycle skills share the CI runtime interpretation policy in
 `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`. Stable PR check names

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -155,22 +155,29 @@ missing sprint-management issue first.
    single-current-issue; parallel execution is achieved by separate issue
    workers/sessions using the SEP as the coordination contract.
 9. Route the selected child issue or lane handoff through `workflow-conductor`.
-10. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
-11. Run only the selected downstream lifecycle or editor skill.
-12. Re-check issue truth. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
-13. If the issue is healthy but waiting on review, checks, or merge, route it into the bounded watch/janitor path rather than surfacing that healthy waiting state as a default sprint stop.
-14. If the issue is merged or otherwise closed but not locally closeouted yet, immediately route `pr-closeout` and finish the child-closeout gate.
-15. If the issue is fully closed out, use the deterministic child-closeout helper path to advance sprint state.
-16. If the issue is still active after the fresh truth check, repeat the routing loop for the same issue.
-17. In `sequential` mode, only after child-closeout truth is satisfied may the
+10. When that handoff starts or resumes live child execution, attach the
+    issue-bound session-goal requirement as part of the SEP handoff rather than
+    as a separate manual reminder.
+11. For SEP-routed child execution, create the goal after bind/readiness
+    succeeds and before implementation starts. Minimum goal content:
+    sprint issue number when present, child issue number, and the bounded
+    session objective.
+12. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
+13. Run only the selected downstream lifecycle or editor skill.
+14. Re-check issue truth. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
+15. If the issue is healthy but waiting on review, checks, or merge, route it into the bounded watch/janitor path rather than surfacing that healthy waiting state as a default sprint stop.
+16. If the issue is merged or otherwise closed but not locally closeouted yet, immediately route `pr-closeout` and finish the child-closeout gate.
+17. If the issue is fully closed out, use the deterministic child-closeout helper path to advance sprint state.
+18. If the issue is still active after the fresh truth check, repeat the routing loop for the same issue.
+19. In `sequential` mode, only after child-closeout truth is satisfied may the
     sprint advance to the next ordered issue. In `parallel` or `hybrid` mode,
     do not treat a lane as clear unless its SEP-defined dependencies, serial
     gates, and issue-local closeout truth are satisfied.
-18. After the final issue closes, assemble sprint review evidence.
-19. Record sprint closeout metrics including coverage and Rust tracker counts.
-20. Run the deterministic sprint closeout helper to classify `ready_to_close`, `needs_remediation`, or `blocked`, write/update the retained closeout artifact, and generate the final sprint close summary.
-21. Only when the closeout helper reports `ready_to_close`, close the sprint-management issue.
-22. Stop with one bounded sprint review/closeout result.
+20. After the final issue closes, assemble sprint review evidence.
+21. Record sprint closeout metrics including coverage and Rust tracker counts.
+22. Run the deterministic sprint closeout helper to classify `ready_to_close`, `needs_remediation`, or `blocked`, write/update the retained closeout artifact, and generate the final sprint close summary.
+23. Only when the closeout helper reports `ready_to_close`, close the sprint-management issue.
+24. Stop with one bounded sprint review/closeout result.
 
 ## Execution Model
 
@@ -188,6 +195,10 @@ This skill enforces:
   mode
 - no intentional parallel lane work unless the SEP names the lane, write-set
   boundary, proof lane, and required coordination
+- no live child implementation handoff without the child issue-bound session
+  goal created after bind/readiness succeeds
+- no SEP-routed child session goal that omits sprint context when a sprint
+  issue exists, the child issue number, or the bounded session objective
 - editor-skill routing when cards drift
 - prompt-template renderer/schema validation when cards need deterministic
   regeneration rather than lifecycle-truth repair
@@ -241,6 +252,9 @@ Preferred per-issue routing model:
 - card-local SOR issue -> `sor-editor`
 - structurally ready but not bound -> `pr-ready`
 - ready for execution bind -> `pr-run`
+- live child execution handoff through `pr-run` must carry the issue-bound
+  session-goal requirement directly in the sprint handoff; do not leave SEP
+  child sessions dependent on a separate manual `create_goal` reminder
 - execution complete, needs publication -> `pr-finish`
 - healthy PR open and awaiting human review, checks, or merge -> `issue-watcher`
 - PR in flight with actual blockers -> `pr-janitor`

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -61,20 +61,28 @@ Optional:
    - in `hybrid`, use the SEP to identify ready lane work until a named serial
      gate blocks progress
 7. Route the selected child issue or lane handoff through `workflow-conductor`.
-8. Run only the selected downstream lifecycle or editor skill.
-9. Re-check issue truth.
-10. If the issue is in a healthy PR-open waiting state, route `issue-watcher`
+8. When the route starts or resumes live child execution, attach the
+   issue-bound session-goal requirement in the same handoff:
+   - create the goal after bind/readiness succeeds and before implementation
+     starts
+   - include the sprint issue number when present, the child issue number, and
+     the bounded session objective
+   - for `parallel` or `hybrid` lanes, each separate worker/session creates its
+     own child-session goal rather than sharing one sprint-global goal
+9. Run only the selected downstream lifecycle or editor skill.
+10. Re-check issue truth.
+11. If the issue is in a healthy PR-open waiting state, route `issue-watcher`
    so the sprint remains attached to the active child without turning healthy
    waiting into a default conversational stop.
-11. If the watcher finds failed checks, conflicts, requested changes, or
+12. If the watcher finds failed checks, conflicts, requested changes, or
    ambiguous path-policy state, route `pr-janitor`.
-12. If the watcher finds that the PR merged or the issue otherwise closed,
+13. If the watcher finds that the PR merged or the issue otherwise closed,
    immediately route `pr-closeout`.
-13. If the issue is fully closed out, use the deterministic child-closeout
+14. If the issue is fully closed out, use the deterministic child-closeout
    helper to mark it complete and move to the next issue.
-14. If the issue is still active after the fresh truth check, repeat the
+15. If the issue is still active after the fresh truth check, repeat the
    routing loop for the same issue.
-15. If any true blocker is encountered, stop and report the blocker in
+16. If any true blocker is encountered, stop and report the blocker in
    sprint-state.
 
 Important: sprint-level aggregate proof must not hide failed, pending,

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -170,6 +170,12 @@ next_handoff:
   target_issue_number: <u32 or null>
   target_pr_url: <url or null>
   next_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | issue-watcher | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
+  child_session_goal:
+    required: true | false
+    create_after_bind: true | false
+    sprint_issue_number: <u32 or null>
+    child_issue_number: <u32 or null>
+    bounded_objective: <bounded text or null>
   rationale: <bounded text>
 artifact:
   sprint_state_path: <path or null>

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -113,6 +113,7 @@ assert_skill_bundle() {
   grep -Fq "planning artifact rather than an execution log" "${root}/skills/spp-editor/SKILL.md"
   grep -Fq "Structured Review Prompt" "${root}/skills/srp-editor/SKILL.md"
   grep -Fq "one issue at a time, fully closed out before the next" "${root}/skills/sprint-conductor/SKILL.md"
+  grep -Fq "attach the issue-bound session-goal requirement as part of the SEP handoff" "${root}/skills/sprint-conductor/SKILL.md"
   grep -Fq "findings-first review orchestrator" "${root}/skills/sprint-review/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -141,6 +141,12 @@ The repository workflow currently treats this as an agent-session requirement,
 not as an ADL runtime-enforced object. `pr.sh` can remind, but it does not
 claim to introspect Codex goal state.
 
+When execution is being routed by a Sprint Execution Packet through
+`sprint-conductor`, attach this same goal step directly to the child-issue
+handoff instead of leaving it as a separate manual reminder. For SEP-routed
+child sessions, the goal should include the sprint issue number when present,
+the child issue number, and the concrete bounded session objective.
+
 Use `update_goal` only for truthful terminal state:
 
 - `complete` when the current session objective is actually achieved, including


### PR DESCRIPTION
Closes #4236

## Summary
Updated the Sprint Execution Packet workflow surfaces so sprint-conductor
handoffs carry the child issue-bound session-goal requirement directly, defined
the SEP-aware minimum goal content, and added a narrow install-time contract
check for the new sprint-conductor guidance.

## Artifacts
- Updated `adl/tools/skills/sprint-conductor/SKILL.md` with SEP child-session
  goal handoff rules and execution-model guardrails.
- Updated `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
  with the same child-session goal handoff details for live routing.
- Updated `adl/tools/skills/sprint-conductor/references/output-contract.md`
  with a machine-readable `next_handoff.child_session_goal` surface.
- Updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md` and
  `docs/default_workflow.md` so sprint/SEP guidance matches the repo's
  session-discipline truth without claiming runtime goal introspection.
- Updated `adl/tools/test_install_adl_operational_skills.sh` with a focused
  installed-bundle contract assertion for the new sprint-conductor wording.

## Validation
- Validation commands and their purpose:
  - `GH_TOKEN="$(gh auth token)" bash adl/tools/pr.sh doctor 4236 --slug v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work --version v0.91.6 --json`
    Verified the issue was correctly bound and identified the stale SOR
    scaffold as the finish-readiness blocker before this normalization pass.
  - `git diff --check -- adl/tools/skills/sprint-conductor/SKILL.md adl/tools/skills/sprint-conductor/references/conductor-playbook.md adl/tools/skills/sprint-conductor/references/output-contract.md adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md docs/default_workflow.md adl/tools/test_install_adl_operational_skills.sh`
    Verified the touched sprint/workflow surfaces are whitespace-clean.
  - `tmpdir="$(mktemp -d)"; CODEX_HOME="$tmpdir/codex-home" bash adl/tools/install_adl_operational_skills.sh >/dev/null; rg -n "SEP handoff|sprint issue number when present|child_session_goal|bounded session objective" "$tmpdir/codex-home/skills/sprint-conductor/SKILL.md" "$tmpdir/codex-home/skills/sprint-conductor/references/output-contract.md"`
    Verified the installed sprint-conductor copy carries the new SEP handoff
    wording and machine-readable contract field.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/sprint-conductor/SKILL.md`
    Verified the changed sprint-conductor skill frontmatter remains valid.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.6/tasks/issue-4236__v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work/srp.md`
    Verified the finalized SRP review record is structurally valid.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.6/tasks/issue-4236__v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work/sor.md`
    Verified this SOR is structurally valid as a finish-ready execution record.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4236__v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4236__v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work/sor.md
- Idempotency-Key: v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work-adl-v0-91-6-tasks-issue-4236-v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work-sip-md-adl-v0-91-6-tasks-issue-4236-v0-91-6-tools-auto-create-session-goals-for-sprint-execution-packet-work-sor-md