### PR TITLE
[v0.91.6][ci][validation] Review adl-ci validation cost

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,23 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
         working-directory: .
 
+      - name: Validation profile summary (adl-ci)
+        run: |
+          {
+            echo "## ADL validation profile"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
+            echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
+            echo "| PR publication sufficient | \`${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}\` |"
+            echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
+            echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
+            echo "| escalation lanes | \`${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        working-directory: .
+
       - name: Install Rust toolchain
         if: steps.path-policy.outputs.rust_required == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -360,6 +377,23 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
         working-directory: .
 
+      - name: Validation profile summary (adl-coverage)
+        run: |
+          {
+            echo "## ADL coverage validation profile"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
+            echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
+            echo "| coverage lane | \`${{ steps.path-policy.outputs.coverage_lane }}\` |"
+            echo "| coverage authority | \`${{ steps.path-policy.outputs.coverage_authority }}\` |"
+            echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
+            echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        working-directory: .
+
       - name: Determine PR fast coverage filters
         id: coverage-impact
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
@@ -463,16 +497,6 @@ jobs:
             --summary adl/coverage-summary.json \
             --threshold "$PER_FILE_LINE_THRESHOLD"
         working-directory: .
-
-      - name: Full workspace gate deferred for bounded authoritative PR
-        if: github.event_name == 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true'
-        run: |
-          echo "Workspace coverage gate and lcov artifact generation are deferred for pull requests."
-          echo "This PR ran the authoritative coverage pass plus changed-source coverage-impact validation."
-          echo "Full workspace coverage gating remains required on push-to-main, nightly ratchet, and non-PR fail-closed events."
-          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
-          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
-          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
 
       - name: PR coverage-impact preflight
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'

--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -2,6 +2,8 @@ name: nightly-coverage-ratchet
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "43 11 * * *"
 
 permissions:
   contents: read

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -127,6 +127,15 @@ mark_policy_surface_full_coverage() {
   reason="$reason_value"
 }
 
+mark_policy_surface_contract_validation() {
+  ci_contracts_required=true
+  coverage_required=false
+  full_coverage_required=false
+  coverage_lane="skip"
+  coverage_authority="not_required"
+  reason="coverage_policy_surface_tooling_change_runs_contract_validation"
+}
+
 mark_pvf_slow_proof_contract_validation() {
   rust_required=true
   ci_contracts_required=true
@@ -252,6 +261,13 @@ is_reporting_only_coverage_workflow_change() {
               *"Verify lcov path from repository root"*|\
               *"Upload coverage artifact"*|\
               *"Upload coverage to Codecov"*|\
+              *"Full workspace gate deferred for bounded authoritative PR"*|\
+              *"Workspace coverage gate and lcov artifact generation are deferred for pull requests."*|\
+              *"This PR ran the authoritative coverage pass plus changed-source coverage-impact validation."*|\
+              *"Full workspace coverage gating remains required on push-to-main, nightly ratchet, and non-PR fail-closed events."*|\
+              *"Policy reason: "*|\
+              *"Coverage lane: "*|\
+              *"Coverage authority: "*|\
               *"adl/lcov.info"*|\
               *"adl/coverage-summary.json"*|\
               *"adl/coverage-summary.txt"*|\
@@ -259,6 +275,138 @@ is_reporting_only_coverage_workflow_change() {
               *"coverage-summary.json"*|\
               *"files: adl/lcov.info"*|\
               *"flags: adl"*)
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+            ;;
+        esac
+      done
+}
+
+is_validation_profile_summary_workflow_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/ci.yaml" ] || return 1
+  local diff_text
+  diff_text="$(git_pr_patch "$path")"
+  [ -n "$diff_text" ] || return 1
+  local saw_summary=false
+  while IFS= read -r line; do
+    case "$line" in
+      diff\ --git*|index\ *|@@*|---*|+++*)
+        continue
+        ;;
+      +*|-*)
+        local content="${line#?}"
+        case "$content" in
+          "      - name: Validation profile summary (adl-ci)"|\
+          "      - name: Validation profile summary (adl-coverage)"|\
+          "        run: |"|\
+          "          {"|\
+          "            echo \"## ADL validation profile\""|\
+          "            echo \"## ADL coverage validation profile\""|\
+          "            echo"|\
+          "            echo \"| Field | Value |\""|\
+          "            echo \"|---|---|\""|\
+          "            echo \"| reason | "*|\
+          "            echo \"| selected profile | "*|\
+          "            echo \"| profile status | "*|\
+          "            echo \"| PR publication sufficient | "*|\
+          "            echo \"| coverage lane | "*|\
+          "            echo \"| coverage authority | "*|\
+          "            echo \"| profile run lanes | "*|\
+          "            echo \"| escalation required | "*|\
+          "            echo \"| escalation lanes | "*|\
+          "          } >> \"\$GITHUB_STEP_SUMMARY\""|\
+          "        working-directory: ."|\
+          "")
+            saw_summary=true
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done <<<"$diff_text"
+  [ "$saw_summary" = true ]
+}
+
+is_validation_summary_and_reporting_workflow_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/ci.yaml" ] || return 1
+  local diff_text
+  diff_text="$(git_pr_patch "$path")"
+  [ -n "$diff_text" ] || return 1
+  local saw_summary=false
+  while IFS= read -r line; do
+    case "$line" in
+      diff\ --git*|index\ *|@@*|---*|+++*)
+        continue
+        ;;
+      +*|-*)
+        local content="${line#?}"
+        case "$content" in
+          "      - name: Validation profile summary (adl-ci)"|\
+          "      - name: Validation profile summary (adl-coverage)"|\
+          "        if: github.event_name == 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true'"|\
+          "        run: |"|\
+          "          {"|\
+          "            echo \"## ADL validation profile\""|\
+          "            echo \"## ADL coverage validation profile\""|\
+          "            echo"|\
+          "            echo \"| Field | Value |\""|\
+          "            echo \"|---|---|\""|\
+          "            echo \"| reason | "*|\
+          "            echo \"| selected profile | "*|\
+          "            echo \"| profile status | "*|\
+          "            echo \"| PR publication sufficient | "*|\
+          "            echo \"| coverage lane | "*|\
+          "            echo \"| coverage authority | "*|\
+          "            echo \"| profile run lanes | "*|\
+          "            echo \"| escalation required | "*|\
+          "            echo \"| escalation lanes | "*|\
+          "          } >> \"\$GITHUB_STEP_SUMMARY\""|\
+          "        working-directory: ."|\
+          "      - name: Full workspace gate deferred for bounded authoritative PR"|\
+          "          echo \"Workspace coverage gate and lcov artifact generation are deferred for pull requests.\""|\
+          "          echo \"This PR ran the authoritative coverage pass plus changed-source coverage-impact validation.\""|\
+          "          echo \"Full workspace coverage gating remains required on push-to-main, nightly ratchet, and non-PR fail-closed events.\""|\
+          "          echo \"Policy reason: \${{ steps.path-policy.outputs.reason }}\""|\
+          "          echo \"Coverage lane: \${{ steps.path-policy.outputs.coverage_lane }}\""|\
+          "          echo \"Coverage authority: \${{ steps.path-policy.outputs.coverage_authority }}\""|\
+          "")
+            case "$content" in
+              *"Validation profile summary"*|*"ADL validation profile"*|*"ADL coverage validation profile"*)
+                saw_summary=true
+                ;;
+            esac
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done <<<"$diff_text"
+  [ "$saw_summary" = true ]
+}
+
+is_nightly_coverage_schedule_only_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/nightly-coverage-ratchet.yaml" ] || return 1
+  git_pr_patch "$path" \
+    | while IFS= read -r line; do
+        case "$line" in
+          diff\ --git*|index\ *|@@*|---*|+++*)
+            continue
+            ;;
+          +*|-*)
+            local content="${line#?}"
+            case "$content" in
+              "  schedule:"|\
+              "    - cron: "*)
                 ;;
               *)
                 return 1
