### PR TITLE
[v0.91.6][tools][sep] Automate sprint execution packets end to end

### DIFF
--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -111,12 +111,13 @@ Preferred structured-prompt preflight helper:
 Preferred missing-sprint-issue helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <descriptive-sprint-objective> --state <path>`
 
-Known helper migration note:
-- the typed issue mutation command surface exists as `pr.sh issue
-  create/comment/edit`
-- if the missing-sprint-issue helper still shells through direct `gh issue
-  create`, route that helper as migration debt and prefer the typed command
-  surface for new sprint setup automation
+Issue command policy note:
+- the missing-sprint-issue helper should use the repo-native typed issue
+  surface by default for child-title lookup and sprint-issue creation
+- test harnesses or controlled bootstrap fixtures may override the helper's
+  issue-view or issue-create command through explicit environment variables,
+  but that override is a bounded fixture hook rather than the normal
+  operational backend
 
 Preferred live-truth helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match`

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -2,14 +2,19 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
+import os
 import re
+import shlex
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from issue_goal_metrics import default_goal_metrics_summary
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[5]
 
 
 def parse_csv_ints(raw: str) -> list[int]:
@@ -25,6 +30,10 @@ def parse_csv_ints(raw: str) -> list[int]:
 def run_json(cmd: list[str]) -> Any:
     out = subprocess.check_output(cmd, text=True)
     return json.loads(out)
