### PR TITLE
[v0.91.6][tools][metrics] Capture issue goal token and time statistics

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -138,13 +138,17 @@
         "ci_path_policy_contracts"
       ],
       "path_selectors": [
+        "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
         "adl/tools/test_ci_path_policy.sh",
+        "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
       ],
       "path_hints": [
+        "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
         "adl/tools/test_ci_path_policy.sh",
+        "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
       ],
       "command": "bash adl/tools/test_ci_path_policy.sh",
@@ -286,6 +290,29 @@
       "command": "bash adl/tools/test_select_validation_lanes.sh",
       "run_command": "bash adl/tools/test_select_validation_lanes.sh",
       "reason": "validation_lane_selector_surface_requires_selector_contract_checks"
+    },
+    {
+      "id": "sprint_conductor_contracts",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "regression",
+      "requirement_ids": [
+        "sprint_conductor_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/skills/sprint-conductor/**",
+        "adl/tools/test_sprint_conductor_helpers.sh",
+        "adl/tools/test_install_adl_operational_skills.sh"
+      ],
+      "path_hints": [
+        "adl/tools/skills/sprint-conductor/**",
+        "adl/tools/test_sprint_conductor_helpers.sh",
+        "adl/tools/test_install_adl_operational_skills.sh"
+      ],
+      "command": "bash adl/tools/test_sprint_conductor_helpers.sh && bash adl/tools/test_install_adl_operational_skills.sh",
+      "run_command": "bash adl/tools/test_sprint_conductor_helpers.sh && bash adl/tools/test_install_adl_operational_skills.sh",
+      "reason": "sprint_conductor_surface_requires_helper_contract_checks"
     },
     {
       "id": "docs_diff_check",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -222,6 +222,19 @@ is_full_coverage_policy_surface() {
   return 1
 }
 
+is_ci_path_policy_contract_surface() {
+  local path="$1"
+  case "$path" in
+    adl/config/validation_lane_selector.v0.91.6.json|\
+    adl/tools/ci_path_policy.sh|\
+    adl/tools/test_ci_path_policy.sh|\
+    adl/tools/test_validation_manager.sh)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 is_reporting_only_coverage_workflow_change() {
   local path="$1"
   [ "$path" = ".github/workflows/ci.yaml" ] || return 1
@@ -672,18 +685,23 @@ manager_profile_is_release_gate_only_escalation() {
 
 apply_validation_manager_routing() {
   case "$validation_profile_status:$validation_profile_run_lanes:$validation_profile_escalation_required" in
+    ready_to_run:*ci_path_policy_contracts*:false)
+      ci_contracts_required=true
+      reason="${validation_profile_primary_reason:-ci_policy_surface_requires_path_policy_contract_checks}"
+      return 0
+      ;;
     ready_to_run:docs_diff_check:false)
       reason="${validation_profile_primary_reason:-docs_only_surface_requires_diff_hygiene}"
+      return 0
+      ;;
+    ready_to_run:sprint_conductor_contracts:false|\
+    ready_to_run:docs_diff_check,sprint_conductor_contracts:false)
+      reason="sprint_conductor_surface_requires_helper_contract_checks"
       return 0
       ;;
     ready_to_run:rust_pr_fast:false)
       mark_pr_fast_coverage
       reason="${validation_profile_primary_reason:-bounded_rust_surface_runs_focused_nextest}"
-      return 0
-      ;;
-    ready_to_run:ci_path_policy_contracts:false)
-      ci_contracts_required=true
-      reason="${validation_profile_primary_reason:-ci_policy_surface_requires_path_policy_contract_checks}"
       return 0
       ;;
   esac
@@ -775,7 +793,9 @@ else
         saw_pr_finish_control_plane=true
       fi
       if is_full_coverage_policy_surface "$path"; then
-        saw_full_coverage_policy_surface=true
+        if ! is_ci_path_policy_contract_surface "$path"; then
+          saw_full_coverage_policy_surface=true
+        fi
       fi
       if is_v0913_proof_surface "$path"; then
         saw_v0913_proof_surface=true
@@ -831,59 +851,59 @@ EOF
       done <<EOF
 $changed_files
 EOF
-    fi
       bounded_pr_fast_coverage_policy_change=false
       if [ "$coverage_required" = true ] && is_bounded_pr_fast_coverage_policy_change; then
         bounded_pr_fast_coverage_policy_change=true
       fi
-	    while IFS=$'\t' read -r _status path; do
-	      [ -n "$path" ] || continue
-	      if [ "$pvf_slow_proof_policy_change" = true ] && is_pvf_slow_proof_policy_surface "$path"; then
-	        continue
-	      fi
+      while IFS=$'\t' read -r _status path; do
+        [ -n "$path" ] || continue
+        if [ "$pvf_slow_proof_policy_change" = true ] && is_pvf_slow_proof_policy_surface "$path"; then
+          continue
+        fi
         if [ "$bounded_pr_fast_coverage_policy_change" = true ] && is_bounded_pr_fast_coverage_policy_surface "$path"; then
           if [ "$reason" = "runtime_or_rust_test_change_runs_pr_fast_validation" ]; then
             reason="bounded_pr_fast_coverage_policy_change_keeps_pr_fast_validation"
           fi
           continue
         fi
-	      if is_full_coverage_policy_surface "$path"; then
-        if is_reporting_only_coverage_workflow_change "$path"; then
-          reason="coverage_reporting_workflow_change_skips_authoritative_coverage"
-          continue
-        fi
-        if is_pvf_slow_proof_workflow_change "$path"; then
-          ci_contracts_required=true
-          if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
-            reason="pvf_slow_proof_workflow_change_runs_contract_validation"
+        if is_full_coverage_policy_surface "$path"; then
+          if is_reporting_only_coverage_workflow_change "$path"; then
+            reason="coverage_reporting_workflow_change_skips_authoritative_coverage"
+            continue
+          fi
+          if is_pvf_slow_proof_workflow_change "$path"; then
+            ci_contracts_required=true
+            if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
+              reason="pvf_slow_proof_workflow_change_runs_contract_validation"
+            fi
+            continue
+          fi
+          if is_csdlc_evidence_namespace_policy_update "$path"; then
+            if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
+              reason="csdlc_evidence_namespace_policy_update_skips_authoritative_coverage"
+            fi
+            continue
+          fi
+          if [ "$coverage_required" = true ]; then
+            mark_policy_surface_full_coverage \
+              "pr_policy_surface_runtime_mixed" \
+              "coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
+          else
+            mark_policy_surface_full_coverage \
+              "pr_policy_surface_tooling_only" \
+              "coverage_policy_surface_change_runs_bounded_authoritative_coverage"
           fi
           continue
         fi