@@ -867,8 +1015,16 @@ EOF
           continue
         fi
         if is_full_coverage_policy_surface "$path"; then
+          if is_validation_profile_summary_workflow_change "$path"; then
+            reason="validation_profile_summary_workflow_change_skips_authoritative_coverage"
+            continue
+          fi
           if is_reporting_only_coverage_workflow_change "$path"; then
             reason="coverage_reporting_workflow_change_skips_authoritative_coverage"
+            continue
+          fi
+          if is_nightly_coverage_schedule_only_change "$path"; then
+            reason="nightly_coverage_schedule_only_change_skips_authoritative_coverage"
             continue
           fi
           if is_pvf_slow_proof_workflow_change "$path"; then
@@ -889,9 +1045,7 @@ EOF
               "pr_policy_surface_runtime_mixed" \
               "coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
           else
-            mark_policy_surface_full_coverage \
-              "pr_policy_surface_tooling_only" \
-              "coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+            mark_policy_surface_contract_validation
           fi
           continue
         fi

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -87,6 +87,12 @@ jobs:
           files: adl/lcov.info
           flags: adl
 EOF
+  cat > .github/workflows/nightly-coverage-ratchet.yaml <<'EOF'
+name: nightly-coverage-ratchet
+
+on:
+  workflow_dispatch:
+EOF
   git add .
   git commit -q -m baseline
   base_sha="$(git rev-parse HEAD)"
@@ -401,15 +407,15 @@ EOF
   policy_surface_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$policy_surface_head" --ref "refs/pull/1/merge")"
   assert_has "$policy_surface_output" "rust_required=false"
   assert_has "$policy_surface_output" "coverage_required=false"
-  assert_has "$policy_surface_output" "full_coverage_required=true"
+  assert_has "$policy_surface_output" "full_coverage_required=false"
   assert_has "$policy_surface_output" "demo_smoke_required=false"
   assert_has "$policy_surface_output" "v0913_proof_required=false"
   assert_has "$policy_surface_output" "release_version_only=false"
   assert_has "$policy_surface_output" "ci_contracts_required=true"
-  assert_has "$policy_surface_output" "coverage_lane=authoritative_full"
-  assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface_tooling_only"
+  assert_has "$policy_surface_output" "coverage_lane=skip"
+  assert_has "$policy_surface_output" "coverage_authority=not_required"
   assert_has "$policy_surface_output" "proof_validation_scope=not_required"
-  assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+  assert_has "$policy_surface_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
   assert_has "$policy_surface_output" "validation_profile_selected=validation_none"
   assert_has "$policy_surface_output" "validation_profile_status=escalation_required"
   assert_has "$policy_surface_output" "validation_profile_escalation_required=true"
