### PR TITLE
[v0.91.6][tools][coordination] Add session coordination and root checkout policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,18 @@ These rules are mandatory for ADL issue work.
 3. Always work in a bound worktree on a specific branch.
    - Never do tracked issue work on `main`.
    - Use the repo-native issue-mode `pr run` flow to bind execution context.
+   - Keep the primary checkout clean on `main` for inspection, bootstrap,
+     doctor/readiness, and issue-mode binding only. After binding, tracked
+     implementation, janitor, finish, and repair edits happen in the issue
+     worktree.
+   - Before issue work, check root `git status --short --branch` and
+     `git worktree list --porcelain`. If the primary checkout is on a feature
+     branch or has tracked changes, stop and route the recovery through
+     `workflow-conductor` / repo-native `pr run` or `pr doctor` evidence when
+     available. Use only the narrowest manual fallback needed to preserve work
+     into an issue worktree and restore the primary checkout to clean `main`.
+   - See `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md` for
+     the cross-session coordination and broadcast-note contract.
 4. Always create an issue-bound session goal before implementation work starts.
    - For tracked issue sessions, call `create_goal` after the issue is ready and
      before bounded implementation begins in the issue worktree.
@@ -148,18 +160,20 @@ For a normal tracked issue:
 
 1. read the source issue prompt and current task bundle
 2. route through `workflow-conductor`
-3. confirm all five C-SDLC cards exist and came from the active prompt-template
+3. confirm the primary checkout is clean on `main`, inspect active worktrees,
+   and preserve any session handoff or collision evidence before binding work
+4. confirm all five C-SDLC cards exist and came from the active prompt-template
    registry
-4. make sure `SIP`, `STP`, and `SPP` are issue-specific and design-time ready
-5. follow the conductor-selected lifecycle step
-6. if the issue is ready for execution binding, use `adl/tools/pr.sh run <issue>`
-7. call `create_goal` for the bound tracked issue session before implementation
+5. make sure `SIP`, `STP`, and `SPP` are issue-specific and design-time ready
+6. follow the conductor-selected lifecycle step
+7. if the issue is ready for execution binding, use `adl/tools/pr.sh run <issue>`
+8. call `create_goal` for the bound tracked issue session before implementation
    starts
-8. make the bounded change in the issue worktree, never on `main`
-9. run the smallest meaningful validation for the touched surface
-10. run a pre-PR subagent review and fix findings
-11. verify PR base/stack topology, then publish through the normal PR workflow
-12. use `update_goal` for truthful terminal session state, then perform closeout
+9. make the bounded change in the issue worktree, never on `main`
+10. run the smallest meaningful validation for the touched surface
+11. run a pre-PR subagent review and fix findings
+12. verify PR base/stack topology, then publish through the normal PR workflow
+13. use `update_goal` for truthful terminal session state, then perform closeout
    after merge/closure
 
 ## Validation Expectations

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -494,6 +494,16 @@ The ADL workflow uses one primary checkout and issue-scoped worktrees.
 - `pr-finish` must publish from the bound issue worktree when the issue branch is checked out there.
 - `pr-janitor` repairs the existing PR branch/worktree; it must not recreate work from primary main.
 
+Before a session starts or resumes tracked issue work, it should check
+`git status --short --branch` and `git worktree list --porcelain` from the
+primary checkout. If root is on a feature branch or has tracked changes, route
+that as `unsafe_root_checkout_execution`: use `workflow-conductor` and
+repo-native worktree evidence when available, use only the narrowest manual
+fallback needed to preserve work in an issue worktree, restore the primary
+checkout to clean `main`, and leave a short broadcast note in the relevant
+issue, PR, sprint packet, or closeout record. The durable policy is
+`docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`.
+
 Canonical blocker names:
 - `unsafe_root_checkout_execution`
 - `mismatched_publication_surface`

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -27,6 +27,15 @@ Canonical local STPs live under `.adl/<version>/tasks/<task-id>__<slug>/`, compa
 GitHub issue state is the source of truth for whether a card is active or complete. Active/current cards stay flat under `.adl/cards/<issue>/` while milestone work is in flight; completed cards may be archived later under `.adl/cards/completed/<milestone>/<issue>/`.
 The browser/editor adapter remains narrower than the full control plane; execution work should follow the `pr ready` -> `pr run` path rather than the older `pr start` model.
 
