### PR TITLE
[v0.91.6][process][metrics] Add variance analysis for estimate misses

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -1099,6 +1099,14 @@ fn render_bootstrap_output_card(
             ("<actual_metrics_source_ref>", "unknown".to_string()),
             ("<actual_metrics_confidence>", "unknown".to_string()),
             ("<estimate_error_percent>", "unknown".to_string()),
+            ("<variance_analysis_required>", "not_applicable".to_string()),
+            ("<variance_analysis_completed>", "not_applicable".to_string()),
+            ("<variance_category>", "not_applicable".to_string()),
+            (
+                "<variance_note>",
+                "Bootstrap scaffold records unknown issue metrics only; variance analysis is deferred until execution produces authoritative estimates and actuals."
+                    .to_string(),
+            ),
         ],
     );
     Ok(text)

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3931,6 +3931,7 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
             closeout_log.display()
         ),
     );
+    let _fixture = GithubCliFixtureGuard::set(&gh_path);
 
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
@@ -5251,6 +5252,7 @@ fn real_pr_finish_opener_failure_is_nonblocking_when_no_open_is_false() {
         &open_path,
         "#!/usr/bin/env bash\nset -euo pipefail\necho 'synthetic open failure' >&2\nexit 42\n",
     );
+    let _fixture = GithubCliFixtureGuard::set(&gh_path);
 
     let old_path = env::var("PATH").unwrap_or_default();
     let prev_dir = env::current_dir().expect("cwd");

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -317,10 +317,7 @@ pub(crate) fn write_alternate_stp_prompt_template(repo: &Path) {
         .expect("read base stp template");
     fs::write(
         alternate_dir.join("stp.md"),
-        base.replace(
-            "Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`",
-            "Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`",
-        ) + "\n\nRegistry route proof: alternate STP template.\n",
+        base + "\n\nRegistry route proof: alternate STP template.\n",
     )
     .expect("write alternate stp template");
     fs::write(

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -271,6 +271,8 @@ pub(crate) fn copy_versioned_prompt_templates(repo: &Path) {
     fs::create_dir_all(target_root.join("1.0.0/schemas")).expect("create prompt template dir");
     fs::create_dir_all(target_root.join("1.0.1")).expect("create prompt template dir");
     fs::create_dir_all(target_root.join("1.0.1/schemas")).expect("create prompt template dir");
+    fs::create_dir_all(target_root.join("1.0.2")).expect("create prompt template dir");
+    fs::create_dir_all(target_root.join("1.0.2/schemas")).expect("create prompt template dir");
     for rel in [
         "current.json",
         "1.0.0/sip.md",
@@ -293,21 +295,31 @@ pub(crate) fn copy_versioned_prompt_templates(repo: &Path) {
         "1.0.1/schemas/spp.structure.json",
         "1.0.1/schemas/srp.structure.json",
         "1.0.1/schemas/sor.structure.json",
+        "1.0.2/sip.md",
+        "1.0.2/stp.md",
+        "1.0.2/spp.md",
+        "1.0.2/srp.md",
+        "1.0.2/sor.md",
+        "1.0.2/schemas/sip.structure.json",
+        "1.0.2/schemas/stp.structure.json",
+        "1.0.2/schemas/spp.structure.json",
+        "1.0.2/schemas/srp.structure.json",
+        "1.0.2/schemas/sor.structure.json",
     ] {
         fs::copy(source_root.join(rel), target_root.join(rel)).expect("copy prompt template");
     }
 }
 
 pub(crate) fn write_alternate_stp_prompt_template(repo: &Path) {
-    let alternate_dir = repo.join("docs/templates/prompts/1.0.1");
+    let alternate_dir = repo.join("docs/templates/prompts/1.0.2");
     fs::create_dir_all(&alternate_dir).expect("create alternate prompt template dir");
-    let base = fs::read_to_string(repo.join("docs/templates/prompts/1.0.0/stp.md"))
+    let base = fs::read_to_string(repo.join("docs/templates/prompts/1.0.2/stp.md"))
         .expect("read base stp template");
     fs::write(
         alternate_dir.join("stp.md"),
         base.replace(
-            "Canonical Template Source: `docs/templates/prompts/1.0.0/stp.md`",
-            "Canonical Template Source: `docs/templates/prompts/1.0.1/stp.md`",
+            "Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`",
+            "Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`",
         ) + "\n\nRegistry route proof: alternate STP template.\n",
     )
     .expect("write alternate stp template");
@@ -315,15 +327,15 @@ pub(crate) fn write_alternate_stp_prompt_template(repo: &Path) {
         repo.join("docs/templates/prompts/current.json"),
         r#"{
   "schema": "adl.csdlc.prompt_template_registry.v1",
-  "csdlc_prompt_template_set": "1.0.1",
-  "semver": "1.0.1",
+  "csdlc_prompt_template_set": "1.0.2",
+  "semver": "1.0.2",
   "status": "active",
   "object_kind": "csdlc_prompt_template_set",
   "lifecycle": ["SIP", "STP", "SPP", "SRP", "SOR"],
   "templates": {
     "stp": {
       "semantic_role": "Structured Task Prompt",
-      "path": "docs/templates/prompts/1.0.1/stp.md"
+      "path": "docs/templates/prompts/1.0.2/stp.md"
     }
   }
 }

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -87,7 +87,7 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
     ] {
         assert!(
             text.contains(&format!(
-                "Canonical Template Source: `docs/templates/prompts/1.0.1/{}.md`",
+                "Canonical Template Source: `docs/templates/prompts/1.0.2/{}.md`",
                 kind.to_ascii_lowercase()
             )),
             "{kind} should identify the versioned template source"
@@ -194,7 +194,7 @@ Fresh bootstrap output contains all five C-SDLC cards with no raw template place
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.1/
+- docs/templates/prompts/1.0.2/
 
 ## Dependencies
 
@@ -259,7 +259,7 @@ Fresh bootstrap output contains all five C-SDLC cards with no raw template place
         let text = fs::read_to_string(path).expect("read refreshed card");
         assert_no_prompt_template_residue(kind, &text);
         assert!(
-            text.contains("Canonical Template Source: `docs/templates/prompts/1.0.1/"),
+            text.contains("Canonical Template Source: `docs/templates/prompts/1.0.2/"),
             "{kind} should be regenerated from the versioned template set"
         );
     }
@@ -316,7 +316,7 @@ Legacy design-time-ready SPP from the pre-template transition window.
     ensure_bootstrap_cards(&repo, &issue_ref, title, "not bound yet", &source_path)
         .expect("legacy SPP should be refreshed");
     let spp = fs::read_to_string(&spp_path).expect("read spp");
-    assert!(spp.contains("Canonical Template Source: `docs/templates/prompts/1.0.1/spp.md`"));
+    assert!(spp.contains("Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`"));
     assert!(!spp.contains("activation_state: \"design_time_ready\""));
 }
 
@@ -553,7 +553,7 @@ review_hooks:
 notes: "Reviewed card should remain stable across pre-run bootstrap."
 ---
 
-Canonical Template Source: `docs/templates/prompts/1.0.1/spp.md`
+Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`
 
 # Structured Plan Prompt
 
@@ -662,7 +662,7 @@ status: "approved"
 activation_state: "design_time_ready"
 ---
 
-Canonical Template Source: `docs/templates/prompts/1.0.1/spp.md`
+Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`
 
 # Structured Plan Prompt
 
@@ -733,7 +733,7 @@ The generated SPP should carry source-prompt facts into the plan.
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.1/spp.md
+- docs/templates/prompts/1.0.2/spp.md
 
 ## Dependencies
 
@@ -849,7 +849,7 @@ All generated prompt cards pass the sprint readiness checker.
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.1/
+- docs/templates/prompts/1.0.2/
 
 ## Dependencies
 
@@ -905,7 +905,7 @@ All generated prompt cards pass the sprint readiness checker.
         "Use dependency truth from the linked source issue prompt",
         "Review source issue prompt and scoped repo inputs",
         "Follow demo/proof requirements from the linked source issue prompt",
-        "Generated from 1.0.1 C-SDLC prompt template; refine with editor skills before execution if needed",
+        "Generated from 1.0.2 C-SDLC prompt template; refine with editor skills before execution if needed",
     ] {
         assert!(
             !stp.contains(marker),
@@ -958,6 +958,6 @@ fn prompt_template_registry_redirects_rust_template_loading() {
         .expect("versioned STP template should render");
     let stp = fs::read_to_string(stp_path).expect("read stp");
 
-    assert!(stp.contains("Canonical Template Source: `docs/templates/prompts/1.0.1/stp.md`"));
+    assert!(stp.contains("Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`"));
     assert!(stp.contains("Registry route proof: alternate STP template."));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -507,6 +507,9 @@ generated_at: "2026-05-26T22:36:52Z"
 card_status: "ready"
 status: "approved"
 activation_state: "design_time_ready"
+initial_pvf_lane: "prompt_template"
+planned_pvf_lane: "prompt_template"
+planned_pvf_lane_source: "matched_initial_issue_lane"
 plan_revision: 2
 source_refs:
   - kind: "issue"

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -115,6 +115,16 @@ fn metrics_pair_known(left: &str, right: &str) -> bool {
     left != "unknown" && right != "unknown"
 }
 
+fn metrics_pair_exceeds_variance_threshold(left: &str, right: &str) -> Option<bool> {
+    if !metrics_pair_known(left, right) {
+        return None;
+    }
+    let left = left.parse::<u64>().ok()?;
+    let right = right.parse::<u64>().ok()?;
+    let diff = left.abs_diff(right);
+    Some(diff.saturating_mul(100) > left.saturating_mul(10))
+}
+
 pub(super) fn real_lint_prompt_spec(args: &[String]) -> Result<()> {
     let input = resolve_issue_or_input_arg(args)?;
     ensure_file(&input, "input card")?;
@@ -421,6 +431,40 @@ fn is_versioned_prompt_template_card(text: &str) -> bool {
         && !text.contains("Compatibility note:")
 }
 
+fn rendered_card_template_set(text: &str, kind: &str) -> Option<String> {
+    let prefix = "Canonical Template Source: `docs/templates/prompts/";
+    let suffix = format!("/{kind}.md`");
+    text.lines().find_map(|line| {
+        let rest = line.strip_prefix(prefix)?;
+        let template_set = rest.strip_suffix(&suffix)?;
+        if template_set.is_empty() {
+            None
+        } else {
+            Some(template_set.to_string())
+        }
+    })
+}
+
+fn template_set_at_least(template_set: &str, minimum: (u32, u32, u32)) -> bool {
+    let mut parts = template_set.split('.');
+    let major = parts.next().and_then(|value| value.parse::<u32>().ok());
+    let minor = parts.next().and_then(|value| value.parse::<u32>().ok());
+    let patch = parts.next().and_then(|value| value.parse::<u32>().ok());
+    if parts.next().is_some() {
+        return false;
+    }
+    match (major, minor, patch) {
+        (Some(major), Some(minor), Some(patch)) => (major, minor, patch) >= minimum,
+        _ => false,
+    }
+}
+
+fn sor_requires_variance_analysis_section(text: &str) -> bool {
+    rendered_card_template_set(text, "sor")
+        .map(|template_set| template_set_at_least(&template_set, (1, 0, 2)))
+        .unwrap_or(false)
+}
+
 fn issue_number_from_task_id(task_id: &str) -> Result<u32> {
     task_id
         .strip_prefix("issue-")
@@ -700,6 +744,12 @@ pub(super) fn validate_sip_text(text: &str, path: &Path, phase: Option<&str>) ->
 
 pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
     ensure_required_sections(text, super::common::REQUIRED_OUTPUT_SECTIONS)?;
+    if sor_requires_variance_analysis_section(text) {
+        ensure!(
+            markdown_has_heading(text, "Variance Analysis"),
+            "missing required sections: Variance Analysis"
+        );
+    }
     ensure!(
         valid_task_id(&markdown_field(text, "Task ID").unwrap_or_default()),
         "Task ID must match issue-0000"
@@ -853,14 +903,26 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         );
     }
 
-    if let Some(metrics_body) = markdown_section_body(text, "Issue Metrics Truth") {
-        let estimated_elapsed = markdown_metric_field(&metrics_body, "Estimated elapsed seconds");
-        let actual_elapsed = markdown_metric_field(&metrics_body, "Actual elapsed seconds");
-        let estimated_tokens = markdown_metric_field(&metrics_body, "Estimated total tokens");
-        let actual_tokens = markdown_metric_field(&metrics_body, "Actual total tokens");
-        let estimated_validation =
-            markdown_metric_field(&metrics_body, "Estimated validation seconds");
-        let actual_validation = markdown_metric_field(&metrics_body, "Actual validation seconds");
+    let metrics_body = markdown_section_body(text, "Issue Metrics Truth");
+    let estimated_elapsed = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Estimated elapsed seconds"));
+    let actual_elapsed = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Actual elapsed seconds"));
+    let estimated_tokens = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Estimated total tokens"));
+    let actual_tokens = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Actual total tokens"));
+    let estimated_validation = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Estimated validation seconds"));
+    let actual_validation = metrics_body
+        .as_ref()
+        .and_then(|body| markdown_metric_field(body, "Actual validation seconds"));
+    if let Some(metrics_body) = metrics_body {
         for label in [
             "Estimated elapsed seconds",
             "Actual elapsed seconds",
@@ -933,6 +995,94 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
                     "Issue Metrics Truth.Estimate error percent requires at least one estimated/actual metric pair"
                 );
             }
+        }
+    }
+    if let Some(variance_body) = markdown_section_body(text, "Variance Analysis") {
+        ensure!(
+            variance_body.contains(
+                "Threshold policy: require variance analysis when any known estimated/actual pair for elapsed seconds, total tokens, or validation seconds differs by more than 10 percent."
+            ),
+            "Variance Analysis must preserve the 10 percent threshold policy text"
+        );
+        let required = markdown_metric_field(&variance_body, "Variance analysis required")
+            .unwrap_or_else(|| "not_applicable".to_string());
+        let completed = markdown_metric_field(&variance_body, "Variance analysis completed")
+            .unwrap_or_else(|| "not_applicable".to_string());
+        let category = markdown_metric_field(&variance_body, "Variance category")
+            .unwrap_or_else(|| "not_applicable".to_string());
+        ensure_allowed_value(
+            "Variance Analysis.Variance analysis required",
+            &required,
+            &["not_applicable", "no", "yes"],
+        )?;
+        ensure_allowed_value(
+            "Variance Analysis.Variance analysis completed",
+            &completed,
+            &["not_applicable", "no", "yes"],
+        )?;
+        ensure_allowed_value(
+            "Variance Analysis.Variance category",
+            &category,
+            &[
+                "not_applicable",
+                "validation_misclassification",
+                "pr_wait",
+                "merge_conflict",
+                "tool_failure",
+                "unclear_scope",
+                "model_drift",
+                "human_wait",
+                "external_api_latency",
+                "overestimated_scope",
+            ],
+        )?;
+        let variance_note = markdown_metric_field(&variance_body, "Variance note")
+            .unwrap_or_else(|| "".to_string());
+        let any_known_pair_exceeds_threshold = [
+            metrics_pair_exceeds_variance_threshold(
+                estimated_elapsed.as_deref().unwrap_or("unknown"),
+                actual_elapsed.as_deref().unwrap_or("unknown"),
+            ),
+            metrics_pair_exceeds_variance_threshold(
+                estimated_tokens.as_deref().unwrap_or("unknown"),
+                actual_tokens.as_deref().unwrap_or("unknown"),
+            ),
+            metrics_pair_exceeds_variance_threshold(
+                estimated_validation.as_deref().unwrap_or("unknown"),
+                actual_validation.as_deref().unwrap_or("unknown"),
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|exceeds| exceeds);
+        if any_known_pair_exceeds_threshold {
+            ensure!(
+                required == "yes",
+                "Variance Analysis.Variance analysis required must be `yes` when any known estimated/actual metric pair differs by more than 10 percent"
+            );
+        }
+        if required == "yes" {
+            ensure!(
+                completed != "not_applicable",
+                "Variance Analysis.Variance analysis completed cannot be `not_applicable` when variance analysis is required"
+            );
+            ensure!(
+                category != "not_applicable",
+                "Variance Analysis.Variance category cannot be `not_applicable` when variance analysis is required"
+            );
+            ensure!(
+                !variance_note.trim().is_empty() && variance_note != "not_applicable",
+                "Variance Analysis.Variance note must be non-empty when variance analysis is required"
+            );
+        } else {
+            ensure!(
+                completed != "yes",
+                "Variance Analysis.Variance analysis completed cannot be `yes` when variance analysis is not required"
+            );
+            ensure!(
+                category == "not_applicable",
+                "Variance Analysis.Variance category must remain `not_applicable` when variance analysis is not required"
+            );
         }
     }
     Ok(())

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -1036,8 +1036,8 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
                 "overestimated_scope",
             ],
         )?;
-        let variance_note = markdown_metric_field(&variance_body, "Variance note")
-            .unwrap_or_else(|| "".to_string());
+        let variance_note =
+            markdown_metric_field(&variance_body, "Variance note").unwrap_or_default();
         let any_known_pair_exceeds_threshold = [
             metrics_pair_exceeds_variance_threshold(
                 estimated_elapsed.as_deref().unwrap_or("unknown"),

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -122,7 +122,7 @@ fn prompt_template_cli_renders_one_card_and_rejects_locked_value_edits() {
 
     let locked = repo.write_rel(
         "locked.values.yaml",
-        "schema: adl.csdlc.prompt_template_values.v1\ntemplate_set: 1.0.1\ncard_kind: stp\nsystem: {}\nvalues:\n  issue: \"1374\"\n",
+        "schema: adl.csdlc.prompt_template_values.v1\ntemplate_set: 1.0.2\ncard_kind: stp\nsystem: {}\nvalues:\n  issue: \"1374\"\n",
     );
     let err = real_tooling(&[
         "prompt-template".to_string(),
@@ -564,6 +564,86 @@ fn prompt_template_validate_values_fails_closed_for_invalid_sor_metrics_coupling
 }
 
 #[test]
+fn prompt_template_validate_values_requires_variance_analysis_for_large_known_sor_estimate_miss() {
+    let repo = TempRepo::new("prompt-template-invalid-sor-variance");
+    let values_dir = repo.path().join("values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    let err = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "sor".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("sor.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "estimated_elapsed_seconds=100".to_string(),
+        "--set".to_string(),
+        "actual_elapsed_seconds=300".to_string(),
+    ])
+    .expect_err("large known SOR estimate miss should require variance analysis");
+    assert!(err
+        .to_string()
+        .contains("sor.variance_analysis_required must be `yes`"));
+}
+
+#[test]
+fn prompt_template_validate_values_requires_variance_note_when_analysis_is_required() {
+    let repo = TempRepo::new("prompt-template-invalid-sor-variance-note");
+    let values_dir = repo.path().join("values");
+
+    real_tooling(&[
+        "prompt-template".to_string(),
+        "write-sample-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--out-dir".to_string(),
+        values_dir.to_string_lossy().to_string(),
+    ])
+    .expect("write sample values");
+
+    let err = real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-values".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tests().to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "sor".to_string(),
+        "--values".to_string(),
+        values_dir
+            .join("sor.values.yaml")
+            .to_string_lossy()
+            .to_string(),
+        "--set".to_string(),
+        "variance_analysis_required=yes".to_string(),
+        "--set".to_string(),
+        "variance_analysis_completed=yes".to_string(),
+        "--set".to_string(),
+        "variance_category=tool_failure".to_string(),
+        "--set".to_string(),
+        "variance_note=not_applicable".to_string(),
+    ])
+    .expect_err("required variance analysis should need a real note");
+    assert!(err.to_string().contains(
+        "sor.variance_note must be non-empty when sor.variance_analysis_required is `yes`"
+    ));
+}
+
+#[test]
 fn prompt_template_cli_edit_rendered_card_uses_values_roundtrip_default_path() {
     let repo = TempRepo::new("prompt-template-edit-rendered");
     let values_dir = repo.path().join("values");
@@ -733,7 +813,7 @@ fn prompt_template_cli_usage_and_error_paths_are_deterministic() {
     let repo = TempRepo::new("prompt-template-errors");
     let values = repo.write_rel(
         "sip.values.yaml",
-        "schema: adl.csdlc.prompt_template_values.v1\ntemplate_set: 1.0.1\ncard_kind: sip\nsystem:\n  issue: \"1374\"\n",
+        "schema: adl.csdlc.prompt_template_values.v1\ntemplate_set: 1.0.2\ncard_kind: sip\nsystem:\n  issue: \"1374\"\n",
     );
 
     real_tooling(&["prompt-template".to_string(), "help".to_string()])

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -284,6 +284,59 @@ fn structured_prompt_sor_issue_metrics_truth_allows_zero_percent_exact_match() {
 }
 
 #[test]
+fn structured_prompt_sor_requires_variance_analysis_for_large_known_estimate_miss() {
+    let sor = valid_sor_text().replace(
+        "- Estimated elapsed seconds: `unknown`",
+        "- Estimated elapsed seconds: `100`",
+    );
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("large known estimate miss should require variance analysis");
+    assert!(err
+        .to_string()
+        .contains("Variance analysis required must be `yes`"));
+}
+
+#[test]
+fn structured_prompt_sor_accepts_completed_variance_analysis_for_large_known_estimate_miss() {
+    let sor = valid_sor_text()
+        .replace(
+            "- Estimated elapsed seconds: `unknown`",
+            "- Estimated elapsed seconds: `100`",
+        )
+        .replace("- Variance analysis required: `no`", "- Variance analysis required: `yes`")
+        .replace(
+            "- Variance analysis completed: `not_applicable`",
+            "- Variance analysis completed: `yes`",
+        )
+        .replace(
+            "- Variance category: `not_applicable`",
+            "- Variance category: `external_api_latency`",
+        )
+        .replace(
+            "- Variance note: `No material estimate miss exceeded the 10 percent threshold in this fixture.`",
+            "- Variance note: `A provider queue stall inflated elapsed time beyond the original estimate.`",
+        );
+    validate_sor_text(&sor, Some("completed"))
+        .expect("completed variance analysis should satisfy large known estimate miss");
+}
+
+#[test]
+fn structured_prompt_sor_rejects_missing_variance_analysis_section() {
+    let sor = format!(
+        "Canonical Template Source: `docs/templates/prompts/1.0.2/sor.md`\n\n{}",
+        valid_sor_text()
+    )
+    .replace(
+        "## Variance Analysis\n- Threshold policy: require variance analysis when any known estimated/actual pair for elapsed seconds, total tokens, or validation seconds differs by more than 10 percent.\n- Variance analysis required: `no`\n- Variance analysis completed: `not_applicable`\n- Variance category: `not_applicable`\n- Variance note: `No material estimate miss exceeded the 10 percent threshold in this fixture.`\n- Sprint rollup guidance: count only completed variance analyses by `Variance category`; keep `not_applicable` out of category totals and never treat unknown metrics as zero variance.\n\n",
+        "",
+    );
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("missing variance analysis section should fail");
+    assert!(err.to_string().contains("missing required sections"));
+    assert!(err.to_string().contains("Variance Analysis"));
+}
+
+#[test]
 fn validate_structured_prompt_accepts_all_supported_prompt_types() {
     let repo = TempRepo::new("structured");
     let stp = repo.write_rel(".tmp/tooling_cmd_tests/stp.md", &valid_stp_text());

--- a/adl/src/cli/tooling_cmd/tests/support.rs
+++ b/adl/src/cli/tooling_cmd/tests/support.rs
@@ -401,6 +401,14 @@ Done.
 - Data-source confidence: `medium`
 - Estimate error percent: `unknown`
 
+## Variance Analysis
+- Threshold policy: require variance analysis when any known estimated/actual pair for elapsed seconds, total tokens, or validation seconds differs by more than 10 percent.
+- Variance analysis required: `no`
+- Variance analysis completed: `not_applicable`
+- Variance category: `not_applicable`
+- Variance note: `No material estimate miss exceeded the 10 percent threshold in this fixture.`
+- Sprint rollup guidance: count only completed variance analyses by `Variance category`; keep `not_applicable` out of category totals and never treat unknown metrics as zero variance.
+
 ## Artifacts produced
 - `docs/tooling/prompt-spec.md`
 

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -93,6 +93,10 @@ const PLACEHOLDERS: &[&str] = &[
     "actual_metrics_source_ref",
     "actual_metrics_confidence",
     "estimate_error_percent",
+    "variance_analysis_required",
+    "variance_analysis_completed",
+    "variance_category",
+    "variance_note",
     "branch_action",
     "findings_status",
     "recommended_outcome",
@@ -756,6 +760,13 @@ fn extract_legacy_sor_values(rendered: &str) -> Result<(BTreeMap<String, String>
         ("actual_metrics_source_ref", "unknown"),
         ("actual_metrics_confidence", "unknown"),
         ("estimate_error_percent", "unknown"),
+        ("variance_analysis_required", "not_applicable"),
+        ("variance_analysis_completed", "not_applicable"),
+        ("variance_category", "not_applicable"),
+        (
+            "variance_note",
+            "Legacy rendered SOR predates explicit variance-analysis tracking.",
+        ),
         ("timestamp", "legacy_import_unknown_timestamp"),
     ] {
         values.insert(key.to_string(), value.to_string());
@@ -1348,7 +1359,97 @@ fn validate_sor_values(card: &PromptCardForm, values: &BTreeMap<String, String>)
             );
         }
     }
+    let variance_required = values
+        .get("variance_analysis_required")
+        .map(String::as_str)
+        .unwrap_or("not_applicable");
+    let variance_completed = values
+        .get("variance_analysis_completed")
+        .map(String::as_str)
+        .unwrap_or("not_applicable");
+    let variance_category = values
+        .get("variance_category")
+        .map(String::as_str)
+        .unwrap_or("not_applicable");
+    let variance_note = values
+        .get("variance_note")
+        .map(String::as_str)
+        .unwrap_or("");
+    let any_known_pair_exceeds_threshold = [
+        metric_pair_exceeds_variance_threshold(
+            values
+                .get("estimated_elapsed_seconds")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+            values
+                .get("actual_elapsed_seconds")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+        ),
+        metric_pair_exceeds_variance_threshold(
+            values
+                .get("estimated_total_tokens")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+            values
+                .get("actual_total_tokens")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+        ),
+        metric_pair_exceeds_variance_threshold(
+            values
+                .get("estimated_validation_seconds")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+            values
+                .get("actual_validation_seconds")
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+        ),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|exceeds| exceeds);
+    if any_known_pair_exceeds_threshold {
+        ensure!(
+            variance_required == "yes",
+            "sor.variance_analysis_required must be `yes` when any estimated/actual metric pair differs by more than 10 percent"
+        );
+    }
+    if variance_required == "yes" {
+        ensure!(
+            variance_completed != "not_applicable",
+            "sor.variance_analysis_completed cannot be `not_applicable` when sor.variance_analysis_required is `yes`"
+        );
+        ensure!(
+            variance_category != "not_applicable",
+            "sor.variance_category cannot be `not_applicable` when sor.variance_analysis_required is `yes`"
+        );
+        ensure!(
+            !variance_note.trim().is_empty() && variance_note != "not_applicable",
+            "sor.variance_note must be non-empty when sor.variance_analysis_required is `yes`"
+        );
+    } else {
+        ensure!(
+            variance_completed != "yes",
+            "sor.variance_analysis_completed cannot be `yes` when sor.variance_analysis_required is not `yes`"
+        );
+        ensure!(
+            variance_category == "not_applicable",
+            "sor.variance_category must remain `not_applicable` when sor.variance_analysis_required is not `yes`"
+        );
+    }
     Ok(())
+}
+
+fn metric_pair_exceeds_variance_threshold(estimated: &str, actual: &str) -> Option<bool> {
+    if estimated == "unknown" || actual == "unknown" {
+        return None;
+    }
+    let estimated = estimated.parse::<u64>().ok()?;
+    let actual = actual.parse::<u64>().ok()?;
+    let diff = estimated.abs_diff(actual);
+    Some(diff.saturating_mul(100) > estimated.saturating_mul(10))
 }
 
 pub fn render_template(template: &str, values: &BTreeMap<String, String>) -> Result<String> {
@@ -1452,7 +1553,7 @@ pub fn sample_values() -> BTreeMap<String, String> {
         ),
         (
             "repo_inputs",
-            "- docs/templates/prompts/current.json\n- docs/templates/prompts/1.0.1/",
+            "- docs/templates/prompts/current.json\n- docs/templates/prompts/1.0.2/",
         ),
         ("dependencies", "- #3286 SemVer prompt templates"),
         (
@@ -1495,7 +1596,7 @@ pub fn sample_values() -> BTreeMap<String, String> {
         ),
         (
             "repo_inputs_inline",
-            "docs/templates/prompts/current.json and docs/templates/prompts/1.0.1/.",
+            "docs/templates/prompts/current.json and docs/templates/prompts/1.0.2/.",
         ),
         (
             "deliverables_inline",
@@ -1541,6 +1642,13 @@ pub fn sample_values() -> BTreeMap<String, String> {
         ("actual_metrics_source_ref", "unknown"),
         ("actual_metrics_confidence", "unknown"),
         ("estimate_error_percent", "unknown"),
+        ("variance_analysis_required", "not_applicable"),
+        ("variance_analysis_completed", "not_applicable"),
+        ("variance_category", "not_applicable"),
+        (
+            "variance_note",
+            "No variance analysis is required in the generated sample.",
+        ),
         (
             "branch_action",
             "Preserved pre-run branch truth in generated sample content.",
@@ -2076,6 +2184,44 @@ fn form_fields(kind: PromptCardKind) -> Vec<PromptField> {
                 true,
                 "Difference between estimated and actual elapsed time, or `unknown`.",
             ));
+            fields.push(select(
+                "variance_analysis_required",
+                "Variance Analysis Required",
+                true,
+                "Whether any known estimate/actual metric pair exceeded the 10 percent threshold.",
+                &["not_applicable", "no", "yes"],
+            ));
+            fields.push(select(
+                "variance_analysis_completed",
+                "Variance Analysis Completed",
+                true,
+                "Whether the required variance analysis was completed.",
+                &["not_applicable", "no", "yes"],
+            ));
+            fields.push(select(
+                "variance_category",
+                "Variance Category",
+                true,
+                "Primary category for a required variance analysis.",
+                &[
+                    "not_applicable",
+                    "validation_misclassification",
+                    "pr_wait",
+                    "merge_conflict",
+                    "tool_failure",
+                    "unclear_scope",
+                    "model_drift",
+                    "human_wait",
+                    "external_api_latency",
+                    "overestimated_scope",
+                ],
+            ));
+            fields.push(textarea(
+                "variance_note",
+                "Variance Note",
+                true,
+                "Short variance-analysis note when the threshold was exceeded.",
+            ));
             fields.push(textarea(
                 "summary",
                 "Summary",
@@ -2273,7 +2419,7 @@ mod tests {
     #[test]
     fn editor_model_covers_all_five_cards() {
         let model = load_editor_model(&repo_root()).expect("model");
-        assert_eq!(model.template_set, "1.0.1");
+        assert_eq!(model.template_set, "1.0.2");
         assert_eq!(
             model.card_status_values,
             [
@@ -2293,7 +2439,7 @@ mod tests {
             .any(|card| card.kind == PromptCardKind::Srp));
         assert!(model.cards.iter().all(|card| card
             .template_path
-            .starts_with("docs/templates/prompts/1.0.1/")));
+            .starts_with("docs/templates/prompts/1.0.2/")));
     }
 
     #[test]

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -2476,10 +2476,10 @@ mod tests {
         assert_eq!(report.comparison, PromptCardRoundTripComparison::Normalized);
 
         let imported_text = fs::read_to_string(&imported).expect("imported values");
-        assert!(imported_text.contains("template_set: \"1.0.1\""));
+        assert!(imported_text.contains("template_set: \"1.0.2\""));
         let normalized_text = fs::read_to_string(&normalized).expect("normalized rendered");
         assert!(normalized_text.contains(&format!(
-            "Canonical Template Source: `docs/templates/prompts/1.0.1/{}.md`",
+            "Canonical Template Source: `docs/templates/prompts/1.0.2/{}.md`",
             kind.key()
         )));
     }

--- a/adl/src/csdlc_prompt_editor/structure.rs
+++ b/adl/src/csdlc_prompt_editor/structure.rs
@@ -690,6 +690,10 @@ const PVF_RENDERED_VALUE_LINE_PREFIXES: &[&str] = &[
     "- Goal metrics source ref:",
     "- Data-source confidence:",
     "- Estimate error percent:",
+    "- Variance analysis required:",
+    "- Variance analysis completed:",
+    "- Variance category:",
+    "- Variance note:",
 ];
 
 fn rendered_value_line_prefixes(kind: PromptCardKind) -> Vec<&'static str> {

--- a/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sor.md
+++ b/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sor.md
@@ -14,15 +14,15 @@ Completed the tracked public `WP-03` proof bundle for the canonical
 
 ## PVF Lane Truth
 
-- Initial PVF lane: `prompt_template`
-- Planned PVF lane: `prompt_template`
-- Final PVF lane: `prompt_template`
-- Lane change reason: `not_applicable`
+- Initial PVF lane: `not_recorded_for_v0.91.3_proof_sample`
+- Planned PVF lane: `not_recorded_for_v0.91.3_proof_sample`
+- Final PVF lane: `not_recorded_for_v0.91.3_proof_sample`
+- Lane change reason: `This historical public proof sample predates the newer PVF lane recording fields and now records that truth explicitly.`
 
 ## Issue Metrics Truth
 
 - Estimated elapsed seconds: `unknown`
-- Actual elapsed seconds: `480`
+- Actual elapsed seconds: `unknown`
 - Estimated total tokens: `unknown`
 - Actual total tokens: `unknown`
 - Estimated validation seconds: `unknown`

--- a/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/spp.md
+++ b/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/spp.md
@@ -101,9 +101,9 @@ issue bundle plus focused validator and doctor expectations.
 
 ## PVF Lane Plan
 
-- Initial PVF lane from issue creation: `prompt_template`
-- Planned PVF lane for execution: `prompt_template`
-- Planning lane source: `matched_initial_issue_lane`
+- Initial PVF lane from issue creation: `not_recorded_for_v0.91.3_proof_sample`
+- Planned PVF lane for execution: `not_recorded_for_v0.91.3_proof_sample`
+- Planning lane source: `legacy_v0.91.3_public_proof_sample`
 - Revision rule: change `planned_pvf_lane` only when planning discovers a better explicit lane; keep `needs_planning_lane_assignment` fail-closed until that happens.
 
 ## Estimate Plan

--- a/docs/templates/prompts/1.0.2/schemas/sip.structure.json
+++ b/docs/templates/prompts/1.0.2/schemas/sip.structure.json
@@ -1,0 +1,554 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.2",
+  "card_kind": "sip",
+  "template_path": "docs/templates/prompts/1.0.2/sip.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [],
+  "headings": [
+    {
+      "level": 1,
+      "text": "ADL Input Card"
+    },
+    {
+      "level": 2,
+      "text": "Agent Execution Rules"
+    },
+    {
+      "level": 2,
+      "text": "Lifecycle Semantics"
+    },
+    {
+      "level": 2,
+      "text": "Prompt Spec"
+    },
+    {
+      "level": 2,
+      "text": "Execution"
+    },
+    {
+      "level": 2,
+      "text": "Goal"
+    },
+    {
+      "level": 2,
+      "text": "Required Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Acceptance Criteria"
+    },
+    {
+      "level": 2,
+      "text": "Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Target Files / Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Validation Plan"
+    },
+    {
+      "level": 2,
+      "text": "Demo / Proof Requirements"
+    },
+    {
+      "level": 2,
+      "text": "Constraints / Policies"
+    },
+    {
+      "level": 2,
+      "text": "System Invariants (must remain true)"
+    },
+    {
+      "level": 2,
+      "text": "Reviewer Checklist (machine-readable hints)"
+    },
+    {
+      "level": 2,
+      "text": "Card Automation Hooks (prompt generation)"
+    },
+    {
+      "level": 2,
+      "text": "Non-goals / Out of scope"
+    },
+    {
+      "level": 2,
+      "text": "Notes / Risks"
+    },
+    {
+      "level": 2,
+      "text": "Instructions to the Agent"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "ADL Input Card",
+        "Prompt Spec"
+      ]
+    },
+    {
+      "ordinal": 1,
+      "info": "yaml",
+      "heading_path": [
+        "ADL Input Card",
+        "Reviewer Checklist (machine-readable hints)"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "ADL Input Card"
+      ],
+      "text": "Semantic role: Structured Issue Prompt (`SIP`)."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card"
+      ],
+      "text": "Context:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- This issue is not started yet; do not assume a branch or worktree already exists."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not run `pr start`; use the current issue-mode `pr run` flow only if execution later becomes necessary."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not delete or recreate cards."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not switch branches unless explicitly instructed."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Do not work on `main`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Only modify files required for the issue."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Use repository-relative paths; avoid absolute host paths."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- Write the output record to the paired local task bundle `sor.md` path."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Agent Execution Rules"
+      ],
+      "text": "- If repository state is unexpected, stop and ask before attempting repository repair."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Lifecycle stage: `SIP`"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Activation state: active after issue-intent review."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Next stage: `STP`, where the selected task or solution is made explicit."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "- Legacy compatibility: older references may call this an input card, but new"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Lifecycle Semantics"
+      ],
+      "text": "  issue work should treat it as the Structured Issue Prompt."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Follow `AGENTS.md`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Use workflow-conductor for lifecycle routing."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Edit cards only with editor skills."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Work only in the bound issue worktree after `pr run`."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Constraints / Policies"
+      ],
+      "text": "- Keep validation focused on the touched surface."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Deterministic execution for identical inputs."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- No hidden state or undeclared side effects."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Artifacts remain replay-compatible with the replay runner."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "System Invariants (must remain true)"
+      ],
+      "text": "- Artifact schema changes are explicit and approved."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "- Prompt source fields:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Goal"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Required Outcome"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Acceptance Criteria"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Inputs"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Target Files / Surfaces"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Validation Plan"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Demo / Proof Requirements"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Constraints / Policies"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - System Invariants"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Reviewer Checklist"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "- Generation requirements:"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Deterministic output for identical SIP content"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - No secrets, tokens, or absolute host paths in generated prompt text"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Preserve traceability back to the source issue prompt"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Card Automation Hooks (prompt generation)"
+      ],
+      "text": "  - Preserve explicit required-outcome and demo/proof requirements"
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Read this file."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Read the linked source issue prompt before starting work."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Do not create a branch or worktree from this card alone."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- When execution is approved, run the repo-native issue-mode `pr run` flow and then perform the work described above."
+    },
+    {
+      "heading_path": [
+        "ADL Input Card",
+        "Instructions to the Agent"
+      ],
+      "text": "- Write execution outcome truth to the paired `sor.md` file during execution."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.2/schemas/sor.structure.json
+++ b/docs/templates/prompts/1.0.2/schemas/sor.structure.json
@@ -1,0 +1,648 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.2",
+  "card_kind": "sor",
+  "template_path": "docs/templates/prompts/1.0.2/sor.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:",
+    "initial_pvf_lane:",
+    "planned_pvf_lane:",
+    "planned_pvf_lane_source:",
+    "estimate_elapsed_seconds:",
+    "estimate_total_tokens:",
+    "estimate_validation_seconds:",
+    "estimate_confidence:",
+    "estimate_data_source:",
+    "estimate_source_ref:",
+    "- Initial PVF lane from issue creation:",
+    "- Planned PVF lane for execution:",
+    "- Planning lane source:",
+    "- Revision rule:",
+    "- Estimated elapsed seconds:",
+    "- Estimated total tokens:",
+    "- Estimated validation seconds:",
+    "- Estimate confidence:",
+    "- Estimate data source:",
+    "- Estimate source ref:",
+    "- Initial PVF lane:",
+    "- Planned PVF lane:",
+    "- Final PVF lane:",
+    "- Lane change reason:",
+    "- Actual elapsed seconds:",
+    "- Actual total tokens:",
+    "- Actual validation seconds:",
+    "- Goal metrics data source:",
+    "- Goal metrics source ref:",
+    "- Data-source confidence:",
+    "- Estimate error percent:",
+    "- Variance analysis required:",
+    "- Variance analysis completed:",
+    "- Variance category:",
+    "- Variance note:"
+  ],
+  "frontmatter_keys": [],
+  "headings": [
+    {
+      "level": 1,
+      "text": null
+    },
+    {
+      "level": 2,
+      "text": "Summary"
+    },
+    {
+      "level": 2,
+      "text": "PVF Lane Truth"
+    },
+    {
+      "level": 2,
+      "text": "Issue Metrics Truth"
+    },
+    {
+      "level": 2,
+      "text": "Variance Analysis"
+    },
+    {
+      "level": 2,
+      "text": "Artifacts produced"
+    },
+    {
+      "level": 2,
+      "text": "Actions taken"
+    },
+    {
+      "level": 2,
+      "text": "Main Repo Integration (REQUIRED)"
+    },
+    {
+      "level": 2,
+      "text": "Validation"
+    },
+    {
+      "level": 2,
+      "text": "Verification Summary"
+    },
+    {
+      "level": 2,
+      "text": "Determinism Evidence"
+    },
+    {
+      "level": 2,
+      "text": "Security / Privacy Checks"
+    },
+    {
+      "level": 2,
+      "text": "Replay Artifacts"
+    },
+    {
+      "level": 2,
+      "text": "Artifact Verification"
+    },
+    {
+      "level": 2,
+      "text": "Decisions / Deviations"
+    },
+    {
+      "level": 2,
+      "text": "Follow-ups / Deferred work"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "<dynamic-heading>",
+        "Verification Summary"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "Execution Record Requirements:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- The output card is a machine-auditable execution record."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- Every command listed must include both what was run and what it verified."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "- If something is not applicable, include a one-line justification."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>"
+      ],
+      "text": "Execution:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Issue Metrics Truth"
+      ],
+      "text": "- Goal-metrics substrate note: consume the `#4264` issue-goal metrics summary when available and record `unknown` instead of duplicating raw session logs here."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Variance Analysis"
+      ],
+      "text": "- Threshold policy: require variance analysis when any known estimated/actual pair for elapsed seconds, total tokens, or validation seconds differs by more than 10 percent."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Variance Analysis"
+      ],
+      "text": "- Sprint rollup guidance: count only completed variance analyses by `Variance category`; keep `not_applicable` out of category totals and never treat unknown metrics as zero variance."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifacts produced"
+      ],
+      "text": "- Tracked implementation artifacts: not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Main-repo paths updated: none"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Worktree-only paths remaining: no tracked implementation artifacts exist yet; execution-time proof surfaces will be established during implementation and PR publication"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Integration state: worktree_only"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Verification scope: main_repo"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Integration method used: local ignored card-bundle scaffold write under the active checkout; tracked implementation artifacts do not exist yet"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Verification performed:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "    Verified bootstrap SOR contract compliance for the local pre-run scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Result: PASS"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "Rules:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Final artifacts must exist in the main repository, not only in a worktree."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Prefer git-aware transfer into the main repo (`git checkout BRANCH -- PATH` or commit + cherry-pick)."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- If artifacts exist only in the worktree, the task is NOT complete."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `Verification scope` describes where the verification commands were run."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- `worktree_only` means at least one required path still exists only outside the main repository path."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- Completed output records must not leave `Status` as `NOT_STARTED`."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Main Repo Integration (REQUIRED)"
+      ],
+      "text": "- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure)."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Validation commands and their purpose:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "    Verified bootstrap SOR contract compliance for the local output scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Results:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "  - PASS"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "Validation command/path rules:"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Prefer repository-relative paths in recorded commands and artifact references."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Do not record absolute host paths in output records unless they are explicitly required and justified."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Validation"
+      ],
+      "text": "- Do not list commands without describing their effect."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Determinism tests executed: not_run; bootstrap scaffold creation has not been replay-verified for this issue yet."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Fixtures or scripts used: `adl/tools/pr.sh` issue-wave opening flow."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Replay verification (same inputs -> same artifacts/order): not yet verified for this specific issue record."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Ordering guarantees (sorting / tie-break rules used): not_applicable for a single-card bootstrap write."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Determinism Evidence"
+      ],
+      "text": "- Artifact stability notes: repository-relative paths only; execution-time proof artifacts are not expected yet."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Secret leakage scan performed: limited content review only; no secrets were intentionally recorded in the scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Prompt / tool argument redaction verified: not_applicable for bootstrap scaffold generation."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Absolute path leakage check: repository-relative paths only in the scaffold."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Security / Privacy Checks"
+      ],
+      "text": "- Sandbox / policy invariants preserved: yes; local ignored issue-record path only."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Trace bundle path(s): not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Run artifact root: not_applicable until execution begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Replay command used for verification: not_run"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Replay Artifacts"
+      ],
+      "text": "- Replay result: NOT_RUN"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Primary proof surface: this local pre-run SOR scaffold and its bootstrap validation result"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Required artifacts present: local output card scaffold only; tracked implementation artifacts are not expected yet"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Artifact schema/version checks: bootstrap SOR validator passed"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Hash/byte-stability checks: not_run"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Artifact Verification"
+      ],
+      "text": "- Missing/optional artifacts and rationale: execution proofs, demos, and tracked outputs are intentionally absent before implementation begins"
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Decisions / Deviations"
+      ],
+      "text": "- Issue-wave opening emits a truthful pre-run SOR scaffold instead of leaving raw template residue for later cleanup."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Decisions / Deviations"
+      ],
+      "text": "- Integration state remains `worktree_only` until execution creates tracked artifacts or opens a PR."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Follow-ups / Deferred work"
+      ],
+      "text": "- Update this record during execution with actual actions, validations, proof surfaces, and integration truth."
+    },
+    {
+      "heading_path": [
+        "<dynamic-heading>",
+        "Follow-ups / Deferred work"
+      ],
+      "text": "- Normalize this record to `pr_open`, `merged`, or `closed_no_pr` during finish/closeout as appropriate."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.2/schemas/spp.structure.json
+++ b/docs/templates/prompts/1.0.2/schemas/spp.structure.json
@@ -1,0 +1,360 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.2",
+  "card_kind": "spp",
+  "template_path": "docs/templates/prompts/1.0.2/spp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:",
+    "initial_pvf_lane:",
+    "planned_pvf_lane:",
+    "planned_pvf_lane_source:",
+    "estimate_elapsed_seconds:",
+    "estimate_total_tokens:",
+    "estimate_validation_seconds:",
+    "estimate_confidence:",
+    "estimate_data_source:",
+    "estimate_source_ref:",
+    "- Initial PVF lane from issue creation:",
+    "- Planned PVF lane for execution:",
+    "- Planning lane source:",
+    "- Revision rule:",
+    "- Estimated elapsed seconds:",
+    "- Estimated total tokens:",
+    "- Estimated validation seconds:",
+    "- Estimate confidence:",
+    "- Estimate data source:",
+    "- Estimate source ref:",
+    "- Initial PVF lane:",
+    "- Planned PVF lane:",
+    "- Final PVF lane:",
+    "- Lane change reason:",
+    "- Actual elapsed seconds:",
+    "- Actual total tokens:",
+    "- Actual validation seconds:",
+    "- Goal metrics data source:",
+    "- Goal metrics source ref:",
+    "- Data-source confidence:",
+    "- Estimate error percent:",
+    "- Variance analysis required:",
+    "- Variance analysis completed:",
+    "- Variance category:",
+    "- Variance note:"
+  ],
+  "frontmatter_keys": [
+    "activation_state",
+    "affected_areas",
+    "alternatives_considered",
+    "artifact_type",
+    "assumptions",
+    "branch",
+    "card_status",
+    "codex_plan",
+    "confidence",
+    "constraints",
+    "estimate_confidence",
+    "estimate_data_source",
+    "estimate_elapsed_seconds",
+    "estimate_source_ref",
+    "estimate_total_tokens",
+    "estimate_validation_seconds",
+    "execution_handoff",
+    "generated_at",
+    "initial_pvf_lane",
+    "invariants_to_preserve",
+    "issue",
+    "name",
+    "notes",
+    "plan_revision",
+    "plan_summary",
+    "planned_pvf_lane",
+    "planned_pvf_lane_source",
+    "proposed_steps",
+    "required_permissions",
+    "review_hooks",
+    "risks_and_edge_cases",
+    "run_id",
+    "schema_version",
+    "scope",
+    "scope.components",
+    "scope.files",
+    "scope.out_of_scope",
+    "source_refs",
+    "status",
+    "stop_conditions",
+    "task_id",
+    "test_strategy",
+    "title",
+    "version"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Plan Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Plan Summary"
+    },
+    {
+      "level": 2,
+      "text": "PVF Lane Plan"
+    },
+    {
+      "level": 2,
+      "text": "Estimate Plan"
+    },
+    {
+      "level": 2,
+      "text": "Codex Plan"
+    },
+    {
+      "level": 2,
+      "text": "Assumptions"
+    },
+    {
+      "level": 2,
+      "text": "Proposed Steps"
+    },
+    {
+      "level": 2,
+      "text": "Affected Areas"
+    },
+    {
+      "level": 2,
+      "text": "Invariants To Preserve"
+    },
+    {
+      "level": 2,
+      "text": "Risks And Edge Cases"
+    },
+    {
+      "level": 2,
+      "text": "Test Strategy"
+    },
+    {
+      "level": 2,
+      "text": "Execution Handoff"
+    },
+    {
+      "level": 2,
+      "text": "Stop Conditions"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    }
+  ],
+  "fenced_blocks": [],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Estimate Plan"
+      ],
+      "text": "- Unknown-value rule: record `unknown`, never `0`, when the estimate is unavailable or intentionally deferred."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "1. [pending] Confirm dependencies and starting state from the source issue prompt."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "2. [pending] Inspect repo inputs and target surfaces before editing."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "3. [pending] Implement the bounded deliverables only."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "4. [pending] Run focused validation and proof gates."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Codex Plan"
+      ],
+      "text": "5. [pending] Record issue-specific SRP findings and SOR outcome truth."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Assumptions"
+      ],
+      "text": "- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Invariants To Preserve"
+      ],
+      "text": "- Keep SPP issue-local; do not turn it into sprint orchestration."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Invariants To Preserve"
+      ],
+      "text": "- Keep SRP as review-result truth and SOR as output truth."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Execution Handoff"
+      ],
+      "text": "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and update SPP if touched files, proof gates, or validation commands change materially."
+    },
+    {
+      "heading_path": [
+        "Structured Plan Prompt",
+        "Stop Conditions"
+      ],
+      "text": "- Stop and route follow-on work if acceptance requires scope outside this issue."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.2/schemas/srp.structure.json
+++ b/docs/templates/prompts/1.0.2/schemas/srp.structure.json
@@ -1,0 +1,365 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.2",
+  "card_kind": "srp",
+  "template_path": "docs/templates/prompts/1.0.2/srp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [
+    "allowed_dispositions",
+    "artifact_type",
+    "branch",
+    "card_status",
+    "evidence_policy",
+    "follow_up_routing",
+    "generated_at",
+    "in_scope_surfaces",
+    "issue",
+    "name",
+    "non_claims",
+    "notes",
+    "policy_refs",
+    "refusal_policy",
+    "review_mode",
+    "review_results",
+    "review_results.findings_status",
+    "review_results.recommended_outcome",
+    "reviewer_constraints",
+    "schema_version",
+    "scope_basis",
+    "source_refs",
+    "status",
+    "task_id",
+    "timing",
+    "title",
+    "validation_inputs",
+    "version"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Review Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Review Summary"
+    },
+    {
+      "level": 2,
+      "text": "Scope Basis"
+    },
+    {
+      "level": 2,
+      "text": "In-Scope Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Evidence Rules"
+    },
+    {
+      "level": 2,
+      "text": "Validation Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Allowed Dispositions"
+    },
+    {
+      "level": 2,
+      "text": "Reviewer Constraints"
+    },
+    {
+      "level": 2,
+      "text": "Refusal Policy"
+    },
+    {
+      "level": 2,
+      "text": "Follow-up Routing"
+    },
+    {
+      "level": 2,
+      "text": "Non-Claims"
+    },
+    {
+      "level": 2,
+      "text": "Review Results"
+    },
+    {
+      "level": 3,
+      "text": "Findings"
+    },
+    {
+      "level": 3,
+      "text": "Dispositions"
+    },
+    {
+      "level": 3,
+      "text": "Recommended Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    }
+  ],
+  "fenced_blocks": [
+    {
+      "ordinal": 0,
+      "info": "yaml",
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results"
+      ]
+    }
+  ],
+  "locked_lines": [
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Summary"
+      ],
+      "text": "Use this prompt to govern the independent pre-PR review for this issue. Review results are intentionally absent before implementation exists and must be finalized before PR publication."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "In-Scope Surfaces"
+      ],
+      "text": "- tracked changes for this issue branch"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Evidence Rules"
+      ],
+      "text": "- Use repository evidence, targeted validation output, and linked issue-bundle artifacts only."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Validation Inputs"
+      ],
+      "text": "- Issue-local proofs recorded in the SOR."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- PASS"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- BLOCK"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Allowed Dispositions"
+      ],
+      "text": "- NEEDS_FOLLOWUP"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Reviewer Constraints"
+      ],
+      "text": "- Do not widen issue scope."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Reviewer Constraints"
+      ],
+      "text": "- Do not merge, publish, or close the issue."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Refusal Policy"
+      ],
+      "text": "- Refuse claims that are unsupported by repository evidence."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Refusal Policy"
+      ],
+      "text": "- Refuse approving behavior outside the recorded issue scope."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Follow-up Routing"
+      ],
+      "text": "- Route actionable defects back to the issue branch before PR publication."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Non-Claims"
+      ],
+      "text": "- This prompt does not claim review has already run."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Non-Claims"
+      ],
+      "text": "- This prompt does not guarantee review quality by itself."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results"
+      ],
+      "text": "When finalizing review, record the machine-readable review result in frontmatter:"
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Findings"
+      ],
+      "text": "- Not run yet; implementation has not been bound."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Dispositions"
+      ],
+      "text": "- Not applicable until review runs."
+    },
+    {
+      "heading_path": [
+        "Structured Review Prompt",
+        "Review Results",
+        "Recommended Outcome"
+      ],
+      "text": "- Not run yet."
+    }
+  ]
+}

