### PR TITLE
[v0.91.6][build][sprint] Publish missing build throughput sprint closeout artifacts

### DIFF
--- a/docs/milestones/v0.91.6/review/V0916_BUILD_THROUGHPUT_MINI_SPRINT_REVIEW_4310.md
+++ b/docs/milestones/v0.91.6/review/V0916_BUILD_THROUGHPUT_MINI_SPRINT_REVIEW_4310.md
@@ -1,0 +1,88 @@
+# v0.91.6 Build Throughput Improvements Mini-Sprint Review
+
+Status: `retained_review_packet`
+Date: 2026-06-21
+Sprint umbrella: `#4310`
+Execution packet:
+`docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_SEP_BUILD_THROUGHPUT_MINI_SPRINT_4310.md`
+Activity log:
+`docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_BUILD_THROUGHPUT_MINI_SPRINT_ACTIVITY_LOG_4310.md`
+
+This review summarizes the bounded `#4310` mini-sprint child wave. It does not
+claim a broader build-system refactor, CI replacement, or live AWS rollout.
+
+## Findings
+
+No sprint-level blockers or regressions remain in the landed child wave.
+
+### P2: Local child closeout truth drift had to be normalized before umbrella closeout
+
+After the child PRs merged and the GitHub issues closed, the canonical ignored
+`.adl` root issue bundle still showed stale child `SRP` and `SOR` state for
+`#4311` through `#4316`. The child wave itself was complete, but umbrella
+closeout could not proceed truthfully until that records-hygiene drift was
+normalized. This is process residue, not a scope blocker in the landed
+throughput work.
+
+### P3: Issue-level elapsed and token metrics remain mostly unknown across the child wave
+
+Validation seconds were captured for each child issue, but elapsed seconds and
+token totals remain mostly `unknown` in the issue-local `SOR` records. The
+sprint can still close truthfully because the retained artifacts and validation
+results are present, but the metrics substrate remains incomplete.
+
+## Child Issue Closure Truth
+
+| Issue | PR | State | Evidence |
+|---|---|---|---|
+| `#4315` | `#4346` | closed / merged | PR `#4346` merged and the retained measurement packet is present at `docs/milestones/v0.91.6/review/build_throughput/BUILD_THROUGHPUT_MEASUREMENT_4315.md`. |
+| `#4311` | `#4348` | closed / merged | PR `#4348` merged and the retained `sccache` packet is present at `docs/milestones/v0.91.6/review/build_throughput/SCCACHE_LOCAL_VALIDATION_4311.md`. |
+| `#4312` | `#4349` | closed / merged | PR `#4349` merged and the retained linker packet is present at `docs/milestones/v0.91.6/review/build_throughput/RUST_LINKER_LOCAL_VALIDATION_4312.md`. |
+| `#4313` | `#4350` | closed / merged | PR `#4350` merged and the retained target-relocation packet is present at `docs/milestones/v0.91.6/review/build_throughput/CARGO_TARGET_DIR_RELOCATION_4313.md`. |
+| `#4314` | `#4353` | closed / merged | PR `#4353` merged and the retained cleanup-policy packet is present at `docs/milestones/v0.91.6/review/build_throughput/SAFE_BUILD_ARTIFACT_CLEANUP_4314.md`. |
+| `#4316` | `#4355` | closed / merged | PR `#4355` merged and the retained CodeBuild evaluation packet is present at `docs/milestones/v0.91.6/review/build_throughput/CODEBUILD_REMOTE_VALIDATION_EVALUATION_4316.md`. |
+
+## Scope Check
+
+The completed child wave is exactly:
+
+- `#4315`
+- `#4311`
+- `#4312`
+- `#4313`
+- `#4314`
+- `#4316`
+
+No additional implementation work was absorbed into the sprint umbrella.
+
+## Outcome Summary
+
+- `#4315` established the measurement baseline and hotspot framing that
+  justified the rest of the sprint.
+- `#4311` and `#4312` produced measured local opt-in recommendations rather
+  than hard-wiring host-specific build defaults into tracked repo state.
+- `#4313` and `#4314` produced a coherent local target-layout and cleanup
+  policy story.
+- `#4316` remained evaluation-only and concluded with a bounded deferral:
+  no CodeBuild pilot in `v0.91.6`.
+
+## Validation And Review Evidence
+
+- Child issue validation seconds recorded in issue-local `SOR` cards sum to
+  `1007` seconds across the sprint:
+  `346` (`#4315`) + `433` (`#4311`) + `139` (`#4312`) + `84` (`#4313`) +
+  `3` (`#4314`) + `2` (`#4316`).
+- Each child issue now reports `lifecycle_state: "closed"` and
+  `ready_status: "PASS"` through the repo-native doctor path.
+- Each child issue has a retained report under
+  `docs/milestones/v0.91.6/review/build_throughput/`.
+- The local child `SRP` and `SOR` closeout truth was normalized before this
+  umbrella review so the sprint closeout does not rely on stale local state.
+
+## Non-Claims
+
+- This review does not claim a repo-wide build refactor or CI throughput
+  replacement landed in the sprint.
+- This review does not claim remote validation infrastructure was implemented;
+  `#4316` remained an evaluation-only lane.
+- This review does not treat missing elapsed/token metrics as zero.

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_BUILD_THROUGHPUT_MINI_SPRINT_ACTIVITY_LOG_4310.md
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_BUILD_THROUGHPUT_MINI_SPRINT_ACTIVITY_LOG_4310.md
@@ -1,0 +1,54 @@
+# v0.91.6 Build Throughput Improvements Mini-Sprint Activity Log
+
+Status: `child_wave_complete`
+Date: 2026-06-21
+Sprint umbrella: `#4310`
+
+This log records sprint-preparation events for the bounded child wave `#4315`,
+`#4311`, `#4312`, `#4313`, `#4314`, and `#4316`.
+
+## 2026-06-20 Preparation
+
+- Verified sprint umbrella `#4310` with `pr.sh doctor`; result:
+  `DOCTOR_STATUS=PASS`, `LIFECYCLE_STATE=pre_run`,
+  `CARD_LIFECYCLE_PR_RUN_READINESS=ready`.
+- Verified child issues `#4311`, `#4312`, `#4313`, `#4314`, `#4315`, and
+  `#4316` each pass `pr.sh doctor` with no preflight blockers, no open PRs,
+  and `CARD_LIFECYCLE_PR_RUN_READINESS=ready`.
+- Read the sprint source prompt, `STP`, `SPP`, and the build-throughput source
+  doc at `.adl/docs/TBD/ADL_BUILD_IMPROVEMENTS.md`.
+- Added the sprint execution packet at
+  `docs/milestones/v0.91.6/review/sprint_execution_packets/V0916_SEP_BUILD_THROUGHPUT_MINI_SPRINT_4310.md`.
+- Declared the sprint review path at
+  `docs/milestones/v0.91.6/review/V0916_BUILD_THROUGHPUT_MINI_SPRINT_REVIEW_4310.md`.
+- Declared measurement-first sequencing:
+  `#4315` first, then local tuning lanes, then cleanup policy, with `#4316`
+  remaining evaluation-only and safe to defer truthfully if needed.
+
+## Open Watch Items
+
+- No child execution watch items remain for the bounded `#4310` wave.
+- Umbrella closeout remains: publish the final sprint packet and review update,
+  record final `#4310` SOR truth, and merge the umbrella closeout work.
+
+## 2026-06-20 To 2026-06-21 Child Execution
+
+- Completed `#4315` through PR `#4346`; the retained report established the
+  build-throughput baseline, warm-build comparisons, and hotspot framing for
+  the rest of the sprint.
+- Completed `#4311` through PR `#4348`; the retained report recorded measured
+  local `sccache` wins as an opt-in recommendation.
+- Completed `#4312` through PR `#4349`; the retained report recorded measured
+  `rust-lld` wins as an opt-in recommendation on the actual host platform.
+- Completed `#4313` through PR `#4350`; the retained report recorded the
+  target-directory relocation strategy and per-worktree isolation guidance.
+- Completed `#4314` through PR `#4353`; the retained report recorded the
+  report-first cleanup policy aligned with the target-relocation truth.
+- Completed `#4316` through PR `#4355`; the retained report recommended no
+  CodeBuild pilot in `v0.91.6` and preserved the no-live-AWS boundary.
+- Verified each child issue now reports `lifecycle_state: "closed"` and
+  `ready_status: "PASS"` through the repo-native doctor path with no open PRs.
+- Recorded one sprint-level process remediation note: child GitHub closure
+  completed before the canonical ignored `.adl` root issue bundle reflected
+  terminal `SRP`/`SOR` truth. That local closeout drift was normalized before
+  the umbrella closeout proceeded.


### PR DESCRIPTION
Closes #4310. Follow-up publication PR after #4359 merged only the SEP for #4310. This PR publishes the missing retained sprint review packet and activity log so the build throughput mini-sprint closeout is complete and the root issue/card truth can be normalized against the full retained surface.