### PR TITLE
[v0.91.6][WP-09][observatory][O-06] Rebuild the HTML Observatory as a mobile-capable governed surface

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -183,6 +183,39 @@
       "reason": "coverage_impact_surface_requires_coverage_impact_contract_checks"
     },
     {
+      "id": "html_observatory_governed_surface",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "demo_contract",
+      "requirement_ids": [
+        "html_observatory_governed_surface"
+      ],
+      "path_selectors": [
+        "adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh",
+        "adl/tools/validate_csm_governed_observatory.py",
+        "demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json",
+        "demos/v0.90.4/csm_observatory_governed_prototype.html",
+        "demos/v0.90.4/csm_observatory_governed_prototype.css",
+        "demos/v0.90.4/csm_observatory_governed_prototype.js",
+        "demos/v0.90.4/csm_observatory_governed_prototype.md",
+        "docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md"
+      ],
+      "path_hints": [
+        "adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh",
+        "adl/tools/validate_csm_governed_observatory.py",
+        "demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json",
+        "demos/v0.90.4/csm_observatory_governed_prototype.html",
+        "demos/v0.90.4/csm_observatory_governed_prototype.css",
+        "demos/v0.90.4/csm_observatory_governed_prototype.js",
+        "demos/v0.90.4/csm_observatory_governed_prototype.md",
+        "docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md"
+      ],
+      "command": "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh",
+      "run_command": "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh",
+      "reason": "portable_html_observatory_surface_requires_governed_demo_smoke"
+    },
+    {
       "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1670,6 +1670,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
             changed_paths,
         ));
     }
+    if finish_issue_needs_html_observatory_validation(issue_number, changed_paths) {
+        return Ok(build_html_observatory_validation_plan(changed_paths));
+    }
     let finish_profile = load_finish_validation_profile(&repo_root()?, changed_paths)?;
     if let Some(plan) = profile_backed_finish_validation_plan(&finish_profile) {
         return Ok(plan);
@@ -1785,6 +1788,66 @@ fn build_unity_observatory_contract_validation_plan(
         push_finish_validation_command(
             &mut commands,
             "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+        );
+    }
+    FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands,
+    }
+}
+
+fn finish_issue_needs_html_observatory_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    issue_number == 4341
+        && !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            finish_path_is_docs_only(trimmed)
+                || finish_path_is_small_binary_focused(trimmed)
+                || finish_path_is_larger_binary_focused(trimmed)
+                || parsed_issue_is_html_observatory_path(issue_number, trimmed)
+        })
+}
+
+fn build_html_observatory_validation_plan(changed_paths: &[String]) -> FinishValidationPlan {
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+        "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh".to_string(),
+    ];
+    if changed_paths.iter().any(|path| {
+        matches!(
+            path.trim().trim_matches('/'),
+            "adl/config/validation_lane_selector.v0.91.6.json"
+                | "adl/tools/test_select_validation_lanes.sh"
+        )
+    }) {
+        push_finish_validation_command(
+            &mut commands,
+            "bash adl/tools/test_select_validation_lanes.sh",
+        );
+    }
+    if changed_paths
+        .iter()
+        .any(|path| finish_path_needs_pr_finish_rust_focused_validation(path))
+    {
+        push_finish_validation_command(
+            &mut commands,
+            "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+        );
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation",
+        );
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+        );
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_html_mobile_observatory_slice_as_small_binary_focused -- --nocapture",
         );
     }
     FinishValidationPlan {
@@ -2551,6 +2614,24 @@ fn parsed_issue_is_unity_observatory_contract_path(issue: u32, path: &str) -> bo
     )
 }
 
+fn parsed_issue_is_html_observatory_path(issue: u32, path: &str) -> bool {
+    if issue != 4341 {
+        return false;
+    }
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        "adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh"
+            | "adl/tools/validate_csm_governed_observatory.py"
+            | "demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json"
+            | "demos/v0.90.4/csm_observatory_governed_prototype.html"
+            | "demos/v0.90.4/csm_observatory_governed_prototype.css"
+            | "demos/v0.90.4/csm_observatory_governed_prototype.js"
+            | "demos/v0.90.4/csm_observatory_governed_prototype.md"
+            | "docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md"
+    )
+}
+
 fn finish_path_needs_small_binary_delegation_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
     matches!(trimmed, "adl/tools/test_pr_small_binary_delegation.sh")
@@ -2991,6 +3072,21 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl-pr-finish",
                             "cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_unity_observatory_contract_slice_as_small_binary_focused",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_html_mobile_observatory_slice_as_small_binary_focused -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-pr-finish",
+                            "cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_html_mobile_observatory_slice_as_small_binary_focused",
                             "--",
                             "--nocapture",
                         ],

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3264,6 +3264,11 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_select_validation_lanes.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
+                "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh" => {
+                    let script =
+                        repo_root.join("adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
                 "bash adl/tools/test_validation_manager.sh" => {
                     let script = repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2724,6 +2724,45 @@ fn finish_validation_runner_executes_locked_cargo_fallback_script_command() {
 }
 
 #[test]
+fn finish_validation_runner_executes_html_observatory_demo_script_command() {
+    let repo = unique_temp_dir("adl-pr-finish-html-observatory-validation");
+    let tools = repo.join("adl/tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    write_executable(
+        &tools.join("check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\n",
+    );
+    write_executable(
+        &tools.join("test_demo_v0904_csm_observatory_governed_prototype.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nrepo_root=\"$(cd \"$(dirname \"$0\")/../..\" && pwd)\"\necho html-observatory-ran > \"$repo_root/html-observatory-ran.txt\"\n",
+    );
+
+    assert!(Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&repo)
+        .status()
+        .expect("git init")
+        .success());
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh".to_string(),
+        ],
+    };
+
+    run_finish_validation_rust(&repo, &plan).expect("validation runner");
+    assert_eq!(
+        fs::read_to_string(repo.join("html-observatory-ran.txt"))
+            .expect("runner marker")
+            .trim(),
+        "html-observatory-ran"
+    );
+}
+
+#[test]
 fn finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4215,

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2053,6 +2053,41 @@ fn finish_validation_profile_classifies_observability_consumption_slice_as_small
 }
 
 #[test]
+fn finish_validation_profile_classifies_html_mobile_observatory_slice_as_small_binary_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        4341,
+        ".",
+        &[
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh".to_string(),
+            "adl/tools/validate_csm_governed_observatory.py".to_string(),
+            "demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json"
+                .to_string(),
+            "demos/v0.90.4/csm_observatory_governed_prototype.html".to_string(),
+            "demos/v0.90.4/csm_observatory_governed_prototype.css".to_string(),
+            "demos/v0.90.4/csm_observatory_governed_prototype.js".to_string(),
+            "demos/v0.90.4/csm_observatory_governed_prototype.md".to_string(),
+            "docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md".to_string(),
+        ],
+    )
+    .expect("html observatory plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan.commands.contains(
+        &"bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_html_mobile_observatory_slice_as_small_binary_focused -- --nocapture".to_string()
+    ));
+}
+
+#[test]
 fn finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         1153,

--- a/adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh
+++ b/adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh
@@ -7,8 +7,9 @@ CSS="${ROOT_DIR}/demos/v0.90.4/csm_observatory_governed_prototype.css"
 JS="${ROOT_DIR}/demos/v0.90.4/csm_observatory_governed_prototype.js"
 DOC="${ROOT_DIR}/demos/v0.90.4/csm_observatory_governed_prototype.md"
 PACKET="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json"
+RUNTIME_PACKET="${ROOT_DIR}/adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
 
