### PR TITLE
[v0.91.6][aws][ddns] Install Wuji DDNS client and launchd automation

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1593,6 +1593,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_wuji_ddns_validation(issue_number, changed_paths) {
         return Ok(build_wuji_ddns_validation_plan());
     }
+    if finish_issue_needs_wuji_ddns_installer_validation(issue_number, changed_paths) {
+        return Ok(build_wuji_ddns_installer_validation_plan());
+    }
     if finish_issue_needs_locked_cargo_fallback_validation(issue_number, changed_paths) {
         return Ok(build_locked_cargo_fallback_validation_plan());
     }
@@ -1986,6 +1989,25 @@ fn finish_issue_needs_wuji_ddns_validation(issue_number: u32, changed_paths: &[S
         })
 }
 
+fn finish_issue_needs_wuji_ddns_installer_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4330 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            matches!(
+                path.trim().trim_matches('/'),
+                "adl/src/cli/pr_cmd/finish_support.rs"
+                    | "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
+                    | "infra/ddns/README.md"
+                    | "infra/ddns/client/install_wuji_ddns_launchd.sh"
+            )
+        })
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -2070,6 +2092,19 @@ fn build_wuji_ddns_validation_plan() -> FinishValidationPlan {
             "terraform -chdir=infra/ddns fmt -check".to_string(),
             "terraform -chdir=infra/ddns init -backend=false".to_string(),
             "terraform -chdir=infra/ddns validate".to_string(),
+        ],
+    }
+}
+
+fn build_wuji_ddns_installer_validation_plan() -> FinishValidationPlan {
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_installer_slice -- --nocapture".to_string(),
+            "sh -n infra/ddns/client/install_wuji_ddns_launchd.sh".to_string(),
+            "sh -n infra/ddns/client/wuji_ddns_update.sh".to_string(),
         ],
     }
 }