+The primary checkout should stay clean on `main`. Before starting issue work,
+check `git status --short --branch` and `git worktree list --porcelain`; if a
+feature branch or tracked changes are sitting in the primary checkout, route
+the recovery through `workflow-conductor` / repo-native `pr run` or `pr doctor`
+evidence when available. Use only the narrowest manual fallback needed to
+preserve work in an issue worktree and restore root to clean `main`. See
+`docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md` for the
+cross-session handoff and broadcast-note rules.
+
 Compression-safe finish validation is allowed only when the issue is low-risk
 docs/static-tooling work and the SOR truthfully records focused local validation
 instead of full local validation. CI remains required before merge.

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -9,6 +9,8 @@ The goal of this directory is to make ADL’s tooling surfaces understandable an
 - Prompt-spec and structured prompt surfaces: `prompt-spec.md`
 - Canonical issue-card lifecycle: `card-lifecycle.md`
 - Structured prompt contracts: `structured-prompt-contracts.md`
+- Session coordination and root checkout policy:
+  `SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`
 - Default contributor workflow: `../default_workflow.md`
 - Editor and authoring proof surfaces: `editor/README.md`
 - Root project overview: `../README.md`
@@ -67,6 +69,7 @@ These docs describe the bounded editor and authoring surfaces used in the v0.85 
 These docs describe worktree governance, large-module tracking, and related maintenance guidance.
 
 - [Worktree Governance](worktree_governance.md)
+- [Session Coordination And Root Checkout Policy](SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md)
 - Rust module size reports are local operational artifacts under `.adl/reports/manual/`; regenerate them with `./adl/tools/report_large_rust_modules.sh`
 - [WP Issue-Wave Generation](WP_ISSUE_WAVE_GENERATION.md)
 - [Historical Public Task Records](../records/README.md)

