### PR TITLE
[v0.91.6][tools][github] Finish Octocrab GitHub convergence

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -185,10 +185,31 @@ fn resolve_start_slug(
     bail!("Could not fetch issue title. Pass --slug or check GitHub token/repo configuration.")
 }
 
+fn looks_like_adl_workflow_path(value: &str) -> bool {
+    value.ends_with(".adl.yaml") || value.ends_with(".adl.yml")
+}
+
+fn reject_runtime_yaml_through_pr_run(args: &[String]) -> Result<()> {
+    let Some(operand) = args.iter().find(|arg| looks_like_adl_workflow_path(arg)) else {
+        return Ok(());
+    };
+    if looks_like_adl_workflow_path(operand) {
+        bail!(
+            "adl pr run cannot execute ADL workflow YAML '{operand}'. Use `adl <adl.yaml> ...` (or `adl-runtime run <adl.yaml>` where that compatibility binary is available) for runtime workflows."
+        );
+    }
+    Ok(())
+}
+
+fn real_pr_run(args: &[String]) -> Result<()> {
+    reject_runtime_yaml_through_pr_run(args)?;
+    real_pr_start(args)
+}
+
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
         );
     };
 
@@ -197,6 +218,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "init" => real_pr_init(&args[1..]),
         "repair-issue-body" => real_pr_repair_issue_body(&args[1..]),
         "start" => real_pr_start(&args[1..]),
+        "run" => real_pr_run(&args[1..]),
         "doctor" => real_pr_doctor(&args[1..]),
         "ready" => real_pr_ready(&args[1..]),
         "preflight" => real_pr_preflight(&args[1..]),

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1930,11 +1930,33 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | repair-issue-body | start | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
+        "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown pr subcommand: bogus"));
+}
+
+#[test]
+fn real_pr_run_rejects_runtime_workflow_yaml_operand() {
+    let err = real_pr(&["run".to_string(), "workflow.adl.yaml".to_string()])
+        .expect_err("runtime workflow YAML must fail closed for adl pr run");
+    assert!(err.to_string().contains(
+        "adl pr run cannot execute ADL workflow YAML 'workflow.adl.yaml'. Use `adl <adl.yaml> ...` (or `adl-runtime run <adl.yaml>` where that compatibility binary is available) for runtime workflows."
+    ));
+}
+
+#[test]
+fn real_pr_run_rejects_runtime_workflow_yaml_operand_after_flags() {
+    let err = real_pr(&[
+        "run".to_string(),
+        "--trace".to_string(),
+        "workflow.adl.yaml".to_string(),
+    ])
+    .expect_err("runtime workflow YAML must fail closed even when flags precede it");
+    assert!(err.to_string().contains(
+        "adl pr run cannot execute ADL workflow YAML 'workflow.adl.yaml'. Use `adl <adl.yaml> ...` (or `adl-runtime run <adl.yaml>` where that compatibility binary is available) for runtime workflows."
+    ));
 }
 
 #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -48,7 +48,6 @@ pub fn usage() -> &'static str {
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
   adl pr repair-issue-body <issue> [--slug <slug>] [--title <title>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>] [--force]
   adl pr run <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
-  adl pr run <adl.yaml> [--trace] [--signature-key <public_key_path>] [--allow-embedded-signature-key] [--allow-unsigned] [--runs-root <dir>] [--out <dir>]
   adl pr doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   adl pr finish <issue> --title <title> [--body <text>] [--paths <csv>] [-f|--input <path>] [--output-card <path>] [--no-checks] [--no-close] [--ready] [--merge] [--no-open]
   adl pr closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]


### PR DESCRIPTION
Closes #4393

## Summary
Repaired the direct `adl pr run` dispatch/help mismatch by wiring `run` into the Rust PR command dispatcher, failing closed when runtime workflow YAML is passed through the PR lifecycle entrypoint, and adding focused coverage so help text and accepted subcommands cannot drift again.

## Artifacts
- Local ignored output card at `.adl/v0.91.6/tasks/issue-4393__v0-91-6-tools-github-finish-octocrab-github-convergence/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/src/cli/usage.rs`
- Additional proof artifacts: `not_applicable`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_dispatch_rejects_missing_and_unknown_subcommands -- --nocapture`
    `Verified the PR dispatcher reports truthful accepted subcommands, including the restored \`run\` path.`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_run_rejects_runtime_workflow_yaml_operand -- --nocapture`
    `Verified \`adl pr run\` fails closed when a runtime workflow YAML is passed through the PR lifecycle path.`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_run_rejects_runtime_workflow_yaml_operand_after_flags -- --nocapture`
    `Verified the runtime-workflow YAML rejection still holds when flags such as \`--trace\` appear before the YAML operand.`
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- --help | rg -n "adl pr run"`
    `Verified the active CLI help advertises only the issue-mode \`adl pr run ISSUE_NUMBER\` path and no longer claims the runtime workflow YAML form.`
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr run workflow.adl.yaml`
    `Verified the direct Rust CLI rejects runtime workflow YAML on the PR lifecycle entrypoint with explicit redirect guidance.`
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr run --trace workflow.adl.yaml`
    `Verified the runtime-workflow YAML rejection still triggers when the YAML appears after flags.`
  - `git diff --check`
    `Verified the patch is whitespace-clean and safe to publish.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4393__v0-91-6-tools-github-finish-octocrab-github-convergence/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4393__v0-91-6-tools-github-finish-octocrab-github-convergence/sor.md
- Idempotency-Key: v0-91-6-tools-github-finish-octocrab-github-convergence-adl-v0-91-6-tasks-issue-4393-v0-91-6-tools-github-finish-octocrab-github-convergence-sip-md-adl-v0-91-6-tasks-issue-4393-v0-91-6-tools-github-finish-octocrab-github-convergence-sor-md