### PR TITLE
[v0.91.6][planning] Consume C-SDLC integration sprint truth

### DIFF
--- a/docs/milestones/v0.91.7/MILESTONE_CHECKLIST_v0.91.7.md
+++ b/docs/milestones/v0.91.7/MILESTONE_CHECKLIST_v0.91.7.md
@@ -26,7 +26,7 @@ Forward checklist. Items are intentionally unchecked because `v0.91.7` execution
 
 ## Process And Validation Substrate
 
-- [ ] SEP/VPP/PVF/template-version work completed or routed.
+- [ ] v0.91.6 `#4388`-`#4398` C-SDLC integration control-plane sprint completed, blocked, deferred, or routed, including SEP, VPP, PVF/template-version work, GitHub/octocrab convergence, goal metrics, logging, watcher/lifecycle automation, runtime dependency routing, tooling reliability, and FastContext evaluation.
 - [ ] Sprint `/goal`, issue goal, watcher, activity log, and closeout rules are reflected in templates/skills or routed.
 - [ ] PVF/VPP lane assignment can be made during planning or is explicitly deferred.
 - [ ] Time/token/resource accounting fields are scheduled for cards/SORs.

--- a/docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md
+++ b/docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md
@@ -63,6 +63,7 @@ These were open at the source-capture pass and should be explicitly closed, comp
 | `#4329` | Per-issue execution metrics foundation | Required for time/token prediction and issue baselines. |
 | `#4331` | First-class nested goal accounting | Closed input that must be consumed by goal-state and SOR metrics planning. |
 | `#4332` | VPP and PVF lane-template mini-sprint | Required validation-planning sprint; should follow template substrate as needed. |
+| `#4388`-`#4398` | v0.91.6 C-SDLC integration control-plane completion sprint | Required v0.91.6 completion sprint for SEP, VPP, PVF lane configuration, prompt-card templates, GitHub/octocrab convergence, goal metrics, logging, watcher/lifecycle automation, runtime dependency routing, tooling reliability, and FastContext evaluation before v0.92 depends on sprint-scale execution. v0.91.7 should consume the closed/blocked/routed truth from this sprint rather than recreate it as new scope. |
 | `#4368` | v0.91.7 planning docs | This source-capture and planning alignment issue. |
 
 ## Local TBD Inputs To Capture Or Route
@@ -105,7 +106,7 @@ Local `.adl/docs/TBD/` files are ignored planning inputs, not tracked proof. The
 | Theme | Why it matters before v0.92 | Scheduling posture |
 | --- | --- | --- |
 | v0.91.6 closeout and release-tail truth | v0.92 cannot consume incomplete or stale bridge truth. | First gate. |
-| SEP/VPP/PVF and template-version work | Sprint execution, validation planning, and time/token accounting must be predictable. | Early process/tooling sprint. |
+| SEP/VPP/PVF and template-version work | Sprint execution, validation planning, and time/token accounting must be predictable. `#4388`-`#4398` is the v0.91.6 completion sprint and must exit complete, blocked, deferred, or routed before v0.92 relies on sprint-scale execution. | v0.91.6 closeout input consumed by v0.91.7 WP-02/WP-03. |
 | Goal state, nested goals, time/token/resource metrics | v0.92 needs continuity and issue/sprint accounting. | Early process/runtime bridge. |
 | Cognitive scheduler and local-agent acceleration | Premium cognition is now a bottleneck; local/deepseek/hosted agent suitability must route work. | Early scheduler/provider sprint. |
 | Capability envelope and capability-testing boundary | v0.92 memory/identity/birthday evidence depends on knowing what capability envelope, witnesses/receipt, and Aptitude Atlas evidence may or may not claim. | Scheduler/provider and handoff bridge. |
@@ -118,7 +119,7 @@ Local `.adl/docs/TBD/` files are ignored planning inputs, not tracked proof. The
 | Security, CAV, SSM, ACIP/A2A/protobuf | Activation cannot hide governance, protocol, or security residuals. | Security/protocol sprint. |
 | Affect, happiness, Godel mechanics, economics, guilds | Public claims need safe boundaries and future governance routes. | Boundary/decision sprint. |
 | CodeFriend, adapter v2, papers, and publication surfaces | Launch and birthday docs must not silently inherit product or publication commitments from later roadmap rows. | Boundary/decision and launch handoff sprint. |
