### PR TITLE
[v0.91.6][tools] Prevent lifecycle delegation from dirtying Cargo.lock before clean-root refusal

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "jsonschema",
+ "loom",
  "markdown",
  "octocrab",
  "once_cell",
@@ -725,6 +726,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1280,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2067,6 +2096,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -190,16 +190,24 @@
         "adl/src/cli/pr_cmd/**",
         "adl/src/cli/pr_cmd_cards.rs",
         "adl/src/cli/pr_cmd_cards/**",
+        "adl/Cargo.lock",
         "adl/tools/pr.sh",
-        "adl/tools/run_owner_validation_lane.sh"
+        "adl/tools/run_owner_validation_lane.sh",
+        "adl/tools/test_control_plane_observability.sh",
+        "adl/tools/test_five_command_regression_suite.sh",
+        "adl/tools/test_pr_*.sh"
       ],
       "path_hints": [
         "adl/src/cli/pr_cmd.rs",
         "adl/src/cli/pr_cmd/**",
         "adl/src/cli/pr_cmd_cards.rs",
         "adl/src/cli/pr_cmd_cards/**",
+        "adl/Cargo.lock",
         "adl/tools/pr.sh",
-        "adl/tools/run_owner_validation_lane.sh"
+        "adl/tools/run_owner_validation_lane.sh",
+        "adl/tools/test_control_plane_observability.sh",
+        "adl/tools/test_five_command_regression_suite.sh",
+        "adl/tools/test_pr_*.sh"
       ],
       "command": "bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan",
       "run_command": "bash adl/tools/run_owner_validation_lane.sh csdlc",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1420,6 +1420,14 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_locked_cargo_fallback_validation(path))
+        {
+            commands.push(
+                "bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh".to_string(),
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_owner_lane_contract_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -1582,6 +1590,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_issue_small_binary_validation(issue_number, changed_paths) {
         return Ok(build_issue_small_binary_validation_plan());
     }
+    if finish_issue_needs_locked_cargo_fallback_validation(issue_number, changed_paths) {
+        return Ok(build_locked_cargo_fallback_validation_plan());
+    }
     select_finish_validation_plan(&changed_paths.join(","))
 }
 
@@ -1640,6 +1651,7 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
         trimmed,
         "adl/tools/pr.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
+            | "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"
             | "adl/tools/validation_manager.py"
             | "adl/tools/validation_manager.sh"
             | "adl/tools/test_validation_manager.sh"
@@ -1716,11 +1728,12 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/tools/test_select_validation_lanes.sh"
             | "adl/tools/run_owner_validation_lane.sh"
             | "adl/tools/test_owner_validation_lane.sh"
+            | "adl/tools/test_control_plane_observability.sh"
+            | "adl/tools/test_five_command_regression_suite.sh"
             | "adl/tools/test_cli_wrapper_migration_contract.sh"
             | "adl/tools/test_pr_run_ambiguity_policy.sh"
             | "adl/tools/test_pr_run_issue_mode.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
-            | "adl/tools/test_control_plane_observability.sh"
             | "adl/tools/test_adl_runtime_compatibility.sh"
             | "adl/tools/test_adl_review_compatibility.sh"
             | "adl/tools/run_slow_proof_family.sh"
@@ -1906,6 +1919,29 @@ fn finish_issue_needs_issue_small_binary_validation(
         })
 }
 
