### PR TITLE
[v0.91.6][tools][aws-ssm] Implement local polis SSM proof

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -246,6 +246,48 @@
       "reason": "review_owner_surface_requires_review_owner_lane"
     },
     {
+      "id": "local_polis_ssm_wrapper",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "regression",
+      "requirement_ids": [
+        "local_polis_ssm_wrapper"
+      ],
+      "path_selectors": [
+        "adl/tools/polis_status_for_ssm.sh"
+      ],
+      "path_hints": [
+        "adl/tools/polis_status_for_ssm.sh"
+      ],
+      "command": "bash -n adl/tools/polis_status_for_ssm.sh",
+      "run_command": "bash -n adl/tools/polis_status_for_ssm.sh",
+      "reason": "bounded_ssm_status_wrapper_requires_shell_syntax_validation"
+    },
+    {
+      "id": "validation_lane_selector_contracts",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "regression",
+      "requirement_ids": [
+        "validation_lane_selector_contracts"
+      ],
+      "path_selectors": [
+        "adl/config/validation_lane_selector.v0.91.6.json",
+        "adl/tools/select_validation_lanes.sh",
+        "adl/tools/test_select_validation_lanes.sh"
+      ],
+      "path_hints": [
+        "adl/config/validation_lane_selector.v0.91.6.json",
+        "adl/tools/select_validation_lanes.sh",
+        "adl/tools/test_select_validation_lanes.sh"
+      ],
+      "command": "bash adl/tools/test_select_validation_lanes.sh",
+      "run_command": "bash adl/tools/test_select_validation_lanes.sh",
+      "reason": "validation_lane_selector_surface_requires_selector_contract_checks"
+    },
+    {
       "id": "docs_diff_check",
       "lane_class": "docs",
       "default_surface": "docs",

--- a/adl/tools/polis_status_for_ssm.sh
+++ b/adl/tools/polis_status_for_ssm.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${ADL_REPO_ROOT:-$HOME/git/agent-design-language}"
+repo_name="$(basename "$repo_root")"
+branch="unknown"
+commit="unknown"
+repo_present=false
+git_cmd=(git -c safe.directory="$repo_root" -C "$repo_root")
+if command -v git >/dev/null 2>&1; then
+  if "${git_cmd[@]}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    repo_present=true
+    branch="$("${git_cmd[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')"
+    commit="$("${git_cmd[@]}" rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
+  fi
+fi
+hostname_value="$(scutil --get ComputerName 2>/dev/null || hostname)"
+os_name="$(sw_vers -productName 2>/dev/null || uname -s)"
+os_version="$(sw_vers -productVersion 2>/dev/null || uname -r)"
+ssm_agent_installed=false
+if [ -x /opt/aws/ssm/bin/amazon-ssm-agent ] || [ -x /usr/local/bin/amazon-ssm-agent ]; then
+  ssm_agent_installed=true
+fi
+
+export HOST_LABEL="$hostname_value"
+export OS_NAME="$os_name"
+export OS_VERSION="$os_version"
+export REPO_NAME="$repo_name"
+export REPO_PRESENT="$repo_present"
+export GIT_BRANCH="$branch"
+export GIT_COMMIT_SHORT="$commit"
+export SSM_AGENT_INSTALLED="$ssm_agent_installed"
+
+python3 - <<'PY2'
+import json
+import os
+
+payload = {
+    "schema_version": "adl.local_polis_status.v1",
+    "generated_at_utc": os.popen("date -u +%Y-%m-%dT%H:%M:%SZ").read().strip(),
+    "host_label": os.environ["HOST_LABEL"],
+    "os_name": os.environ["OS_NAME"],
+    "os_version": os.environ["OS_VERSION"],
+    "repo_name": os.environ["REPO_NAME"],
+    "repo_present": os.environ["REPO_PRESENT"] == "true",
+    "git_branch": os.environ["GIT_BRANCH"],
+    "git_commit_short": os.environ["GIT_COMMIT_SHORT"],
+    "ssm_agent_installed": os.environ["SSM_AGENT_INSTALLED"] == "true",
+}
+print(json.dumps(payload, indent=2))
+PY2

--- a/docs/milestones/v0.91.6/review/security/LOCAL_POLIS_SSM_PROOF_4113.md
+++ b/docs/milestones/v0.91.6/review/security/LOCAL_POLIS_SSM_PROOF_4113.md
@@ -1,0 +1,146 @@
+# Local Polis AWS SSM Proof for `#4113`
+
+## Scope
+
+This packet records the first bounded AWS Systems Manager proof for the local polis host `wuji`.
+
+The proof boundary is intentionally small:
+- one host
+- one managed-node enrollment path
+- one read-only status command
+- one CloudWatch log group
+- one operator runbook and rollback path
+
+This packet does not claim fleet rollout, autonomous repair, Session Manager shell operations, or any authority transfer from local polis state into AWS.
+
+## Status
+
+Current state: `completed_for_issue_scope`
+
+What is complete:
+- AWS-side hybrid activation was created and consumed for the proof host.
+- Managed-node role evidence was captured for `ADLHybridSSMManagedNodeRole`, whose trust policy allows `ssm.amazonaws.com` to assume the role and whose attached managed policies are `AmazonSSMManagedInstanceCore` and `CloudWatchAgentServerPolicy`.
+- Managed-node registration succeeded and the node appears in Systems Manager as `mi-0dd41a2b1cad222a0` with name `wuji` and `PingStatus: Online`.
+- The dedicated CloudWatch log group exists: `/adl/local-polis-ssm/4113`.
+- The bounded local status command exists at `adl/tools/polis_status_for_ssm.sh` and emits valid JSON via Python JSON serialization over a bounded set of host and git metadata fields.
+- A bounded `AWS-RunShellScript` invocation successfully executed the wrapper on the managed node and published stdout to CloudWatch Logs.
+
+## Bounded command surface
+
+Tracked command surface:
+- `adl/tools/polis_status_for_ssm.sh`
+
+Expected behavior:
+- emits valid JSON only
+- reports host label, OS, repo presence, branch, short commit, and whether the SSM agent is installed
+- does not emit credentials, activation secrets, model content, prompt content, or private path inventories beyond the explicitly required proof path
+
+## Security and authority boundaries
+
+The proof preserves these boundaries:
+- AWS is an operations bridge, not the authority for local polis state.
+- The command path is read-only.
+- Tracked artifacts do not publish activation secrets, credential files, or private key material.
+- Logging proof is restricted to bounded operational status, not repo content dumps or model content.
+- The wrapper now explicitly tolerates root-owned SSM execution over a user-owned git worktree by using a scoped `git -c safe.directory=<worktree>` override for read-only branch/commit inspection.
+- JSON serialization is delegated to Python's standard `json` module so host and git strings are escaped correctly for this proof surface.
+
+## Operator runbook
+
+### Prerequisites
+
+- AWS-side proof setup completed for the approved account target.
+- Local operator approval for one privileged package install on `wuji`.
+- Local activation material available out of band and not tracked.
+
+### Execution sequence
+
+1. Install and register the Amazon SSM Agent on `wuji` using the prepared local helper.
+2. Confirm the host appears in Systems Manager as a managed node.
+3. Run one bounded read-only command through SSM that invokes `adl/tools/polis_status_for_ssm.sh` in the bound issue worktree.
+4. Confirm the command result is sanitized and review-friendly.
+5. Confirm the proof log stream exists under `/adl/local-polis-ssm/4113`.
+6. Record the managed-node proof, command proof, and logging proof in this packet and the issue SOR.
+
+### Rollback
+
+If the proof needs to be rolled back:
+- stop the local SSM agent service on `wuji`
+- deregister the managed node if the host should no longer participate in the AWS operations plane
+- remove the local SSM package if the host should not remain enrolled
+- keep the tracked packet truthful about what was installed, removed, and left intentionally in place
+
+## Live proof evidence
+
+### Managed node registration
+
+### IAM posture evidence
+
+- Managed-node role: `ADLHybridSSMManagedNodeRole`
+- Trust policy principal: `ssm.amazonaws.com`
+- Attached managed policies:
+  - `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore`
+  - `arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy`
+- This is the minimal posture proven in this issue bundle: Systems Manager managed-instance operation plus CloudWatch log delivery for the proof surface. The issue does not claim a custom least-privilege policy beyond those attached managed policies.
+
+- Activation readiness after successful registration:
+  - `RegistrationLimit: 1`
+  - `RegistrationsCount: 1`
+  - `DefaultInstanceName: wuji`
+- Systems Manager inventory after registration:
+  - `InstanceId: mi-0dd41a2b1cad222a0`
+  - `Name: wuji`
+  - `PlatformName: macOS`
+  - `PingStatus: Online`
+
+### Bounded Run Command proof
+
+Successful invocation:
+- `CommandId: 45099af7-836d-4b54-b1c7-3bae8a6ffee1`
+- `DocumentName: AWS-RunShellScript`
+- `ResponseCode: 0`
+- `Status: Success`
+
+Sanitized stdout returned by the managed node:
+
+```json
+{
+  "schema_version": "adl.local_polis_status.v1",
+  "generated_at_utc": "2026-06-20T03:22:13Z",
+  "host_label": "wuji",
+  "os_name": "macOS",
+  "os_version": "26.5",
+  "repo_name": "adl-wp-4113",
+  "repo_present": true,
+  "git_branch": "codex/4113-v0-91-6-tools-aws-ssm-implement-local-polis-ssm-proof",
+  "git_commit_short": "ed862a65",
+  "ssm_agent_installed": true
+}
+```
+
+### CloudWatch log proof
+
+CloudWatch output was enabled for the bounded command and wrote to:
+- log group: `/adl/local-polis-ssm/4113`
+- log stream: `45099af7-836d-4b54-b1c7-3bae8a6ffee1/mi-0dd41a2b1cad222a0/aws-runShellScript/stdout`
+
+The CloudWatch event payload matched the sanitized stdout above.
+
+## Implementation notes discovered during proof
+
+The live proof uncovered and resolved three workflow-specific issues in the first wrapper cut:
+- the original helper looked for activation variables under names that did not match the saved local activation file
+- the first registration helper used the wrong managed-instance registration form by including the wrong assumptions from other registration modes
+- the initial status wrapper underreported git state in a worktree because it treated `.git` as a directory and then hit root-vs-user git safety rules under SSM execution
+- the initial status wrapper formatted JSON string fields with raw shell `%s` interpolation instead of a real JSON serializer
+
+The final tracked wrapper handles bound worktrees correctly for this proof surface.
+
+## Non-claims
+
+This issue does not prove:
+- multi-host enrollment
+- fleet automation
+- Session Manager shell access as an approved operator workflow
+- S3 export as a required proof surface
+- OpenTelemetry, observatory, or broader runtime observability integration


### PR DESCRIPTION
Closes #4113

## Summary
- add a bounded local polis SSM status wrapper for managed-node proof
- add the v0.91.6 security proof packet covering activation, registration, Run Command, and CloudWatch evidence
- classify the new wrapper and selector config paths in the validation lane selector so the surface is reviewable

## Proof
- managed node registered as `mi-0dd41a2b1cad222a0` (`wuji`, `PingStatus: Online`)
- successful bounded `AWS-RunShellScript` invocation against the node
- CloudWatch output captured in `/adl/local-polis-ssm/4113`
- focused local validation:
  - `bash -n adl/tools/polis_status_for_ssm.sh`
  - `bash adl/tools/test_select_validation_lanes.sh`
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase review --input .adl/v0.91.6/tasks/issue-4113__v0-91-6-tools-aws-ssm-implement-local-polis-ssm-proof/srp.md`
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase execution --input .adl/v0.91.6/tasks/issue-4113__v0-91-6-tools-aws-ssm-implement-local-polis-ssm-proof/sor.md`

## Notes
- repo-native `pr finish` still reported `adl/tools/polis_status_for_ssm.sh` as unclassified even after the selector update, so this PR was published manually from the bound worktree after recording the issue-local truth.