--- a/docs/templates/prompts/1.0.2/schemas/stp.structure.json
+++ b/docs/templates/prompts/1.0.2/schemas/stp.structure.json
@@ -1,0 +1,217 @@
+{
+  "schema": "adl.csdlc.prompt_card_structure.v1",
+  "template_set": "1.0.2",
+  "card_kind": "stp",
+  "template_path": "docs/templates/prompts/1.0.2/stp.md",
+  "parser": "markdown-rs 1.0.0",
+  "editable_sections": [
+    "Acceptance Criteria",
+    "Actions taken",
+    "Affected Areas",
+    "Deliverables",
+    "Demo / Proof Requirements",
+    "Demo Expectations",
+    "Dependencies",
+    "Goal",
+    "Inputs",
+    "Issue-Graph Notes",
+    "Non-goals",
+    "Non-goals / Out of scope",
+    "Notes",
+    "Notes / Risks",
+    "Outputs",
+    "Plan Summary",
+    "Policy Refs",
+    "Proposed Steps",
+    "Repo Inputs",
+    "Required Outcome",
+    "Risks And Edge Cases",
+    "Scope Basis",
+    "Summary",
+    "Target Files / Surfaces",
+    "Test Strategy",
+    "Tooling Notes",
+    "Validation Plan"
+  ],
+  "scaffold_lines": [
+    "---",
+    "```yaml",
+    "```",
+    "labels:",
+    "supersedes: []",
+    "duplicates: []",
+    "depends_on: []",
+    "canonical_files: []",
+    "demo_names: []",
+    "pr_start:",
+    "enabled: true",
+    "source_refs:",
+    "scope:",
+    "files:",
+    "components:",
+    "out_of_scope:",
+    "constraints:",
+    "assumptions:",
+    "proposed_steps:",
+    "codex_plan:",
+    "affected_areas:",
+    "invariants_to_preserve:",
+    "risks_and_edge_cases:",
+    "test_strategy:",
+    "required_permissions:",
+    "stop_conditions:",
+    "alternatives_considered:",
+    "review_hooks:",
+    "review_results:"
+  ],
+  "scaffold_line_prefixes": [
+    "- kind:",
+    "kind:",
+    "ref:",
+    "- id:",
+    "description:",
+    "expected_output:",
+    "allowed_mode:",
+    "- step:",
+    "status:",
+    "- description:",
+    "reason_not_chosen:"
+  ],
+  "rendered_value_line_prefixes": [
+    "Task ID:",
+    "Run ID:",
+    "Version:",
+    "Title:",
+    "Branch:",
+    "Card Status:",
+    "Status:",
+    "Generated:",
+    "- Actor:",
+    "- Model:",
+    "- Start Time:",
+    "- End Time:",
+    "- Issue:",
+    "- PR:",
+    "- Source Issue Prompt:",
+    "- Docs:",
+    "- Other:",
+    "- Agent:",
+    "- Provider:",
+    "- Tools allowed:",
+    "- Sandbox / approvals:",
+    "- Source issue-prompt slug:",
+    "- Required outcome type:",
+    "- Demo required:",
+    "- Local ignored output-card scaffold at",
+    "- `bash adl/tools/validate_structured_prompt.sh",
+    "Source issue-prompt slug:",
+    "Required outcome type:",
+    "Demo required:",
+    "Canonical Template Source:",
+    "Generated from",
+    "name:",
+    "issue:",
+    "task_id:",
+    "run_id:",
+    "version:",
+    "title:",
+    "branch:",
+    "generated_at:",
+    "card_status:",
+    "activation_state:",
+    "plan_revision:",
+    "confidence:",
+    "plan_summary:",
+    "execution_handoff:",
+    "notes:"
+  ],
+  "frontmatter_keys": [
+    "action",
+    "canonical_files",
+    "card_status",
+    "demo_names",
+    "demo_required",
+    "depends_on",
+    "duplicates",
+    "generated_at",
+    "issue_card_schema",
+    "issue_graph_notes",
+    "issue_number",
+    "labels",
+    "milestone_sprint",
+    "pr_start",
+    "pr_start.enabled",
+    "pr_start.slug",
+    "repo_inputs",
+    "required_outcome_type",
+    "slug",
+    "status",
+    "supersedes",
+    "title",
+    "wp"
+  ],
+  "headings": [
+    {
+      "level": 1,
+      "text": "Structured Task Prompt"
+    },
+    {
+      "level": 2,
+      "text": "Summary"
+    },
+    {
+      "level": 2,
+      "text": "Goal"
+    },
+    {
+      "level": 2,
+      "text": "Required Outcome"
+    },
+    {
+      "level": 2,
+      "text": "Deliverables"
+    },
+    {
+      "level": 2,
+      "text": "Acceptance Criteria"
+    },
+    {
+      "level": 2,
+      "text": "Repo Inputs"
+    },
+    {
+      "level": 2,
+      "text": "Dependencies"
+    },
+    {
+      "level": 2,
+      "text": "Target Files / Surfaces"
+    },
+    {
+      "level": 2,
+      "text": "Validation Plan"
+    },
+    {
+      "level": 2,
+      "text": "Demo Expectations"
+    },
+    {
+      "level": 2,
+      "text": "Non-goals"
+    },
+    {
+      "level": 2,
+      "text": "Issue-Graph Notes"
+    },
+    {
+      "level": 2,
+      "text": "Notes"
+    },
+    {
+      "level": 2,
+      "text": "Tooling Notes"
+    }
+  ],
+  "fenced_blocks": [],
+  "locked_lines": []
+}

