### PR TITLE
[v0.91.6][tools][vpp] Make VPP the default validation planning surface

### DIFF
--- a/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+++ b/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
@@ -9,6 +9,7 @@ pub(super) fn build_doctor_card_lifecycle(
     sip_path: &Path,
     stp_path: &Path,
     spp_path: &Path,
+    vpp_path: &Path,
     srp_path: &Path,
     sor_path: &Path,
 ) -> DoctorCardLifecycleJson {
@@ -16,6 +17,7 @@ pub(super) fn build_doctor_card_lifecycle(
         classify_sip_stage(repo_root, sip_path),
         classify_stp_stage(repo_root, stp_path),
         classify_spp_stage(repo_root, spp_path),
+        classify_vpp_stage(repo_root, vpp_path),
         classify_srp_stage(repo_root, srp_path),
         classify_sor_stage(repo_root, sor_path),
     ];
@@ -26,7 +28,7 @@ pub(super) fn build_doctor_card_lifecycle(
     let active_stage = next_required_stage.unwrap_or("SOR");
     let pr_run_readiness = if stages
         .iter()
-        .filter(|stage| ["SIP", "STP", "SPP", "SRP"].contains(&stage.stage))
+        .filter(|stage| ["SIP", "STP", "SPP", "VPP", "SRP"].contains(&stage.stage))
         .all(|stage| stage.design_time_complete)
     {
         "ready"
@@ -45,13 +47,74 @@ pub(super) fn build_doctor_card_lifecycle(
     };
 
     DoctorCardLifecycleJson {
-        order: vec!["SIP", "STP", "SPP", "SRP", "SOR"],
+        order: vec!["SIP", "STP", "SPP", "VPP", "SRP", "SOR"],
         active_stage,
         next_required_stage,
         pr_run_readiness,
         pr_finish_readiness,
         stages,
     }
+}
+
+fn classify_vpp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
+    let Some(text) = read_card_text(path) else {
+        return missing_stage(repo_root, "VPP", path, "vpp-editor");
+    };
+    let status = line_value_after_prefix(&text, "status:").unwrap_or_default();
+    if !design_time_card_status_allows_execution(&text) {
+        return card_stage(
+            repo_root,
+            "VPP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("vpp-editor"),
+                "VPP card_status must be ready or approved before execution binding.",
+            ),
+        );
+    }
+    if has_generic_vpp_design_time_scaffold(&text) {
+        return card_stage(
+            repo_root,
+            "VPP",
+            path,
+            stage_truth(
+                "scaffold",
+                false,
+                false,
+                Some("vpp-editor"),
+                "VPP is still generic validation-planning text and needs lane truth.",
+            ),
+        );
+    }
+    if ["ready", "reviewed", "approved"].contains(&status.trim_matches('"')) {
+        return card_stage(
+            repo_root,
+            "VPP",
+            path,
+            stage_truth(
+                "complete",
+                true,
+                false,
+                None,
+                "VPP has ready, reviewed, or approved validation planning state.",
+            ),
+        );
+    }
+    card_stage(
+        repo_root,
+        "VPP",
+        path,
+        stage_truth(
+            "active",
+            false,
+            false,
+            Some("vpp-editor"),
+            "VPP is present but not yet marked ready, reviewed, or approved.",
+        ),
+    )
 }
 
 pub(super) fn doctor_ready_status_for(lifecycle: &DoctorCardLifecycleJson) -> &'static str {
@@ -278,6 +341,27 @@ fn has_generic_spp_design_time_scaffold(text: &str) -> bool {
     MARKERS.iter().any(|marker| text.contains(marker)) || has_truncation_sentinel_line(text)
 }
 