--- a/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
+++ b/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
@@ -1,0 +1,157 @@
+# Session Coordination And Root Checkout Policy
+
+## Purpose
+
+ADL sessions often run in parallel. They share the same Git repository, issue
+queue, local worktrees, and operator attention, but they do not automatically
+share chat history or intent. This policy makes the root checkout and session
+handoff rules explicit so one session does not strand another on the wrong
+branch, overwrite active work, or hide important workflow state in memory.
+
+## Current Authority
+
+This document clarifies the existing workflow rules in:
+
+- `AGENTS.md`
+- `docs/onboarding.md`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- the `workflow-conductor` and `pr-run` skill contracts
+
+If this document conflicts with `AGENTS.md`, `AGENTS.md` wins until both files
+are updated together.
+
+## Root Checkout Ownership
+
+The primary checkout is the repository root, for example:
+
+```text
+/Users/daniel/git/agent-design-language
+```
+
+The primary checkout must normally stay on clean `main`.
+
+Allowed primary-checkout uses:
+
+- read-only inspection
+- issue creation/bootstrap
+- `pr ready` / `pr doctor`
+- issue-mode `pr run` binding when `main` is clean
+- fast-forwarding `main`
+- checking root/worktree state before routing
+
+Disallowed primary-checkout uses:
+
+- tracked implementation edits
+- janitor repairs to PR branches
+- finish staging for an issue branch
+- leaving the root checkout on a feature branch
+- parking untracked issue artifacts in root when a bound worktree exists
+
+After an issue is bound, tracked edits happen in the bound issue worktree.
+
+## Required Startup Check
+
+Before starting or resuming tracked issue work, a session must check:
+
+```bash
+git status --short --branch
+git worktree list --porcelain
+```
+
+Expected root state:
+
+```text
+## main...origin/main
+```
+
+If the primary checkout is not on `main`, has tracked changes, or is occupied by
+an issue branch, stop before implementation. Route the recovery through
+`workflow-conductor` and repo-native `pr run` or `pr doctor` evidence when the
+issue/worktree can be identified. Use only the narrowest manual fallback needed
+to preserve work in an issue worktree, restore the primary checkout to clean
+`main`, and record what moved where.
+
+If a broad process check is needed, use the permission-safe process helper from
+`docs/tooling/PERMISSION_SAFE_PROCESS_STATUS.md`; do not use broad `ps`,
+`pgrep`, or `lsof` scans as workflow control.
+
+## Active Session Registry
+
+ADL needs a first-class local session registry. Until the registry command
+exists, sessions should treat the following fields as the required coordination
+shape for handoff notes and future registry records:
+
+- `session_id` or thread identifier when known
+- issue number or sprint umbrella
+- branch
+- worktree path
+- current lifecycle stage
+- PR number or URL when known
+- do-not-touch paths
+- watcher or janitor owner when one exists
+- last meaningful update time
+- known blockers
+
+Future tooling should expose this through commands such as:
+
+```text
+adl session status
+adl session claim
+adl session heartbeat
+adl session release
+```
+
+That implementation is intentionally follow-on work. This policy issue only
+establishes the documented contract.
+
+## Broadcast Notes
+
+When a session changes shared workflow state, it must leave a short durable note
+in the relevant issue, sprint packet, PR, or closeout record. Examples:
+
+- root checkout repaired
+- feature branch moved from root into `.worktrees/...`
+- issue is active in another session
+- issue is waiting on CI, review, or watcher
+- raw GitHub fallback was used because repo-native tooling failed
+- lifecycle wrapper stalled or failed and a bounded fallback was used
+
+Broadcast notes should be factual, brief, and free of secrets. They should name
+the issue, branch, worktree, and next expected owner/action.
+
+## Collision Handling
+
+When another session appears to own an issue or worktree:
+
+1. Do not start duplicate implementation work.
+2. Inspect the issue, PR, branch, and worktree state.
+3. If the state is healthy, leave it alone or watch it.
+4. If the state is stale or broken, record the evidence and route through
+   `workflow-conductor`, `pr-janitor`, or `pr-closeout` as appropriate.
+5. If root is occupied by that work, route through `workflow-conductor` and
+   repo-native worktree evidence first. Use manual preservation only as a
+   bounded fallback to move the work into an issue worktree before restoring
+   root to clean `main`.
+
+## Tooling Failure Handling
+
+If a repo-native lifecycle command fails or hangs:
+
+- stop the command rather than waiting indefinitely
+- verify whether it partially created an issue, worktree, PR, or local bundle
+- record the failure in the issue or a remediation issue
+- use the narrowest fallback needed to preserve root checkout safety
+- do not normalize the fallback into the preferred workflow
+
+This rule exists so emergency cleanup does not become a second, undocumented
+workflow.
+
+## Non-Goals
+
+This policy does not:
+
+- implement the future session registry commands
+- replace `workflow-conductor`
+- replace issue cards or closeout truth
+- permit tracked work on `main`
+- make chat memory authoritative


### PR DESCRIPTION
## Summary

Adds a tracked session coordination and root checkout policy so parallel ADL/Codex sessions can discover shared Git/worktree state before acting.

## Changes

- Add `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`.
- Update `AGENTS.md` startup rules for root checkout checks and cross-session coordination.
- Update `docs/onboarding.md` and `docs/tooling/README.md` so the policy is discoverable.
- Update `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md` to name `unsafe_root_checkout_execution` recovery behavior.

## Validation

- `git diff --check`
- focused Python smoke check for policy cross-links and future-registry non-claim
- focused `rg` check for root-checkout/session-coordination policy references
- bounded subagent review; fixed both findings

## Tooling Notes

`adl/tools/pr.sh create`, `init`, and `finish` each stalled after starting the Rust delegate in this session. Issue #4405 records the deviation. The branch was created in `.worktrees/adl-wp-4405`, root was restored/verified clean on `main`, and this PR was opened with `gh` as a narrow fallback because the repo-native publication path did not complete.

Closes #4405