### PR TITLE
adl: add runtime aws heartbeat publisher seam

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1689,7 +1689,9 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/provider_communication.rs"
             | "adl/src/resilience.rs"
             | "adl/src/long_lived_agent.rs"
+            | "adl/src/long_lived_agent/storage.rs"
             | "adl/src/long_lived_agent/tests.rs"
+            | "adl/src/runtime_aws_signal.rs"
             | "adl/src/execute/runner.rs"
             | "adl/src/execute/tests.rs"
             | "adl/src/remote_exec.rs"
@@ -1857,7 +1859,9 @@ fn finish_path_needs_long_lived_agent_tokio_validation(path: &str) -> bool {
     matches!(
         trimmed,
         "adl/src/long_lived_agent.rs"
+            | "adl/src/long_lived_agent/storage.rs"
             | "adl/src/long_lived_agent/tests.rs"
+            | "adl/src/runtime_aws_signal.rs"
             | "adl/src/bin/run_v0916_integrated_runtime_soak.rs"
     )
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1997,7 +1997,9 @@ fn finish_validation_profile_classifies_long_lived_agent_tokio_paths() {
         ".",
         &[
             "adl/src/long_lived_agent.rs".to_string(),
+            "adl/src/long_lived_agent/storage.rs".to_string(),
             "adl/src/long_lived_agent/tests.rs".to_string(),
+            "adl/src/runtime_aws_signal.rs".to_string(),
         ],
     )
     .expect("long-lived tokio plan");

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -73,6 +73,7 @@ pub mod red_blue_agent_architecture;
 pub mod remote_exec;
 pub mod resilience;
 pub mod resolve;
+pub mod runtime_aws_signal;
 pub mod runtime_environment;
 pub mod runtime_v2;
 pub mod rust_native_gws_adapter_boundary;

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -178,3 +178,265 @@ pub(super) fn append_operator_event(
     });
     append_jsonl(&operator_events_path(loaded), &record)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::long_lived_agent::{
+        AgentSpec, AgentStatusState, HeartbeatSpec, LeaseRecord, StatusError, WorkflowSpec,
+    };
+    use crate::observability::test_env_lock;
+    use chrono::Duration as ChronoDuration;
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::MutexGuard;
+
+    static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    struct MultiEnvGuard {
+        saved: Vec<(String, Option<OsString>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl MultiEnvGuard {
+        fn set_all(values: &[(&str, &str)]) -> Self {
+            let lock = test_env_lock();
+            let tracked = [
+                "ADL_AWS_SIGNAL_MODE",
+                "ADL_AWS_REGION",
+                "ADL_AWS_HEARTBEAT_TARGET",
+                "ADL_AWS_SIGNAL_APPROVED",
+                "ADL_AWS_HEARTBEAT_LOG_GROUP",
+                "ADL_AWS_HEARTBEAT_LOG_STREAM",
+            ];
+            let mut saved = Vec::with_capacity(tracked.len());
+            for key in tracked {
+                saved.push((key.to_string(), env::var_os(key)));
+                unsafe {
+                    env::remove_var(key);
+                }
+            }
+            for (key, value) in values {
+                unsafe {
+                    env::set_var(key, value);
+                }
+            }
+            Self { saved, _lock: lock }
+        }
+    }
+
+    impl Drop for MultiEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                for (key, old) in self.saved.iter().rev() {
+                    match old {
+                        Some(value) => env::set_var(key, value),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "adl-storage-tests-{prefix}-{}-{}",
+            std::process::id(),
+            TEMP_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn sample_loaded(root: &Path) -> LoadedAgentSpec {
+        LoadedAgentSpec {
+            spec: AgentSpec {
+                schema: "adl.long_lived_agent_spec.v1".to_string(),
+                agent_instance_id: "storage-agent".to_string(),
+                display_name: "Storage Agent".to_string(),
+                state_root: PathBuf::from("state"),
+                workflow: WorkflowSpec {
+                    kind: "demo_adapter".to_string(),
+                    name: Some("storage-heartbeat".to_string()),
+                    path: None,
+                    run_args: json!({}),
+                },
+                heartbeat: HeartbeatSpec {
+                    interval_secs: Some(30),
+                    max_cycles: Some(5),
+                    stale_lease_after_secs: Some(60),
+                },
+                safety: json!({}),
+                memory: json!({}),
+            },
+            spec_path: root.join("agent.yaml"),
+            state_root: root.join("state"),
+        }
+    }
+
+    fn sample_status(state: AgentStatusState) -> StatusRecord {
+        StatusRecord {
+            schema: "adl.long_lived_agent_status.v1".to_string(),
+            agent_instance_id: "storage-agent".to_string(),
+            state,
+            last_cycle_id: Some("cycle-000001".to_string()),
+            last_cycle_status: Some("success".to_string()),
+            completed_cycle_count: 1,
+            consecutive_failure_count: 0,
+            active_lease: None,
+            stop_requested: false,
+            last_error: None,
+            safety_policy: json!({"allow_network": false}),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn storage_paths_and_json_helpers_round_trip() {
+        let root = temp_dir("helpers");
+        let loaded = sample_loaded(&root);
+        assert_eq!(cycles_dir(&loaded), root.join("state/cycles"));
+        assert_eq!(
+            locked_spec_path(&loaded),
+            root.join("state/agent_spec.locked.json")
+        );
+        assert_eq!(continuity_path(&loaded), root.join("state/continuity.json"));
+        assert_eq!(
+            cycle_ledger_path(&loaded),
+            root.join("state/cycle_ledger.jsonl")
+        );
+        assert_eq!(
+            provider_binding_history_path(&loaded),
+            root.join("state/provider_binding_history.jsonl")
+        );
+        assert_eq!(
+            memory_index_path(&loaded),
+            root.join("state/memory_index.json")
+        );
+        assert_eq!(
+            operator_events_path(&loaded),
+            root.join("state/operator_events.jsonl")
+        );
+        assert_eq!(status_path(&loaded), root.join("state/status.json"));
+        assert_eq!(lease_path(&loaded), root.join("state/lease.json"));
+        assert_eq!(stop_path(&loaded), root.join("state/stop.json"));
+
+        let json_path = root.join("nested/object.json");
+        write_json_pretty(&json_path, &json!({"hello": "world"})).expect("write json");
+        let parsed = read_json_required(&json_path).expect("read required");
+        assert_eq!(parsed["hello"], "world");
+
+        let optional_missing: Option<StatusRecord> =
+            read_json_optional(&root.join("missing.json")).expect("optional missing");
+        assert!(optional_missing.is_none());
+    }
+
+    #[test]
+    fn storage_jsonl_and_operator_event_helpers_append_reviewable_rows() {
+        let root = temp_dir("jsonl");
+        let loaded = sample_loaded(&root);
+        let jsonl = root.join("state/rows.jsonl");
+        ensure_jsonl_file(&jsonl).expect("ensure jsonl");
+        append_jsonl(&jsonl, &json!({"step": 1})).expect("append row");
+        write_jsonl(&jsonl, &[json!({"step": 2}), json!({"step": 3})]).expect("rewrite rows");
+        let rows = fs::read_to_string(&jsonl).expect("rows");
+        assert_eq!(rows.lines().count(), 2);
+        assert!(rows.contains("\"step\":2"));
+        assert!(rows.contains("\"step\":3"));
+
+        append_operator_event(&loaded, "storage_test", json!({"detail": "ok"}))
+            .expect("append operator event");
+        let events = fs::read_to_string(operator_events_path(&loaded)).expect("events");
+        assert!(events.contains("\"event\":\"storage_test\""));
+        assert!(events.contains("\"schema\":\"adl.long_lived_agent_operator_event.v1\""));
+    }
+
+    #[test]
+    fn storage_status_and_control_records_round_trip_with_mock_heartbeat() {
+        let root = temp_dir("status");
+        let loaded = sample_loaded(&root);
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_AWS_SIGNAL_MODE", "mock"),
+            ("ADL_AWS_REGION", "us-west-2"),
+        ]);
+
+        let mut status = sample_status(AgentStatusState::RunningCycle);
+        status.active_lease = Some(LeaseRecord {
+            schema: "adl.long_lived_agent_lease.v1".to_string(),
+            agent_instance_id: "storage-agent".to_string(),
+            lease_id: "lease-1".to_string(),
+            cycle_id: "cycle-000001".to_string(),
+            owner_pid: 55,
+            hostname: "local".to_string(),
+            started_at: status.updated_at - ChronoDuration::seconds(5),
+            expires_at: status.updated_at + ChronoDuration::seconds(55),
+            status: "active".to_string(),
+        });
+        write_status(&loaded, &status).expect("write status");
+
+        let persisted = read_status(&loaded)
+            .expect("read status")
+            .expect("status exists");
+        assert_eq!(persisted.state, AgentStatusState::RunningCycle);
+        assert!(persisted.active_lease.is_some());
+
+        let heartbeat =
+            fs::read_to_string(loaded.state_root.join("aws_runtime_heartbeat_mock.jsonl"))
+                .expect("heartbeat");
+        assert_eq!(heartbeat.lines().count(), 1);
+
+        let lease = LeaseRecord {
+            schema: "adl.long_lived_agent_lease.v1".to_string(),
+            agent_instance_id: "storage-agent".to_string(),
+            lease_id: "lease-2".to_string(),
+            cycle_id: "cycle-000002".to_string(),
+            owner_pid: 77,
+            hostname: "local".to_string(),
+            started_at: Utc::now(),
+            expires_at: Utc::now() + ChronoDuration::seconds(60),
+            status: "active".to_string(),
+        };
+        write_json_pretty(&lease_path(&loaded), &lease).expect("write lease");
+        let persisted_lease = read_lease(&loaded)
+            .expect("read lease")
+            .expect("lease exists");
+        assert_eq!(persisted_lease.cycle_id, "cycle-000002");
+        remove_lease(&loaded).expect("remove lease");
+        remove_lease(&loaded).expect("remove missing lease");
+        assert!(read_lease(&loaded).expect("read removed lease").is_none());
+
+        let stop = StopRecord {
+            schema: "adl.long_lived_agent_stop.v1".to_string(),
+            agent_instance_id: "storage-agent".to_string(),
+            reason: "operator pause".to_string(),
+            requested_by: "operator".to_string(),
+            mode: "stop_before_next_cycle".to_string(),
+            requested_at: Utc::now(),
+        };
+        write_json_pretty(&stop_path(&loaded), &stop).expect("write stop");
+        let persisted_stop = read_stop(&loaded).expect("read stop").expect("stop exists");
+        assert_eq!(persisted_stop.reason, "operator pause");
+    }
+
+    #[test]
+    fn storage_json_optional_reports_parse_failures() {
+        let root = temp_dir("parse-failure");
+        let broken = root.join("broken.json");
+        fs::create_dir_all(broken.parent().expect("parent")).expect("mkdir");
+        fs::write(&broken, "{not-json").expect("write broken json");
+        let err = read_json_optional::<StatusRecord>(&broken).expect_err("invalid json");
+        assert!(err.to_string().contains("failed parsing json artifact"));
+
+        let status = StatusRecord {
+            last_error: Some(StatusError {
+                class: "workflow_failed".to_string(),
+                message: "boom".to_string(),
+            }),
+            ..sample_status(AgentStatusState::Failed)
+        };
+        write_json_pretty(&root.join("status.json"), &status).expect("write failed status");
+        let persisted = read_json_required(&root.join("status.json")).expect("read status");
+        assert_eq!(persisted["last_error"]["class"], "workflow_failed");
+    }
+}

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -1,6 +1,7 @@
 //! Persistent storage helpers for long-lived agent state artifacts.
 use super::schema::OPERATOR_EVENT_SCHEMA;
 use super::types::{LeaseRecord, LoadedAgentSpec, StatusRecord, StopRecord};
+use crate::runtime_aws_signal::publish_runtime_heartbeat_signal;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -67,7 +68,9 @@ pub(super) fn read_status(loaded: &LoadedAgentSpec) -> Result<Option<StatusRecor
 }
 
 pub(super) fn write_status(loaded: &LoadedAgentSpec, status: &StatusRecord) -> Result<()> {
-    write_json_pretty(&status_path(loaded), status)
+    write_json_pretty(&status_path(loaded), status)?;
+    let _ = publish_runtime_heartbeat_signal(loaded, status);
+    Ok(())
 }
 
 pub(super) fn read_lease(loaded: &LoadedAgentSpec) -> Result<Option<LeaseRecord>> {

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1,6 +1,11 @@
 //! Integration tests for long-lived agent execution and artifact invariants.
 use super::*;
+use crate::observability::test_env_lock;
+use crate::runtime_aws_signal::mock_signal_artifact_path;
+use std::env;
+use std::ffi::OsString;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::MutexGuard;
 use std::time::Instant;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -121,6 +126,38 @@ fn guardrail_check_result<'a>(guardrails: &'a Value, check_id: &str) -> &'a str 
         .unwrap_or_else(|| panic!("missing check {check_id}"))
 }
 
+struct MultiEnvGuard {
+    saved: Vec<(String, Option<OsString>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl MultiEnvGuard {
+    fn set_all(values: &[(&str, &str)]) -> Self {
+        let lock = test_env_lock();
+        let mut saved = Vec::with_capacity(values.len());
+        for (key, value) in values {
+            saved.push(((*key).to_string(), env::var_os(key)));
+            unsafe {
+                env::set_var(key, value);
+            }
+        }
+        Self { saved, _lock: lock }
+    }
+}
+
+impl Drop for MultiEnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            for (key, old) in self.saved.iter().rev() {
+                match old {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn status_initializes_required_continuity_files_without_running_cycle() {
     let root = temp_dir("init");
@@ -219,6 +256,195 @@ fn tick_creates_state_status_full_cycle_bundle_and_removes_lease() {
         "cycles/cycle-000001/memory_writes.jsonl"
     );
     assert!(!root.join("state/lease.json").exists());
+}
+
+#[test]
+fn tick_mock_mode_writes_runtime_aws_heartbeat_envelopes() {
+    let root = temp_dir("aws-heartbeat-mock");
+    let spec = write_spec(&root);
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_REGION", "us-west-2"),
+    ]);
+
+    let status = tick(&spec, TickOptions::default()).expect("tick");
+
+    assert_eq!(status.state, AgentStatusState::Idle);
+    let loaded = load_spec(&spec).expect("load");
+    let mock_path = mock_signal_artifact_path(&loaded);
+    assert!(mock_path.exists(), "missing {}", mock_path.display());
+    let lines = fs::read_to_string(&mock_path).expect("read heartbeat mock log");
+    let events = lines
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse heartbeat envelope"))
+        .collect::<Vec<_>>();
+    assert!(
+        events.len() >= 3,
+        "expected initialization, running, and completed heartbeat events"
+    );
+    let last = events.last().expect("last envelope");
+    assert_eq!(last["schema_version"], "adl.runtime.aws_signal.v1");
+    assert_eq!(last["signal_kind"], "heartbeat");
+    assert_eq!(last["runtime_id"], "test-agent");
+    assert_eq!(last["cycle_id"], "cycle-000001");
+    assert_eq!(last["projection_level"], "operations_safe");
+    assert_eq!(last["transport"]["mode"], "mock");
+    assert_eq!(last["transport"]["target_kind"], "cloudwatch_logs");
+    assert_eq!(last["transport"]["region"], "us-west-2");
+    assert_eq!(last["payload"]["state"], "idle");
+    assert_eq!(
+        last["payload"]["next_cycle_hint"],
+        "sleep_until_next_heartbeat"
+    );
+    assert_eq!(last["payload"]["lease_state"], "clear");
+}
+
+#[test]
+fn repeated_mock_heartbeats_advance_sequence_and_correlation_id() {
+    let root = temp_dir("aws-heartbeat-sequence");
+    let spec = write_spec(&root);
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_REGION", "us-west-2"),
+    ]);
+
+    tick(&spec, TickOptions::default()).expect("tick");
+    let status_after_tick = status(&spec).expect("status");
+    assert_eq!(status_after_tick.state, AgentStatusState::Idle);
+
+    let loaded = load_spec(&spec).expect("load");
+    let lines = fs::read_to_string(mock_signal_artifact_path(&loaded)).expect("read mock log");
+    let events = lines
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse heartbeat envelope"))
+        .collect::<Vec<_>>();
+    let mut completed_cycle_events = events
+        .iter()
+        .filter(|value| {
+            value["cycle_id"] == "cycle-000001"
+                && value["payload"]["state"] == "idle"
+                && value["status"] == "completed"
+        })
+        .collect::<Vec<_>>();
+    completed_cycle_events.sort_by_key(|value| value["heartbeat_seq"].as_u64().unwrap_or(0));
+    assert!(
+        completed_cycle_events.len() >= 2,
+        "expected repeated completed heartbeats for the same cycle"
+    );
+    let first = completed_cycle_events[0];
+    let later = completed_cycle_events[1];
+    assert!(
+        later["heartbeat_seq"].as_u64().expect("later seq")
+            > first["heartbeat_seq"].as_u64().expect("first seq")
+    );
+    assert_ne!(later["correlation_id"], first["correlation_id"]);
+}
+
+#[test]
+fn mock_mode_rejects_unsupported_heartbeat_target() {
+    let root = temp_dir("aws-heartbeat-unsupported-target");
+    let spec = write_spec(&root);
+    let observability_log = root.join("aws-heartbeat-events.log");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_REGION", "us-west-2"),
+        ("ADL_AWS_HEARTBEAT_TARGET", "sns"),
+        (
+            "ADL_OBSERVABILITY_LOG",
+            observability_log.to_str().expect("observability path utf8"),
+        ),
+        ("ADL_OBSERVABILITY_STDERR", "0"),
+    ]);
+
+    let status = tick(&spec, TickOptions::default()).expect("tick should still succeed");
+
+    assert_eq!(status.state, AgentStatusState::Idle);
+    let logged = fs::read_to_string(&observability_log).expect("read observability log");
+    assert!(logged.contains("stage=aws_runtime_heartbeat"));
+    assert!(logged.contains("result=failed"));
+    assert!(logged.contains("failure_class=aws_signal_unsupported_target"));
+
+    let loaded = load_spec(&spec).expect("load");
+    assert!(
+        !mock_signal_artifact_path(&loaded).exists(),
+        "unsupported target should not write mock heartbeat envelopes"
+    );
+}
+
+#[test]
+fn disabled_mode_skips_without_writing_mock_or_cursor_artifacts() {
+    let root = temp_dir("aws-heartbeat-disabled");
+    let spec = write_spec(&root);
+    let observability_log = root.join("aws-heartbeat-events.log");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_AWS_SIGNAL_MODE", "disabled"),
+        (
+            "ADL_OBSERVABILITY_LOG",
+            observability_log.to_str().expect("observability path utf8"),
+        ),
+        ("ADL_OBSERVABILITY_STDERR", "0"),
+    ]);
+
+    let status = tick(&spec, TickOptions::default()).expect("tick should still succeed");
+    assert_eq!(status.state, AgentStatusState::Idle);
+
+    let logged = fs::read_to_string(&observability_log).expect("read observability log");
+    assert!(logged.contains("stage=aws_runtime_heartbeat"));
+    assert!(logged.contains("result=skipped"));
+
+    let loaded = load_spec(&spec).expect("load");
+    assert!(
+        !mock_signal_artifact_path(&loaded).exists(),
+        "disabled mode should not write mock heartbeat envelopes"
+    );
+    assert!(
+        !loaded
+            .state_root
+            .join("aws_runtime_heartbeat_cursor.json")
+            .exists(),
+        "disabled mode should not allocate heartbeat cursor state"
+    );
+}
+
+#[test]
+fn tick_live_mode_without_approval_stays_fail_closed_and_observable() {
+    let root = temp_dir("aws-heartbeat-live-blocked");
+    let spec = write_spec(&root);
+    let observability_log = root.join("aws-heartbeat-events.log");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_AWS_SIGNAL_MODE", "live"),
+        ("ADL_AWS_REGION", "us-west-2"),
+        ("ADL_AWS_HEARTBEAT_TARGET", "cloudwatch_logs"),
+        (
+            "ADL_AWS_HEARTBEAT_LOG_GROUP",
+            "arn:aws:logs:us-west-2:123456789012:log-group/private",
+        ),
+        (
+            "ADL_AWS_HEARTBEAT_LOG_STREAM",
+            "arn:aws:logs:us-west-2:123456789012:log-stream/private",
+        ),
+        (
+            "ADL_OBSERVABILITY_LOG",
+            observability_log.to_str().expect("observability path utf8"),
+        ),
+        ("ADL_OBSERVABILITY_STDERR", "0"),
+    ]);
+
+    let status = tick(&spec, TickOptions::default()).expect("tick should still succeed");
+
+    assert_eq!(status.state, AgentStatusState::Idle);
+    let logged = fs::read_to_string(&observability_log).expect("read observability log");
+    assert!(logged.contains("stage=aws_runtime_heartbeat"));
+    assert!(logged.contains("result=failed"));
+    assert!(logged.contains("failure_class=aws_signal_live_not_approved"));
+    assert!(!logged.contains("123456789012"));
+    assert!(!logged.contains("arn:aws:logs"));
+
+    let loaded = load_spec(&spec).expect("load");
+    assert!(
+        !mock_signal_artifact_path(&loaded).exists(),
+        "live-blocked mode should not write mock heartbeat envelopes"
+    );
 }
 
 #[test]

