### PR TITLE
[v0.91.6][aws][ddns] Implement Wuji dynamic IP Route 53 updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ artifacts/
 issue-*.sh
 *.profraw
 *.profdata
+infra/ddns/.terraform/
+infra/ddns/tfplan
+infra/ddns/build/
+infra/ddns/terraform.tfstate
+infra/ddns/terraform.tfstate.backup
 
 # Local worktrees (generated)
 .worktrees/

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1590,6 +1590,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_issue_small_binary_validation(issue_number, changed_paths) {
         return Ok(build_issue_small_binary_validation_plan());
     }
+    if finish_issue_needs_wuji_ddns_validation(issue_number, changed_paths) {
+        return Ok(build_wuji_ddns_validation_plan());
+    }
     if finish_issue_needs_locked_cargo_fallback_validation(issue_number, changed_paths) {
         return Ok(build_locked_cargo_fallback_validation_plan());
     }
@@ -1959,6 +1962,20 @@ fn finish_issue_needs_locked_cargo_fallback_validation(
         })
 }
 
+fn finish_issue_needs_wuji_ddns_validation(issue_number: u32, changed_paths: &[String]) -> bool {
+    if issue_number != 4284 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            trimmed == ".gitignore"
+                || trimmed == "adl/src/cli/pr_cmd/finish_support.rs"
+                || trimmed == "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
+                || trimmed.starts_with("infra/ddns/")
+        })
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -2028,6 +2045,22 @@ fn build_issue_small_binary_validation_plan() -> FinishValidationPlan {
     FinishValidationPlan {
         mode: FinishValidationMode::SmallBinaryFocused,
         commands,
+    }
+}
+
+fn build_wuji_ddns_validation_plan() -> FinishValidationPlan {
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_slice -- --nocapture".to_string(),
+            "python3 -m unittest infra/ddns/tests/test_handler.py".to_string(),
+            "sh -n infra/ddns/client/wuji_ddns_update.sh".to_string(),
+            "terraform -chdir=infra/ddns fmt -check".to_string(),
+            "terraform -chdir=infra/ddns init -backend=false".to_string(),
+            "terraform -chdir=infra/ddns validate".to_string(),
+        ],
     }
 }
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2583,6 +2583,48 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_slice -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-pr-finish",
+                            "wuji_ddns_slice",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "python3 -m unittest infra/ddns/tests/test_handler.py" => {
+                    run_finish_validation_status(
+                        "python3",
+                        &["-m", "unittest", "infra/ddns/tests/test_handler.py"],
+                    )?;
+                }
+                "sh -n infra/ddns/client/wuji_ddns_update.sh" => {
+                    run_finish_validation_status("sh", &["-n", "infra/ddns/client/wuji_ddns_update.sh"])?;
+                }
+                "terraform -chdir=infra/ddns fmt -check" => {
+                    run_finish_validation_status(
+                        "terraform",
+                        &["-chdir=infra/ddns", "fmt", "-check"],
+                    )?;
+                }
+                "terraform -chdir=infra/ddns init -backend=false" => {
+                    run_finish_validation_status(
+                        "terraform",
+                        &["-chdir=infra/ddns", "init", "-backend=false"],
+                    )?;
+                }
+                "terraform -chdir=infra/ddns validate" => {
+                    run_finish_validation_status(
+                        "terraform",
+                        &["-chdir=infra/ddns", "validate"],
+                    )?;
+                }
                 "cargo test --manifest-path adl/Cargo.toml --bin adl-csdlc public_prompt_packet" => {
                     run_finish_validation_status(
                         "cargo",

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2298,6 +2298,62 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_wuji_ddns_slice() {
+    let changed_paths = vec![
+        ".gitignore".to_string(),
+        "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+        "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        "infra/ddns/.terraform.lock.hcl".to_string(),
+        "infra/ddns/README.md".to_string(),
+        "infra/ddns/client/com.agentlogic.wuji-ddns.plist".to_string(),
+        "infra/ddns/client/wuji_ddns_update.sh".to_string(),
+        "infra/ddns/iam.tf".to_string(),
+        "infra/ddns/lambda.tf".to_string(),
+        "infra/ddns/lambda/handler.py".to_string(),
+        "infra/ddns/locals.tf".to_string(),
+        "infra/ddns/outputs.tf".to_string(),
+        "infra/ddns/providers.tf".to_string(),
+        "infra/ddns/route53.tf".to_string(),
+        "infra/ddns/ssm.tf".to_string(),
+        "infra/ddns/tests/test_handler.py".to_string(),
+        "infra/ddns/variables.tf".to_string(),
+        "infra/ddns/versions.tf".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(4284, &requested_paths, &changed_paths)
+        .expect("wuji ddns focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_slice -- --nocapture"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"python3 -m unittest infra/ddns/tests/test_handler.py".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"sh -n infra/ddns/client/wuji_ddns_update.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"terraform -chdir=infra/ddns fmt -check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"terraform -chdir=infra/ddns init -backend=false".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"terraform -chdir=infra/ddns validate".to_string()));
+
+    let unrelated_err =
+        select_finish_validation_plan_for_finish(4285, &requested_paths, &changed_paths)
+            .expect_err("unrelated issue should not inherit the wuji ddns focused allowance");
+    assert!(unrelated_err
+        .to_string()
+        .contains("changed paths are not classified"));
+}
+
+#[test]
 fn finish_validation_runner_executes_locked_cargo_fallback_script_command() {
     let repo = unique_temp_dir("adl-pr-finish-locked-cargo-fallback-validation");
     let tools = repo.join("adl/tools");

--- a/infra/ddns/.terraform.lock.hcl
+++ b/infra/ddns/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/ddns/README.md
+++ b/infra/ddns/README.md
@@ -39,6 +39,11 @@ be stood up from a single apply.
 The token is still secret material and therefore lives in Terraform state. Use
 secure state custody before broad operational rollout.
 
+The current provider-compatible Function URL permission bridge also requires
+local `aws` CLI and `jq` availability at apply time because Terraform must use
+the tracked `local-exec` compatibility shim until the provider surface can own
+`invoked_via_function_url` directly.
+
 ## Required Operator Inputs
 
 Before Terraform apply, provide:
@@ -71,6 +76,9 @@ terraform -chdir=infra/ddns plan -out=tfplan
 2. Run `terraform -chdir=infra/ddns plan -out=tfplan`.
 3. Review the plan.
 4. Apply with `terraform -chdir=infra/ddns apply -auto-approve tfplan`.
+   This compatibility path currently expects `aws` and `jq` to be installed on
+   the operator machine because the apply uses a bounded `local-exec` bridge for
+   the missing Function URL invoke-via-URL permission surface.
 5. Retrieve the token for Wuji from Terraform output and write it to the local
    token file.
 6. Install the Wuji client script and filled-in plist.

--- a/infra/ddns/README.md
+++ b/infra/ddns/README.md
@@ -1,0 +1,118 @@
+# Wuji Dynamic DNS
+
+This directory contains the Phase 1 Terraform-managed DDNS slice for
+`wuji.agent-logic.ai`.
+
+## Tracked Source Layout
+
+- `lambda/handler.py`: Lambda Function URL handler.
+- `tests/test_handler.py`: focused local proof for auth, idempotence, UPSERT, and
+  sanitized logging behavior.
+- `client/wuji_ddns_update.sh`: Wuji-side client that calls the Lambda URL over
+  HTTPS without AWS credentials.
+- `client/com.agentlogic.wuji-ddns.plist`: `launchd` template for five-minute
+  execution and reboot survival.
+- `*.tf`: Terraform package for the DDNS infrastructure.
+
+## Local-Only Terraform Artifacts
+
+Keep these paths untracked:
+
+- `infra/ddns/.terraform/`
+- `infra/ddns/tfplan`
+- `infra/ddns/build/`
+
+The tracked package keeps local Lambda zip output under `infra/ddns/build/` so
+the Terraform surface stays self-contained without turning build byproducts into
+review artifacts.
+
+## Bootstrap Boundary
+
+This slice now creates the bearer token via Terraform so the DDNS service can
+be stood up from a single apply.
+
+- If `ddns_bearer_token` is unset, Terraform generates a strong token and
+  writes it into the SecureString parameter.
+- If `ddns_bearer_token` is supplied through a secure local variable source,
+  Terraform writes that exact value instead.
+
+The token is still secret material and therefore lives in Terraform state. Use
+secure state custody before broad operational rollout.
+
+## Required Operator Inputs
+
+Before Terraform apply, provide:
+
+- `route53_hosted_zone_id`
+- `allowed_hostnames` if different from the default
+- optionally `ddns_bearer_token` if you want to supply the token instead of
+  letting Terraform generate one
+
+## Validation
+
+Run the focused local proof set:
+
+```sh
+python3 -m unittest infra/ddns/tests/test_handler.py
+terraform -chdir=infra/ddns fmt -check
+terraform -chdir=infra/ddns init -backend=false
+terraform -chdir=infra/ddns validate
+```
+
+If you want a local plan after supplying real variable values:
+
+```sh
+terraform -chdir=infra/ddns plan -out=tfplan
+```
+
+## Apply Flow
+
+1. Run Terraform validation.
+2. Run `terraform -chdir=infra/ddns plan -out=tfplan`.
+3. Review the plan.
+4. Apply with `terraform -chdir=infra/ddns apply -auto-approve tfplan`.
+5. Retrieve the token for Wuji from Terraform output and write it to the local
+   token file.
+6. Install the Wuji client script and filled-in plist.
+7. Load the plist with `launchctl bootstrap` or `launchctl kickstart`.
+
+If you are using local state during bootstrap, capture the token immediately
+after apply and then move to a secure backend or other secure state custody.
+
+## Wuji Client Install
+
+1. Copy `client/wuji_ddns_update.sh` to a stable local path on Wuji.
+2. Write the Terraform-managed token to a local file with restrictive
+   permissions, for example:
+
+```sh
+mkdir -p ~/.config/wuji-ddns
+terraform -chdir=infra/ddns output -raw ddns_bearer_token > ~/.config/wuji-ddns/token
+chmod 600 ~/.config/wuji-ddns/token
+```
+
+This command requires access to the same Terraform state that created the
+token. If local state is only temporary, export the token before removing or
+relocating that state.
+
+3. Replace the placeholders in `client/com.agentlogic.wuji-ddns.plist`:
+   - `__WUJI_DDNS_SCRIPT_PATH__`
+   - `__WUJI_DDNS_FUNCTION_URL__`
+   - `__WUJI_DDNS_TOKEN_FILE__`
+   - `__WUJI_DDNS_LOG_DIR__`
+4. Install the plist under `~/Library/LaunchAgents/`.
+5. Start it:
+
+```sh
+launchctl bootout gui/"$(id -u)" ~/Library/LaunchAgents/com.agentlogic.wuji-ddns.plist 2>/dev/null || true
+launchctl bootstrap gui/"$(id -u)" ~/Library/LaunchAgents/com.agentlogic.wuji-ddns.plist
+launchctl kickstart -k gui/"$(id -u)"/com.agentlogic.wuji-ddns
+```
+
+## Failure Behavior
+
+- ISP address changes: the next scheduled run updates Route 53.
+- Lambda failure: DNS stays unchanged and the next scheduled run retries.
+- Route 53 failure: Lambda returns failure and CloudWatch logs capture the
+  error.
+- Wuji offline: DNS remains on the last successful IP until Wuji returns.

--- a/infra/ddns/client/com.agentlogic.wuji-ddns.plist
+++ b/infra/ddns/client/com.agentlogic.wuji-ddns.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentlogic.wuji-ddns</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__WUJI_DDNS_SCRIPT_PATH__</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>DDNS_FUNCTION_URL</key>
+    <string>__WUJI_DDNS_FUNCTION_URL__</string>
+    <key>DDNS_HOSTNAME</key>
+    <string>wuji.agent-logic.ai</string>
+    <key>DDNS_TOKEN_FILE</key>
+    <string>__WUJI_DDNS_TOKEN_FILE__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <key>StandardOutPath</key>
+  <string>__WUJI_DDNS_LOG_DIR__/wuji-ddns.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>__WUJI_DDNS_LOG_DIR__/wuji-ddns.stderr.log</string>
+</dict>
+</plist>

--- a/infra/ddns/client/wuji_ddns_update.sh
+++ b/infra/ddns/client/wuji_ddns_update.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${DDNS_FUNCTION_URL:-}" ]; then
+  echo "DDNS_FUNCTION_URL must be set" >&2
+  exit 1
+fi
+
+if [ -z "${DDNS_HOSTNAME:-}" ]; then
+  echo "DDNS_HOSTNAME must be set" >&2
+  exit 1
+fi
+
+TOKEN_FILE="${DDNS_TOKEN_FILE:-$HOME/.config/wuji-ddns/token}"
+if [ ! -r "$TOKEN_FILE" ]; then
+  echo "DDNS token file is not readable: $TOKEN_FILE" >&2
+  exit 1
+fi
+
+set +e
+RESPONSE=$(
+  DDNS_FUNCTION_URL="$DDNS_FUNCTION_URL" \
+  DDNS_HOSTNAME="$DDNS_HOSTNAME" \
+  DDNS_TOKEN_FILE="$TOKEN_FILE" \
+  python3 <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+url = os.environ["DDNS_FUNCTION_URL"]
+hostname = os.environ["DDNS_HOSTNAME"]
+token_file = os.environ["DDNS_TOKEN_FILE"]
+
+with open(token_file, "r", encoding="utf-8") as handle:
+    token = handle.read().strip()
+
+payload = json.dumps({"hostname": hostname}).encode("utf-8")
+request = urllib.request.Request(
+    url,
+    data=payload,
+    method="POST",
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(request, timeout=15) as response:
+        body = response.read().decode("utf-8")
+        print(json.dumps({"http_code": response.getcode(), "body": body}))
+except urllib.error.HTTPError as exc:
+    body = exc.read().decode("utf-8")
+    print(json.dumps({"http_code": exc.code, "body": body}))
+    sys.exit(1)
+except Exception as exc:
+    print(json.dumps({"http_code": 0, "body": f"request_error: {exc}"}))
+    sys.exit(2)
+PY
+)
+STATUS=$?
+set -e
+HTTP_CODE=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["http_code"])')
+BODY=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["body"])')
+
+case "$HTTP_CODE" in
+  200)
+    printf '%s\n' "$BODY"
+    ;;
+  *)
+    printf 'DDNS update failed with HTTP %s: %s\n' "$HTTP_CODE" "$BODY" >&2
+    exit "${STATUS:-1}"
+    ;;
+esac