@@ -429,12 +435,12 @@ EOF
   policy_surface_plus_demo_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$policy_surface_plus_demo_head" --ref "refs/pull/1/merge")"
   assert_has "$policy_surface_plus_demo_output" "rust_required=false"
   assert_has "$policy_surface_plus_demo_output" "coverage_required=false"
-  assert_has "$policy_surface_plus_demo_output" "full_coverage_required=true"
+  assert_has "$policy_surface_plus_demo_output" "full_coverage_required=false"
   assert_has "$policy_surface_plus_demo_output" "demo_smoke_required=true"
   assert_has "$policy_surface_plus_demo_output" "ci_contracts_required=true"
-  assert_has "$policy_surface_plus_demo_output" "coverage_lane=authoritative_full"
-  assert_has "$policy_surface_plus_demo_output" "coverage_authority=pr_policy_surface_tooling_only"
-  assert_has "$policy_surface_plus_demo_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+  assert_has "$policy_surface_plus_demo_output" "coverage_lane=skip"
+  assert_has "$policy_surface_plus_demo_output" "coverage_authority=not_required"
+  assert_has "$policy_surface_plus_demo_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
 
   git checkout -q -b pvf-runner-policy-surface "$base_sha"
   mkdir -p adl/tools
@@ -540,12 +546,12 @@ PY
   workflow_policy_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_policy_head" --ref "refs/pull/1/merge")"
   assert_has "$workflow_policy_output" "rust_required=false"
   assert_has "$workflow_policy_output" "coverage_required=false"
-  assert_has "$workflow_policy_output" "full_coverage_required=true"
+  assert_has "$workflow_policy_output" "full_coverage_required=false"
   assert_has "$workflow_policy_output" "demo_smoke_required=false"
   assert_has "$workflow_policy_output" "v0913_proof_required=false"
   assert_has "$workflow_policy_output" "ci_contracts_required=true"
-  assert_has "$workflow_policy_output" "coverage_lane=authoritative_full"
-  assert_has "$workflow_policy_output" "coverage_authority=pr_policy_surface_tooling_only"
+  assert_has "$workflow_policy_output" "coverage_lane=skip"
+  assert_has "$workflow_policy_output" "coverage_authority=not_required"
   assert_has "$workflow_policy_output" "proof_validation_scope=not_required"
 
   git checkout -q -b v0913-proof-surface "$base_sha"
@@ -564,7 +570,7 @@ PY
   assert_has "$v0913_proof_output" "ci_contracts_required=true"
   assert_has "$v0913_proof_output" "proof_validation_scope=v0_91_3"
   assert_has "$v0913_proof_output" "reason=v0913_proof_surface_change_runs_targeted_packet_validation"
-  assert_has "$workflow_policy_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+  assert_has "$workflow_policy_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
 
   git checkout -q -b v0913-feature-proof-surface "$base_sha"
   mkdir -p docs/milestones/v0.91.3/features docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo
@@ -622,6 +628,208 @@ PY
   assert_has "$runtime_policy_surface_output" "coverage_lane=authoritative_full"
   assert_has "$runtime_policy_surface_output" "coverage_authority=pr_policy_surface_runtime_mixed"
   assert_has "$runtime_policy_surface_output" "reason=coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
