### PR TITLE
[v0.91.6][tools][templates] Repair prompt-card template edge cases

### DIFF
--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 
 #[test]
 fn write_output_card_emits_truthful_pre_run_scaffold() {
@@ -139,6 +140,85 @@ fn bootstrap_cards_use_versioned_prompt_templates_when_available() {
     assert!(sor.contains("- Validation planning prompt: `.adl/v0.91.3/tasks/issue-3286__tools-versioned-csdlc-prompt-templates/vpp.md`"));
     assert!(sor.contains("Integration method used: local ignored card-bundle scaffold write under the active checkout; tracked implementation artifacts do not exist yet"));
     assert!(!sor.contains("direct write in main repo for the local ignored pre-run record"));
+}
+
+#[test]
+fn versioned_bootstrap_bundle_from_issue_prompt_includes_valid_six_cards_without_template_residue()
+{
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-six-card-bundle");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4394,
+        "v0.91.6".to_string(),
+        "tools-templates-repair-prompt-card-template-edge-cases".to_string(),
+    )
+    .expect("issue ref");
+    let title = "[v0.91.6][tools][templates] Repair prompt-card template edge cases";
+    write_authored_issue_prompt(&repo, &issue_ref, title);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+
+    let bundle_stp = ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    let (_bundle_stp, bundle_input, bundle_output) =
+        ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path)
+            .expect("pre-run bootstrap cards");
+
+    validate_bootstrap_stp(&repo, &bundle_stp).expect("generated stp should validate");
+    validate_bootstrap_output_card(
+        &repo,
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        "not bound yet",
+        &bundle_output,
+    )
+    .expect("generated sor should validate in bootstrap phase");
+
+    let structured_paths = StructuredBundlePaths {
+        plan_path: &issue_ref.task_bundle_plan_path(&repo),
+        validation_plan_path: &issue_ref.task_bundle_validation_plan_path(&repo),
+        review_policy_path: &issue_ref.task_bundle_review_policy_path(&repo),
+    };
+    validate_initialized_cards(
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        &bundle_input,
+        &bundle_output,
+        &repo,
+        structured_paths,
+    )
+    .expect("generated post-init/pre-run bundle should validate in doctor-ready state");
+
+    for (kind, path) in [
+        ("STP", issue_ref.task_bundle_stp_path(&repo)),
+        ("SIP", bundle_input.clone()),
+        ("SPP", issue_ref.task_bundle_plan_path(&repo)),
+        ("VPP", issue_ref.task_bundle_validation_plan_path(&repo)),
+        ("SRP", issue_ref.task_bundle_review_policy_path(&repo)),
+        ("SOR", bundle_output.clone()),
+    ] {
+        assert!(
+            path.is_file(),
+            "{kind} should be present in the generated six-card bundle"
+        );
+        let text = fs::read_to_string(path).expect("read generated card");
+        assert_no_prompt_template_residue(kind, &text);
+    }
+
+    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
+        .expect("read generated vpp");
+    assert!(vpp.contains("artifact_type: \"structured_validation_planning_prompt\""));
+    assert!(vpp.contains("status: \"ready\""));
+    assert!(vpp.contains("## Validation Planning Summary"));
+
+    let sor = fs::read_to_string(bundle_output).expect("read generated sor");
+    assert!(sor.contains("Status: NOT_STARTED"));
+    assert!(sor.contains("Branch: not bound yet"));
+    assert!(sor.contains("## Issue Metrics Truth"));
+    assert!(!sor.contains("- Start Time: `"));
+    assert!(!sor.contains("- End Time: `"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4394

## Summary
Confirmed that the active `1.0.3` bootstrap path already emits a clean six-card issue bundle for `#4394`, then added focused regression coverage so `STP`, `SIP`, `SPP`, `VPP`, `SRP`, and bootstrap-phase `SOR` validation remain locked together without placeholder residue or timestamp-format regressions.

## Artifacts
- Local ignored output card at `.adl/v0.91.6/tasks/issue-4394__v0-91-6-tools-templates-repair-prompt-card-template-edge-cases/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`
- Additional proof artifacts: `not_applicable`

## Validation
- Validation commands and their purpose:
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" bash adl/tools/pr.sh doctor 4394 --mode ready --json`
    `Verified the active root bundle is doctor-ready in pre-run state, uses the six-card lifecycle, and includes VPP under the active prompt-template registry.`
  - `for f in .adl/v0.91.6/tasks/issue-4394__v0-91-6-tools-templates-repair-prompt-card-template-edge-cases/*; do echo "--- $f"; rg -n '<[a-z0-9_]+>' "$f" || true; done`
    `Verified the generated live six-card bundle contains no unresolved prompt-template placeholder residue.`
  - `for f in .adl/v0.91.6/tasks/issue-4394__v0-91-6-tools-templates-repair-prompt-card-template-edge-cases/*; do case "$f" in *.md) echo "VALIDATE $f"; bash adl/tools/validate_structured_prompt.sh --type "$(basename "$f" .md)" --phase bootstrap --input "$f" || true;; esac; done`
    `Verified each generated live card in the six-card bundle passes the focused structured-prompt validator.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl versioned_bootstrap_bundle_from_issue_prompt_includes_valid_six_cards_without_template_residue -- --nocapture`
    `Verified the regression test proves the issue-prompt/bootstrap flow yields a valid six-card bundle, explicitly validates generated STP and bootstrap-phase SOR, and guards against prompt-template residue plus bootstrap timestamp-format drift.`
  - `git diff --check`
    `Verified the patch is whitespace-clean and safe to publish.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4394__v0-91-6-tools-templates-repair-prompt-card-template-edge-cases/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4394__v0-91-6-tools-templates-repair-prompt-card-template-edge-cases/sor.md
- Idempotency-Key: v0-91-6-tools-templates-repair-prompt-card-template-edge-cases-adl-v0-91-6-tasks-issue-4394-v0-91-6-tools-templates-repair-prompt-card-template-edge-cases-sip-md-adl-v0-91-6-tasks-issue-4394-v0-91-6-tools-templates-repair-prompt-card-template-edge-cases-sor-md