--- a/adl/src/runtime_aws_signal.rs
+++ b/adl/src/runtime_aws_signal.rs
@@ -1,0 +1,487 @@
+use crate::long_lived_agent::{AgentStatusState, LoadedAgentSpec, StatusRecord};
+use crate::observability::emit_event;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+const AWS_SIGNAL_SCHEMA_VERSION: &str = "adl.runtime.aws_signal.v1";
+const HEARTBEAT_TARGET_KIND: &str = "cloudwatch_logs";
+const MOCK_SIGNAL_ARTIFACT: &str = "aws_runtime_heartbeat_mock.jsonl";
+const HEARTBEAT_CURSOR_ARTIFACT: &str = "aws_runtime_heartbeat_cursor.json";
+const HEARTBEAT_CURSOR_SCHEMA: &str = "adl.runtime.aws_signal_heartbeat_cursor.v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AwsSignalMode {
+    Disabled,
+    Mock,
+    Live,
+}
+
+#[derive(Debug, Clone)]
+struct HeartbeatPublisherConfig {
+    mode: AwsSignalMode,
+    configured: bool,
+    region: Option<String>,
+    target_kind: String,
+    approved: bool,
+    log_group_configured: bool,
+    log_stream_configured: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublishDisposition {
+    Skipped,
+    PublishedMock,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PublishOutcome {
+    pub(crate) disposition: PublishDisposition,
+    pub(crate) failure_class: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HeartbeatCursor {
+    schema: String,
+    next_heartbeat_seq: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RuntimeAwsSignalEnvelope {
+    pub(crate) schema_version: String,
+    pub(crate) signal_kind: String,
+    pub(crate) runtime_id: String,
+    pub(crate) agent_id: String,
+    pub(crate) cycle_id: String,
+    pub(crate) heartbeat_seq: u64,
+    pub(crate) status: String,
+    pub(crate) timestamp: DateTime<Utc>,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) failure_class: Option<String>,
+    pub(crate) correlation_id: String,
+    pub(crate) projection_level: String,
+    pub(crate) transport: RuntimeAwsSignalTransport,
+    pub(crate) payload: RuntimeHeartbeatPayload,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RuntimeAwsSignalTransport {
+    pub(crate) mode: String,
+    pub(crate) target_kind: String,
+    pub(crate) region: Option<String>,
+    pub(crate) approved: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RuntimeHeartbeatPayload {
+    pub(crate) state: String,
+    pub(crate) elapsed_ms: i64,
+    pub(crate) next_cycle_hint: String,
+    pub(crate) stop_requested: bool,
+    pub(crate) lease_state: String,
+}
+
+impl HeartbeatPublisherConfig {
+    fn from_env() -> Self {
+        let mode_env = env::var("ADL_AWS_SIGNAL_MODE").ok();
+        let mode = match mode_env
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("mock") => AwsSignalMode::Mock,
+            Some("live") => AwsSignalMode::Live,
+            _ => AwsSignalMode::Disabled,
+        };
+        let region = env::var("ADL_AWS_REGION")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let target_kind = env::var("ADL_AWS_HEARTBEAT_TARGET")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| HEARTBEAT_TARGET_KIND.to_string());
+        let approved = env::var("ADL_AWS_SIGNAL_APPROVED")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|value| matches!(value, "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(false);
+        let log_group_configured = env::var("ADL_AWS_HEARTBEAT_LOG_GROUP")
+            .ok()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false);
+        let log_stream_configured = env::var("ADL_AWS_HEARTBEAT_LOG_STREAM")
+            .ok()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false);
+        Self {
+            mode,
+            configured: mode_env.is_some(),
+            region,
+            target_kind,
+            approved,
+            log_group_configured,
+            log_stream_configured,
+        }
+    }
+
+    fn mode_label(&self) -> &'static str {
+        match self.mode {
+            AwsSignalMode::Disabled => "disabled",
+            AwsSignalMode::Mock => "mock",
+            AwsSignalMode::Live => "live",
+        }
+    }
+
+    fn live_block_reason(&self) -> &'static str {
+        if !self.approved {
+            "aws_signal_live_not_approved"
+        } else if self.region.is_none() {
+            "aws_signal_region_missing"
+        } else if self.target_kind != HEARTBEAT_TARGET_KIND {
+            "aws_signal_unsupported_target"
+        } else if !self.log_group_configured {
+            "aws_signal_log_group_missing"
+        } else if !self.log_stream_configured {
+            "aws_signal_log_stream_missing"
+        } else {
+            "aws_signal_live_transport_not_implemented"
+        }
+    }
+}
+
+pub(crate) fn mock_signal_artifact_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join(MOCK_SIGNAL_ARTIFACT)
+}
+
+fn heartbeat_cursor_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join(HEARTBEAT_CURSOR_ARTIFACT)
+}
+
+pub(crate) fn publish_runtime_heartbeat_signal(
+    loaded: &LoadedAgentSpec,
+    status: &StatusRecord,
+) -> PublishOutcome {
+    let config = HeartbeatPublisherConfig::from_env();
+    if !config.configured {
+        return PublishOutcome {
+            disposition: PublishDisposition::Skipped,
+            failure_class: None,
+        };
+    }
+
+    if matches!(config.mode, AwsSignalMode::Disabled) {
+        emit_event(
+            "agent",
+            "aws_runtime_heartbeat",
+            "skipped",
+            &[
+                ("mode", config.mode_label()),
+                ("target_kind", config.target_kind.as_str()),
+                ("runtime_id", loaded.spec.agent_instance_id.as_str()),
+                ("cycle_id", cycle_id_for_status(status).as_str()),
+                ("heartbeat_seq", "not_allocated"),
+                ("signal_status", runtime_signal_status(status)),
+            ],
+        );
+        return PublishOutcome {
+            disposition: PublishDisposition::Skipped,
+            failure_class: None,
+        };
+    }
+
+    if matches!(config.mode, AwsSignalMode::Mock | AwsSignalMode::Live)
+        && config.target_kind != HEARTBEAT_TARGET_KIND
+    {
+        let failure_class = "aws_signal_unsupported_target";
+        emit_publish_failure(
+            &config,
+            loaded.spec.agent_instance_id.as_str(),
+            cycle_id_for_status(status).as_str(),
+            "not_allocated",
+            runtime_signal_status(status),
+            failure_class,
+        );
+        return PublishOutcome {
+            disposition: PublishDisposition::Blocked,
+            failure_class: Some(failure_class.to_string()),
+        };
+    }
+
+    let heartbeat_seq = match reserve_heartbeat_seq(loaded) {
+        Ok(sequence) => sequence,
+        Err(_) => {
+            let failure_class = "aws_signal_cursor_write_failed";
+            emit_publish_failure(
+                &config,
+                loaded.spec.agent_instance_id.as_str(),
+                cycle_id_for_status(status).as_str(),
+                "not_allocated",
+                runtime_signal_status(status),
+                failure_class,
+            );
+            return PublishOutcome {
+                disposition: PublishDisposition::Blocked,
+                failure_class: Some(failure_class.to_string()),
+            };
+        }
+    };
+
+    let envelope = build_runtime_heartbeat_envelope(loaded, status, &config, heartbeat_seq);
+    let heartbeat_seq_label = envelope.heartbeat_seq.to_string();
+
+    match config.mode {
+        AwsSignalMode::Disabled => unreachable!("disabled mode returns before sequence allocation"),
+        AwsSignalMode::Mock => match append_mock_signal(loaded, &envelope) {
+            Ok(()) => {
+                emit_event(
+                    "agent",
+                    "aws_runtime_heartbeat",
+                    "completed",
+                    &[
+                        ("mode", config.mode_label()),
+                        ("target_kind", config.target_kind.as_str()),
+                        ("runtime_id", envelope.runtime_id.as_str()),
+                        ("cycle_id", envelope.cycle_id.as_str()),
+                        ("heartbeat_seq", heartbeat_seq_label.as_str()),
+                        ("signal_status", envelope.status.as_str()),
+                    ],
+                );
+                PublishOutcome {
+                    disposition: PublishDisposition::PublishedMock,
+                    failure_class: None,
+                }
+            }
+            Err(_) => {
+                let failure_class = "aws_signal_mock_write_failed";
+                emit_publish_failure(
+                    &config,
+                    envelope.runtime_id.as_str(),
+                    envelope.cycle_id.as_str(),
+                    heartbeat_seq_label.as_str(),
+                    envelope.status.as_str(),
+                    failure_class,
+                );
+                PublishOutcome {
+                    disposition: PublishDisposition::Blocked,
+                    failure_class: Some(failure_class.to_string()),
+                }
+            }
+        },
+        AwsSignalMode::Live => {
+            let failure_class = config.live_block_reason();
+            emit_publish_failure(
+                &config,
+                envelope.runtime_id.as_str(),
+                envelope.cycle_id.as_str(),
+                heartbeat_seq_label.as_str(),
+                envelope.status.as_str(),
+                failure_class,
+            );
+            PublishOutcome {
+                disposition: PublishDisposition::Blocked,
+                failure_class: Some(failure_class.to_string()),
+            }
+        }
+    }
+}
+
+fn emit_publish_failure(
+    config: &HeartbeatPublisherConfig,
+    runtime_id: &str,
+    cycle_id: &str,
+    heartbeat_seq: &str,
+    signal_status: &str,
+    failure_class: &str,
+) {
+    emit_event(
+        "agent",
+        "aws_runtime_heartbeat",
+        "failed",
+        &[
+            ("mode", config.mode_label()),
+            ("target_kind", config.target_kind.as_str()),
+            ("runtime_id", runtime_id),
+            ("cycle_id", cycle_id),
+            ("heartbeat_seq", heartbeat_seq),
+            ("signal_status", signal_status),
+            ("failure_class", failure_class),
+        ],
+    );
+}
+
+fn build_runtime_heartbeat_envelope(
+    loaded: &LoadedAgentSpec,
+    status: &StatusRecord,
+    config: &HeartbeatPublisherConfig,
+    heartbeat_seq: u64,
+) -> RuntimeAwsSignalEnvelope {
+    let cycle_id = cycle_id_for_status(status);
+    let runtime_id = loaded.spec.agent_instance_id.clone();
+    let agent_id = loaded
+        .spec
+        .workflow
+        .name
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| loaded.spec.display_name.clone());
+    RuntimeAwsSignalEnvelope {
+        schema_version: AWS_SIGNAL_SCHEMA_VERSION.to_string(),
+        signal_kind: "heartbeat".to_string(),
+        runtime_id: runtime_id.clone(),
+        agent_id,
+        cycle_id: cycle_id.clone(),
+        heartbeat_seq,
+        status: runtime_signal_status(status).to_string(),
+        timestamp: status.updated_at,
+        capabilities: vec![
+            "long_lived_agent".to_string(),
+            "heartbeat".to_string(),
+            loaded.spec.workflow.kind.clone(),
+        ],
+        failure_class: status.last_error.as_ref().map(|err| err.class.clone()),
+        correlation_id: format!("heartbeat:{runtime_id}:{cycle_id}:{heartbeat_seq}"),
+        projection_level: "operations_safe".to_string(),
+        transport: RuntimeAwsSignalTransport {
+            mode: config.mode_label().to_string(),
+            target_kind: config.target_kind.clone(),
+            region: config.region.clone(),
+            approved: config.approved,
+        },
+        payload: RuntimeHeartbeatPayload {
+            state: agent_state_label(&status.state).to_string(),
+            elapsed_ms: elapsed_ms(status),
+            next_cycle_hint: next_cycle_hint(status).to_string(),
+            stop_requested: status.stop_requested,
+            lease_state: lease_state_label(status).to_string(),
+        },
+    }
+}
+
+fn append_mock_signal(loaded: &LoadedAgentSpec, envelope: &RuntimeAwsSignalEnvelope) -> Result<()> {
+    let path = mock_signal_artifact_path(loaded);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed opening {}", path.display()))?;
+    serde_json::to_writer(&mut file, envelope)
+        .with_context(|| format!("failed writing {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("failed finalizing {}", path.display()))?;
+    Ok(())
+}
+
+fn cycle_id_for_status(status: &StatusRecord) -> String {
+    status
+        .last_cycle_id
+        .clone()
+        .or_else(|| {
+            status
+                .active_lease
+                .as_ref()
+                .map(|lease| lease.cycle_id.clone())
+        })
+        .unwrap_or_else(|| "not_applicable".to_string())
+}
+
+fn runtime_signal_status(status: &StatusRecord) -> &'static str {
+    match status.state {
+        AgentStatusState::NotStarted => "started",
+        AgentStatusState::RunningCycle | AgentStatusState::Leased => "heartbeat",
+        AgentStatusState::Idle | AgentStatusState::Completed | AgentStatusState::Stopped => {
+            "completed"
+        }
+        AgentStatusState::Failed => "failed",
+    }
+}
+
+fn next_cycle_hint(status: &StatusRecord) -> &'static str {
+    match status.state {
+        AgentStatusState::RunningCycle | AgentStatusState::Leased => "cycle_in_progress",
+        AgentStatusState::Idle | AgentStatusState::Completed => "sleep_until_next_heartbeat",
+        AgentStatusState::Stopped => "stop_requested",
+        AgentStatusState::Failed => "inspect_status_and_cycle_artifacts",
+        AgentStatusState::NotStarted => "await_first_cycle",
+    }
+}
+
+fn lease_state_label(status: &StatusRecord) -> &'static str {
+    if status.active_lease.is_some() {
+        "active"
+    } else if status.stop_requested {
+        "stop_requested"
+    } else {
+        "clear"
+    }
+}
+
+fn agent_state_label(state: &AgentStatusState) -> &'static str {
+    match state {
+        AgentStatusState::NotStarted => "not_started",
+        AgentStatusState::Idle => "idle",
+        AgentStatusState::Leased => "leased",
+        AgentStatusState::RunningCycle => "running_cycle",
+        AgentStatusState::Stopped => "stopped",
+        AgentStatusState::Failed => "failed",
+        AgentStatusState::Completed => "completed",
+    }
+}
+
+fn elapsed_ms(status: &StatusRecord) -> i64 {
+    status
+        .active_lease
+        .as_ref()
+        .map(|lease| {
+            status
+                .updated_at
+                .signed_duration_since(lease.started_at)
+                .num_milliseconds()
+                .max(0)
+        })
+        .unwrap_or(0)
+}
+
+fn reserve_heartbeat_seq(loaded: &LoadedAgentSpec) -> Result<u64> {
+    let path = heartbeat_cursor_path(loaded);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    let mut cursor = if path.exists() {
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed reading {}", path.display()))?;
+        serde_json::from_str::<HeartbeatCursor>(&raw)
+            .with_context(|| format!("failed parsing {}", path.display()))?
+    } else {
+        HeartbeatCursor {
+            schema: HEARTBEAT_CURSOR_SCHEMA.to_string(),
+            next_heartbeat_seq: 1,
+        }
+    };
+    let reserved = cursor.next_heartbeat_seq;
+    cursor.next_heartbeat_seq = cursor.next_heartbeat_seq.saturating_add(1);
+    let file =
+        File::create(&path).with_context(|| format!("failed creating {}", path.display()))?;
+    serde_json::to_writer_pretty(&file, &cursor)
+        .with_context(|| format!("failed writing {}", path.display()))?;
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed finalizing {}", path.display()))?
+        .write_all(b"\n")
+        .with_context(|| format!("failed finalizing {}", path.display()))?;
+    Ok(reserved)
+}