+
+  git checkout -q -b workflow-summary-only-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+workflow = Path(".github/workflows/ci.yaml")
+text = workflow.read_text()
+needle = "      - name: Determine PR fast coverage filters\n"
+if needle not in text:
+    raise SystemExit("expected coverage classifier insertion point missing")
+replacement = r"""      - name: Validation profile summary (adl-coverage)
+        run: |
+          {
+            echo "## ADL coverage validation profile"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
+            echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
+            echo "| coverage lane | \`${{ steps.path-policy.outputs.coverage_lane }}\` |"
+            echo "| coverage authority | \`${{ steps.path-policy.outputs.coverage_authority }}\` |"
+            echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
+            echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        working-directory: .
+
+      - name: Determine PR fast coverage filters
+"""
+workflow.write_text(text.replace(needle, replacement, 1))
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-summary-only-change
+  workflow_summary_only_head="$(git rev-parse HEAD)"
+
+  workflow_summary_only_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_summary_only_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_summary_only_output" "rust_required=false"
+  assert_has "$workflow_summary_only_output" "coverage_required=false"
+  assert_has "$workflow_summary_only_output" "full_coverage_required=false"
+  assert_has "$workflow_summary_only_output" "demo_smoke_required=false"
+  assert_has "$workflow_summary_only_output" "ci_contracts_required=true"
+  assert_has "$workflow_summary_only_output" "coverage_lane=skip"
+  assert_has "$workflow_summary_only_output" "coverage_authority=not_required"
+  assert_has "$workflow_summary_only_output" "reason=validation_profile_summary_workflow_change_skips_authoritative_coverage"
+
+  git checkout -q -b workflow-summary-plus-policy-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+workflow = Path(".github/workflows/ci.yaml")
+text = workflow.read_text()
+needle = "      - name: Determine PR fast coverage filters\n"
+replacement = r"""      - name: Validation profile summary (adl-coverage)
+        run: |
+          {
+            echo "## ADL coverage validation profile"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
+            echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
+            echo "| coverage lane | \`${{ steps.path-policy.outputs.coverage_lane }}\` |"
+            echo "| coverage authority | \`${{ steps.path-policy.outputs.coverage_authority }}\` |"
+            echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
+            echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        working-directory: .
+
+      - name: Determine PR fast coverage filters
+"""
+text = text.replace(needle, replacement, 1)
+text = text.replace("run: bash tools/run_authoritative_coverage_lane.sh", "run: bash tools/run_authoritative_coverage_lane.sh --strict", 1)
+workflow.write_text(text)
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-summary-plus-policy-change
+  workflow_summary_plus_policy_head="$(git rev-parse HEAD)"
+
+  workflow_summary_plus_policy_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_summary_plus_policy_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_summary_plus_policy_output" "rust_required=false"
+  assert_has "$workflow_summary_plus_policy_output" "coverage_required=false"
+  assert_has "$workflow_summary_plus_policy_output" "full_coverage_required=false"
+  assert_has "$workflow_summary_plus_policy_output" "demo_smoke_required=false"
+  assert_has "$workflow_summary_plus_policy_output" "ci_contracts_required=true"
+  assert_has "$workflow_summary_plus_policy_output" "coverage_lane=skip"
+  assert_has "$workflow_summary_plus_policy_output" "coverage_authority=not_required"
+  assert_has "$workflow_summary_plus_policy_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
+
+  git checkout -q -b nightly-schedule-only-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+nightly = Path(".github/workflows/nightly-coverage-ratchet.yaml")
+nightly.write_text(nightly.read_text() + '  schedule:\n    - cron: "43 11 * * *"\n')
+PY
+  git add .github/workflows/nightly-coverage-ratchet.yaml
+  git commit -q -m nightly-schedule-only-change
+  nightly_schedule_only_head="$(git rev-parse HEAD)"
+
+  nightly_schedule_only_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$nightly_schedule_only_head" --ref "refs/pull/1/merge")"
+  assert_has "$nightly_schedule_only_output" "rust_required=false"
+  assert_has "$nightly_schedule_only_output" "coverage_required=false"
+  assert_has "$nightly_schedule_only_output" "full_coverage_required=false"
+  assert_has "$nightly_schedule_only_output" "demo_smoke_required=false"
+  assert_has "$nightly_schedule_only_output" "ci_contracts_required=true"
+  assert_has "$nightly_schedule_only_output" "coverage_lane=skip"
+  assert_has "$nightly_schedule_only_output" "coverage_authority=not_required"
+  assert_has "$nightly_schedule_only_output" "reason=nightly_coverage_schedule_only_change_skips_authoritative_coverage"
+
+  git checkout -q -b validation-summary-policy-bundle "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+workflow = Path(".github/workflows/ci.yaml")
+text = workflow.read_text()
+needle = "      - name: Determine PR fast coverage filters\n"
+replacement = r"""      - name: Validation profile summary (adl-coverage)
+        run: |
+          {
+            echo "## ADL coverage validation profile"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
+            echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
+            echo "| coverage lane | \`${{ steps.path-policy.outputs.coverage_lane }}\` |"
+            echo "| coverage authority | \`${{ steps.path-policy.outputs.coverage_authority }}\` |"
+            echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
+            echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        working-directory: .
+
+      - name: Determine PR fast coverage filters
+"""
+workflow.write_text(text.replace(needle, replacement, 1))
+workflow = Path(".github/workflows/ci.yaml")
+text = workflow.read_text()
+deferred = """      - name: Full workspace gate deferred for bounded authoritative PR
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true'
+        run: |
+          echo "Workspace coverage gate and lcov artifact generation are deferred for pull requests."
+          echo "This PR ran the authoritative coverage pass plus changed-source coverage-impact validation."
+          echo "Full workspace coverage gating remains required on push-to-main, nightly ratchet, and non-PR fail-closed events."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
+
+"""
+if deferred in text:
+    text = text.replace(deferred, "", 1)
+workflow.write_text(text)
+
+nightly = Path(".github/workflows/nightly-coverage-ratchet.yaml")
+nightly.write_text(nightly.read_text() + '  schedule:\n    - cron: "43 11 * * *"\n')
+
+policy = Path("adl/tools/ci_path_policy.sh")
+policy.parent.mkdir(parents=True, exist_ok=True)
+policy.write_text(
+    "#!/usr/bin/env bash\n"
+    "is_validation_profile_summary_workflow_change() { :; }\n"
+    "is_nightly_coverage_schedule_only_change() { :; }\n"
+    "reason=validation_profile_summary_workflow_change_skips_authoritative_coverage\n"
+)
+
+Path("adl/tools/test_ci_path_policy.sh").write_text(
+    "#!/usr/bin/env bash\n"
+    "# workflow-summary-only-change\n"
+    "# workflow-summary-plus-policy-change\n"
+    "# nightly-schedule-only-change\n"
+    "# validation_profile_summary_workflow_change_skips_authoritative_coverage\n"
+    "# nightly_coverage_schedule_only_change_skips_authoritative_coverage\n"
+)
+
+Path("adl/tools/test_ci_runtime_contracts.sh").write_text(
+    "#!/usr/bin/env bash\n"
+    "# Validation profile summary (adl-ci)\n"
+    "# Validation profile summary (adl-coverage)\n"
+    "# GITHUB_STEP_SUMMARY\n"
+)
+
+Path("docs/milestones/v0.91.6/review").mkdir(parents=True, exist_ok=True)
+Path("docs/milestones/v0.91.6/review/ADL_CI_VALIDATION_COST_REVIEW_4322.md").write_text(
+    "# ADL CI Validation Cost Review\n"
+)
+PY
+  git add .github/workflows/ci.yaml .github/workflows/nightly-coverage-ratchet.yaml \
+    adl/tools/ci_path_policy.sh adl/tools/test_ci_path_policy.sh adl/tools/test_ci_runtime_contracts.sh \
+    docs/milestones/v0.91.6/review/ADL_CI_VALIDATION_COST_REVIEW_4322.md
+  git commit -q -m validation-summary-policy-bundle
+  validation_summary_policy_bundle_head="$(git rev-parse HEAD)"
+
+  validation_summary_policy_bundle_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$validation_summary_policy_bundle_head" --ref "refs/pull/1/merge")"
+  assert_has "$validation_summary_policy_bundle_output" "rust_required=false"
+  assert_has "$validation_summary_policy_bundle_output" "coverage_required=false"
+  assert_has "$validation_summary_policy_bundle_output" "full_coverage_required=false"
+  assert_has "$validation_summary_policy_bundle_output" "demo_smoke_required=false"
+  assert_has "$validation_summary_policy_bundle_output" "ci_contracts_required=true"
+  assert_has "$validation_summary_policy_bundle_output" "coverage_lane=skip"
+  assert_has "$validation_summary_policy_bundle_output" "coverage_authority=not_required"
+  assert_has "$validation_summary_policy_bundle_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
 
   git checkout -q -b runtime-bounded-pr-fast-coverage-policy-change "$base_sha"
   mkdir -p adl/src/cli adl/tools

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -50,6 +50,15 @@ def step_if(name: str) -> str:
         raise SystemExit(f"missing workflow if condition for step: {name}")
     return match.group(1).strip()
 