+fn finish_issue_needs_locked_cargo_fallback_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4306 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            matches!(
+                path.trim().trim_matches('/'),
+                "adl/Cargo.lock"
+                    | "adl/config/validation_lane_selector.v0.91.6.json"
+                    | "adl/src/cli/pr_cmd/finish_support.rs"
+                    | "adl/tools/pr.sh"
+                    | "adl/tools/run_owner_validation_lane.sh"
+                    | "adl/tools/test_control_plane_observability.sh"
+                    | "adl/tools/test_five_command_regression_suite.sh"
+                    | "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"
+            )
+        })
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -1924,6 +1960,27 @@ fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
         &mut commands,
         "cargo test --manifest-path adl/Cargo.toml long_lived_agent",
     );
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
+}
+
+fn build_locked_cargo_fallback_validation_plan() -> FinishValidationPlan {
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+    ];
+    push_finish_validation_command(
+        &mut commands,
+        "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation",
+    );
+    commands.push("bash adl/tools/test_ci_path_policy.sh".to_string());
+    commands.push("bash adl/tools/run_owner_validation_lane.sh csdlc".to_string());
     FinishValidationPlan {
         mode: FinishValidationMode::LargerBinaryFocused,
         commands,
@@ -2047,12 +2104,24 @@ fn finish_path_needs_small_binary_delegation_validation(path: &str) -> bool {
     matches!(trimmed, "adl/tools/test_pr_small_binary_delegation.sh")
 }
 
+fn finish_path_needs_locked_cargo_fallback_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/Cargo.lock"
+            | "adl/tools/pr.sh"
+            | "adl/tools/test_five_command_regression_suite.sh"
+            | "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"
+    )
+}
+
 fn finish_path_needs_owner_lane_contract_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     matches!(
         trimmed,
         "adl/tools/run_owner_validation_lane.sh"
             | "adl/tools/test_owner_validation_lane.sh"
+            | "adl/tools/test_control_plane_observability.sh"
             | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
             | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
     )
@@ -2510,6 +2579,11 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "bash adl/tools/test_pr_small_binary_delegation.sh" => {
                     let script = repo_root.join("adl/tools/test_pr_small_binary_delegation.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh" => {
+                    let script =
+                        repo_root.join("adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 "bash adl/tools/test_owner_validation_lane.sh" => {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1933,11 +1933,16 @@ fn finish_issue_needs_locked_cargo_fallback_validation(
                 "adl/Cargo.lock"
                     | "adl/config/validation_lane_selector.v0.91.6.json"
                     | "adl/src/cli/pr_cmd/finish_support.rs"
+                    | "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
+                    | "adl/tools/check_coverage_impact.sh"
                     | "adl/tools/pr.sh"
+                    | "adl/tools/run_pr_fast_test_lane.sh"
                     | "adl/tools/run_owner_validation_lane.sh"
+                    | "adl/tools/test_check_coverage_impact.sh"
                     | "adl/tools/test_control_plane_observability.sh"
                     | "adl/tools/test_five_command_regression_suite.sh"
                     | "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"
+                    | "adl/tools/test_run_pr_fast_test_lane.sh"
             )
         })
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1751,6 +1751,87 @@ fn finish_validation_profile_classifies_issue_small_binary_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
+    let changed_paths = vec![
+        "adl/Cargo.lock".to_string(),
+        "adl/config/validation_lane_selector.v0.91.6.json".to_string(),
+        "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+        "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        "adl/tools/check_coverage_impact.sh".to_string(),
+        "adl/tools/pr.sh".to_string(),
+        "adl/tools/run_pr_fast_test_lane.sh".to_string(),
+        "adl/tools/run_owner_validation_lane.sh".to_string(),
+        "adl/tools/test_check_coverage_impact.sh".to_string(),
+        "adl/tools/test_control_plane_observability.sh".to_string(),
+        "adl/tools/test_five_command_regression_suite.sh".to_string(),
+        "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh".to_string(),
+        "adl/tools/test_run_pr_fast_test_lane.sh".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(4306, &requested_paths, &changed_paths)
+        .expect("locked Cargo fallback focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
+
+    let unrelated_err =
+        select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths)
+            .expect_err("unrelated issue should not get the issue-local Cargo.lock allowance");
+    assert!(unrelated_err
+        .to_string()
+        .contains("changed paths are not classified"));
+}
+
+#[test]
+fn finish_validation_runner_executes_locked_cargo_fallback_script_command() {
+    let repo = unique_temp_dir("adl-pr-finish-locked-cargo-fallback-validation");
+    let tools = repo.join("adl/tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    write_executable(
+        &tools.join("check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\n",
+    );
+    write_executable(
+        &tools.join("test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nrepo_root=\"$(cd \"$(dirname \"$0\")/../..\" && pwd)\"\necho locked-fallback-ran > \"$repo_root/locked-fallback-ran.txt\"\n",
+    );
+
+    assert!(Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&repo)
+        .status()
+        .expect("git init")
+        .success());
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh".to_string(),
+        ],
+    };
+
+    run_finish_validation_rust(&repo, &plan).expect("validation runner");
+    assert_eq!(
+        fs::read_to_string(repo.join("locked-fallback-ran.txt"))
+            .expect("runner marker")
+            .trim(),
+        "locked-fallback-ran"
+    );
+}
+
+#[test]
 fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4215,

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -264,7 +264,7 @@ nextest_expression_for_filter() {
       printf 'test(/^cli::tooling_cmd::github_release::/)'
       ;;
     finish)
