### PR TITLE
[v0.91.6][tools][github] Fix typed issue close and transport wording

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -276,6 +276,7 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                     status: "created",
                     issue: parse_issue_number_from_url(&url).ok(),
                     url: Some(url),
+                    reason: None,
                 })?;
             } else {
                 println!("{url}");
@@ -294,6 +295,7 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                     status: "commented",
                     issue: Some(issue),
                     url: None,
+                    reason: None,
                 })?;
             }
         }
@@ -329,6 +331,23 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                     status: "edited",
                     issue: Some(issue),
                     url: None,
+                    reason: None,
+                })?;
+            }
+        }
+        IssueArgs::Close(parsed) => {
+            let repo = parsed
+                .repo
+                .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+                .unwrap_or(default_repo(&repo_root)?);
+            let issue = parse_issue_ref_number("issue close", &parsed.issue_ref)?;
+            github::gh_issue_close(&repo, issue, parsed.reason)?;
+            if parsed.json {
+                print_json(&IssueMutationResult {
+                    status: "closed",
+                    issue: Some(issue),
+                    url: None,
+                    reason: Some(parsed.reason.as_str()),
                 })?;
             }
         }
@@ -341,6 +360,8 @@ struct IssueMutationResult {
     status: &'static str,
     issue: Option<u32>,
     url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
 }
 
 fn parse_issue_ref_number(command: &str, issue_ref: &str) -> Result<u32> {
@@ -779,7 +800,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let mut slug = parsed.slug.clone().unwrap_or_default();
     let mut slug_from_local_identity = false;
     if title.is_empty() && !parsed.no_fetch_issue {
-        eprintln!("• Fetching issue title via gh…");
+        eprintln!("• Fetching issue title via ADL GitHub transport…");
         title = gh_issue_title(parsed.issue, &repo)?.unwrap_or_default();
     }
     if slug.is_empty() {
@@ -1107,7 +1128,7 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     let mut slug_from_local_identity = false;
 
     if title.is_empty() && !parsed.no_fetch_issue {
-        eprintln!("• Fetching issue title via gh…");
+        eprintln!("• Fetching issue title via ADL GitHub transport…");
         title = gh_issue_title(issue, &repo)?.unwrap_or_default();
     }
     if slug.is_empty() {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -8,6 +8,7 @@ use crate::cli::pr_cmd::github_client::{
     plan_issue_metadata_parity, pr_matches_main_version_wave, redact_for_diagnostics,
     AdlGithubClient, GithubClientBackend, IssueMetadataSnapshot, PullRequestMetadataSnapshot,
 };
+use crate::cli::pr_cmd_args::IssueCloseReason;
 use crate::cli::pr_cmd_args::IssueStateFilter;
 use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use crate::cli::tokio_runtime::with_current_thread_runtime;
@@ -1596,6 +1597,33 @@ pub(super) fn gh_issue_comment(repo: &str, issue: u32, body: &str) -> Result<()>
         .with_context(|| format!("issue comment: gh fixture comment failed for issue #{issue}"));
     }
     issue_comment_octocrab(repo, issue, body)
+}
+
+pub(super) fn gh_issue_close(repo: &str, issue: u32, reason: IssueCloseReason) -> Result<()> {
+    #[cfg(test)]
+    if test_gh_fixture_fallback_allowed("issue.close")? {
+        return run_gh_status_shell(
+            "issue.close",
+            &[
+                "issue",
+                "close",
+                &issue.to_string(),
+                "-R",
+                repo,
+                "--reason",
+                reason.as_str(),
+            ],
+        )
+        .with_context(|| format!("issue close: gh fixture close failed for issue #{issue}"));
+    }
+    issue_close_octocrab(repo, issue, issue_close_reason(reason))
+}
+
+fn issue_close_reason(reason: IssueCloseReason) -> octocrab::models::issues::IssueStateReason {
+    match reason {
+        IssueCloseReason::Completed => octocrab::models::issues::IssueStateReason::Completed,
+        IssueCloseReason::NotPlanned => octocrab::models::issues::IssueStateReason::NotPlanned,
+    }
 }
 
 #[cfg(test)]

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -257,17 +257,29 @@ pub(super) fn issue_close_octocrab(
     issue: u32,
     reason: octocrab::models::issues::IssueStateReason,
 ) -> Result<()> {
+    #[derive(Serialize)]
+    struct IssueClosePayload<'a> {
+        state: &'a str,
+        state_reason: &'a str,
+    }
+
     let repo_parts = parse_repo(repo)?;
     with_octocrab("issue.close", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
+        let route = format!("/repos/{owner}/{name}/issues/{issue}");
+        let state_reason = match reason {
+            octocrab::models::issues::IssueStateReason::Completed => "completed",
+            octocrab::models::issues::IssueStateReason::NotPlanned => "not_planned",
+            _ => "completed",
+        };
+        let payload = IssueClosePayload {
+            state: "closed",
+            state_reason,
+        };
         block_on_octocrab(runtime, "issue.close", || async {
-            octo.issues(&owner, &name)
-                .update(issue as u64)
-                .state(octocrab::models::IssueState::Closed)
-                .state_reason(reason.clone())
-                .send()
-                .await
+            let _: serde_json::Value = octo.patch(route.as_str(), Some(&payload)).await?;
+            Ok(())
         })?;
         Ok(())
     })

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -182,6 +182,29 @@ pub(crate) struct IssueEditArgs {
     pub(crate) json: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IssueCloseReason {
+    Completed,
+    NotPlanned,
+}
+
+impl IssueCloseReason {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::NotPlanned => "not_planned",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueCloseArgs {
+    pub(crate) issue_ref: String,
+    pub(crate) reason: IssueCloseReason,
+    pub(crate) repo: Option<String>,
+    pub(crate) json: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IssueArgs {
     List(IssueListArgs),
@@ -190,6 +213,7 @@ pub(crate) enum IssueArgs {
     Create(IssueCreateArgs),
     Comment(IssueCommentArgs),
     Edit(IssueEditArgs),
+    Close(IssueCloseArgs),
 }
 
 pub(crate) fn parse_init_args(args: &[String]) -> Result<InitArgs> {
@@ -683,7 +707,7 @@ pub(crate) fn parse_closeout_args(args: &[String]) -> Result<CloseoutArgs> {
 
 pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
     let Some(subcommand) = args.first().map(|value| value.as_str()) else {
-        bail!("issue: missing subcommand (list | search | view | create | comment | edit)");
+        bail!("issue: missing subcommand (list | search | view | create | comment | edit | close)");
     };
 
     match subcommand {
@@ -693,6 +717,7 @@ pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
         "create" => parse_issue_create_args(&args[1..]).map(IssueArgs::Create),
         "comment" => parse_issue_comment_args(&args[1..]).map(IssueArgs::Comment),
         "edit" => parse_issue_edit_args(&args[1..]).map(IssueArgs::Edit),
+        "close" => parse_issue_close_args(&args[1..]).map(IssueArgs::Close),
         other => bail!("issue: unknown subcommand: {other}"),
     }
 }
@@ -984,6 +1009,41 @@ fn parse_issue_edit_args(args: &[String]) -> Result<IssueEditArgs> {
     Ok(parsed)
 }
 
+fn parse_issue_close_args(args: &[String]) -> Result<IssueCloseArgs> {
+    let issue_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("issue close: missing <issue-number-or-url>"))?
+        .clone();
+    let mut parsed = IssueCloseArgs {
+        issue_ref,
+        reason: IssueCloseReason::Completed,
+        repo: None,
+        json: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--reason" | "--state-reason" => {
+                parsed.reason = parse_issue_close_reason(&require_value(
+                    args,
+                    i,
+                    "issue close",
+                    args[i].as_str(),
+                )?)?;
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "issue close", args[i].as_str())?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue close: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    Ok(parsed)
+}
+
 fn split_labels(raw: &str) -> Vec<String> {
     raw.split(',')
         .map(str::trim)
@@ -998,6 +1058,16 @@ fn parse_issue_state_filter(cmd: &str, value: &str) -> Result<IssueStateFilter> 
         "closed" => Ok(IssueStateFilter::Closed),
         "all" => Ok(IssueStateFilter::All),
         other => bail!("{cmd}: unsupported --state value: {other}"),
+    }
+}
+
+fn parse_issue_close_reason(value: &str) -> Result<IssueCloseReason> {
+    match value {
+        "completed" => Ok(IssueCloseReason::Completed),
+        "not_planned" | "not-planned" => Ok(IssueCloseReason::NotPlanned),
+        other => {
+            bail!("issue close: unsupported --reason '{other}'; expected completed or not_planned")
+        }
     }
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd_args::IssueCloseReason;
 use crate::cli::pr_cmd_args::IssueStateFilter;
 use crate::cli::pr_cmd_cards::render_issue_prompt_from_body;
 
@@ -317,6 +318,23 @@ fn parse_issue_args_accepts_list_search_and_view_modes() {
         }
         other => panic!("expected edit args, got {other:?}"),
     }
+
+    let parsed = parse_issue_args(&[
+        "close".to_string(),
+        "https://github.com/owner/repo/issues/77".to_string(),
+        "--reason".to_string(),
+        "not_planned".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse issue close");
+    match parsed {
+        IssueArgs::Close(parsed) => {
+            assert_eq!(parsed.issue_ref, "https://github.com/owner/repo/issues/77");
+            assert_eq!(parsed.reason, IssueCloseReason::NotPlanned);
+            assert!(parsed.json);
+        }
+        other => panic!("expected close args, got {other:?}"),
+    }
 }
 
 #[test]
@@ -451,7 +469,7 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     std::fs::write(&body_path, "Created body\n").expect("write body");
     let comment_path = repo.join("comment.md");
     std::fs::write(&comment_path, "Comment body\n").expect("write comment");
-    let (base_uri, server) = spawn_issue_octocrab_test_server(8);
+    let (base_uri, server) = spawn_issue_octocrab_test_server(9);
     unsafe {
         std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
         std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
@@ -497,10 +515,17 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
         "area:tools".to_string(),
     ])
     .expect("issue edit");
+    real_pr_issue(&[
+        "close".to_string(),
+        "77".to_string(),
+        "--reason".to_string(),
+        "not_planned".to_string(),
+    ])
+    .expect("issue close");
 
     std::env::set_current_dir(prev_dir).expect("restore cwd");
     let seen = server.join().expect("server join");
-    assert_eq!(seen.len(), 8);
+    assert_eq!(seen.len(), 9);
     assert!(seen[0].starts_with("GET /repos/owner/repo/issues?"));
     assert!(seen[1].contains("/search/issues?"));
     assert!(seen[2].starts_with("GET /repos/owner/repo/issues/77"));
@@ -512,6 +537,9 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     assert!(seen[6].starts_with("GET /repos/owner/repo/labels?"));
     assert!(seen[7].starts_with("PATCH /repos/owner/repo/issues/77 "));
     assert!(seen[7].contains("area:tools"));
+    assert!(seen[8].starts_with("PATCH /repos/owner/repo/issues/77 "));
+    assert!(seen[8].contains("\"state\":\"closed\""));
+    assert!(seen[8].contains("\"state_reason\":\"not_planned\""));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2641,6 +2641,7 @@ Usage:
   adl/tools/pr.sh issue create --title "<title>" [--body "<markdown>" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]
   adl/tools/pr.sh issue comment <issue-number-or-url> [--body "<markdown>" | --body-file <path>] [-R owner/repo] [--json]
   adl/tools/pr.sh issue edit <issue-number-or-url> [--title "<title>"] [--body "<markdown>" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]
+  adl/tools/pr.sh issue close <issue-number-or-url> [--reason completed|not_planned] [-R owner/repo] [--json]
 
 Behavior:
 - delegates to the Rust-owned issue inspection and mutation surface
@@ -2652,7 +2653,7 @@ Behavior:
   command environment without echoing it; do not fall back to direct `gh`
   commands or connector issue APIs
 - defaults `-R/--repo` from the current checkout when omitted
-- infers `owner/repo` from a GitHub issue URL on `issue view` when possible
+- infers `owner/repo` from a GitHub issue URL on `issue view` or `issue close` when possible
 - keeps machine-readable JSON on stdout when `--json` is set
 EOF
 }


### PR DESCRIPTION
Closes #4255

## Summary
Executed `#4255` by adding typed `adl/tools/pr.sh issue close` support on the
Rust-owned issue control-plane, reusing the Octocrab-backed GitHub transport,
and replacing stale operator-facing `via gh` wording with ADL-native transport
wording.

The bounded result is:

- `issue close` is now parsed, repo-aware, and dispatched through the typed ADL
  issue surface;
- JSON output for `issue close` returns status, issue number, and close reason;
- the GitHub transport closes issues through the existing ADL-owned Octocrab
  path rather than a raw `gh issue close` escape hatch; and
- stale issue-title fetch messages no longer claim direct `gh` usage.

## Artifacts
- Updated CLI/control-plane sources:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/transport.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr.sh`

## Validation
- Validation commands and their purpose:
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" bash adl/tools/pr.sh repair-issue-body 4255 --body-file temp-repair-body.md --force`
    Repaired the under-specified issue body and regenerated a valid local
    source prompt/task bundle for `#4255`.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" bash adl/tools/pr.sh doctor 4255 --mode ready --json`
    Verified the issue was structurally ready for execution after source-body
    repair.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" bash adl/tools/pr.sh run 4255 --allow-open-pr-wave`
    Bound `#4255` to `.worktrees/adl-wp-4255` on
    `codex/4255-v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl parse_issue_args_accepts_list_search_and_view_modes -- --test-threads=1`
    Verified the typed issue parser accepts the new `issue close` form,
    including issue URLs, close reasons, and JSON mode.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_issue_covers_list_search_view_and_mutation_against_mock_github -- --test-threads=1`
    Verified the end-to-end issue command surface covers list/search/view/create/comment/edit/close against the mock GitHub server and records the close payload correctly.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl octocrab_transport_covers_pr_and_issue_operations_against_mock_github -- --test-threads=1`
    Verified the Octocrab transport still covers PR and issue operations, including completed and not-planned issue close payloads.
  - `if rg -n "via gh" adl/src adl/tools -g '!target/**'; then exit 1; else echo 'no matches'; fi`
    Verified the touched CLI/tooling surface no longer contains the stale
    `via gh` wording.
  - `git diff --check`
    Verified whitespace and patch hygiene on the tracked diff.
  - bounded independent subagent review of the tracked `#4255` diff
    Verified there were no actionable correctness or regression findings before PR publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4255__v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4255__v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording/sor.md
- Idempotency-Key: v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-sh-adl-v0-91-6-tasks-issue-4255-v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording-sip-md-adl-v0-91-6-tasks-issue-4255-v0-91-6-tools-github-fix-typed-issue-close-and-transport-wording-sor-md