--- a/docs/templates/prompts/1.0.2/sip.md
+++ b/docs/templates/prompts/1.0.2/sip.md
@@ -1,0 +1,176 @@
+# ADL Input Card
+
+Semantic role: Structured Issue Prompt (`SIP`).
+Canonical Template Source: `docs/templates/prompts/1.0.2/sip.md`
+
+Task ID: issue-<issue_padded>
+Run ID: issue-<issue_padded>
+Version: <version>
+Title: <title>
+Branch: <branch>
+Card Status: <card_status>
+Generated: <timestamp>
+
+Context:
+- Issue: <issue_url>
+- PR:
+- Source Issue Prompt: <source_issue_prompt>
+- Docs: <docs_context>
+- Other: none
+
+## Agent Execution Rules
+- This issue is not started yet; do not assume a branch or worktree already exists.
+- Do not run `pr start`; use the current issue-mode `pr run` flow only if execution later becomes necessary.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Lifecycle Semantics
+- Lifecycle stage: `SIP`
+- Activation state: active after issue-intent review.
+- Next stage: `STP`, where the selected task or solution is made explicit.
+- Legacy compatibility: older references may call this an input card, but new
+  issue work should treat it as the Structured Issue Prompt.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: <output_card>
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+## Execution
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug: <slug>
+- Required outcome type: <required_outcome_type>
+- Demo required: <demo_required>
+
+## Goal
+
+<goal>
+
+## Required Outcome
+
+<required_outcome>
+
+## Acceptance Criteria
+
+<acceptance_criteria>
+
+## Inputs
+
+<inputs>
+
+## Target Files / Surfaces
+
+<target_files_surfaces>
+
+## Validation Plan
+
+<validation_plan>
+
+## Demo / Proof Requirements
+
+<demo_proof_requirements>
+
+## Constraints / Policies
+
+- Follow `AGENTS.md`.
+- Use workflow-conductor for lifecycle routing.
+- Edit cards only with editor skills.
+- Work only in the bound issue worktree after `pr run`.
+- Keep validation focused on the touched surface.
+
+## System Invariants (must remain true)
+
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical SIP content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+<non_goals>
+
+## Notes / Risks
+
+<notes_risks>
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do not create a branch or worktree from this card alone.
+- When execution is approved, run the repo-native issue-mode `pr run` flow and then perform the work described above.
+- Write execution outcome truth to the paired `sor.md` file during execution.