--- a/infra/ddns/iam.tf
+++ b/infra/ddns/iam.tf
@@ -1,0 +1,64 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ddns_lambda" {
+  name               = "${local.name_prefix}-ddns-lambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "ddns_lambda" {
+  statement {
+    sid = "ReadTokenParameter"
+
+    actions = [
+      "ssm:GetParameter",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${var.ddns_token_parameter_name}",
+    ]
+  }
+
+  statement {
+    sid = "ManageSingleHostedZoneRecords"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets",
+    ]
+
+    resources = [
+      "arn:aws:route53:::hostedzone/${var.route53_hosted_zone_id}",
+    ]
+  }
+
+  statement {
+    sid = "WriteBoundedLambdaLogs"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.ddns_lambda.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ddns_lambda" {
+  name   = "${local.name_prefix}-ddns-lambda"
+  role   = aws_iam_role.ddns_lambda.id
+  policy = data.aws_iam_policy_document.ddns_lambda.json
+}

--- a/infra/ddns/lambda.tf
+++ b/infra/ddns/lambda.tf
@@ -61,6 +61,8 @@ resource "terraform_data" "ddns_function_public_invoke_via_url" {
     statement_id  = "AllowPublicInvokeViaFunctionUrl"
   }
 
+  # Provider compatibility bridge: this apply path expects local aws CLI and jq
+  # until the provider can express invoked_via_function_url directly.
   provisioner "local-exec" {
     command = <<-EOT
       set -eu

--- a/infra/ddns/lambda.tf
+++ b/infra/ddns/lambda.tf
@@ -1,0 +1,93 @@
+data "archive_file" "ddns_lambda" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/handler.py"
+  output_path = local.lambda_package_path
+}
+
+resource "aws_cloudwatch_log_group" "ddns_lambda" {
+  name              = local.log_group_name
+  retention_in_days = 14
+  tags              = var.tags
+}
+
+resource "aws_lambda_function" "ddns_updater" {
+  function_name    = local.lambda_function_name
+  role             = aws_iam_role.ddns_lambda.arn
+  runtime          = "python3.12"
+  handler          = "handler.lambda_handler"
+  filename         = data.archive_file.ddns_lambda.output_path
+  source_code_hash = data.archive_file.ddns_lambda.output_base64sha256
+  timeout          = var.lambda_timeout_seconds
+  memory_size      = var.lambda_memory_size_mb
+
+  environment {
+    variables = {
+      DDNS_ALLOWED_HOSTNAMES = local.allowed_hostnames_csv
+      DDNS_HOSTED_ZONE_ID    = var.route53_hosted_zone_id
+      DDNS_RECORD_TTL        = tostring(var.dns_record_ttl)
+      DDNS_TOKEN_PARAMETER   = aws_ssm_parameter.ddns_token.name
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.ddns_lambda,
+  ]
+
+  tags = var.tags
+}
+
+resource "aws_lambda_function_url" "ddns_updater" {
+  function_name      = aws_lambda_function.ddns_updater.function_name
+  authorization_type = "NONE"
+
+  cors {
+    allow_methods = ["POST"]
+    allow_origins = ["*"]
+  }
+}
+
+resource "aws_lambda_permission" "ddns_function_url_public_invoke" {
+  statement_id           = "AllowPublicFunctionUrlInvoke"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.ddns_updater.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
+resource "terraform_data" "ddns_function_public_invoke_via_url" {
+  input = {
+    function_name = aws_lambda_function.ddns_updater.function_name
+    region        = var.aws_region
+    statement_id  = "AllowPublicInvokeViaFunctionUrl"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -eu
+      if aws --region ${self.input.region} lambda get-policy --function-name ${self.input.function_name} >/tmp/wuji_ddns_lambda_policy.json 2>/dev/null && \
+         jq -e '.Policy | fromjson | .Statement[] | select(.Sid == "'"${self.input.statement_id}"'")' /tmp/wuji_ddns_lambda_policy.json >/dev/null 2>&1; then
+        exit 0
+      fi
+      aws --region ${self.input.region} lambda add-permission \
+        --function-name ${self.input.function_name} \
+        --statement-id ${self.input.statement_id} \
+        --action lambda:InvokeFunction \
+        --principal '*' \
+        --invoked-via-function-url
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      aws --region ${self.input.region} lambda remove-permission \
+        --function-name ${self.input.function_name} \
+        --statement-id ${self.input.statement_id} >/dev/null 2>&1 || true
+    EOT
+  }
+
+  depends_on = [
+    aws_lambda_function.ddns_updater,
+    aws_lambda_function_url.ddns_updater,
+  ]
+}

--- a/infra/ddns/lambda/handler.py
+++ b/infra/ddns/lambda/handler.py
@@ -1,0 +1,210 @@
+import base64
+import binascii
+import hmac
+import ipaddress
+import json
+import logging
+import os
+from typing import Dict, Optional
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    import boto3
+
+    return handle_event(event, boto3.client("route53"), boto3.client("ssm"))
+
+
+def handle_event(event, route53_client, ssm_client):
+    config = load_config()
+    auth_header = get_header(event, "authorization")
+    expected_token = fetch_token(ssm_client, config["token_parameter_name"])
+    if not token_matches(auth_header, expected_token):
+        log_event("rejected", hostname=None, old_ip=None, new_ip=None, detail="unauthorized")
+        return response(401, {"ok": False, "error": "unauthorized"})
+
+    try:
+        hostname = extract_hostname(event)
+    except ValueError as exc:
+        log_event("rejected", hostname=None, old_ip=None, new_ip=None, detail=str(exc))
+        return response(400, {"ok": False, "error": str(exc)})
+    if hostname not in config["allowed_hostnames"]:
+        log_event("rejected", hostname=hostname, old_ip=None, new_ip=None, detail="hostname_not_allowed")
+        return response(400, {"ok": False, "error": "hostname_not_allowed"})
+
+    try:
+        source_ip = extract_source_ip(event)
+    except ValueError as exc:
+        log_event("rejected", hostname=hostname, old_ip=None, new_ip=None, detail=str(exc))
+        return response(400, {"ok": False, "error": str(exc)})
+
+    current_ip = get_current_a_record(route53_client, config["hosted_zone_id"], hostname)
+    if current_ip == source_ip:
+        log_event("no_change", hostname=hostname, old_ip=current_ip, new_ip=source_ip, detail=None)
+        return response(
+            200,
+            {
+                "ok": True,
+                "hostname": hostname,
+                "current_ip": current_ip,
+                "changed": False,
+            },
+        )
+
+    upsert_a_record(
+        route53_client,
+        hosted_zone_id=config["hosted_zone_id"],
+        hostname=hostname,
+        ip_address=source_ip,
+        ttl=config["record_ttl"],
+    )
+    log_event("updated", hostname=hostname, old_ip=current_ip, new_ip=source_ip, detail=None)
+    return response(
+        200,
+        {
+            "ok": True,
+            "hostname": hostname,
+            "previous_ip": current_ip,
+            "current_ip": source_ip,
+            "changed": True,
+        },
+    )
+
+
+def load_config() -> Dict[str, object]:
+    allowed_hostnames = tuple(
+        hostname.strip()
+        for hostname in os.environ["DDNS_ALLOWED_HOSTNAMES"].split(",")
+        if hostname.strip()
+    )
+    return {
+        "allowed_hostnames": allowed_hostnames,
+        "hosted_zone_id": os.environ["DDNS_HOSTED_ZONE_ID"],
+        "record_ttl": int(os.environ.get("DDNS_RECORD_TTL", "60")),
+        "token_parameter_name": os.environ["DDNS_TOKEN_PARAMETER"],
+    }
+
+
+def fetch_token(ssm_client, parameter_name: str) -> str:
+    parameter = ssm_client.get_parameter(Name=parameter_name, WithDecryption=True)
+    return parameter["Parameter"]["Value"]
+
+
+def get_header(event, expected_name: str) -> Optional[str]:
+    headers = event.get("headers") or {}
+    for key, value in headers.items():
+        if key.lower() == expected_name:
+            return value
+    return None
+
+
+def token_matches(auth_header: Optional[str], expected_token: str) -> bool:
+    if not auth_header:
+        return False
+    prefix = "Bearer "
+    if not auth_header.startswith(prefix):
+        return False
+    return hmac.compare_digest(auth_header[len(prefix) :], expected_token)
+
+
+def extract_hostname(event) -> Optional[str]:
+    body = event.get("body")
+    if not body:
+        raise ValueError("missing_body")
+    if event.get("isBase64Encoded"):
+        try:
+            body = base64.b64decode(body).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            raise ValueError("invalid_base64_body") from exc
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError("invalid_json_body") from exc
+    hostname = payload.get("hostname")
+    if not hostname:
+        raise ValueError("missing_hostname")
+    return hostname
+
+
+def extract_source_ip(event) -> Optional[str]:
+    ip_candidate = (
+        event.get("requestContext", {})
+        .get("http", {})
+        .get("sourceIp")
+    )
+    if ip_candidate is None:
+        raise ValueError("missing_source_ip")
+    parsed = ipaddress.ip_address(ip_candidate)
+    if parsed.version != 4:
+        raise ValueError("ipv6_not_supported_in_phase1")
+    return str(parsed)
+
+
+def get_current_a_record(route53_client, hosted_zone_id: str, hostname: str) -> Optional[str]:
+    response_payload = route53_client.list_resource_record_sets(
+        HostedZoneId=hosted_zone_id,
+        StartRecordName=hostname,
+        StartRecordType="A",
+        MaxItems="1",
+    )
+    for record_set in response_payload.get("ResourceRecordSets", []):
+        if normalize_record_name(record_set.get("Name")) != hostname:
+            continue
+        if record_set.get("Type") != "A":
+            continue
+        records = record_set.get("ResourceRecords", [])
+        if not records:
+            return None
+        return records[0]["Value"]
+    return None
+
+
+def normalize_record_name(record_name: Optional[str]) -> Optional[str]:
+    if record_name is None:
+        return None
+    return record_name.rstrip(".")
+
+
+def upsert_a_record(route53_client, hosted_zone_id: str, hostname: str, ip_address: str, ttl: int) -> None:
+    route53_client.change_resource_record_sets(
+        HostedZoneId=hosted_zone_id,
+        ChangeBatch={
+            "Comment": "ADL Wuji DDNS update",
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Name": hostname,
+                        "Type": "A",
+                        "TTL": ttl,
+                        "ResourceRecords": [{"Value": ip_address}],
+                    },
+                }
+            ],
+        },
+    )
+
+
+def log_event(result: str, hostname: Optional[str], old_ip: Optional[str], new_ip: Optional[str], detail: Optional[str]) -> None:
+    payload = {
+        "result": result,
+        "hostname": hostname,
+        "old_ip": old_ip,
+        "new_ip": new_ip,
+    }
+    if detail:
+        payload["detail"] = detail
+    LOGGER.info(json.dumps(payload, sort_keys=True))
+
+
+def response(status_code: int, payload: Dict[str, object]) -> Dict[str, object]:
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "content-type": "application/json",
+        },
+        "body": json.dumps(payload, sort_keys=True),
+    }