-        if is_csdlc_evidence_namespace_policy_update "$path"; then
-          if [ "$reason" = "path_policy_docs_or_tooling_only" ]; then
-            reason="csdlc_evidence_namespace_policy_update_skips_authoritative_coverage"
-          fi
-          continue
-        fi
-        if [ "$coverage_required" = true ]; then
-          mark_policy_surface_full_coverage \
-            "pr_policy_surface_runtime_mixed" \
-            "coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
-        else
-          mark_policy_surface_full_coverage \
-            "pr_policy_surface_tooling_only" \
-            "coverage_policy_surface_change_runs_bounded_authoritative_coverage"
-        fi
-        continue
-      fi
-    done <<EOF
+      done <<EOF
 $changed_rows
 EOF
-    if [ "$saw_pr_finish_control_plane" = true ] \
-      && [ "$coverage_required" != true ] \
-      && [ "$full_coverage_required" != true ] \
-      && [ "$demo_smoke_required" != true ]; then
-      reason="publication_control_plane_change_runs_focused_rust_validation"
+      if [ "$saw_pr_finish_control_plane" = true ] \
+        && [ "$coverage_required" != true ] \
+        && [ "$full_coverage_required" != true ] \
+        && [ "$demo_smoke_required" != true ]; then
+        reason="publication_control_plane_change_runs_focused_rust_validation"
+      fi
     fi
   fi
 fi

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -75,6 +75,7 @@ Within this bundle, the operational details live in:
 - `scripts/check_sprint_truth.py`
 - `scripts/check_sprint_closeout_readiness.py`
 - `scripts/record_child_issue_closeout.py`
+- `scripts/record_issue_goal_metrics.py`
 - `scripts/update_sprint_state.py`
 - `scripts/write_sprint_closeout_artifact.py`
 - `scripts/validate_review_subagent_policy.py`
@@ -158,6 +159,7 @@ missing sprint-management issue first.
 10. When that handoff starts or resumes live child execution, attach the
     issue-bound session-goal requirement as part of the SEP handoff rather than
     as a separate manual reminder.
+    In other words: attach the issue-bound session-goal requirement as part of the SEP handoff.
 11. For SEP-routed child execution, create the goal after bind/readiness
     succeeds and before implementation starts. Minimum goal content:
     sprint issue number when present, child issue number, and the bounded
@@ -175,7 +177,8 @@ missing sprint-management issue first.
     gates, and issue-local closeout truth are satisfied.
 20. After the final issue closes, assemble sprint review evidence.
 21. Record sprint closeout metrics including coverage and Rust tracker counts.
-22. Run the deterministic sprint closeout helper to classify `ready_to_close`, `needs_remediation`, or `blocked`, write/update the retained closeout artifact, and generate the final sprint close summary.
+22. When issue-goal token/time metrics are available, record them in the local goal-metrics sink and refresh the issue/sprint summaries without treating unknown values as zero.
+23. Run the deterministic sprint closeout helper to classify `ready_to_close`, `needs_remediation`, or `blocked`, write/update the retained closeout artifact, and generate the final sprint close summary.
 23. Only when the closeout helper reports `ready_to_close`, close the sprint-management issue.
 24. Stop with one bounded sprint review/closeout result.
 
@@ -210,6 +213,7 @@ This skill enforces:
 - no sprint-state advancement without a fresh matched live GitHub truth check
 - no next-child advancement without explicit child-closeout gate satisfaction
 - no live sprint execution without an explicit installed-skill parity/readiness result when sprint policy requires it
+- no sprint goal-metrics rollup may treat unknown or unavailable elapsed/token values as zero
 - no child issue execution when `SIP`, `STP`, or `SPP` has a `card_status`
   other than `ready` or `approved`
 - no child closeout acceptance when `SRP` or `SOR` overclaims

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -119,6 +119,7 @@ execution:
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py --state <path> --out <path> --summary-out <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py --state <path> --issue-number <n> --issue-closed true --pr-state <merged|closed_no_merge|not_applicable> --root-sor-status <done|failed> --worktree-status <pruned|retained_with_reason|not_applicable>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py --state <path> --issue-number <n> --sink <jsonl> --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --data-source <codex_goal_tool|manual_entry|derived_sprint_state|unknown>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py --state <path> --out <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -70,6 +70,12 @@ Optional:
    - for `parallel` or `hybrid` lanes, each separate worker/session creates its
      own child-session goal rather than sharing one sprint-global goal
 9. Run only the selected downstream lifecycle or editor skill.
+9a. When issue-goal metrics are available from the active session or closeout handoff, record them in the local JSONL sink:
+   - use `record_issue_goal_metrics.py`
+   - capture stage should be one of `issue_start`, `pr_publication`,
+     `review_handoff`, `merge_closeout`, or `sprint_closeout`
+   - preserve `unknown` / `not_available` for missing elapsed or token data;
+     do not substitute zero
 10. Re-check issue truth.
 11. If the issue is in a healthy PR-open waiting state, route `issue-watcher`
    so the sprint remains attached to the active child without turning healthy