--- a/docs/templates/prompts/1.0.2/sor.md
+++ b/docs/templates/prompts/1.0.2/sor.md
@@ -1,0 +1,159 @@
+# <slug>
+
+Canonical Template Source: `docs/templates/prompts/1.0.2/sor.md`
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-<issue_padded>
+Run ID: issue-<issue_padded>
+Version: <version>
+Title: <title>
+Branch: <branch>
+Card Status: <card_status>
+Status: <status>
+Generated: <timestamp>
+
+Execution:
+- Actor: issue-wave bootstrap
+- Model: not_applicable
+- Provider: not_applicable
+- Start Time: <timestamp>
+- End Time: <timestamp>
+
+## Summary
+
+Pre-run output scaffold initialized during issue-wave opening. No implementation has started yet.
+
+## PVF Lane Truth
+- Initial PVF lane: `<initial_pvf_lane>`
+- Planned PVF lane: `<planned_pvf_lane>`
+- Final PVF lane: `<final_pvf_lane>`
+- Lane change reason: `<lane_change_reason>`
+
+## Issue Metrics Truth
+- Estimated elapsed seconds: `<estimated_elapsed_seconds>`
+- Actual elapsed seconds: `<actual_elapsed_seconds>`
+- Estimated total tokens: `<estimated_total_tokens>`
+- Actual total tokens: `<actual_total_tokens>`
+- Estimated validation seconds: `<estimated_validation_seconds>`
+- Actual validation seconds: `<actual_validation_seconds>`
+- Goal metrics data source: `<actual_metrics_data_source>`
+- Goal metrics source ref: `<actual_metrics_source_ref>`
+- Data-source confidence: `<actual_metrics_confidence>`
+- Estimate error percent: `<estimate_error_percent>`
+- Goal-metrics substrate note: consume the `#4264` issue-goal metrics summary when available and record `unknown` instead of duplicating raw session logs here.
+
+## Variance Analysis
+- Threshold policy: require variance analysis when any known estimated/actual pair for elapsed seconds, total tokens, or validation seconds differs by more than 10 percent.
+- Variance analysis required: `<variance_analysis_required>`
+- Variance analysis completed: `<variance_analysis_completed>`
+- Variance category: `<variance_category>`
+- Variance note: `<variance_note>`
+- Sprint rollup guidance: count only completed variance analyses by `Variance category`; keep `not_applicable` out of category totals and never treat unknown metrics as zero variance.
+
+## Artifacts produced
+- Local ignored output-card scaffold at `<output_card>`
+- Tracked implementation artifacts: not_applicable until execution begins
+
+## Actions taken
+- Opened the local issue bundle and wrote a truthful pre-run output scaffold.
+- <branch_action>
+- Deferred implementation, proof capture, and release integration to the execution lifecycle and PR publication.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none
+- Worktree-only paths remaining: no tracked implementation artifacts exist yet; execution-time proof surfaces will be established during implementation and PR publication
+- Integration state: worktree_only
+- Verification scope: main_repo
+- Integration method used: local ignored card-bundle scaffold write under the active checkout; tracked implementation artifacts do not exist yet
+- Verification performed:
+  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input <output_card>`
+    Verified bootstrap SOR contract compliance for the local pre-run scaffold.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout BRANCH -- PATH` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input <output_card>`
+    Verified bootstrap SOR contract compliance for the local output scaffold.
+- Results:
+  - PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input <output_card>"
+  determinism:
+    status: NOT_RUN
+    replay_verified: unknown
+    ordering_guarantees_verified: unknown
+  security_privacy:
+    status: PARTIAL
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: not_run; bootstrap scaffold creation has not been replay-verified for this issue yet.
+- Fixtures or scripts used: `adl/tools/pr.sh` issue-wave opening flow.
+- Replay verification (same inputs -> same artifacts/order): not yet verified for this specific issue record.
+- Ordering guarantees (sorting / tie-break rules used): not_applicable for a single-card bootstrap write.
+- Artifact stability notes: repository-relative paths only; execution-time proof artifacts are not expected yet.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: limited content review only; no secrets were intentionally recorded in the scaffold.
+- Prompt / tool argument redaction verified: not_applicable for bootstrap scaffold generation.
+- Absolute path leakage check: repository-relative paths only in the scaffold.
+- Sandbox / policy invariants preserved: yes; local ignored issue-record path only.
+
+## Replay Artifacts
+- Trace bundle path(s): not_applicable until execution begins
+- Run artifact root: not_applicable until execution begins
+- Replay command used for verification: not_run
+- Replay result: NOT_RUN
+
+## Artifact Verification
+- Primary proof surface: this local pre-run SOR scaffold and its bootstrap validation result
+- Required artifacts present: local output card scaffold only; tracked implementation artifacts are not expected yet
+- Artifact schema/version checks: bootstrap SOR validator passed
+- Hash/byte-stability checks: not_run
+- Missing/optional artifacts and rationale: execution proofs, demos, and tracked outputs are intentionally absent before implementation begins
+
+## Decisions / Deviations
+- Issue-wave opening emits a truthful pre-run SOR scaffold instead of leaving raw template residue for later cleanup.
+- Integration state remains `worktree_only` until execution creates tracked artifacts or opens a PR.
+
+## Follow-ups / Deferred work
+- Update this record during execution with actual actions, validations, proof surfaces, and integration truth.
+- Normalize this record to `pr_open`, `merged`, or `closed_no_pr` during finish/closeout as appropriate.

--- a/docs/templates/prompts/1.0.2/spp.md
+++ b/docs/templates/prompts/1.0.2/spp.md
@@ -1,0 +1,181 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+name: "<slug>-execution-plan"
+issue: <issue>
+task_id: "issue-<issue_padded>"
+run_id: "issue-<issue_padded>"
+version: "<version>"
+title: "<title>"
+branch: "<branch>"
+generated_at: "<timestamp>"
+card_status: "<card_status>"
+status: "<status>"
+activation_state: "<activation_state>"
+plan_revision: 1
+initial_pvf_lane: "<initial_pvf_lane>"
+planned_pvf_lane: "<planned_pvf_lane>"
+planned_pvf_lane_source: "<planned_pvf_lane_source>"
+estimate_elapsed_seconds: "<estimated_elapsed_seconds>"
+estimate_total_tokens: "<estimated_total_tokens>"
+estimate_validation_seconds: "<estimated_validation_seconds>"
+estimate_confidence: "<estimate_confidence>"
+estimate_data_source: "<estimate_data_source>"
+estimate_source_ref: "<estimate_source_ref>"
+source_refs:
+  - kind: "issue"
+    ref: "<issue_url>"
+  - kind: "source_issue_prompt"
+    ref: "<source_issue_prompt>"
+  - kind: "stp"
+    ref: "<stp_card>"
+  - kind: "sip"
+    ref: "<sip_card>"
+scope:
+  files:
+    - "<target_files_surfaces_inline>"
+  components:
+    - "<slug>"
+  out_of_scope:
+    - "<non_goals_inline>"
+constraints:
+  - "design_time_plan_must_be_reviewed_before_execution"
+  - "runtime_execution_must_update_spp_if_plan_changes"
+  - "no_hidden_scope_expansion"
+confidence: "medium"
+plan_summary: "<plan_summary>"
+assumptions:
+  - "The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+proposed_steps:
+  - id: "step-1"
+    description: "Confirm dependency readiness and starting state: <dependencies_inline>"
+    expected_output: "<sip_card>"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-2"
+    description: "Review repo inputs and scoped surfaces before editing: <repo_inputs_inline>"
+    expected_output: "<stp_card>"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-3"
+    description: "Implement only the bounded deliverables: <deliverables_inline>"
+    expected_output: "tracked issue work product"
+    allowed_mode: "execution_after_approval"
+  - id: "step-4"
+    description: "Run focused proof gates for acceptance: <acceptance_criteria_inline>"
+    expected_output: "validation evidence recorded in SOR"
+    allowed_mode: "execution_after_approval"
+  - id: "step-5"
+    description: "Record issue-specific review findings in SRP, issue outcome truth in SOR, and refresh this SPP if execution diverges."
+    expected_output: "reviewed SRP and truthful SOR"
+    allowed_mode: "execution_after_approval"
+codex_plan:
+  - step: "Confirm dependencies and starting state from the source issue prompt."
+    status: "pending"
+  - step: "Inspect repo inputs and target surfaces before editing."
+    status: "pending"
+  - step: "Implement the bounded deliverables only."
+    status: "pending"
+  - step: "Run focused validation and proof gates."
+    status: "pending"
+  - step: "Record issue-specific SRP findings and SOR outcome truth."
+    status: "pending"
+affected_areas:
+  - "<slug>"
+invariants_to_preserve:
+  - "Keep SPP issue-local; do not turn it into sprint orchestration."
+  - "Keep SRP as review-result truth and SOR as output truth."
+risks_and_edge_cases:
+  - "<risks_inline>"
+test_strategy:
+  - "<validation_plan_inline>"
+execution_handoff: "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
+required_permissions:
+  - "workspace-write after execution approval"
+stop_conditions:
+  - "Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+  - "Stop and update SPP if touched files, proof gates, or validation commands change materially."
+  - "Stop and route follow-on work if acceptance requires scope outside this issue."
+alternatives_considered:
+  - description: "Rely only on transient chat planning."
+    reason_not_chosen: "Chat-only planning is not durable or reviewable enough for this workflow surface."
+review_hooks:
+  - "Check dependency truth, scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
+notes: "<notes_risks_inline>"
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`
+
+# Structured Plan Prompt
+
+## Plan Summary
+
+Design-time operative plan for `<title>`.
+
+<plan_summary>
+
+## PVF Lane Plan
+
+- Initial PVF lane from issue creation: `<initial_pvf_lane>`
+- Planned PVF lane for execution: `<planned_pvf_lane>`
+- Planning lane source: `<planned_pvf_lane_source>`
+- Revision rule: change `planned_pvf_lane` only when planning discovers a better explicit lane; keep `needs_planning_lane_assignment` fail-closed until that happens.
+
+## Estimate Plan
+
+- Estimated elapsed seconds: `<estimated_elapsed_seconds>`
+- Estimated total tokens: `<estimated_total_tokens>`
+- Estimated validation seconds: `<estimated_validation_seconds>`
+- Estimate confidence: `<estimate_confidence>`
+- Estimate data source: `<estimate_data_source>`
+- Estimate source ref: `<estimate_source_ref>`
+- Unknown-value rule: record `unknown`, never `0`, when the estimate is unavailable or intentionally deferred.
+
+## Codex Plan
+
+1. [pending] Confirm dependencies and starting state from the source issue prompt.
+2. [pending] Inspect repo inputs and target surfaces before editing.
+3. [pending] Implement the bounded deliverables only.
+4. [pending] Run focused validation and proof gates.
+5. [pending] Record issue-specific SRP findings and SOR outcome truth.
+
+## Assumptions
+
+- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs.
+
+## Proposed Steps
+
+1. Confirm dependency readiness and starting state: <dependencies_inline>
+2. Review repo inputs and scoped surfaces before editing: <repo_inputs_inline>
+3. Implement only the bounded deliverables: <deliverables_inline>
+4. Run focused proof gates for acceptance: <acceptance_criteria_inline>
+5. Record issue-specific review findings in SRP, issue outcome truth in SOR, and refresh this SPP if execution diverges.
+
+## Affected Areas
+
+- <slug>
+
+## Invariants To Preserve
+
+- Keep SPP issue-local; do not turn it into sprint orchestration.
+- Keep SRP as review-result truth and SOR as output truth.
+
+## Risks And Edge Cases
+
+- <risks_inline>
+
+## Test Strategy
+
+- <validation_plan_inline>
+
+## Execution Handoff
+
+Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes.
+
+## Stop Conditions
+
+- Stop and re-plan if dependencies are unmet or materially different from this design-time plan.
+- Stop and update SPP if touched files, proof gates, or validation commands change materially.
+- Stop and route follow-on work if acceptance requires scope outside this issue.
+
+## Notes
+
+<notes_risks_inline>