@@ -2608,6 +2643,21 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_installer_slice -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-pr-finish",
+                            "wuji_ddns_installer_slice",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
                 "python3 -m unittest infra/ddns/tests/test_handler.py" => {
                     run_finish_validation_status(
                         "python3",
@@ -2616,6 +2666,12 @@ pub(super) fn run_finish_validation_rust(
                 }
                 "sh -n infra/ddns/client/wuji_ddns_update.sh" => {
                     run_finish_validation_status("sh", &["-n", "infra/ddns/client/wuji_ddns_update.sh"])?;
+                }
+                "sh -n infra/ddns/client/install_wuji_ddns_launchd.sh" => {
+                    run_finish_validation_status(
+                        "sh",
+                        &["-n", "infra/ddns/client/install_wuji_ddns_launchd.sh"],
+                    )?;
                 }
                 "terraform -chdir=infra/ddns fmt -check" => {
                     run_finish_validation_status(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2379,6 +2379,39 @@ fn finish_validation_profile_classifies_wuji_ddns_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_wuji_ddns_installer_slice() {
+    let changed_paths = vec![
+        "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+        "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        "infra/ddns/README.md".to_string(),
+        "infra/ddns/client/install_wuji_ddns_launchd.sh".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(4330, &requested_paths, &changed_paths)
+        .expect("wuji ddns installer focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_installer_slice -- --nocapture"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"sh -n infra/ddns/client/install_wuji_ddns_launchd.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"sh -n infra/ddns/client/wuji_ddns_update.sh".to_string()));
+
+    let unrelated_err =
+        select_finish_validation_plan_for_finish(4331, &requested_paths, &changed_paths)
+            .expect_err("unrelated issue should not inherit the installer focused allowance");
+    assert!(unrelated_err
+        .to_string()
+        .contains("changed paths are not classified"));
+}
+
+#[test]
 fn finish_validation_runner_executes_locked_cargo_fallback_script_command() {
     let repo = unique_temp_dir("adl-pr-finish-locked-cargo-fallback-validation");
     let tools = repo.join("adl/tools");

--- a/infra/ddns/README.md
+++ b/infra/ddns/README.md
@@ -89,6 +89,40 @@ after apply and then move to a secure backend or other secure state custody.
 
 ## Wuji Client Install
 
+Preferred path:
+
+```sh
+infra/ddns/client/install_wuji_ddns_launchd.sh
+```
+
+This installer:
+
+- reads `lambda_function_url` and `ddns_bearer_token` from Terraform output
+- falls back to the live AWS Function URL and SSM SecureString when Terraform
+  CLI access or state custody lives elsewhere, as long as the local DDNS
+  package checkout is present
+- installs `wuji_ddns_update.sh` to `~/.local/bin/wuji_ddns_update.sh`
+- writes the token to `~/.config/wuji-ddns/token` with `0600` permissions
+- renders the launch agent into
+  `~/Library/LaunchAgents/com.agentlogic.wuji-ddns.plist`
+- loads and kickstarts the launch agent for the current user
+- runs one immediate updater proof after installation
+
+Useful options:
+
+```sh
+infra/ddns/client/install_wuji_ddns_launchd.sh --no-load
+infra/ddns/client/install_wuji_ddns_launchd.sh --terraform-dir /path/to/infra/ddns
+infra/ddns/client/install_wuji_ddns_launchd.sh --aws-region us-west-2
+```
+
+When using the AWS fallback path, the local checkout must still include
+`infra/ddns/client/wuji_ddns_update.sh` and
+`infra/ddns/client/com.agentlogic.wuji-ddns.plist` because the installer copies
+those repo-managed client artifacts onto Wuji.
+
+Manual fallback:
+
 1. Copy `client/wuji_ddns_update.sh` to a stable local path on Wuji.
 2. Write the Terraform-managed token to a local file with restrictive
    permissions, for example:

--- a/infra/ddns/client/install_wuji_ddns_launchd.sh
+++ b/infra/ddns/client/install_wuji_ddns_launchd.sh
@@ -1,0 +1,246 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: install_wuji_ddns_launchd.sh [--terraform-dir <dir>] [--hostname <hostname>] [--aws-region <region>] [--lambda-function-name <name>] [--token-parameter-name <name>] [--no-load]
+
+Installs the Wuji DDNS updater script, token file, and launchd plist for the
+current user by reading Terraform outputs from the DDNS stack.
+EOF
+}
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)
+TERRAFORM_DIR="$REPO_ROOT/infra/ddns"
+HOSTNAME_VALUE="wuji.agent-logic.ai"
+AWS_REGION="us-west-2"
+LAMBDA_FUNCTION_NAME="wuji-agent-logic-ddns-updater"
+TOKEN_PARAMETER_NAME=""
+LOAD_AGENT=1
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --terraform-dir)
+      shift
+      [ "$#" -gt 0 ] || {
+        echo "--terraform-dir requires a value" >&2
+        exit 2
+      }
+      TERRAFORM_DIR="$1"
+      ;;
+    --hostname)
+      shift
+      [ "$#" -gt 0 ] || {
+        echo "--hostname requires a value" >&2
+        exit 2
+      }
+      HOSTNAME_VALUE="$1"
+      ;;
+    --aws-region)
+      shift
+      [ "$#" -gt 0 ] || {
+        echo "--aws-region requires a value" >&2
+        exit 2
+      }
+      AWS_REGION="$1"
+      ;;
+    --lambda-function-name)
+      shift
+      [ "$#" -gt 0 ] || {
+        echo "--lambda-function-name requires a value" >&2
+        exit 2
+      }
+      LAMBDA_FUNCTION_NAME="$1"
+      ;;
+    --token-parameter-name)
+      shift
+      [ "$#" -gt 0 ] || {
+        echo "--token-parameter-name requires a value" >&2
+        exit 2
+      }
+      TOKEN_PARAMETER_NAME="$1"
+      ;;
+    --no-load)
+      LOAD_AGENT=0
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+terraform_output_raw() {
+  [ -d "$TERRAFORM_DIR" ] || return 1
+  command -v terraform >/dev/null 2>&1 || return 1
+  terraform -chdir="$TERRAFORM_DIR" output -raw "$1" 2>/dev/null || return 1
+}
+
+terraform_output_value() {
+  tf_value="$(terraform_output_raw "$1" || true)"
+  case "$tf_value" in
+    ""|"null")
+      return 1
+      ;;
+    *)
+      printf '%s\n' "$tf_value"
+      return 0
+      ;;
+  esac
+}
+
+resolve_function_url() {
+  if tf_value="$(terraform_output_value lambda_function_url)"; then
+    printf '%s\n' "$tf_value"
+    return 0
+  fi
+
+  command -v aws >/dev/null 2>&1 || {
+    echo "aws CLI is required when Terraform outputs are unavailable" >&2
+    exit 1
+  }
+  aws --region "$AWS_REGION" lambda get-function-url-config \
+    --function-name "$LAMBDA_FUNCTION_NAME" \
+    --query FunctionUrl \
+    --output text
+}
+
+resolve_token_parameter_name() {
+  if [ -n "$TOKEN_PARAMETER_NAME" ]; then
+    printf '%s\n' "$TOKEN_PARAMETER_NAME"
+    return 0
+  fi
+
+  if tf_value="$(terraform_output_value token_parameter_name)"; then
+    printf '%s\n' "$tf_value"
+    return 0
+  fi
+
+  command -v aws >/dev/null 2>&1 || {
+    echo "aws CLI is required when Terraform outputs are unavailable" >&2
+    exit 1
+  }
+  aws --region "$AWS_REGION" lambda get-function-configuration \
+    --function-name "$LAMBDA_FUNCTION_NAME" \
+    --query 'Environment.Variables.DDNS_TOKEN_PARAMETER' \
+    --output text
+}
+
+write_token_file() {
+  token_tmp="$(mktemp "$(dirname "$TOKEN_FILE")/token.tmp.XXXXXX")"
+  cleanup_token_tmp() {
+    rm -f "$token_tmp"
+  }
+  trap cleanup_token_tmp EXIT INT TERM
+
+  if tf_value="$(terraform_output_value ddns_bearer_token)"; then
+    printf '%s' "$tf_value" > "$token_tmp"
+    mv "$token_tmp" "$TOKEN_FILE"
+    trap - EXIT INT TERM
+    return 0
+  fi
+
+  command -v aws >/dev/null 2>&1 || {
+    echo "aws CLI is required when Terraform outputs are unavailable" >&2
+    exit 1
+  }
+
+  parameter_name="$(resolve_token_parameter_name)"
+  aws --region "$AWS_REGION" ssm get-parameter \
+    --with-decryption \
+    --name "$parameter_name" \
+    --query Parameter.Value \
+    --output text > "$token_tmp"
+  [ -s "$token_tmp" ] || {
+    echo "Retrieved empty DDNS token for $parameter_name" >&2
+    exit 1
+  }
+  mv "$token_tmp" "$TOKEN_FILE"
+  trap - EXIT INT TERM
+}
+
+UPDATER_SOURCE="$REPO_ROOT/infra/ddns/client/wuji_ddns_update.sh"
+PLIST_TEMPLATE="$REPO_ROOT/infra/ddns/client/com.agentlogic.wuji-ddns.plist"
+
+[ -f "$UPDATER_SOURCE" ] || {
+  echo "Updater source not found: $UPDATER_SOURCE" >&2
+  exit 1
+}
+
+[ -f "$PLIST_TEMPLATE" ] || {
+  echo "launchd plist template not found: $PLIST_TEMPLATE" >&2
+  exit 1
+}
+
+CONFIG_DIR="$HOME/.config/wuji-ddns"
+BIN_DIR="$HOME/.local/bin"
+STATE_DIR="$HOME/.local/state/wuji-ddns"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+TOKEN_FILE="$CONFIG_DIR/token"
+INSTALL_SCRIPT_PATH="$BIN_DIR/wuji_ddns_update.sh"
+PLIST_PATH="$PLIST_DIR/com.agentlogic.wuji-ddns.plist"
+
+mkdir -p "$CONFIG_DIR" "$BIN_DIR" "$STATE_DIR" "$PLIST_DIR"
+
+FUNCTION_URL=$(resolve_function_url)
+write_token_file
+chmod 600 "$TOKEN_FILE"
+
+install -m 755 "$UPDATER_SOURCE" "$INSTALL_SCRIPT_PATH"
+
+env \
+  PLIST_TEMPLATE="$PLIST_TEMPLATE" \
+  PLIST_PATH="$PLIST_PATH" \
+  INSTALL_SCRIPT_PATH="$INSTALL_SCRIPT_PATH" \
+  FUNCTION_URL="$FUNCTION_URL" \
+  TOKEN_FILE="$TOKEN_FILE" \
+  STATE_DIR="$STATE_DIR" \
+  python3 <<'PY'
+import os
+
+template_path = os.environ["PLIST_TEMPLATE"]
+output_path = os.environ["PLIST_PATH"]
+replacements = {
+    "__WUJI_DDNS_SCRIPT_PATH__": os.environ["INSTALL_SCRIPT_PATH"],
+    "__WUJI_DDNS_FUNCTION_URL__": os.environ["FUNCTION_URL"],
+    "__WUJI_DDNS_TOKEN_FILE__": os.environ["TOKEN_FILE"],
+    "__WUJI_DDNS_LOG_DIR__": os.environ["STATE_DIR"],
+}
+
+with open(template_path, "r", encoding="utf-8") as handle:
+    rendered = handle.read()
+
+for needle, replacement in replacements.items():
+    rendered = rendered.replace(needle, replacement)
+
+with open(output_path, "w", encoding="utf-8") as handle:
+    handle.write(rendered)
+PY
+
+if [ "$LOAD_AGENT" -eq 1 ]; then
+  launchctl bootout "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+  launchctl kickstart -k "gui/$(id -u)/com.agentlogic.wuji-ddns"
+fi
+
+DDNS_FUNCTION_URL="$FUNCTION_URL" \
+DDNS_HOSTNAME="$HOSTNAME_VALUE" \
+DDNS_TOKEN_FILE="$TOKEN_FILE" \
+"$INSTALL_SCRIPT_PATH"
+
+cat <<EOF
+Installed Wuji DDNS updater.
+  script: $INSTALL_SCRIPT_PATH
+  token: $TOKEN_FILE
+  plist: $PLIST_PATH
+  log dir: $STATE_DIR
+  hostname: $HOSTNAME_VALUE
+  function url: $FUNCTION_URL
+EOF