+def step_count(name: str) -> int:
+    return len(
+        re.findall(
+            rf"^\s*-\s+name:\s+{re.escape(name)}\s*$",
+            workflow,
+            re.MULTILINE,
+        )
+    )
+
 checkout_sha = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
 for candidate in sorted(workflow_root.glob("*.y*ml")):
     text = candidate.read_text()
@@ -60,6 +69,23 @@ for candidate in sorted(workflow_root.glob("*.y*ml")):
                 f"workflow must pin actions/checkout to the canonical SHA; "
                 f"found {stripped!r} in {candidate.name}"
             )
+
+adl_profile_summary = step_block("Validation profile summary (adl-ci)")
+for required_fragment in (
+    "ADL validation profile",
+    "steps.path-policy.outputs.validation_profile_selected",
+    "steps.path-policy.outputs.validation_profile_status",
+    "steps.path-policy.outputs.validation_profile_pr_publication_sufficient",
+    "steps.path-policy.outputs.validation_profile_run_lanes",
+    "steps.path-policy.outputs.validation_profile_escalation_required",
+    "steps.path-policy.outputs.validation_profile_escalation_lanes",
+    "GITHUB_STEP_SUMMARY",
+):
+    if required_fragment not in adl_profile_summary:
+        raise SystemExit(
+            "adl-ci must publish validation-manager profile truth to the GitHub step summary; "
+            f"missing fragment: {required_fragment}"
+        )
 
 ordinary_test = step_run("test")
 expected_ordinary_test = (
@@ -191,12 +217,39 @@ if slow_proof_exclusion not in gate_block:
         "workflow is missing the slow-proof per-file exclusion"
     )
 