--- a/docs/templates/prompts/1.0.2/srp.md
+++ b/docs/templates/prompts/1.0.2/srp.md
@@ -1,0 +1,133 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "<slug>-review-prompt"
+issue: <issue>
+task_id: "issue-<issue_padded>"
+version: "<version>"
+title: "<title>"
+branch: "<branch>"
+generated_at: "<timestamp>"
+card_status: "<card_status>"
+status: "draft"
+source_refs:
+  - kind: "issue"
+    ref: "<issue_url>"
+  - kind: "stp"
+    ref: "<stp_card>"
+  - kind: "sip"
+    ref: "<sip_card>"
+  - kind: "spp"
+    ref: "<spp_card>"
+  - kind: "sor"
+    ref: "<sor_card>"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - "<stp_card>"
+  - "<sip_card>"
+in_scope_surfaces:
+  - "tracked changes for this issue branch"
+evidence_policy:
+  - "Use repository evidence, targeted validation output, and linked issue-bundle artifacts only."
+validation_inputs:
+  - "Issue-local proofs recorded in the SOR."
+allowed_dispositions:
+  - "PASS"
+  - "BLOCK"
+  - "NEEDS_FOLLOWUP"
+reviewer_constraints:
+  - "Do not widen issue scope."
+  - "Do not merge, publish, or close the issue."
+refusal_policy:
+  - "Refuse claims that are unsupported by repository evidence."
+  - "Refuse approving behavior outside the recorded issue scope."
+follow_up_routing:
+  - "Route actionable defects back to the issue branch before PR publication."
+non_claims:
+  - "This prompt does not claim review has already run."
+  - "This prompt does not guarantee review quality by itself."
+policy_refs:
+  - "<stp_card>"
+  - "<sip_card>"
+review_results:
+  findings_status: "<findings_status>"
+  recommended_outcome: "<recommended_outcome>"
+notes: "Structured Review Prompt prepared before execution; finalize with actual review findings before PR publication."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.2/srp.md`
+
+# Structured Review Prompt
+
+## Review Summary
+
+Use this prompt to govern the independent pre-PR review for this issue. Review results are intentionally absent before implementation exists and must be finalized before PR publication.
+
+## Scope Basis
+
+- <stp_card>
+- <sip_card>
+
+## In-Scope Surfaces
+
+- tracked changes for this issue branch
+
+## Evidence Rules
+
+- Use repository evidence, targeted validation output, and linked issue-bundle artifacts only.
+
+## Validation Inputs
+
+- Issue-local proofs recorded in the SOR.
+
+## Allowed Dispositions
+
+- PASS
+- BLOCK
+- NEEDS_FOLLOWUP
+
+## Reviewer Constraints
+
+- Do not widen issue scope.
+- Do not merge, publish, or close the issue.
+
+## Refusal Policy
+
+- Refuse claims that are unsupported by repository evidence.
+- Refuse approving behavior outside the recorded issue scope.
+
+## Follow-up Routing
+
+- Route actionable defects back to the issue branch before PR publication.
+
+## Non-Claims
+
+- This prompt does not claim review has already run.
+- This prompt does not guarantee review quality by itself.
+
+## Review Results
+
+When finalizing review, record the machine-readable review result in frontmatter:
+
+```yaml
+review_results:
+  findings_status: "no_findings | findings_present"
+  recommended_outcome: "pass | block | needs_followup"
+```
+
+### Findings
+
+- Not run yet; implementation has not been bound.
+
+### Dispositions
+
+- Not applicable until review runs.
+
+### Recommended Outcome
+
+- Not run yet.
+
+## Notes
+
+Structured Review Prompt prepared before execution; finalize with actual review findings before PR publication.

--- a/docs/templates/prompts/1.0.2/stp.md
+++ b/docs/templates/prompts/1.0.2/stp.md
@@ -1,0 +1,90 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "<wp>"
+slug: "<slug>"
+title: "<title>"
+labels:
+  - "track:roadmap"
+issue_number: <issue>
+generated_at: "<timestamp>"
+card_status: "<card_status>"
+status: "draft"
+action: "edit"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "<version>"
+required_outcome_type:
+  - "<required_outcome_type>"
+repo_inputs:
+  - "<source_issue_prompt>"
+canonical_files: []
+demo_required: <demo_required>
+demo_names: []
+issue_graph_notes:
+  - "<issue_graph_note>"
+pr_start:
+  enabled: true
+  slug: "<slug>"
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.2/stp.md`
+Generated: <timestamp>
+
+# Structured Task Prompt
+
+## Summary
+
+<summary>
+
+## Goal
+
+<goal>
+
+## Required Outcome
+
+<required_outcome>
+
+## Deliverables
+
+<deliverables>
+
+## Acceptance Criteria
+
+<acceptance_criteria>
+
+## Repo Inputs
+
+<repo_inputs>
+
+## Dependencies
+
+<dependencies>
+
+## Target Files / Surfaces
+
+<target_files_surfaces>
+
+## Validation Plan
+
+<validation_plan>
+
+## Demo Expectations
+
+<demo_proof_requirements>
+
+## Non-goals
+
+<non_goals>
+
+## Issue-Graph Notes
+
+<issue_graph_notes>
+
+## Notes
+
+<notes_risks>
+
+## Tooling Notes
+
+<tooling_notes>

