### PR TITLE
[v0.91.6][build] Add safe cleanup policy for stale build artifacts

### DIFF
--- a/docs/milestones/v0.91.6/review/build_throughput/SAFE_BUILD_ARTIFACT_CLEANUP_4314.md
+++ b/docs/milestones/v0.91.6/review/build_throughput/SAFE_BUILD_ARTIFACT_CLEANUP_4314.md
@@ -1,0 +1,205 @@
+# Safe Build Artifact Cleanup Policy for `#4314`
+
+Status: `report_first_cleanup_policy_ready`
+Issue: `#4314`
+Sprint umbrella: `#4310`
+Date: 2026-06-20
+
+## Scope
+
+This packet defines a safe local cleanup policy for stale Rust build artifacts
+in ADL main and worktree checkouts.
+
+It does not:
+
+- delete worktrees wholesale
+- delete dirty source, docs, or evidence changes
+- delete `.codex`, user caches, or unrelated host directories
+- assume every large `adl/target` directory is safe to remove immediately
+
+## Cleanup Goal
+
+Keep build artifacts bounded while preserving:
+
+- active issue worktrees
+- source and documentation changes
+- retained review/evidence artifacts
+- the per-worktree target isolation model established by `#4313`
+
+## Current Cleanup Pressure
+
+Visible `adl/target` directories in the repo worktree fleet still consume
+substantial disk:
+
+- `26G` at `adl-wp-4246/adl/target`
+- `17G` at `adl-wp-4248/adl/target`
+- `14G` at `adl-wp-4298/adl/target`
+- `14G` at `adl-wp-4299/adl/target`
+- `12G` at `adl-process-status-fanout/adl/target`
+- several additional worktree target trees in the `2G` to `5G` range
+
+Interpretation:
+
+- stale build artifacts are a real system-volume pressure source
+- cleanup must be selective because some large targets still belong to active
+  worktrees
+
+## Classification Model
+
+### Safe to preserve
+
+Preserve target artifacts for worktrees that are still active or ambiguous:
+
+- active run-bound issues such as `#4298` and `#4299`
+- any worktree with dirty tracked source/doc/evidence changes
+- detached/manual utility worktrees unless the operator explicitly classifies
+  them as disposable
+
+### Candidate for target-only cleanup
+
+Target-only cleanup is safe when all of these are true:
+
+1. the issue is already closed or otherwise no longer active for execution
+2. the worktree has no dirty tracked source/doc/evidence changes
+3. the cleanup removes only `adl/target`
+4. the worktree root itself is preserved
+
+### Not safe by default
+
+Do not automatically clean:
+
+- worktrees still in `run_bound` state
+- worktrees with modified tracked files
+- shared relocated target roots that may back multiple active leaves
+- root directories such as `/Volumes/FastWork/adl-cargo-targets/agent-design-language`
+
+## Recommended Report-First Workflow
+
+### 1. Inventory large targets
+
+```bash
+for d in /Users/daniel/git/agent-design-language/.worktrees/*/adl/target; do
+  [ -d "$d" ] && du -sh "$d"
+done | sort -h
+```
+
+### 2. Classify the owning worktree before deletion
+
+Check:
+
+- worktree path and branch
+- whether tracked files are dirty
+- whether the issue is still open/run-bound
+
+Representative commands:
+
+```bash
+git worktree list --porcelain
+git -C /path/to/worktree status --short --branch
+ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token \
+  adl-pr-doctor <issue> --json
+```
+
+### 3. Delete only the target leaf
+
+```bash
+rm -rf /path/to/worktree/adl/target
+```
+
+### 4. Re-check the worktree
+
+```bash
+git -C /path/to/worktree status --short --branch
+```
+
+If the post-cleanup git status changes, stop and investigate.
+
+## Proof: One Safe Cleanup
+
+Selected proof worktree:
+
+- `adl-wp-4305`
+
+Why it qualified:
+
+- `adl-pr-doctor 4305 --json` reported the issue as closed and blocked on stale
+  canonical closeout truth rather than active execution
+- `git status --short --branch` in the worktree showed no dirty tracked files
+- the worktree still had `2.4G` under `adl/target`
+
+Proof commands:
+
+```text
+du -sh /path/to/closed-clean-worktree/adl/target
+git -C /path/to/closed-clean-worktree status --short --branch
+rm -rf /path/to/closed-clean-worktree/adl/target
+git -C /path/to/closed-clean-worktree status --short --branch
+```
+
+Proof result:
+
+- before: `2.4G`
+- after: `adl/target` absent
+- post-cleanup git status unchanged
+
+Interpretation:
+
+- target-only cleanup can reclaim meaningful disk for closed issue worktrees
+  without touching tracked work
+
+## Active-Worktree Preservation Proof
+
+Representative preserve examples:
+
+- `#4298` remains `run_bound` and still has about `14G` in `adl/target`
+- `#4299` remains `run_bound` and still has about `14G` in `adl/target`
+
+Policy consequence:
+
+- do not delete their target trees in routine cleanup
+- defer those targets until the issue lifecycle is actually closed or the
+  operator explicitly authorizes cleanup
+
+## `cargo sweep` Evaluation
+
+Observed on this host:
+
+- `cargo-sweep` / `cargo sweep` is not installed
+
+Recommendation:
+
+- do not require `cargo sweep` for routine ADL cleanup in this issue
+- prefer explicit worktree classification plus target-leaf deletion
+- age-based cleanup may be a future follow-on, but it is not needed to
+  establish the safe baseline policy
+
+## Cleanup Rules
+
+1. Never delete a worktree root as part of ordinary build-artifact cleanup.
+2. Never delete dirty tracked source/doc/evidence changes.
+3. Never clean active run-bound issue worktrees unless explicitly requested.
+4. Prefer deleting one `adl/target` leaf at a time.
+5. For relocated targets from `#4313`, delete one leaf such as
+   `$ADL_CARGO_TARGET_ROOT/adl-wp-4313`,
+   not the whole root.
+6. Re-run `git status --short --branch` after cleanup to confirm only build
+   artifacts were removed.
+
+## Recommended Runbook
+
+For ordinary cleanup:
+
+1. inventory large targets
+2. classify each owner worktree
+3. skip active or dirty worktrees
+4. remove only `adl/target` for clean closed worktrees
+5. verify post-cleanup git status
+
+## Non-Claims
+
+- This packet does not claim every stale target should be deleted now.
+- This packet does not claim detached/manual worktrees are safe to clean
+  automatically.
+- This packet does not claim `cargo sweep` is required.
+- This packet does not claim active issue worktrees should lose cached build
+  artifacts during routine hygiene.