--- a/adl/src/runtime_aws_signal.rs
+++ b/adl/src/runtime_aws_signal.rs
@@ -485,3 +485,320 @@ fn reserve_heartbeat_seq(loaded: &LoadedAgentSpec) -> Result<u64> {
         .with_context(|| format!("failed finalizing {}", path.display()))?;
     Ok(reserved)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::long_lived_agent::{
+        AgentSpec, AgentStatusState, HeartbeatSpec, LeaseRecord, StatusError, StatusRecord,
+        WorkflowSpec,
+    };
+    use crate::observability::test_env_lock;
+    use chrono::Duration as ChronoDuration;
+    use serde_json::json;
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::MutexGuard;
+
+    static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    struct MultiEnvGuard {
+        saved: Vec<(String, Option<OsString>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl MultiEnvGuard {
+        fn set_all(values: &[(&str, &str)]) -> Self {
+            let lock = test_env_lock();
+            let tracked = [
+                "ADL_AWS_SIGNAL_MODE",
+                "ADL_AWS_REGION",
+                "ADL_AWS_HEARTBEAT_TARGET",
+                "ADL_AWS_SIGNAL_APPROVED",
+                "ADL_AWS_HEARTBEAT_LOG_GROUP",
+                "ADL_AWS_HEARTBEAT_LOG_STREAM",
+            ];
+            let mut saved = Vec::with_capacity(tracked.len());
+            for key in tracked {
+                saved.push((key.to_string(), env::var_os(key)));
+                unsafe {
+                    env::remove_var(key);
+                }
+            }
+            for (key, value) in values {
+                unsafe {
+                    env::set_var(key, value);
+                }
+            }
+            Self { saved, _lock: lock }
+        }
+    }
+
+    impl Drop for MultiEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                for (key, old) in self.saved.iter().rev() {
+                    match old {
+                        Some(value) => env::set_var(key, value),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "adl-runtime-aws-signal-{prefix}-{}-{}",
+            std::process::id(),
+            TEMP_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn sample_loaded(root: &Path) -> LoadedAgentSpec {
+        let spec_path = root.join("agent.yaml");
+        LoadedAgentSpec {
+            spec: AgentSpec {
+                schema: "adl.long_lived_agent_spec.v1".to_string(),
+                agent_instance_id: "runtime-agent".to_string(),
+                display_name: "Runtime Agent".to_string(),
+                state_root: PathBuf::from("state"),
+                workflow: WorkflowSpec {
+                    kind: "demo_adapter".to_string(),
+                    name: Some("runtime-heartbeat".to_string()),
+                    path: None,
+                    run_args: json!({}),
+                },
+                heartbeat: HeartbeatSpec {
+                    interval_secs: Some(30),
+                    max_cycles: Some(5),
+                    stale_lease_after_secs: Some(60),
+                },
+                safety: json!({}),
+                memory: json!({}),
+            },
+            spec_path,
+            state_root: root.join("state"),
+        }
+    }
+
+    fn sample_status(state: AgentStatusState) -> StatusRecord {
+        StatusRecord {
+            schema: "adl.long_lived_agent_status.v1".to_string(),
+            agent_instance_id: "runtime-agent".to_string(),
+            state,
+            last_cycle_id: Some("cycle-000123".to_string()),
+            last_cycle_status: Some("success".to_string()),
+            completed_cycle_count: 3,
+            consecutive_failure_count: 0,
+            active_lease: None,
+            stop_requested: false,
+            last_error: None,
+            safety_policy: json!({}),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn runtime_aws_signal_config_parses_modes_and_live_block_reasons() {
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "live"),
+                ("ADL_AWS_SIGNAL_APPROVED", "true"),
+                ("ADL_AWS_REGION", "us-west-2"),
+            ]);
+            let config = HeartbeatPublisherConfig::from_env();
+            assert_eq!(config.mode, AwsSignalMode::Live);
+            assert!(config.configured);
+            assert_eq!(config.mode_label(), "live");
+            assert_eq!(config.live_block_reason(), "aws_signal_log_group_missing");
+        }
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "live"),
+                ("ADL_AWS_SIGNAL_APPROVED", "true"),
+                ("ADL_AWS_REGION", "us-west-2"),
+                ("ADL_AWS_HEARTBEAT_LOG_GROUP", "group"),
+            ]);
+            let config = HeartbeatPublisherConfig::from_env();
+            assert_eq!(config.live_block_reason(), "aws_signal_log_stream_missing");
+        }
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "live"),
+                ("ADL_AWS_SIGNAL_APPROVED", "true"),
+                ("ADL_AWS_REGION", "us-west-2"),
+                ("ADL_AWS_HEARTBEAT_LOG_GROUP", "group"),
+                ("ADL_AWS_HEARTBEAT_LOG_STREAM", "stream"),
+            ]);
+            let config = HeartbeatPublisherConfig::from_env();
+            assert_eq!(
+                config.live_block_reason(),
+                "aws_signal_live_transport_not_implemented"
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_aws_signal_helper_labels_cover_status_variants() {
+        let mut status = sample_status(AgentStatusState::RunningCycle);
+        let lease_started_at = status.updated_at - ChronoDuration::seconds(12);
+        status.active_lease = Some(LeaseRecord {
+            schema: "adl.long_lived_agent_lease.v1".to_string(),
+            agent_instance_id: "runtime-agent".to_string(),
+            lease_id: "lease-1".to_string(),
+            cycle_id: "cycle-lease".to_string(),
+            owner_pid: 42,
+            hostname: "local".to_string(),
+            started_at: lease_started_at,
+            expires_at: status.updated_at + ChronoDuration::seconds(60),
+            status: "active".to_string(),
+        });
+        assert_eq!(cycle_id_for_status(&status), "cycle-000123");
+        assert_eq!(runtime_signal_status(&status), "heartbeat");
+        assert_eq!(next_cycle_hint(&status), "cycle_in_progress");
+        assert_eq!(lease_state_label(&status), "active");
+        assert_eq!(agent_state_label(&status.state), "running_cycle");
+        assert!(elapsed_ms(&status) >= 12_000);
+
+        let mut failed = sample_status(AgentStatusState::Failed);
+        failed.last_cycle_id = None;
+        failed.stop_requested = true;
+        failed.active_lease = None;
+        failed.last_error = Some(StatusError {
+            class: "workflow_failed".to_string(),
+            message: "cycle failed".to_string(),
+        });
+        assert_eq!(cycle_id_for_status(&failed), "not_applicable");
+        assert_eq!(runtime_signal_status(&failed), "failed");
+        assert_eq!(
+            next_cycle_hint(&failed),
+            "inspect_status_and_cycle_artifacts"
+        );
+        assert_eq!(lease_state_label(&failed), "stop_requested");
+        assert_eq!(agent_state_label(&failed.state), "failed");
+
+        let idle = sample_status(AgentStatusState::Idle);
+        assert_eq!(runtime_signal_status(&idle), "completed");
+        assert_eq!(next_cycle_hint(&idle), "sleep_until_next_heartbeat");
+    }
+
+    #[test]
+    fn runtime_aws_signal_mock_publish_writes_envelope_and_cursor() {
+        let root = temp_dir("mock");
+        let loaded = sample_loaded(&root);
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_AWS_SIGNAL_MODE", "mock"),
+            ("ADL_AWS_REGION", "us-west-2"),
+        ]);
+
+        let outcome = publish_runtime_heartbeat_signal(
+            &loaded,
+            &sample_status(AgentStatusState::RunningCycle),
+        );
+        assert_eq!(outcome.disposition, PublishDisposition::PublishedMock);
+        assert_eq!(outcome.failure_class, None);
+
+        let artifact = fs::read_to_string(mock_signal_artifact_path(&loaded)).expect("artifact");
+        let envelope: serde_json::Value =
+            serde_json::from_str(artifact.lines().next().expect("jsonl line"))
+                .expect("parse envelope");
+        assert_eq!(envelope["schema_version"], AWS_SIGNAL_SCHEMA_VERSION);
+        assert_eq!(envelope["signal_kind"], "heartbeat");
+        assert_eq!(envelope["transport"]["mode"], "mock");
+        assert_eq!(envelope["transport"]["target_kind"], HEARTBEAT_TARGET_KIND);
+        assert_eq!(envelope["heartbeat_seq"], 1);
+        assert_eq!(
+            envelope["correlation_id"],
+            "heartbeat:runtime-agent:cycle-000123:1"
+        );
+        assert_eq!(envelope["payload"]["state"], "running_cycle");
+        assert_eq!(envelope["payload"]["next_cycle_hint"], "cycle_in_progress");
+
+        let cursor: HeartbeatCursor = serde_json::from_str(
+            &fs::read_to_string(heartbeat_cursor_path(&loaded)).expect("cursor"),
+        )
+        .expect("parse cursor");
+        assert_eq!(cursor.schema, HEARTBEAT_CURSOR_SCHEMA);
+        assert_eq!(cursor.next_heartbeat_seq, 2);
+    }
+
+    #[test]
+    fn runtime_aws_signal_publish_handles_disabled_unsupported_and_live_blocked_modes() {
+        let root = temp_dir("publish-modes");
+        let loaded = sample_loaded(&root);
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[("ADL_AWS_SIGNAL_MODE", "disabled")]);
+            let disabled =
+                publish_runtime_heartbeat_signal(&loaded, &sample_status(AgentStatusState::Idle));
+            assert_eq!(disabled.disposition, PublishDisposition::Skipped);
+            assert!(!mock_signal_artifact_path(&loaded).exists());
+            assert!(!heartbeat_cursor_path(&loaded).exists());
+        }
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "mock"),
+                ("ADL_AWS_HEARTBEAT_TARGET", "sns"),
+            ]);
+            let unsupported =
+                publish_runtime_heartbeat_signal(&loaded, &sample_status(AgentStatusState::Idle));
+            assert_eq!(unsupported.disposition, PublishDisposition::Blocked);
+            assert_eq!(
+                unsupported.failure_class.as_deref(),
+                Some("aws_signal_unsupported_target")
+            );
+        }
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "live"),
+                ("ADL_AWS_REGION", "us-west-2"),
+            ]);
+            let blocked =
+                publish_runtime_heartbeat_signal(&loaded, &sample_status(AgentStatusState::Idle));
+            assert_eq!(blocked.disposition, PublishDisposition::Blocked);
+            assert_eq!(
+                blocked.failure_class.as_deref(),
+                Some("aws_signal_live_not_approved")
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_aws_signal_sequence_and_envelope_helpers_are_stable() {
+        let root = temp_dir("sequence");
+        let loaded = sample_loaded(&root);
+        let first = reserve_heartbeat_seq(&loaded).expect("first seq");
+        let second = reserve_heartbeat_seq(&loaded).expect("second seq");
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+
+        let config = HeartbeatPublisherConfig {
+            mode: AwsSignalMode::Mock,
+            configured: true,
+            region: Some("us-west-2".to_string()),
+            target_kind: HEARTBEAT_TARGET_KIND.to_string(),
+            approved: false,
+            log_group_configured: false,
+            log_stream_configured: false,
+        };
+        let mut stopped = sample_status(AgentStatusState::Stopped);
+        stopped.last_cycle_id = None;
+        let envelope = build_runtime_heartbeat_envelope(&loaded, &stopped, &config, second);
+        assert_eq!(envelope.agent_id, "runtime-heartbeat");
+        assert_eq!(envelope.cycle_id, "not_applicable");
+        assert_eq!(envelope.status, "completed");
+        assert_eq!(envelope.transport.region.as_deref(), Some("us-west-2"));
+        assert!(!envelope.transport.approved);
+        assert_eq!(envelope.payload.state, "stopped");
+        assert_eq!(envelope.payload.next_cycle_hint, "stop_requested");
+        assert_eq!(envelope.payload.lease_state, "clear");
+    }
+}

