### PR TITLE
[v0.91.6][pvf][templates] Add VPP validation planning prompt and externalized lane registry

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -140,6 +140,9 @@
       "path_selectors": [
         "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
+        "adl/tools/select_validation_lanes.py",
+        "adl/tools/test_select_validation_lanes.sh",
+        "adl/tools/validation_manager.py",
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
@@ -147,12 +150,15 @@
       "path_hints": [
         "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
+        "adl/tools/select_validation_lanes.py",
+        "adl/tools/test_select_validation_lanes.sh",
+        "adl/tools/validation_manager.py",
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
       ],
-      "command": "bash adl/tools/test_ci_path_policy.sh",
-      "run_command": "bash adl/tools/test_ci_path_policy.sh",
+      "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh",
+      "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh",
       "reason": "ci_policy_surface_requires_path_policy_contract_checks"
     },
     {
@@ -365,7 +371,17 @@
       ],
       "command": "git diff --check",
       "run_command": "git diff --check",
-      "reason": "docs_only_surface_requires_diff_hygiene"
+      "reason": "docs_only_surface_requires_diff_hygiene",
+      "vpp_record": {
+        "contract_version": "vpp.lane.v1",
+        "artifacts": [
+          "working_tree_diff_hygiene"
+        ],
+        "expected_runtime_class": "tiny",
+        "parallel_group": "docs_hygiene",
+        "cache_equivalence_group": "git_diff_check",
+        "failure_semantics": "fail_closed"
+      }
     }
   ],
   "special_surfaces": {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1064,6 +1064,18 @@ pub(super) struct FinishValidationProfileRunItem {
     pub lane_id: String,
     pub command: String,
     pub reason: String,
+    #[serde(default)]
+    pub vpp_record: Option<FinishValidationVppRecord>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub(super) struct FinishValidationVppRecord {
+    pub contract_version: String,
+    pub artifacts: Vec<String>,
+    pub expected_runtime_class: String,
+    pub parallel_group: String,
+    pub cache_equivalence_group: String,
+    pub failure_semantics: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1621,7 +1633,36 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_locked_cargo_fallback_validation(issue_number, changed_paths) {
         return Ok(build_locked_cargo_fallback_validation_plan());
     }
+    let finish_profile = load_finish_validation_profile(&repo_root()?, changed_paths)?;
+    if let Some(plan) = profile_backed_finish_validation_plan(&finish_profile) {
+        return Ok(plan);
+    }
     select_finish_validation_plan(&changed_paths.join(","))
+}
+
+fn profile_backed_finish_validation_plan(
+    profile: &FinishValidationProfile,
+) -> Option<FinishValidationPlan> {
+    if profile.status != "ready_to_run"
+        || !profile.pr_publication_sufficient
+        || profile.escalation.required
+    {
+        return None;
+    }
+    if profile.run.len() != 1 {
+        return None;
+    }
+    let item = &profile.run[0];
+    if item.lane_id != "docs_diff_check" {
+        return None;
+    }
+    let mut commands =
+        vec!["bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()];
+    push_finish_validation_command(&mut commands, &item.command);
+    Some(FinishValidationPlan {
+        mode: FinishValidationMode::DocsOnly,
+        commands,
+    })
 }
 
 fn finish_path_is_docs_only(path: &str) -> bool {
@@ -3103,6 +3144,17 @@ pub(super) fn render_default_finish_validation(
                     sanitize_validation_profile_command(&item.command)
                 ));
                 lines.push(format!("    reason: {}", item.reason));
+                if let Some(vpp) = &item.vpp_record {
+                    lines.push(format!(
+                        "    vpp: contract={} runtime_class={} parallel_group={} cache_equivalence_group={} failure_semantics={}",
+                        vpp.contract_version,
+                        vpp.expected_runtime_class,
+                        vpp.parallel_group,
+                        vpp.cache_equivalence_group,
+                        vpp.failure_semantics
+                    ));
+                    lines.push(format!("    artifacts: {}", vpp.artifacts.join(", ")));
+                }
             }
         }
         if profile.not_run.is_empty() {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -11,7 +11,7 @@ use crate::cli::pr_cmd::finish_support::{
     run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
     FinishValidationPlan, FinishValidationProfile, FinishValidationProfileEscalation,
     FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
-    FinishValidationProfileSurfaceItem,
+    FinishValidationProfileSurfaceItem, FinishValidationVppRecord,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 use std::os::unix::fs::PermissionsExt;
@@ -439,11 +439,20 @@ fn render_default_finish_validation_includes_profile_truth_and_sanitizes_changed
                 lane_id: "csdlc_owner_lane".to_string(),
                 command: "bash adl/tools/run_owner_validation_lane.sh csdlc".to_string(),
                 reason: "csdlc_owner_surface_requires_csdlc_owner_lane".to_string(),
+                vpp_record: Some(FinishValidationVppRecord {
+                    contract_version: "vpp.lane.v1".to_string(),
+                    artifacts: vec!["working_tree_diff_hygiene".to_string()],
+                    expected_runtime_class: "tiny".to_string(),
+                    parallel_group: "docs_hygiene".to_string(),
+                    cache_equivalence_group: "git_diff_check".to_string(),
+                    failure_semantics: "fail_closed".to_string(),
+                }),
             },
             FinishValidationProfileRunItem {
                 lane_id: "rust_pr_fast".to_string(),
                 command: "bash adl/tools/run_pr_fast_test_lane.sh --changed-files /private/tmp/changed-files.txt".to_string(),
                 reason: "bounded_rust_surface_runs_focused_nextest".to_string(),
+                vpp_record: None,
             },
         ],
         not_run: vec![FinishValidationProfileSurfaceItem {
@@ -470,6 +479,10 @@ fn render_default_finish_validation_includes_profile_truth_and_sanitizes_changed
     assert!(rendered.contains("Profile-selected run lanes:"));
     assert!(rendered
         .contains("`csdlc_owner_lane` via `bash adl/tools/run_owner_validation_lane.sh csdlc`"));
+    assert!(rendered.contains(
+        "vpp: contract=vpp.lane.v1 runtime_class=tiny parallel_group=docs_hygiene cache_equivalence_group=git_diff_check failure_semantics=fail_closed"
+    ));
+    assert!(rendered.contains("artifacts: working_tree_diff_hygiene"));
     assert!(rendered.contains("`rust_pr_fast` via `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`"));
     assert!(rendered.contains("Profile-skipped proof surfaces:"));
     assert!(rendered

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -198,9 +198,11 @@ pub(crate) fn copy_bootstrap_support_files(repo: &Path) {
         .to_path_buf();
     env::set_var("ADL_TOOLING_MANIFEST_ROOT", &workspace_root);
     let tools_dir = repo.join("adl/tools");
+    let config_dir = repo.join("adl/config");
     let templates_dir = repo.join("adl/templates/cards");
     let schemas_dir = repo.join("adl/schemas");
     fs::create_dir_all(&tools_dir).expect("tools dir");
+    fs::create_dir_all(&config_dir).expect("config dir");
     fs::create_dir_all(&templates_dir).expect("templates dir");
     fs::create_dir_all(&schemas_dir).expect("schemas dir");
 
@@ -216,6 +218,38 @@ pub(crate) fn copy_bootstrap_support_files(repo: &Path) {
         (
             workspace_root.join("adl/tools/lint_prompt_spec.sh"),
             tools_dir.join("lint_prompt_spec.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/validation_manager.py"),
+            tools_dir.join("validation_manager.py"),
+        ),
+        (
+            workspace_root.join("adl/tools/validation_manager.sh"),
+            tools_dir.join("validation_manager.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/test_validation_manager.sh"),
+            tools_dir.join("test_validation_manager.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/select_validation_lanes.py"),
+            tools_dir.join("select_validation_lanes.py"),
+        ),
+        (
+            workspace_root.join("adl/tools/select_validation_lanes.sh"),
+            tools_dir.join("select_validation_lanes.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/run_pr_fast_test_lane.sh"),
+            tools_dir.join("run_pr_fast_test_lane.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/run_slow_proof_family.sh"),
+            tools_dir.join("run_slow_proof_family.sh"),
+        ),
+        (
+            workspace_root.join("adl/tools/run_owner_validation_lane.sh"),
+            tools_dir.join("run_owner_validation_lane.sh"),
         ),
         (
             workspace_root.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
@@ -244,6 +278,14 @@ pub(crate) fn copy_bootstrap_support_files(repo: &Path) {
         (
             workspace_root.join("adl/schemas/structured_output_record.contract.yaml"),
             schemas_dir.join("structured_output_record.contract.yaml"),
+        ),
+        (
+            workspace_root.join("adl/config/validation_lane_selector.v0.91.6.json"),
+            config_dir.join("validation_lane_selector.v0.91.6.json"),
+        ),
+        (
+            workspace_root.join("adl/config/slow_proof_families.v0.91.6.json"),
+            config_dir.join("slow_proof_families.v0.91.6.json"),
         ),
     ];
 

--- a/adl/tools/select_validation_lanes.py
+++ b/adl/tools/select_validation_lanes.py
@@ -98,6 +98,33 @@ def selectors_for(entry: dict[str, Any]) -> list[str]:
     return selectors
 
 
+def validate_vpp_record(entry: dict[str, Any], *, entry_id: str, manifest_path: Path) -> None:
+    record = entry.get("vpp_record")
+    if record is None:
+        return
+    if not isinstance(record, dict):
+        fail(f"{manifest_path}: entry {entry_id} vpp_record must be an object")
+    for key in (
+        "contract_version",
+        "artifacts",
+        "expected_runtime_class",
+        "parallel_group",
+        "cache_equivalence_group",
+        "failure_semantics",
+    ):
+        if key not in record:
+            fail(f"{manifest_path}: entry {entry_id} vpp_record missing required key: {key}")
+    if not isinstance(record["contract_version"], str) or not record["contract_version"]:
+        fail(f"{manifest_path}: entry {entry_id} vpp_record.contract_version must be a non-empty string")
+    if not isinstance(record["artifacts"], list) or not record["artifacts"] or not all(
+        isinstance(item, str) and item for item in record["artifacts"]
+    ):
+        fail(f"{manifest_path}: entry {entry_id} vpp_record.artifacts must be a non-empty array of strings")
+    for key in ("expected_runtime_class", "parallel_group", "cache_equivalence_group", "failure_semantics"):
+        if not isinstance(record[key], str) or not record[key]:
+            fail(f"{manifest_path}: entry {entry_id} vpp_record.{key} must be a non-empty string")
+
+
 REQUIRED_SURFACE_METADATA = (
     "owner",
     "resource_class",
@@ -108,19 +135,22 @@ REQUIRED_SURFACE_METADATA = (
 )
 
 
-def merge_surface_defaults(manifest: dict[str, Any], entry: dict[str, Any], *, entry_id: str) -> dict[str, Any]:
+def merge_surface_defaults(
+    manifest: dict[str, Any], entry: dict[str, Any], *, entry_id: str, manifest_path: Path = DEFAULT_MANIFEST
+) -> dict[str, Any]:
     default_surface = entry.get("default_surface")
     if not isinstance(default_surface, str) or not default_surface:
-        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required key: default_surface")
+        fail(f"{manifest_path}: entry {entry_id} missing required key: default_surface")
     surface_defaults = manifest["surface_defaults"].get(default_surface)
     if not isinstance(surface_defaults, dict):
-        fail(f"{DEFAULT_MANIFEST}: entry {entry_id} references unknown default_surface: {default_surface}")
+        fail(f"{manifest_path}: entry {entry_id} references unknown default_surface: {default_surface}")
     merged = dict(surface_defaults)
     merged.update(entry)
     merged["path_selectors"] = selectors_for(entry)
     for key in REQUIRED_SURFACE_METADATA:
         if not isinstance(merged.get(key), str) or not merged[key]:
-            fail(f"{DEFAULT_MANIFEST}: entry {entry_id} missing required surface metadata: {key}")
+            fail(f"{manifest_path}: entry {entry_id} missing required surface metadata: {key}")
+    validate_vpp_record(merged, entry_id=entry_id, manifest_path=manifest_path)
     return merged
 
 
@@ -158,16 +188,20 @@ def plan_entry(
     broad_lane_reason = normalized.get("broad_lane_reason")
     if broad_lane_reason:
         result["broad_lane_reason"] = broad_lane_reason
+    if "vpp_record" in normalized:
+        result["vpp_record"] = normalized["vpp_record"]
     if extra:
         result.update(extra)
     return result
 
 
-def manifest_entry_for(manifest: dict[str, Any], surface_id: str, fallback: dict[str, Any]) -> dict[str, Any]:
+def manifest_entry_for(
+    manifest: dict[str, Any], surface_id: str, fallback: dict[str, Any], *, manifest_path: Path = DEFAULT_MANIFEST
+) -> dict[str, Any]:
     special_surfaces = manifest.get("special_surfaces", {})
     entry = special_surfaces.get(surface_id, fallback)
     if not isinstance(entry, dict):
-        fail(f"{DEFAULT_MANIFEST}: special_surfaces.{surface_id} must be an object")
+        fail(f"{manifest_path}: special_surfaces.{surface_id} must be an object")
     return entry
 
 
@@ -193,7 +227,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
         selectors_for(lane)
         if "run_command" in lane and not isinstance(lane["run_command"], str):
             fail(f"{path}: lane {lane['id']} run_command must be a string")
-        merge_surface_defaults(manifest, lane, entry_id=lane["id"])
+        merge_surface_defaults(manifest, lane, entry_id=lane["id"], manifest_path=path)
     special_surfaces = manifest.get("special_surfaces", {})
     if special_surfaces:
         if not isinstance(special_surfaces, dict):
@@ -205,7 +239,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
                 if key not in surface:
                     fail(f"{path}: special_surfaces.{surface_id} missing required key: {key}")
             selectors_for(surface)
-            merge_surface_defaults(manifest, surface, entry_id=surface_id)
+            merge_surface_defaults(manifest, surface, entry_id=surface_id, manifest_path=path)
     for key in ("release_gate_hints", "rust_path_hints"):
         if not isinstance(manifest[key], list):
             fail(f"{path}: {key} must be an array")
@@ -252,6 +286,7 @@ def select_lanes(
             "run_command": "",
             "reason": "changed_surface_requires_release_or_ci_policy_review",
         },
+        manifest_path=manifest_path,
     )
     rust_entry = manifest_entry_for(
         manifest,
@@ -267,6 +302,7 @@ def select_lanes(
             "run_command": "bash adl/tools/run_pr_fast_test_lane.sh",
             "reason": "delegate_rust_changed_surface_to_pr_fast_lane_selector",
         },
+        manifest_path=manifest_path,
     )
     slow_proof_entry = manifest_entry_for(
         manifest,
@@ -286,6 +322,7 @@ def select_lanes(
             "run_command": "",
             "reason": "changed_surface_requires_slow_proof_review",
         },
+        manifest_path=manifest_path,
     )
 
     release_gate_paths = [
@@ -412,6 +449,17 @@ def print_text(plan: dict[str, Any]) -> None:
         print(f"    command={lane['command']}")
         if lane.get("run_command") and lane.get("run_command") != lane.get("command"):
             print(f"    run_command={lane['run_command']}")
+        if lane.get("vpp_record"):
+            record = lane["vpp_record"]
+            print(
+                "    vpp_record="
+                f"contract={record['contract_version']} "
+                f"runtime={record['expected_runtime_class']} "
+                f"parallel={record['parallel_group']} "
+                f"cache={record['cache_equivalence_group']} "
+                f"failure={record['failure_semantics']}"
+            )
+            print(f"    artifacts={','.join(record['artifacts'])}")
         for path in lane["matched_paths"]:
             print(f"    path={path}")
 

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -87,6 +87,11 @@ assert docs_lane["owner"] == "docs"
 assert docs_lane["default_surface"] == "docs"
 assert docs_lane["resource_class"] == "tiny"
 assert docs_lane["proof_role"] == "diff_hygiene"
+assert docs_lane["vpp_record"]["contract_version"] == "vpp.lane.v1"
+assert docs_lane["vpp_record"]["expected_runtime_class"] == "tiny"
+assert docs_lane["vpp_record"]["parallel_group"] == "docs_hygiene"
+assert docs_lane["vpp_record"]["cache_equivalence_group"] == "git_diff_check"
+assert docs_lane["vpp_record"]["failure_semantics"] == "fail_closed"
 PY
 
 bash "$SCRIPT" --changed-files "$focused_rust" --json >"$TMP/focused.json"
@@ -184,7 +189,96 @@ if bash "$SCRIPT" --manifest "$invalid_manifest" --changed-files "$docs_only" >"
   echo "expected invalid manifest to fail" >&2
   exit 1
 fi
+assert_has "$TMP/invalid.err" "$invalid_manifest"
 assert_has "$TMP/invalid.err" "references unknown default_surface: missing_surface"
+
+invalid_vpp_manifest="$TMP/invalid-vpp-manifest.json"
+cat >"$invalid_vpp_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene",
+      "vpp_record": {
+        "contract_version": "vpp.lane.v1",
+        "artifacts": [
+          "working_tree_diff_hygiene"
+        ],
+        "parallel_group": "docs_hygiene",
+        "cache_equivalence_group": "git_diff_check",
+        "failure_semantics": "fail_closed"
+      }
+    }
+  ],
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$invalid_vpp_manifest" --changed-files "$docs_only" >"$TMP/invalid-vpp.out" 2>"$TMP/invalid-vpp.err"; then
+  echo "expected invalid vpp manifest to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/invalid-vpp.err" "$invalid_vpp_manifest"
+assert_has "$TMP/invalid-vpp.err" "vpp_record missing required key: expected_runtime_class"
+
+invalid_special_surface_manifest="$TMP/invalid-special-surface-manifest.json"
+cat >"$invalid_special_surface_manifest" <<'EOF'
+{
+  "schema_version": "adl.validation_lane_selector.v1",
+  "surface_defaults": {
+    "docs": {
+      "owner": "docs",
+      "resource_class": "tiny",
+      "determinism_posture": "deterministic",
+      "proof_role": "diff_hygiene",
+      "risk_class": "low",
+      "escalation_rule": "none"
+    }
+  },
+  "lanes": [
+    {
+      "id": "docs_diff_check",
+      "lane_class": "docs",
+      "default_surface": "docs",
+      "path_selectors": [
+        "docs/**"
+      ],
+      "command": "git diff --check",
+      "run_command": "git diff --check",
+      "reason": "docs_only_surface_requires_diff_hygiene"
+    }
+  ],
+  "special_surfaces": {
+    "release_gate_review": "broken"
+  },
+  "release_gate_hints": [],
+  "rust_path_hints": []
+}
+EOF
+if bash "$SCRIPT" --manifest "$invalid_special_surface_manifest" --changed-files "$docs_only" >"$TMP/invalid-special.out" 2>"$TMP/invalid-special.err"; then
+  echo "expected invalid special surface manifest to fail" >&2
+  exit 1
+fi
+assert_has "$TMP/invalid-special.err" "$invalid_special_surface_manifest"
+assert_has "$TMP/invalid-special.err" "special_surfaces.release_gate_review must be an object"
 
 special_surface_manifest="$TMP/special-surface-manifest.json"
 cat >"$special_surface_manifest" <<'EOF'

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -304,6 +304,7 @@ def build_profile(plan: dict[str, Any], guardrails: dict[str, Any], manifest_pat
                     "command": command,
                     "reason": lane.get("reason", "selector_selected_lane"),
                     "matched_paths": lane.get("matched_paths", []),
+                    "vpp_record": lane.get("vpp_record"),
                 }
             )
 

--- a/docs/milestones/v0.91.6/features/README.md
+++ b/docs/milestones/v0.91.6/features/README.md
@@ -18,6 +18,7 @@ They are planning and bridge documents, not runtime implementation proof.
 - [AEE, Memory/ObsMem, And ACP Bridge Accounting](AEE_MEMORY_ACP_BRIDGE_ACCOUNTING_v0.91.6.md)
 
 - [Cognitive Scheduler v1](COGNITIVE_SCHEDULER_v0.91.6.md)
+- [VPP Validation Planning And PVF Lane Registry](VPP_VALIDATION_PLANNING_AND_PVF_LANE_REGISTRY_v0.91.6.md)
 
 ## Guardrails
 

--- a/docs/milestones/v0.91.6/features/VPP_VALIDATION_PLANNING_AND_PVF_LANE_REGISTRY_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/VPP_VALIDATION_PLANNING_AND_PVF_LANE_REGISTRY_v0.91.6.md
@@ -1,0 +1,144 @@
+# VPP Validation Planning And PVF Lane Registry
+
+## Status
+
+- Status: bridge-defined in `v0.91.6`
+- Scope: validation-planning contract plus registry-backed finish proving slice
+- Outcome type: tooling + contract + feature packet
+- Does not prove: active six-card prompt-template lifecycle adoption, universal registry-backed finish execution for every lane, or full replacement of all hard-coded validation routing in one issue
+
+## Why this exists
+
+ADL already has partial PVF lane planning surfaces:
+
+- issue bootstrap infers an initial PVF lane
+- `SPP` and `SOR` carry planned/final PVF lane truth
+- `adl/tools/select_validation_lanes.py` selects lanes from a machine-readable manifest
+- `adl/tools/validation_manager.py` builds a fail-closed validation profile from that selector
+
+But the control plane still had two important gaps:
+
+- validation planning was not yet named as its own first-class lifecycle contract
+- `pr finish` still relied on hard-coded Rust path classification even when a machine-readable validation profile already existed
+
+This feature defines the missing VPP contract boundary and lands a bounded registry-backed finish slice so later issues can expand from a truthful foundation.
+
+## VPP meaning
+
+`VPP` means `Validation Planning Prompt`.
+
+It is the planned proof surface between design/execution planning and review/closeout:
+
+`SIP -> STP -> SPP -> VPP -> SRP -> SOR`
+
+## What VPP owns
+
+A future first-class `VPP` card should own:
+
+- selected PVF lanes
+- proof commands and run commands
+- expected proof artifacts
+- expected runtime class
+- parallel grouping
+- cache/equivalence grouping
+- failure semantics
+- release-gate posture
+- selection evidence and rationale
+- linkage back to the parent issue plan and forward to `SRP`/`SOR`
+
+## v0.91.6 proving slice
+
+This issue lands a bounded proving slice instead of the whole active prompt-template expansion:
+
+- the selector registry now carries VPP-grade metadata for a migrated lane
+- the validation profile preserves that lane metadata for downstream consumers
+- `pr finish` can consume the registry-backed profile for the migrated docs lane instead of relying only on hard-coded Rust classification
+- invalid registry metadata continues to fail closed
+
+The migrated first slice is the `docs_diff_check` lane.
+
+## Current control-plane split
+
+### Already machine-readable
+
+- `adl/config/validation_lane_selector.v0.91.6.json`
+- `adl/tools/select_validation_lanes.py`
+- `adl/tools/validation_manager.py`
+
+These surfaces already classify changed paths, preserve fail-closed escalation behavior, and emit machine-readable lane/profile truth.
+
+### Still partially hard-coded before this issue
+
+- `adl/src/cli/pr_cmd/finish_support.rs`
+
+Before this slice, `pr finish` rendered the machine-readable validation profile for operator visibility, but execution still fell back to hard-coded Rust path classifiers.
+
+## What this issue changes
+
+- enrich the lane registry with VPP-grade metadata for the migrated lane:
+  - `contract_version`
+  - `artifacts`
+  - `expected_runtime_class`
+  - `parallel_group`
+  - `cache_equivalence_group`
+  - `failure_semantics`
+- validate that malformed VPP metadata fails closed at manifest-load time
+- carry that lane metadata through the validation profile
+- allow `pr finish` to execute the registry-backed `docs_diff_check` lane when the profile is runnable and publication-sufficient
+- preserve the existing hard-coded Rust fallback for non-migrated lanes and explicit issue-number special cases
+
+## Why the docs lane first
+
+The docs-only lane is the safest proving migration because it is:
+
+- already explicit in the selector manifest
+- deterministic
+- low-risk
+- easy to fail closed
+- representative of the planning-to-finish control-plane handoff
+
+It proves the registry-backed execution seam without widening this issue into a full rewrite of all finish validation routing.
+
+## Handoff to #4309
+
+This issue intentionally does **not** activate a sixth lifecycle card in the current prompt-template registry.
+
+That expansion belongs to `#4309`, which is the explicit next-version prompt-template issue for:
+
+- active template-set evolution
+- new card kind support in the renderer/validator stack
+- VPP/time/token/goal field integration across the lifecycle
+
+In other words:
+
+- `#4308` defines the VPP contract boundary and proves registry-backed consumption
+- `#4309` performs the next prompt-template version rollout for the first-class card
+
+## Fail-closed rules
+
+The VPP/registry path must remain fail-closed:
+
+- malformed lane metadata is invalid manifest data
+- uncovered changed paths still escalate
+- release-only or slow-proof paths still escalate rather than pretending ordinary PR sufficiency
+- `pr finish` uses the registry-backed path only when the profile is runnable and publication-sufficient
+- non-migrated lanes continue to use existing hard-coded routing until their registry-backed execution paths are proven
+
+## Non-claims
+
+This feature does not claim:
+
+- that `VPP` is already an active card in the current prompt-template registry
+- that every existing finish lane is registry-backed
+- that all PVF execution already routes through one universal manifest runner
+- that release-gate or slow-proof decisions can be automated away
+
+## Validation posture
+
+The proving surface for this issue should stay focused on:
+
+- selector manifest contract behavior
+- invalid metadata fail-closed behavior
+- validation-profile carry-through
+- registry-backed docs-lane finish selection
+- issue-local card truth


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4308 remains open.

## Summary
Completed the bounded `#4308` slice for VPP contract definition and registry-backed finish consumption. Added the v0.91.6 feature packet documenting the VPP lifecycle contract and `#4309` handoff, enriched the lane registry/profile surfaces with VPP-grade metadata for the migrated docs lane, taught `pr finish` to consume that registry-backed docs lane when the profile is runnable, tightened the issue-local plan truth, and repaired all review findings before publication.

## Artifacts
- `docs/milestones/v0.91.6/features/VPP_VALIDATION_PLANNING_AND_PVF_LANE_REGISTRY_v0.91.6.md`
- `docs/milestones/v0.91.6/features/README.md`
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/tools/select_validation_lanes.py`
- `adl/tools/test_select_validation_lanes.sh`
- `adl/tools/validation_manager.py`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `.adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/spp.md`
- `.adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/srp.md`
- `.adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/sor.md`

## Validation
- Validation commands and their purpose:
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh doctor 4308 --mode ready --json`
    Verified the issue bundle was structurally ready before execution binding.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh run 4308`
    Verified the normal ADL lifecycle could bind the issue to a branch/worktree.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/spp.md`
    Verified the SPP remained valid after aligning the issue-local plan to the actual bounded slice.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified valid selector behavior and invalid-manifest fail-closed behavior, including malformed VPP metadata and malformed `special_surfaces` entries.
  - `bash adl/tools/test_validation_manager.sh`
    Verified the validation profile still carries selector truth and fail-closed escalation behavior after the registry self-coverage expansion.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::render_default_finish_validation_includes_profile_truth_and_sanitizes_changed_files -- --exact --nocapture`
    Verified finish rendering includes the profile-backed lane metadata and sanitizes changed-file paths.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_treats_issue_records_and_skill_docs_as_docs_only -- --exact --nocapture`
    Verified the registry-backed docs lane continues to produce the expected docs-only finish plan.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request -- --exact --nocapture`
    Verified finish selection still follows actual changed paths for docs-only and focused slices.
  - `git diff --check`
    Verified patch/whitespace hygiene for the touched files.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4308__vpp-validation-planning-prompt-and-pvf-lane-registry/sor.md
- Idempotency-Key: v0-91-6-pvf-templates-add-vpp-validation-planning-prompt-and-externalized-lane-registry-adl-v0-91-6-tasks-issue-4308-vpp-validation-planning-prompt-and-pvf-lane-registry-sip-md-adl-v0-91-6-tasks-issue-4308-vpp-validation-planning-prompt-and-pvf-lane-registry-sor-md