### PR DESCRIPTION
Closes #4330

## Summary
Completed the Wuji-side DDNS install path in the bound `#4330` worktree and
proved it on the live `wuji.local` host. The issue added a repeatable installer
that can source the Function URL and bearer token from Terraform output when
state is available, or fall back to the Terraform-managed AWS resources when
state custody lives elsewhere. The installer wrote the local token file with
restrictive permissions, installed the updater script, rendered and loaded the
`launchd` agent, produced successful host-side updater proof against the live
Lambda URL and Route 53 record, and added the bounded native `pr finish`
classifier support required to publish this installer/readme slice through the
standard workflow after the DDNS infrastructure base merged to `main`.

## Artifacts
- Tracked issue-branch implementation changes:
  - `infra/ddns/README.md`
  - `infra/ddns/client/install_wuji_ddns_launchd.sh`
- Tracked native finish-classifier support for this installer slice:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Local host install artifacts on Wuji:
  - `~/.config/wuji-ddns/token`
  - `~/.local/bin/wuji_ddns_update.sh`
  - `~/Library/LaunchAgents/com.agentlogic.wuji-ddns.plist`
  - `~/.local/state/wuji-ddns/wuji-ddns.stdout.log`
  - `~/.local/state/wuji-ddns/wuji-ddns.stderr.log`