@@ -109,6 +115,9 @@ Preferred live-truth helper:
 
 Preferred child-closeout advancement helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py --state <path> --issue-number <n> --issue-closed true --pr-state <merged|closed_no_merge|not_applicable> --root-sor-status <done|failed> --worktree-status <pruned|retained_with_reason|not_applicable>`
+
+Preferred issue-goal metrics helper:
+- `python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py --state <path> --issue-number <n> --sink <jsonl> --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --data-source <codex_goal_tool|manual_entry|derived_sprint_state|unknown>`
 
 ## Editor-Skill Rule
 
@@ -169,6 +178,7 @@ Record:
 - per-issue PR URLs
 - per-issue artifact links
 - sprint review result
+- issue-goal metrics rollup, when available
 - coverage snapshot
 - Rust tracker counts
 - next action

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -41,6 +41,32 @@ sprint:
       pr_url: <url or null>
       artifact_paths:
         - <path>
+      goal_metrics:
+        status: not_recorded | recorded
+        raw_log_path: <path or null>
+        record_count: <int>
+        phases_recorded:
+          - issue_start | pr_publication | review_handoff | merge_closeout | sprint_closeout
+        selected_stage: issue_start | pr_publication | review_handoff | merge_closeout | sprint_closeout | null
+        recorded_at: <timestamp or null>
+        data_source: codex_goal_tool | manual_entry | derived_sprint_state | unknown
+        goal_id: <string or null>
+        goal_id_availability: known | unknown | not_available
+        started_at: <timestamp or null>
+        completed_at: <timestamp or null>
+        elapsed_seconds: <int or null>
+        elapsed_availability: known | unknown | not_available
+        token_usage:
+          total_tokens: <int or null>
+          prompt_tokens: <int or null>
+          completion_tokens: <int or null>
+          availability: known | unknown | not_available
+          total_availability: known | unknown | not_available
+          prompt_availability: known | unknown | not_available
+          completion_availability: known | unknown | not_available
+        model_ref: <string or null>
+        session_ref: <string or null>
+        thread_id: <string or null>
       closeout_gate:
         issue_closed: true | false
         pr_state: merged | closed_no_merge | not_applicable | unknown
@@ -155,6 +181,16 @@ closeout:
   closeout_artifact_path: <path or null>
   sprint_issue_close_summary: <bounded text or null>
   closure_cleanliness: clean | clean_with_post_sprint_followups | residual_debt | unknown
+  goal_metrics_rollup:
+    issue_count: <int>
+    issues_with_recorded_metrics: <int>
+    issues_without_recorded_metrics: <int>
+    issues_with_known_elapsed: <int>
+    issues_with_unknown_elapsed: <int>
+    issues_with_known_total_tokens: <int>
+    issues_with_unknown_total_tokens: <int>
+    total_elapsed_seconds_known_sum: <int>
+    total_tokens_known_sum: <int>
   coverage:
     source: local_run | ci | existing_quality_gate | not_applicable | missing
     summary: <bounded text>

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -9,6 +9,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from issue_goal_metrics import default_goal_metrics_summary
+
 
 def parse_csv_ints(raw: str) -> list[int]:
     values: list[int] = []
@@ -204,6 +206,7 @@ def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
             'status': 'pending',
             'pr_url': None,
             'artifact_paths': [],
+            'goal_metrics': default_goal_metrics_summary(),
         }
         for issue in ordered
     ]

--- a/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+
+AVAILABILITY_VALUES = {"known", "unknown", "not_available"}
+CAPTURE_STAGES = {
+    "issue_start",
+    "pr_publication",
+    "review_handoff",
+    "merge_closeout",
+    "sprint_closeout",
+}
+DATA_SOURCE_VALUES = {
+    "codex_goal_tool",
+    "manual_entry",
+    "derived_sprint_state",
+    "unknown",
+}
+STAGE_PRIORITY = {
+    "issue_start": 1,
+    "pr_publication": 2,
+    "review_handoff": 3,
+    "merge_closeout": 4,
+    "sprint_closeout": 5,
+}
+
+
+def iso_now_utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_goal_metrics_summary() -> dict[str, Any]:
+    return {
+        "status": "not_recorded",
+        "raw_log_path": None,
+        "record_count": 0,
+        "phases_recorded": [],
+        "selected_stage": None,
+        "recorded_at": None,
+        "data_source": "unknown",
+        "goal_id": None,
+        "goal_id_availability": "unknown",
+        "started_at": None,
+        "completed_at": None,
+        "elapsed_seconds": None,
+        "elapsed_availability": "unknown",
+        "token_usage": {
+            "total_tokens": None,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "availability": "unknown",
+            "total_availability": "unknown",
+            "prompt_availability": "unknown",
+            "completion_availability": "unknown",
+        },
+        "model_ref": None,
+        "session_ref": None,
+        "thread_id": None,
+    }
+
+
+def parse_availability_int(raw: str | None) -> tuple[str, int | None]:
+    if raw is None:
+        return "unknown", None
+    lowered = raw.strip().lower()
+    if lowered in {"unknown", "not_available"}:
+        return lowered, None
+    return "known", int(lowered)
+
+
+def normalize_goal_id(goal_id: str | None, goal_id_state: str | None) -> tuple[str | None, str]:
+    if goal_id is not None:
+        return goal_id, "known"
+    if goal_id_state is None:
+        return None, "unknown"
+    lowered = goal_id_state.strip().lower()
+    if lowered not in AVAILABILITY_VALUES:
+        raise ValueError(f"invalid goal_id availability: {goal_id_state}")
+    return None, lowered
+
+
+def build_issue_goal_metrics_record(
+    *,
+    sprint_issue_number: int | None,
+    issue_number: int,
+    capture_stage: str,
+    data_source: str,
+    raw_log_path: str,
+    recorded_at: str | None,
+    goal_id: str | None,
+    goal_id_state: str | None,
+    started_at: str | None,
+    completed_at: str | None,
+    elapsed_seconds_raw: str | None,
+    total_tokens_raw: str | None,
+    prompt_tokens_raw: str | None,
+    completion_tokens_raw: str | None,
+    model_ref: str | None,
+    session_ref: str | None,
+    thread_id: str | None,
+) -> dict[str, Any]:
+    if capture_stage not in CAPTURE_STAGES:
+        raise ValueError(f"invalid capture stage: {capture_stage}")
+    if data_source not in DATA_SOURCE_VALUES:
+        raise ValueError(f"invalid data source: {data_source}")
+
+    goal_id_value, goal_id_availability = normalize_goal_id(goal_id, goal_id_state)
+    elapsed_availability, elapsed_seconds = parse_availability_int(elapsed_seconds_raw)
+    total_availability, total_tokens = parse_availability_int(total_tokens_raw)
+    prompt_availability, prompt_tokens = parse_availability_int(prompt_tokens_raw)
+    completion_availability, completion_tokens = parse_availability_int(completion_tokens_raw)
+    token_availability = (
+        "known"
+        if any(value == "known" for value in (total_availability, prompt_availability, completion_availability))
+        else "not_available"
+        if all(value == "not_available" for value in (total_availability, prompt_availability, completion_availability))
+        else "unknown"
+    )
+
+    return {
+        "schema_version": "issue_goal_metrics.v1",
+        "recorded_at": recorded_at or iso_now_utc(),
+        "sprint_issue_number": sprint_issue_number,
+        "issue_number": issue_number,
+        "capture_stage": capture_stage,
+        "data_source": data_source,
+        "raw_log_path": raw_log_path,
+        "goal_id": goal_id_value,
+        "goal_id_availability": goal_id_availability,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "elapsed_seconds": elapsed_seconds,
+        "elapsed_availability": elapsed_availability,
+        "token_usage": {
+            "total_tokens": total_tokens,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "availability": token_availability,
+            "total_availability": total_availability,
+            "prompt_availability": prompt_availability,
+            "completion_availability": completion_availability,
+        },
+        "model_ref": model_ref,
+        "session_ref": session_ref,
+        "thread_id": thread_id,
+    }
+
+
+def summarize_issue_goal_metrics(records: list[dict[str, Any]], raw_log_path: str | None) -> dict[str, Any]:
+    if not records:
+        summary = default_goal_metrics_summary()
+        summary["raw_log_path"] = raw_log_path
+        return summary
+
+    def sort_key(record: dict[str, Any]) -> tuple[int, str]:
+        return (
+            STAGE_PRIORITY.get(record.get("capture_stage"), 0),
+            record.get("recorded_at") or "",
+        )
+
+    selected = sorted(records, key=sort_key)[-1]
+    summary = default_goal_metrics_summary()
+    summary["status"] = "recorded"
+    summary["raw_log_path"] = raw_log_path
+    summary["record_count"] = len(records)
+    summary["phases_recorded"] = sorted(
+        {record.get("capture_stage") for record in records if record.get("capture_stage")}
+    )
+    summary["selected_stage"] = selected.get("capture_stage")
+    summary["recorded_at"] = selected.get("recorded_at")
+    summary["data_source"] = selected.get("data_source") or "unknown"
+    summary["goal_id"] = selected.get("goal_id")
+    summary["goal_id_availability"] = selected.get("goal_id_availability") or "unknown"
+    summary["started_at"] = selected.get("started_at")
+    summary["completed_at"] = selected.get("completed_at")
+    summary["elapsed_seconds"] = selected.get("elapsed_seconds")
+    summary["elapsed_availability"] = selected.get("elapsed_availability") or "unknown"
+    summary["token_usage"] = deepcopy(selected.get("token_usage") or summary["token_usage"])
+    summary["model_ref"] = selected.get("model_ref")
+    summary["session_ref"] = selected.get("session_ref")
+    summary["thread_id"] = selected.get("thread_id")
+    return summary
+
+
+def compute_goal_metrics_rollup(issue_records: list[dict[str, Any]]) -> dict[str, Any]:
+    rollup = {
+        "issue_count": 0,
+        "issues_with_recorded_metrics": 0,
+        "issues_without_recorded_metrics": 0,
+        "issues_with_known_elapsed": 0,
+        "issues_with_unknown_elapsed": 0,
+        "issues_with_known_total_tokens": 0,
+        "issues_with_unknown_total_tokens": 0,
+        "total_elapsed_seconds_known_sum": 0,
+        "total_tokens_known_sum": 0,
+    }
+    for record in issue_records:
+        rollup["issue_count"] += 1
+        summary = record.get("goal_metrics") or default_goal_metrics_summary()
+        if summary.get("status") == "recorded":
+            rollup["issues_with_recorded_metrics"] += 1
+        else:
+            rollup["issues_without_recorded_metrics"] += 1
+
+        if summary.get("elapsed_availability") == "known" and isinstance(summary.get("elapsed_seconds"), int):
+            rollup["issues_with_known_elapsed"] += 1
+            rollup["total_elapsed_seconds_known_sum"] += int(summary["elapsed_seconds"])
+        else:
+            rollup["issues_with_unknown_elapsed"] += 1
+
+        token_usage = summary.get("token_usage") or {}
+        if token_usage.get("total_availability") == "known" and isinstance(token_usage.get("total_tokens"), int):
+            rollup["issues_with_known_total_tokens"] += 1
+            rollup["total_tokens_known_sum"] += int(token_usage["total_tokens"])
+        else:
+            rollup["issues_with_unknown_total_tokens"] += 1
+    return rollup

--- a/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from issue_goal_metrics import default_goal_metrics_summary
+
 
 DETERMINISTIC_CLOSEOUT_ELIGIBLE_STATUSES = {'pending', 'active', 'waiting_for_review'}
 
@@ -24,12 +26,14 @@ def ensure_issue_record(state: dict[str, Any], issue_number: int) -> dict[str, A
         if record.get('issue_number') == issue_number:
             record.setdefault('artifact_paths', [])
             record.setdefault('pr_url', None)
+            record.setdefault('goal_metrics', default_goal_metrics_summary())
             return record
     record = {
         'issue_number': issue_number,
         'status': 'pending',
         'pr_url': None,
         'artifact_paths': [],
+        'goal_metrics': default_goal_metrics_summary(),
     }
     state['issue_records'].append(record)
     return record

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from issue_goal_metrics import (
+    CAPTURE_STAGES,
+    DATA_SOURCE_VALUES,
+    build_issue_goal_metrics_record,
+    compute_goal_metrics_rollup,
+    default_goal_metrics_summary,
+    summarize_issue_goal_metrics,
+)
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def write_state(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def ensure_issue_record(state: dict[str, Any], issue_number: int) -> dict[str, Any]:
+    for record in state.setdefault("issue_records", []):
+        if record.get("issue_number") == issue_number:
+            record.setdefault("artifact_paths", [])
+            record.setdefault("pr_url", None)
+            record.setdefault("goal_metrics", default_goal_metrics_summary())
+            return record
+    raise ValueError(f"issue #{issue_number} is not present in sprint issue_records")
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        rows.append(json.loads(stripped))
+    return rows
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--issue-number", type=int, required=True)
+    parser.add_argument("--sink", required=True)
+    parser.add_argument("--capture-stage", required=True, choices=sorted(CAPTURE_STAGES))
+    parser.add_argument("--data-source", required=True, choices=sorted(DATA_SOURCE_VALUES))
+    parser.add_argument("--recorded-at")
+    parser.add_argument("--goal-id")
+    parser.add_argument("--goal-id-state", choices=["known", "unknown", "not_available"])
+    parser.add_argument("--started-at")
+    parser.add_argument("--completed-at")
+    parser.add_argument("--elapsed-seconds")
+    parser.add_argument("--total-tokens")
+    parser.add_argument("--prompt-tokens")
+    parser.add_argument("--completion-tokens")
+    parser.add_argument("--model-ref")
+    parser.add_argument("--session-ref")
+    parser.add_argument("--thread-id")
+    parser.add_argument("--print-json", action="store_true")
+    args = parser.parse_args()
+
+    state_path = Path(args.state)
+    state = load_state(state_path)
+    sink_path = Path(args.sink)
+    ordered_issue_numbers = set(state.get("ordered_issue_numbers", []))
+    if args.issue_number not in ordered_issue_numbers:
+        raise ValueError(f"issue #{args.issue_number} is not present in ordered_issue_numbers")
+
+    record = build_issue_goal_metrics_record(
+        sprint_issue_number=state.get("sprint_issue_number"),
+        issue_number=args.issue_number,
+        capture_stage=args.capture_stage,
+        data_source=args.data_source,
+        raw_log_path=str(sink_path),
+        recorded_at=args.recorded_at,
+        goal_id=args.goal_id,
+        goal_id_state=args.goal_id_state,
+        started_at=args.started_at,
+        completed_at=args.completed_at,
+        elapsed_seconds_raw=args.elapsed_seconds,
+        total_tokens_raw=args.total_tokens,
+        prompt_tokens_raw=args.prompt_tokens,
+        completion_tokens_raw=args.completion_tokens,
+        model_ref=args.model_ref,
+        session_ref=args.session_ref,
+        thread_id=args.thread_id,
+    )
+    append_jsonl(sink_path, record)
+
+    all_rows = read_jsonl(sink_path)
+    issue_rows = [row for row in all_rows if row.get("issue_number") == args.issue_number]
+    issue_record = ensure_issue_record(state, args.issue_number)
+    issue_record["goal_metrics"] = summarize_issue_goal_metrics(issue_rows, str(sink_path))
+
+    closeout = state.setdefault("closeout", {})
+    closeout["goal_metrics_rollup"] = compute_goal_metrics_rollup(state.get("issue_records", []))
+
+    write_state(state_path, state)
+
+    result = {
+        "recorded": record,
+        "issue_goal_metrics_summary": issue_record["goal_metrics"],
+        "goal_metrics_rollup": closeout["goal_metrics_rollup"],
+        "state_path": str(state_path),
+        "sink_path": str(sink_path),
+    }
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(str(sink_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from issue_goal_metrics import default_goal_metrics_summary
+
 
 def parse_csv_ints(raw: str) -> list[int]:
     values = []
@@ -24,6 +26,7 @@ def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
             'status': 'pending',
             'pr_url': None,
             'artifact_paths': [],
+            'goal_metrics': default_goal_metrics_summary(),
         }
         for issue in ordered
     ]
@@ -64,12 +67,14 @@ def ensure_issue_record(state: dict[str, Any], issue_number: int) -> dict[str, A
         if record.get('issue_number') == issue_number:
             record.setdefault('artifact_paths', [])
             record.setdefault('pr_url', None)
+            record.setdefault('goal_metrics', default_goal_metrics_summary())
             return record
     record = {
         'issue_number': issue_number,
         'status': 'pending',
         'pr_url': None,
         'artifact_paths': [],
+        'goal_metrics': default_goal_metrics_summary(),
     }
     state['issue_records'].append(record)
     return record

--- a/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
+++ b/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
@@ -5,6 +5,8 @@ import argparse
 import json
 from pathlib import Path
 
+from issue_goal_metrics import compute_goal_metrics_rollup, default_goal_metrics_summary
+
 
 def closure_cleanliness(state: dict) -> str:
     records = {record.get('issue_number'): record for record in state.get('issue_records', [])}
@@ -38,6 +40,7 @@ def main() -> int:
 
     records = {record.get('issue_number'): record for record in state.get('issue_records', [])}
     cleanliness = closure_cleanliness(state)
+    goal_metrics_rollup = compute_goal_metrics_rollup(state.get('issue_records', []))
 
     lines = [
         '# Sprint Closeout Artifact',
@@ -69,6 +72,18 @@ def main() -> int:
             worktree_note = closeout_gate.get('worktree_note')
             if worktree_note:
                 lines.append(f"  - worktree note: {worktree_note}")
+        goal_metrics = record.get('goal_metrics') or default_goal_metrics_summary()
+        lines.append(
+            "  - goal metrics: "
+            f"`status={goal_metrics.get('status', 'not_recorded')}, "
+            f"stage={goal_metrics.get('selected_stage') or 'not_recorded'}, "
+            f"goal_id={goal_metrics.get('goal_id') or goal_metrics.get('goal_id_availability', 'unknown')}, "
+            f"elapsed={goal_metrics.get('elapsed_seconds') if goal_metrics.get('elapsed_seconds') is not None else goal_metrics.get('elapsed_availability', 'unknown')}, "
+            f"total_tokens={goal_metrics.get('token_usage', {}).get('total_tokens') if goal_metrics.get('token_usage', {}).get('total_tokens') is not None else goal_metrics.get('token_usage', {}).get('total_availability', goal_metrics.get('token_usage', {}).get('availability', 'unknown'))}, "
+            f"source={goal_metrics.get('data_source') or 'unknown'}`"
+        )
+        if goal_metrics.get('raw_log_path'):
+            lines.append(f"  - goal metrics log: `{goal_metrics['raw_log_path']}`")
 
     lines.extend(['', '## Follow-up Issues', ''])
     follow_ups = state.get('follow_up_issues', [])