--- a/infra/ddns/locals.tf
+++ b/infra/ddns/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  name_prefix           = var.name_prefix
+  lambda_function_name  = "${local.name_prefix}-ddns-updater"
+  lambda_package_path   = "${path.module}/build/${local.lambda_function_name}.zip"
+  log_group_name        = "/aws/lambda/${local.lambda_function_name}"
+  allowed_hostnames_csv = join(",", var.allowed_hostnames)
+}

--- a/infra/ddns/outputs.tf
+++ b/infra/ddns/outputs.tf
@@ -1,0 +1,35 @@
+output "lambda_function_name" {
+  description = "Name of the DDNS Lambda."
+  value       = aws_lambda_function.ddns_updater.function_name
+}
+
+output "lambda_function_url" {
+  description = "HTTPS endpoint that Wuji calls every five minutes."
+  value       = aws_lambda_function_url.ddns_updater.function_url
+}
+
+output "allowed_hostnames" {
+  description = "Hostnames this DDNS slice is allowed to manage."
+  value       = var.allowed_hostnames
+}
+
+output "token_parameter_name" {
+  description = "SSM parameter the Lambda reads for bearer-token validation."
+  value       = aws_ssm_parameter.ddns_token.name
+}
+
+output "ddns_bearer_token" {
+  description = "Bearer token Terraform wrote to SSM. Treat this output as secret material."
+  value       = local.ddns_bearer_token_value
+  sensitive   = true
+}
+
+output "cloudwatch_log_group_name" {
+  description = "CloudWatch log group for DDNS execution logs."
+  value       = aws_cloudwatch_log_group.ddns_lambda.name
+}
+
+output "terraform_artifact_policy" {
+  description = "Reminder that tfplan, .terraform, and build outputs are local-only."
+  value       = "Keep infra/ddns/tfplan, infra/ddns/.terraform/, and infra/ddns/build/ untracked."
+}