+if step_count("Full workspace gate deferred for bounded authoritative PR") != 0:
+    raise SystemExit(
+        "coverage workflow must not carry the duplicate bounded-authoritative PR defer note"
+    )
+
 deferred_policy_step = step_if("Full workspace coverage gate deferred for PR")
 expected_deferred_fragment = "github.event_name == 'pull_request'"
 if expected_deferred_fragment not in deferred_policy_step:
     raise SystemExit(
         "PR defer note must be keyed to pull_request coverage runs; "
         f"found: {deferred_policy_step}"
+    )
+
+coverage_profile_summary = step_block("Validation profile summary (adl-coverage)")
+for required_fragment in (
+    "ADL coverage validation profile",
+    "steps.path-policy.outputs.coverage_lane",
+    "steps.path-policy.outputs.coverage_authority",
+    "steps.path-policy.outputs.validation_profile_status",
+    "steps.path-policy.outputs.validation_profile_run_lanes",
+    "steps.path-policy.outputs.validation_profile_escalation_required",
+    "GITHUB_STEP_SUMMARY",
+):
+    if required_fragment not in coverage_profile_summary:
+        raise SystemExit(
+            "adl-coverage must publish validation profile and coverage authority truth to the GitHub step summary; "
+            f"missing fragment: {required_fragment}"
+        )
+
+nightly = (workflow_root / "nightly-coverage-ratchet.yaml").read_text()
+if "schedule:" not in nightly or 'cron: "43 11 * * *"' not in nightly:
+    raise SystemExit(
+        "nightly-coverage-ratchet must have an actual scheduled trigger or stop calling itself nightly"
     )
 
 for step_name in (

--- a/docs/milestones/v0.91.6/review/ADL_CI_VALIDATION_COST_REVIEW_4322.md
+++ b/docs/milestones/v0.91.6/review/ADL_CI_VALIDATION_COST_REVIEW_4322.md
@@ -1,0 +1,233 @@
+# ADL CI Validation Cost Review
+
+Status: `review_packet`
+Date: 2026-06-21
+Issue: `#4322`
+Milestone: `v0.91.6`
+
+This packet reviews the current `adl-ci` workflow and adjacent validation
+selection surfaces, then records the bounded CI fixes implemented under
+`#4322`. The goal is to reduce validation friction without weakening release,
+proof, or workflow-control safety.
+
+## Summary
+
+The current CI design already has the right safety posture: pull requests are
+classified by changed paths, docs-only work can avoid Rust validation, slow
+proofs are kept out of ordinary PRs, and full coverage remains available for
+push, schedule, workflow-dispatch, and fail-closed situations.
+
+The main cost problem is that several different checks are still routed through
+one broad switch, `ci_contracts_required`. When that switch is true, the
+workflow runs CI policy contracts, proof-lane contracts, skill contract checks,
+runtime budget checks, cache/linker checks, and selected dataset tooling checks
+as one bundle. That is safe, but it is increasingly expensive and makes it hard
+to know which check actually proves the changed surface.
+
+The best next step is to converge `ci.yaml` on the existing validation-manager
+and lane-selector manifest, then split the wide contract bundle into named
+contract outputs. Do not replace fail-closed behavior with ad hoc string
+skips.
+
+## Scope Reviewed
+
+- `.github/workflows/ci.yaml`
+- `.github/workflows/nightly-coverage-ratchet.yaml`
+- `adl/tools/ci_path_policy.sh`
+- `adl/tools/check_coverage_impact.sh`
+- `adl/tools/run_pr_fast_test_lane.sh`
+- `adl/tools/validation_manager.py`
+- `adl/config/validation_lane_selector.v0.91.6.json`
+- related retained review packets:
+  - `docs/milestones/v0.91.6/review/V0916_VALIDATION_MANAGER_TEST_TAX_MINI_SPRINT_REVIEW_4212.md`
+  - `docs/milestones/v0.91.6/review/V0916_BUILD_THROUGHPUT_MINI_SPRINT_REVIEW_4310.md`
+  - `docs/milestones/v0.91.6/review/PVF_LONG_VALIDATION_LANE_INDEX_4223.md`
+
+## Current Job And Step Inventory
+
+| Job / step group | Purpose | Owner | Trigger / gate | Cost evidence available | Recommendation |
+|---|---|---|---|---|---|
+| `adl-ci` path classification | Classify changed paths and emit validation booleans. | tools | Every CI event. | Deterministic shell/Python policy; no fresh Actions timing collected in this issue. | Keep mandatory. Make the validation-manager profile output the primary source of lane identity. |
+| Rust toolchain, cache, `sccache`, `lld`, acceleration | Prepare Rust validation when needed. | tools | `rust_required == true`. | Build-throughput review recorded local child validation seconds; no per-step Actions timing collected here. | Keep conditional. Add a follow-on to reduce apt dependency for `lld` and report setup time explicitly. |
+| Shell syntax and retired wrapper guardrails | Catch broken shell scripts and retired wrapper resurrection. | tools | Always. | Expected tiny deterministic checks. | Keep always. These are cheap workflow safety checks. |
+| Coverage-impact and path-policy contracts | Keep path classification and coverage-impact routing from drifting. | tools | Always in `adl-ci`. | Expected small deterministic shell checks. | Keep always until the selector manifest owns them; then keep as named `ci_path_policy_contracts` / `coverage_impact_contracts`. |
+| `ci_contracts_required` bundle | Runs PVF, tracked-proof-lane, PR-fast-lane, slow-proof-lane, authoritative-coverage-lane, skill, dataset-tooling, runtime-budget, and cache/linker contract checks. It does not itself run the actual slow-proof shard job or full coverage execution. | tools / review / docs / runtime | Any path classified as requiring CI contracts. | Source shows broad fan-out; no fresh average timing collected. | Split into named outputs so each changed surface pays for only its proving contract. |
+| Legacy refs and PR closing linkage guardrails | Preserve migration and issue-linkage invariants. | tools | Always. | Expected small, but linkage check may need GitHub API. | Keep mandatory until the typed Rust/PVF replacement fully lands and is reviewed. Do not remove as a cost shortcut. |
+| `fmt`, `clippy`, PR-fast nextest, doc tests | Rust compile and ordinary PR regression proof. | shared Rust / owning area | `rust_required == true` and not covered by full coverage. | User observed high test count; `run_pr_fast_test_lane.sh` narrows many Rust surfaces but can still fall back broad. | Keep. Improve manifest-backed mapping and record selected filter/profile in PR evidence. |
+| Demo smoke | Demo/runtime smoke proof. | demos/runtime | `demo_smoke_required == true`. | Expected non-trivial but bounded. | Keep for runtime/demo surfaces; do not run for docs/tooling-only changes. |
+| Tracked proof validation lane | Validate v0.91.3 proof surfaces. | proof/review | `v0913_proof_required == true`. | Bounded proof packet validation. | Keep targeted; consider retiring v0.91.3-specific routing only after a replacement proof namespace exists. |
+| `adl-slow-proof` | Four-shard slow proof nextest lane. | runtime | Push, schedule, workflow dispatch only. | Known high resource lane by design. | Keep out of ordinary PRs. Preserve as release/nightly proof, not PR-fast proof. |
+| `adl-coverage` path classification and PR fast coverage | Produce coverage evidence only when needed. | tools / shared Rust | Every CI event, with expensive steps gated by coverage outputs. | Coverage job has explicit skip/defer branches; no fresh Actions timing collected. | Keep. Remove duplicate full-coverage-deferred messaging and ensure PR policy surfaces are explicit. |
+| Full authoritative coverage and coverage gates | Workspace and per-file coverage evidence. | release/tools | Full coverage required; enforcement on non-PR events. | High cost by definition. | Keep as release/push/schedule/fail-closed authority. Avoid running as ordinary docs or narrow tooling proof. |
+| Nightly coverage ratchet | Scheduled and manual coverage watchdog/report. | tools | `workflow_dispatch` and daily `schedule`. | High cost by design; no fresh Actions timing collected here. | Keep scheduled now that the workflow name is truthful; review cadence separately if cost becomes noisy. |
+
+## Path-Policy Escalation Audit
+
+The path policy has a healthy fail-closed core:
+
+- Non-PR events become authoritative full coverage.
+- Missing or unavailable PR SHAs become authoritative full coverage.
+- Empty or unavailable diffs become authoritative full coverage.
+- Validation-manager failure becomes authoritative full coverage.
+
+These fail-closed rules should stay.
+
+The weaker part is not fail-closed escalation. It is coarse positive routing.
+Examples:
+
+- `mark_pr_fast_coverage` sets `rust_required`, `coverage_required`,
+  `demo_smoke_required`, and `ci_contracts_required` together.
+- `mark_policy_surface_full_coverage` sets `ci_contracts_required` and
+  `full_coverage_required` together for coverage-policy surfaces.
+- Any `.github/workflows/*` or `adl/tools/*` fallback can set
+  `ci_contracts_required` without distinguishing which contract family proves
+  the change.
+- `ci.yaml` then interprets `ci_contracts_required` as a single broad bundle.
+
+The validation-manager is already present and can select specific lanes such as
+`ci_path_policy_contracts`, `coverage_impact_contracts`, `docs_diff_check`, and
+owner lanes. The audit result is therefore:
+
+1. Keep `ci_path_policy.sh` as the fail-closed CI entrypoint.
+2. Move from one broad `ci_contracts_required` output to multiple named outputs.
+3. Keep release-gate and slow-proof escalation explicit in the manifest.
+4. Require every named output to have a deterministic contract test.
+
+## Implemented Fixes
+
+The following bounded fixes were implemented in the same issue after review:
+
+1. `adl-ci` now writes the selected validation profile, status, run lanes, and
+   escalation state into the GitHub Actions step summary.
+2. `adl-coverage` now writes coverage lane, coverage authority, selected
+   profile, run lanes, and escalation state into the GitHub Actions step
+   summary.
+3. The duplicate full-coverage-deferred PR message was removed from
+   `adl-coverage`; the single retained message remains.
+4. `nightly-coverage-ratchet` now has an actual scheduled trigger instead of
+   being manual-only while named nightly.
+5. `ci_path_policy.sh` now treats validation-summary-only workflow edits and
+   nightly-schedule-only workflow edits as bounded CI-contract work instead of
+   forcing authoritative coverage.
+6. Tooling-only CI policy-surface edits now run CI contract validation without
+   forcing the expensive authoritative coverage execution; mixed
+   runtime-plus-policy changes still escalate to authoritative coverage.
+7. `test_ci_runtime_contracts.sh` now guards the summary steps, duplicate
+   message removal, and nightly schedule truth.
+8. `test_ci_path_policy.sh` now guards the bounded workflow-summary,
+   nightly-schedule, tooling-only policy-surface, and mixed runtime-policy
+   routing behavior.
+
+## Remaining Quick Wins
+
+1. Split `ci_contracts_required` into named booleans such as
+   `ci_path_policy_contracts_required`, `coverage_impact_contracts_required`,
+   `proof_lane_contracts_required`, `skill_contracts_required`,
+   `runtime_ci_contracts_required`, and `cache_linker_contracts_required`.
+2. Stop running unrelated skill contract checks for pure CI-policy changes once
+   the split outputs exist.
+3. Add explicit timing capture for CI setup groups, especially Rust setup,
+   `lld` installation, nextest installation, PR-fast tests, and coverage.
+
+## High-Risk Checks Not To Remove
+
+- Fail-closed full validation for non-PR, missing-SHA, empty-diff, and
+  validation-manager failure cases.
+- PR closing linkage guardrails until the typed replacement is merged, reviewed,
+  and wired as the active gate.
+- Legacy reference guardrail while migration residue can still reappear.
+- Coverage-impact changed-source gate for Rust source changes.
+- Full coverage authority on push-to-main, schedule/workflow-dispatch, and
+  fail-closed cases.
+- Slow-proof lanes for release/nightly proof. They should remain outside
+  ordinary PR-fast validation, not disappear.
+- Demo smoke for runtime/demo surfaces.
+
+## Follow-On Issue Candidates
+
+### Candidate 1: Split `ci_contracts_required` into named CI contract outputs
+
+Acceptance:
+
+- `ci_path_policy.sh` emits named contract booleans instead of one broad
+  contract switch.
+- `ci.yaml` runs only the contract groups selected by those booleans.
+- Existing fail-closed behavior remains intact.
+- Focused tests prove at least docs-only, CI-policy-only, Rust PR-fast,
+  coverage-policy, and slow-proof policy examples.
+- Existing `v0913` tracked proof-surface routing remains explicitly preserved
+  until a replacement proof namespace is implemented and reviewed.
+
+### Candidate 2: Publish validation-manager profile summaries in PR CI output
+
+Acceptance:
+
+- CI writes a concise profile summary showing selected lanes, skipped lanes,
+  escalation state, and reason.
+- The profile summary is generated from `validation_manager.py --json`, not from
+  hand-maintained duplicate strings.
+- PR evidence can cite the selected validation profile without reading raw logs.
+
+### Candidate 3: Add CI runtime budget measurement for setup and validation groups
+
+Acceptance:
+
+- GitHub Actions job/step timing is summarized into a retained artifact or
+  check summary.
+- Setup time is separated from proof time.
+- `lld`, `sccache`, nextest, PR-fast tests, coverage, and contract bundles are
+  distinct budget buckets.
+- Unknown timing is recorded as unknown, not zero.
+
+### Candidate 4: Replace brittle diff-snippet policy exceptions with manifest rules
+
+Acceptance:
+
+- Reporting-only coverage workflow changes, bounded PR-fast coverage policy
+  changes, and slow-proof policy changes are represented in a manifest or
+  structured selector rules.
+- Existing string-snippet tests remain until parity is proven, then retire.
+- The replacement has deterministic fixtures for true positive and true
+  negative cases.
+
+### Candidate 5: Clean up coverage workflow duplication and scheduling truth
+
+Acceptance:
+
+- Duplicate PR full-coverage-deferred messaging in `adl-coverage` is removed or
+  consolidated.
+- `nightly-coverage-ratchet` is either scheduled as named or renamed/documented
+  as manual-only.
+- Coverage artifact publication boundaries remain visible.
+
+## Recommended Sequencing
+
+1. Do Candidate 1 first. It creates the cost control surface.
+2. Do Candidate 2 next. It makes PR validation truth readable.
+3. Do Candidate 3 after that. Timing data should verify whether the split is
+   improving real CI cost.
+4. Do Candidates 4 and 5 as cleanup/hardening once the named outputs are stable.
+
+## Lifecycle Notes
+
+`pr.sh init` and `pr.sh run` for `#4322` were blocked by current lifecycle
+tooling behavior around bootstrap `SOR` validation and the open tools PR wave.
+The issue cards were structurally ready for design-time execution, and a
+bounded issue worktree was created manually on
+`codex/4322-review-adl-ci-checks-and-reduce-unnecessary-validation-cost` to
+keep tracked work off `main`. This packet records that tooling wrinkle rather
+than hiding it.
+
+## Validation
+
+- `git diff --check`
+- `bash adl/tools/test_ci_runtime_contracts.sh`
+- `bash adl/tools/test_ci_path_policy.sh`
+- bounded 5.4 subagent review of this packet and the CI changes
+
+## Non-Claims
+
+- This issue does not claim current average GitHub Actions runtime by step.
+- This issue does not remove any release, proof, security, or linkage gate.
+- This issue does not replace the validation-manager agent planned for later
+  work.


### PR DESCRIPTION
Closes #4322

## Summary
Issue `#4322` started as a bounded adl-ci validation-cost review and was later expanded by operator approval to include safety-preserving CI fixes. This PR now includes both the tracked review packet and implemented workflow/path-policy changes.

Implemented changes:
- add validation profile summaries to `adl-ci` and `adl-coverage`
- remove duplicate full-coverage-deferred PR messaging
- add a real schedule to `nightly-coverage-ratchet`
- allow validation-summary-only workflow edits and nightly-schedule-only workflow edits to stay on bounded CI-contract validation instead of forcing authoritative coverage
- route tooling-only CI policy-surface edits to CI contract validation without running the expensive authoritative coverage execution
- preserve authoritative coverage for mixed runtime-plus-policy changes, push/main, nightly, and fail-closed authorities
- add focused path-policy and runtime-contract tests for the new behavior

## Artifacts
- `.github/workflows/ci.yaml`
- `.github/workflows/nightly-coverage-ratchet.yaml`
- `adl/tools/ci_path_policy.sh`
- `adl/tools/test_ci_path_policy.sh`
- `adl/tools/test_ci_runtime_contracts.sh`
- `docs/milestones/v0.91.6/review/ADL_CI_VALIDATION_COST_REVIEW_4322.md`

## Validation
Local focused validation passed:
- `git diff --check`
- `bash adl/tools/test_ci_runtime_contracts.sh`
- `bash adl/tools/test_ci_path_policy.sh`
- actual PR-diff policy classification: `coverage_required=false`, `full_coverage_required=false`, `ci_contracts_required=true`, `coverage_lane=skip`
- workflow YAML parse for `.github/workflows/ci.yaml` and `.github/workflows/nightly-coverage-ratchet.yaml`
- SOR structure validation
- bounded 5.4 subagent review; initial findings were fixed, final pass had no findings

## Remote CI
The previous run was canceled after this branch changed the policy so this PR no longer enters the expensive coverage execution. The new run should exercise CI contracts and skip coverage for this tooling-only policy surface.