--- a/docs/milestones/v0.91.6/README.md
+++ b/docs/milestones/v0.91.6/README.md
@@ -172,6 +172,8 @@ Expected `v0.91.7` residuals:
   [review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md](review/CSDLC_GITHUB_PROJECTION_CONVERGENCE_REVIEW_3935.md)
 - Runtime AWS signal bridge design:
   [review/runtime_aws_signal_bridge/RUNTIME_AWS_SIGNAL_BRIDGE_DESIGN_4294.md](review/runtime_aws_signal_bridge/RUNTIME_AWS_SIGNAL_BRIDGE_DESIGN_4294.md)
+- Runtime AWS heartbeat publisher proof:
+  [review/runtime_aws_signal_bridge/RUNTIME_AWS_HEARTBEAT_PUBLISHER_PROOF_4295.md](review/runtime_aws_signal_bridge/RUNTIME_AWS_HEARTBEAT_PUBLISHER_PROOF_4295.md)
 - Validation-tail A/B index:
   [review/PVF_LONG_VALIDATION_LANE_INDEX_4223.md](review/PVF_LONG_VALIDATION_LANE_INDEX_4223.md)
 

--- a/docs/milestones/v0.91.6/review/runtime_aws_signal_bridge/RUNTIME_AWS_HEARTBEAT_PUBLISHER_PROOF_4295.md
+++ b/docs/milestones/v0.91.6/review/runtime_aws_signal_bridge/RUNTIME_AWS_HEARTBEAT_PUBLISHER_PROOF_4295.md
@@ -1,0 +1,134 @@
+# Runtime AWS Heartbeat Publisher Proof For `#4295`
+
+## Status
+
+- Issue: `#4295`
+- Milestone: `v0.91.6`
+- Status: `local_mock_proof`
+- Scope: bounded runtime heartbeat publication proof against the `#4294`
+  runtime AWS signal bridge contract
+- Proof mode: focused Rust validation plus local/mock event inspection; no live
+  AWS mutation
+
+## What Landed
+
+`#4295` adds the first runtime heartbeat publication slice for the long-lived
+agent runtime surface.
+
+The landed behavior is intentionally narrow:
+
+- emits `adl.runtime.aws_signal.v1` heartbeat envelopes from long-lived-agent
+  status writes
+- supports three operator-facing modes through `ADL_AWS_SIGNAL_MODE`:
+  - `mock`
+  - `live`
+  - explicit `disabled`
+- keeps the unconfigured default quiet instead of emitting synthetic AWS noise
+- writes mock heartbeat envelopes to a local reviewer-readable JSONL artifact
+- allocates monotonic heartbeat sequence numbers from a local cursor artifact so
+  later heartbeats advance identity instead of collapsing into retry lookalikes
+- keeps `live` fail-closed and observable until a later issue lands the real
+  CloudWatch transport
+
+## Contract Alignment With `#4294`
+
+The emitted heartbeat envelope preserves the `#4294` contract:
+
+- `schema_version = adl.runtime.aws_signal.v1`
+- `signal_kind = heartbeat`
+- includes `runtime_id`, `agent_id`, `cycle_id`, `heartbeat_seq`, `status`,
+  `timestamp`, `capabilities`, `failure_class`, `correlation_id`,
+  `projection_level`, `transport`, and `payload`
+- uses `projection_level = operations_safe`
+- keeps the payload to bounded operational fields only:
+  - `state`
+  - `elapsed_ms`
+  - `next_cycle_hint`
+  - `stop_requested`
+  - `lease_state`
+
+Non-claims preserved:
+
+- no ACIP-to-SNS implementation in this issue
+- no raw private state publication
+- no provider prompts/responses
+- no AWS account ids, private ARNs, or credentials in committed proof artifacts
+- no live CloudWatch mutation claim
+
+## Mode Behavior
+
+### Unconfigured default
+
+- no AWS heartbeat publication path is activated
+- no mock artifact is written
+- no live configuration is inferred
+
+### `mock`
+
+- no AWS credentials required
+- no live AWS mutation
+- reviewer-readable JSONL artifact written at:
+  `state/aws_runtime_heartbeat_mock.jsonl`
+- monotonic sequence cursor written at:
+  `state/aws_runtime_heartbeat_cursor.json`
+- observability emits `stage=aws_runtime_heartbeat result=completed`
+
+### `live`
+
+- requires explicit operator approval through `ADL_AWS_SIGNAL_APPROVED`
+- requires explicit region/target/log-group/log-stream configuration
+- currently fails closed with observable `adl_event` output instead of
+  inventing a CloudWatch client path
+- does not make the underlying runtime cycle pretend publication succeeded
+
+### explicit `disabled`
+
+- emits observable skip classification
+- does not require AWS credentials or write the mock artifact
+
+## Focused Validation
+
+- `cargo fmt --manifest-path adl/Cargo.toml --all`
+  - verified formatting for the bounded Rust changes
+- `cargo test --manifest-path adl/Cargo.toml long_lived_agent -- --nocapture`
+  - verified the long-lived-agent lane plus the new runtime AWS heartbeat
+    publisher tests
+
+## Tests Added / Covered
+
+Focused proof now covers:
+
+- mock mode writes reviewer-readable runtime AWS heartbeat envelopes
+- emitted envelopes carry the `#4294` schema/version and bounded heartbeat
+  payload fields
+- live mode without explicit approval stays fail-closed
+- unsupported heartbeat targets are rejected instead of being written into mock
+  proof artifacts
+- live-blocked mode remains observable through `adl_event`
+- live-blocked mode does not leak private ARN/account strings into the
+  observability log
+- repeated heartbeats for the same cycle advance `heartbeat_seq` and
+  `correlation_id`
+- live-blocked mode does not downgrade the underlying runtime cycle into a fake
+  external-delivery success claim
+
+## Reviewer Read Path
+
+1. Inspect `adl/src/runtime_aws_signal.rs` for mode parsing, envelope shaping,
+   and fail-closed live gating.
+2. Inspect `adl/src/long_lived_agent/storage.rs` to confirm publication is
+   hooked to status writes rather than a separate synthetic timer.
+3. Inspect `adl/src/long_lived_agent/tests.rs` for the mock and live-blocked
+   proof cases.
+4. Run the focused validation commands above.
+
+## Residuals / Follow-on Work
+
+- Real CloudWatch Logs transport remains deferred; this issue only stages the
+  contract seam and fail-closed live gate.
+- Downstream SNS projection remains owned by `#4296`.
+- If live transport is later added, it must preserve:
+  - no secret/account/ARN leakage
+  - fail-closed behavior
+  - tail-friendly observability
+  - non-authoritative AWS posture