## Validation
- Validation commands and their purpose:
  - `sh -n infra/ddns/client/install_wuji_ddns_launchd.sh`
    Verified the installer shell syntax after adding Terraform-output and AWS fallback logic.
  - `sh -n infra/ddns/client/wuji_ddns_update.sh`
    Verified the updater shell wrapper remained syntactically valid.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish wuji_ddns_installer_slice -- --nocapture`
    Verified the native finish classifier recognizes the `#4330` installer
    slice and its bounded finish-support hook so publication can proceed
    through the standard finish path.
  - `python3 -m unittest infra/ddns/tests/test_handler.py`
    Verified the carried-forward DDNS Lambda behavior still passes its focused auth, idempotence, UPSERT, and sanitized-logging proof surface.
  - `terraform -chdir=infra/ddns fmt -check && terraform -chdir=infra/ddns init -backend=false && terraform -chdir=infra/ddns validate`
    Verified the carried-forward DDNS Terraform package stays formatted, initializes cleanly, and remains structurally valid in this branch.
  - `aws --region us-west-2 lambda get-function-url-config --function-name wuji-agent-logic-ddns-updater --query FunctionUrl --output text`
    Verified the live Function URL fallback source is available.
  - `aws --region us-west-2 lambda get-function-configuration --function-name wuji-agent-logic-ddns-updater --query 'Environment.Variables.DDNS_TOKEN_PARAMETER' --output text`
    Verified the installer can discover the Terraform-managed token parameter name from the live Lambda environment.
  - `aws --region us-west-2 ssm get-parameter --with-decryption --name /agent-logic/ddns/wuji/token --query Parameter.Value --output text | python3 -c 'import sys; data=sys.stdin.read(); print(len(data.strip()))'`
    Verified the live SecureString token exists and is non-empty without printing the token contents.
  - `infra/ddns/client/install_wuji_ddns_launchd.sh --aws-region us-west-2`
    Installed the Wuji DDNS script, token file, and launch agent on `wuji.local`, then proved one immediate successful updater run.
  - `TMP_HOME=<temporary sandbox-safe home> MISSING_TERRAFORM_DIR=<nonexistent temp dir> AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/credentials" AWS_CONFIG_FILE="$HOME/.aws/config" HOME="$TMP_HOME" infra/ddns/client/install_wuji_ddns_launchd.sh --aws-region us-west-2 --terraform-dir "$MISSING_TERRAFORM_DIR" --no-load`
    Verified the post-fix AWS fallback path succeeds even when the Terraform directory is absent, as long as the local DDNS package checkout and AWS credentials are available.
  - `TMP_HOME=<temporary sandbox-safe home with seeded token> MISSING_TERRAFORM_DIR=<nonexistent temp dir> HOME="$TMP_HOME" infra/ddns/client/install_wuji_ddns_launchd.sh --aws-region us-west-2 --terraform-dir "$MISSING_TERRAFORM_DIR" --token-parameter-name /agent-logic/ddns/wuji/does-not-exist`
    Forced token retrieval failure and verified the existing token file contents remained unchanged, proving the atomic token-refresh path does not truncate a good token on failure.
  - `launchctl print gui/$(id -u)/com.agentlogic.wuji-ddns | sed -n '1,140p'`
    Verified the loaded launch agent points at the expected script path, token file, Function URL, and reports `last exit code = 0`.
  - `: > ~/.local/state/wuji-ddns/wuji-ddns.stdout.log && : > ~/.local/state/wuji-ddns/wuji-ddns.stderr.log && launchctl kickstart -k gui/$(id -u)/com.agentlogic.wuji-ddns && sleep 2 && cat ~/.local/state/wuji-ddns/wuji-ddns.stdout.log && cat ~/.local/state/wuji-ddns/wuji-ddns.stderr.log`
    Verified a clean post-fix launch-agent run emits the expected JSON success line on stdout and nothing on stderr.
  - `curl -fsSL https://api.ipify.org`
    Verified the current Wuji public IP.
  - `dig +short wuji.agent-logic.ai | tail -n 1`
    Verified Route 53 still resolves `wuji.agent-logic.ai` to the current public IP after install.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4330__v0-91-6-aws-ddns-install-wuji-ddns-client-and-launchd-automation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4330__v0-91-6-aws-ddns-install-wuji-ddns-client-and-launchd-automation/sor.md
- Idempotency-Key: v0-91-6-aws-ddns-install-wuji-ddns-client-and-launchd-automation-infra-ddns-readme-md-infra-ddns-client-install-wuji-ddns-launchd-sh-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4330-v0-91-6-aws-ddns-install-wuji-ddns-client-and-launchd-automation-sip-md-adl-v0-91-6-tasks-issue-4330-v0-91-6-aws-ddns-install-wuji-ddns-client-and-launchd-automation-sor-md