### PR TITLE
[v0.91.6][process][goals] Reconcile sprint umbrella and child issue goal requirements

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -101,6 +101,9 @@ handoff should carry the same issue-bound session-goal requirement directly
 instead of relying on a separate manual reminder. For SEP-routed child work,
 the minimum goal surface is the sprint issue number when present, the child
 issue number, and the bounded session objective.
+The sprint umbrella's own goal field is descriptive coordination context, not
+the active Codex session goal during child implementation, unless a later issue
+proves explicit nested-goal support.
 `adl-milestone-creator` is a bounded milestone setup helper for creating full milestone packages, bridge milestones, issue-routing truth, feature/proof coverage, and downstream handoff docs without relying on session memory.
 `issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
 `issue-splitter` is a bounded issue-scope helper for deciding whether one issue should stay intact, split now, defer splitting, or stop for operator review.

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -138,6 +138,12 @@ sprint:
       status: declared | needs_repair
       paths:
         - /absolute/or/repo-relative/path
+    goal_policy:
+      status: descriptive_only | nested_child_goals_supported
+      sprint_goal_role: descriptive_sprint_objective | active_parent_goal
+      active_session_goal_required: child_issue_only | nested_child_goal_allowed
+      notes:
+        - <bounded text>
     issue_repairs:
       - issue_number: <u32>
         status: ready | needs_editor_repair | blocked
@@ -193,3 +199,6 @@ Notes:
   first child issue runs.
 - Review and activity-log paths are declaration surfaces for future sprint
   artifacts; readiness does not require those files to exist yet.
+- `sprint.goal` is descriptive sprint coordination context. It must not be
+  treated as the active Codex session goal during child implementation unless a
+  later issue proves explicit nested-goal support.

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -105,7 +105,7 @@ At minimum, gather:
 - `sprint.issue_number` when it already exists
 - `sprint.ordered_issue_numbers`
 - `sprint.execution_mode`
-- `sprint.goal`
+- `sprint.goal` or equivalent descriptive sprint objective text
 - one explicit policy block
 
 Useful additional inputs:
@@ -163,6 +163,8 @@ missing sprint-management issue first.
     issue-bound session-goal requirement as part of the SEP handoff rather than
     as a separate manual reminder.
     In other words: attach the issue-bound session-goal requirement as part of the SEP handoff.
+    The sprint umbrella goal or objective is descriptive coordination context,
+    not a substitute for the active child-session goal.
 11. For SEP-routed child execution, create the goal after bind/readiness
     succeeds and before implementation starts. Minimum goal content:
     sprint issue number when present, child issue number, and the bounded
@@ -205,6 +207,9 @@ This skill enforces:
   speculative, or blocked on dependencies
 - no live child implementation handoff without the child issue-bound session
   goal created after bind/readiness succeeds
+- no sprint-global active session goal may stand in for the child issue-bound
+  session goal during implementation; sprint goals are descriptive planning
+  context only unless a later issue proves explicit nested-goal support
 - no SEP-routed child session goal that omits sprint context when a sprint
   issue exists, the child issue number, or the bounded session objective
 - editor-skill routing when cards drift

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -116,7 +116,7 @@ execution:
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py --repo-root <repo> --ordered-issues <csv> --execution-mode <sequential|parallel|hybrid> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py --repo-root <repo> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root <repo> --ordered-issues <csv> --state <path>"
-    - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <descriptive-sprint-objective> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py --state <path> --summary <text>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py --state <path> --out <path> --summary-out <path>"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -20,7 +20,7 @@ Required:
 - ordered child issue list
 - declared execution mode
 - Sprint Execution Packet for parallel or hybrid modes
-- sprint goal
+- descriptive sprint objective
 - explicit policy block
 
 Optional:
@@ -71,6 +71,9 @@ Optional:
      the bounded session objective
    - for `parallel` or `hybrid` lanes, each separate worker/session creates its
      own child-session goal rather than sharing one sprint-global goal
+   - treat the sprint objective as descriptive coordination context only; it
+     must not occupy the active Codex session-goal slot during child issue
+     implementation unless nested-goal support is explicitly proven later
 9. Run only the selected downstream lifecycle or editor skill.
 9a. When issue-goal metrics are available from the active session or closeout handoff, record them in the local JSONL sink:
    - use `record_issue_goal_metrics.py`
@@ -106,7 +109,7 @@ Preferred structured-prompt preflight helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root <repo> --ordered-issues <csv> --state <path>`
 
 Preferred missing-sprint-issue helper:
-- `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>`
+- `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <descriptive-sprint-objective> --state <path>`
 
 Known helper migration note:
 - the typed issue mutation command surface exists as `pr.sh issue

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -11,6 +11,12 @@ sprint:
   execution_packet_path: <path or null>
   follow_up_issue_policy: post_sprint_follow_on | must_land_before_sprint_close
   goal: <string or null>
+  goal_policy:
+    status: descriptive_only | nested_child_goals_supported
+    sprint_goal_role: descriptive_sprint_objective | active_parent_goal
+    active_session_goal_required: child_issue_only | nested_child_goal_allowed
+    notes:
+      - <bounded text>
   ordered_issue_numbers:
     - <u32>
   recommended_execution_order:

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py
@@ -178,6 +178,19 @@ def overall_status(
     return 'ready'
 
 
+def sprint_goal_policy() -> dict[str, Any]:
+    return {
+        'status': 'descriptive_only',
+        'sprint_goal_role': 'descriptive_sprint_objective',
+        'active_session_goal_required': 'child_issue_only',
+        'notes': [
+            'Sprint state may record a descriptive sprint objective, but that objective does not satisfy the active Codex session-goal requirement for child issue execution.',
+            'Each child issue session must create its own issue-bound goal after bind/readiness succeeds and before implementation starts.',
+            'Do not keep a competing sprint-global active session goal in the same thread while a child issue implementation session is active.',
+        ],
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--repo-root', required=True)
@@ -236,6 +249,7 @@ def main() -> int:
         'status': overall_status(parity, preflight, packet, review_paths, activity_log_paths),
         'ordered_issue_numbers': ordered_issues,
         'execution_mode': args.execution_mode,
+        'goal_policy': sprint_goal_policy(),
         'execution_packet': packet,
         'review_paths': review_paths,
         'activity_log_paths': activity_log_paths,

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -117,7 +117,7 @@ def fallback_bootstrap_local_bundle(
         '<required_outcome>': 'Create a concrete sprint-management issue with complete local C-SDLC cards.',
         '<deliverables>': 'Sprint issue body and five-card local task bundle.',
         '<acceptance_criteria>': 'All five local cards exist and are ready for sprint preflight review.',
-        '<repo_inputs>': 'Ordered child issue list and sprint goal.',
+        '<repo_inputs>': 'Ordered child issue list and descriptive sprint objective.',
         '<dependencies>': 'Child issue cards must exist and validate before sprint execution.',
         '<target_files_surfaces>': 'Local sprint issue body and task bundle.',
         '<validation_plan>': 'Run sprint structured-prompt readiness before execution starts.',
@@ -130,7 +130,7 @@ def fallback_bootstrap_local_bundle(
         '<non_goals_inline>': 'Do not execute child issues from this bootstrap helper.',
         '<plan_summary>': f'Design-time sprint-management plan for {title}.',
         '<dependencies_inline>': 'Child issue cards must exist and validate before execution.',
-        '<repo_inputs_inline>': 'Ordered child issue list and sprint goal.',
+        '<repo_inputs_inline>': 'Ordered child issue list and descriptive sprint objective.',
         '<deliverables_inline>': 'Sprint issue body and five-card local task bundle.',
         '<acceptance_criteria_inline>': 'All five cards exist and pass preflight readiness.',
         '<risks_inline>': 'Sprint state can drift if child closeout is skipped.',
@@ -212,6 +212,19 @@ def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
     ]
 
 
+def default_goal_policy() -> dict[str, Any]:
+    return {
+        'status': 'descriptive_only',
+        'sprint_goal_role': 'descriptive_sprint_objective',
+        'active_session_goal_required': 'child_issue_only',
+        'notes': [
+            'Sprint state may record a descriptive sprint objective, but that objective does not satisfy the active Codex session-goal requirement for child issue execution.',
+            'Each child issue session must create its own issue-bound goal after bind/readiness succeeds and before implementation starts.',
+            'Do not keep a competing sprint-global active session goal in the same thread while a child issue implementation session is active.',
+        ],
+    }
+
+
 def build_body(goal: str, ordered: list[int], child_titles: dict[int, str], notes: str | None) -> str:
     ordered_lines = '\n'.join(
         f"{idx}. #{issue} {child_titles.get(issue, '').strip()}".rstrip()
@@ -221,7 +234,7 @@ def build_body(goal: str, ordered: list[int], child_titles: dict[int, str], note
 
 Create the concrete sprint-management issue required to run one bounded `sprint-conductor` sprint.
 
-## Goal
+## Sprint Objective
 
 {goal}
 
@@ -234,6 +247,8 @@ Create the concrete sprint-management issue required to run one bounded `sprint-
 - Declare sprint execution mode: `sequential`, `parallel`, or `hybrid`.
 - For `parallel` or `hybrid` sprints, include or link a Sprint Execution Packet with safe lanes, serial gates, PVF notes, and residual routing.
 - Current sprint helper state remains single-current-issue; use separate issue workers or sessions for intentional parallel lanes.