### PR DESCRIPTION
Closes #4295

## Summary
Implemented the bounded runtime AWS heartbeat publisher seam for the long-lived
agent runtime surface, shipped mock/local proof, and staged live mode as
explicit fail-closed observability rather than live CloudWatch mutation.

## Artifacts
- Code:
  - `adl/src/runtime_aws_signal.rs`
  - `adl/src/long_lived_agent/storage.rs`
  - `adl/src/long_lived_agent/tests.rs`
  - `adl/src/lib.rs`
- Docs:
  - `docs/milestones/v0.91.6/review/runtime_aws_signal_bridge/RUNTIME_AWS_HEARTBEAT_PUBLISHER_PROOF_4295.md`
  - `docs/milestones/v0.91.6/README.md`
- Local issue record:
  - `.adl/v0.91.6/tasks/issue-4295__aws-runtime-heartbeat-publisher/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified formatting for the bounded Rust implementation and test changes.
  - `cargo test --manifest-path adl/Cargo.toml long_lived_agent -- --nocapture`
    Verified the long-lived-agent lane plus mock/live-blocked heartbeat proof,
    unsupported-target rejection, and repeated-heartbeat sequence advancement.
  - `git diff --check`
    Verified no whitespace or malformed patch fragments in the issue diff.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.6/tasks/issue-4295__aws-runtime-heartbeat-publisher/spp.md`
    Verified the updated issue-local execution plan remained contract-valid
    after execution diverged from the bootstrap draft.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4295__aws-runtime-heartbeat-publisher/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4295__aws-runtime-heartbeat-publisher/sor.md
- Idempotency-Key: adl-add-runtime-aws-heartbeat-publisher-seam-adl-src-runtime-aws-signal-rs-adl-src-long-lived-agent-storage-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-milestones-v0-91-6-review-runtime-aws-signal-bridge-runtime-aws-heartbeat-publisher-proof-4295-md-docs-milestones-v0-91-6-readme-md-adl-v0-91-6-tasks-issue-4295-aws-runtime-heartbeat-publisher-sip-md-adl-v0-91-6-tasks-issue-4295-aws-runtime-heartbeat-publisher-sor-md