--- a/docs/templates/prompts/current.json
+++ b/docs/templates/prompts/current.json
@@ -1,35 +1,35 @@
 {
   "schema": "adl.csdlc.prompt_template_registry.v1",
-  "csdlc_prompt_template_set": "1.0.1",
-  "semver": "1.0.1",
+  "csdlc_prompt_template_set": "1.0.2",
+  "semver": "1.0.2",
   "status": "active",
   "object_kind": "csdlc_prompt_template_set",
   "lifecycle": ["SIP", "STP", "SPP", "SRP", "SOR"],
   "templates": {
     "sip": {
       "semantic_role": "Structured Issue Prompt",
-      "path": "docs/templates/prompts/1.0.1/sip.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.1/schemas/sip.structure.json"
+      "path": "docs/templates/prompts/1.0.2/sip.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/sip.structure.json"
     },
     "stp": {
       "semantic_role": "Structured Task Prompt",
-      "path": "docs/templates/prompts/1.0.1/stp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.1/schemas/stp.structure.json"
+      "path": "docs/templates/prompts/1.0.2/stp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/stp.structure.json"
     },
     "spp": {
       "semantic_role": "Structured Plan Prompt",
-      "path": "docs/templates/prompts/1.0.1/spp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.1/schemas/spp.structure.json"
+      "path": "docs/templates/prompts/1.0.2/spp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/spp.structure.json"
     },
     "srp": {
       "semantic_role": "Structured Review Prompt",
-      "path": "docs/templates/prompts/1.0.1/srp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.1/schemas/srp.structure.json"
+      "path": "docs/templates/prompts/1.0.2/srp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/srp.structure.json"
     },
     "sor": {
       "semantic_role": "Structured Outcome Record",
-      "path": "docs/templates/prompts/1.0.1/sor.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.1/schemas/sor.structure.json"
+      "path": "docs/templates/prompts/1.0.2/sor.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/sor.structure.json"
     }
   },
   "compatibility_fallbacks": {


### PR DESCRIPTION
Closes #4279

## Summary
Implemented variance-analysis enforcement for large estimate misses, added the new SOR variance-analysis surface to the active `1.0.2` prompt-template set, regenerated the tracked structure schemas, and added focused proof for both the structured-prompt and prompt-template validation paths.

## Artifacts
- `adl/src/cli/tooling_cmd/structured_prompt.rs`
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`
- `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`
- `adl/src/cli/tooling_cmd/tests/support.rs`
- `adl/src/csdlc_prompt_editor.rs`
- `adl/src/csdlc_prompt_editor/structure.rs`
- `docs/templates/prompts/current.json`
- `docs/templates/prompts/1.0.2/`

## Validation
- Validation commands and their purpose:
  - `cargo run --manifest-path adl/Cargo.toml -- tooling prompt-template write-structure-schemas --out-dir docs/templates/prompts/1.0.2/schemas`
    Regenerated the tracked prompt-card structure schemas after the `1.0.2` template update.
  - `cargo test --manifest-path adl/Cargo.toml editor_model_covers_all_five_cards -- --nocapture`
    Verified the active template registry bump is reflected in the editor model.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_sor_requires_variance_analysis_for_large_known_estimate_miss -- --nocapture`
    Verified above-threshold SOR variance analysis is required.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_sor_accepts_completed_variance_analysis_for_large_known_estimate_miss -- --nocapture`
    Verified a completed typed variance analysis satisfies the SOR validator.
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_validate_values_requires_variance_analysis_for_large_known_sor_estimate_miss -- --nocapture`
    Verified SOR prompt-template values fail closed when above-threshold variance analysis is missing.
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_validate_values_requires_variance_note_when_analysis_is_required -- --nocapture`
    Verified required variance analysis also requires a non-empty variance note in prompt-template values validation.
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_cli_renders_and_validates_all_five_cards_from_values -- --nocapture`
    Verified the active prompt-template set still renders and validates all five cards end to end.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_sor_rejects_missing_variance_analysis_section -- --nocapture`
    Verified the `Variance Analysis` section itself is mandatory in completed SOR validation.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4279__v0-91-6-process-metrics-add-variance-analysis-for-estimate-misses/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4279__v0-91-6-process-metrics-add-variance-analysis-for-estimate-misses/sor.md
- Idempotency-Key: v0-91-6-process-metrics-add-variance-analysis-for-estimate-misses-adl-v0-91-6-tasks-issue-4279-v0-91-6-process-metrics-add-variance-analysis-for-estimate-misses-sip-md-adl-v0-91-6-tasks-issue-4279-v0-91-6-process-metrics-add-variance-analysis-for-estimate-misses-sor-md