### PR TITLE
[v0.91.6][tools][projection] Complete GitHub/C-SDLC projection convergence map

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -12,8 +12,9 @@ use std::sync::{Mutex, OnceLock};
 use super::pr_cmd_args::parse_finish_args;
 use super::pr_cmd_args::{
     parse_closeout_args, parse_create_args, parse_doctor_args, parse_init_args, parse_issue_args,
-    parse_preflight_args, parse_ready_args, parse_repair_issue_body_args, parse_start_args,
-    parse_validation_args, DoctorArgs, DoctorMode, IssueArgs,
+    parse_preflight_args, parse_projection_map_args, parse_ready_args,
+    parse_repair_issue_body_args, parse_start_args, parse_validation_args, DoctorArgs, DoctorMode,
+    IssueArgs,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -153,7 +154,7 @@ fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | projection-map | closeout"
         );
     };
 
@@ -168,9 +169,182 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "finish" => finish_support::real_pr_finish(&args[1..]),
         "validation" => real_pr_validation(&args[1..]),
         "issue" => real_pr_issue(&args[1..]),
+        "projection-map" => real_pr_projection_map(&args[1..]),
         "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct ProjectionSurfaceV1 {
+    pub(crate) surface: &'static str,
+    pub(crate) source_of_truth: &'static str,
+    pub(crate) projection_policy: &'static str,
+    pub(crate) primary_command: &'static str,
+    pub(crate) repair_behavior: &'static str,
+    pub(crate) fail_closed_gate: &'static str,
+    pub(crate) status: &'static str,
+    pub(crate) follow_on: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ProjectionMapReportV1 {
+    schema_version: &'static str,
+    issue: &'static str,
+    purpose: &'static str,
+    surfaces: Vec<ProjectionSurfaceV1>,
+}
+
+pub(crate) fn github_csdlc_projection_surfaces_v1() -> Vec<ProjectionSurfaceV1> {
+    vec![
+        ProjectionSurfaceV1 {
+            surface: "github.issue.title",
+            source_of_truth: "GitHub issue title plus SIP/STP issue metadata",
+            projection_policy: "managed_projection",
+            primary_command: "adl/tools/pr.sh create|init|repair-issue-body|doctor",
+            repair_behavior: "metadata parity repairs the title when issue metadata is incomplete or stale",
+            fail_closed_gate: "doctor and init fail if required version/slug metadata cannot be inferred or repaired",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.issue.labels",
+            source_of_truth: "issue metadata, milestone version, and ADL label taxonomy",
+            projection_policy: "managed_projection",
+            primary_command: "adl/tools/pr.sh create|init|repair-issue-body|doctor",
+            repair_behavior: "required labels are created when missing and applied during metadata parity repair",
+            fail_closed_gate: "metadata repair fails before mutation when required repository labels cannot be proven",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.issue.body",
+            source_of_truth: "source issue prompt under .adl/<version>/bodies plus authored GitHub issue body",
+            projection_policy: "drift_checked_projection",
+            primary_command: "adl/tools/pr.sh create|init|repair-issue-body",
+            repair_behavior: "repair-issue-body may refresh the local source prompt and issue body only with explicit authored input or force",
+            fail_closed_gate: "metadata-only repair refuses to overwrite authored prompt/body content without explicit force",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.pr.title",
+            source_of_truth: "finish command title and SOR integration record",
+            projection_policy: "managed_projection",
+            primary_command: "adl/tools/pr.sh finish",
+            repair_behavior: "finish creates or updates the PR title for the issue-bound branch",
+            fail_closed_gate: "finish refuses publication when required output-card and integration inputs are invalid",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.pr.body",
+            source_of_truth: "SOR, finish input, changed paths, validation record, and closing linkage",
+            projection_policy: "managed_projection",
+            primary_command: "adl/tools/pr.sh finish",
+            repair_behavior: "finish renders the canonical PR body and stages/publicizes the issue output truth",
+            fail_closed_gate: "finish fails when completed SOR, paths, or validation inputs are missing or contradictory",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.pr.closing_linkage",
+            source_of_truth: "issue number and finish-rendered PR body",
+            projection_policy: "managed_projection",
+            primary_command: "adl/tools/pr.sh finish; adl/tools/check_pr_closing_linkage.sh",
+            repair_behavior: "finish body includes closing linkage; legacy CI guard checks the live PR body or event payload",
+            fail_closed_gate: "publication/CI fail when the PR body lacks closing linkage for the issue",
+            status: "implemented_with_legacy_ci_guard",
+            follow_on: "route shell guard into Rust/PVF when the validation manager owns PR linkage checks",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.pr.validation_checks",
+            source_of_truth: "GitHub Actions check runs plus local focused validation records",
+            projection_policy: "linked_surface_only",
+            primary_command: "adl/tools/pr.sh validation",
+            repair_behavior: "validation reports check state; it does not rewrite GitHub check runs",
+            fail_closed_gate: "watch mode fails when checks conclude unsuccessfully",
+            status: "implemented",
+            follow_on: "none",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.review_comments",
+            source_of_truth: "GitHub human/subagent review threads",
+            projection_policy: "linked_surface_only",
+            primary_command: "review-comment-triage skill; pr janitor workflow",
+            repair_behavior: "comments are triaged into code/doc/card changes or follow-on issues; they are not rewritten as C-SDLC state",
+            fail_closed_gate: "unresolved requested changes block merge readiness",
+            status: "implemented_by_process",
+            follow_on: "add typed review-thread inventory after octocrab review APIs are promoted",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.closeout_comment",
+            source_of_truth: "SOR closeout truth and merged/closed GitHub issue state",
+            projection_policy: "drift_checked_projection",
+            primary_command: "adl/tools/pr.sh closeout",
+            repair_behavior: "closeout verifies closed-completed state and records local truth; final comments remain bounded process output",
+            fail_closed_gate: "closeout fails when GitHub issue closure truth and local SOR truth disagree",
+            status: "partially_implemented",
+            follow_on: "promote final closeout comment creation/update into typed octocrab path when closeout automation is hardened",
+        },
+        ProjectionSurfaceV1 {
+            surface: "github.milestone_and_project_fields",
+            source_of_truth: "milestone planning docs and GitHub project/milestone metadata",
+            projection_policy: "explicitly_deferred",
+            primary_command: "none",
+            repair_behavior: "no automatic projection in this tranche",
+            fail_closed_gate: "manual review only",
+            status: "deferred",
+            follow_on: "schedule typed milestone/project projection after issue/PR convergence is stable",
+        },
+        ProjectionSurfaceV1 {
+            surface: "csdlc.cards.sip_stp_spp_srp_sor",
+            source_of_truth: "repo-local prompt-template rendered cards and editor-skill truth repairs",
+            projection_policy: "card_local_only",
+            primary_command: "adl-csdlc tooling prompt-template ...; card editor skills; pr doctor",
+            repair_behavior: "cards are rendered, validated, and repaired locally; GitHub links to their outcomes rather than owning their full content",
+            fail_closed_gate: "doctor/finish/closeout fail when required card truth is missing or stale for the lifecycle phase",
+            status: "implemented",
+            follow_on: "none",
+        },
+    ]
+}
+
+fn projection_map_report_v1() -> ProjectionMapReportV1 {
+    ProjectionMapReportV1 {
+        schema_version: "adl.github_csdlc_projection_map.v1",
+        issue: "#4047",
+        purpose: "Classify which GitHub and C-SDLC surfaces are managed projections, drift-checked projections, linked surfaces, card-local surfaces, or explicitly deferred surfaces.",
+        surfaces: github_csdlc_projection_surfaces_v1(),
+    }
+}
+
+fn real_pr_projection_map(args: &[String]) -> Result<()> {
+    let parsed = parse_projection_map_args(args)?;
+    let report = projection_map_report_v1();
+    if parsed.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!(
+        "GitHub/C-SDLC projection convergence map ({})",
+        report.schema_version
+    );
+    println!("{}", report.purpose);
+    for surface in &report.surfaces {
+        println!();
+        println!("- {} [{}]", surface.surface, surface.projection_policy);
+        println!("  source: {}", surface.source_of_truth);
+        println!("  command: {}", surface.primary_command);
+        println!("  repair: {}", surface.repair_behavior);
+        println!("  gate: {}", surface.fail_closed_gate);
+        println!("  status: {}", surface.status);
+        if surface.follow_on != "none" {
+            println!("  follow_on: {}", surface.follow_on);
+        }
+    }
+    Ok(())
 }
 
 fn real_pr_validation(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -112,6 +112,11 @@ pub(crate) struct CloseoutArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectionMapArgs {
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IssueStateFilter {
     Open,
     Closed,
@@ -720,6 +725,17 @@ pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
         "close" => parse_issue_close_args(&args[1..]).map(IssueArgs::Close),
         other => bail!("issue: unknown subcommand: {other}"),
     }
+}
+
+pub(crate) fn parse_projection_map_args(args: &[String]) -> Result<ProjectionMapArgs> {
+    let mut parsed = ProjectionMapArgs { json: false };
+    for arg in args {
+        match arg.as_str() {
+            "--json" => parsed.json = true,
+            other => bail!("projection-map: unknown arg: {other}"),
+        }
+    }
+    Ok(parsed)
 }
 
 fn parse_issue_list_args(args: &[String]) -> Result<IssueListArgs> {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1405,11 +1405,76 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | closeout"
+        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | issue | projection-map | closeout"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown pr subcommand: bogus"));
+}
+
+#[test]
+fn projection_map_covers_required_surface_policies() {
+    let parsed = crate::cli::pr_cmd_args::parse_projection_map_args(&["--json".to_string()])
+        .expect("parse projection-map --json");
+    assert!(parsed.json);
+
+    let err = crate::cli::pr_cmd_args::parse_projection_map_args(&["--bogus".to_string()])
+        .expect_err("unknown projection-map arg");
+    assert!(err
+        .to_string()
+        .contains("projection-map: unknown arg: --bogus"));
+
+    let report = projection_map_report_v1();
+    assert_eq!(report.schema_version, "adl.github_csdlc_projection_map.v1");
+    assert_eq!(report.issue, "#4047");
+
+    let surfaces = github_csdlc_projection_surfaces_v1();
+    assert_eq!(surfaces, report.surfaces);
+    let names = surfaces
+        .iter()
+        .map(|surface| surface.surface)
+        .collect::<std::collections::BTreeSet<_>>();
+    for required in [
+        "github.issue.title",
+        "github.issue.labels",
+        "github.issue.body",
+        "github.pr.title",
+        "github.pr.body",
+        "github.pr.closing_linkage",
+        "github.pr.validation_checks",
+        "github.review_comments",
+        "github.closeout_comment",
+        "github.milestone_and_project_fields",
+        "csdlc.cards.sip_stp_spp_srp_sor",
+    ] {
+        assert!(
+            names.contains(required),
+            "missing projection surface: {required}"
+        );
+    }
+
+    let policies = surfaces
+        .iter()
+        .map(|surface| surface.projection_policy)
+        .collect::<std::collections::BTreeSet<_>>();
+    for required in [
+        "managed_projection",
+        "drift_checked_projection",
+        "linked_surface_only",
+        "card_local_only",
+        "explicitly_deferred",
+    ] {
+        assert!(
+            policies.contains(required),
+            "missing projection policy: {required}"
+        );
+    }
+
+    assert!(surfaces.iter().any(|surface| {
+        surface.surface == "github.pr.closing_linkage"
+            && surface.status == "implemented_with_legacy_ci_guard"
+            && surface.follow_on.contains("Rust/PVF")
+    }));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2336,6 +2336,18 @@ cmd_issue() {
   delegate_pr_command_to_rust issue "$@"
 }
 
+cmd_projection_map() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    note "Usage: adl/tools/pr.sh projection-map [--json]"
+    note ""
+    note "Reports the GitHub/C-SDLC projection ownership map for issue, PR, and card surfaces."
+    return 0
+  fi
+  adl_obs_event "pr.sh" "projection-map" "started"
+  require_rust_pr_delegate projection-map
+  delegate_pr_command_to_rust projection-map "$@"
+}
+
 cmd_closeout() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     usage_closeout
