### PR TITLE
[v0.91.6][tools] Fix pr run slug-drift identity binding

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -150,6 +150,41 @@ fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(
     resolve_issue_scope_and_slug_from_local_state(repo_root, issue)
 }
 
+fn resolve_start_slug(
+    parsed_slug: Option<&str>,
+    title: &str,
+    local_identity: Option<&(String, String)>,
+    no_fetch_issue: bool,
+) -> Result<(String, bool)> {
+    if let Some((_, local_slug)) = local_identity {
+        return Ok((local_slug.clone(), true));
+    }
+
+    if let Some(parsed_slug) = parsed_slug {
+        if !parsed_slug.trim().is_empty() {
+            let slug = sanitize_slug(parsed_slug);
+            if slug.is_empty() {
+                bail!("start: --slug produced empty slug after sanitization");
+            }
+            return Ok((slug, false));
+        }
+    }
+
+    if !title.is_empty() {
+        let slug = sanitize_slug(title);
+        if slug.is_empty() {
+            bail!("start: --title produced empty slug after sanitization");
+        }
+        return Ok((slug, false));
+    }
+
+    if no_fetch_issue {
+        bail!("start: --slug is required when --no-fetch-issue is set");
+    }
+
+    bail!("Could not fetch issue title. Pass --slug or check GitHub token/repo configuration.")
+}
+
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
@@ -970,34 +1005,16 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     }
 
     let mut title = parsed.title_arg.clone().unwrap_or_default();
-    let mut slug = parsed.slug.clone().unwrap_or_default();
-    let mut slug_from_local_identity = false;
     if title.is_empty() && !parsed.no_fetch_issue {
         eprintln!("• Fetching issue title via ADL GitHub transport…");
         title = gh_issue_title(parsed.issue, &repo)?.unwrap_or_default();
     }
-    if slug.is_empty() {
-        if let Some((_, local_slug)) = local_identity.as_ref() {
-            slug = local_slug.clone();
-            slug_from_local_identity = true;
-        } else if !title.is_empty() {
-            slug = sanitize_slug(&title);
-            if slug.is_empty() {
-                bail!("start: --title produced empty slug after sanitization");
-            }
-        } else if parsed.no_fetch_issue {
-            bail!("start: --slug is required when --no-fetch-issue is set");
-        }
-        if slug.is_empty() && title.is_empty() {
-            bail!(
-                "Could not fetch issue #{} title. Pass --slug or check GitHub token/repo configuration.",
-                parsed.issue
-            );
-        }
-        if slug.is_empty() {
-            slug = sanitize_slug(&title);
-        }
-    }
+    let (mut slug, slug_from_local_identity) = resolve_start_slug(
+        parsed.slug.as_deref(),
+        &title,
+        local_identity.as_ref(),
+        parsed.no_fetch_issue,
+    )?;
     if !same_checkout_root(&repo_root, &primary_root)? {
         bail!(
             "start: issue-mode run must be invoked from the primary checkout, not from an existing issue worktree. Current checkout: '{}'. Primary checkout: '{}'. Remediation: continue working in the current issue worktree if it already matches your target issue, or rerun `adl/tools/pr.sh run {}` from the primary checkout.",

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1174,6 +1174,53 @@ fn ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle(
 }
 
 #[test]
+fn resolve_start_slug_reuses_single_local_identity_over_explicit_slug_drift() {
+    let local_identity = (
+        "v0.91.6".to_string(),
+        "prompt-template-next-version-vpp-time-token-goal-fields".to_string(),
+    );
+    let (slug, from_local_identity) = resolve_start_slug(
+        Some("plan-next-prompt-template-version-with-vpp-time-token-and-goal-fields"),
+        "[v0.91.6][templates] Plan next prompt-template version with VPP time token and goal fields",
+        Some(&local_identity),
+        false,
+    )
+    .expect("single local identity should be reusable");
+
+    assert_eq!(
+        slug,
+        "prompt-template-next-version-vpp-time-token-goal-fields"
+    );
+    assert!(from_local_identity);
+}
+
+#[test]
+fn resolve_start_slug_uses_explicit_slug_without_local_identity() {
+    let (slug, from_local_identity) =
+        resolve_start_slug(Some("operator supplied slug"), "", None, true)
+            .expect("explicit slug should be usable without local identity");
+
+    assert_eq!(slug, "operator-supplied-slug");
+    assert!(!from_local_identity);
+}
+
+#[test]
+fn resolve_issue_scope_and_slug_rejects_multiple_local_identities_before_slug_selection() {
+    let repo = unique_temp_dir("adl-pr-start-duplicate-local-identity");
+    fs::create_dir_all(repo.join(".adl/v0.91.6/tasks/issue-4309__first-slug"))
+        .expect("first identity");
+    fs::create_dir_all(repo.join(".adl/v0.91.6/tasks/issue-4309__second-slug"))
+        .expect("second identity");
+
+    let err = resolve_local_issue_identity(&repo, 4309)
+        .expect_err("multiple local identities should fail closed");
+
+    assert!(err
+        .to_string()
+        .contains("duplicate local task-bundle identities detected"));
+}
+
+#[test]
 fn infer_repo_from_remote_supports_https_and_ssh() {
     assert_eq!(
         infer_repo_from_remote("https://github.com/danielbaustin/agent-design-language.git"),


### PR DESCRIPTION
Closes #4356

## Summary
Implemented a focused `pr run` / `start` identity-resolution fix so a single existing local issue identity wins over explicit or title-derived slug drift. This prevents a renamed GitHub issue from making the existing local bundle look like a duplicate. True duplicate local task-bundle identities still fail closed through the existing local identity resolver.

## Artifacts
- Updated `adl/src/cli/pr_cmd.rs` with local-identity-first start slug resolution.
- Updated `adl/src/cli/tests/pr_cmd_inline/basics.rs` with focused regression coverage for explicit-slug drift and explicit-slug fallback.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml slug -- --nocapture`
    Verified the new slug-drift helper tests, duplicate local identity fail-closed coverage, and the existing full start-path canonical-local-slug integration coverage.
- Results:
  - PASS. The first malformed two-filter Cargo invocation failed before running tests; the corrected single-filter `slug` run passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4356__fix-pr-run-slug-drift-identity-binding/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4356__fix-pr-run-slug-drift-identity-binding/sor.md
- Idempotency-Key: v0-91-6-tools-fix-pr-run-slug-drift-identity-binding-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-v0-91-6-tasks-issue-4356-fix-pr-run-slug-drift-identity-binding-sip-md-adl-v0-91-6-tasks-issue-4356-fix-pr-run-slug-drift-identity-binding-sor-md