### PR TITLE
[v0.91.6][runtime][tokio] Add async tracing and runtime health correlation

### DIFF
--- a/adl/src/remote_exec.rs
+++ b/adl/src/remote_exec.rs
@@ -16,8 +16,19 @@ use tiny_http::{Header, Method, Response, Server};
 #[cfg(test)]
 use crate::adl;
 use crate::provider;
+use crate::resilience::remote_exec_health_payload;
+#[cfg(test)]
+use crate::resilience::{
+    ResilienceSurfaceV1, RuntimeCorrelationFieldsV1, RUNTIME_CORRELATION_FIELDS_SCHEMA_V1,
+    RUNTIME_HEALTH_STATUS_SCHEMA_V1,
+};
 #[cfg(test)]
 use crate::sandbox;
+#[cfg(test)]
+use crate::trace_schema_v1::{
+    TraceActorTypeV1, TraceActorV1, TraceErrorV1, TraceEventTypeV1, TraceEventV1,
+    TraceScopeLevelV1, TraceScopeV1,
+};
 
 mod errors;
 mod security;
@@ -142,7 +153,8 @@ pub fn run_server(bind_addr: &str) -> Result<()> {
             (Method::Get, "/v1/health") => {
                 let body = serde_json::to_vec(&serde_json::json!({
                     "ok": true,
-                    "protocol_version": PROTOCOL_VERSION
+                    "protocol_version": PROTOCOL_VERSION,
+                    "health": remote_exec_health_payload()
                 }))?;
                 request.respond(json_response(200, body))?;
             }
@@ -289,6 +301,108 @@ mod tests {
         assert!(
             resp.contains("413"),
             "expected 413 response for oversized payload, got:\n{resp}"
+        );
+    }
+
+    #[test]
+    fn server_health_endpoint_exposes_runtime_health_contract() {
+        let Some(port) = reserve_local_port() else {
+            return;
+        };
+        let bind_addr = format!("127.0.0.1:{port}");
+        thread::spawn({
+            let bind_addr = bind_addr.clone();
+            move || {
+                let _ = run_server(&bind_addr);
+            }
+        });
+        std::thread::sleep(std::time::Duration::from_millis(120));
+
+        let mut stream = std::net::TcpStream::connect(&bind_addr).expect("connect");
+        let req = format!("GET /v1/health HTTP/1.1\r\nHost: {bind_addr}\r\n\r\n");
+        stream.write_all(req.as_bytes()).unwrap();
+        stream.flush().unwrap();
+
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+            .unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).expect("read response");
+        let resp = String::from_utf8_lossy(&buf[..n]);
+        assert!(resp.contains("\"protocol_version\":\"0.1\""));
+        assert!(resp.contains("\"schema_version\":\"adl.runtime.health_status.v1\""));
+        assert!(resp.contains("\"component\":\"remote_exec\""));
+        assert!(resp.contains("\"field_contract\":[\"run_id\",\"trace_id\",\"span_id\",\"parent_span_id\",\"task_id\",\"fault_code\",\"component\",\"surface\"]"));
+    }
+
+    #[test]
+    fn runtime_correlation_fields_extract_trace_runtime_keys() {
+        let event = TraceEventV1 {
+            event_id: "event-1".to_string(),
+            timestamp: "2026-06-20T00:00:00.000Z".to_string(),
+            event_type: TraceEventTypeV1::Error,
+            trace_id: "trace-1".to_string(),
+            run_id: "run-1".to_string(),
+            span_id: "step:task-1".to_string(),
+            parent_span_id: Some("run:run-1".to_string()),
+            actor: TraceActorV1 {
+                r#type: TraceActorTypeV1::System,
+                id: "runtime".to_string(),
+            },
+            scope: TraceScopeV1 {
+                level: TraceScopeLevelV1::Step,
+                name: "task-1".to_string(),
+            },
+            inputs_ref: None,
+            outputs_ref: None,
+            artifact_ref: None,
+            decision_context: None,
+            provider: None,
+            error: Some(TraceErrorV1 {
+                code: "RUNTIME_TIMEOUT".to_string(),
+                message: "task timed out".to_string(),
+                details: None,
+            }),
+            contract_validation: None,
+            governance: None,
+            redaction: None,
+        };
+        let fields = RuntimeCorrelationFieldsV1::from_trace_event(
+            &event,
+            ResilienceSurfaceV1::Runtime,
+            "tokio_runtime",
+        );
+        assert_eq!(fields.schema_version, RUNTIME_CORRELATION_FIELDS_SCHEMA_V1);
+        assert_eq!(fields.run_id.as_deref(), Some("run-1"));
+        assert_eq!(fields.trace_id.as_deref(), Some("trace-1"));
+        assert_eq!(fields.span_id.as_deref(), Some("step:task-1"));
+        assert_eq!(fields.parent_span_id.as_deref(), Some("run:run-1"));
+        assert_eq!(fields.task_id.as_deref(), Some("task-1"));
+        assert_eq!(fields.fault_code.as_deref(), Some("RUNTIME_TIMEOUT"));
+        assert_eq!(fields.component, "tokio_runtime");
+        assert_eq!(fields.surface, ResilienceSurfaceV1::Runtime);
+    }
+
+    #[test]
+    fn remote_exec_health_payload_uses_shared_runtime_schema() {
+        let payload = remote_exec_health_payload();
+        assert_eq!(
+            payload
+                .pointer("/schema_version")
+                .and_then(serde_json::Value::as_str),
+            Some(RUNTIME_HEALTH_STATUS_SCHEMA_V1)
+        );
+        assert_eq!(
+            payload
+                .pointer("/correlation/schema_version")
+                .and_then(serde_json::Value::as_str),
+            Some(RUNTIME_CORRELATION_FIELDS_SCHEMA_V1)
+        );
+        assert_eq!(
+            payload
+                .pointer("/correlation/component")
+                .and_then(serde_json::Value::as_str),
+            Some("remote_exec")
         );
     }
 