--- a/infra/ddns/providers.tf
+++ b/infra/ddns/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/ddns/route53.tf
+++ b/infra/ddns/route53.tf
@@ -1,0 +1,4 @@
+data "aws_route53_zone" "target" {
+  zone_id      = var.route53_hosted_zone_id
+  private_zone = false
+}

--- a/infra/ddns/ssm.tf
+++ b/infra/ddns/ssm.tf
@@ -1,0 +1,22 @@
+# Terraform owns the DDNS bearer token so the whole slice can be created from a
+# single apply. The token is still secret material and therefore persists in
+# Terraform state, so state custody must be treated as part of the security
+# boundary.
+resource "random_password" "ddns_token" {
+  count            = var.ddns_bearer_token == null ? 1 : 0
+  length           = 48
+  special          = true
+  override_special = "-_"
+}
+
+locals {
+  ddns_bearer_token_value = var.ddns_bearer_token != null ? var.ddns_bearer_token : random_password.ddns_token[0].result
+}
+
+resource "aws_ssm_parameter" "ddns_token" {
+  name      = var.ddns_token_parameter_name
+  type      = "SecureString"
+  value     = local.ddns_bearer_token_value
+  overwrite = true
+  tags      = var.tags
+}

--- a/infra/ddns/tests/test_handler.py
+++ b/infra/ddns/tests/test_handler.py
@@ -1,0 +1,156 @@
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lambda"))
+
+import handler  # noqa: E402
+
+
+class FakeSsmClient:
+    def __init__(self, token):
+        self.token = token
+
+    def get_parameter(self, Name, WithDecryption):
+        return {"Parameter": {"Value": self.token}}
+
+
+class FakeRoute53Client:
+    def __init__(self, current_ip=None):
+        self.current_ip = current_ip
+        self.changes = []
+
+    def list_resource_record_sets(self, HostedZoneId, StartRecordName, StartRecordType, MaxItems):
+        if self.current_ip is None:
+            return {"ResourceRecordSets": []}
+        return {
+            "ResourceRecordSets": [
+                {
+                    "Name": StartRecordName,
+                    "Type": "A",
+                    "ResourceRecords": [{"Value": self.current_ip}],
+                }
+            ]
+        }
+
+    def change_resource_record_sets(self, HostedZoneId, ChangeBatch):
+        self.changes.append({"HostedZoneId": HostedZoneId, "ChangeBatch": ChangeBatch})
+
+
+class HandlerTests(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(
+            os.environ,
+            {
+                "DDNS_ALLOWED_HOSTNAMES": "wuji.agent-logic.ai",
+                "DDNS_HOSTED_ZONE_ID": "ZTEST123",
+                "DDNS_RECORD_TTL": "60",
+                "DDNS_TOKEN_PARAMETER": "/agent-logic/ddns/wuji/token",
+            },
+            clear=False,
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_rejects_missing_token(self):
+        response = handler.handle_event(
+            self.make_event(headers={}),
+            FakeRoute53Client(),
+            FakeSsmClient("super-secret"),
+        )
+        self.assertEqual(response["statusCode"], 401)
+        self.assertEqual(json.loads(response["body"])["error"], "unauthorized")
+
+    def test_rejects_disallowed_hostname(self):
+        response = handler.handle_event(
+            self.make_event(hostname="nessus.agent-logic.ai"),
+            FakeRoute53Client(),
+            FakeSsmClient("super-secret"),
+        )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(json.loads(response["body"])["error"], "hostname_not_allowed")
+
+    def test_no_change_is_idempotent(self):
+        route53 = FakeRoute53Client(current_ip="203.0.113.10")
+        response = handler.handle_event(
+            self.make_event(source_ip="203.0.113.10"),
+            route53,
+            FakeSsmClient("super-secret"),
+        )
+        payload = json.loads(response["body"])
+        self.assertEqual(response["statusCode"], 200)
+        self.assertFalse(payload["changed"])
+        self.assertEqual(route53.changes, [])
+
+    def test_changed_ip_upserts_record(self):
+        route53 = FakeRoute53Client(current_ip="203.0.113.10")
+        response = handler.handle_event(
+            self.make_event(source_ip="203.0.113.11"),
+            route53,
+            FakeSsmClient("super-secret"),
+        )
+        payload = json.loads(response["body"])
+        self.assertEqual(response["statusCode"], 200)
+        self.assertTrue(payload["changed"])
+        self.assertEqual(len(route53.changes), 1)
+        record = route53.changes[0]["ChangeBatch"]["Changes"][0]["ResourceRecordSet"]
+        self.assertEqual(record["Name"], "wuji.agent-logic.ai")
+        self.assertEqual(record["ResourceRecords"][0]["Value"], "203.0.113.11")
+
+    def test_logs_stay_sanitized(self):
+        route53 = FakeRoute53Client(current_ip="203.0.113.10")
+        with self.assertLogs(handler.LOGGER, level="INFO") as captured:
+            handler.handle_event(
+                self.make_event(source_ip="203.0.113.10"),
+                route53,
+                FakeSsmClient("super-secret"),
+            )
+        emitted = "\n".join(captured.output)
+        self.assertNotIn("super-secret", emitted)
+        self.assertNotIn("Authorization", emitted)
+        self.assertIn("wuji.agent-logic.ai", emitted)
+
+    def test_ipv6_request_is_rejected_cleanly(self):
+        response = handler.handle_event(
+            self.make_event(source_ip="2001:db8::1"),
+            FakeRoute53Client(),
+            FakeSsmClient("super-secret"),
+        )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(json.loads(response["body"])["error"], "ipv6_not_supported_in_phase1")
+
+    def test_invalid_base64_body_is_rejected_cleanly(self):
+        event = self.make_event()
+        event["isBase64Encoded"] = True
+        event["body"] = "%%%not-base64%%%"
+        response = handler.handle_event(
+            event,
+            FakeRoute53Client(),
+            FakeSsmClient("super-secret"),
+        )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(json.loads(response["body"])["error"], "invalid_base64_body")
+
+    @staticmethod
+    def make_event(hostname="wuji.agent-logic.ai", source_ip="203.0.113.10", headers=None):
+        if headers is None:
+            headers = {"Authorization": "Bearer super-secret"}
+        return {
+            "headers": headers,
+            "requestContext": {
+                "http": {
+                    "sourceIp": source_ip,
+                }
+            },
+            "body": json.dumps({"hostname": hostname}),
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/ddns/variables.tf
+++ b/infra/ddns/variables.tf
@@ -1,0 +1,62 @@
+variable "aws_region" {
+  description = "AWS region for the DDNS Lambda and supporting resources."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "name_prefix" {
+  description = "Stable prefix for DDNS resources."
+  type        = string
+  default     = "wuji-agent-logic"
+}
+
+variable "allowed_hostnames" {
+  description = "Permitted hostnames the Lambda may update."
+  type        = list(string)
+  default     = ["wuji.agent-logic.ai"]
+}
+
+variable "route53_hosted_zone_id" {
+  description = "Public Route 53 hosted zone id for agent-logic.ai. Keep the actual value outside the repository."
+  type        = string
+}
+
+variable "ddns_token_parameter_name" {
+  description = "SSM SecureString parameter name containing the shared bearer token."
+  type        = string
+  default     = "/agent-logic/ddns/wuji/token"
+}
+
+variable "ddns_bearer_token" {
+  description = "Optional bearer token value to write into SSM. Leave null to let Terraform generate one."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "dns_record_ttl" {
+  description = "TTL, in seconds, for the managed Route 53 A record."
+  type        = number
+  default     = 60
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Execution timeout for the DDNS Lambda."
+  type        = number
+  default     = 10
+}
+
+variable "lambda_memory_size_mb" {
+  description = "Memory size for the DDNS Lambda."
+  type        = number
+  default     = 256
+}
+
+variable "tags" {
+  description = "Common tags for DDNS resources."
+  type        = map(string)
+  default = {
+    ManagedBy = "terraform"
+    Service   = "wuji-ddns"
+  }
+}

--- a/infra/ddns/versions.tf
+++ b/infra/ddns/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.5"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}


### PR DESCRIPTION
Closes #4284

## Summary
Implemented the Phase 1 DDNS Terraform package under `infra/ddns/`, changed the token/bootstrap path to be Terraform-owned, validated the local code and Terraform package, applied the stack in AWS, invoked the Function URL successfully, verified that `wuji.agent-logic.ai` now resolves publicly to `47.146.81.109`, and added the bounded native `pr finish` classifier support needed to publish this infrastructure slice through the normal workflow.

## Artifacts
- Tracked Terraform and runtime package under `infra/ddns/`:
  - `versions.tf`, `providers.tf`, `locals.tf`, `variables.tf`, `iam.tf`, `lambda.tf`, `route53.tf`, `ssm.tf`, `outputs.tf`
  - `lambda/handler.py`
  - `tests/test_handler.py`
  - `client/wuji_ddns_update.sh`
  - `client/com.agentlogic.wuji-ddns.plist`
  - `README.md`
- Tracked local-artifact hygiene change in `.gitignore` for `infra/ddns/.terraform/`, `tfplan`, `build/`, and local Terraform state files.
- Tracked native finish-classifier support for this infrastructure slice:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated issue-local planning/execution records (local-only, not tracked publication payload):
  - `.adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/stp.md`
  - `.adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/spp.md`
  - `.adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/sor.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m unittest infra/ddns/tests/test_handler.py`
    Verified token rejection, hostname allow-listing, idempotent no-change behavior, UPSERT intent, sanitized logging, IPv6 rejection, and invalid base64 rejection for the Lambda handler.
  - `sh -n infra/ddns/client/wuji_ddns_update.sh`
    Verified shell syntax for the Wuji client wrapper after the token-handling rewrite.
  - `terraform -chdir=infra/ddns fmt -check`
    Verified Terraform formatting for the DDNS package.
  - `terraform -chdir=infra/ddns init -backend=false`
    Verified provider initialization for local structural validation without claiming remote backend setup.
  - `terraform -chdir=infra/ddns validate`
    Verified the DDNS Terraform package structure after the token/bootstrap change and Lambda permission compatibility bridge.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_slice -- --nocapture`
    Verified the native finish classifier recognizes the `#4284` DDNS package and its bounded finish-support hook so the infrastructure slice can publish through the standard finish path.
  - `adl/target/debug/adl-csdlc tooling prompt-template validate-structure --kind stp --input .adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/stp.md`
    Verified the updated STP structure.
  - `adl/target/debug/adl-csdlc tooling prompt-template validate-structure --kind spp --input .adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/spp.md`
    Verified the updated SPP structure.
  - `terraform -chdir=infra/ddns plan -out=tfplan -var route53_hosted_zone_id=Z0105194MPK8MKMH2XAQ`
    Verified the live AWS plan before apply and confirmed the intended DDNS resources, generated token path, and outputs.
  - `terraform -chdir=infra/ddns apply -auto-approve tfplan`
    Verified successful creation of the initial DDNS stack in AWS.
  - `aws --region us-west-2 lambda get-function-url-config --function-name wuji-agent-logic-ddns-updater`
    Verified the Function URL exists with `AuthType: NONE` in `us-west-2`.
  - `aws --region us-west-2 lambda get-policy --function-name wuji-agent-logic-ddns-updater`
    Verified both Function URL permission statements and the additional invoke-via-URL permission are present.
  - `LOG_GROUP_NAME=<ddns lambda log group> aws --region us-west-2 logs tail "$LOG_GROUP_NAME" --since 10m`
    Verified a successful live invocation log entry showing `result: updated` for `wuji.agent-logic.ai` and `47.146.81.109`.
  - `FUNCTION_URL=$(aws --region us-west-2 lambda get-function-url-config --function-name wuji-agent-logic-ddns-updater --query FunctionUrl --output text) && TOKEN_PARAMETER_NAME=<ddns token parameter> aws --region us-west-2 ssm get-parameter --with-decryption --name "$TOKEN_PARAMETER_NAME" --query Parameter.Value --output text | DDNS_FUNCTION_URL="$FUNCTION_URL" python3 -c "import json, os, sys, urllib.request; token=sys.stdin.read().strip(); req=urllib.request.Request(os.environ['DDNS_FUNCTION_URL'], data=json.dumps({'hostname': 'wuji.agent-logic.ai'}).encode(), method='POST', headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}); resp=urllib.request.urlopen(req, timeout=15); print(resp.read().decode())"`
    Verified the live DDNS endpoint accepted the current bearer token and returned a successful no-change replay without placing the token on process argv.
  - `dig +short wuji.agent-logic.ai`
    Verified public DNS resolution to the current public IP.
  - `aws route53 list-resource-record-sets --hosted-zone-id Z0105194MPK8MKMH2XAQ --query "ResourceRecordSets[?Name == 'wuji.agent-logic.ai.']"`
    Verified the Route 53 `A` record exists with TTL `60` and value `47.146.81.109`.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4284__v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater/sor.md
- Idempotency-Key: v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater-gitignore-infra-ddns-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4284-v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater-sip-md-adl-v0-91-6-tasks-issue-4284-v0-91-6-aws-ddns-implement-wuji-dynamic-ip-route-53-updater-sor-md