@@ -2399,7 +2411,8 @@ Commands:
   doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
   validation <pr-number-or-url> [-R owner/repo] [--watch] [--json]
-  issue   <list|search|view> ...
+  issue   <list|search|view|create|comment|edit|close> ...
+  projection-map [--json]
   closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Compatibility / maintenance commands:
@@ -2706,6 +2719,7 @@ main() {
     finish) cmd_finish "$@" ;;
     validation) cmd_validation "$@" ;;
     issue) cmd_issue "$@" ;;
+    projection-map) cmd_projection_map "$@" ;;
     closeout) cmd_closeout "$@" ;;
     card) cmd_card "$@" ;;
     output) cmd_output "$@" ;;

--- a/docs/milestones/v0.91.6/review/github_projection/GITHUB_CSDLC_PROJECTION_MAP_4047.md
+++ b/docs/milestones/v0.91.6/review/github_projection/GITHUB_CSDLC_PROJECTION_MAP_4047.md
@@ -1,0 +1,72 @@
+# GitHub/C-SDLC Projection Map For #4047
+
+Status: implemented as a report-only convergence surface.
+
+Issue: #4047
+
+## Summary
+
+`#4047` makes GitHub/C-SDLC projection ownership explicit. The goal is not to rewrite every GitHub surface automatically. The goal is to make it deterministic which surfaces ADL owns, which surfaces ADL checks for drift, which surfaces remain linked external state, which surfaces are local card truth, and which surfaces are explicitly deferred.
+
+The command surface is:
+
+```bash
+adl/tools/pr.sh projection-map
+adl/tools/pr.sh projection-map --json
+```
+
+The Rust command emits schema `adl.github_csdlc_projection_map.v1`.
+
+## Projection Policies
+
+| Policy | Meaning |
+| --- | --- |
+| `managed_projection` | ADL owns the projection and may create, update, or repair the GitHub surface through the typed workflow path. |
+| `drift_checked_projection` | ADL checks or records drift and may offer bounded repair, but does not treat the surface as freely rewritable. |
+| `linked_surface_only` | ADL links to or reads the surface, but GitHub remains the authority. |
+| `card_local_only` | The surface belongs to local C-SDLC cards/templates and is not projected wholesale into GitHub. |
+| `explicitly_deferred` | The surface is intentionally out of scope for this tranche and must be routed separately before automation claims are made. |
+
+## Current Surface Map
+
+| Surface | Policy | Current status | Notes |
+| --- | --- | --- | --- |
+| `github.issue.title` | `managed_projection` | implemented | Managed by issue creation/init/repair metadata parity. |
+| `github.issue.labels` | `managed_projection` | implemented | Required labels are created/applied through metadata parity. |
+| `github.issue.body` | `drift_checked_projection` | implemented | Repair refuses to overwrite authored prompt/body content without explicit force. |
+| `github.pr.title` | `managed_projection` | implemented | Owned by `pr finish`. |
+| `github.pr.body` | `managed_projection` | implemented | Owned by `pr finish` from SOR/output-card truth. |
+| `github.pr.closing_linkage` | `managed_projection` | implemented with legacy CI guard | Finish renders linkage; `check_pr_closing_linkage.sh` still guards CI until Rust/PVF owns it. |
+| `github.pr.validation_checks` | `linked_surface_only` | implemented | Reported by `pr validation`; GitHub Actions remains the source. |
+| `github.review_comments` | `linked_surface_only` | implemented by process | Routed through review triage/janitor work, not rewritten as local state. |
+| `github.closeout_comment` | `drift_checked_projection` | partially implemented | Closeout verifies local/GitHub closure truth; typed final-comment automation remains follow-on work. |
+| `github.milestone_and_project_fields` | `explicitly_deferred` | deferred | Needs a separate typed milestone/project projection tranche. |
+| `csdlc.cards.sip_stp_spp_srp_sor` | `card_local_only` | implemented | Cards are local prompt-template/editor-skill truth surfaces. |
+
+## Relationship To Earlier Work
+
+`#4255` already landed the immediate typed issue-close and stale wording fix. This tranche therefore does not duplicate that work.
+
+Existing metadata parity is already Rust-owned. The retired `check_issue_metadata_parity.sh` path now points operators toward `pr doctor` or future Rust/PVF validation lanes.
+
+`check_pr_closing_linkage.sh` remains a legacy CI guard. That is acceptable for this tranche because the guard is explicit, narrow, and still proves the PR closing-linkage invariant. It should be migrated into Rust/PVF when validation-manager ownership is ready.
+
+## Non-Claims
+
+This does not claim:
+
+- automatic GitHub milestone/project-field synchronization
+- automatic rewrite of review comments
+- full closeout-comment projection
+- removal of every legacy shell guard
+- replacement of C-SDLC card truth with GitHub issue bodies
+
+## Validation Surface
+
+Focused validation should prove:
+
+- `projection-map --json` emits parseable schema `adl.github_csdlc_projection_map.v1`
+- all five projection policies are represented
+- the required GitHub and C-SDLC surfaces are represented
+- public `pr.sh projection-map` delegates to the Rust command
+