@@ -96,16 +111,31 @@ def main() -> int:
     )
     lines.append(f"- sprint close summary: `{closeout.get('sprint_issue_close_summary') or state.get('sprint_issue_close_summary') or 'not_recorded'}`")
 
+    lines.extend(['', '## Goal Metrics Rollup', ''])
+    lines.append(f"- issues with recorded metrics: `{goal_metrics_rollup['issues_with_recorded_metrics']}/{goal_metrics_rollup['issue_count']}`")
+    lines.append(
+        f"- elapsed seconds: `known_sum={goal_metrics_rollup['total_elapsed_seconds_known_sum']}, "
+        f"known_issue_count={goal_metrics_rollup['issues_with_known_elapsed']}, "
+        f"unknown_issue_count={goal_metrics_rollup['issues_with_unknown_elapsed']}`"
+    )
+    lines.append(
+        f"- total tokens: `known_sum={goal_metrics_rollup['total_tokens_known_sum']}, "
+        f"known_issue_count={goal_metrics_rollup['issues_with_known_total_tokens']}, "
+        f"unknown_issue_count={goal_metrics_rollup['issues_with_unknown_total_tokens']}`"
+    )
+
     out_path.write_text('\n'.join(lines).rstrip() + '\n', encoding='utf-8')
 
     state.setdefault('closeout', {})
     state['closeout']['closeout_artifact_path'] = str(out_path)
     state['closeout']['closure_cleanliness'] = cleanliness