-      printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)'
+      printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)'
       ;;
     tooling_cmd)
       printf 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::/)'

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -332,11 +332,11 @@ delegate_pr_command_to_rust() {
     exec "$cached_bin" pr "$subcommand" "$@"
   fi
   if direct_bin="$(rust_pr_subcommand_binary_name "$subcommand" || true)"; [[ -n "$direct_bin" ]]; then
-    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "$direct_bin"
-    exec cargo run --quiet --manifest-path "$manifest" --bin "$direct_bin" -- "$@"
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "$direct_bin" "lock_mode" "locked"
+    exec cargo run --quiet --locked --manifest-path "$manifest" --bin "$direct_bin" -- "$@"
   fi
-  adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "adl"
-  exec cargo run --quiet --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
+  adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "adl" "lock_mode" "locked"
+  exec cargo run --quiet --locked --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
 }
 
 require_rust_pr_delegate() {

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -107,6 +107,8 @@ run_csdlc_lane() {
     bash adl/tools/test_pr_run_ambiguity_policy.sh
   run_command "C-SDLC PR small-binary delegation" \
     bash adl/tools/test_pr_small_binary_delegation.sh
+  run_command "C-SDLC PR locked Cargo fallback" \
+    bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
   run_command "C-SDLC control-plane observability contract" \
     bash adl/tools/test_control_plane_observability.sh
 }

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -424,7 +424,7 @@ TOKEN_MAP = {
     "process_status": 'binary_id(adl::cli_smoke) and test(/^process_status::/)',
     "tokio_bootstrap": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/)',
     "pr_cmd": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)',
-    "pr_cmd_finish": 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)',
+    "pr_cmd_finish": 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)',
     "pr_cmd::github": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/)',
     "github_release_": 'test(/^cli::tooling_cmd::github_release::/)',
     "long_lived_agent": 'test(/^long_lived_agent::/)',

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -160,7 +160,7 @@ if bash "$SCRIPT" --changed-files "$finish_helper_changed" --require-summary-for
   exit 1
 fi
 grep -F "candidate filter: finish" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-finish-helper-missing.out >/dev/null
 
 if bash "$SCRIPT" --changed-files "$process_status_changed" --require-summary-for-risk >/tmp/coverage-impact-process-status-missing.out 2>&1; then
   echo "expected process status helper guidance to fail without summary" >&2