-| GitHub convergence/control-plane tooling | Sprint execution should know whether octocrab/tooling convergence is complete, blocked, deferred, or routed before relying on it. | Process/tooling bridge. |
+| GitHub convergence/control-plane tooling | Sprint execution should know whether octocrab/tooling convergence is complete, blocked, deferred, or routed before relying on it. `#4388`-`#4398` should consume the remaining GitHub/octocrab, watcher, lifecycle automation, logging, template-edge, and FastContext evaluation defects as one v0.91.6 control-plane completion gate. | v0.91.6 process/tooling bridge consumed by v0.91.7 planning. |
 | Launch/birthday planning | July launch and v0.92 birthday must align without scope explosion. | Closeout/handoff sprint. |
 
 ## Explicit Non-Claims

--- a/docs/milestones/v0.91.7/README.md
+++ b/docs/milestones/v0.91.7/README.md
@@ -30,7 +30,7 @@ This package does not implement runtime features and does not claim `v0.92` acti
 It must convert the remaining major pre-birthday surfaces into reviewable issue routes, sprint structure, feature docs, and handoff truth:
 
 - v0.91.6 closeout truth, ADR release-tail decisions, and release-tail cleanup;
-- SEP, VPP, PVF lane planning, prompt-template versioning, and sprint execution discipline;
+- the v0.91.6 `#4388`-`#4398` C-SDLC integration control-plane completion sprint: SEP, VPP, PVF lane planning, prompt-template versioning, GitHub/octocrab convergence, goal metrics, logging, watcher/lifecycle automation, FastContext evaluation, and sprint execution discipline;
 - goal state, nested goals, per-issue time/token/resource metrics, and predictable execution baselines;
 - cognitive scheduler, cognitive economics, provider suitability, and local-agent acceleration;
 - build throughput, validation manager, remote/local build runners, and CI/test-tax reduction;
@@ -65,7 +65,7 @@ Every surface must exit as one of:
 | Work stream | Required output before v0.92 |
 | --- | --- |
 | Closeout truth | v0.91.6 release-tail and ADR issues closed or routed, with v0.91.7 not inheriting stale truth. |
-| SEP/VPP/PVF | Sprint Execution Packets, VPP, lane registry, template-version changes, and `/goal`/watcher/closeout rules scheduled. |
+| C-SDLC integration control plane | v0.91.6 `#4388` and child issues `#4389`-`#4398` scheduled as the completion sprint for SEP, VPP, PVF lane registry, template-version changes, GitHub/octocrab convergence, goal metrics, logging, `/goal`/watcher/closeout rules, lifecycle automation, and FastContext evaluation; v0.91.7 consumes its closed/blocked/routed truth. |
 | Goal and metrics | Goal state, nested goals, SOR time/token/resource fields, and outlier analysis routes scheduled. |
 | Scheduler and providers | Cognitive scheduler, provider profiles, local/hosted model suitability, and local-agent delegation routes scheduled. |
 | Build and validation throughput | Validation manager, long-test fanout, CI log archive/S3, Nessus/CodeBuild, sccache/linker/target-dir work scheduled. |

--- a/docs/milestones/v0.91.7/SPRINT_PLAN_v0.91.7.md
+++ b/docs/milestones/v0.91.7/SPRINT_PLAN_v0.91.7.md
@@ -33,7 +33,7 @@ Complete the final bridge/readiness tranche before `v0.92` activation refresh. T
 | Order | Sprint / workstream | Primary WPs | Parallelism notes | Status |
 | --- | --- | --- | --- | --- |
 | 1 | Planning promotion, closeout-truth, and ADR release-tail gate | WP-01, WP-02 | Must start first; can run issue-list/source-capture checks and ADR route checks in parallel. | planned |