+- Treat the sprint objective as descriptive coordination context, not as the active session goal during child issue implementation.
+- Each child issue execution session must create its own issue-bound goal after bind/readiness succeeds and before implementation starts.
 - Do not start the next child issue until the current one is fully closed out.
 - Use the existing issue lifecycle and editor skills for child issue execution.
 - Allow the bounded review-subagent exception only during sprint review when sprint policy explicitly enables it.
@@ -308,6 +323,7 @@ def main() -> int:
             'completed_issue_numbers': [],
             'blocked_issue_number': None,
             'continuation': 'continue',
+            'goal_policy': default_goal_policy(),
             'local_bundle': local_bundle,
             'issue_records': default_issue_records(ordered),
             'structured_prompt_preflight': {

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -32,9 +32,24 @@ def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
     ]
 
 
+def default_goal_policy() -> dict[str, Any]:
+    return {
+        'status': 'descriptive_only',
+        'sprint_goal_role': 'descriptive_sprint_objective',
+        'active_session_goal_required': 'child_issue_only',
+        'notes': [
+            'Sprint state may record a descriptive sprint objective, but that objective does not satisfy the active Codex session-goal requirement for child issue execution.',
+            'Each child issue session must create its own issue-bound goal after bind/readiness succeeds and before implementation starts.',
+            'Do not keep a competing sprint-global active session goal in the same thread while a child issue implementation session is active.',
+        ],
+    }
+
+
 def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, Any]:
     if path.exists():
-        return json.loads(path.read_text())
+        state = json.loads(path.read_text())
+        state.setdefault('goal_policy', default_goal_policy())
+        return state
     return {
         'sprint_issue_number': sprint_issue,
         'ordered_issue_numbers': ordered,
@@ -42,6 +57,7 @@ def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, A
         'completed_issue_numbers': [],
         'blocked_issue_number': None,
         'continuation': 'continue',
+        'goal_policy': default_goal_policy(),
         'issue_records': default_issue_records(ordered),
         'structured_prompt_preflight': {
             'status': 'not_run',

--- a/docs/planning/ADL_MILESTONE_WP_ORDERING_STANDARD.md
+++ b/docs/planning/ADL_MILESTONE_WP_ORDERING_STANDARD.md
@@ -43,7 +43,7 @@ issues are first-class lifecycle records, not optional notes.
 
 Sprint umbrella issues should record:
 
-- sprint goal and boundary;
+- descriptive sprint objective and boundary;
 - child issue list;
 - dependency order;
 - proof and validation expectations;


### PR DESCRIPTION
Closes #4300

## Summary
- make sprint umbrella goals explicit descriptive-only coordination context
- persist goal policy into sprint readiness and sprint state helpers
- align sprint-conductor docs and bootstrap wording with child issue-bound session goals

## Validation
- python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
- python3 module-load probes for sprint goal policy helpers
- python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_readiness.py --repo-root /Users/daniel/git/agent-design-language/.worktrees/adl-wp-4300 --ordered-issues 4300 --execution-mode sequential --review-path docs/planning/ADL_MILESTONE_WP_ORDERING_STANDARD.md --activity-log-path .adl/v0.91.6/tasks/issue-4300__v0-91-6-process-goals-reconcile-sprint-umbrella-and-child-issue-goal-requirements/sor.md --print-json
- git diff --check