### PR DESCRIPTION
Closes #4047

## Summary
Implemented a typed, report-only GitHub/C-SDLC projection convergence map for `#4047`. The new `projection-map` command classifies GitHub issue, PR, review, closeout, milestone/project, and C-SDLC card surfaces as `managed_projection`, `drift_checked_projection`, `linked_surface_only`, `card_local_only`, or `explicitly_deferred`.

The implementation intentionally does not duplicate the already-merged `#4255` typed issue-close and stale wording fixes. It also does not claim automatic milestone/project synchronization or full closeout-comment projection.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
  - Added `projection-map` Rust command dispatch and schema `adl.github_csdlc_projection_map.v1`.
  - Added the authoritative projection-surface inventory used by text and JSON output.
- `adl/src/cli/pr_cmd_args.rs`
  - Added `ProjectionMapArgs` and `parse_projection_map_args` for `--json`.
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - Added coverage that the projection map contains all required surfaces and all required projection policy categories.
- `adl/tools/pr.sh`
  - Added public `projection-map [--json]` wrapper delegation into the Rust command.
- `docs/milestones/v0.91.6/review/github_projection/GITHUB_CSDLC_PROJECTION_MAP_4047.md`
  - Added durable review packet documenting the projection map, non-claims, and follow-on boundaries.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl projection_map_covers_required_surface_policies -- --nocapture`
    Proved required projection-map surface and policy coverage.
  - `bash adl/tools/pr.sh projection-map --json > .adl/runs/issue-4047/projection_map.json && python3 - <<'PY' ... PY`
    Proved JSON command output is parseable and policy-complete.
  - `bash adl/tools/pr.sh projection-map > .adl/runs/issue-4047/projection_map.txt && test -s .adl/runs/issue-4047/projection_map.txt && head -n 3 .adl/runs/issue-4047/projection_map.txt`
    Proved text command output exists on the public wrapper path.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Proved Rust formatting.
  - `git diff --check`
    Proved diff whitespace hygiene.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4047__github-csdlc-projection-convergence-tranche/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4047__github-csdlc-projection-convergence-tranche/sor.md
- Idempotency-Key: v0-91-6-tools-projection-complete-github-c-sdlc-projection-convergence-map-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-sh-docs-milestones-v0-91-6-review-github-projection-github-csdlc-projection-map-4047-md-adl-v0-91-6-tasks-issue-4047-github-csdlc-projection-convergence-tranche-sip-md-adl-v0-91-6-tasks-issue-4047-github-csdlc-projection-convergence-tranche-sor-md