+
+
+def run_capture(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
 
 
 def sanitize_slug(raw: str) -> str:
@@ -44,6 +53,15 @@ def infer_version_from_title(title: str) -> str:
     return match.group(1)
 
 
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def milestone_doc_prefix(version: str) -> str:
+    digits = re.sub(r'[^0-9]', '', version)
+    return f'V{digits}' if digits else 'VUNKNOWN'
+
+
 def issue_prompt_path(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
     return repo_root / '.adl' / version / 'bodies' / f'issue-{issue_number:04d}-{slug}.md'
 
@@ -52,9 +70,73 @@ def task_bundle_dir(repo_root: Path, version: str, issue_number: int, slug: str)
     return repo_root / '.adl' / version / 'tasks' / f'issue-{issue_number:04d}__{slug}'
 
 
+def sprint_bundle_dir(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
+    return repo_root / '.adl' / version / 'sprints' / f'issue-{issue_number:04d}__{slug}'
+
+
+def sprint_execution_packet_path(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
+    return sprint_bundle_dir(repo_root, version, issue_number, slug) / 'SPRINT_EXECUTION_PACKET.md'
+
+
+def sprint_closeout_note_path(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
+    return sprint_bundle_dir(repo_root, version, issue_number, slug) / 'SPRINT_CLOSEOUT_SUMMARY.md'
+
+
+def sprint_review_dir(repo_root: Path, version: str) -> Path:
+    return repo_root / 'docs' / 'milestones' / version / 'review' / 'sprint_execution_packets'
+
+
+def sprint_activity_log_path(repo_root: Path, version: str, issue_number: int) -> Path:
+    return sprint_review_dir(repo_root, version) / f'{milestone_doc_prefix(version)}_SPRINT_ACTIVITY_LOG_{issue_number}.md'
+
+
+def sprint_review_path(repo_root: Path, version: str, issue_number: int) -> Path:
+    return sprint_review_dir(repo_root, version) / f'{milestone_doc_prefix(version)}_SPRINT_REVIEW_{issue_number}.md'
+
+
+def sprint_closeout_artifact_path(repo_root: Path, version: str, issue_number: int) -> Path:
+    return sprint_review_dir(repo_root, version) / f'{milestone_doc_prefix(version)}_SPRINT_CLOSEOUT_{issue_number}.md'
+
+
 def write_file(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
+
+
+def default_issue_command(subcommand: str) -> list[str]:
+    issue_binary = SCRIPT_REPO_ROOT / 'adl' / 'target' / 'debug' / 'adl-issue'
+    if issue_binary.is_file():
+        return [str(issue_binary), subcommand]
+    return ['bash', str(SCRIPT_REPO_ROOT / 'adl' / 'tools' / 'pr.sh'), 'issue', subcommand]
+
+
+def command_with_override(env_var: str, default: list[str]) -> list[str]:
+    raw = os.environ.get(env_var)
+    if not raw:
+        return default
+    return shlex.split(raw)
+
+
+def issue_view(issue_number: int) -> dict[str, Any]:
+    cmd = command_with_override('ADL_SPRINT_ISSUE_VIEW_CMD', default_issue_command('view'))
+    return run_json(cmd + [str(issue_number), '--json'])
+
+
+def issue_create(title: str, body_path: Path) -> dict[str, Any]:
+    cmd = command_with_override('ADL_SPRINT_ISSUE_CREATE_CMD', default_issue_command('create'))
+    raw = run_capture(cmd + ['--title', title, '--body-file', str(body_path), '--json'])
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        payload = {'url': raw}
+    if 'number' not in payload:
+        issue_url = payload.get('url', raw)
+        match = re.search(r'/issues/(\d+)$', issue_url)
+        if not match:
+            raise SystemExit(f'Unable to parse created issue number from issue-create output: {raw}')
+        payload['number'] = int(match.group(1))
+        payload['url'] = issue_url
+    return payload
 
 
 def render_prompt_template(repo_root: Path, kind: str, replacements: dict[str, str]) -> str | None:
@@ -225,7 +307,222 @@ def default_goal_policy() -> dict[str, Any]:
     }
 
 
-def build_body(goal: str, ordered: list[int], child_titles: dict[int, str], notes: str | None) -> str:
+def render_execution_packet(
+    repo_root: Path,
+    version: str,
+    sprint_issue_number: int,
+    title: str,
+    goal: str,
+    ordered: list[int],
+    child_titles: dict[int, str],
+    execution_mode: str,
+    notes: str | None,
+) -> str:
+    activity_log = sprint_activity_log_path(repo_root, version, sprint_issue_number)
+    review_path = sprint_review_path(repo_root, version, sprint_issue_number)
+    ordered_issue_lines = '\n'.join(
+        f"| #{issue} | child_issue | pending | issue-specific implementation surface | {child_titles.get(issue, '').strip() or 'title not yet resolved'} |"
+        for issue in ordered
+    )
+    execution_order = '\n'.join(
+        f"{idx}. Start `#{issue}` only when its sprint gate is clear; title: `{child_titles.get(issue, '').strip() or 'title not yet resolved'}`."
+        for idx, issue in enumerate(ordered, start=1)
+    )
+    if not execution_order:
+        execution_order = '1. No child issues were declared.'
+    safe_parallel = (
+        '| serial-default | none yet | Default helper posture keeps execution serial until an operator or later issue proves safe parallel lanes. | Add explicit write-set and PVF coordination before widening. |'
+    )
+    candidate_parallel = '\n'.join(
+        f"| issue-{issue} | {'serial_gate' if idx == 0 else 'blocked_until_dependency'} | #{issue} | issue-specific write set not yet classified | not_recorded_yet | not_recorded_yet | closeout of prior ordered gate | possible control-plane collisions until classified | required | optional | helper bootstrap keeps this lane serial until issue-local proof exists | reclassify during sprint planning or follow-on automation |"
+        for idx, issue in enumerate(ordered)
+    )
+    if not candidate_parallel:
+        candidate_parallel = '| none | serial_gate | none | no child issues declared | not_recorded_yet | not_recorded_yet | no child issues declared | not_applicable | required | optional | no lane to classify | none |'
+    serial_gates = '\n'.join(
+        f"| ordered-issue-{idx} | later ordered child issues | `#{issue}` closes out truthfully before the next issue starts unless the SEP is updated with a safe parallel lane. | sprint-conductor |"
+        for idx, issue in enumerate(ordered, start=1)
+    )
+    if not serial_gates:
+        serial_gates = '| no-child-issues | none | no child issues declared | sprint-conductor |'
+    shared_docs = [
+        str((repo_root / 'docs' / 'templates' / 'sprints' / 'current.json').relative_to(repo_root)),
+        str((repo_root / 'docs' / 'templates' / 'sprints' / '1.0.0' / 'sprint_execution_packet.md').relative_to(repo_root)),
+    ]
+    lines = [
+        f'# Sprint Execution Packet: #{sprint_issue_number} {title}',
+        '',
+        '## Metadata',
+        '',
+        f'- Sprint issue: `#{sprint_issue_number}`',
+        f'- Sprint title: `{title}`',
+        f'- Milestone: `{version}`',
+        f'- Execution mode: `{execution_mode}`',
+        '- Owner: `sprint-conductor`',
+        f'- Last updated: `{utc_now()}`',
+        '',
+        '## Sprint Goal',
+        '',
+        goal,
+        '',
+        '## Sprint Boundary',
+        '',
+        'In scope:',
+        '',
+        '- Create the sprint-management issue and local bundle through repo-native issue operations.',
+        '- Materialize a retained Sprint Execution Packet with watcher, review, and closeout expectations.',
+        '',
+        'Out of scope:',
+        '',
+        '- Executing the child issues directly from this helper.',
+        '- Claiming safe parallelism before write-set and PVF coordination is proven.',
+        '',
+        '## Child Issue Wave',
+        '',
+        '| Issue | Role | Status | Primary surface | Notes |',
+        '|---|---|---|---|---|',
+        ordered_issue_lines or '| none | none | pending | not_applicable | no child issues declared |',
+        '',
+        '## Dependency Graph',
+        '',
+        '```mermaid',
+        'flowchart LR',
+    ]
+    if ordered:
+        for idx, issue in enumerate(ordered):
+            node = f'N{idx + 1}'
+            lines.append(f'  {node}["#{issue}"]')
+            if idx > 0:
+                prev = f'N{idx}'
+                lines.append(f'  {prev} --> {node}')
+    else:
+        lines.append('  A["No child issues declared"]')
+    lines.extend(
+        [
+            '```',
+            '',
+            '## Recommended Execution Order',
+            '',
+            execution_order,
+            '',
+            '## Issue Lifecycle Policy',
+            '',
+            '- Each child issue must end in one explicit terminal state: `closed_after_merge`, `closed_no_merge`, `deferred_with_route`, or `failed_with_route`.',
+            '- Completed child issues must close as soon as review, merge outcome, closeout, and worktree pruning are complete.',
+            '- Every child issue closeout should be owned by an explicit closeout handoff or closeout agent.',
+            '',
+            '## Watcher Policy',
+            '',
+            '- Every active child issue must have a watcher or equivalent lifecycle monitor for readiness, implementation, PR checks, review, merge, closeout, and worktree pruning.',
+            '- Watchers must classify `complete`, `failed`, `blocked`, or `waiting_with_next_check`.',
+            '- Wait states without a watcher are not valid sprint state.',
+            '',
+            '## Safe Parallel Lanes',
+            '',
+            '| Lane | Issues | Why parallel-safe | Required coordination |',
+            '|---|---|---|---|',
+            safe_parallel,
+            '',
+            '## Candidate Parallel Lanes',
+            '',
+            '| Lane | Classification | Issues | Expected write sets | Expected PVF lanes | Validation lanes | Dependency gates | Collision risks | Watcher | Subagent | Why safe or why not | Required coordination |',
+            '|---|---|---|---|---|---|---|---|---|---|---|---|',
+            candidate_parallel,
+            '',
+            '## Serial Gates',
+            '',
+            '| Gate | Blocks | Exit condition | Owner |',
+            '|---|---|---|---|',
+            serial_gates,
+            '',
+            '## PVF / Validation-Tail Notes',
+            '',
+            '- Immediate issue-local proof: `Use the smallest proving lane per child issue; this helper does not widen proof automatically.`',
+            '- Parallel validation lanes: `not_recorded_yet`',
+            '- Serial validation gates: `child closeout and review truth remain mandatory before advancing the ordered wave.`',
+            '- Reusable proof criteria: `only when the touched surface and declared lane truly match.`',
+            '- Fail-closed rule: `missing lane truth, missing watcher truth, or missing closeout truth blocks sprint advancement.`',
+            '',
+            '## Parallelism Outcome Plan',
+            '',
+            f'- Planned summary: `Sprint bootstrap starts in {execution_mode} mode; actual achieved parallelism must be recorded during execution.`',
+            '- Actual summary placeholder: `Fill this during closeout once actual concurrency is known.`',
+            '- Prediction-miss capture rule: `Record any lane that turned out not to be safe and why.`',
+            '- Closeout requirement: record every lane that proved safe, every lane that stayed serial, and every lane prediction that was wrong.',
+            '',
+            '## Sprint Activity Log',
+            '',
+            f'- Log artifact path: `{activity_log.relative_to(repo_root)}`',
+            '- Required events: issue start, card repair, worktree bind, PR publication, watcher state, validation result, review result, merge/closeout, and worktree prune.',
+            '- Log policy: `append-only retained sprint activity log with issue/PR/check state transitions.`',
+            '',
+            '## Sprint-Level Review',
+            '',
+            f'- Sprint review artifact: `{review_path.relative_to(repo_root)}`',
+            '- Review scope: child issues, PRs, changed files, logs, validation proof, closeout truth, residual routing, and failed/deferred lanes.',
+            '- All actionable sprint-level findings must be fixed, routed, or explicitly accepted before the sprint umbrella closes.',
+            '',
+            '## Subagent / Local Model Policy',
+            '',
+            '- Subagent strategy: `bounded reviewer or watcher subagents only when policy explicitly enables them.`',
+            '- Local model candidates: `not_recorded_yet`',
+            '- Simple delegated roles: watcher, card validator, docs lint reviewer, closeout checker, issue-state summarizer.',
+            '- Local agents must produce bounded, reviewable output and must not mutate repo state unless an issue explicitly grants that authority.',
+            '',
+            '## Template/AST Policy',
+            '',
+            '- SEP templates should be maintained through the same AST-backed template path as other C-SDLC templates once the markdown.rs editor lane is available.',
+            '- Direct Markdown edits are acceptable only as a temporary bootstrap surface until the AST-backed SEP renderer is implemented and proven.',
+            '',
+            '## Shared Inputs And Artifacts',
+            '',
+            f"- Shared source docs: `{', '.join(shared_docs)}`",
+            '- Shared code surfaces: `adl/tools/skills/sprint-conductor/*`',
+            '- Shared review packets: `not_recorded_yet`',
+            '- Shared logs or observability surfaces: `issue/PR watcher outputs and sprint activity log.`',
+            '',
+            '## Cross-Sprint Dependencies',
+            '',
+            '- Upstream dependencies: `child issue cards must exist and be ready before execution begins.`',
+            '- Downstream consumers: `sprint review, closeout artifact, and child issue execution sessions.`',
+            '- Collision risks: `shared workflow-control files until lanes are explicitly classified.`',
+            '- Routing rule: `do not widen scope silently; route follow-ons instead.`',
+            '',
+            '## Review Bar',
+            '',
+            '- Review scope: `code, docs, validation proof, watcher state, and closeout truth for the sprint wave.`',
+            '- Required review skills: `repo-packet-builder`, `repo-review-code`, `repo-review-tests`, and synthesis; add docs/security review when the touched surface warrants it.',
+            '- Code-facing review required: `true`',
+            '- Docs-facing review required: `true`',
+            '- Security review required: `false unless the sprint changes trust boundaries or credential flows.`',
+            '',
+            '## Closeout Bar',
+            '',
+            '- Every child issue is closed or explicitly deferred with rationale.',
+            '- Every child PR is merged, closed without merge, or routed with truthful state.',
+            '- Sprint review findings are either fixed, routed, or recorded as residual risk.',
+            '- Sprint closeout artifact records child issue status, PR URLs, proof surfaces, validation state, and follow-up routing.',
+            '- Worktrees are pruned or retained with an explicit reason.',
+            '',
+            '## Residual Routing Policy',
+            '',
+            '- Must-fix-before-sprint-close: `issue-local closeout truth, watcher coverage, and sprint review completion.`',
+            '- Post-sprint follow-ons: `default disposition is post_sprint_follow_on unless the sprint policy says otherwise.`',
+            '- Deferred work: `must be recorded explicitly rather than left ambient.`',
+            '- Explicit non-blockers: `descriptive sprint objective and planning notes are not substitutes for child issue execution proof.`',
+            '',
+            '## Non-Claims',
+            '',
+            '- This bootstrap helper does not execute child issues or prove safe parallelism by itself.',
+            '- Creating the sprint issue and SEP does not replace child issue review, PR publication, or closeout truth.',
+        ]
+    )
+    if notes:
+        lines.extend(['', '## Notes', '', notes.strip()])
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def build_body(goal: str, ordered: list[int], child_titles: dict[int, str], execution_mode: str, notes: str | None) -> str:
     ordered_lines = '\n'.join(
         f"{idx}. #{issue} {child_titles.get(issue, '').strip()}".rstrip()
         for idx, issue in enumerate(ordered, start=1)
@@ -245,6 +542,7 @@ Create the concrete sprint-management issue required to run one bounded `sprint-
 ## Trial Rules
 
 - Declare sprint execution mode: `sequential`, `parallel`, or `hybrid`.
+- Selected execution mode for this sprint-management issue: `{execution_mode}`.
 - For `parallel` or `hybrid` sprints, include or link a Sprint Execution Packet with safe lanes, serial gates, PVF notes, and residual routing.
 - Current sprint helper state remains single-current-issue; use separate issue workers or sessions for intentional parallel lanes.
 - Treat the sprint objective as descriptive coordination context, not as the active session goal during child issue implementation.
@@ -274,6 +572,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--repo-root', required=True)
     parser.add_argument('--ordered-issues', required=True)
+    parser.add_argument('--execution-mode', choices=['sequential', 'parallel', 'hybrid'], default='sequential')
     parser.add_argument('--title', required=True)
     parser.add_argument('--goal', required=True)
     parser.add_argument('--state')
@@ -285,29 +584,55 @@ def main() -> int:
     ordered = parse_csv_ints(args.ordered_issues)
     child_titles: dict[int, str] = {}
     for issue in ordered:
-        issue_json = run_json(['gh', 'issue', 'view', str(issue), '--json', 'number,title'])
+        issue_json = issue_view(issue)
         child_titles[issue] = issue_json.get('title', '')
 
-    body = build_body(args.goal, ordered, child_titles, args.notes)
+    body = build_body(args.goal, ordered, child_titles, args.execution_mode, args.notes)
     with tempfile.NamedTemporaryFile('w', delete=False, suffix='.md') as handle:
         handle.write(body)
         body_path = Path(handle.name)
 
-    issue_url = subprocess.check_output(
-        ['gh', 'issue', 'create', '--title', args.title, '--body-file', str(body_path)],
-        text=True,
-    ).strip()
-    match = re.search(r'/issues/(\d+)$', issue_url)
-    if not match:
-        raise SystemExit(f'Unable to parse created issue number from URL: {issue_url}')
-    sprint_issue_number = int(match.group(1))
+    created_issue = issue_create(args.title, body_path)
+    sprint_issue_number = int(created_issue['number'])
+    issue_url = str(created_issue['url'])
     local_bundle = bootstrap_local_bundle(repo_root, sprint_issue_number, args.title, issue_url, body)
+    packet_path = sprint_execution_packet_path(
+        repo_root,
+        local_bundle['version'],
+        sprint_issue_number,
+        local_bundle['slug'],
+    )
+    write_file(
+        packet_path,
+        render_execution_packet(
+            repo_root,
+            local_bundle['version'],
+            sprint_issue_number,
+            args.title,
+            args.goal,
+            ordered,
+            child_titles,
+            args.execution_mode,
+            args.notes,
+        ),
+    )
+    review_path = sprint_review_path(repo_root, local_bundle['version'], sprint_issue_number)
+    activity_log_path = sprint_activity_log_path(repo_root, local_bundle['version'], sprint_issue_number)
+    closeout_artifact_path = sprint_closeout_artifact_path(repo_root, local_bundle['version'], sprint_issue_number)
+    closeout_note_path = sprint_closeout_note_path(
+        repo_root,
+        local_bundle['version'],
+        sprint_issue_number,
+        local_bundle['slug'],
+    )
 
     result = {
         'created': True,
         'sprint_issue_number': sprint_issue_number,
         'sprint_issue_url': issue_url,
         'ordered_issue_numbers': ordered,
+        'execution_mode': args.execution_mode,
+        'execution_packet_path': str(packet_path),
         'local_bundle': local_bundle,
     }
 
@@ -319,13 +644,18 @@ def main() -> int:
             'sprint_issue_created_by_skill': True,
             'issue_created_by_skill': True,
             'ordered_issue_numbers': ordered,
+            'execution_mode': args.execution_mode,
+            'execution_packet_path': str(packet_path),
+            'follow_up_issue_policy': 'post_sprint_follow_on',
             'current_issue_number': ordered[0] if ordered else None,
             'completed_issue_numbers': [],
             'blocked_issue_number': None,
+            'deferred_issue_numbers': [],
             'continuation': 'continue',
             'goal_policy': default_goal_policy(),
             'local_bundle': local_bundle,
             'issue_records': default_issue_records(ordered),
+            'follow_up_issues': [],
             'structured_prompt_preflight': {
                 'status': 'not_run',
                 'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'srp.md'],
@@ -334,6 +664,32 @@ def main() -> int:
                     'Run sprint-wide structured prompt preflight before starting issue execution, including SPP and SRP design-time readiness.',
                 ],
             },
+            'readiness_sweep': {
+                'status': 'not_run',
+                'ordered_issue_numbers': ordered,
+                'execution_mode': args.execution_mode,
+                'goal_policy': default_goal_policy(),
+                'execution_packet': {
+                    'status': 'present',
+                    'path': str(packet_path),
+                    'missing_sections': [],
+                    'notes': [f'execution packet bootstrapped by helper: {packet_path}'],
+                },
+                'review_paths': {
+                    'status': 'declared',
+                    'paths': [str(review_path)],
+                    'missing_paths': [str(review_path)],
+                    'notes': ['review artifact path declared; file creation is expected later during sprint review.'],
+                },
+                'activity_log_paths': {
+                    'status': 'declared',
+                    'paths': [str(activity_log_path)],
+                    'missing_paths': [str(activity_log_path)],
+                    'notes': ['activity log path declared; file creation is expected later during sprint execution.'],
+                },
+                'issue_repairs': [],
+                'notes': ['Run the full readiness sweep before starting child execution; helper declarations are bootstrap truth only.'],
+            },
             'truth_check': {
                 'status': 'not_run',
                 'source': 'sprint_state_only',
@@ -341,6 +697,57 @@ def main() -> int:
                 'checked_issue_numbers': [],
                 'checked_pr_urls': [],
                 'notes': ['Sprint issue created by skill; run live GitHub truth check before the first state transition.'],
+            },
+            'current_state': {
+                'selected_skill': 'workflow-conductor',
+                'current_phase': 'intake',
+                'blocker_reason': 'none',
+            },
+            'review': {
+                'status': 'not_started',
+                'selected_skills': [],
+                'review_subagent_ids': [],
+                'packet_path': str(review_path),
+                'code_review_path': None,
+                'test_review_path': None,
+                'docs_review_path': None,
+                'security_review_path': None,
+                'synthesis_path': None,
+                'findings_summary': {
+                    'confirmed_findings': None,
+                    'unresolved_questions': None,
+                },
+            },
+            'closeout': {
+                'status': 'not_started',
+                'readiness': 'unknown',
+                'closeout_note_path': str(closeout_note_path),
+                'closeout_artifact_path': str(closeout_artifact_path),
+                'sprint_issue_close_summary': None,
+                'planned_vs_actual_parallelism': {
+                    'planned_summary': f'Bootstrap declared execution mode `{args.execution_mode}`; actual achieved parallelism is not recorded yet.',
+                    'actual_summary': None,
+                    'prediction_misses': [],
+                },
+            },
+            'actions_taken': [
+                'Created sprint-management issue through the repo-native issue command surface.',
+                'Bootstrapped the local sprint task bundle through the canonical issue init path.',
+                'Materialized a retained Sprint Execution Packet with watcher, review, and closeout declaration surfaces.',
+            ],
+            'next_handoff': {
+                'status': 'continue',
+                'target_issue_number': ordered[0] if ordered else None,
+                'target_pr_url': None,
+                'next_skill': 'workflow-conductor',
+                'child_session_goal': {
+                    'required': bool(ordered),
+                    'create_after_bind': bool(ordered),
+                    'sprint_issue_number': sprint_issue_number,
+                    'child_issue_number': ordered[0] if ordered else None,
+                    'bounded_objective': 'Start the first ordered child issue only after readiness and bind succeed.' if ordered else None,
+                },
+                'rationale': 'Sprint-management issue and SEP bootstrap are complete; continue through workflow-conductor and the readiness sweep before child execution.',
             },
         }
         state_path.parent.mkdir(parents=True, exist_ok=True)

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -64,11 +64,57 @@ exit 1
 GH_EOF
 chmod +x "${fakebin}/gh"
 
+cat >"${fakebin}/adl-issue" <<'ADL_ISSUE_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+subcommand="$1"
+shift
+
+case "${subcommand}" in
+  view)
+    issue_number="$1"
+    if [[ "${issue_number}" == "2827" ]]; then
+      state="$(cat "${FAKE_ISSUE_2827_STATE}")"
+      printf '{"number":2827,"title":"[v0.91.1][WP-05][runtime] Citizen standing model","state":"%s","url":"https://github.com/danielbaustin/agent-design-language/issues/2827"}\n' "${state}"
+      exit 0
+    fi
+    if [[ "${issue_number}" == "2828" ]]; then
+      state="$(cat "${FAKE_ISSUE_2828_STATE}")"
+      printf '{"number":2828,"title":"[v0.91.1][WP-06][runtime] Citizen state substrate","state":"%s","url":"https://github.com/danielbaustin/agent-design-language/issues/2828"}\n' "${state}"
+      exit 0
+    fi
+    if [[ "${issue_number}" == "3001" ]]; then
+      echo '{"number":3001,"title":"[v0.91.1][sprint-1][management] Trial sprint","state":"OPEN","url":"https://github.com/danielbaustin/agent-design-language/issues/3001"}'
+      exit 0
+    fi
+    echo "unexpected adl-issue view ${issue_number}" >&2
+    exit 1
+    ;;
+  create)
+    echo '{"number":3001,"url":"https://github.com/danielbaustin/agent-design-language/issues/3001"}'
+    exit 0
+    ;;
+  *)
+    echo "unexpected adl-issue invocation: ${subcommand} $*" >&2
+    exit 1
+    ;;
+esac
+ADL_ISSUE_EOF
+chmod +x "${fakebin}/adl-issue"
+
+fake_tool_repo="${tmpdir}/fake-tool-repo"
+mkdir -p "${fake_tool_repo}/adl/target/debug"
+cp "${fakebin}/adl-issue" "${fake_tool_repo}/adl/target/debug/adl-issue"
+chmod +x "${fake_tool_repo}/adl/target/debug/adl-issue"
+
 export PATH="${fakebin}:${PATH}"
 export FAKE_GH_LOG="${log_path}"
 export FAKE_ISSUE_2827_STATE="${issue_2827_state_file}"
 export FAKE_ISSUE_2828_STATE="${issue_2828_state_file}"
 export FAKE_PR_4001_STATE="${pr_4001_state_file}"
+export ADL_SPRINT_ISSUE_VIEW_CMD="${fakebin}/adl-issue view"
+export ADL_SPRINT_ISSUE_CREATE_CMD="${fakebin}/adl-issue create"
 
 state_path="${tmpdir}/sprint-state.json"
 fake_repo="${tmpdir}/fake-repo"
@@ -257,10 +303,36 @@ printf 'alpha\n' > "${readiness_installed_skill_dir}/SKILL.md"
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
   --repo-root "${fake_repo}" \
   --ordered-issues "2827,2828" \
+  --execution-mode hybrid \
   --title "[v0.91.1][sprint-1][management] Trial sprint" \
   --goal "Run the narrow sprint-conductor trial" \
   --state "${state_path}" \
   >/dev/null
+
+python3 - "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" "${fake_tool_repo}" <<'PY'
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+fake_tool_repo = Path(sys.argv[2])
+fake_issue_binary = fake_tool_repo / "adl" / "target" / "debug" / "adl-issue"
+sys.path.insert(0, str(script_path.parent))
+spec = importlib.util.spec_from_file_location("create_missing_sprint_issue", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+module.SCRIPT_REPO_ROOT = fake_tool_repo
+os.environ.pop("ADL_SPRINT_ISSUE_VIEW_CMD", None)
+os.environ.pop("ADL_SPRINT_ISSUE_CREATE_CMD", None)
+assert module.default_issue_command("view") == [str(fake_issue_binary), "view"]
+assert module.default_issue_command("create") == [str(fake_issue_binary), "create"]
+assert module.issue_view(2827)["title"] == "[v0.91.1][WP-05][runtime] Citizen standing model"
+created = module.issue_create("Trial sprint", Path("/tmp/unused.md"))
+assert created["number"] == 3001
+assert created["url"].endswith("/issues/3001")
+PY
 
 python3 - "${state_path}" <<'PY'
 import json
@@ -271,8 +343,15 @@ state = json.loads(Path(sys.argv[1]).read_text())
 assert state["sprint_issue_number"] == 3001
 assert state["sprint_issue_created_by_skill"] is True
 assert state["current_issue_number"] == 2827
+assert state["execution_mode"] == "hybrid"
+assert state["execution_packet_path"].endswith("issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md")
 assert len(state["issue_records"]) == 2
 assert state["structured_prompt_preflight"]["required_card_types"] == ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"]
+assert state["readiness_sweep"]["execution_packet"]["status"] == "present"
+assert state["readiness_sweep"]["review_paths"]["status"] == "declared"
+assert state["readiness_sweep"]["activity_log_paths"]["status"] == "declared"
+assert state["review"]["status"] == "not_started"
+assert state["closeout"]["status"] == "not_started"
 assert state["truth_check"]["status"] == "not_run"
 assert state["truth_check"]["gate_passed"] is False
 bundle = state["local_bundle"]
@@ -283,9 +362,16 @@ test -f "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-s
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sip.md"
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sor.md"
+test -f "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
 grep -q "Run the narrow sprint-conductor trial" "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-sprint.md"
 grep -q "Run the narrow sprint-conductor trial" "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
 grep -q "# Structured Task Prompt" "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
+grep -q "## Watcher Policy" "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
+grep -q "## Sprint Activity Log" "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
+grep -q "## Sprint-Level Review" "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
+grep -q 'Execution mode: `hybrid`' "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
+grep -q '^  N1\["#2827"\]$' "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
+grep -q '^  N1 --> N2$' "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md"
 if grep -q "generic pr init" "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-sprint.md"; then
   echo "expected preferred-path bootstrap to replace generic local source prompt" >&2
   exit 1
@@ -318,7 +404,7 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_rea
   --repo-root "${fake_repo}" \
   --ordered-issues "2827,2828" \
   --execution-mode hybrid \
-  --execution-packet-path "${readiness_packet}" \
+  --execution-packet-path "${fake_repo}/.adl/v0.91.1/sprints/issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md" \
   --review-path "${readiness_review}" \
   --activity-log-path "${readiness_activity}" \
   --tracked-skill-dir "${readiness_tracked_skill_dir}" \
@@ -1015,7 +1101,10 @@ assert state["sprint_issue_close_summary"] == "Sprint completed cleanly."
 assert state["closeout"]["closure_cleanliness"] == "clean_with_post_sprint_followups"
 PY
 
-grep -Fq "issue create" "${log_path}"
+if grep -Fq "issue create" "${log_path}"; then
+  echo "expected sprint helper bootstrap to avoid raw gh issue create in the default fixture path" >&2
+  exit 1
+fi
 grep -Fq "issue close 3001 --comment Sprint completed cleanly." "${log_path}"
 grep -Fq "pr view https://github.com/danielbaustin/agent-design-language/pull/4001 --json state,isDraft,url" "${log_path}"
 


### PR DESCRIPTION
Closes #4391

## Summary
Automated sprint-execution-packet bootstrapping moved off raw `gh` defaults onto the repo-native issue surface, expanded the retained sprint-state bootstrap to include execution-packet and review/closeout truth, and added focused helper coverage for the new default command path plus execution-mode packet generation.

## Artifacts
- Local ignored output card at `.adl/v0.91.6/tasks/issue-4391__v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end/sor.md`
- Tracked implementation artifacts:
  - `adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py`
  - `adl/tools/test_sprint_conductor_helpers.sh`
  - `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
- Additional proof artifacts: `not_applicable`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    `Verified helper bootstrap behavior, repo-native issue-command resolution, execution-mode state capture, and sprint execution-packet generation.`
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py`
    `Verified the updated sprint-conductor helper parses successfully after the repo-native backend and state-bootstrap changes.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4391__v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4391__v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end/sor.md
- Idempotency-Key: v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end-adl-v0-91-6-tasks-issue-4391-v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end-sip-md-adl-v0-91-6-tasks-issue-4391-v0-91-6-tools-sep-automate-sprint-execution-packets-end-to-end-sor-md