--- a/adl/tools/test_control_plane_observability.sh
+++ b/adl/tools/test_control_plane_observability.sh
@@ -83,7 +83,7 @@ validate_cmd=(
   tooling validate-structured-prompt
   --type sor
   --phase bootstrap
-  --input "$ROOT_DIR/.adl/v0.91.6/tasks/issue-3968__v0-91-6-wp-03-tools-complete-logging-and-tooling-proof-loop-reliability/sor.md"
+  --input "$ROOT_DIR/docs/milestones/v0.91.5/review/evidence/csdlc/issues/issue-3472-v0-91-5-wp-04-tools-add-public-c-sdlc-prompt-packet-exporter/cards/sor.md"
 )
 if [[ -n "$TOOLING_BIN" ]]; then
   ADL_OBSERVABILITY_STDERR=0 ADL_OBSERVABILITY_LOG="$bad_sink" \

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -15,6 +15,7 @@ run_check() {
 run_check adl/tools/test_pr_init.sh
 run_check adl/tools/test_pr_create.sh
 run_check adl/tools/test_pr_delegate_exit_status.sh
+run_check adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
 run_check adl/tools/test_pr_ready_prefers_built_binary.sh
 run_check adl/tools/test_pr_finish_delegates_to_rust.sh
 run_check adl/tools/test_pr_start_template_validation.sh

--- a/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
+++ b/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$mockbin"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+
+cat >"$repo/adl/Cargo.toml" <<'EOF_CARGO_TOML'
+[package]
+name = "adl"
+version = "0.1.0"
+edition = "2021"
+EOF_CARGO_TOML
+
+cat >"$repo/adl/Cargo.lock" <<'EOF_LOCK'
+# synthetic lockfile fixture
+EOF_LOCK
+
+cat >"$mockbin/cargo" <<'EOF_MOCK_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TMP_CARGO_ARGS"
+if [[ " $* " != *" --locked "* ]]; then
+  printf '\n# mutated by fallback\n' >> "$TMP_LOCKFILE"
+  echo "cargo fallback unexpectedly ran without --locked" >&2
+  exit 97
+fi
+echo "error: the lock file $TMP_LOCKFILE needs to be updated but --locked was passed to prevent this" >&2
+exit 42
+EOF_MOCK_CARGO
+chmod +x "$mockbin/cargo"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md adl/Cargo.toml adl/Cargo.lock adl/tools/pr.sh adl/tools/card_paths.sh
+  git commit -q -m "init"
+)
+
+TMP_CARGO_ARGS="$tmpdir/cargo_args.txt"
+TMP_LOCKFILE="$repo/adl/Cargo.lock"
+export TMP_CARGO_ARGS TMP_LOCKFILE
+export PATH="$mockbin:$PATH"
+
+set +e
+run_output="$(
+  cd "$repo" &&
+  "$BASH_BIN" adl/tools/pr.sh run 4306 --slug locked-fallback --no-fetch-issue --version v0.86 2>&1
+)"
+run_status=$?
+set -e
+
+[[ $run_status -eq 42 ]] || {
+  echo "assertion failed: expected locked cargo refusal status 42, got $run_status" >&2
+  echo "$run_output" >&2
+  exit 1
+}
+
+grep -Fq -- "--locked" "$TMP_CARGO_ARGS" || {
+  echo "assertion failed: expected cargo fallback to include --locked" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+
+grep -Fq "needs to be updated but --locked was passed" <<<"$run_output" || {
+  echo "assertion failed: expected actionable stale-lockfile refusal output" >&2
+  echo "$run_output" >&2
+  exit 1
+}
+
+git_status="$(cd "$repo" && git status --short)"
+[[ -z "$git_status" ]] || {
+  echo "assertion failed: expected stale-lock refusal to leave checkout clean" >&2
+  echo "$git_status" >&2
+  exit 1
+}
+
+echo "pr.sh run locked cargo fallback refuses stale lockfile without dirtying checkout: ok"

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -277,7 +277,7 @@ manifest_plus_finish_output="$(bash "$SCRIPT" --changed-files "$manifest_plus_fi
 assert_has "$manifest_plus_finish_output" "mode=focused"
 assert_has "$manifest_plus_finish_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$manifest_plus_finish_output" "filter_tokens=manifest_support,pr_cmd_finish"
-assert_has "$manifest_plus_finish_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
+assert_has "$manifest_plus_finish_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)"
 
 process_status_wave="$TMP/process_status_wave.txt"
 cat >"$process_status_wave" <<'EOF'
@@ -294,7 +294,7 @@ process_status_wave_output="$(bash "$SCRIPT" --changed-files "$process_status_wa
 assert_has "$process_status_wave_output" "mode=focused"
 assert_has "$process_status_wave_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$process_status_wave_output" "filter_tokens=cli_dispatch,process_status,cli_smoke_basics,pr_cmd_finish"
-assert_has "$process_status_wave_output" "filter_expression=test(/^cli::tests::top_level_dispatch_routes_/) or binary_id(adl::cli_smoke) and test(/^process_status::/) or binary_id(adl::cli_smoke) and test(/^basics::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
+assert_has "$process_status_wave_output" "filter_expression=test(/^cli::tests::top_level_dispatch_routes_/) or binary_id(adl::cli_smoke) and test(/^process_status::/) or binary_id(adl::cli_smoke) and test(/^basics::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)"
 
 manifest_only_pair="$TMP/manifest_only_pair.txt"
 cat >"$manifest_only_pair" <<'EOF'
@@ -323,7 +323,7 @@ finish_only_output="$(bash "$SCRIPT" --changed-files "$finish_only" --print-plan
 assert_has "$finish_only_output" "mode=focused"
 assert_has "$finish_only_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$finish_only_output" "filter_tokens=pr_cmd_finish"
-assert_has "$finish_only_output" "filter_expression=binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/)"
+assert_has "$finish_only_output" "filter_expression=binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)"
 
 long_lived_agent_only="$TMP/long_lived_agent_only.txt"
 cat >"$long_lived_agent_only" <<'EOF'


### PR DESCRIPTION
Closes #4306

## Summary
Fixed the lifecycle lockfile mutation bug by making `pr.sh` Cargo fallback
delegation use `cargo run --locked`, so stale lockfiles fail closed instead of
being refreshed before lifecycle guards finish. The issue also records the
minimal missing `loom` lockfile closure from `#4290`, adds a focused regression
test, wires that test into the C-SDLC owner lane, and makes the owner-lane
observability test self-contained by using a tracked SOR fixture. After PR
publication, the GitHub coverage check exposed that the finish-helper coverage
filter was too narrow for `finish_support.rs`; the issue now expands the finish
filter to include `finish_support::tests` and records the passing local
coverage-impact proof.

## Artifacts
- `adl/Cargo.lock`
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/tools/check_coverage_impact.sh`
- `adl/tools/pr.sh`
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/run_owner_validation_lane.sh`
- `adl/tools/test_check_coverage_impact.sh`
- `adl/tools/test_control_plane_observability.sh`
- `adl/tools/test_five_command_regression_suite.sh`
- `adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`
- `adl/tools/test_run_pr_fast_test_lane.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`
    Proved the issue-specific stale-lockfile refusal behavior.
  - `bash adl/tools/test_pr_doctor_prefers_built_binary.sh`
    Proved direct-binary delegation still works for doctor.
  - `bash adl/tools/test_pr_ready_prefers_built_binary.sh`
    Proved direct-binary delegation still works for ready.
  - `bash adl/tools/test_ci_path_policy.sh`
    Proved selector/CI path policy remains valid.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Proved the selected owner lane after adding the new regression.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Proved Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation`
    Proved finish validation classifier behavior.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Proved PR-fast finish filter contract after adding `finish_support::tests`.
  - `bash adl/tools/test_check_coverage_impact.sh`
    Proved coverage-impact finish filter contract.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E '<finish filter from check_coverage_impact.sh>' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json && bash adl/tools/check_coverage_impact.sh --changed-files <temporary-changed-files-list> --summary adl/target/coverage-impact-summary.json --require-summary-for-risk --threshold 80`
    Proved the previously failing GitHub coverage-impact gate passes locally.
  - `python3 adl/tools/validation_manager.py --changed-files <temporary-changed-files-list> --json`
    Proved validation-manager routing for all changed paths.
  - `bash -n ...`
    Proved edited shell scripts parse.
  - `git diff --check`
    Proved diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4306__v0-91-6-tools-prevent-lifecycle-delegation-from-dirtying-cargo-lock-before-clean-root-refusal/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4306__v0-91-6-tools-prevent-lifecycle-delegation-from-dirtying-cargo-lock-before-clean-root-refusal/sor.md
- Idempotency-Key: v0-91-6-tools-prevent-lifecycle-delegation-from-dirtying-cargo-lock-before-clean-root-refusal-adl-cargo-lock-adl-config-validation-lane-selector-v0-91-6-json-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-check-coverage-impact-sh-adl-tools-pr-sh-adl-tools-run-pr-fast-test-lane-sh-adl-tools-run-owner-validation-lane-sh-adl-tools-test-check-coverage-impact-sh-adl-tools-test-control-plane-observability-sh-adl-tools-test-five-command-regression-suite-sh-adl-tools-test-pr-run-locked-cargo-fallback-refuses-cleanly-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-6-tasks-issue-4306-v0-91-6-tools-prevent-lifecycle-delegation-from-dirtying-cargo-lock-before-clean-root-refusal-sip-md-adl-v0-91-6-tasks-issue-4306-v0-91-6-tools-prevent-lifecycle-delegation-from-dirtying-cargo-lock-before-clean-root-refusal-sor-md