### PR DESCRIPTION
Closes #4314

## Summary
Produced a bounded local cleanup-policy packet for `#4314` with report-first
classification rules, explicit preserve rules for active worktrees, one safe
target-only cleanup proof on a closed issue worktree, and a recommendation not
to require `cargo sweep` for the baseline hygiene path.

## Artifacts
- Tracked retained cleanup-policy packet at `docs/milestones/v0.91.6/review/build_throughput/SAFE_BUILD_ARTIFACT_CLEANUP_4314.md`
- Updated local execution record at `.adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/sor.md`

## Validation
- Validation commands and their purpose:
  - `which cargo-sweep`
    Confirmed `cargo-sweep` is not installed on this host, so the cleanup
    baseline should not depend on it.
  - `find [repo-worktrees-root] -maxdepth 3 -type d -name target -path '*/adl/target' -exec du -sh {} + | sort -h`
    Measured visible `adl/target` pressure across existing worktrees.
  - `git worktree list --porcelain`
    Enumerated worktree roots for classification and preservation decisions.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token [adl-pr-doctor] 4298 --json`
    Verified `#4298` remains run-bound and should not be cleaned as routine
    stale-artifact hygiene.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token [adl-pr-doctor] 4299 --json`
    Verified `#4299` remains run-bound and should not be cleaned as routine
    stale-artifact hygiene.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token [adl-pr-doctor] 4281 --json`
    Verified `#4281` is closed and blocked on stale closeout truth rather than
    active execution.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token [adl-pr-doctor] 4305 --json`
    Verified `#4305` is closed and blocked on stale closeout truth rather than
    active execution.
  - `git -C [closed-clean-worktree] status --short --branch`
    Verified the selected closed issue worktree had no dirty tracked
    source/doc/evidence changes before cleanup.
  - `du -sh [closed-clean-worktree]/adl/target`
    Measured the stale target footprint before cleanup.
  - `rm -rf [closed-clean-worktree]/adl/target`
    Performed one safe target-only cleanup proof on a closed clean issue
    worktree.
  - `git -C [closed-clean-worktree] status --short --branch`
    Verified post-cleanup git status was unchanged after deleting only
    build-artifact content.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --phase execution --input .adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/spp.md`
    Verified the updated SPP matches the current publication contract shape.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase review --input .adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/srp.md`
    Verified the finalized SRP matches the recorded pre-PR review truth before
    publication.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase execution --input .adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/sor.md`
    Verified this execution record remains structurally valid after recording
    the retained report and cleanup proof.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
  - `git diff --check`
    Verified whitespace and patch hygiene on the docs-only changed surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4314__safe-cleanup-policy-stale-build-artifacts/sor.md
- Idempotency-Key: v0-91-6-build-add-safe-cleanup-policy-for-stale-build-artifacts-docs-milestones-v0-91-6-review-build-throughput-safe-build-artifact-cleanup-4314-md-adl-v0-91-6-tasks-issue-4314-safe-cleanup-policy-stale-build-artifacts-sip-md-adl-v0-91-6-tasks-issue-4314-safe-cleanup-policy-stale-build-artifacts-sor-md