--- a/adl/src/resilience.rs
+++ b/adl/src/resilience.rs
@@ -1,4 +1,5 @@
 use crate::model_identity::observed_at_now_v1;
+use crate::trace_schema_v1::{TraceEventTypeV1, TraceEventV1, TraceScopeLevelV1};
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -30,12 +31,141 @@ pub const RESILIENCE_FALLBACK_EXECUTION_TRACE_SCHEMA_V1: &str =
     "adl.resilience.fallback_execution_trace.v1";
 pub const RESILIENCE_POLICY_SCHEMA_V1: &str = "adl.resilience.policy.v1";
 pub const RESILIENCE_SUBSTRATE_SCHEMA_V1: &str = "adl.resilience.substrate_manifest.v1";
+pub const RUNTIME_CORRELATION_FIELDS_SCHEMA_V1: &str = "adl.runtime.correlation_fields.v1";
+pub const RUNTIME_HEALTH_STATUS_SCHEMA_V1: &str = "adl.runtime.health_status.v1";
 
 static TIMEOUT_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CIRCUIT_BREAKER_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 static RATE_LIMIT_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 static BULKHEAD_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 static FALLBACK_EXECUTION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeHealthStateV1 {
+    Healthy,
+    Degraded,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeCorrelationFieldsV1 {
+    pub schema_version: String,
+    pub surface: ResilienceSurfaceV1,
+    pub component: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fault_code: Option<String>,
+}
+
+impl RuntimeCorrelationFieldsV1 {
+    pub fn new(surface: ResilienceSurfaceV1, component: impl Into<String>) -> Self {
+        Self {
+            schema_version: RUNTIME_CORRELATION_FIELDS_SCHEMA_V1.to_string(),
+            surface,
+            component: component.into(),
+            run_id: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            task_id: None,
+            fault_code: None,
+        }
+    }
+
+    pub fn from_trace_event(
+        event: &TraceEventV1,
+        surface: ResilienceSurfaceV1,
+        component: impl Into<String>,
+    ) -> Self {
+        let task_id = match event.scope.level {
+            TraceScopeLevelV1::Step => Some(event.scope.name.clone()),
+            _ => None,
+        };
+        let fault_code = match event.event_type {
+            TraceEventTypeV1::Error => event.error.as_ref().map(|error| error.code.clone()),
+            _ => None,
+        };
+        Self {
+            schema_version: RUNTIME_CORRELATION_FIELDS_SCHEMA_V1.to_string(),
+            surface,
+            component: component.into(),
+            run_id: Some(event.run_id.clone()),
+            trace_id: Some(event.trace_id.clone()),
+            span_id: Some(event.span_id.clone()),
+            parent_span_id: event.parent_span_id.clone(),
+            task_id,
+            fault_code,
+        }
+    }
+
+    pub fn field_contract() -> &'static [&'static str] {
+        &[
+            "run_id",
+            "trace_id",
+            "span_id",
+            "parent_span_id",
+            "task_id",
+            "fault_code",
+            "component",
+            "surface",
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeHealthStatusV1 {
+    pub schema_version: String,
+    pub state: RuntimeHealthStateV1,
+    pub summary: String,
+    pub correlation: RuntimeCorrelationFieldsV1,
+    pub field_contract: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl RuntimeHealthStatusV1 {
+    pub fn healthy_runtime_component(
+        component: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: RUNTIME_HEALTH_STATUS_SCHEMA_V1.to_string(),
+            state: RuntimeHealthStateV1::Healthy,
+            summary: summary.into(),
+            correlation: RuntimeCorrelationFieldsV1::new(ResilienceSurfaceV1::Runtime, component),
+            field_contract: RuntimeCorrelationFieldsV1::field_contract()
+                .iter()
+                .map(|field| (*field).to_string())
+                .collect(),
+            detail: None,
+        }
+    }
+
+    pub fn to_json_value(&self) -> Value {
+        serde_json::to_value(self).expect("runtime health status is serializable")
+    }
+}
+
+pub fn remote_exec_health_payload() -> Value {
+    RuntimeHealthStatusV1::healthy_runtime_component(
+        "remote_exec",
+        "remote execution server ready for bounded request handling",
+    )
+    .to_json_value()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Closes #4242

## Summary
Implemented a bounded runtime observability slice for the tokio follow-on wave by adding shared runtime health/correlation payload builders in `adl/src/resilience.rs` and wiring the remote execution health endpoint in `adl/src/remote_exec.rs` to emit the shared machine-readable contract.

## Artifacts
- Updated runtime observability contract surfaces in `adl/src/resilience.rs`
- Updated remote execution health endpoint and focused regression coverage in `adl/src/remote_exec.rs`
- Updated issue execution record at `.adl/v0.91.6/tasks/issue-4242__v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_correlation_fields_extract_trace_runtime_keys -- --nocapture`
    Verified trace-event correlation extraction produces the expected runtime metadata fields.
  - `cargo test --manifest-path adl/Cargo.toml server_health_endpoint_exposes_runtime_health_contract -- --nocapture`
    Verified the `/v1/health` endpoint emits the shared runtime health schema payload.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" adl/tools/pr.sh finish 4242 --title "[v0.91.6][runtime][tokio] Add async tracing and runtime health correlation" --paths "adl/src/resilience.rs,adl/src/remote_exec.rs" --output-card .adl/v0.91.6/tasks/issue-4242__v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation/sor.md`
    Verified bounded publication readiness, including `cargo fmt`, focused runtime regression tests, and `bash adl/tools/run_owner_validation_lane.sh runtime --build`.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4242__v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4242__v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation/sor.md
- Idempotency-Key: v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation-adl-src-resilience-rs-adl-src-remote-exec-rs-adl-v0-91-6-tasks-issue-4242-v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation-sip-md-adl-v0-91-6-tasks-issue-4242-v0-91-6-runtime-tokio-add-async-tracing-and-runtime-health-correlation-sor-md