-for path in "${HTML}" "${CSS}" "${JS}" "${DOC}" "${PACKET}"; do
+for path in "${HTML}" "${CSS}" "${JS}" "${DOC}" "${PACKET}" "${RUNTIME_PACKET}"; do
   [[ -f "${path}" ]] || {
     echo "missing governed Observatory artifact: ${path}" >&2
     exit 1
@@ -19,33 +20,46 @@ python3 "${ROOT_DIR}/adl/tools/validate_csm_visibility_packet.py" "${PACKET}" >/
 python3 "${ROOT_DIR}/adl/tools/validate_csm_governed_observatory.py" \
   --html "${HTML}" \
   --js "${JS}" \
-  --packet "${PACKET}" >/dev/null
+  --packet "${RUNTIME_PACKET}" >/dev/null
 python3 -m json.tool "${PACKET}" >/dev/null
+python3 -m json.tool "${RUNTIME_PACKET}" >/dev/null
 
 grep -Fq "Proposal-only actions" "${HTML}"
 grep -Fq "Corporate Investor UI" "${HTML}"
+grep -Fq "Proof posture at a glance" "${HTML}"
+grep -Fq "HTML and Unity stay separate" "${HTML}"
 grep -Fq "World / Reality" "${HTML}"
 grep -Fq "Operator / Governance" "${HTML}"
 grep -Fq "Review / Export Surface" "${HTML}"
 grep -Fq "No live mutation" "${HTML}"
+grep -Fq "../../adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json" "${HTML}"
 
 grep -Fq "proposal-only" "${DOC}"
 grep -Fq "Corporate Investor mode" "${DOC}"
-grep -Fq "fixture_backed" "${DOC}"
+grep -Fq "fixture_backed_governed_mobile_surface" "${DOC}"
+grep -Fq "HTML versus Unity lane split" "${DOC}"
+grep -Fq "adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json" "${DOC}"
 
+grep -Fq "surface_classification" "${JS}"
+grep -Fq "lane_split" "${JS}"
+grep -Fq "mergePacket" "${JS}"
 grep -Fq "proposal_cases" "${JS}"
 grep -Fq "renderPrototype" "${JS}"
 grep -Fq "fallbackPacket" "${JS}"
 grep -Fq "Toggle Corporate Investor UI" "${HTML}"
 grep -Fq "keyboard_shortcut" "${PACKET}"
 grep -Fq "Cognition / Internal State" "${PACKET}"
+grep -Fq "Unity Observatory" "${JS}"
 
 grep -Fq ".chip" "${CSS}"
 grep -Fq ".proposal-card" "${CSS}"
 grep -Fq ".observatory-governed-shell.is-investor-mode" "${CSS}"
+grep -Fq ".status-band" "${CSS}"
+grep -Fq "overflow-wrap: anywhere" "${CSS}"
+grep -Fq "@media (max-width: 720px)" "${CSS}"
 
 if grep -REn '/Users/|/private/var/|localhost:[0-9]|192\.168\.|bearer[[:space:]]+[A-Za-z0-9._-]{8,}|(api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[A-Za-z0-9._-]{8,}' \
-  "${HTML}" "${CSS}" "${JS}" "${DOC}" "${PACKET}"; then
+  "${HTML}" "${CSS}" "${JS}" "${DOC}" "${PACKET}" "${RUNTIME_PACKET}"; then
   echo "governed Observatory prototype leaked private path, endpoint, or secret-like text" >&2
   exit 1
 fi

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -411,4 +411,31 @@ if bash "$SCRIPT" --manifest "$missing_metadata_manifest" --changed-files "$docs
 fi
 assert_has "$TMP/missing-metadata.err" "missing required surface metadata: proof_role"
 
+html_observatory="$TMP/html-observatory.txt"
+cat >"$html_observatory" <<'EOF'
+M	adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh
+M	adl/tools/validate_csm_governed_observatory.py
+M	demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json
+M	demos/v0.90.4/csm_observatory_governed_prototype.html
+M	demos/v0.90.4/csm_observatory_governed_prototype.css
+M	demos/v0.90.4/csm_observatory_governed_prototype.js
+M	demos/v0.90.4/csm_observatory_governed_prototype.md
+M	docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md
+EOF
+bash "$SCRIPT" --changed-files "$html_observatory" --json >"$TMP/html-observatory.json"
+python3 - <<'PY' "$TMP/html-observatory.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert set(profile["lanes"].keys()) == {"html_observatory_governed_surface"}
+lane = profile["lanes"]["html_observatory_governed_surface"]
+assert lane["status"] == "selected"
+assert lane["proof_role"] == "demo_contract"
+assert lane["owner"] == "review"
+PY
+
 echo "PASS test_select_validation_lanes"

--- a/adl/tools/validate_csm_governed_observatory.py
+++ b/adl/tools/validate_csm_governed_observatory.py
@@ -33,24 +33,40 @@ def assert_contains(label: str, observed: str | None, expected: str) -> None:
         fail(f"{label} did not contain {expected!r}")
 
 
-def run_render_smoke(js_path: Path) -> dict[str, Any]:
+def run_render_smoke(js_path: Path, packet_path: Path) -> dict[str, Any]:
     appended_js = """
-packet = fallbackPacket;
+packet = mergePacket(JSON.parse(fs.readFileSync(packetPath, "utf8")));
+const defaultDot = packet.observatory_ui?.default_memory_dot;
+if (defaultDot) {
+  applyMemoryDot(defaultDot);
+}
 renderPrototype();
+const docketNodes = nodeLists.get("[data-target]") || [];
+if (docketNodes[0]) {
+  docketNodes[0].click();
+}
 globalThis.__governedSmoke = {
   fallbackPacket,
+  loadedPacketId: packet.packet_id,
+  classificationSummary: elements.get("#classification-summary")?.textContent,
+  laneSplitSummary: elements.get("#lane-split-summary")?.textContent,
   atlasSummary: elements.get("#atlas-summary")?.textContent,
   governanceSummary: elements.get("#governance-summary")?.textContent,
   inspectorHeading: elements.get("#inspector-heading")?.textContent,
   inspectorAllowed: elements.get("#inspector-allowed")?.textContent,
   proposalModeStatement: elements.get("#proposal-mode-statement")?.textContent,
+  classificationCards: elements.get("#classification-cards")?.innerHTML,
+  laneSplitCards: elements.get("#lane-split-cards")?.innerHTML,
+  currentInputs: elements.get("#current-inputs")?.innerHTML,
   proposalCards: elements.get("#proposal-cards")?.innerHTML,
   proposalDetail: elements.get("#proposal-detail")?.innerHTML,
   reviewLinks: elements.get("#review-links")?.innerHTML,
   traceRibbon: elements.get("#trace-ribbon")?.innerHTML,
   roomTabs: elements.get("#room-tabs")?.innerHTML,
   lensTabs: elements.get("#lens-tabs")?.innerHTML,
-  memoryDots: elements.get("#memory-dots")?.innerHTML
+  memoryDots: elements.get("#memory-dots")?.innerHTML,
+  postDocketRoom: state.room,
+  postDocketCitizen: state.selectedCitizenId
 };
 """
     node_program = textwrap.dedent(
@@ -59,6 +75,7 @@ globalThis.__governedSmoke = {
         const vm = require("vm");
 
         const elements = new Map();
+        const nodeLists = new Map();
         function element(selector, extra = {{}}) {{
           if (!elements.has(selector)) {{
             elements.set(selector, {{
@@ -74,6 +91,54 @@ globalThis.__governedSmoke = {
           return elements.get(selector);
         }}
 
+        function createNode(dataset) {{
+          const listeners = new Map();
+          return {{
+            dataset,
+            addEventListener(type, handler) {{
+              listeners.set(type, handler);
+            }},
+            click() {{
+              const handler = listeners.get("click");
+              if (handler) {{
+                handler({{ currentTarget: this, target: this }});
+              }}
+            }}
+          }};
+        }}
+
+        function parseNodes(selector) {{
+          const nodes = [];
+          const patterns = {{
+            "[data-citizen]": /data-citizen="([^"]+)"/g,
+            "[data-proposal]": /data-proposal="([^"]+)"/g,
+            "[data-target]": /data-target="([^"]+)"/g,
+            "[data-key='room_id']": /data-key="room_id"\\s+data-value="([^"]+)"/g,
+            "[data-key='lens_id']": /data-key="lens_id"\\s+data-value="([^"]+)"/g,
+            "[data-key='dot_id']": /data-key="dot_id"\\s+data-value="([^"]+)"/g
+          }};
+          const pattern = patterns[selector];
+          if (!pattern) {{
+            return nodes;
+          }}
+          for (const value of elements.values()) {{
+            pattern.lastIndex = 0;
+            let match;
+            while ((match = pattern.exec(value.innerHTML)) !== null) {{
+              if (selector === "[data-citizen]") {{
+                nodes.push(createNode({{ citizen: match[1] }}));
+              }} else if (selector === "[data-proposal]") {{
+                nodes.push(createNode({{ proposal: match[1] }}));
+              }} else if (selector === "[data-target]") {{
+                nodes.push(createNode({{ target: match[1] }}));
+              }} else {{
+                nodes.push(createNode({{ value: match[1] }}));
+              }}
+            }}
+          }}
+          return nodes;
+        }}
+
         const document = {{
           body: element("body", {{ classList: {{ toggle() {{}} }} }}),
           querySelector(selector) {{
@@ -82,14 +147,24 @@ globalThis.__governedSmoke = {
             }}
             return element(selector);
           }},
-          querySelectorAll() {{
-            return [];
+          querySelectorAll(selector) {{
+            const nodes = parseNodes(selector);
+            nodeLists.set(selector, nodes);
+            return nodes;
           }},
           addEventListener() {{}}
         }};
 
         const source = fs.readFileSync({json.dumps(str(js_path))}, "utf8") + {json.dumps(appended_js)};
-        const context = {{ document, fetch: undefined, console, elements }};
+        const context = {{
+          document,
+          fetch: undefined,
+          console,
+          elements,
+          nodeLists,
+          fs,
+          packetPath: {json.dumps(str(packet_path))}
+        }};
         vm.runInNewContext(source, context);
         process.stdout.write(JSON.stringify(context.__governedSmoke));
         """
@@ -117,26 +192,35 @@ def main() -> int:
     args = parser.parse_args()
 
     html = args.html.read_text(encoding="utf-8")
+    js_source = args.js.read_text(encoding="utf-8")
     packet = load_json(args.packet)
-    ui = packet.get("observatory_ui", {})
-    smoke = run_render_smoke(args.js)
+    smoke = run_render_smoke(args.js, args.packet)
     fallback = smoke["fallbackPacket"]
 
     assert_contains(
         "HTML packet reference",
         html,
-        "data-packet-ref=\"../fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json\"",
+        "data-packet-ref=\"../../adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json\"",
     )
     assert_equal("packet schema", packet["schema"], "adl.csm_visibility_packet.v1")
     assert_equal("fallback schema", fallback["schema"], packet["schema"])
-    assert_equal("fallback packet_id", fallback["packet_id"], packet["packet_id"])
-    assert_equal("default room", fallback["observatory_ui"]["default_room"], ui["default_room"])
-    assert_equal("default lens", fallback["observatory_ui"]["default_lens"], ui["default_lens"])
-    assert_equal(
-        "proposal ids",
-        [item["proposal_id"] for item in fallback["observatory_ui"]["proposal_cases"]],
-        [item["proposal_id"] for item in ui["proposal_cases"]],
+    assert_equal("loaded packet id", smoke["loadedPacketId"], packet["packet_id"])
+    assert_contains(
+        "fallback current input ref",
+        smoke["currentInputs"],
+        "adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json",
     )
+    assert_equal("default room", fallback["observatory_ui"]["default_room"], "world")
+    assert_equal("default lens", fallback["observatory_ui"]["default_lens"], "operator")
+    assert_contains("classification summary", smoke["classificationSummary"], "Fail-closed")
+    assert_contains("lane split summary", smoke["laneSplitSummary"], "HTML stays portable")
+    assert_contains("classification cards", smoke["classificationCards"], "Proof")
+    assert_contains("classification cards", smoke["classificationCards"], "Deferred")
+    assert_contains("lane split cards", smoke["laneSplitCards"], "HTML Observatory")
+    assert_contains("lane split cards", smoke["laneSplitCards"], "Unity Observatory")
+    assert_contains("docket target handler", js_source, "[data-target]")
+    assert_equal("docket click room", smoke["postDocketRoom"], "governance")
+    assert_equal("docket click citizen", smoke["postDocketCitizen"], packet["citizens"][0]["citizen_id"])
     assert_contains("atlas summary", smoke["atlasSummary"], packet["manifold"]["health"]["summary"])
     assert_contains("governance summary", smoke["governanceSummary"], "allow")
     assert_equal("inspector heading", smoke["inspectorHeading"], packet["citizens"][0]["display_name"])
@@ -144,8 +228,16 @@ def main() -> int:
     assert_contains("proposal mode statement", smoke["proposalModeStatement"], "proposal")
     assert_contains("proposal cards", smoke["proposalCards"], "Inspect Alpha continuity packet")
     assert_contains("proposal detail", smoke["proposalDetail"], "validate operator identity")
-    assert_contains("review links", smoke["reviewLinks"], "runtime_v2/observatory/operator_report.md")
-    assert_contains("trace ribbon", smoke["traceRibbon"], "Operator opened a continuity review request")
+    assert_contains(
+        "review links",
+        smoke["reviewLinks"],
+        "docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md",
+    )
+    assert_contains(
+        "trace ribbon",
+        smoke["traceRibbon"],
+        packet["trace"]["trace_tail"][0]["summary"],
+    )
     assert_contains("room tabs", smoke["roomTabs"], "World / Reality")
     assert_contains("lens tabs", smoke["lensTabs"], "Operator lens")
     assert_contains("memory dots", smoke["memoryDots"], "Corporate Investor")

--- a/demos/v0.90.4/csm_observatory_governed_prototype.css
+++ b/demos/v0.90.4/csm_observatory_governed_prototype.css
@@ -90,7 +90,7 @@ h1,
 h2 {
   margin: 0;
   font-family: var(--font-display);
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
 }
 
 h1 {
@@ -131,6 +131,50 @@ h2 {
   text-transform: uppercase;
 }
 
+.status-band {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.status-panel {
+  padding: 1rem;
+}
+
+.status-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.status-card {
+  min-height: 8.5rem;
+  border: 1px solid var(--line);
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.9rem;
+}
+
+.status-card strong,
+.lane-card strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.status-card p,
+.lane-card p {
+  margin: 0.45rem 0 0;
+}
+
+.status-card__meta,
+.lane-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+}
+
 .control-strip {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
@@ -159,6 +203,8 @@ h2 {
   background: rgba(255, 255, 255, 0.04);
   padding: 0.48rem 0.72rem;
   cursor: pointer;
+  min-height: 2.75rem;
+  touch-action: manipulation;
   transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
@@ -185,6 +231,8 @@ h2 {
   background: rgba(255, 191, 104, 0.08);
   cursor: pointer;
   min-height: 100%;
+  min-width: 11rem;
+  touch-action: manipulation;
 }
 
 .observatory-grid {
@@ -283,7 +331,8 @@ h2 {
 
 .citizen-card,
 .docket-card,
-.proposal-card {
+.proposal-card,
+.lane-card {
   width: 100%;
   text-align: left;
   border: 1px solid var(--line);
@@ -433,6 +482,19 @@ h2 {
   color: var(--cyan);
   font-family: var(--font-mono);
   font-size: 0.86rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.status-card code,
+#current-inputs code {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--cyan);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .observatory-governed-shell.is-investor-mode {
@@ -454,6 +516,7 @@ h2 {
 }
 
 @media (max-width: 1100px) {
+  .status-band,
   .control-strip,
   .observatory-grid {
     grid-template-columns: 1fr;
@@ -466,6 +529,55 @@ h2 {
   .manifold-metrics,
   .inspector-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 0.85rem;
+  }
+
+  .hero__mast,
+  .panel__header {
+    flex-direction: column;
+  }
+
+  .truth-strip {
+    justify-content: start;
+    max-width: none;
+  }
+
+  .control-strip__group,
+  .panel,
+  .status-panel {
+    padding: 0.85rem;
+  }
+
+  .chip-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.2rem;
+    scrollbar-width: thin;
+  }
+
+  .chip-row .chip {
+    flex: 0 0 auto;
+  }
+
+  .status-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .atlas-orb {
+    min-height: 11rem;
+  }
+
+  h1 {
+    font-size: clamp(2.35rem, 12vw, 3.4rem);
+  }
+
+  h2 {
+    font-size: 1.35rem;
   }
 }
 

--- a/demos/v0.90.4/csm_observatory_governed_prototype.html
+++ b/demos/v0.90.4/csm_observatory_governed_prototype.html
@@ -9,7 +9,7 @@
   <body>
     <main
       class="observatory-governed-shell"
-      data-packet-ref="../fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json"
+      data-packet-ref="../../adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
     >
       <section class="hero" aria-labelledby="prototype-title">
         <div class="hero__backdrop" aria-hidden="true"></div>
@@ -18,7 +18,7 @@
             <p class="eyebrow">CSM Observatory / governed prototype</p>
             <h1 id="prototype-title">Prototype CSM 02</h1>
             <p class="hero__lede" id="hero-lede">
-              Fixture-backed Observatory prototype with rooms, lenses, memory dots, and proposal-only controls.
+              Portable governed Observatory consuming bounded runtime visibility artifacts with rooms, lenses, memory dots, and proposal-only controls.
             </p>
           </div>
           <div class="truth-strip" aria-label="Truth boundary">
@@ -28,6 +28,27 @@
             <span id="investor-mode-tag">Atlas mode</span>
           </div>
         </header>
+
+        <section class="status-band" aria-label="WP-09 surface status">
+          <article class="status-panel panel" aria-labelledby="classification-heading">
+            <p class="eyebrow">Surface Classification</p>
+            <div class="panel__header">
+              <h2 id="classification-heading">Proof posture at a glance</h2>
+              <p id="classification-summary" class="panel-note"></p>
+            </div>
+            <div id="classification-cards" class="status-card-grid"></div>
+          </article>
+
+          <article class="status-panel panel" aria-labelledby="lane-split-heading">
+            <p class="eyebrow">Lane Split</p>
+            <div class="panel__header">
+              <h2 id="lane-split-heading">HTML and Unity stay separate</h2>
+              <p id="lane-split-summary" class="panel-note"></p>
+            </div>
+            <div id="lane-split-cards" class="status-card-grid"></div>
+            <ul id="current-inputs" class="review-links"></ul>
+          </article>
+        </section>
 
         <section class="control-strip" aria-label="Observatory navigation">
           <div class="control-strip__group">

--- a/demos/v0.90.4/csm_observatory_governed_prototype.js
+++ b/demos/v0.90.4/csm_observatory_governed_prototype.js
@@ -1,12 +1,14 @@
 const fallbackPacket = {
   schema: "adl.csm_visibility_packet.v1",
   packet_id: "csm-observatory-fixture-proto-csm-02",
+  generated_at: "2026-06-21T00:00:00Z",
   source: {
-    mode: "fixture",
-    evidence_level: "fixture_backed",
+    mode: "fixture_overlay",
+    evidence_level: "fixture_backed_with_runtime_visibility_overlay",
     fixture: true,
     runtime_artifact_root: "adl/tests/fixtures/runtime_v2/observatory",
-    claim_boundary: "Fixture-backed governed Observatory prototype. This is not a live Runtime v2 capture and it does not grant direct mutation authority."
+    claim_boundary:
+      "This HTML Observatory consumes bounded runtime visibility artifacts and layers governed prototype UI metadata on top. It is not a live mutation console."
   },
   manifold: {
     manifold_id: "proto-csm-02",
@@ -15,7 +17,8 @@ const fallbackPacket = {
     current_tick: 14,
     health: {
       level: "nominal",
-      summary: "Bounded polis state is inspectable, trace-backed, and still explicitly governed.",
+      summary:
+        "Bounded polis state is inspectable, trace-backed, and still explicitly governed.",
       attention_items: [
         "All active-looking controls remain proposal-only.",
         "Challenge and quarantine remain visible protection boundaries."
@@ -45,8 +48,15 @@ const fallbackPacket = {
       resource_balance: { compute_units: 6 },
       alerts: ["resource pressure visible under operator lens"],
       capability_envelope: {
-        allowed: ["bounded_reviewable_episode", "answer_operator_prompt_with_bounded_summary"],
-        forbidden: ["direct_runtime_mutation", "unmediated_state_commit", "cross_polis_export"]
+        allowed: [
+          "bounded_reviewable_episode",
+          "answer_operator_prompt_with_bounded_summary"
+        ],
+        forbidden: [
+          "direct_runtime_mutation",
+          "unmediated_state_commit",
+          "cross_polis_export"
+        ]
       },
       evidence_refs: [
         "runtime_v2/citizens/proto-citizen-alpha.json",
@@ -64,7 +74,11 @@ const fallbackPacket = {
       alerts: ["standing is bounded to guest view"],
       capability_envelope: {
         allowed: ["read_only_observation", "challenge_review"],
-        forbidden: ["citizen_rights_escalation", "direct_runtime_mutation", "cross_polis_export"]
+        forbidden: [
+          "citizen_rights_escalation",
+          "direct_runtime_mutation",
+          "cross_polis_export"
+        ]
       },
       evidence_refs: [
         "runtime_v2/citizens/proto-citizen-beta.json",
@@ -90,51 +104,167 @@ const fallbackPacket = {
       ]
     }
   ],
-  freedom_gate: {
-    recent_docket: [
-      { decision_id: "fg-alpha-allow-0007", actor: "proto-citizen-alpha", action: "answer_operator_prompt_with_bounded_summary", decision: "allow", rationale: "bounded summary request stayed within the active capability envelope" },
-      { decision_id: "fg-beta-challenge-0004", actor: "proto-citizen-beta", action: "request_citizen_rights_escalation", decision: "defer", rationale: "escalation request moved into governed challenge review" },
-      { decision_id: "fg-snapshot-quarantine-0003", actor: "operator.demo", action: "request_snapshot_review", decision: "refuse", rationale: "snapshot request is visible as a proposal only until a governed handler exists" }
+  trace: {
+    trace_tail: [
+      {
+        event_sequence: 11,
+        actor: "operator.demo",
+        summary: "Operator opened a continuity review request in Governance Mode."
+      },
+      {
+        event_sequence: 12,
+        actor: "kernel.freedom_gate",
+        summary: "Freedom Gate allowed a bounded continuity summary request."
+      },
+      {
+        event_sequence: 13,
+        actor: "proto-citizen-beta",
+        summary: "Guest standing escalation entered challenge review instead of silent promotion."
+      },
+      {
+        event_sequence: 14,
+        actor: "shepherd.service",
+        summary: "Review export links were prepared without mutating citizen state."
+      }
     ]
   },
   resources: {
-    compute_units: "9 total / 3 reserved / 6 visible active",
     memory_pressure: "moderate",
-    queue_depth: "2 governed requests waiting on review or handler availability",
-    fairness_notes: [
-      "Service actor remains bounded to support work rather than hidden execution authority.",
-      "Guest requests do not silently acquire citizen standing."
-    ]
+    queue_depth: "2 governed requests waiting on review or handler availability"
   },
-  trace: {
-    trace_tail: [
-      { event_sequence: 11, actor: "operator.demo", summary: "Operator opened a continuity review request in Governance Mode." },
-      { event_sequence: 12, actor: "kernel.freedom_gate", summary: "Freedom Gate allowed a bounded continuity summary request." },
-      { event_sequence: 13, actor: "proto-citizen-beta", summary: "Guest standing escalation entered challenge review instead of silent promotion." },
-      { event_sequence: 14, actor: "shepherd.service", summary: "Review export links were prepared without mutating citizen state." }
+  freedom_gate: {
+    recent_docket: [
+      {
+        decision_id: "fg-alpha-allow-0007",
+        actor: "proto-citizen-alpha",
+        action: "answer_operator_prompt_with_bounded_summary",
+        decision: "allow",
+        rationale:
+          "bounded summary request stayed within the active capability envelope"
+      },
+      {
+        decision_id: "fg-beta-challenge-0004",
+        actor: "proto-citizen-beta",
+        action: "request_citizen_rights_escalation",
+        decision: "defer",
+        rationale: "escalation request moved into governed challenge review"
+      },
+      {
+        decision_id: "fg-snapshot-quarantine-0003",
+        actor: "operator.demo",
+        action: "request_snapshot_review",
+        decision: "refuse",
+        rationale:
+          "snapshot request is visible as a proposal only until a governed handler exists"
+      }
     ]
   },
   review: {
     primary_artifacts: [
-      "runtime_v2/observatory/visibility_packet.json",
-      "runtime_v2/observatory/operator_report.md",
-      "docs/milestones/v0.90.3/OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md"
+      "adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json",
+      "docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md",
+      "docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md",
+      "docs/milestones/v0.91.6/review/security/UNITY_OBSERVATORY_INHABITANT_READINESS_SECURITY_REVIEW_4023.md"
     ],
     caveats: [
       "This is not a live mutation console.",
-      "Corporate Investor mode does not change evidence, authority, or trace boundaries."
+      "Corporate Investor mode does not change evidence, authority, or trace boundaries.",
+      "Unity remains the richer inhabitant-facing lane; this HTML surface stays operator and reviewer oriented."
     ],
-    demo_classification: "fixture_backed_governed_prototype"
+    demo_classification: "fixture_backed_governed_mobile_surface",
+    current_inputs: [
+      "../../adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json",
+      "docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md",
+      "docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md"
+    ],
+    surface_classification: [
+      {
+        surface_id: "proof",
+        label: "Proof",
+        state: "active",
+        summary:
+          "Runtime visibility packet, review artifacts, and trace-backed packet references are consumable proof surfaces.",
+        artifact_ref: "adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
+      },
+      {
+        surface_id: "rehearsal",
+        label: "Rehearsal",
+        state: "bounded",
+        summary:
+          "This HTML shell is a serious rehearsal surface, but it does not prove live Runtime v2 mutation or Unity parity.",
+        artifact_ref:
+          "demos/v0.90.4/csm_observatory_governed_prototype.html"
+      },
+      {
+        surface_id: "substrate",
+        label: "Substrate",
+        state: "consumed",
+        summary:
+          "The governed UI consumes the existing runtime visibility artifact contract and redaction posture rather than inventing a new backend.",
+        artifact_ref: "adl/tests/fixtures/runtime_v2/observatory/operator_report.md"
+      },
+      {
+        surface_id: "blocked",
+        label: "Blocked",
+        state: "fail_closed",
+        summary:
+          "Live governed action handlers and direct mutation authority remain intentionally unavailable from this lane.",
+        artifact_ref: "issue-owned residual: #4030, #4031, #4032"
+      },
+      {
+        surface_id: "deferred",
+        label: "Deferred",
+        state: "explicit",
+        summary:
+          "Umbrella closeout and full WP-09 readiness remain deferred until the remaining issue-owned proofs land.",
+        artifact_ref: "docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md"
+      }
+    ],
+    lane_split: [
+      {
+        lane_id: "html",
+        label: "HTML Observatory",
+        owner_role: "portable operator / reviewer / mobile surface",
+        status: "implemented_here",
+        summary:
+          "Touch-safe bounded observability with explicit proof posture and redaction-safe artifact routing.",
+        artifact_ref:
+          "demos/v0.90.4/csm_observatory_governed_prototype.html"
+      },
+      {
+        lane_id: "unity",
+        label: "Unity Observatory",
+        owner_role: "richer inhabitant / interactive surface",
+        status: "separate_lane",
+        summary:
+          "Unity remains the deeper inhabitant-facing lane and must not be implied complete by this HTML proof.",
+        artifact_ref:
+          "docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md"
+      }
+    ]
   },
   observatory_ui: {
     default_room: "world",
     default_lens: "operator",
     default_memory_dot: "triage_overview",
-    proposal_mode_statement: "Every active-looking control is a governed request proposal only. No direct runtime mutation is performed from this surface.",
+    proposal_mode_statement:
+      "Every active-looking control is a governed request proposal only. No direct runtime mutation is performed from this surface.",
     rooms: [
-      { room_id: "world", label: "World / Reality", question: "What exists, where is it, and what is moving?" },
-      { room_id: "governance", label: "Operator / Governance", question: "What decision, policy, or challenge needs judgment?" },
-      { room_id: "cognition", label: "Cognition / Internal State", question: "What coupling or degradation is visible without overclaiming?" }
+      {
+        room_id: "world",
+        label: "World / Reality",
+        question: "What exists, where is it, and what is moving?"
+      },
+      {
+        room_id: "governance",
+        label: "Operator / Governance",
+        question: "What decision, policy, or challenge needs judgment?"
+      },
+      {
+        room_id: "cognition",
+        label: "Cognition / Internal State",
+        question: "What coupling or degradation is visible without overclaiming?"
+      }
     ],
     lenses: [
       { lens_id: "public", label: "Public lens", summary: "Boardroom-safe projection with heavy redaction." },
@@ -153,7 +283,8 @@ const fallbackPacket = {
     corporate_investor_fallback: {
       label: "Corporate Investor UI",
       keyboard_shortcut: "i",
-      claim_boundary: "Presentation mode only; evidence, authority, and trace boundaries do not change."
+      claim_boundary:
+        "Presentation mode only; evidence, authority, and trace boundaries do not change."
     },
     proposal_cases: [
       {
@@ -164,8 +295,13 @@ const fallbackPacket = {
         room: "world",
         lens: "continuity",
         disposition: "available",
-        summary: "Open continuity evidence, standing, and packet links for the active worker.",
-        authority_checks: ["validate_operator_identity", "validate_projection_class", "append_trace_anchor"],
+        summary:
+          "Open continuity evidence, standing, and packet links for the active worker.",
+        authority_checks: [
+          "validate_operator_identity",
+          "validate_projection_class",
+          "append_trace_anchor"
+        ],
         disabled_reason: null,
         trace_anchor: "runtime_v2/observatory/visibility_packet.json#citizens[0]",
         review_export: "runtime_v2/observatory/operator_report.md"
@@ -178,9 +314,15 @@ const fallbackPacket = {
         room: "governance",
         lens: "quarantine",
         disposition: "challenge",
-        summary: "Route a guest standing escalation into challenge instead of silent promotion.",
-        authority_checks: ["validate_guest_scope", "route_to_challenge_boundary", "emit_review_anchor"],
-        disabled_reason: "Requires reviewer and operator judgment before any standing change.",
+        summary:
+          "Route a guest standing escalation into challenge instead of silent promotion.",
+        authority_checks: [
+          "validate_guest_scope",
+          "route_to_challenge_boundary",
+          "emit_review_anchor"
+        ],
+        disabled_reason:
+          "Requires reviewer and operator judgment before any standing change.",
         trace_anchor: "runtime_v2/observatory/private_state_projection_report.md",
         review_export: "runtime_v2/observatory/operator_report.md#guest-standing"
       },
@@ -192,9 +334,15 @@ const fallbackPacket = {
         room: "governance",
         lens: "operator",
         disposition: "defer",
-        summary: "Prepare a guarded snapshot proposal without invoking a live handler.",
-        authority_checks: ["validate_operator_identity", "validate_snapshot_policy", "require_confirmation_phrase"],
-        disabled_reason: "Governed snapshot execution remains future work until handler and review path land.",
+        summary:
+          "Prepare a guarded snapshot proposal without invoking a live handler.",
+        authority_checks: [
+          "validate_operator_identity",
+          "validate_snapshot_policy",
+          "require_confirmation_phrase"
+        ],
+        disabled_reason:
+          "Governed snapshot execution remains future work until handler and review path land.",
         trace_anchor: "runtime_v2/observatory/operator_report.md#snapshot-review",
         review_export: "runtime_v2/observatory/operator_report.md#snapshot-review"
       },
@@ -206,8 +354,13 @@ const fallbackPacket = {
         room: "governance",
         lens: "reviewer",
         disposition: "available",
-        summary: "Collect packet/report links for a reviewer without mutating citizen state.",
-        authority_checks: ["validate_service_actor_scope", "redact_private_state_by_lens", "append_export_trace"],
+        summary:
+          "Collect packet and policy links for a reviewer without mutating citizen state.",
+        authority_checks: [
+          "validate_service_actor_scope",
+          "redact_private_state_by_lens",
+          "append_export_trace"
+        ],
         disabled_reason: null,
         trace_anchor: "runtime_v2/observatory/operator_report.md#review-export",
         review_export: "runtime_v2/observatory/operator_report.md#review-export"
@@ -228,7 +381,55 @@ const state = {
 };
 
 const byId = (id) => document.querySelector(`#${id}`);
-const formatLabel = (value) => String(value).replaceAll("_", " ").replaceAll("-", " ");
+const formatLabel = (value) => String(value || "").replaceAll("_", " ").replaceAll("-", " ");
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergePacket(loadedPacket) {
+  const merged = clone(fallbackPacket);
+  const uniqueList = (items) => [...new Set((items || []).filter(Boolean))];
+  merged.packet_id = loadedPacket.packet_id || merged.packet_id;
+  merged.generated_at = loadedPacket.generated_at || merged.generated_at;
+  merged.source = { ...merged.source, ...(loadedPacket.source || {}) };
+  merged.manifold = { ...merged.manifold, ...(loadedPacket.manifold || {}) };
+  merged.kernel = { ...merged.kernel, ...(loadedPacket.kernel || {}) };
+  merged.resources = { ...merged.resources, ...(loadedPacket.resources || {}) };
+  merged.trace = { ...merged.trace, ...(loadedPacket.trace || {}) };
+  merged.freedom_gate = { ...merged.freedom_gate, ...(loadedPacket.freedom_gate || {}) };
+  merged.citizens = Array.isArray(loadedPacket.citizens) && loadedPacket.citizens.length
+    ? loadedPacket.citizens
+    : merged.citizens;
+  merged.episodes = Array.isArray(loadedPacket.episodes) && loadedPacket.episodes.length
+    ? loadedPacket.episodes
+    : merged.episodes;
+  merged.review = { ...merged.review, ...(loadedPacket.review || {}) };
+  merged.review.primary_artifacts = uniqueList([
+    ...(loadedPacket.review?.primary_artifacts || []),
+    ...(fallbackPacket.review.primary_artifacts || [])
+  ]);
+  merged.review.caveats = uniqueList([
+    ...(loadedPacket.review?.caveats || []),
+    ...(fallbackPacket.review.caveats || [])
+  ]);
+  merged.observatory_ui = { ...merged.observatory_ui, ...(loadedPacket.observatory_ui || {}) };
+  return merged;
+}
+
+function ensureFreedomGateCounts() {
+  const docket = packet.freedom_gate?.recent_docket || [];
+  const counts = docket.reduce(
+    (acc, item) => {
+      acc[item.decision] = (acc[item.decision] || 0) + 1;
+      return acc;
+    },
+    {}
+  );
+  packet.freedom_gate.allow_count = packet.freedom_gate.allow_count ?? counts.allow ?? 0;
+  packet.freedom_gate.defer_count = packet.freedom_gate.defer_count ?? counts.defer ?? 0;
+  packet.freedom_gate.refuse_count = packet.freedom_gate.refuse_count ?? counts.refuse ?? 0;
+}
 
 function renderChips(targetId, items, key, activeValue, extraClass = "") {
   const target = byId(targetId);
@@ -244,8 +445,49 @@ function renderChips(targetId, items, key, activeValue, extraClass = "") {
   `).join("");
 }
 
+function renderStatus() {
+  const review = packet.review || {};
+  const classifications = review.surface_classification || [];
+  const laneSplit = review.lane_split || [];
+  const currentInputs = review.current_inputs || [];
+
+  byId("classification-summary").textContent =
+    `${review.demo_classification || "bounded_surface"}. Fail-closed on blocked and deferred lanes.`;
+  byId("lane-split-summary").textContent =
+    "HTML stays portable and reviewer-facing; Unity stays richer and inhabitant-facing.";
+
+  byId("classification-cards").innerHTML = classifications.map((item) => `
+    <article class="status-card">
+      <span class="badge badge--${item.surface_id}">${item.label}</span>
+      <strong>${formatLabel(item.state)}</strong>
+      <p class="panel-note">${item.summary}</p>
+      <div class="status-card__meta">
+        <span class="badge">${formatLabel(item.surface_id)}</span>
+        <code>${item.artifact_ref}</code>
+      </div>
+    </article>
+  `).join("");
+
+  byId("lane-split-cards").innerHTML = laneSplit.map((item) => `
+    <article class="lane-card">
+      <span class="badge badge--${item.lane_id}">${item.label}</span>
+      <strong>${item.owner_role}</strong>
+      <p class="panel-note">${item.summary}</p>
+      <div class="lane-card__meta">
+        <span class="badge">${formatLabel(item.status)}</span>
+        <code>${item.artifact_ref}</code>
+      </div>
+    </article>
+  `).join("");
+
+  byId("current-inputs").innerHTML = currentInputs.map((item) => `<li><code>${item}</code></li>`).join("");
+}
+
 function renderAtlas() {
-  byId("manifold-core-id").textContent = packet.manifold.manifold_id.split("-").at(-1).toUpperCase();
+  byId("manifold-core-id").textContent = (packet.manifold.manifold_id || "csm")
+    .split("-")
+    .at(-1)
+    .toUpperCase();
   byId("atlas-summary").textContent = packet.manifold.health.summary;
   const target = byId("citizen-atlas");
   target.innerHTML = packet.citizens.map((citizen) => `
@@ -254,16 +496,16 @@ function renderAtlas() {
       <div class="citizen-card__meta">
         <span class="badge">${formatLabel(citizen.lifecycle_state)}</span>
         <span>${formatLabel(citizen.role)}</span>
-        <span>${citizen.resource_balance.compute_units} compute</span>
+        <span>${citizen.resource_balance?.compute_units ?? 0} compute</span>
       </div>
-      <p class="panel-note">${citizen.alerts[0] || formatLabel(citizen.continuity_status)}</p>
+      <p class="panel-note">${(citizen.alerts && citizen.alerts[0]) || formatLabel(citizen.continuity_status)}</p>
     </button>
   `).join("");
 
   byId("manifold-metrics").innerHTML = `
     <div class="metric">
-      <span>Current tick</span>
-      <strong>${packet.manifold.current_tick}</strong>
+      <span>Packet generated</span>
+      <strong>${packet.generated_at || "fixture-backed"}</strong>
     </div>
     <div class="metric">
       <span>Kernel pulse</span>
@@ -281,8 +523,9 @@ function renderAtlas() {
 }
 
 function renderGovernance() {
-  byId("governance-summary").textContent = `${packet.freedom_gate.allow_count} allow / ${packet.freedom_gate.defer_count} defer / ${packet.freedom_gate.refuse_count} refuse`;
-  byId("docket-cases").innerHTML = packet.freedom_gate.recent_docket.map((item) => `
+  byId("governance-summary").textContent =
+    `${packet.freedom_gate.allow_count} allow / ${packet.freedom_gate.defer_count} defer / ${packet.freedom_gate.refuse_count} refuse`;
+  byId("docket-cases").innerHTML = (packet.freedom_gate.recent_docket || []).map((item) => `
     <button class="docket-card" type="button" data-target="${item.actor}">
       <strong>${formatLabel(item.action)}</strong>
       <div class="docket-card__meta">
@@ -300,13 +543,13 @@ function renderInspector() {
   byId("inspector-summary").textContent = `${formatLabel(citizen.lifecycle_state)} / ${formatLabel(citizen.continuity_status)}`;
   byId("inspector-role").textContent = formatLabel(citizen.role);
   byId("inspector-episode").textContent = citizen.current_episode || "none";
-  byId("inspector-allowed").textContent = citizen.capability_envelope.allowed.map(formatLabel).join(", ");
-  byId("inspector-forbidden").textContent = citizen.capability_envelope.forbidden.map(formatLabel).join(", ");
-  byId("inspector-evidence").innerHTML = citizen.evidence_refs.map((ref) => `<li><code>${ref}</code></li>`).join("");
+  byId("inspector-allowed").textContent = (citizen.capability_envelope?.allowed || []).map(formatLabel).join(", ");
+  byId("inspector-forbidden").textContent = (citizen.capability_envelope?.forbidden || []).map(formatLabel).join(", ");
+  byId("inspector-evidence").innerHTML = (citizen.evidence_refs || []).map((ref) => `<li><code>${ref}</code></li>`).join("");
 }
 
 function renderTrace() {
-  byId("trace-ribbon").innerHTML = packet.trace.trace_tail.map((item) => `
+  byId("trace-ribbon").innerHTML = (packet.trace.trace_tail || []).map((item) => `
     <li class="trace-row">
       <span class="trace-seq">${String(item.event_sequence).padStart(2, "0")}</span>
       <div>
@@ -331,7 +574,8 @@ function renderProposals() {
     </button>
   `).join("");
 
-  const proposal = packet.observatory_ui.proposal_cases.find((item) => item.proposal_id === state.selectedProposalId) || packet.observatory_ui.proposal_cases[0];
+  const proposal = packet.observatory_ui.proposal_cases.find((item) => item.proposal_id === state.selectedProposalId)
+    || packet.observatory_ui.proposal_cases[0];
   byId("proposal-detail").innerHTML = `
     <h3>${proposal.title}</h3>
     <p class="panel-note">${proposal.summary}</p>
@@ -346,7 +590,8 @@ function renderProposals() {
 }
 
 function renderReview() {
-  byId("review-summary").textContent = `${packet.review.demo_classification}. ${packet.observatory_ui.corporate_investor_fallback.claim_boundary}`;
+  byId("review-summary").textContent =
+    `${packet.review.demo_classification}. ${packet.observatory_ui.corporate_investor_fallback.claim_boundary}`;
   byId("review-links").innerHTML = packet.review.primary_artifacts.map((ref) => `<li><code>${ref}</code></li>`).join("");
   byId("review-caveats").innerHTML = packet.review.caveats.map((item) => `<li>${item}</li>`).join("");
 }
@@ -386,6 +631,16 @@ function wireInteractions() {
       renderPrototype();
     });
   });
+  document.querySelectorAll("[data-target]").forEach((node) => {
+    node.addEventListener("click", () => {
+      const citizen = packet.citizens.find((item) => item.citizen_id === node.dataset.target);
+      if (citizen) {
+        state.selectedCitizenId = citizen.citizen_id;
+      }
+      state.room = "governance";
+      renderPrototype();
+    });
+  });
   document.querySelectorAll("[data-key='room_id']").forEach((node) => {
     node.addEventListener("click", () => {
       state.room = node.dataset.value;
@@ -417,6 +672,8 @@ function wireInteractions() {
 }
 
 function renderPrototype() {
+  ensureFreedomGateCounts();
+  renderStatus();
   renderControls();
   renderAtlas();
   renderGovernance();
@@ -429,7 +686,7 @@ function renderPrototype() {
 
 async function loadPacket() {
   const ref = document.querySelector(".observatory-governed-shell")?.dataset.packetRef;
-  if (!ref) {
+  if (!ref || typeof fetch !== "function") {
     renderPrototype();
     return;
   }
@@ -437,7 +694,7 @@ async function loadPacket() {
   try {
     const response = await fetch(ref);
     if (response.ok) {
-      packet = await response.json();
+      packet = mergePacket(await response.json());
       const defaultDot = packet.observatory_ui?.default_memory_dot;
       if (defaultDot) {
         applyMemoryDot(defaultDot);

--- a/demos/v0.90.4/csm_observatory_governed_prototype.md
+++ b/demos/v0.90.4/csm_observatory_governed_prototype.md
@@ -2,8 +2,8 @@
 
 ## What This Is
 
-This is a fixture-backed governed Observatory prototype that extends the
-`v0.90.1` static console line into a richer reviewer-facing surface:
+This is a portable governed Observatory surface that extends the `v0.90.1`
+static console line into a richer reviewer-facing and mobile-capable surface:
 
 - rooms
 - lenses
@@ -13,10 +13,21 @@ This is a fixture-backed governed Observatory prototype that extends the
 - proposal-only operator controls
 - review/export links
 - Corporate Investor UI fallback
+- explicit proof / rehearsal / substrate / blocked / deferred posture
+- explicit HTML versus Unity lane split
 
-It is intentionally not a live Runtime v2 control room. It is a serious product
-prototype for how an active Observatory could feel once the underlying governed
-tool and authority substrate exists.
+It consumes the bounded runtime visibility artifact at:
+
+```text
+adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json
+```
+
+and overlays governed prototype UI metadata for rooms, lenses, classification,
+and review posture.
+
+It is intentionally not a live Runtime v2 control room. It is a serious
+portable prototype for how an operator/reviewer Observatory can feel once the
+underlying governed tool and authority substrate exists.
 
 ## Open Locally
 
@@ -26,26 +37,32 @@ Open:
 demos/v0.90.4/csm_observatory_governed_prototype.html
 ```
 
-The HTML records the canonical packet reference:
+The HTML records the current bounded runtime visibility packet:
 
 ```text
-demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json
+adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json
 ```
 
 If browser file restrictions block `fetch`, the page falls back to a
-deterministic embedded packet projection sourced from the same fixture shape.
+deterministic embedded governed packet overlay sourced from the same bounded
+artifact family and policy inputs.
 
 ## Truth Boundary
 
-Demo classification: `fixture_backed`.
+Demo classification: `fixture_backed_governed_mobile_surface`.
 
 This prototype proves:
 
 - the Observatory can feel like a civic instrument panel rather than a generic
   dashboard
 - rooms, lenses, and memory dots can stay tied to explicit packet state
+- a portable HTML surface can consume current bounded runtime visibility inputs
+  without depending on Unity
 - active-looking controls can remain proposal-only with disabled reasons,
   authority checks, trace anchors, and review exports
+- proof / rehearsal / substrate / blocked / deferred posture can stay visible
+  instead of being implied
+- HTML and Unity lane responsibilities can stay explicit
 - Corporate Investor mode can be a presentation fallback without changing
   evidence, authority, or redaction posture
 
@@ -56,7 +73,7 @@ This prototype does not prove:
 - unrestricted operator authority
 - raw private-state browsing
 - production security hardening
-- production UI readiness
+- Unity lane completion
 
 ## Validation
 
@@ -67,6 +84,6 @@ bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh
 ```
 
 The validation checks that the prototype artifacts exist, reference the
-canonical packet, keep proposal-only claim boundaries explicit, render the
-required surface regions, avoid private path or secret leakage, and pass a
-deterministic semantic/render smoke test.
+current bounded runtime packet, keep proposal-only claim boundaries explicit,
+render the required surface regions, avoid private path or secret leakage, and
+pass a deterministic semantic/render smoke test.

--- a/docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md
+++ b/docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md
@@ -1,0 +1,79 @@
+# HTML Mobile Governed Observatory Proof for #4341
+
+## Scope
+
+This packet records the bounded proof surface for the rebuilt HTML Observatory
+lane in `#4341`.
+
+It proves a portable operator/reviewer/mobile Observatory surface. It does not
+claim Unity completion, live governed mutation, or WP-09 umbrella closeout.
+
+## Source Evidence
+
+- `demos/v0.90.4/csm_observatory_governed_prototype.html`
+- `demos/v0.90.4/csm_observatory_governed_prototype.css`
+- `demos/v0.90.4/csm_observatory_governed_prototype.js`
+- `demos/v0.90.4/csm_observatory_governed_prototype.md`
+- `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+- `demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json`
+- `docs/milestones/v0.91.6/features/OBSERVATORY_UNITY_CONSUMPTION_CLASSIFICATION_v0.91.6.md`
+- `docs/milestones/v0.91.6/review/observatory/WP09_WORKING_UNITY_OBSERVATORY_CLOSEOUT_4035.md`
+
+## What Changed
+
+- The HTML Observatory now loads the current bounded runtime visibility packet
+  rather than pointing only at the older governed prototype packet.
+- The portable surface keeps an embedded governed fallback overlay so direct
+  file-open and fetch-blocked cases still render truthfully.
+- The UI now exposes proof, rehearsal, substrate, blocked, and deferred
+  posture directly in the surface.
+- The UI now exposes the HTML versus Unity lane split directly in the surface.
+- Mobile/touch-safe affordances were tightened for phone and tablet widths.
+
+## Proof Claims
+
+This issue proves:
+
+- the HTML Observatory can consume current bounded runtime visibility artifacts
+  without depending on Unity;
+- the portable surface keeps redaction and proposal-only boundaries explicit;
+- mobile-oriented navigation remains readable and touch-safe in the authored
+  layout contract;
+- proof posture and HTML/Unity role split are explicit instead of implied.
+
+This issue does not prove:
+
+- live AWS, runtime, or governed-tool mutation;
+- Unity Observatory readiness or completion;
+- WP-09 umbrella closeout;
+- production OTel/security closure beyond the cited bounded review inputs.
+
+## Validation
+
+Run:
+
+```text
+bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh
+```
+
+That focused proof checks:
+
+- artifact existence;
+- packet-schema validity for the fallback governed packet;
+- JSON readability for the current runtime visibility packet consumed by the
+  HTML surface;
+- current runtime packet reference in the HTML;
+- classification and lane-split surface rendering through the JS smoke test;
+- authored mobile CSS guardrails and touch-target affordance tokens;
+- secret/path leakage absence across the demo artifacts.
+
+## Reviewer Takeaway
+
+`#4341` should be accepted if reviewers agree that the HTML Observatory is now a
+truthful portable lane:
+
+- HTML Observatory = operator / reviewer / mobile surface
+- Unity Observatory = richer inhabitant / interactive surface
+
+and that the rebuilt surface leaves blocked and deferred WP-09 work explicit
+instead of smearing it into false readiness.


### PR DESCRIPTION
Closes #4341

## Summary
Rebuilt the portable HTML Observatory lane on top of the existing governed
prototype by wiring it to the current bounded runtime visibility packet,
preserving a governed fallback overlay, surfacing proof/rehearsal/substrate/
blocked/deferred posture, making the HTML versus Unity split explicit, and
leaving a focused reviewer packet.

## Artifacts
- `demos/v0.90.4/csm_observatory_governed_prototype.html`
- `demos/v0.90.4/csm_observatory_governed_prototype.css`
- `demos/v0.90.4/csm_observatory_governed_prototype.js`
- `demos/v0.90.4/csm_observatory_governed_prototype.md`
- `adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh`
- `adl/tools/validate_csm_governed_observatory.py`
- `docs/milestones/v0.91.6/review/observatory/HTML_MOBILE_GOVERNED_OBSERVATORY_PROOF_4341.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh`
    Ran the focused HTML Observatory proof lane for artifact existence,
    governed packet validation, runtime packet consumption, merge/render smoke,
    authored mobile guardrails, and leakage checks.
  - `python3 adl/tools/validate_csm_governed_observatory.py --html demos/v0.90.4/csm_observatory_governed_prototype.html --js demos/v0.90.4/csm_observatory_governed_prototype.js --packet adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
    Re-ran the semantic/render validator directly against the current runtime
    visibility packet to prove the consumed merge path outside the shell
    wrapper.
  - `node --check demos/v0.90.4/csm_observatory_governed_prototype.js`
    Checked JS syntax after the rebuild and review-driven fixes.
  - `git diff --check`
    Checked the bounded patch for diff hygiene problems.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4341__v0-91-6-wp-09-observatory-o-06-rebuild-the-html-observatory-as-a-mobile-capable-governed-surface/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4341__v0-91-6-wp-09-observatory-o-06-rebuild-the-html-observatory-as-a-mobile-capable-governed-surface/sor.md
- Idempotency-Key: v0-91-6-wp-09-observatory-o-06-rebuild-the-html-observatory-as-a-mobile-capable-governed-surface-adl-config-validation-lane-selector-v0-91-6-json-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-test-demo-v0904-csm-observatory-governed-prototype-sh-adl-tools-test-select-validation-lanes-sh-adl-tools-validate-csm-governed-observatory-py-demos-fixtures-csm-observatory-proto-csm-02-governed-observatory-packet-json-demos-v0-90-4-csm-observatory-governed-prototype-html-demos-v0-90-4-csm-observatory-governed-prototype-css-demos-v0-90-4-csm-observatory-governed-prototype-js-demos-v0-90-4-csm-observatory-governed-prototype-md-docs-milestones-v0-91-6-review-observatory-html-mobile-governed-observatory-proof-4341-md-adl-v0-91-6-tasks-issue-4341-v0-91-6-wp-09-observatory-o-06-rebuild-the-html-observatory-as-a-mobile-capable-governed-surface-sip-md-adl-v0-91-6-tasks-issue-4341-v0-91-6-wp-09-observatory-o-06-rebuild-the-html-observatory-as-a-mobile-capable-governed-surface-sor-md