+    state['closeout']['goal_metrics_rollup'] = goal_metrics_rollup
     state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
 
     result = {
         'closeout_artifact_path': str(out_path),
         'closure_cleanliness': cleanliness,
+        'goal_metrics_rollup': goal_metrics_rollup,
     }
     if args.print_json:
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -249,6 +249,104 @@ EOF
   assert_has "$rust_test_manifest_output" "coverage_authority=pr_changed_surface"
   assert_has "$rust_test_manifest_output" "reason=bounded_rust_surface_runs_focused_nextest"
 
+  git checkout -q -b sprint-conductor-surface "$base_sha"
+  mkdir -p adl/tools/skills/sprint-conductor/scripts
+  printf '# sprint conductor skill\n' > adl/tools/skills/sprint-conductor/SKILL.md
+  printf 'print(\"goal metrics\")\n' > adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_sprint_conductor_helpers.sh
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_install_adl_operational_skills.sh
+  printf '\nsprint conductor note\n' >> docs/readme.md
+  git add adl/tools/skills/sprint-conductor/SKILL.md \
+    adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py \
+    adl/tools/test_sprint_conductor_helpers.sh \
+    adl/tools/test_install_adl_operational_skills.sh \
+    docs/readme.md
+  git commit -q -m sprint-conductor-surface
+  sprint_conductor_head="$(git rev-parse HEAD)"
+
+  sprint_conductor_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$sprint_conductor_head" --ref "refs/pull/1/merge")"
+  assert_has "$sprint_conductor_output" "rust_required=false"
+  assert_has "$sprint_conductor_output" "coverage_required=false"
+  assert_has "$sprint_conductor_output" "full_coverage_required=false"
+  assert_has "$sprint_conductor_output" "demo_smoke_required=false"
+  assert_has "$sprint_conductor_output" "v0913_proof_required=false"
+  assert_has "$sprint_conductor_output" "release_version_only=false"
+  assert_has "$sprint_conductor_output" "ci_contracts_required=false"
+  assert_has "$sprint_conductor_output" "fail_closed=false"
+  assert_has "$sprint_conductor_output" "coverage_lane=skip"
+  assert_has "$sprint_conductor_output" "coverage_authority=not_required"
+  assert_has "$sprint_conductor_output" "reason=sprint_conductor_surface_requires_helper_contract_checks"
+  assert_has "$sprint_conductor_output" "validation_profile_status=ready_to_run"
+  assert_has "$sprint_conductor_output" "validation_profile_escalation_required=false"
+  assert_has "$sprint_conductor_output" "validation_profile_run_lanes=docs_diff_check,sprint_conductor_contracts"
+
+  git checkout -q -b sprint-conductor-only "$base_sha"
+  mkdir -p adl/tools/skills/sprint-conductor/scripts
+  printf '# sprint conductor skill\n' > adl/tools/skills/sprint-conductor/SKILL.md
+  printf 'print(\"goal metrics\")\n' > adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_sprint_conductor_helpers.sh
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_install_adl_operational_skills.sh
+  git add adl/tools/skills/sprint-conductor/SKILL.md \
+    adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py \
+    adl/tools/test_sprint_conductor_helpers.sh \
+    adl/tools/test_install_adl_operational_skills.sh
+  git commit -q -m sprint-conductor-only
+  sprint_conductor_only_head="$(git rev-parse HEAD)"
+
+  sprint_conductor_only_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$sprint_conductor_only_head" --ref "refs/pull/1/merge")"
+  assert_has "$sprint_conductor_only_output" "rust_required=false"
+  assert_has "$sprint_conductor_only_output" "coverage_required=false"
+  assert_has "$sprint_conductor_only_output" "full_coverage_required=false"
+  assert_has "$sprint_conductor_only_output" "demo_smoke_required=false"
+  assert_has "$sprint_conductor_only_output" "v0913_proof_required=false"
+  assert_has "$sprint_conductor_only_output" "release_version_only=false"
+  assert_has "$sprint_conductor_only_output" "ci_contracts_required=false"
+  assert_has "$sprint_conductor_only_output" "fail_closed=false"
+  assert_has "$sprint_conductor_only_output" "coverage_lane=skip"
+  assert_has "$sprint_conductor_only_output" "coverage_authority=not_required"
+  assert_has "$sprint_conductor_only_output" "reason=sprint_conductor_surface_requires_helper_contract_checks"
+  assert_has "$sprint_conductor_only_output" "validation_profile_status=ready_to_run"
+  assert_has "$sprint_conductor_only_output" "validation_profile_escalation_required=false"
+  assert_has "$sprint_conductor_only_output" "validation_profile_run_lanes=sprint_conductor_contracts"
+
+  git checkout -q -b classifier-followup "$base_sha"
+  mkdir -p adl/tools/skills/sprint-conductor/scripts adl/config adl/tools
+  printf '# sprint conductor skill\n' > adl/tools/skills/sprint-conductor/SKILL.md
+  printf 'print(\"goal metrics\")\n' > adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_sprint_conductor_helpers.sh
+  printf '#!/usr/bin/env bash\nexit 0\n' > adl/tools/test_install_adl_operational_skills.sh
+  printf '#!/usr/bin/env bash\nprintf ok\\n' > adl/tools/ci_path_policy.sh
+  printf '#!/usr/bin/env bash\nprintf ok\\n' > adl/tools/test_ci_path_policy.sh
+  printf '{\"schema_version\":\"adl.validation_lane_selector.v1\",\"surface_defaults\":{},\"lanes\":[],\"special_surfaces\":{},\"manager_guardrails\":{\"docs_only_forbidden_lane_ids\":[\"rust_pr_fast\"],\"pr_fast\":{\"max_rust_surface_count\":4,\"max_filter_token_count\":4,\"max_family_token_count\":3,\"blocked_modes\":[\"full\",\"contract_only\"]}},\"release_gate_hints\":[],\"rust_path_hints\":[]}\n' > adl/config/validation_lane_selector.v0.91.6.json
+  printf '#!/usr/bin/env bash\nprintf ok\\n' > adl/tools/test_validation_manager.sh
+  printf '\nclassifier followup note\n' >> docs/readme.md
+  git add adl/config/validation_lane_selector.v0.91.6.json \
+    adl/tools/ci_path_policy.sh \
+    adl/tools/test_ci_path_policy.sh \
+    adl/tools/test_validation_manager.sh \
+    adl/tools/skills/sprint-conductor/SKILL.md \
+    adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py \
+    adl/tools/test_sprint_conductor_helpers.sh \
+    adl/tools/test_install_adl_operational_skills.sh \
+    docs/readme.md
+  git commit -q -m classifier-followup
+  classifier_followup_head="$(git rev-parse HEAD)"
+
+  classifier_followup_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$classifier_followup_head" --ref "refs/pull/1/merge")"
+  assert_has "$classifier_followup_output" "rust_required=false"
+  assert_has "$classifier_followup_output" "coverage_required=false"
+  assert_has "$classifier_followup_output" "full_coverage_required=false"
+  assert_has "$classifier_followup_output" "demo_smoke_required=false"
+  assert_has "$classifier_followup_output" "v0913_proof_required=false"
+  assert_has "$classifier_followup_output" "release_version_only=false"
+  assert_has "$classifier_followup_output" "ci_contracts_required=true"
+  assert_has "$classifier_followup_output" "fail_closed=false"
+  assert_has "$classifier_followup_output" "coverage_lane=skip"
+  assert_has "$classifier_followup_output" "coverage_authority=not_required"
+  assert_has "$classifier_followup_output" "reason=ci_policy_surface_requires_path_policy_contract_checks"
+  assert_has "$classifier_followup_output" "validation_profile_status=ready_to_run"
+  assert_has "$classifier_followup_output" "validation_profile_escalation_required=false"
+
   git checkout -q -b new-runtime-file "$base_sha"
   printf 'pub fn contract_schema() -> bool { true }\n' > adl/src/contract_schema.rs
   git add adl/src/contract_schema.rs

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -75,6 +75,7 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/close_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/record_child_issue_closeout.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/record_issue_goal_metrics.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_truth.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/validate_review_subagent_policy.py" ]]
@@ -117,6 +118,7 @@ assert_skill_bundle() {
   grep -Fq "Structured Review Prompt" "${root}/skills/srp-editor/SKILL.md"
   grep -Fq "one issue at a time, fully closed out before the next" "${root}/skills/sprint-conductor/SKILL.md"
   grep -Fq "attach the issue-bound session-goal requirement as part of the SEP handoff" "${root}/skills/sprint-conductor/SKILL.md"
+  grep -Fq "issue-goal metrics are available" "${root}/skills/sprint-conductor/references/conductor-playbook.md"
   grep -Fq "findings-first review orchestrator" "${root}/skills/sprint-review/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1017,6 +1017,165 @@ assert "srp.md" in problem["missing_cards"]
 assert "srp-editor" in problem["required_editor_skills"]
 PY
 
+goal_metrics_state_path="${tmpdir}/goal-metrics-state.json"
+cat >"${goal_metrics_state_path}" <<'JSON'
+{
+  "sprint_issue_number": 7001,
+  "ordered_issue_numbers": [7002, 7003],
+  "issue_records": [
+    {"issue_number": 7002, "status": "closed_out", "pr_url": null, "artifact_paths": []},
+    {"issue_number": 7003, "status": "closed_out", "pr_url": null, "artifact_paths": []}
+  ],
+  "closeout": {}
+}
+JSON
+goal_metrics_log="${tmpdir}/issue-goal-metrics.jsonl"
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py" \
+  --state "${goal_metrics_state_path}" \
+  --issue-number 7002 \
+  --sink "${goal_metrics_log}" \
+  --capture-stage merge_closeout \
+  --data-source codex_goal_tool \
+  --recorded-at "2026-06-20T03:00:00Z" \
+  --goal-id "goal-7002" \
+  --started-at "2026-06-20T02:30:00Z" \
+  --completed-at "2026-06-20T02:56:02Z" \
+  --elapsed-seconds 1562 \
+  --total-tokens 325020 \
+  --model-ref "gpt-5-codex" \
+  --session-ref "codex-session-7002" \
+  --thread-id "thread-7002" >/dev/null
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py" \
+  --state "${goal_metrics_state_path}" \
+  --issue-number 7003 \
+  --sink "${goal_metrics_log}" \
+  --capture-stage review_handoff \
+  --data-source manual_entry \
+  --recorded-at "2026-06-20T03:10:00Z" \
+  --goal-id-state not_available \
+  --elapsed-seconds not_available \
+  --total-tokens unknown \
+  --model-ref "gpt-5-codex" >/dev/null
+
+python3 - "${goal_metrics_state_path}" "${goal_metrics_log}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+lines = [json.loads(line) for line in Path(sys.argv[2]).read_text().splitlines() if line.strip()]
+assert len(lines) == 2
+record_7002 = next(record for record in state["issue_records"] if record["issue_number"] == 7002)
+record_7003 = next(record for record in state["issue_records"] if record["issue_number"] == 7003)
+assert record_7002["goal_metrics"]["status"] == "recorded"
+assert record_7002["goal_metrics"]["elapsed_seconds"] == 1562
+assert record_7002["goal_metrics"]["elapsed_availability"] == "known"
+assert record_7002["goal_metrics"]["token_usage"]["total_tokens"] == 325020
+assert record_7002["goal_metrics"]["token_usage"]["total_availability"] == "known"
+assert record_7003["goal_metrics"]["goal_id_availability"] == "not_available"
+assert record_7003["goal_metrics"]["elapsed_availability"] == "not_available"
+assert record_7003["goal_metrics"]["token_usage"]["total_availability"] == "unknown"
+rollup = state["closeout"]["goal_metrics_rollup"]
+assert rollup["issue_count"] == 2
+assert rollup["issues_with_recorded_metrics"] == 2
+assert rollup["issues_with_known_elapsed"] == 1
+assert rollup["issues_with_unknown_elapsed"] == 1
+assert rollup["issues_with_known_total_tokens"] == 1
+assert rollup["issues_with_unknown_total_tokens"] == 1
+assert rollup["total_elapsed_seconds_known_sum"] == 1562
+assert rollup["total_tokens_known_sum"] == 325020
+PY
+
+goal_metrics_default_state_path="${tmpdir}/goal-metrics-default-state.json"
+cat >"${goal_metrics_default_state_path}" <<'JSON'
+{
+  "sprint_issue_number": 7001,
+  "ordered_issue_numbers": [7002],
+  "issue_records": [
+    {
+      "issue_number": 7002,
+      "status": "pending",
+      "pr_url": null,
+      "artifact_paths": [],
+      "goal_metrics": {
+        "status": "not_recorded",
+        "raw_log_path": null,
+        "record_count": 0,
+        "phases_recorded": [],
+        "selected_stage": null,
+        "recorded_at": null,
+        "data_source": "unknown",
+        "goal_id": null,
+        "goal_id_availability": "unknown",
+        "started_at": null,
+        "completed_at": null,
+        "elapsed_seconds": null,
+        "elapsed_availability": "unknown",
+        "token_usage": {
+          "total_tokens": null,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "availability": "unknown",
+          "total_availability": "unknown",
+          "prompt_availability": "unknown",
+          "completion_availability": "unknown"
+        },
+        "model_ref": null,
+        "session_ref": null,
+        "thread_id": null
+      }
+    }
+  ],
+  "closeout": {}
+}
+JSON
+
+python3 - "${goal_metrics_default_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+token_usage = state["issue_records"][0]["goal_metrics"]["token_usage"]
+assert token_usage["availability"] == "unknown"
+assert token_usage["total_availability"] == "unknown"
+assert token_usage["prompt_availability"] == "unknown"
+assert token_usage["completion_availability"] == "unknown"
+PY
+
+goal_metrics_invalid_log="${tmpdir}/issue-goal-metrics-invalid.jsonl"
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py" \
+  --state "${goal_metrics_state_path}" \
+  --issue-number 7999 \
+  --sink "${goal_metrics_invalid_log}" \
+  --capture-stage merge_closeout \
+  --data-source codex_goal_tool >/dev/null 2>"${tmpdir}/goal-metrics-invalid.stderr"; then
+  echo "expected non-member issue metrics recording to fail" >&2
+  exit 1
+fi
+grep -Fq 'issue #7999 is not present in ordered_issue_numbers' "${tmpdir}/goal-metrics-invalid.stderr"
+python3 - "${goal_metrics_state_path}" "${goal_metrics_invalid_log}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+assert [record["issue_number"] for record in state["issue_records"]] == [7002, 7003]
+assert not Path(sys.argv[2]).exists()
+PY
+
+goal_metrics_artifact="${tmpdir}/goal-metrics-closeout.md"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py" \
+  --state "${goal_metrics_state_path}" \
+  --out "${goal_metrics_artifact}" >/dev/null
+
+grep -Fq '## Goal Metrics Rollup' "${goal_metrics_artifact}"
+grep -Fq 'issues with recorded metrics: `2/2`' "${goal_metrics_artifact}"
+grep -Fq 'elapsed seconds: `known_sum=1562, known_issue_count=1, unknown_issue_count=1`' "${goal_metrics_artifact}"
+grep -Fq 'total tokens: `known_sum=325020, known_issue_count=1, unknown_issue_count=1`' "${goal_metrics_artifact}"
+
 echo "PASS test_sprint_conductor_helpers"
 
 closeout_readiness_blocked_state="${tmpdir}/closeout-readiness-blocked-state.json"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -218,6 +218,88 @@ if bash "$SCRIPT" --changed-files "$mixed" --run >"$TMP/mixed-run.out" 2>"$TMP/m
 fi
 assert_has "$TMP/mixed-run.err" "refusing --run for non-runnable profile"
 
+sprint_conductor="$TMP/sprint-conductor.txt"
+cat >"$sprint_conductor" <<'EOF'
+M	adl/tools/skills/sprint-conductor/SKILL.md
+M	adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+M	adl/tools/test_sprint_conductor_helpers.sh
+M	adl/tools/test_install_adl_operational_skills.sh
+EOF
+bash "$SCRIPT" --changed-files "$sprint_conductor" --json >"$TMP/sprint-conductor.json"
+python3 - <<'PY' "$TMP/sprint-conductor.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "sprint_conductor_contracts_profile"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert [item["lane_id"] for item in profile["run"]] == ["sprint_conductor_contracts"]
+surface_ids = {surface["id"] for surface in profile["behavior_surfaces"]}
+assert "regression_sprint_conductor_contracts" in surface_ids
+assert profile["diagnostics"] == []
+assert profile["escalation"]["required"] is False
+PY
+
+sprint_conductor_mixed="$TMP/sprint-conductor-mixed.txt"
+cat >"$sprint_conductor_mixed" <<'EOF'
+M	adl/tools/skills/sprint-conductor/SKILL.md
+M	adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+M	adl/tools/test_sprint_conductor_helpers.sh
+M	adl/tools/test_install_adl_operational_skills.sh
+M	docs/milestones/v0.91.6/README.md
+EOF
+bash "$SCRIPT" --changed-files "$sprint_conductor_mixed" --json >"$TMP/sprint-conductor-mixed.json"
+python3 - <<'PY' "$TMP/sprint-conductor-mixed.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert {item["lane_id"] for item in profile["run"]} == {
+    "sprint_conductor_contracts",
+    "docs_diff_check",
+}
+surface_ids = {surface["id"] for surface in profile["behavior_surfaces"]}
+assert "regression_sprint_conductor_contracts" in surface_ids
+assert "diff_hygiene_docs_diff_check" in surface_ids
+assert profile["diagnostics"] == []
+assert profile["escalation"]["required"] is False
+PY
+
+classifier_followup="$TMP/classifier-followup.txt"
+cat >"$classifier_followup" <<'EOF'
+M	adl/config/validation_lane_selector.v0.91.6.json
+M	adl/tools/ci_path_policy.sh
+M	adl/tools/test_ci_path_policy.sh
+M	adl/tools/test_validation_manager.sh
+M	adl/tools/skills/sprint-conductor/SKILL.md
+M	adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+M	adl/tools/test_sprint_conductor_helpers.sh
+M	adl/tools/test_install_adl_operational_skills.sh
+M	docs/milestones/v0.91.6/README.md
+EOF
+bash "$SCRIPT" --changed-files "$classifier_followup" --json >"$TMP/classifier-followup.json"
+python3 - <<'PY' "$TMP/classifier-followup.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert {item["lane_id"] for item in profile["run"]} == {
+    "ci_path_policy_contracts",
+    "sprint_conductor_contracts",
+    "docs_diff_check",
+}
+assert profile["escalation"]["required"] is False
+assert profile["diagnostics"] == []
+PY
+
 owner_mix="$TMP/owner-mix.txt"
 printf 'M\tadl/tools/pr.sh\nM\tadl/src/bin/adl_runtime.rs\n' >"$owner_mix"
 bash "$SCRIPT" --changed-files "$owner_mix" --json >"$TMP/owner-mix.json"