+fn has_generic_vpp_design_time_scaffold(text: &str) -> bool {
+    let unresolved_planned_lane = line_value_after_prefix(text, "planned_pvf_lane:")
+        .as_deref()
+        .map(|value| value == "needs_planning_lane_assignment")
+        .unwrap_or_else(|| {
+            text.contains("Planned PVF lane for execution: `needs_planning_lane_assignment`")
+        });
+    let unresolved_selected_lane = text.contains("- \"needs_planning_lane_assignment\"")
+        || text.contains("- needs_planning_lane_assignment");
+    let unresolved_failure_policy = line_value_after_prefix(text, "failure_policy:")
+        .as_deref()
+        .map(|value| value == "fail_closed_until_validation_lane_is_selected")
+        .unwrap_or_else(|| text.contains("fail_closed_until_validation_lane_is_selected"));
+    const MARKERS: &[&str] = &["selected_lanes_inline: needs_planning_lane_assignment"];
+    unresolved_planned_lane
+        || unresolved_selected_lane
+        || unresolved_failure_policy
+        || MARKERS.iter().any(|marker| text.contains(marker))
+        || has_truncation_sentinel_line(text)
+}
+
 fn has_truncation_sentinel_line(text: &str) -> bool {
     text.lines()
         .map(str::trim)
@@ -404,6 +488,7 @@ pub(super) fn validate_closed_completed_ready_bundle(
         || !ensure_nonempty_file_path(root_bundle_input)?
         || !ensure_nonempty_file_path(root_bundle_output)?
         || !ensure_nonempty_file_path(bundle_paths.plan_path)?
+        || !ensure_nonempty_file_path(bundle_paths.validation_plan_path)?
         || !ensure_nonempty_file_path(bundle_paths.review_policy_path)?;
     if canonical_bundle_missing {
         bail!(
@@ -622,7 +707,8 @@ fn card_stage(
         path: path_relative_to_repo(repo_root, path),
         state: truth.state,
         complete: truth.complete,
-        design_time_complete: matches!(stage, "SIP" | "STP" | "SPP" | "SRP") && truth.complete,
+        design_time_complete: matches!(stage, "SIP" | "STP" | "SPP" | "VPP" | "SRP")
+            && truth.complete,
         final_ready: truth.final_ready,
         next_editor: truth.next_editor,
         detail: truth.detail.to_string(),

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -68,7 +68,7 @@ pub(super) fn doctor_preflight_status(
         (true, true) => (
             "BLOCK",
             "card_run_readiness",
-            "Repair issue-local SIP/STP/SPP/SRP/SOR readiness before execution; do not override this as queue pressure.",
+            "Repair issue-local SIP/STP/SPP/VPP/SRP/SOR readiness before execution; do not override this as queue pressure.",
         ),
         (false, true) => (
             "BLOCK",
@@ -85,13 +85,16 @@ pub(super) fn preflight_card_run_readiness(
     let sip = issue_ref.task_bundle_input_path(repo_root);
     let stp = issue_ref.task_bundle_stp_path(repo_root);
     let spp = issue_ref.task_bundle_plan_path(repo_root);
+    let vpp = issue_ref.task_bundle_validation_plan_path(repo_root);
     let srp = issue_ref.task_bundle_review_policy_path(repo_root);
     let sor = issue_ref.task_bundle_output_path(repo_root);
-    if [&sip, &stp, &spp, &srp, &sor]
+    if [&sip, &stp, &spp, &vpp, &srp, &sor]
         .iter()
         .any(|path| !path.is_file())
     {
-        return None;
+        return Some("blocked");
     }
-    Some(build_doctor_card_lifecycle(repo_root, &sip, &stp, &spp, &srp, &sor).pr_run_readiness)
+    Some(
+        build_doctor_card_lifecycle(repo_root, &sip, &stp, &spp, &vpp, &srp, &sor).pr_run_readiness,
+    )
 }

--- a/adl/src/cli/pr_cmd/doctor/ready.rs
+++ b/adl/src/cli/pr_cmd/doctor/ready.rs
@@ -101,6 +101,8 @@ pub(super) fn run_doctor_ready(
     ]
     .iter()
     .all(|path| path.is_file());
+    let validation_repo_root =
+        ready_validation_repo_root(repo_root, &worktree_path, wt_bundle_complete);
     if !root_bundle_complete && worktree_path.is_dir() && wt_bundle_complete {
         let wt_branch = run_capture(
             "git",
@@ -167,7 +169,7 @@ pub(super) fn run_doctor_ready(
         issue_ref.slug(),
         &root_bundle_input,
         &root_bundle_output,
-        repo_root,
+        validation_repo_root,
         StructuredBundlePaths {
             plan_path: &root_bundle_plan,
             validation_plan_path: &root_bundle_validation_plan,
@@ -262,6 +264,31 @@ pub(super) fn run_doctor_ready(
         ],
     )?;
     if wt_branch.trim() != branch {
+        if stale_worktree_branch_mismatch_preserves_pre_run(root_indicates_pre_run, branch, wt_branch.trim()) {
+            let card_lifecycle = build_doctor_card_lifecycle(
+                repo_root,
+                &root_bundle_input,
+                &root_stp,
+                &root_bundle_plan,
+                &root_bundle_validation_plan,
+                &root_bundle_review_policy,
+                &root_bundle_output,
+            );
+            let status = doctor_ready_status_for(&card_lifecycle);
+            return Ok(DoctorReadyResult {
+                lifecycle_state: "pre_run",
+                worktree: None,
+                source: path_relative_to_repo(repo_root, &source_path),
+                root_stp: path_relative_to_repo(repo_root, &root_stp),
+                root_input: path_relative_to_repo(repo_root, &root_bundle_input),
+                root_output: path_relative_to_repo(repo_root, &root_bundle_output),
+                wt_stp: None,
+                wt_input: None,
+                wt_output: None,
+                card_lifecycle,
+                status,
+            });
+        }
         bail!(
             "doctor: worktree branch mismatch for {}",
             worktree_path.display()
@@ -273,7 +300,7 @@ pub(super) fn run_doctor_ready(
     validate_bootstrap_stp(&worktree_path, &wt_stp)?;
     validate_authored_prompt_surface("doctor", &wt_stp, PromptSurfaceKind::Stp)?;
     validate_ready_cards(
-        repo_root,
+        validation_repo_root,
         issue_ref.issue_number(),
         issue_ref.slug(),
         wt_branch.trim(),
@@ -383,4 +410,24 @@ pub(super) fn ensure_pr_run_design_time_ready(
         issue_ref.issue_number(),
         blockers.join("\n")
     )
+}
+
+pub(super) fn ready_validation_repo_root<'a>(
+    repo_root: &'a Path,
+    worktree_path: &'a Path,
+    wt_bundle_complete: bool,
+) -> &'a Path {
+    if worktree_path != repo_root && wt_bundle_complete {
+        worktree_path
+    } else {
+        repo_root
+    }
+}
+
+pub(super) fn stale_worktree_branch_mismatch_preserves_pre_run(
+    root_indicates_pre_run: bool,
+    expected_branch: &str,
+    observed_branch: &str,
+) -> bool {
+    root_indicates_pre_run && observed_branch.trim() != expected_branch
 }

--- a/adl/src/cli/pr_cmd/doctor/ready.rs
+++ b/adl/src/cli/pr_cmd/doctor/ready.rs
@@ -264,7 +264,11 @@ pub(super) fn run_doctor_ready(
         ],
     )?;
     if wt_branch.trim() != branch {
-        if stale_worktree_branch_mismatch_preserves_pre_run(root_indicates_pre_run, branch, wt_branch.trim()) {
+        if stale_worktree_branch_mismatch_preserves_pre_run(
+            root_indicates_pre_run,
+            branch,
+            wt_branch.trim(),
+        ) {
             let card_lifecycle = build_doctor_card_lifecycle(
                 repo_root,
                 &root_bundle_input,

--- a/adl/src/cli/pr_cmd/doctor/ready.rs
+++ b/adl/src/cli/pr_cmd/doctor/ready.rs
@@ -32,10 +32,12 @@ pub(super) fn run_doctor_ready(
     let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
     let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
     let root_bundle_plan = issue_ref.task_bundle_plan_path(repo_root);
+    let root_bundle_validation_plan = issue_ref.task_bundle_validation_plan_path(repo_root);
     let root_bundle_review_policy = issue_ref.task_bundle_review_policy_path(repo_root);
     let wt_bundle_input = issue_ref.task_bundle_input_path(&worktree_path);
     let wt_bundle_output = issue_ref.task_bundle_output_path(&worktree_path);
     let wt_bundle_plan = issue_ref.task_bundle_plan_path(&worktree_path);
+    let wt_bundle_validation_plan = issue_ref.task_bundle_validation_plan_path(&worktree_path);
     let wt_bundle_review_policy = issue_ref.task_bundle_review_policy_path(&worktree_path);
     let closed_completed = crate::cli::pr_cmd::lifecycle::issue_is_closed_and_completed(
         issue_ref.issue_number(),
@@ -53,6 +55,7 @@ pub(super) fn run_doctor_ready(
             &root_bundle_output,
             StructuredBundlePaths {
                 plan_path: &root_bundle_plan,
+                validation_plan_path: &root_bundle_validation_plan,
                 review_policy_path: &root_bundle_review_policy,
             },
         )?;
@@ -71,6 +74,7 @@ pub(super) fn run_doctor_ready(
                 &root_bundle_input,
                 &root_stp,
                 &root_bundle_plan,
+                &root_bundle_validation_plan,
                 &root_bundle_review_policy,
                 &root_bundle_output,
             ),
@@ -82,6 +86,7 @@ pub(super) fn run_doctor_ready(
         &root_bundle_input,
         &root_bundle_output,
         &root_bundle_plan,
+        &root_bundle_validation_plan,
         &root_bundle_review_policy,
     ]
     .iter()
@@ -91,6 +96,7 @@ pub(super) fn run_doctor_ready(
         &wt_bundle_input,
         &wt_bundle_output,
         &wt_bundle_plan,
+        &wt_bundle_validation_plan,
         &wt_bundle_review_policy,
     ]
     .iter()
@@ -123,6 +129,7 @@ pub(super) fn run_doctor_ready(
             &wt_bundle_output,
             StructuredBundlePaths {
                 plan_path: &wt_bundle_plan,
+                validation_plan_path: &wt_bundle_validation_plan,
                 review_policy_path: &wt_bundle_review_policy,
             },
         )?;
@@ -131,6 +138,7 @@ pub(super) fn run_doctor_ready(
             &wt_bundle_input,
             &wt_stp,
             &wt_bundle_plan,
+            &wt_bundle_validation_plan,
             &wt_bundle_review_policy,
             &wt_bundle_output,
         );
@@ -162,6 +170,7 @@ pub(super) fn run_doctor_ready(
         repo_root,
         StructuredBundlePaths {
             plan_path: &root_bundle_plan,
+            validation_plan_path: &root_bundle_validation_plan,
             review_policy_path: &root_bundle_review_policy,
         },
     )?;
@@ -194,6 +203,7 @@ pub(super) fn run_doctor_ready(
                 &root_bundle_input,
                 &root_stp,
                 &root_bundle_plan,
+                &root_bundle_validation_plan,
                 &root_bundle_review_policy,
                 &root_bundle_output,
             );
@@ -222,6 +232,7 @@ pub(super) fn run_doctor_ready(
             &root_bundle_input,
             &root_stp,
             &root_bundle_plan,
+            &root_bundle_validation_plan,
             &root_bundle_review_policy,
             &root_bundle_output,
         );
@@ -270,6 +281,7 @@ pub(super) fn run_doctor_ready(
         &root_bundle_output,
         StructuredBundlePaths {
             plan_path: &root_bundle_plan,
+            validation_plan_path: &root_bundle_validation_plan,
             review_policy_path: &root_bundle_review_policy,
         },
     )?;
@@ -282,6 +294,7 @@ pub(super) fn run_doctor_ready(
         &wt_bundle_output,
         StructuredBundlePaths {
             plan_path: &wt_bundle_plan,
+            validation_plan_path: &wt_bundle_validation_plan,
             review_policy_path: &wt_bundle_review_policy,
         },
     )?;
@@ -291,6 +304,7 @@ pub(super) fn run_doctor_ready(
         &wt_bundle_input,
         &wt_stp,
         &wt_bundle_plan,
+        &wt_bundle_validation_plan,
         &wt_bundle_review_policy,
         &wt_bundle_output,
     );
@@ -320,6 +334,7 @@ pub(super) fn ensure_pr_run_design_time_ready(
     let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
     let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
     let root_bundle_plan = issue_ref.task_bundle_plan_path(repo_root);
+    let root_bundle_validation_plan = issue_ref.task_bundle_validation_plan_path(repo_root);
     let root_bundle_review_policy = issue_ref.task_bundle_review_policy_path(repo_root);
     validate_initialized_cards(
         issue_ref.issue_number(),
@@ -329,6 +344,7 @@ pub(super) fn ensure_pr_run_design_time_ready(
         repo_root,
         StructuredBundlePaths {
             plan_path: &root_bundle_plan,
+            validation_plan_path: &root_bundle_validation_plan,
             review_policy_path: &root_bundle_review_policy,
         },
     )?;
@@ -337,6 +353,7 @@ pub(super) fn ensure_pr_run_design_time_ready(
         &root_bundle_input,
         &root_stp,
         &root_bundle_plan,
+        &root_bundle_validation_plan,
         &root_bundle_review_policy,
         &root_bundle_output,
     );
@@ -347,7 +364,7 @@ pub(super) fn ensure_pr_run_design_time_ready(
     let blockers = lifecycle
         .stages
         .iter()
-        .filter(|stage| ["SIP", "STP", "SPP", "SRP"].contains(&stage.stage))
+        .filter(|stage| ["SIP", "STP", "SPP", "VPP", "SRP"].contains(&stage.stage))
         .filter(|stage| !stage.design_time_complete)
         .map(|stage| {
             format!(

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -1,5 +1,8 @@
 use super::preflight::{doctor_preflight_status, preflight_card_run_readiness};
 use super::*;
+use crate::cli::pr_cmd::doctor::ready::{
+    ready_validation_repo_root, stale_worktree_branch_mismatch_preserves_pre_run,
+};
 use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -22,6 +25,44 @@ fn doctor_issue_prompt_resolution_falls_back_to_bound_worktree_prompt() {
         resolve_doctor_issue_prompt_path(&repo, &issue_ref).expect("doctor source prompt");
 
     assert_eq!(resolved, source_path);
+}
+
+#[test]
+fn doctor_ready_uses_bound_worktree_root_for_validation_once_bundle_exists() {
+    let repo = lifecycle_temp_repo("doctor-ready-validation-root");
+    let worktree = repo.join(".worktrees/adl-wp-3065");
+
+    let selected = ready_validation_repo_root(&repo, &worktree, true);
+
+    assert_eq!(selected, worktree.as_path());
+}
+
+#[test]
+fn doctor_ready_keeps_primary_repo_root_when_no_bound_bundle_exists() {
+    let repo = lifecycle_temp_repo("doctor-ready-primary-root");
+    let worktree = repo.join(".worktrees/adl-wp-3065");
+
+    let selected = ready_validation_repo_root(&repo, &worktree, false);
+
+    assert_eq!(selected, repo.as_path());
+}
+
+#[test]
+fn doctor_ready_preserves_pre_run_truth_for_stale_worktree_branch_mismatch() {
+    assert!(stale_worktree_branch_mismatch_preserves_pre_run(
+        true,
+        "codex/4389-expected",
+        "codex/stale-branch"
+    ));
+}
+
+#[test]
+fn doctor_ready_blocks_branch_mismatch_once_issue_is_run_bound() {
+    assert!(!stale_worktree_branch_mismatch_preserves_pre_run(
+        false,
+        "codex/4389-expected",
+        "codex/stale-branch"
+    ));
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -43,7 +43,7 @@ fn doctor_full_stays_blocked_for_issue_local_card_readiness() {
 
     assert_eq!(preflight_status, "BLOCK");
     assert_eq!(block_kind, "card_run_readiness");
-    assert!(guidance.contains("SIP/STP/SPP/SRP/SOR"));
+    assert!(guidance.contains("SIP/STP/SPP/VPP/SRP/SOR"));
     assert_eq!(
         doctor_full_status(preflight_status, block_kind, Some("PASS")),
         "BLOCK"
@@ -78,7 +78,7 @@ fn card_lifecycle_marks_legacy_srp_policy_as_not_finish_ready() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SRP");
@@ -104,7 +104,7 @@ fn card_lifecycle_does_not_treat_placeholder_srp_results_as_final() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SRP");
@@ -128,7 +128,7 @@ fn card_lifecycle_does_not_treat_unknown_srp_result_values_as_final() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SRP");
@@ -151,7 +151,7 @@ fn card_lifecycle_allows_explicit_srp_policy_exception() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_stage(&lifecycle, "SRP", "final", true, true);
@@ -173,7 +173,7 @@ fn card_lifecycle_accepts_pre_review_srp_prompt_without_final_results() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "ready");
@@ -203,7 +203,7 @@ fn card_lifecycle_does_not_treat_pre_execution_srp_absence_as_final_exception() 
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "ready");
@@ -226,7 +226,7 @@ fn card_lifecycle_accepts_terminal_structured_review_prompt_exception() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_finish_readiness, "ready");
@@ -243,6 +243,7 @@ fn closed_ready_validation_is_read_only_and_reports_truth_drift() {
     let sip = bundle.join("sip.md");
     let stp = bundle.join("stp.md");
     let spp = bundle.join("spp.md");
+    let vpp = bundle.join("vpp.md");
     let srp = bundle.join("srp.md");
     let sor = bundle.join("sor.md");
 
@@ -268,9 +269,15 @@ fn closed_ready_validation_is_read_only_and_reports_truth_drift() {
             task_id = issue_ref.task_issue_id(),
             bundle = issue_ref.task_bundle_dir_name(),
         );
+    let vpp_text = format!(
+        "---\nschema_version: \"0.1\"\nartifact_type: \"structured_validation_planning_prompt\"\nname: \"fixture-validation-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: \"v0.91.2\"\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"unknown\"\nplanned_validation_tokens: \"unknown\"\nissue_goal_ref: \"issue-{issue}\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"fixture\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Lane Registry Inputs\n\n- Registry path: `docs/validation/pvf_lanes.json`\n- Registry template set: `vpp.lane.v1`\n- Initial PVF lane from issue creation: `tooling`\n- Planned PVF lane for execution: `tooling`\n\n## Selected Validation Lanes\n\n- tooling\n\n## Parallelization Plan\n\n- Parallel groups: local\n- Validation runtime class: `tiny`\n- Validation resource profile: `local`\n\n## Goal Accounting Hooks\n\n- Issue goal ref: `issue-{issue}`\n- Sprint goal ref: `unknown`\n- Goal metrics rollup ref: `unknown`\n\n## Proof Cost / Runtime Expectations\n\n- Expected proof cost: `small`\n- Planned validation seconds: `unknown`\n- Planned validation tokens: `unknown`\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\n\n## Failure Semantics\n\n- fail_closed\n\n## Handoff\n\nUse this fixture VPP as the validation plan.\n\n## Notes\n\nfixture\n",
+        issue = issue_ref.issue_number(),
+        task_id = issue_ref.task_issue_id(),
+    );
     fs::write(&sip, sip_text).expect("write sip");
     fs::write(&stp, stp_text).expect("write stp");
     fs::write(&spp, spp_text).expect("write spp");
+    fs::write(&vpp, vpp_text).expect("write vpp");
     fs::write(&srp, srp_text).expect("write srp");
     let stale_sor = "# issue-1410-fixture\n\nTask ID: issue-1410\nRun ID: issue-1410\nVersion: v0.91.2\nTitle: Fixture\nBranch: codex/1410-fixture\nStatus: IN_PROGRESS\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: adl/src/foo.rs\n- Integration state: pr_open\n- Verification scope: worktree\n- Result: PASS\n";
     fs::write(&sor, stale_sor).expect("write stale sor");
@@ -282,6 +289,7 @@ fn closed_ready_validation_is_read_only_and_reports_truth_drift() {
         &sor,
         StructuredBundlePaths {
             plan_path: &spp,
+            validation_plan_path: &vpp,
             review_policy_path: &srp,
         },
     )
@@ -306,7 +314,7 @@ fn card_lifecycle_allows_ellipsis_in_reviewed_spp_prose() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "ready");
@@ -328,7 +336,7 @@ fn card_lifecycle_blocks_generic_pre_run_spp_before_execution() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "blocked");
@@ -367,7 +375,7 @@ fn card_lifecycle_blocks_approved_generic_spp_before_execution() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "blocked");
@@ -397,7 +405,7 @@ fn card_lifecycle_blocks_generic_sip_before_execution() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "blocked");
@@ -427,7 +435,7 @@ fn card_lifecycle_blocks_draft_design_time_card_status_before_execution() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_run_readiness, "blocked");
@@ -458,7 +466,7 @@ fn card_lifecycle_blocks_completed_srp_without_review_results() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_finish_readiness, "blocked");
@@ -480,7 +488,7 @@ fn card_lifecycle_blocks_completed_sor_before_terminal_closeout() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_finish_readiness, "blocked");
@@ -514,6 +522,11 @@ fn preflight_card_readiness_reports_blocked_for_draft_design_time_card() {
     )
     .expect("write spp");
     fs::write(
+        issue_ref.task_bundle_validation_plan_path(&repo),
+        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"ready\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n",
+    )
+    .expect("write vpp");
+    fs::write(
             issue_ref.task_bundle_review_policy_path(&repo),
             "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
         )
@@ -531,6 +544,77 @@ fn preflight_card_readiness_reports_blocked_for_draft_design_time_card() {
 }
 
 #[test]
+fn preflight_card_readiness_reports_blocked_when_vpp_is_missing() {
+    let repo = lifecycle_temp_repo("preflight-missing-vpp");
+    let issue_ref = IssueRef::new(
+        3297,
+        "v0.91.3".to_string(),
+        "v0-91-3-tools-enforce-c-sdlc-card-status-transitions-in-skills".to_string(),
+    )
+    .expect("issue ref");
+    let bundle = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle).expect("create bundle");
+    fs::write(
+        issue_ref.task_bundle_input_path(&repo),
+        "Card Status: ready\nBranch: not bound yet\n",
+    )
+    .expect("write sip");
+    fs::write(
+        issue_ref.task_bundle_stp_path(&repo),
+        "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
+    )
+    .expect("write stp");
+    fs::write(
+        issue_ref.task_bundle_plan_path(&repo),
+        "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+    )
+    .expect("write spp");
+    fs::write(
+        issue_ref.task_bundle_review_policy_path(&repo),
+        "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
+    )
+    .expect("write srp");
+    fs::write(
+        issue_ref.task_bundle_output_path(&repo),
+        "Branch: not bound yet\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+    )
+    .expect("write sor");
+
+    assert_eq!(
+        preflight_card_run_readiness(&repo, &issue_ref),
+        Some("blocked")
+    );
+}
+
+#[test]
+fn card_lifecycle_treats_ready_vpp_as_design_time_complete() {
+    let repo = lifecycle_temp_repo("ready-vpp-design-time-complete");
+    let paths = write_lifecycle_fixture(
+        &repo,
+        LifecycleFixture {
+            sip: "Card Status: ready\nBranch: codex/3065-test\n",
+            stp: complete_stp_fixture(),
+            spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"approved\"\n---\n",
+            srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
+            sor: "Branch: codex/3065-test\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+        },
+    );
+
+    let lifecycle = build_doctor_card_lifecycle(
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
+    );
+
+    assert_eq!(lifecycle.pr_run_readiness, "ready");
+    let vpp = lifecycle
+        .stages
+        .iter()
+        .find(|stage| stage.stage == "VPP")
+        .expect("vpp stage exists");
+    assert!(vpp.complete);
+    assert!(vpp.design_time_complete);
+}
+
+#[test]
 fn card_lifecycle_distinguishes_active_plan_from_scaffold_output() {
     let repo = lifecycle_temp_repo("active-spp-scaffold-sor");
     let paths = write_lifecycle_fixture(
@@ -545,7 +629,7 @@ fn card_lifecycle_distinguishes_active_plan_from_scaffold_output() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SPP");
@@ -570,7 +654,7 @@ fn card_lifecycle_blocks_run_readiness_for_incomplete_active_stp() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "STP");
@@ -594,7 +678,7 @@ fn card_lifecycle_blocks_sparse_stp_before_execution() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "STP");
@@ -618,7 +702,7 @@ fn card_lifecycle_does_not_treat_embedded_heading_text_as_complete_stp() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "STP");
@@ -642,7 +726,7 @@ fn card_lifecycle_reports_final_review_and_output_truth() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SOR");
@@ -667,7 +751,7 @@ fn card_lifecycle_accepts_terminal_sor_with_retained_dirty_worktree_truth() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.active_stage, "SOR");
@@ -691,7 +775,7 @@ fn card_lifecycle_blocks_final_sor_with_contradictory_status_and_result() {
         );
 
     let lifecycle = build_doctor_card_lifecycle(
-        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
     );
 
     assert_eq!(lifecycle.pr_finish_readiness, "blocked");
@@ -712,6 +796,7 @@ fn card_lifecycle_accepts_tracked_csdlc_bundle() {
         &bundle.join("sip.md"),
         &bundle.join("stp.md"),
         &bundle.join("spp.md"),
+        &bundle.join("vpp.md"),
         &bundle.join("srp.md"),
         &bundle.join("sor.md"),
     );
@@ -739,6 +824,7 @@ struct LifecycleFixturePaths {
     sip: PathBuf,
     stp: PathBuf,
     spp: PathBuf,
+    vpp: PathBuf,
     srp: PathBuf,
     sor: PathBuf,
 }
@@ -763,12 +849,18 @@ fn write_lifecycle_fixture(repo: &Path, fixture: LifecycleFixture<'_>) -> Lifecy
         sip: bundle.join("sip.md"),
         stp: bundle.join("stp.md"),
         spp: bundle.join("spp.md"),
+        vpp: bundle.join("vpp.md"),
         srp: bundle.join("srp.md"),
         sor: bundle.join("sor.md"),
     };
     fs::write(&paths.sip, fixture.sip).expect("write sip");
     fs::write(&paths.stp, fixture.stp).expect("write stp");
     fs::write(&paths.spp, fixture.spp).expect("write spp");
+    fs::write(
+        &paths.vpp,
+        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"ready\"\ninitial_pvf_lane: \"needs_planning_lane_assignment\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"unknown\"\nplanned_validation_tokens: \"unknown\"\nissue_goal_ref: \"issue-3065\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"Generated from docs/templates/prompts/1.0.3/vpp.md template; confirm lane selection before relying on this plan. Lane source: initial_pvf_lane.\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n",
+    )
+    .expect("write vpp");
     fs::write(&paths.srp, fixture.srp).expect("write srp");
     fs::write(&paths.sor, fixture.sor).expect("write sor");
     paths

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1886,6 +1886,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
             | "adl/src/cli/usage.rs"
             | "adl/src/cli/tokio_runtime.rs"
             | "adl/src/cli/github_token.rs"
+            | "adl/src/control_plane.rs"
             | "adl/src/lib.rs"
             | "adl/src/scheduler.rs"
             | "adl/src/agent_comms.rs"
@@ -2041,7 +2042,8 @@ fn finish_path_needs_github_token_focused_validation(path: &str) -> bool {
 
 fn finish_path_needs_owner_binary_rust_slice_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
-    trimmed == "adl/src/lib.rs"
+    trimmed == "adl/src/control_plane.rs"
+        || trimmed == "adl/src/lib.rs"
         || trimmed == "adl/src/csdlc_prompt_editor.rs"
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
         || trimmed == "adl/src/cli/run_artifacts_types.rs"

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -21,7 +21,7 @@ use super::validation::{
 };
 use ::adl::control_plane::{
     card_input_path, card_output_path, card_plan_path, card_review_policy_path, card_stp_path,
-    resolve_cards_root, IssueRef,
+    card_validation_plan_path, resolve_cards_root, IssueRef,
 };
 
 pub(crate) fn ensure_task_bundle_stp(
@@ -490,6 +490,10 @@ pub(crate) fn sync_root_task_bundle_into_worktree(
             issue_ref.worktree_task_bundle_plan_path(worktree_root),
         ),
         (
+            issue_ref.task_bundle_validation_plan_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_validation_plan_path(worktree_root),
+        ),
+        (
             issue_ref.task_bundle_review_policy_path(primary_checkout_root),
             issue_ref.worktree_task_bundle_review_policy_path(worktree_root),
         ),
@@ -530,6 +534,7 @@ pub(crate) fn ensure_worktree_task_bundle_materialized(
         issue_ref.worktree_task_bundle_input_path(worktree_root),
         issue_ref.worktree_task_bundle_output_path(worktree_root),
         issue_ref.worktree_task_bundle_plan_path(worktree_root),
+        issue_ref.worktree_task_bundle_validation_plan_path(worktree_root),
         issue_ref.worktree_task_bundle_review_policy_path(worktree_root),
     ];
     let missing: Vec<String> = expected
@@ -589,6 +594,7 @@ fn ensure_bootstrap_cards_with_mode(
     let bundle_input = issue_ref.task_bundle_input_path(root);
     let bundle_output = issue_ref.task_bundle_output_path(root);
     let bundle_plan = issue_ref.task_bundle_plan_path(root);
+    let bundle_validation_plan = issue_ref.task_bundle_validation_plan_path(root);
     let bundle_review_policy = issue_ref.task_bundle_review_policy_path(root);
     let bundle_stp_created = !bundle_stp.is_file();
     if let Some(parent) = bundle_input.parent() {
@@ -626,6 +632,20 @@ fn ensure_bootstrap_cards_with_mode(
     } else if bind_existing_cards && field_line_value(&bundle_plan, "branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_plan, "branch", &format!("\"{branch}\""))?;
     }
+    if prompt_surface_needs_template_refresh(&bundle_validation_plan)? {
+        write_validation_plan_card(
+            root,
+            &bundle_validation_plan,
+            issue_ref,
+            title,
+            branch,
+            source_path,
+        )?;
+    } else if bind_existing_cards
+        && field_line_value(&bundle_validation_plan, "branch")?.trim() != format!("\"{branch}\"")
+    {
+        replace_field_line_in_file(&bundle_validation_plan, "branch", &format!("\"{branch}\""))?;
+    }
     if prompt_surface_needs_template_refresh(&bundle_review_policy)? {
         write_review_policy_card(root, &bundle_review_policy, issue_ref, title, branch)?;
     } else if bind_existing_cards
@@ -639,15 +659,18 @@ fn ensure_bootstrap_cards_with_mode(
     let compat_input = card_input_path(&cards_root, issue_ref.issue_number());
     let compat_output = card_output_path(&cards_root, issue_ref.issue_number());
     let compat_plan = card_plan_path(&cards_root, issue_ref.issue_number());
+    let compat_validation_plan = card_validation_plan_path(&cards_root, issue_ref.issue_number());
     let compat_review_policy = card_review_policy_path(&cards_root, issue_ref.issue_number());
     ensure_symlink(&compat_stp, &bundle_stp)?;
     ensure_symlink(&compat_input, &bundle_input)?;
     ensure_symlink(&compat_output, &bundle_output)?;
     ensure_symlink(&compat_plan, &bundle_plan)?;
+    ensure_symlink(&compat_validation_plan, &bundle_validation_plan)?;
     ensure_symlink(&compat_review_policy, &bundle_review_policy)?;
 
     let structured_paths = StructuredBundlePaths {
         plan_path: &bundle_plan,
+        validation_plan_path: &bundle_validation_plan,
         review_policy_path: &bundle_review_policy,
     };
     if bind_existing_cards {
@@ -695,6 +718,20 @@ pub(crate) fn write_plan_card(
     source_path: &Path,
 ) -> Result<()> {
     let text = render_bootstrap_plan_card(repo_root, issue_ref, title, branch, source_path)?;
+    fs::write(path, text)?;
+    Ok(())
+}
+
+pub(crate) fn write_validation_plan_card(
+    repo_root: &Path,
+    path: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    source_path: &Path,
+) -> Result<()> {
+    let text =
+        render_bootstrap_validation_plan_card(repo_root, issue_ref, title, branch, source_path)?;
     fs::write(path, text)?;
     Ok(())
 }
@@ -1039,6 +1076,10 @@ fn render_bootstrap_output_card(
 ) -> Result<String> {
     let output_rel =
         path_relative_to_repo(repo_root, &issue_ref.task_bundle_output_path(repo_root));
+    let vpp_rel = path_relative_to_repo(
+        repo_root,
+        &issue_ref.task_bundle_validation_plan_path(repo_root),
+    );
     let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
     let pre_run_unbound = branch_indicates_unbound_state(branch);
     let status = if pre_run_unbound {
@@ -1105,11 +1146,14 @@ fn render_bootstrap_output_card(
             ("<lane_change_reason>", "not_recorded_yet".to_string()),
             ("<expected_runtime_class>", "unknown".to_string()),
             ("<estimate_elapsed_seconds>", "unknown".to_string()),
+            ("<estimated_elapsed_seconds>", "unknown".to_string()),
             ("<actual_elapsed_seconds>", "unknown".to_string()),
             ("<actual_active_work_seconds>", "unknown".to_string()),
             ("<estimate_total_tokens>", "unknown".to_string()),
+            ("<estimated_total_tokens>", "unknown".to_string()),
             ("<actual_total_tokens>", "unknown".to_string()),
             ("<estimate_validation_seconds>", "unknown".to_string()),
+            ("<estimated_validation_seconds>", "unknown".to_string()),
             ("<actual_validation_seconds>", "unknown".to_string()),
             ("<actual_pr_wait_seconds>", "unknown".to_string()),
             ("<actual_ci_wait_seconds>", "unknown".to_string()),
@@ -1118,6 +1162,10 @@ fn render_bootstrap_output_card(
             ("<actual_metrics_confidence>", "unknown".to_string()),
             ("<estimate_error_percent>", "unknown".to_string()),
             ("<completion_state>", "unknown".to_string()),
+            ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
+            ("<sprint_goal_ref>", "unknown".to_string()),
+            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+            ("<vpp_card>", vpp_rel),
             ("<variance_analysis_required>", "not_applicable".to_string()),
             ("<variance_analysis_completed>", "not_applicable".to_string()),
             ("<variance_category>", "not_applicable".to_string()),
@@ -1139,6 +1187,7 @@ fn render_bootstrap_output_card(
                 "Opened the local issue bundle and wrote a truthful pre-run output scaffold."
                     .to_string(),
             ),
+            ("<branch_action>", branch_action.to_string()),
             ("<actions_taken_line_2>", branch_action.to_string()),
             (
                 "<actions_taken_line_3>",
@@ -1351,6 +1400,10 @@ fn render_bootstrap_plan_card(
     let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
     let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
     let spp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_plan_path(repo_root));
+    let vpp_rel = path_relative_to_repo(
+        repo_root,
+        &issue_ref.task_bundle_validation_plan_path(repo_root),
+    );
     let source_rel = path_relative_to_repo(repo_root, source_path);
     let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     let prompt = fs::read_to_string(source_path).unwrap_or_default();
@@ -1419,6 +1472,7 @@ fn render_bootstrap_plan_card(
             ("<stp_card>", stp_rel),
             ("<sip_card>", sip_rel),
             ("<spp_card>", spp_rel),
+            ("<vpp_card>", vpp_rel),
             ("<target_files_surfaces_inline>", repo_inputs_step.clone()),
             ("<non_goals_inline>", non_goals_step),
             ("<plan_summary>", format!("Issue-local execution plan for {title}.")),
@@ -1444,11 +1498,111 @@ fn render_bootstrap_plan_card(
             ("<planned_pvf_lane_source>", planned_pvf_lane_source.clone()),
             ("<expected_runtime_class>", "unknown".to_string()),
             ("<estimate_elapsed_seconds>", "unknown".to_string()),
+            ("<estimated_elapsed_seconds>", "unknown".to_string()),
             ("<estimate_total_tokens>", "unknown".to_string()),
+            ("<estimated_total_tokens>", "unknown".to_string()),
             ("<estimate_validation_seconds>", "unknown".to_string()),
+            ("<estimated_validation_seconds>", "unknown".to_string()),
             ("<estimate_confidence>", "unknown".to_string()),
             ("<estimate_data_source>", "unknown".to_string()),
             ("<estimate_source_ref>", "unknown".to_string()),
+            ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
+            ("<sprint_goal_ref>", "unknown".to_string()),
+            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+        ],
+    );
+    Ok(text)
+}
+
+fn render_bootstrap_validation_plan_card(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    source_path: &Path,
+) -> Result<String> {
+    let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
+    let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
+    let spp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_plan_path(repo_root));
+    let source_rel = path_relative_to_repo(repo_root, source_path);
+    let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let prompt = fs::read_to_string(source_path).unwrap_or_default();
+    let metadata = SourcePromptMetadata::from_prompt(&prompt);
+    let initial_pvf_lane = resolved_initial_pvf_lane(&metadata, title, &prompt);
+    let initial_pvf_lane_source =
+        resolved_initial_pvf_lane_source(&metadata, title, &prompt, &initial_pvf_lane);
+    let planned_pvf_lane = resolved_planned_pvf_lane(&initial_pvf_lane);
+    let planned_pvf_lane_source =
+        resolved_planned_pvf_lane_source(&initial_pvf_lane, &initial_pvf_lane_source);
+    let failure_policy = if planned_pvf_lane == NEEDS_PLANNING_PVF_LANE {
+        "fail_closed_until_validation_lane_is_selected"
+    } else {
+        "fail_closed"
+    };
+    let validation_strategy = issue_prompt_section(&prompt, "Validation Plan")
+        .or_else(|| issue_prompt_section(&prompt, "Tooling Notes"))
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| {
+            "Select the smallest proving validation lane before execution proceeds.".to_string()
+        });
+    let validation_command = yaml_inline(&validation_strategy);
+    let mut text = read_prompt_template(repo_root, "vpp", &[])?;
+    let issue_url = format!(
+        "https://github.com/{}/issues/{}",
+        default_repo(repo_root)
+            .unwrap_or_else(|_| "danielbaustin/agent-design-language".to_string()),
+        issue_ref.issue_number()
+    );
+    apply_template_values(
+        &mut text,
+        &[
+            ("<issue>", issue_ref.issue_number().to_string()),
+            ("<issue_padded>", issue_ref.padded_issue_number().to_string()),
+            ("<task_id>", format!("issue-{}", issue_ref.padded_issue_number())),
+            ("<run_id>", format!("issue-{}", issue_ref.padded_issue_number())),
+            ("<version>", issue_ref.scope().to_string()),
+            ("<slug>", issue_ref.slug().to_string()),
+            ("<title>", title.to_string()),
+            ("<branch>", branch.to_string()),
+            ("<timestamp>", timestamp),
+            ("<card_status>", "ready".to_string()),
+            ("<status>", "ready".to_string()),
+            ("<issue_url>", issue_url),
+            ("<stp_card>", stp_rel),
+            ("<sip_card>", sip_rel),
+            ("<spp_card>", spp_rel),
+            ("<initial_pvf_lane>", initial_pvf_lane),
+            ("<planned_pvf_lane>", planned_pvf_lane.clone()),
+            (
+                "<lane_registry_path>",
+                "docs/validation/pvf_lanes.json".to_string(),
+            ),
+            ("<lane_registry_template_set>", "vpp.lane.v1".to_string()),
+            ("<validation_runtime_class>", "unknown".to_string()),
+            ("<validation_resource_profile>", "unknown".to_string()),
+            ("<expected_proof_cost>", "unknown".to_string()),
+            ("<planned_validation_seconds>", "unknown".to_string()),
+            ("<planned_validation_tokens>", "unknown".to_string()),
+            ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
+            ("<sprint_goal_ref>", "unknown".to_string()),
+            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+            ("<selected_lanes_inline>", planned_pvf_lane),
+            ("<parallel_groups_inline>", "unknown".to_string()),
+            ("<validation_commands_inline>", validation_command),
+            ("<failure_policy>", failure_policy.to_string()),
+            (
+                "<notes_risks_inline>",
+                format!(
+                    "Generated from {} template; confirm lane selection before relying on this plan. Lane source: {planned_pvf_lane_source}.",
+                    active_prompt_template_set_label(repo_root)
+                ),
+            ),
+            (
+                "<plan_summary>",
+                format!(
+                    "Validation planning prompt for {title}; source issue prompt: {source_rel}."
+                ),
+            ),
         ],
     );
     Ok(text)
@@ -1536,6 +1690,10 @@ fn render_bootstrap_review_policy_card(
     let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
     let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
     let spp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_plan_path(repo_root));
+    let vpp_rel = path_relative_to_repo(
+        repo_root,
+        &issue_ref.task_bundle_validation_plan_path(repo_root),
+    );
     let srp_rel = path_relative_to_repo(
         repo_root,
         &issue_ref.task_bundle_review_policy_path(repo_root),
@@ -1571,6 +1729,7 @@ fn render_bootstrap_review_policy_card(
             ("<stp_card>", stp_rel),
             ("<sip_card>", sip_rel),
             ("<spp_card>", spp_rel),
+            ("<vpp_card>", vpp_rel),
             ("<srp_card>", srp_rel),
             ("<sor_card>", sor_rel),
             ("<findings_status>", "not_run".to_string()),

--- a/adl/src/cli/pr_cmd_cards/validation.rs
+++ b/adl/src/cli/pr_cmd_cards/validation.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 pub(crate) struct StructuredBundlePaths<'a> {
     pub(crate) plan_path: &'a Path,
+    pub(crate) validation_plan_path: &'a Path,
     pub(crate) review_policy_path: &'a Path,
 }
 
@@ -82,6 +83,13 @@ pub(crate) fn validate_ready_cards(
     validate_started_structured_artifact(
         repo_root,
         "ready",
+        structured_paths.validation_plan_path,
+        "vpp",
+        actual_branch,
+    )?;
+    validate_started_structured_artifact(
+        repo_root,
+        "ready",
         structured_paths.review_policy_path,
         "srp",
         actual_branch,
@@ -119,6 +127,12 @@ pub(crate) fn validate_initialized_cards(
         bail!("doctor: output card title mismatch");
     }
     validate_structured_artifact(repo_root, "doctor", structured_paths.plan_path, "spp")?;
+    validate_structured_artifact(
+        repo_root,
+        "doctor",
+        structured_paths.validation_plan_path,
+        "vpp",
+    )?;
     validate_structured_artifact(
         repo_root,
         "doctor",
@@ -185,6 +199,12 @@ pub(crate) fn validate_bootstrap_cards(
         bail!("start: output card title mismatch");
     }
     validate_structured_artifact(repo_root, "start", structured_paths.plan_path, "spp")?;
+    validate_structured_artifact(
+        repo_root,
+        "start",
+        structured_paths.validation_plan_path,
+        "vpp",
+    )?;
     validate_structured_artifact(
         repo_root,
         "start",

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3373,6 +3373,26 @@ fn finish_validation_profile_classifies_pr_cmd_prompt_and_versioned_bootstrap_pa
 }
 
 #[test]
+fn finish_validation_profile_classifies_control_plane_path() {
+    let plan = select_finish_validation_plan("adl/src/control_plane.rs")
+        .expect("control_plane larger-binary plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(
+        plan.commands
+            .iter()
+            .any(|command| command.contains("cargo fmt --manifest-path")),
+        "control-plane larger-binary plan should require cargo fmt"
+    );
+    assert!(
+        plan.commands
+            .iter()
+            .any(|command| command.contains("cargo test --manifest-path adl/Cargo.toml --bin adl")),
+        "control-plane larger-binary plan should include owner-binary validation"
+    );
+}
+
+#[test]
 fn finish_validation_profile_classifies_prompt_template_and_structured_prompt_paths() {
     let plan = select_finish_validation_plan(
         "adl/src/cli/tooling_cmd/common.rs,adl/src/cli/tooling_cmd/prompt_template.rs,adl/src/cli/tooling_cmd/structured_prompt.rs,adl/src/cli/tooling_cmd/tests/prompt_template.rs,adl/src/cli/tooling_cmd/tests/structured_prompt.rs,adl/src/cli/tooling_cmd/tests/support.rs",

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -315,6 +315,8 @@ pub(crate) fn copy_versioned_prompt_templates(repo: &Path) {
     fs::create_dir_all(target_root.join("1.0.1/schemas")).expect("create prompt template dir");
     fs::create_dir_all(target_root.join("1.0.2")).expect("create prompt template dir");
     fs::create_dir_all(target_root.join("1.0.2/schemas")).expect("create prompt template dir");
+    fs::create_dir_all(target_root.join("1.0.3")).expect("create prompt template dir");
+    fs::create_dir_all(target_root.join("1.0.3/schemas")).expect("create prompt template dir");
     for rel in [
         "current.json",
         "1.0.0/sip.md",
@@ -347,6 +349,18 @@ pub(crate) fn copy_versioned_prompt_templates(repo: &Path) {
         "1.0.2/schemas/spp.structure.json",
         "1.0.2/schemas/srp.structure.json",
         "1.0.2/schemas/sor.structure.json",
+        "1.0.3/sip.md",
+        "1.0.3/stp.md",
+        "1.0.3/spp.md",
+        "1.0.3/vpp.md",
+        "1.0.3/srp.md",
+        "1.0.3/sor.md",
+        "1.0.3/schemas/sip.structure.json",
+        "1.0.3/schemas/stp.structure.json",
+        "1.0.3/schemas/spp.structure.json",
+        "1.0.3/schemas/vpp.structure.json",
+        "1.0.3/schemas/srp.structure.json",
+        "1.0.3/schemas/sor.structure.json",
     ] {
         fs::copy(source_root.join(rel), target_root.join(rel)).expect("copy prompt template");
     }

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -74,6 +74,8 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
     let stp = fs::read_to_string(&bundle_stp).expect("read stp");
     let sip = fs::read_to_string(&bundle_input).expect("read sip");
     let spp = fs::read_to_string(issue_ref.task_bundle_plan_path(&repo)).expect("read spp");
+    let vpp =
+        fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo)).expect("read vpp");
     let srp =
         fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo)).expect("read srp");
     let sor = fs::read_to_string(&bundle_output).expect("read sor");
@@ -82,12 +84,13 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
         ("STP", &stp),
         ("SIP", &sip),
         ("SPP", &spp),
+        ("VPP", &vpp),
         ("SRP", &srp),
         ("SOR", &sor),
     ] {
         assert!(
             text.contains(&format!(
-                "Canonical Template Source: `docs/templates/prompts/1.0.2/{}.md`",
+                "Canonical Template Source: `docs/templates/prompts/1.0.3/{}.md`",
                 kind.to_ascii_lowercase()
             )),
             "{kind} should identify the versioned template source"
@@ -117,7 +120,14 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
     assert!(spp.contains(
         "- Unknown-value rule: record `unknown`, never `0`, when the estimate is unavailable or intentionally deferred."
     ));
+    assert!(vpp.contains("artifact_type: \"structured_validation_planning_prompt\""));
+    assert!(vpp.contains("status: \"ready\""));
+    assert!(vpp.contains("initial_pvf_lane: \"prompt_template\""));
+    assert!(vpp.contains("planned_pvf_lane: \"prompt_template\""));
+    assert!(vpp.contains("## Validation Planning Summary"));
+    assert!(vpp.contains("## Selected Validation Lanes"));
     assert!(srp.contains("artifact_type: \"structured_review_prompt\""));
+    assert!(srp.contains("vpp.md"));
     assert!(sor.contains("Status: IN_PROGRESS"));
     assert!(sor.contains("## PVF Lane Truth"));
     assert!(sor.contains("## Issue Metrics Truth"));
@@ -126,6 +136,7 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
     assert!(sor.contains("- Goal metrics data source: `unknown`"));
     assert!(sor.contains("- Goal metrics source ref: `unknown`"));
     assert!(sor.contains("- Estimate error percent: `unknown`"));
+    assert!(sor.contains("- Validation planning prompt: `.adl/v0.91.3/tasks/issue-3286__tools-versioned-csdlc-prompt-templates/vpp.md`"));
     assert!(sor.contains("Integration method used: local ignored card-bundle scaffold write under the active checkout; tracked implementation artifacts do not exist yet"));
     assert!(!sor.contains("direct write in main repo for the local ignored pre-run record"));
 }
@@ -194,7 +205,7 @@ Fresh bootstrap output contains all five C-SDLC cards with no raw template place
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.2/
+- docs/templates/prompts/1.0.3/
 
 ## Dependencies
 
@@ -259,7 +270,7 @@ Fresh bootstrap output contains all five C-SDLC cards with no raw template place
         let text = fs::read_to_string(path).expect("read refreshed card");
         assert_no_prompt_template_residue(kind, &text);
         assert!(
-            text.contains("Canonical Template Source: `docs/templates/prompts/1.0.2/"),
+            text.contains("Canonical Template Source: `docs/templates/prompts/1.0.3/"),
             "{kind} should be regenerated from the versioned template set"
         );
     }
@@ -316,7 +327,7 @@ Legacy design-time-ready SPP from the pre-template transition window.
     ensure_bootstrap_cards(&repo, &issue_ref, title, "not bound yet", &source_path)
         .expect("legacy SPP should be refreshed");
     let spp = fs::read_to_string(&spp_path).expect("read spp");
-    assert!(spp.contains("Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`"));
+    assert!(spp.contains("Canonical Template Source: `docs/templates/prompts/1.0.3/spp.md`"));
     assert!(!spp.contains("activation_state: \"design_time_ready\""));
 }
 
@@ -556,7 +567,7 @@ review_hooks:
 notes: "Reviewed card should remain stable across pre-run bootstrap."
 ---
 
-Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`
+Canonical Template Source: `docs/templates/prompts/1.0.3/spp.md`
 
 # Structured Plan Prompt
 
@@ -665,7 +676,7 @@ status: "approved"
 activation_state: "design_time_ready"
 ---
 
-Canonical Template Source: `docs/templates/prompts/1.0.2/spp.md`
+Canonical Template Source: `docs/templates/prompts/1.0.3/spp.md`
 
 # Structured Plan Prompt
 
@@ -736,7 +747,7 @@ The generated SPP should carry source-prompt facts into the plan.
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.2/spp.md
+- docs/templates/prompts/1.0.3/spp.md
 
 ## Dependencies
 
@@ -852,7 +863,7 @@ All generated prompt cards pass the sprint readiness checker.
 ## Repo Inputs
 
 - adl/src/cli/pr_cmd_cards/cards.rs
-- docs/templates/prompts/1.0.2/
+- docs/templates/prompts/1.0.3/
 
 ## Dependencies
 
@@ -908,7 +919,7 @@ All generated prompt cards pass the sprint readiness checker.
         "Use dependency truth from the linked source issue prompt",
         "Review source issue prompt and scoped repo inputs",
         "Follow demo/proof requirements from the linked source issue prompt",
-        "Generated from 1.0.2 C-SDLC prompt template; refine with editor skills before execution if needed",
+        "Generated from 1.0.3 C-SDLC prompt template; refine with editor skills before execution if needed",
     ] {
         assert!(
             !stp.contains(marker),

--- a/adl/src/control_plane.rs
+++ b/adl/src/control_plane.rs
@@ -118,6 +118,11 @@ impl IssueRef {
             .join("spp.md")
     }
 
+    pub fn task_bundle_validation_plan_path(&self, primary_checkout_root: &Path) -> PathBuf {
+        self.task_bundle_dir_path(primary_checkout_root)
+            .join("vpp.md")
+    }
+
     pub fn task_bundle_review_policy_path(&self, primary_checkout_root: &Path) -> PathBuf {
         self.task_bundle_dir_path(primary_checkout_root)
             .join("srp.md")
@@ -165,6 +170,11 @@ impl IssueRef {
     pub fn worktree_task_bundle_plan_path(&self, worktree_root: &Path) -> PathBuf {
         self.worktree_task_bundle_dir_path(worktree_root)
             .join("spp.md")
+    }
+
+    pub fn worktree_task_bundle_validation_plan_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("vpp.md")
     }
 
     pub fn worktree_task_bundle_review_policy_path(&self, worktree_root: &Path) -> PathBuf {
@@ -266,6 +276,10 @@ pub fn card_output_path(cards_root: &Path, issue_number: u32) -> PathBuf {
 
 pub fn card_plan_path(cards_root: &Path, issue_number: u32) -> PathBuf {
     card_dir_path(cards_root, issue_number).join(format!("plan_{issue_number}.md"))
+}
+
+pub fn card_validation_plan_path(cards_root: &Path, issue_number: u32) -> PathBuf {
+    card_dir_path(cards_root, issue_number).join(format!("vpp_{issue_number}.md"))
 }
 
 pub fn card_review_policy_path(cards_root: &Path, issue_number: u32) -> PathBuf {

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -791,6 +791,7 @@ PROMPT_TEMPLATE_ROOT="docs/templates/prompts/1.0.0"
 INPUT_TEMPLATE="$PROMPT_TEMPLATE_ROOT/sip.md"
 STP_TEMPLATE="$PROMPT_TEMPLATE_ROOT/stp.md"
 SPP_TEMPLATE="$PROMPT_TEMPLATE_ROOT/spp.md"
+VPP_TEMPLATE="$PROMPT_TEMPLATE_ROOT/vpp.md"
 SRP_TEMPLATE="$PROMPT_TEMPLATE_ROOT/srp.md"
 OUTPUT_TEMPLATE="$PROMPT_TEMPLATE_ROOT/sor.md"
 COMPAT_INPUT_TEMPLATE="adl/templates/cards/input_card_template.md"
@@ -805,6 +806,7 @@ resolve_prompt_template() {
     sip) primary="$INPUT_TEMPLATE"; compat="$COMPAT_INPUT_TEMPLATE"; legacy="$LEGACY_INPUT_TEMPLATE" ;;
     stp) primary="$STP_TEMPLATE" ;;
     spp) primary="$SPP_TEMPLATE" ;;
+    vpp) primary="$VPP_TEMPLATE" ;;
     srp) primary="$SRP_TEMPLATE" ;;
     sor) primary="$OUTPUT_TEMPLATE"; compat="$COMPAT_OUTPUT_TEMPLATE"; legacy="$LEGACY_OUTPUT_TEMPLATE" ;;
     *) die "unknown prompt template kind: $kind" ;;
@@ -1074,6 +1076,8 @@ seed_input_card() {
     "<slug>" "$source_slug" \
     "<title>" "$title" \
     "<branch>" "$branch" \
+    "<card_status>" "ready" \
+    "<timestamp>" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     "<issue_url>" "$issue_url" \
     "<source_issue_prompt>" "$(path_relative_to_repo "$source_path")" \
     "<docs_context>" "$docs_value" \
@@ -1155,10 +1159,33 @@ seed_output_card() {
     "<slug>" "$issue_slug" \
     "<title>" "$title" \
     "<branch>" "$branch" \
+    "<card_status>" "draft" \
     "<status>" "$status" \
     "<timestamp>" "$timestamp" \
     "<output_card>" "$output_rel" \
-    "<branch_action>" "$branch_action"
+    "<branch_action>" "$branch_action" \
+    "<initial_pvf_lane>" "needs_planning_lane_assignment" \
+    "<planned_pvf_lane>" "needs_planning_lane_assignment" \
+    "<final_pvf_lane>" "not_recorded_yet" \
+    "<lane_change_reason>" "not_recorded_yet" \
+    "<estimated_elapsed_seconds>" "unknown" \
+    "<actual_elapsed_seconds>" "unknown" \
+    "<estimated_total_tokens>" "unknown" \
+    "<actual_total_tokens>" "unknown" \
+    "<estimated_validation_seconds>" "unknown" \
+    "<actual_validation_seconds>" "unknown" \
+    "<actual_metrics_data_source>" "unavailable_before_issue_execution" \
+    "<actual_metrics_source_ref>" "not_recorded_yet" \
+    "<actual_metrics_confidence>" "unknown" \
+    "<estimate_error_percent>" "not_recorded_yet" \
+    "<issue_goal_ref>" "issue-${issue}" \
+    "<sprint_goal_ref>" "unknown" \
+    "<goal_metrics_rollup_ref>" "unknown" \
+    "<vpp_card>" "$(path_relative_to_repo "$(task_bundle_dir_path "$issue" "$ver" "$issue_slug")/vpp.md")" \
+    "<variance_analysis_required>" "not_recorded_yet" \
+    "<variance_analysis_completed>" "not_recorded_yet" \
+    "<variance_category>" "not_recorded_yet" \
+    "<variance_note>" "No issue execution metrics have been recorded yet."
 
   set_field_line "$tmp" "Task ID" "$task_id"
   set_field_line "$tmp" "Run ID" "$run_id"
@@ -1252,7 +1279,8 @@ source_section_one_line() {
 
 seed_prompt_template_card() {
   local kind="$1" path="$2" issue="$3" title="$4" branch="$5" ver="$6" source_path="$7" slug="$8"
-  local tpl tmp repo issue_url bundle_dir stp_rel sip_rel spp_rel srp_rel sor_rel source_rel target_inline
+  local tpl tmp repo issue_url bundle_dir stp_rel sip_rel spp_rel vpp_rel srp_rel sor_rel source_rel target_inline
+  local timestamp template_source_note
   local source_summary source_goal source_required_outcome source_deliverables source_acceptance source_repo_inputs
   local source_dependencies source_validation source_demo source_non_goals source_issue_graph source_notes
   tpl="$(resolve_prompt_template "$kind")"
@@ -1261,11 +1289,13 @@ seed_prompt_template_card() {
 
   repo="$(default_repo)"
   issue_url="https://github.com/${repo}/issues/${issue}"
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   bundle_dir="$(task_bundle_dir_path "$issue" "$ver" "$slug")"
   source_rel="$(path_relative_to_repo "$source_path")"
   stp_rel="$(path_relative_to_repo "$bundle_dir/stp.md")"
   sip_rel="$(path_relative_to_repo "$bundle_dir/sip.md")"
   spp_rel="$(path_relative_to_repo "$bundle_dir/spp.md")"
+  vpp_rel="$(path_relative_to_repo "$bundle_dir/vpp.md")"
   srp_rel="$(path_relative_to_repo "$bundle_dir/srp.md")"
   sor_rel="$(path_relative_to_repo "$bundle_dir/sor.md")"
   source_summary="$(source_section_one_line "$source_path" "Summary" "Issue-local task surface for $title.")"
@@ -1500,6 +1530,7 @@ EOF
     die "missing $kind prompt template: $tpl"
   fi
   ensure_nonempty_file "$tmp" || die "rendered $kind card is empty: $tmp"
+  template_source_note="Generated from $(path_relative_to_repo "$tpl")."
 
   apply_prompt_template_values "$tmp" \
     "<issue>" "$issue" \
@@ -1510,11 +1541,16 @@ EOF
     "<slug>" "$slug" \
     "<title>" "$title" \
     "<branch>" "$branch" \
+    "<timestamp>" "$timestamp" \
+    "<card_status>" "ready" \
+    "<status>" "ready" \
+    "<activation_state>" "ready" \
     "<issue_url>" "$issue_url" \
     "<source_issue_prompt>" "$source_rel" \
     "<stp_card>" "$stp_rel" \
     "<sip_card>" "$sip_rel" \
     "<spp_card>" "$spp_rel" \
+    "<vpp_card>" "$vpp_rel" \
     "<srp_card>" "$srp_rel" \
     "<sor_card>" "$sor_rel" \
     "<output_card>" "$sor_rel" \
@@ -1535,7 +1571,7 @@ EOF
     "<non_goals>" "$source_non_goals" \
     "<issue_graph_notes>" "$source_issue_graph" \
     "<notes_risks>" "$source_notes" \
-    "<tooling_notes>" "Generated from docs/templates/prompts/1.0.0/." \
+    "<tooling_notes>" "$template_source_note" \
     "<target_files_surfaces_inline>" "$target_inline" \
     "<non_goals_inline>" "$source_non_goals" \
     "<plan_summary>" "Issue-local execution plan for $title." \
@@ -1545,7 +1581,43 @@ EOF
     "<acceptance_criteria_inline>" "$source_acceptance" \
     "<risks_inline>" "Generated card may need editor tightening if the source issue prompt is underspecified." \
     "<validation_plan_inline>" "$source_validation" \
-    "<notes_risks_inline>" "Generated from 1.0.0 template; update before continuing if execution diverges."
+    "<notes_risks_inline>" "$template_source_note Update before continuing if execution diverges." \
+    "<initial_pvf_lane>" "needs_planning_lane_assignment" \
+    "<planned_pvf_lane>" "needs_planning_lane_assignment" \
+    "<planned_pvf_lane_source>" "bootstrap_default_fail_closed" \
+    "<estimated_elapsed_seconds>" "unknown" \
+    "<estimated_total_tokens>" "unknown" \
+    "<estimated_validation_seconds>" "unknown" \
+    "<estimate_confidence>" "unknown" \
+    "<estimate_data_source>" "unknown" \
+    "<estimate_source_ref>" "not_recorded_yet" \
+    "<issue_goal_ref>" "issue-${issue}" \
+    "<sprint_goal_ref>" "unknown" \
+    "<goal_metrics_rollup_ref>" "unknown" \
+    "<findings_status>" "not_run" \
+    "<recommended_outcome>" "not_applicable"
+
+  if [[ "$kind" == "vpp" ]]; then
+    apply_prompt_template_values "$tmp" \
+      "<card_status>" "ready" \
+      "<status>" "ready" \
+      "<initial_pvf_lane>" "needs_planning_lane_assignment" \
+      "<planned_pvf_lane>" "needs_planning_lane_assignment" \
+      "<lane_registry_path>" "docs/validation/pvf_lanes.json" \
+      "<lane_registry_template_set>" "vpp.lane.v1" \
+      "<validation_runtime_class>" "unknown" \
+      "<validation_resource_profile>" "unknown" \
+      "<expected_proof_cost>" "unknown" \
+      "<planned_validation_seconds>" "unknown" \
+      "<planned_validation_tokens>" "unknown" \
+      "<issue_goal_ref>" "issue-${issue}" \
+      "<sprint_goal_ref>" "unknown" \
+      "<goal_metrics_rollup_ref>" "unknown" \
+      "<selected_lanes_inline>" "needs_planning_lane_assignment" \
+      "<parallel_groups_inline>" "unknown" \
+      "<validation_commands_inline>" "needs_planning_lane_assignment" \
+      "<failure_policy>" "fail_closed_until_validation_lane_is_selected"
+  fi
 
   mv "$tmp" "$path"
 }
@@ -1575,8 +1647,9 @@ seed_bootstrap_surfaces() {
 
   in_path="$(input_card_path "$issue" "$version" "$slug")"
   out_path="$(output_card_path "$issue" "$version" "$slug")"
-  local spp_path srp_path
+  local spp_path vpp_path srp_path
   spp_path="$bundle_dir/spp.md"
+  vpp_path="$bundle_dir/vpp.md"
   srp_path="$bundle_dir/srp.md"
   ensure_adl_dirs
   if ! ensure_nonempty_file "$in_path" || input_card_is_bootstrap_stub "$in_path"; then
@@ -1597,6 +1670,12 @@ seed_bootstrap_surfaces() {
   else
     note "SPP card exists: $spp_path" >&2
   fi
+  if ! ensure_nonempty_file "$vpp_path"; then
+    note "Creating VPP card: $vpp_path" >&2
+    seed_prompt_template_card vpp "$vpp_path" "$issue" "$title" "$branch" "$version" "$source_path" "$slug"
+  else
+    note "VPP card exists: $vpp_path" >&2
+  fi
   if ! ensure_nonempty_file "$srp_path"; then
     note "Creating SRP card: $srp_path" >&2
     seed_prompt_template_card srp "$srp_path" "$issue" "$title" "$branch" "$version" "$source_path" "$slug"
@@ -1606,9 +1685,10 @@ seed_bootstrap_surfaces() {
   sync_legacy_links_for_issue "$issue" "$version" "$slug"
   validate_bootstrap_stp "$stp_path"
   validate_structured_card spp "$spp_path"
+  validate_structured_card vpp "$vpp_path"
   validate_structured_card srp "$srp_path"
   validate_bootstrap_cards "$issue" "$slug" "$branch" "$in_path" "$out_path"
-  printf '%s\n%s\n%s\n%s\n%s\n' "$stp_path" "$in_path" "$out_path" "$spp_path" "$srp_path"
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n' "$stp_path" "$in_path" "$out_path" "$spp_path" "$vpp_path" "$srp_path"
 }
 
 

--- a/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/vpp.md
+++ b/docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/vpp.md
@@ -1,0 +1,103 @@
+---
+schema_version: "0.1"
+artifact_type: "structured_validation_planning_prompt"
+name: "v0-91-3-wp-03-card-lifecycle-demo-validation-plan"
+issue: 3201
+task_id: "issue-3201"
+run_id: "issue-3201"
+version: "v0.91.3"
+title: "[v0.91.3][wp-03][cards] Card lifecycle demo"
+branch: "main"
+generated_at: "2026-06-22T00:00:00Z"
+card_status: "ready"
+status: "reviewed"
+initial_pvf_lane: "docs"
+planned_pvf_lane: "docs"
+lane_registry_path: "docs/validation/pvf_lanes.json"
+lane_registry_template_set: "vpp.lane.v1"
+validation_runtime_class: "tiny"
+validation_resource_profile: "local"
+expected_proof_cost: "small"
+planned_validation_seconds: "unknown"
+planned_validation_tokens: "unknown"
+issue_goal_ref: "issue-3201"
+sprint_goal_ref: "unknown"
+goal_metrics_rollup_ref: "unknown"
+source_refs:
+  - kind: "stp"
+    ref: "docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/stp.md"
+  - kind: "sip"
+    ref: "docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sip.md"
+  - kind: "spp"
+    ref: "docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/spp.md"
+selected_lanes:
+  - "docs"
+parallel_groups:
+  - "local"
+validation_commands:
+  - "bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sip.md"
+  - "bash adl/tools/validate_structured_prompt.sh --type stp --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/stp.md"
+  - "bash adl/tools/validate_structured_prompt.sh --type spp --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/spp.md"
+  - "bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/srp.md"
+  - "bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sor.md"
+failure_policy: "fail_closed"
+notes: "Retained VPP added when VPP became a first-class lifecycle surface so the historical card-lifecycle demo remains structurally complete."
+---
+
+Canonical Template Source: `docs/templates/prompts/1.0.3/vpp.md`
+
+# Structured Validation Planning Prompt
+
+## Validation Planning Summary
+
+Historical retained VPP for the `v0.91.3` card-lifecycle demo packet.
+
+## Lane Registry Inputs
+
+- Registry path: `docs/validation/pvf_lanes.json`
+- Registry template set: `vpp.lane.v1`
+- Initial PVF lane from issue creation: `docs`
+- Planned PVF lane for execution: `docs`
+
+## Selected Validation Lanes
+
+- docs
+
+## Parallelization Plan
+
+- Parallel groups: local
+- Validation runtime class: `tiny`
+- Validation resource profile: `local`
+
+## Goal Accounting Hooks
+
+- Issue goal ref: `issue-3201`
+- Sprint goal ref: `unknown`
+- Goal metrics rollup ref: `unknown`
+
+## Proof Cost / Runtime Expectations
+
+- Expected proof cost: `small`
+- Planned validation seconds: `unknown`
+- Planned validation tokens: `unknown`
+- Unknown-value rule: record `unknown`, never `0`, when the estimate is unavailable or intentionally deferred.
+
+## Validation Commands
+
+- bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sip.md
+- bash adl/tools/validate_structured_prompt.sh --type stp --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/stp.md
+- bash adl/tools/validate_structured_prompt.sh --type spp --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/spp.md
+- bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/srp.md
+- bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/sor.md
+
+## Failure Semantics
+
+- fail_closed
+
+## Handoff
+
+This retained VPP records the validation-planning truth needed for the historical lifecycle demo after VPP became a required stage.
+
+## Notes
+
+Retained VPP added when VPP became a first-class lifecycle surface so the historical card-lifecycle demo remains structurally complete.

--- a/docs/templates/prompts/1.0.3/spp.md
+++ b/docs/templates/prompts/1.0.3/spp.md
@@ -16,9 +16,9 @@ plan_revision: 1
 initial_pvf_lane: "<initial_pvf_lane>"
 planned_pvf_lane: "<planned_pvf_lane>"
 planned_pvf_lane_source: "<planned_pvf_lane_source>"
-estimate_elapsed_seconds: "<estimated_elapsed_seconds>"
-estimate_total_tokens: "<estimated_total_tokens>"
-estimate_validation_seconds: "<estimated_validation_seconds>"
+estimate_elapsed_seconds: "<estimate_elapsed_seconds>"
+estimate_total_tokens: "<estimate_total_tokens>"
+estimate_validation_seconds: "<estimate_validation_seconds>"
 estimate_confidence: "<estimate_confidence>"
 estimate_data_source: "<estimate_data_source>"
 estimate_source_ref: "<estimate_source_ref>"
@@ -124,9 +124,9 @@ Design-time operative plan for `<title>`.
 
 ## Estimate Plan
 
-- Estimated elapsed seconds: `<estimated_elapsed_seconds>`
-- Estimated total tokens: `<estimated_total_tokens>`
-- Estimated validation seconds: `<estimated_validation_seconds>`
+- Estimated elapsed seconds: `<estimate_elapsed_seconds>`
+- Estimated total tokens: `<estimate_total_tokens>`
+- Estimated validation seconds: `<estimate_validation_seconds>`
 - Estimate confidence: `<estimate_confidence>`
 - Estimate data source: `<estimate_data_source>`
 - Estimate source ref: `<estimate_source_ref>`

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -9,25 +9,22 @@ used by prompt-card structure validation.
 
 ## Current Set
 
-- Template set: `1.0.2`
-- Lifecycle: `SIP -> STP -> SPP -> SRP -> SOR`
-- Template root: `docs/templates/prompts/1.0.2/`
+- Template set: `1.0.3`
+- Lifecycle: `SIP -> STP -> SPP -> VPP -> SRP -> SOR`
+- Template root: `docs/templates/prompts/1.0.3/`
 - Registry: `docs/templates/prompts/current.json`
-- Structure schemas: `docs/templates/prompts/1.0.2/schemas/*.structure.json`
+- Structure schemas: `docs/templates/prompts/1.0.3/schemas/*.structure.json`
 - Implementation owner: Rust tooling owns the canonical template registry,
   field model, schema extraction, and validation path. Python sprint helpers may
   load schema artifacts, fill templates, or call the Rust-backed validators, but
   they should not become a separate template authority.
 
-## Staged Next Set
+## Previous Set
 
-- Template set: `1.0.3`
+- Template set: `1.0.2`
 - Lifecycle: `SIP -> STP -> SPP -> VPP -> SRP -> SOR`
-- Status: staged for renderer/schema validation in `#4309`; not yet the active
-  issue-bundle lifecycle
-- Template root: `docs/templates/prompts/1.0.3/`
-- Activation boundary: downstream issue-bundle/bootstrap adoption must land
-  before `current.json` moves from `1.0.2` to `1.0.3`
+- Status: superseded by `1.0.3` for new issue-bundle generation.
+- Template root: `docs/templates/prompts/1.0.2/`
 
 ## Values Renderer
 
@@ -81,15 +78,15 @@ intentionally:
 ```sh
 adl-csdlc tooling prompt-template \
   write-structure-schemas \
-  --template-set 1.0.2 \
-  --out-dir docs/templates/prompts/1.0.2/schemas
+  --template-set 1.0.3 \
+  --out-dir docs/templates/prompts/1.0.3/schemas
 ```
 
 Then run both Rust and Python-readable schema checks:
 
 ```sh
-adl-csdlc tooling prompt-template validate-schemas --template-set 1.0.2
-python3 adl/tools/test_prompt_template_structure_schemas.py --template-set 1.0.2
+adl-csdlc tooling prompt-template validate-schemas --template-set 1.0.3
+python3 adl/tools/test_prompt_template_structure_schemas.py --template-set 1.0.3
 ```
 
 If `adl-csdlc` is not already on `PATH`, run the same owner-binary commands
@@ -98,8 +95,8 @@ from a fresh checkout.
 
 `current.json` should not move to a new active template set until every card
 kind in that set has renderer fixtures, values validation, and compatibility
-notes. For staged six-card sets such as `1.0.3`, that means `VPP` must be
-validated alongside the existing five cards before activation.
+notes. `1.0.3` is the first active six-card set, so new issue bundles include
+`VPP` as validation-planning truth between `SPP` and `SRP`.
 
 ## Local Editor
 

--- a/docs/templates/prompts/current.json
+++ b/docs/templates/prompts/current.json
@@ -1,35 +1,40 @@
 {
   "schema": "adl.csdlc.prompt_template_registry.v1",
-  "csdlc_prompt_template_set": "1.0.2",
-  "semver": "1.0.2",
+  "csdlc_prompt_template_set": "1.0.3",
+  "semver": "1.0.3",
   "status": "active",
   "object_kind": "csdlc_prompt_template_set",
-  "lifecycle": ["SIP", "STP", "SPP", "SRP", "SOR"],
+  "lifecycle": ["SIP", "STP", "SPP", "VPP", "SRP", "SOR"],
   "templates": {
     "sip": {
       "semantic_role": "Structured Issue Prompt",
-      "path": "docs/templates/prompts/1.0.2/sip.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/sip.structure.json"
+      "path": "docs/templates/prompts/1.0.3/sip.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/sip.structure.json"
     },
     "stp": {
       "semantic_role": "Structured Task Prompt",
-      "path": "docs/templates/prompts/1.0.2/stp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/stp.structure.json"
+      "path": "docs/templates/prompts/1.0.3/stp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/stp.structure.json"
     },
     "spp": {
       "semantic_role": "Structured Plan Prompt",
-      "path": "docs/templates/prompts/1.0.2/spp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/spp.structure.json"
+      "path": "docs/templates/prompts/1.0.3/spp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/spp.structure.json"
+    },
+    "vpp": {
+      "semantic_role": "Structured Validation Planning Prompt",
+      "path": "docs/templates/prompts/1.0.3/vpp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/vpp.structure.json"
     },
     "srp": {
       "semantic_role": "Structured Review Prompt",
-      "path": "docs/templates/prompts/1.0.2/srp.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/srp.structure.json"
+      "path": "docs/templates/prompts/1.0.3/srp.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/srp.structure.json"
     },
     "sor": {
       "semantic_role": "Structured Outcome Record",
-      "path": "docs/templates/prompts/1.0.2/sor.md",
-      "structure_schema_path": "docs/templates/prompts/1.0.2/schemas/sor.structure.json"
+      "path": "docs/templates/prompts/1.0.3/sor.md",
+      "structure_schema_path": "docs/templates/prompts/1.0.3/schemas/sor.structure.json"
     }
   },
   "compatibility_fallbacks": {


### PR DESCRIPTION
Closes #4389

## Summary
Implemented the VPP-default execution slice for issue bootstrap and doctor readiness. The active prompt-template registry now exposes the six-card `SIP -> STP -> SPP -> VPP -> SRP -> SOR` lifecycle, Rust issue bootstrap materializes and validates `vpp.md`, doctor/preflight treat VPP as a required design-time surface, `pr finish` classifies the touched Rust/tooling paths correctly, and the active 1.0.3 SPP template now round-trips estimate fields cleanly through render/import/edit workflows.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.6/tasks/issue-4389__v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface/sor.md`
- Tracked implementation artifacts: `docs/templates/prompts/current.json`; `docs/templates/prompts/README.md`; `docs/templates/prompts/1.0.3/spp.md`; `docs/milestones/v0.91.3/review/evidence/csdlc/issues/issue-3201-card-lifecycle-demo/cards/vpp.md`; `adl/src/control_plane.rs`; `adl/src/cli/pr_cmd_cards/cards.rs`; `adl/src/cli/pr_cmd_cards/validation.rs`; `adl/src/cli/pr_cmd/doctor/preflight.rs`; `adl/src/cli/pr_cmd/doctor/ready.rs`; `adl/src/cli/pr_cmd/doctor/card_lifecycle.rs`; `adl/src/cli/pr_cmd/doctor/tests.rs`; `adl/src/cli/pr_cmd/finish_support.rs`; `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`; `adl/src/cli/tests/pr_cmd_inline/support.rs`; `adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`; `adl/tools/pr.sh`
- Additional proof artifacts: focused command output from prompt-template workflow integration and versioned bootstrap regression tests

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_prompt_template_workflow_integration.sh 1.0.3`
    `Verified prompt-template 1.0.3 values/render/import/schema workflow including VPP.`
  - `cargo test --manifest-path adl/Cargo.toml bootstrap_cards_use_versioned_prompt_templates_when_available -- --nocapture`
    `Verified versioned Rust bootstrap creates the six-card lifecycle bundle and references VPP from SRP/SOR.`
  - `cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture`
    `Verified closed-ready doctor validation remains read-only with VPP included in the structured bundle.`
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_registry_redirects_rust_template_loading -- --nocapture`
    `Verified registry redirects and alternate-template routing stay truthful after the VPP-default lifecycle changes.`
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_cli_imports_lifecycle_updated_spp_values -- --nocapture`
    `Verified SPP import-values keeps lifecycle-updated estimate fields representable under the active template set.`
  - `cargo test --manifest-path adl/Cargo.toml prompt_template_cli_edit_rendered_card_uses_values_roundtrip_default_path -- --nocapture`
    `Verified SPP edit-rendered uses the values roundtrip path without failing on active-template estimate placeholders.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4389__v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4389__v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface/sor.md
- Idempotency-Key: v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface-adl-v0-91-6-tasks-issue-4389-v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface-sip-md-adl-v0-91-6-tasks-issue-4389-v0-91-6-tools-vpp-make-vpp-the-default-validation-planning-surface-sor-md