-| 2 | SEP/VPP/PVF/template process sprint | WP-03, WP-04 | Can run template/schema work, sprint skills, closeout skills, and goal/metrics docs in parallel if branch boundaries are clear. | planned |
+| 2 | v0.91.6 C-SDLC integration control-plane truth gate | WP-02, WP-03, WP-04 | Consume v0.91.6 `#4388` and child issues `#4389`-`#4398`: VPP defaults, externalized PVF lanes, SEP automation, goal/time/token metrics, GitHub/octocrab convergence, prompt-card/template edge repair, runtime dependency routing, logging/reliability rough edges, watcher/lifecycle automation, and FastContext evaluation. Only create v0.91.7 follow-ons for incomplete or explicitly blocked surfaces. | planned |
 | 3 | Scheduler/provider/local-agent sprint | WP-05 | Can run alongside build-throughput work after WP-03 boundaries are stable. | planned |
 | 4 | Build throughput and validation-cost sprint | WP-06 | Can run in parallel with scheduler/provider work; isolate CI/workflow changes carefully. | planned |
 | 5 | Runtime fire-up / Soak #2 sprint | WP-07, WP-08 | Starts after enough scheduler/build/runtime substrate is ready; AWS/SSM/SNS work can parallelize with local soak proof. | planned |
@@ -47,7 +47,7 @@ Complete the final bridge/readiness tranche before `v0.92` activation refresh. T
 
 - Each tracked issue follows `SIP -> STP -> SPP -> SRP -> SOR`.
 - Each sprint should start with a sprint-level `/goal` prompt and each child issue should keep its issue-level goal.
-- Each issue should declare an expected PVF/VPP validation lane during planning.
+- Each issue should declare an expected PVF/VPP validation lane during planning; the v0.91.6 `#4388`-`#4398` completion sprint is the control-plane gate for making this default rather than chat-memory policy.
 - Each issue should record estimated and actual time/token/resource cost in its SOR when the template support exists.
 - Sprint watchers should track issue/PR/check status so completed issues close promptly and failed lanes are routed quickly.
 - Planning docs alone never prove runtime readiness.
@@ -57,7 +57,7 @@ Complete the final bridge/readiness tranche before `v0.92` activation refresh. T
 ## Risks / Dependencies
 
 - Dependency: v0.91.6 release-tail and open closeout issues must not remain ambiguous.
-- Dependency: template/version changes may affect VPP/goal/time-token fields.
+- Dependency: template/version changes may affect VPP/goal/time-token fields; v0.91.6 `#4388`-`#4398` must either land those defaults or leave explicit blockers/follow-ons before v0.92 execution depends on them.
 - Risk: the milestone becomes too broad.
   - Mitigation: every source item is either implemented, explicitly routed, blocked, or deferred; no narrative-only expansion.
 - Risk: runtime proof arrives too late.
@@ -72,7 +72,7 @@ Required review should inspect:
 - source-capture completeness;
 - v0.91.6 closeout truth;
 - whether every open issue/carryover has a disposition;
-- whether VPP/PVF/SEP work is scheduled before sprint execution depends on it;
+- whether v0.91.6 `#4388`-`#4398` / VPP / PVF / SEP / GitHub convergence / metrics / watcher / FastContext work is complete, blocked, deferred, or routed before sprint execution depends on it;
 - whether runtime Soak #2 and Observatory proof are concrete enough for v0.92;
 - whether security/protocol residuals remain activation-path work;
 - whether launch/birthday docs avoid unsupported product, affect, wellbeing, or runtime claims.

--- a/docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md
+++ b/docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md
@@ -44,7 +44,7 @@ implementation proof.
 
 | Surface | Required state before v0.92 |
 | --- | --- |
-| SEP / VPP / PVF / templates | Complete, blocked, deferred, or routed with clear sprint-execution consequences. |
+| C-SDLC integration control plane | v0.91.6 `#4388`-`#4398` / SEP / VPP / PVF / templates / GitHub-octocrab convergence / goal metrics / logging / watcher-lifecycle automation / FastContext complete, blocked, deferred, or routed with clear sprint-execution consequences. |
 | Goal and metrics accounting | Time/token/resource and nested-goal route explicit enough for v0.92 issue planning. |
 | Scheduler/provider/local agents | Routing policy and suitability path explicit enough to protect premium cognition. |
 | Capability envelope and capability testing | Memory grounding, capability envelope, birth witnesses/receipt, and Aptitude Atlas boundaries explicitly consumed, deferred, blocked, or routed before birthday evidence relies on them. |

