### PR TITLE
[v0.91.6][tooling] Preserve child issue bundles created from disposable worktrees

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -27,12 +27,12 @@ use super::pr_cmd_cards::{
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;
 use super::pr_cmd_prompt::{
-    ensure_no_duplicate_issue_identities, infer_required_outcome_type, infer_workflow_queue,
-    normalize_issue_title_for_version, normalize_labels_csv, parse_issue_number_from_url,
-    render_generated_issue_body, resolve_issue_body, resolve_issue_prompt_path,
-    resolve_issue_prompt_workflow_queue, resolve_issue_scope_and_slug_from_local_state,
-    validate_issue_prompt_exists, version_from_labels_csv, version_from_title,
-    WorkflowQueueResolution,
+    ensure_no_duplicate_issue_identities, ensure_no_duplicate_issue_identities_against_root,
+    infer_required_outcome_type, infer_workflow_queue, normalize_issue_title_for_version,
+    normalize_labels_csv, parse_issue_number_from_url, render_generated_issue_body,
+    resolve_issue_body, resolve_issue_prompt_path, resolve_issue_prompt_workflow_queue,
+    resolve_issue_scope_and_slug_from_local_state, validate_issue_prompt_exists,
+    version_from_labels_csv, version_from_title, WorkflowQueueResolution,
 };
 use super::pr_cmd_validate::{
     bootstrap_stub_reason, validate_authored_prompt_surface, PromptSurfaceKind,
@@ -856,6 +856,7 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
 fn real_pr_create(args: &[String]) -> Result<()> {
     let parsed = parse_create_args(args)?;
     let repo_root = repo_root()?;
+    let primary_root = primary_checkout_root()?;
     let repo = issue_create_repo(&repo_root)?;
 
     let raw_title = parsed.title_arg.clone().unwrap_or_default();
@@ -900,12 +901,21 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     } else {
         body.clone()
     };
-    validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &create_body)?;
+    validate_issue_body_for_create(
+        &primary_root,
+        &title,
+        &normalized_labels,
+        &slug,
+        &create_body,
+    )?;
     let issue_url = gh_issue_create(&repo, &title, &create_body, &normalized_labels)?;
     let issue = parse_issue_number_from_url(&issue_url)?;
     ensure_issue_metadata_parity(&repo, issue, &title, &normalized_labels)?;
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
-    ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
+    ensure_no_duplicate_issue_identities(&primary_root, &issue_ref)?;
+    if repo_root != primary_root {
+        ensure_no_duplicate_issue_identities_against_root(&repo_root, &primary_root, &issue_ref)?;
+    }
     let final_body = if body.trim().is_empty() {
         render_generated_issue_body(
             &title,
@@ -916,22 +926,22 @@ fn real_pr_create(args: &[String]) -> Result<()> {
         body
     };
     let source_path = write_source_issue_prompt(
-        &repo_root,
+        &primary_root,
         &issue_ref,
         &title,
         &normalized_labels,
         &issue_url,
         &final_body,
     )?;
-    validate_bootstrap_stp(&repo_root, &source_path)?;
+    validate_bootstrap_stp(&primary_root, &source_path)?;
     if create_body != final_body {
         gh_issue_edit_body(&repo, issue, &final_body)?;
     }
     let (stp_path, bundle_input, bundle_output, bundle_dir) =
-        bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
-    run_create_post_bootstrap_test_hook(&repo_root, &issue_ref)?;
+        bootstrap_root_task_bundle(&primary_root, &issue_ref, &title, &source_path)?;
+    run_create_post_bootstrap_test_hook(&primary_root, &issue_ref)?;
     let ready = doctor::run_doctor_ready(
-        &repo_root,
+        &primary_root,
         &repo,
         &issue_ref,
         &issue_ref.branch_name("codex"),
@@ -950,34 +960,37 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     println!("  SLUG       {slug}");
     println!(
         "  SOURCE     {}",
-        path_relative_to_repo(&repo_root, &source_path)
+        path_relative_to_repo(&primary_root, &source_path)
     );
     println!(
         "  STP        {}",
-        path_relative_to_repo(&repo_root, &stp_path)
+        path_relative_to_repo(&primary_root, &stp_path)
     );
     println!(
         "  SPP        {}",
-        path_relative_to_repo(&repo_root, &issue_ref.task_bundle_plan_path(&repo_root))
+        path_relative_to_repo(
+            &primary_root,
+            &issue_ref.task_bundle_plan_path(&primary_root)
+        )
     );
     println!(
         "  SRP        {}",
         path_relative_to_repo(
-            &repo_root,
-            &issue_ref.task_bundle_review_policy_path(&repo_root),
+            &primary_root,
+            &issue_ref.task_bundle_review_policy_path(&primary_root),
         )
     );
     println!(
         "  SIP        {}",
-        path_relative_to_repo(&repo_root, &bundle_input)
+        path_relative_to_repo(&primary_root, &bundle_input)
     );
     println!(
         "  SOR        {}",
-        path_relative_to_repo(&repo_root, &bundle_output)
+        path_relative_to_repo(&primary_root, &bundle_output)
     );
     println!(
         "  BUNDLE     {}",
-        path_relative_to_repo(&repo_root, &bundle_dir)
+        path_relative_to_repo(&primary_root, &bundle_dir)
     );
     println!(
         "  READY      {}",

--- a/adl/src/cli/pr_cmd_prompt.rs
+++ b/adl/src/cli/pr_cmd_prompt.rs
@@ -99,19 +99,20 @@ pub(crate) fn normalize_issue_title_for_version(title: &str, version: &str) -> S
     format!("{expected_prefix}{trimmed}")
 }
 
-pub(crate) fn ensure_no_duplicate_issue_identities(
-    repo_root: &Path,
+fn collect_duplicate_issue_identity_paths(
+    search_root: &Path,
+    canonical_root: &Path,
     issue_ref: &IssueRef,
-) -> Result<()> {
-    let adl_root = repo_root.join(".adl");
+) -> Result<Vec<PathBuf>> {
+    let adl_root = search_root.join(".adl");
     if !adl_root.is_dir() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let body_prefix = format!("issue-{:04}-", issue_ref.issue_number());
     let task_prefix = format!("issue-{:04}__", issue_ref.issue_number());
-    let canonical_body = issue_ref.issue_prompt_path(repo_root);
-    let canonical_bundle = issue_ref.task_bundle_dir_path(repo_root);
+    let canonical_body = issue_ref.issue_prompt_path(canonical_root);
+    let canonical_bundle = issue_ref.task_bundle_dir_path(canonical_root);
     let mut duplicates = Vec::new();
 
     for scope_entry in fs::read_dir(&adl_root)? {
@@ -145,6 +146,23 @@ pub(crate) fn ensure_no_duplicate_issue_identities(
 
     duplicates.sort();
     duplicates.dedup();
+    Ok(duplicates)
+}
+
+pub(crate) fn ensure_no_duplicate_issue_identities(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    ensure_no_duplicate_issue_identities_against_root(repo_root, repo_root, issue_ref)
+}
+
+pub(crate) fn ensure_no_duplicate_issue_identities_against_root(
+    search_root: &Path,
+    canonical_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let duplicates =
+        collect_duplicate_issue_identity_paths(search_root, canonical_root, issue_ref)?;
     if duplicates.is_empty() {
         return Ok(());
     }
@@ -152,7 +170,7 @@ pub(crate) fn ensure_no_duplicate_issue_identities(
     let rendered = duplicates
         .iter()
         .map(|path| {
-            path.strip_prefix(repo_root)
+            path.strip_prefix(search_root)
                 .unwrap_or(path)
                 .display()
                 .to_string()

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -2454,6 +2454,249 @@ fn real_pr_create_fails_when_post_bootstrap_ready_validation_fails() {
 }
 
 #[test]
+fn real_pr_create_from_disposable_worktree_bootstraps_bundle_in_primary_checkout() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-real-create-worktree-root");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    let readme = repo.join("README.md");
+    fs::write(&readme, "seed repo for create-from-worktree test\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(&repo)
+        .env("GIT_AUTHOR_NAME", "Test User")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test User")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("git commit")
+        .success());
+
+    let worktrees_root = repo.join(".worktrees");
+    fs::create_dir_all(&worktrees_root).expect("worktrees root");
+    let child_branch = "codex/1199-parent-issue";
+    run_status(
+        "git",
+        &[
+            "-C",
+            repo.to_str().expect("repo utf-8"),
+            "branch",
+            child_branch,
+            "HEAD",
+        ],
+    )
+    .expect("create child branch");
+    let child_worktree = worktrees_root.join("adl-wp-1199");
+    run_status(
+        "git",
+        &[
+            "-C",
+            repo.to_str().expect("repo utf-8"),
+            "worktree",
+            "add",
+            child_worktree.to_str().expect("worktree utf-8"),
+            child_branch,
+        ],
+    )
+    .expect("create child worktree");
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = repo.join("gh.log");
+    let issue_body_log = repo.join("issue_body.log");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"label list\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1206\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.86][tools] Durable child bundle\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            issue_body_log.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&child_worktree).expect("chdir into child worktree");
+
+    let result = real_pr(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Durable child bundle".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-durable-child-bundle".to_string(),
+        "--body".to_string(),
+        "## Summary\n\nEnsure child issue creation remains durable when invoked from a disposable worktree.\n\n## Goal\n\nBootstrap canonical issue artifacts in the primary checkout.\n\n## Required Outcome\n\nThis issue ships tooling code and tests.\n\n## Deliverables\n\n- primary-checkout create anchoring\n\n## Acceptance Criteria\n\n- create writes the source prompt and task bundle under the primary checkout even when invoked from a disposable worktree\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- worktree start lifecycle changes\n\n## Issue-Graph Notes\n\n- regression test\n\n## Notes\n\n- authored test body\n\n## Tooling Notes\n\n- should pass source-prompt validation\n".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    result.expect("real_pr create from child worktree");
+
+    let root_source = repo.join(".adl/v0.86/bodies/issue-1206-v0-86-tools-durable-child-bundle.md");
+    let root_bundle = repo.join(".adl/v0.86/tasks/issue-1206__v0-86-tools-durable-child-bundle");
+    assert!(
+        root_source.is_file(),
+        "create should write the source prompt in the primary checkout"
+    );
+    assert!(
+        root_bundle.join("sip.md").is_file(),
+        "create should bootstrap the canonical bundle in the primary checkout"
+    );
+    assert!(
+        root_bundle.join("sor.md").is_file(),
+        "create should bootstrap the canonical output card in the primary checkout"
+    );
+
+    let worktree_source =
+        child_worktree.join(".adl/v0.86/bodies/issue-1206-v0-86-tools-durable-child-bundle.md");
+    let worktree_bundle =
+        child_worktree.join(".adl/v0.86/tasks/issue-1206__v0-86-tools-durable-child-bundle");
+    assert!(
+        !worktree_source.exists(),
+        "create should not strand the source prompt inside the disposable worktree"
+    );
+    assert!(
+        !worktree_bundle.exists(),
+        "create should not strand the canonical task bundle inside the disposable worktree"
+    );
+}
+
+#[test]
+fn real_pr_create_from_disposable_worktree_fails_closed_on_stale_local_duplicate() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-real-create-worktree-duplicate");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    let readme = repo.join("README.md");
+    fs::write(
+        &readme,
+        "seed repo for create-from-worktree duplicate test\n",
+    )
+    .expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(&repo)
+        .env("GIT_AUTHOR_NAME", "Test User")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test User")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("git commit")
+        .success());
+
+    let worktrees_root = repo.join(".worktrees");
+    fs::create_dir_all(&worktrees_root).expect("worktrees root");
+    let child_branch = "codex/1199-parent-issue";
+    run_status(
+        "git",
+        &[
+            "-C",
+            repo.to_str().expect("repo utf-8"),
+            "branch",
+            child_branch,
+            "HEAD",
+        ],
+    )
+    .expect("create child branch");
+    let child_worktree = worktrees_root.join("adl-wp-1199");
+    run_status(
+        "git",
+        &[
+            "-C",
+            repo.to_str().expect("repo utf-8"),
+            "worktree",
+            "add",
+            child_worktree.to_str().expect("worktree utf-8"),
+            child_branch,
+        ],
+    )
+    .expect("create child worktree");
+
+    let stranded_source =
+        child_worktree.join(".adl/v0.86/bodies/issue-1207-v0-86-tools-duplicate-child-bundle.md");
+    fs::create_dir_all(stranded_source.parent().expect("stranded source parent"))
+        .expect("stranded source dir");
+    fs::write(&stranded_source, "stale source prompt\n").expect("write stranded source");
+    let stranded_bundle =
+        child_worktree.join(".adl/v0.86/tasks/issue-1207__v0-86-tools-duplicate-child-bundle");
+    fs::create_dir_all(&stranded_bundle).expect("stranded bundle dir");
+    fs::write(stranded_bundle.join("sip.md"), "stale sip\n").expect("write stranded sip");
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"label list\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  printf 'https://github.com/example/repo/issues/1207\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.86][tools] Duplicate child bundle\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&child_worktree).expect("chdir into child worktree");
+
+    let err = real_pr(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Duplicate child bundle".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-duplicate-child-bundle".to_string(),
+        "--body".to_string(),
+        "## Summary\n\nReject stale worktree-local duplicates before creating a canonical child bundle.\n\n## Goal\n\nFail closed when a disposable worktree already contains stranded issue artifacts.\n\n## Required Outcome\n\nThis issue ships tooling code and tests.\n\n## Deliverables\n\n- duplicate detection across primary and disposable worktree roots\n\n## Acceptance Criteria\n\n- create fails with actionable guidance when the current disposable worktree already contains a duplicate source prompt or task bundle for the same issue identity\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- automatically deleting stale worktree artifacts\n\n## Issue-Graph Notes\n\n- regression test\n\n## Notes\n\n- authored test body\n\n## Tooling Notes\n\n- should pass source-prompt validation before duplicate detection fails closed\n".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("create should fail closed on a stranded worktree-local duplicate");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err
+        .to_string()
+        .contains("duplicate local issue identities detected for issue #1207"));
+    assert!(
+        err.to_string()
+            .contains(".adl/v0.86/bodies/issue-1207-v0-86-tools-duplicate-child-bundle.md")
+            || err
+                .to_string()
+                .contains(".adl/v0.86/tasks/issue-1207__v0-86-tools-duplicate-child-bundle"),
+        "error should point at the stale worktree-local duplicate"
+    );
+    assert!(
+        !repo.join(".adl/v0.86/bodies/issue-1207-v0-86-tools-duplicate-child-bundle.md")
+            .exists(),
+        "create should not write a second canonical source prompt after detecting the stale worktree-local duplicate"
+    );
+}
+
+#[test]
 fn real_pr_create_fails_before_creating_issue_when_repo_labels_are_missing() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create-missing-labels");


### PR DESCRIPTION
Closes #4378

## Summary
Updated the `pr create` lifecycle so child issue bundles created from a disposable worktree are anchored to the primary checkout for canonical writes and ready-state validation. Also restored fail-closed duplicate detection by rejecting stale worktree-local duplicates that match the same issue identity before a second canonical bundle can be created, then published the issue branch as draft PR `#4381`.

## Artifacts
- Local issue-bundle review and execution records at:
  - `.adl/v0.91.6/tasks/issue-4378__v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees/srp.md`
  - `.adl/v0.91.6/tasks/issue-4378__v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd_prompt.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- Additional proof artifacts: `none; proof was captured through focused cargo test commands recorded below`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_from_disposable_worktree_ -- --nocapture`
    `Verified the disposable-worktree create behavior directly, including both the canonical-write and stale-duplicate fail-closed regressions.`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_ -- --nocapture`
    `Verified the broader focused create-path regression slice after the lifecycle fix and duplicate-detection repair landed.`
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh doctor 4378 --json`
    `Verified bound issue readiness and truthful lifecycle state before PR preparation.`
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh finish 4378 --title "tooling: preserve child issue bundles created from disposable worktrees" --output-card .adl/v0.91.6/tasks/issue-4378__v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees/sor.md --paths "adl/src/cli/pr_cmd.rs,adl/src/cli/pr_cmd_prompt.rs,adl/src/cli/tests/pr_cmd_inline/basics.rs"`
    `Verified the finish/publication lane, including output-card validation, issue-branch commit/push, and draft PR creation for the tracked implementation files.`
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh validation https://github.com/danielbaustin/agent-design-language/pull/4381 --json`
    `Verified the initial live GitHub validation snapshot for draft PR #4381 after publication.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4378__v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4378__v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees/sor.md
- Idempotency-Key: v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-prompt-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-v0-91-6-tasks-issue-4378-v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees-sip-md-adl-v0-91-6-tasks-issue-4378-v0-91-6-tooling-preserve-child-issue-bundles-created-from-disposable-worktrees-sor-md