### PR DESCRIPTION
Closes #4264

## Summary
Added bounded sprint-conductor support for issue-bound goal token/time metrics
capture by introducing explicit goal-metrics record and rollup helpers,
threading default goal-metrics summaries through sprint state helpers,
extending the sprint closeout artifact and contract to surface per-issue and
rollup metrics truthfully, and adding focused proof for known, unknown, and
rejected metrics-capture paths.

## Artifacts
- Tracked documentation and contract updates in
  `adl/tools/skills/sprint-conductor/SKILL.md`,
  `adl/tools/skills/sprint-conductor/adl-skill.yaml`,
  `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`, and
  `adl/tools/skills/sprint-conductor/references/output-contract.md`
- New tracked helpers in
  `adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py` and
  `adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py`
- Tracked sprint-state and closeout helper updates in
  `adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py`,
  `adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py`,
  `adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py`, and
  `adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py`
- Tracked focused proof updates in `adl/tools/test_sprint_conductor_helpers.sh`
  and `adl/tools/test_install_adl_operational_skills.sh`
- Local ignored review/execution record updates in this issue bundle

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py adl/tools/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py`
    Verified the new metrics helpers and touched sprint-conductor scripts parse
    cleanly as Python.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/sprint-conductor/SKILL.md`
    Verified the changed sprint-conductor skill frontmatter remains valid.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified the focused sprint helper lane, including per-issue goal-metrics
    capture, closeout rollups, default availability shape, and fail-closed
    rejection of non-member issue numbers.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified the installed operational skills bundle carries the new
    sprint-conductor metrics helper and documentation surfaces.
  - `git diff --check`
    Verified whitespace and patch hygiene for the tracked issue diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4264__v0-91-6-tools-capture-issue-goal-token-and-time-statistics/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4264__v0-91-6-tools-capture-issue-goal-token-and-time-statistics/sor.md
- Idempotency-Key: v0-91-6-tools-metrics-capture-issue-goal-token-and-time-statistics-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sprint-conductor-adl-skill-yaml-adl-tools-skills-sprint-conductor-references-conductor-playbook-md-adl-tools-skills-sprint-conductor-references-output-contract-md-adl-tools-skills-sprint-conductor-scripts-create-missing-sprint-issue-py-adl-tools-skills-sprint-conductor-scripts-issue-goal-metrics-py-adl-tools-skills-sprint-conductor-scripts-record-child-issue-closeout-py-adl-tools-skills-sprint-conductor-scripts-record-issue-goal-metrics-py-adl-tools-skills-sprint-conductor-scripts-update-sprint-state-py-adl-tools-skills-sprint-conductor-scripts-write-sprint-closeout-artifact-py-adl-tools-test-install-adl-operational-skills-sh-adl-tools-test-sprint-conductor-helpers-sh-adl-v0-91-6-tasks-issue-4264-v0-91-6-tools-capture-issue-goal-token-and-time-statistics-sip-md-adl-v0-91-6-tasks-issue-4264-v0-91-6-tools-capture-issue-goal-token-and-time-statistics-sor-md