--- a/docs/milestones/v0.91.7/WBS_v0.91.7.md
+++ b/docs/milestones/v0.91.7/WBS_v0.91.7.md
@@ -24,8 +24,8 @@ WP-01 should consume this document, `PLANNING_SOURCE_CAPTURE_v0.91.7.md`, and [W
 | WP | Work Package | Description | Primary deliverable | Dependencies |
 | --- | --- | --- | --- | --- |
 | WP-01 | Planning promotion and issue-wave readiness | Promote the refreshed planning package, reconcile v0.91.6 closeout truth, classify every source in the source-capture ledger, sync the feature-list/roadmap truth, and open the issue wave. | Opened issue wave, C-SDLC card bundles, and source/feature-list disposition ledger. | `#3778`, `#3800`, `#3801`, `#4368`, v0.91.6 closeout. |
-| WP-02 | v0.91.6 closeout truth, ADR release-tail, and cleanup | Ensure open v0.91.6 closeout/release-tail WPs, Observatory carryover, closed ADR release-tail issues `#4324` / `#4369`-`#4376`, and open tooling remediation `#4378` are consumed, closed, blocked, deferred, or routed. | Closeout truth ledger, ADR route, tooling-remediation route, and carryover routing updates. | WP-01. |
-| WP-03 | SEP, VPP, PVF, and template-version substrate | Complete Sprint Execution Packet process, VPP, external lane registry, prompt-template next version, `/goal` rules, watchers, sprint closeout, and AST/template integration routes. | Process/tooling sprint with template and skill updates. | WP-01, `#4308`, `#4309`, `#4332`. |
+| WP-02 | v0.91.6 closeout truth, ADR release-tail, C-SDLC control-plane sprint, and cleanup | Ensure open v0.91.6 closeout/release-tail WPs, Observatory carryover, closed ADR release-tail issues `#4324` / `#4369`-`#4376`, open tooling remediation `#4378`, and the v0.91.6 C-SDLC integration sprint `#4388`-`#4398` are consumed, closed, blocked, deferred, or routed. | Closeout truth ledger, ADR route, tooling-remediation route, C-SDLC control-plane sprint disposition, and carryover routing updates. | WP-01. |
+| WP-03 | Consume C-SDLC integration control-plane truth | Consume the v0.91.6 `#4388`-`#4398` completion truth for Sprint Execution Packets, VPP, external PVF lane registry, prompt-template next version, GitHub/octocrab convergence, `/goal` rules, issue/sprint metrics, logging, watchers, closeout, AST/template integration routes, and FastContext evaluation. Do not recreate this as fresh v0.91.7 implementation scope unless WP-02 records a blocker or routed follow-on. | Process/tooling truth-consumption gate with explicit blocker/follow-on routes only where v0.91.6 did not complete. | WP-01, WP-02, `#4308`, `#4309`, `#4332`, `#4388`-`#4398`. |
 | WP-04 | Goal state, nested goals, and execution metrics | Define first-class goal-state consumption, issue/sprint goal nesting, SOR time/token/resource accounting, and outlier analysis route. | Goal/metrics feature route and template-field plan. | WP-03, `#4329`, `#4331`. |
 | WP-05 | Cognitive scheduler and provider/local-agent routing | Build or route scheduler v1, provider profiles, model suitability, local/hosted agent routing, capability-envelope inputs, and cheapest-validated-outcome policy. | Scheduler/provider execution route, role suitability matrix, and capability-envelope routing. | WP-03, WP-04, provider sprint outputs. |
 | WP-06 | Build throughput and validation-cost reduction | Route validation manager, long-test fanout, CI log archive/S3, Nessus, CodeBuild runner evaluation, sccache/linker/target-dir cleanup, and validation DAG/build graph convergence. | Build/validation throughput sprint and proof plan. | WP-03, validation sprint outputs. |
@@ -50,12 +50,12 @@ WP-01 should consume this document, `PLANNING_SOURCE_CAPTURE_v0.91.7.md`, and [W
 ## Acceptance Mapping
 
 - v0.91.6 closeout truth and ADR release-tail decisions must be consumed before `v0.92` opens.
-- SEP/VPP/PVF/template work must make sprint execution predictable rather than chat-memory driven.
+- SEP/VPP/PVF/template work must make sprint execution predictable rather than chat-memory driven, with `#4388`-`#4398` serving as the v0.91.6 completion sprint for the integrated control plane.
 - Goal and metrics work must preserve issue/sprint token/time/resource accounting.
 - Scheduler/provider work must protect premium capacity and support local/hosted model routing.
 - Capability-envelope, capability-testing, and Aptitude Atlas boundaries must be explicit before v0.92 consumes memory/identity/birthday evidence.
 - Build/validation work must reduce the validation tail without weakening proof.
-- GitHub convergence/control-plane work must be either reliable enough for sprint execution or explicitly routed as a blocker/follow-on.
+- GitHub convergence/control-plane work must be either reliable enough for sprint execution or explicitly routed as a blocker/follow-on through the v0.91.6 `#4388`-`#4398` completion sprint.
 - Runtime integration/Soak #2 must prove one assembled minimal runtime path or name blockers before birthday activation.
 - Runtime architecture diet must identify keep/merge/defer/retire boundaries without hiding speculative refactoring inside the integration sprint.
 - Security and ACIP/A2A residuals must not silently defer out of activation.

--- a/docs/milestones/v0.91.7/WP_ISSUE_WAVE_v0.91.7.yaml
+++ b/docs/milestones/v0.91.7/WP_ISSUE_WAVE_v0.91.7.yaml
@@ -24,20 +24,22 @@ work_packages:
       - "Source-capture disposition ledger"
       - "Feature-list/roadmap disposition entry"
   - wp: WP-02
-    title: v0.91.6 closeout truth ADR release-tail and cleanup
-    outcome: Close, block, defer, or route open v0.91.6 closeout/release-tail, ADR release-tail, and Observatory carryover work before v0.92 consumes it.
+    title: v0.91.6 closeout truth ADR release-tail C-SDLC control-plane sprint and cleanup
+    outcome: Close, block, defer, or route open v0.91.6 closeout/release-tail, ADR release-tail, Observatory carryover, and #4388-#4398 C-SDLC integration control-plane work before v0.92 consumes it.
     depends_on: ["WP-01"]
     deliverables:
       - "Closeout truth ledger"
       - "ADR release-tail route"
+      - "C-SDLC control-plane sprint disposition"
       - "Carryover routing updates"
   - wp: WP-03
-    title: SEP VPP PVF and template-version substrate
-    outcome: Complete sprint execution packet, validation planning prompt, externalized PVF lane registry, prompt-template next version, goal/watch/closeout rules, and AST/template routes.
-    depends_on: ["WP-01", "#4308", "#4309", "#4332"]
+    title: Consume C-SDLC integration control-plane truth
+    outcome: Consume the v0.91.6 #4388-#4398 completion sprint truth for SEP, VPP, externalized PVF lane configuration, prompt-card templates, GitHub/octocrab convergence, goal/time/token metrics, logging, watcher/lifecycle automation, runtime dependency routing, tooling reliability, and FastContext evaluation. Create v0.91.7 follow-ons only for surfaces that are incomplete, blocked, or explicitly routed by WP-02.
+    depends_on: ["WP-01", "WP-02", "#4308", "#4309", "#4332", "#4388-#4398"]
     deliverables:
-      - "SEP/VPP/PVF/template sprint"
-      - "Template and skill update plan"
+      - "C-SDLC integration control-plane truth-consumption ledger"
+      - "SEP/VPP/PVF/template completion or blocker route"
+      - "GitHub/octocrab, metrics, logging, watcher, lifecycle automation, FastContext disposition"
   - wp: WP-04
     title: Goal state nested goals and execution metrics
     outcome: Define goal-state consumption, issue/sprint nested goals, SOR time-token-resource accounting, and outlier analysis route.


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4368 is already closed; this PR carries follow-up planning-doc alignment and does not close the issue.

Refs #4368

## Summary

Corrects the pre-v0.92 planning packet so the C-SDLC integration control-plane sprint is treated as v0.91.6 work: `#4388`-`#4398`.

The planning packet now consumes the v0.91.6 completion truth for SEP, VPP, PVF lane configuration, prompt-card templates, GitHub/octocrab convergence, goal/time/token metrics, logging, watcher/lifecycle automation, runtime dependency routing, tooling reliability, and FastContext evaluation rather than scheduling that work as new downstream scope.

## Scope

Planning-doc update only. This PR does not execute `#4388`-`#4398`.

## Validation

- `git diff --check origin/main...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.7/WP_ISSUE_WAVE_v0.91.7.yaml"); puts "yaml: ok"'`
