### PR TITLE
[v0.91.6][tools][watcher] Prove or implement repo-native sprint watcher

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -478,11 +478,8 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
         .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
         .unwrap_or_else(|| sanitize_slug(&issue_record.title));
     let issue_ref = IssueRef::new(issue, version, slug)?;
-    let linked_prs = github::linked_prs_for_issue(
-        &repo,
-        issue,
-        Some(issue_ref.branch_name("codex").as_str()),
-    )?;
+    let linked_prs =
+        github::linked_prs_for_issue(&repo, issue, Some(issue_ref.branch_name("codex").as_str()))?;
     let linked_pr = match linked_prs.len() {
         0 => None,
         1 => {

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -464,21 +464,6 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
     let issue = parse_issue_ref_number("watch", &parsed.issue_ref)?;
     let issue_record = github::gh_issue_view(&repo, issue)?;
     let closed_completed = github::gh_issue_is_closed_completed(issue, &repo)?;
-    let linked_prs = github::open_prs_linked_to_issue(&repo, issue)?;
-    let linked_pr = match linked_prs.len() {
-        0 => None,
-        1 => {
-            let pr = linked_prs
-                .into_iter()
-                .next()
-                .expect("single linked PR should exist");
-            let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
-            Some((pr, validation))
-        }
-        count => bail!(
-            "watch: issue #{issue} has {count} linked open PRs; watcher requires a single unambiguous lifecycle target"
-        ),
-    };
     let version = resolve_version_for_existing_issue(
         &repo_root,
         &repo,
@@ -493,16 +478,45 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
         .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
         .unwrap_or_else(|| sanitize_slug(&issue_record.title));
     let issue_ref = IssueRef::new(issue, version, slug)?;
-    let ready = doctor::run_doctor_ready(
+    let linked_prs = github::linked_prs_for_issue(
+        &repo,
+        issue,
+        Some(issue_ref.branch_name("codex").as_str()),
+    )?;
+    let linked_pr = match linked_prs.len() {
+        0 => None,
+        1 => {
+            let pr = linked_prs
+                .into_iter()
+                .next()
+                .expect("single linked PR should exist");
+            let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
+            Some((pr, validation))
+        }
+        count => bail!(
+            "watch: issue #{issue} has {count} linked PRs; watcher requires a single unambiguous lifecycle target"
+        ),
+    };
+    let local_readiness = doctor::run_doctor_ready(
         &repo_root,
         &repo,
         &issue_ref,
         &issue_ref.branch_name("codex"),
-    )?;
+    )
+    .map(|ready| github::IssueWatchLocalReadinessReport {
+        status: "ready".to_string(),
+        pr_run_readiness: ready.card_lifecycle.pr_run_readiness.to_string(),
+        reason: "doctor_ready_pass".to_string(),
+    })
+    .unwrap_or_else(|err| github::IssueWatchLocalReadinessReport {
+        status: "failed".to_string(),
+        pr_run_readiness: "unknown".to_string(),
+        reason: err.to_string(),
+    });
     let report = github::build_issue_watch_report(
         &issue_record,
         closed_completed,
-        ready.card_lifecycle.pr_run_readiness,
+        local_readiness,
         linked_pr,
     );
     if parsed.json {
@@ -749,10 +763,16 @@ fn print_issue_watch_report(report: &github::IssueWatchReport) {
     );
     println!("state: {}", report.issue_state);
     println!("continuation: {}", report.continuation);
+    println!(
+        "local_readiness: status={} pr_run_readiness={} reason={}",
+        report.local_readiness.status,
+        report.local_readiness.pr_run_readiness,
+        report.local_readiness.reason
+    );
     if let Some(pr) = &report.linked_pr {
         println!(
-            "linked_pr: #{} draft={} disposition={}",
-            pr.number, pr.is_draft, pr.validation.disposition
+            "linked_pr: #{} state={} draft={} disposition={}",
+            pr.number, pr.state, pr.is_draft, pr.validation.disposition
         );
         println!("linked_pr_url: {}", pr.url);
         if !pr.validation.failed_checks.is_empty() {

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -14,7 +14,7 @@ use super::pr_cmd_args::{
     parse_closeout_args, parse_closing_linkage_args, parse_create_args, parse_doctor_args,
     parse_init_args, parse_issue_args, parse_preflight_args, parse_projection_map_args,
     parse_ready_args, parse_repair_issue_body_args, parse_start_args, parse_validation_args,
-    DoctorArgs, DoctorMode, IssueArgs,
+    parse_watch_args, DoctorArgs, DoctorMode, IssueArgs,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -209,7 +209,7 @@ fn real_pr_run(args: &[String]) -> Result<()> {
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
+            "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | watch | closing-linkage | issue | projection-map | closeout"
         );
     };
 
@@ -224,6 +224,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "preflight" => real_pr_preflight(&args[1..]),
         "finish" => finish_support::real_pr_finish(&args[1..]),
         "validation" => real_pr_validation(&args[1..]),
+        "watch" => real_pr_watch(&args[1..]),
         "closing-linkage" => real_pr_closing_linkage(&args[1..]),
         "issue" => real_pr_issue(&args[1..]),
         "projection-map" => real_pr_projection_map(&args[1..]),
@@ -449,6 +450,65 @@ fn real_pr_validation(args: &[String]) -> Result<()> {
             report.pr_number,
             report.disposition
         );
+    }
+    Ok(())
+}
+
+fn real_pr_watch(args: &[String]) -> Result<()> {
+    let parsed = parse_watch_args(args)?;
+    let repo_root = repo_root()?;
+    let repo = parsed
+        .repo
+        .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+        .unwrap_or(default_repo(&repo_root)?);
+    let issue = parse_issue_ref_number("watch", &parsed.issue_ref)?;
+    let issue_record = github::gh_issue_view(&repo, issue)?;
+    let closed_completed = github::gh_issue_is_closed_completed(issue, &repo)?;
+    let linked_prs = github::open_prs_linked_to_issue(&repo, issue)?;
+    let linked_pr = match linked_prs.len() {
+        0 => None,
+        1 => {
+            let pr = linked_prs
+                .into_iter()
+                .next()
+                .expect("single linked PR should exist");
+            let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
+            Some((pr, validation))
+        }
+        count => bail!(
+            "watch: issue #{issue} has {count} linked open PRs; watcher requires a single unambiguous lifecycle target"
+        ),
+    };
+    let version = resolve_version_for_existing_issue(
+        &repo_root,
+        &repo,
+        issue,
+        parsed.version,
+        false,
+        "watch",
+    )?;
+    let local_identity = resolve_local_issue_identity(&repo_root, issue)?;
+    let slug = parsed
+        .slug
+        .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
+        .unwrap_or_else(|| sanitize_slug(&issue_record.title));
+    let issue_ref = IssueRef::new(issue, version, slug)?;
+    let ready = doctor::run_doctor_ready(
+        &repo_root,
+        &repo,
+        &issue_ref,
+        &issue_ref.branch_name("codex"),
+    )?;
+    let report = github::build_issue_watch_report(
+        &issue_record,
+        closed_completed,
+        ready.card_lifecycle.pr_run_readiness,
+        linked_pr,
+    );
+    if parsed.json {
+        print_json(&report)?;
+    } else {
+        print_issue_watch_report(&report);
     }
     Ok(())
 }
@@ -680,6 +740,44 @@ fn format_issue_rows(issues: &[IssueRecord]) -> String {
 
 fn print_issue_view(issue: &IssueRecord) {
     println!("{}", format_issue_view(issue));
+}
+
+fn print_issue_watch_report(report: &github::IssueWatchReport) {
+    println!(
+        "Issue #{} watch: {} -> {} ({})",
+        report.issue, report.classification, report.next_skill, report.reason
+    );
+    println!("state: {}", report.issue_state);
+    println!("continuation: {}", report.continuation);
+    if let Some(pr) = &report.linked_pr {
+        println!(
+            "linked_pr: #{} draft={} disposition={}",
+            pr.number, pr.is_draft, pr.validation.disposition
+        );
+        println!("linked_pr_url: {}", pr.url);
+        if !pr.validation.failed_checks.is_empty() {
+            println!(
+                "failed_checks: {}",
+                pr.validation
+                    .failed_checks
+                    .iter()
+                    .map(|check| check.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        if !pr.validation.pending_checks.is_empty() {
+            println!(
+                "pending_checks: {}",
+                pr.validation
+                    .pending_checks
+                    .iter()
+                    .map(|check| check.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
 }
 
 fn format_issue_view(issue: &IssueRecord) -> String {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -36,9 +36,9 @@ use self::transport::{
 };
 use self::transport::{
     create_pr_octocrab, current_pr_url_octocrab, issue_close_octocrab, issue_comment_octocrab,
-    list_prs_by_head_ref_octocrab, list_prs_octocrab, mark_pr_ready_octocrab, merge_pr_octocrab, pr_base_ref_octocrab,
-    pr_body_octocrab, pr_closing_issue_numbers_octocrab, update_pr_body_octocrab,
-    update_pr_title_body_octocrab,
+    list_prs_by_head_ref_octocrab, list_prs_octocrab, mark_pr_ready_octocrab, merge_pr_octocrab,
+    pr_base_ref_octocrab, pr_body_octocrab, pr_closing_issue_numbers_octocrab,
+    update_pr_body_octocrab, update_pr_title_body_octocrab,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,9 +58,14 @@ pub(super) struct OpenPullRequest {
     pub(super) base_ref_name: String,
     #[serde(rename = "isDraft")]
     pub(super) is_draft: bool,
+    #[serde(default = "default_open_pr_state")]
     pub(super) state: String,
     #[serde(skip)]
     pub(super) queue: Option<String>,
+}
+
+fn default_open_pr_state() -> String {
+    "OPEN".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -36,7 +36,7 @@ use self::transport::{
 };
 use self::transport::{
     create_pr_octocrab, current_pr_url_octocrab, issue_close_octocrab, issue_comment_octocrab,
-    list_open_prs_octocrab, mark_pr_ready_octocrab, merge_pr_octocrab, pr_base_ref_octocrab,
+    list_prs_by_head_ref_octocrab, list_prs_octocrab, mark_pr_ready_octocrab, merge_pr_octocrab, pr_base_ref_octocrab,
     pr_body_octocrab, pr_closing_issue_numbers_octocrab, update_pr_body_octocrab,
     update_pr_title_body_octocrab,
 };
@@ -58,6 +58,7 @@ pub(super) struct OpenPullRequest {
     pub(super) base_ref_name: String,
     #[serde(rename = "isDraft")]
     pub(super) is_draft: bool,
+    pub(super) state: String,
     #[serde(skip)]
     pub(super) queue: Option<String>,
 }
@@ -158,7 +159,15 @@ pub(crate) struct IssueWatchLinkedPrReport {
     pub(crate) head_ref_name: String,
     pub(crate) base_ref_name: String,
     pub(crate) is_draft: bool,
+    pub(crate) state: String,
     pub(crate) validation: PrValidationReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct IssueWatchLocalReadinessReport {
+    pub(crate) status: String,
+    pub(crate) pr_run_readiness: String,
+    pub(crate) reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -172,6 +181,7 @@ pub(crate) struct IssueWatchReport {
     pub(crate) next_skill: String,
     pub(crate) continuation: String,
     pub(crate) reason: String,
+    pub(crate) local_readiness: IssueWatchLocalReadinessReport,
     pub(crate) linked_pr: Option<IssueWatchLinkedPrReport>,
 }
 
@@ -400,9 +410,23 @@ pub(super) fn pr_validation_report(repo: &str, pr_ref: &str) -> Result<PrValidat
     transport::pr_validation_report(repo, pr_ref)
 }
 
-pub(crate) fn open_prs_linked_to_issue(repo: &str, issue: u32) -> Result<Vec<OpenPullRequest>> {
+pub(crate) fn linked_prs_for_issue(
+    repo: &str,
+    issue: u32,
+    branch_hint: Option<&str>,
+) -> Result<Vec<OpenPullRequest>> {
     let mut linked = Vec::new();
-    for pr in list_open_prs_octocrab(repo)? {
+    let prs = if let Some(branch_hint) = branch_hint {
+        let prs = list_prs_by_head_ref_octocrab(repo, branch_hint)?;
+        if prs.is_empty() {
+            list_prs_octocrab(repo)?
+        } else {
+            prs
+        }
+    } else {
+        list_prs_octocrab(repo)?
+    };
+    for pr in prs {
         let pr_ref = pr.number.to_string();
         let linked_issues =
             pr_closing_issue_numbers_octocrab(repo, &pr_ref).with_context(|| {
@@ -423,7 +447,7 @@ pub(crate) fn open_prs_linked_to_issue(repo: &str, issue: u32) -> Result<Vec<Ope
 pub(crate) fn build_issue_watch_report(
     issue: &IssueRecord,
     closed_completed: bool,
-    ready_status: &str,
+    local_readiness: IssueWatchLocalReadinessReport,
     linked_pr: Option<(OpenPullRequest, PrValidationReport)>,
 ) -> IssueWatchReport {
     if closed_completed {
@@ -437,12 +461,14 @@ pub(crate) fn build_issue_watch_report(
             next_skill: "pr-closeout".to_string(),
             continuation: "action_required".to_string(),
             reason: "issue_closed_completed".to_string(),
+            local_readiness,
             linked_pr: linked_pr.map(|(pr, validation)| IssueWatchLinkedPrReport {
                 number: pr.number,
                 url: pr.url,
                 head_ref_name: pr.head_ref_name,
                 base_ref_name: pr.base_ref_name,
                 is_draft: pr.is_draft,
+                state: pr.state,
                 validation,
             }),
         };
@@ -459,33 +485,43 @@ pub(crate) fn build_issue_watch_report(
             next_skill: "human_review".to_string(),
             continuation: "ask_operator".to_string(),
             reason: "issue_closed_without_completed_reason".to_string(),
+            local_readiness,
             linked_pr: linked_pr.map(|(pr, validation)| IssueWatchLinkedPrReport {
                 number: pr.number,
                 url: pr.url,
                 head_ref_name: pr.head_ref_name,
                 base_ref_name: pr.base_ref_name,
                 is_draft: pr.is_draft,
+                state: pr.state,
                 validation,
             }),
         };
     }
 
     let Some((pr, validation)) = linked_pr else {
-        let (classification, next_skill, continuation, reason) = if ready_status == "ready" {
-            (
-                "ready_for_run",
-                "pr-run",
-                "continue",
-                "issue_ready_without_linked_pr",
-            )
-        } else {
-            (
-                "structurally_unready",
-                "pr-ready",
-                "action_required",
-                "issue_missing_execution_readiness",
-            )
-        };
+        let (classification, next_skill, continuation, reason) =
+            if local_readiness.pr_run_readiness == "ready" {
+                (
+                    "ready_for_run",
+                    "pr-run",
+                    "continue",
+                    "issue_ready_without_linked_pr",
+                )
+            } else if local_readiness.status == "failed" {
+                (
+                    "blocked",
+                    "pr-ready",
+                    "action_required",
+                    "issue_local_readiness_failed",
+                )
+            } else {
+                (
+                    "unknown",
+                    "issue-watcher",
+                    "ask_operator",
+                    "issue_local_readiness_unknown",
+                )
+            };
         return IssueWatchReport {
             schema: "adl.pr.watch.v1",
             issue: issue.number,
@@ -496,11 +532,19 @@ pub(crate) fn build_issue_watch_report(
             next_skill: next_skill.to_string(),
             continuation: continuation.to_string(),
             reason: reason.to_string(),
+            local_readiness,
             linked_pr: None,
         };
     };
 
-    let (classification, next_skill, continuation, reason) = if validation.is_draft {
+    let (classification, next_skill, continuation, reason) = if validation.pr_state == "MERGED" {
+        (
+            "merged_pending_closeout",
+            "pr-closeout",
+            "action_required",
+            "linked_pr_merged_closeout_pending",
+        )
+    } else if validation.is_draft {
         ("pr_open", "issue-watcher", "continue", "linked_pr_draft")
     } else {
         match validation.disposition.as_str() {
@@ -541,12 +585,14 @@ pub(crate) fn build_issue_watch_report(
         next_skill: next_skill.to_string(),
         continuation: continuation.to_string(),
         reason: reason.to_string(),
+        local_readiness,
         linked_pr: Some(IssueWatchLinkedPrReport {
             number: pr.number,
             url: pr.url,
             head_ref_name: pr.head_ref_name,
             base_ref_name: pr.base_ref_name,
             is_draft: pr.is_draft,
+            state: pr.state,
             validation,
         }),
     }
@@ -928,9 +974,9 @@ fn run_octocrab_capture(operation: &str, args: &[&str]) -> Result<String> {
             let branch = arg_after(args, "--head")?;
             current_pr_url_octocrab(repo, branch).map(|url| url.unwrap_or_default())
         }
-        "pr.list.open_wave" => {
+        "pr.list.open_wave" | "pr.list.wave" => {
             let repo = arg_after(args, "-R")?;
-            let prs = list_open_prs_octocrab(repo)?;
+            let prs = list_prs_octocrab(repo)?;
             serde_json::to_string(&prs).context("failed to serialize octocrab PR list")
         }
         "pr.view.body" => {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -151,6 +151,30 @@ pub(super) struct PrValidationReport {
     pub(super) pending_checks: Vec<PrValidationCheckReport>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct IssueWatchLinkedPrReport {
+    pub(crate) number: u32,
+    pub(crate) url: String,
+    pub(crate) head_ref_name: String,
+    pub(crate) base_ref_name: String,
+    pub(crate) is_draft: bool,
+    pub(crate) validation: PrValidationReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct IssueWatchReport {
+    pub(crate) schema: &'static str,
+    pub(crate) issue: u32,
+    pub(crate) issue_state: String,
+    pub(crate) authoritative_classifier: &'static str,
+    pub(crate) advisory_agent_mode: &'static str,
+    pub(crate) classification: String,
+    pub(crate) next_skill: String,
+    pub(crate) continuation: String,
+    pub(crate) reason: String,
+    pub(crate) linked_pr: Option<IssueWatchLinkedPrReport>,
+}
+
 pub(super) fn wait_for_pr_validation_finish(repo: &str, pr_ref: &str) -> Result<()> {
     transport::wait_for_pr_validation_finish(repo, pr_ref)
 }
@@ -374,6 +398,158 @@ pub(super) fn wait_for_pr_validation_report(
 
 pub(super) fn pr_validation_report(repo: &str, pr_ref: &str) -> Result<PrValidationReport> {
     transport::pr_validation_report(repo, pr_ref)
+}
+
+pub(crate) fn open_prs_linked_to_issue(repo: &str, issue: u32) -> Result<Vec<OpenPullRequest>> {
+    let mut linked = Vec::new();
+    for pr in list_open_prs_octocrab(repo)? {
+        let pr_ref = pr.number.to_string();
+        let linked_issues =
+            pr_closing_issue_numbers_octocrab(repo, &pr_ref).with_context(|| {
+                format!(
+                    "watch: failed to inspect closing issues for PR #{}",
+                    pr.number
+                )
+            })?;
+        if linked_issues.contains(&issue)
+            || issue_number_from_codex_branch(&pr.head_ref_name) == Some(issue)
+        {
+            linked.push(pr);
+        }
+    }
+    Ok(linked)
+}
+
+pub(crate) fn build_issue_watch_report(
+    issue: &IssueRecord,
+    closed_completed: bool,
+    ready_status: &str,
+    linked_pr: Option<(OpenPullRequest, PrValidationReport)>,
+) -> IssueWatchReport {
+    if closed_completed {
+        return IssueWatchReport {
+            schema: "adl.pr.watch.v1",
+            issue: issue.number,
+            issue_state: issue.state.to_uppercase(),
+            authoritative_classifier: "adl",
+            advisory_agent_mode: "local_agent_advisory_only",
+            classification: "closeout_needed".to_string(),
+            next_skill: "pr-closeout".to_string(),
+            continuation: "action_required".to_string(),
+            reason: "issue_closed_completed".to_string(),
+            linked_pr: linked_pr.map(|(pr, validation)| IssueWatchLinkedPrReport {
+                number: pr.number,
+                url: pr.url,
+                head_ref_name: pr.head_ref_name,
+                base_ref_name: pr.base_ref_name,
+                is_draft: pr.is_draft,
+                validation,
+            }),
+        };
+    }
+
+    if !issue.state.eq_ignore_ascii_case("open") {
+        return IssueWatchReport {
+            schema: "adl.pr.watch.v1",
+            issue: issue.number,
+            issue_state: issue.state.to_uppercase(),
+            authoritative_classifier: "adl",
+            advisory_agent_mode: "local_agent_advisory_only",
+            classification: "closed".to_string(),
+            next_skill: "human_review".to_string(),
+            continuation: "ask_operator".to_string(),
+            reason: "issue_closed_without_completed_reason".to_string(),
+            linked_pr: linked_pr.map(|(pr, validation)| IssueWatchLinkedPrReport {
+                number: pr.number,
+                url: pr.url,
+                head_ref_name: pr.head_ref_name,
+                base_ref_name: pr.base_ref_name,
+                is_draft: pr.is_draft,
+                validation,
+            }),
+        };
+    }
+
+    let Some((pr, validation)) = linked_pr else {
+        let (classification, next_skill, continuation, reason) = if ready_status == "ready" {
+            (
+                "ready_for_run",
+                "pr-run",
+                "continue",
+                "issue_ready_without_linked_pr",
+            )
+        } else {
+            (
+                "structurally_unready",
+                "pr-ready",
+                "action_required",
+                "issue_missing_execution_readiness",
+            )
+        };
+        return IssueWatchReport {
+            schema: "adl.pr.watch.v1",
+            issue: issue.number,
+            issue_state: issue.state.to_uppercase(),
+            authoritative_classifier: "adl",
+            advisory_agent_mode: "local_agent_advisory_only",
+            classification: classification.to_string(),
+            next_skill: next_skill.to_string(),
+            continuation: continuation.to_string(),
+            reason: reason.to_string(),
+            linked_pr: None,
+        };
+    };
+
+    let (classification, next_skill, continuation, reason) = if validation.is_draft {
+        ("pr_open", "issue-watcher", "continue", "linked_pr_draft")
+    } else {
+        match validation.disposition.as_str() {
+            "pending" => (
+                "checks_running",
+                "issue-watcher",
+                "continue",
+                "linked_pr_checks_pending",
+            ),
+            "failed" | "cancelled" | "timed_out" => (
+                "checks_failed",
+                "pr-janitor",
+                "action_required",
+                "linked_pr_checks_failed",
+            ),
+            "success" | "skipped" => (
+                "checks_green",
+                "human_review",
+                "ask_operator",
+                "linked_pr_checks_green",
+            ),
+            _ => (
+                "blocked",
+                "issue-watcher",
+                "ask_operator",
+                "linked_pr_validation_ambiguous",
+            ),
+        }
+    };
+
+    IssueWatchReport {
+        schema: "adl.pr.watch.v1",
+        issue: issue.number,
+        issue_state: issue.state.to_uppercase(),
+        authoritative_classifier: "adl",
+        advisory_agent_mode: "local_agent_advisory_only",
+        classification: classification.to_string(),
+        next_skill: next_skill.to_string(),
+        continuation: continuation.to_string(),
+        reason: reason.to_string(),
+        linked_pr: Some(IssueWatchLinkedPrReport {
+            number: pr.number,
+            url: pr.url,
+            head_ref_name: pr.head_ref_name,
+            base_ref_name: pr.base_ref_name,
+            is_draft: pr.is_draft,
+            validation,
+        }),
+    }
 }
 
 fn github_client(operation: &str) -> Result<AdlGithubClient> {

--- a/adl/src/cli/pr_cmd/github/tests.rs
+++ b/adl/src/cli/pr_cmd/github/tests.rs
@@ -7,6 +7,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tiny_http::{Header, Response, Server};
 
+mod watch;
+
 fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     cli_env_lock()
 }
@@ -531,6 +533,58 @@ fn spawn_validation_status_paginated_server() -> (String, thread::JoinHandle<Vec
                 )
             };
             let _ = request.respond(json_response(response));
+        }
+        seen
+    });
+    (base_uri, handle)
+}
+
+fn spawn_open_prs_paginated_server() -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_test_http_server("bind open PR pagination server");
+    let next_url = format!("{base_uri}/repos/owner/repo/pulls?page=2");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        for page in 1..=2 {
+            let Some(request) = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("open PR pagination server receive")
+            else {
+                break;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            seen.push(format!("{method} {url}"));
+            let response_body = if page == 1 {
+                format!(
+                    "[{}]",
+                    pr_fixture(
+                        2101,
+                        "[v0.91.6][tools] First page PR",
+                        "Closes #4301",
+                        "codex/4301-first-page",
+                        "main"
+                    )
+                )
+            } else {
+                format!(
+                    "[{}]",
+                    pr_fixture(
+                        2102,
+                        "[v0.91.6][tools] Second page PR",
+                        "Closes #4302",
+                        "codex/4302-second-page",
+                        "main"
+                    )
+                )
+            };
+            let mut response = json_response(response_body);
+            if page == 1 {
+                let link = format!(r#"<{next_url}>; rel="next""#);
+                if let Ok(header) = Header::from_bytes("Link", link) {
+                    response = response.with_header(header);
+                }
+            }
+            let _ = request.respond(response);
         }
         seen
     });

--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
+++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
@@ -457,6 +457,33 @@ fn pr_validation_status_query_paginates_status_rollup_contexts() {
 }
 
 #[test]
+fn list_open_prs_octocrab_paginates_rest_results() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let (base_uri, server) = spawn_open_prs_paginated_server();
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+
+    let prs = list_open_prs_octocrab("owner/repo").expect("paginated open PRs");
+    assert_eq!(prs.len(), 2);
+    assert_eq!(prs[0].number, 2101);
+    assert_eq!(prs[1].number, 2102);
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 2, "unexpected pagination calls: {seen:#?}");
+    assert!(seen[0].contains("/repos/owner/repo/pulls?"));
+    assert!(seen[1].contains("/repos/owner/repo/pulls?page=2"));
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
 fn pr_validation_watch_returns_failed_report_without_second_fetch() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();

--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
+++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
@@ -457,7 +457,7 @@ fn pr_validation_status_query_paginates_status_rollup_contexts() {
 }
 
 #[test]
-fn list_open_prs_octocrab_paginates_rest_results() {
+fn list_prs_octocrab_paginates_rest_results() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
     let (base_uri, server) = spawn_open_prs_paginated_server();
@@ -467,7 +467,7 @@ fn list_open_prs_octocrab_paginates_rest_results() {
         std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
     }
 
-    let prs = list_open_prs_octocrab("owner/repo").expect("paginated open PRs");
+    let prs = list_prs_octocrab("owner/repo").expect("paginated PRs");
     assert_eq!(prs.len(), 2);
     assert_eq!(prs[0].number, 2101);
     assert_eq!(prs[1].number, 2102);

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -1,5 +1,21 @@
 use super::*;
 
+fn readiness_ready() -> IssueWatchLocalReadinessReport {
+    IssueWatchLocalReadinessReport {
+        status: "ready".to_string(),
+        pr_run_readiness: "ready".to_string(),
+        reason: "doctor_ready_pass".to_string(),
+    }
+}
+
+fn readiness_failed() -> IssueWatchLocalReadinessReport {
+    IssueWatchLocalReadinessReport {
+        status: "failed".to_string(),
+        pr_run_readiness: "unknown".to_string(),
+        reason: "doctor: sor failed validation".to_string(),
+    }
+}
+
 fn open_issue(number: u32) -> IssueRecord {
     IssueRecord {
         number,
@@ -21,6 +37,7 @@ fn linked_pr(number: u32, is_draft: bool) -> OpenPullRequest {
         head_ref_name: format!("codex/{}-fixture", number + 1000),
         base_ref_name: "main".to_string(),
         is_draft,
+        state: "OPEN".to_string(),
         queue: None,
     }
 }
@@ -62,9 +79,22 @@ fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
     }
 }
 
+fn merged_validation_report() -> PrValidationReport {
+    PrValidationReport {
+        pr_number: 77,
+        commit_sha: "abc".to_string(),
+        pr_state: "MERGED".to_string(),
+        is_draft: false,
+        disposition: "success".to_string(),
+        checks: vec![],
+        failed_checks: vec![],
+        pending_checks: vec![],
+    }
+}
+
 #[test]
 fn issue_watch_routes_ready_issue_without_pr_to_pr_run() {
-    let report = build_issue_watch_report(&open_issue(4397), false, "ready", None);
+    let report = build_issue_watch_report(&open_issue(4397), false, readiness_ready(), None);
     assert_eq!(report.authoritative_classifier, "adl");
     assert_eq!(report.advisory_agent_mode, "local_agent_advisory_only");
     assert_eq!(report.classification, "ready_for_run");
@@ -78,7 +108,7 @@ fn issue_watch_routes_draft_pr_to_issue_watcher() {
     let report = build_issue_watch_report(
         &open_issue(4397),
         false,
-        "ready",
+        readiness_ready(),
         Some((pr, validation_report("pending", true))),
     );
     assert_eq!(report.classification, "pr_open");
@@ -91,7 +121,7 @@ fn issue_watch_routes_failed_checks_to_pr_janitor() {
     let report = build_issue_watch_report(
         &open_issue(4397),
         false,
-        "ready",
+        readiness_ready(),
         Some((pr, validation_report("failed", false))),
     );
     assert_eq!(report.classification, "checks_failed");
@@ -104,7 +134,7 @@ fn issue_watch_routes_pending_checks_to_issue_watcher() {
     let report = build_issue_watch_report(
         &open_issue(4397),
         false,
-        "ready",
+        readiness_ready(),
         Some((pr, validation_report("pending", false))),
     );
     assert_eq!(report.classification, "checks_running");
@@ -118,7 +148,7 @@ fn issue_watch_routes_green_checks_to_human_review() {
     let report = build_issue_watch_report(
         &open_issue(4397),
         false,
-        "ready",
+        readiness_ready(),
         Some((pr, validation_report("success", false))),
     );
     assert_eq!(report.classification, "checks_green");
@@ -130,7 +160,30 @@ fn issue_watch_routes_closed_completed_issue_to_closeout() {
     let mut issue = open_issue(4397);
     issue.state = "closed".to_string();
     issue.closed_at = Some("2026-06-22T00:00:00Z".to_string());
-    let report = build_issue_watch_report(&issue, true, "ready", None);
+    let report = build_issue_watch_report(&issue, true, readiness_ready(), None);
     assert_eq!(report.classification, "closeout_needed");
     assert_eq!(report.next_skill, "pr-closeout");
+}
+
+#[test]
+fn issue_watch_routes_merged_pr_to_merged_pending_closeout() {
+    let mut pr = linked_pr(77, false);
+    pr.state = "MERGED".to_string();
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        readiness_ready(),
+        Some((pr, merged_validation_report())),
+    );
+    assert_eq!(report.classification, "merged_pending_closeout");
+    assert_eq!(report.next_skill, "pr-closeout");
+    assert_eq!(report.continuation, "action_required");
+}
+
+#[test]
+fn issue_watch_routes_failed_local_readiness_without_pr_to_blocked() {
+    let report = build_issue_watch_report(&open_issue(4397), false, readiness_failed(), None);
+    assert_eq!(report.classification, "blocked");
+    assert_eq!(report.next_skill, "pr-ready");
+    assert_eq!(report.local_readiness.reason, "doctor: sor failed validation");
 }

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -185,5 +185,8 @@ fn issue_watch_routes_failed_local_readiness_without_pr_to_blocked() {
     let report = build_issue_watch_report(&open_issue(4397), false, readiness_failed(), None);
     assert_eq!(report.classification, "blocked");
     assert_eq!(report.next_skill, "pr-ready");
-    assert_eq!(report.local_readiness.reason, "doctor: sor failed validation");
+    assert_eq!(
+        report.local_readiness.reason,
+        "doctor: sor failed validation"
+    );
 }

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+fn open_issue(number: u32) -> IssueRecord {
+    IssueRecord {
+        number,
+        title: format!("Issue {number}"),
+        state: "open".to_string(),
+        url: format!("https://github.com/owner/repo/issues/{number}"),
+        closed_at: None,
+        body: None,
+        labels: vec![],
+        milestone: None,
+    }
+}
+
+fn linked_pr(number: u32, is_draft: bool) -> OpenPullRequest {
+    OpenPullRequest {
+        number,
+        title: format!("PR {number}"),
+        url: format!("https://github.com/owner/repo/pull/{number}"),
+        head_ref_name: format!("codex/{}-fixture", number + 1000),
+        base_ref_name: "main".to_string(),
+        is_draft,
+        queue: None,
+    }
+}
+
+fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
+    let failed_checks = if disposition == "failed" {
+        vec![PrValidationCheckReport {
+            name: "adl-ci".to_string(),
+            status: "COMPLETED".to_string(),
+            conclusion: "FAILURE".to_string(),
+            job_run_id: "1".to_string(),
+        }]
+    } else {
+        vec![]
+    };
+    let pending_checks = if disposition == "pending" && !is_draft {
+        vec![PrValidationCheckReport {
+            name: "adl-ci".to_string(),
+            status: "IN_PROGRESS".to_string(),
+            conclusion: "PENDING".to_string(),
+            job_run_id: "2".to_string(),
+        }]
+    } else {
+        vec![]
+    };
+    PrValidationReport {
+        pr_number: 77,
+        commit_sha: "abc".to_string(),
+        pr_state: "OPEN".to_string(),
+        is_draft,
+        disposition: disposition.to_string(),
+        checks: failed_checks
+            .iter()
+            .chain(pending_checks.iter())
+            .cloned()
+            .collect(),
+        failed_checks,
+        pending_checks,
+    }
+}
+
+#[test]
+fn issue_watch_routes_ready_issue_without_pr_to_pr_run() {
+    let report = build_issue_watch_report(&open_issue(4397), false, "ready", None);
+    assert_eq!(report.authoritative_classifier, "adl");
+    assert_eq!(report.advisory_agent_mode, "local_agent_advisory_only");
+    assert_eq!(report.classification, "ready_for_run");
+    assert_eq!(report.next_skill, "pr-run");
+    assert_eq!(report.continuation, "continue");
+}
+
+#[test]
+fn issue_watch_routes_draft_pr_to_issue_watcher() {
+    let pr = linked_pr(77, true);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        "ready",
+        Some((pr, validation_report("pending", true))),
+    );
+    assert_eq!(report.classification, "pr_open");
+    assert_eq!(report.next_skill, "issue-watcher");
+}
+
+#[test]
+fn issue_watch_routes_failed_checks_to_pr_janitor() {
+    let pr = linked_pr(77, false);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        "ready",
+        Some((pr, validation_report("failed", false))),
+    );
+    assert_eq!(report.classification, "checks_failed");
+    assert_eq!(report.next_skill, "pr-janitor");
+}
+
+#[test]
+fn issue_watch_routes_pending_checks_to_issue_watcher() {
+    let pr = linked_pr(77, false);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        "ready",
+        Some((pr, validation_report("pending", false))),
+    );
+    assert_eq!(report.classification, "checks_running");
+    assert_eq!(report.next_skill, "issue-watcher");
+    assert_eq!(report.continuation, "continue");
+}
+
+#[test]
+fn issue_watch_routes_green_checks_to_human_review() {
+    let pr = linked_pr(77, false);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        "ready",
+        Some((pr, validation_report("success", false))),
+    );
+    assert_eq!(report.classification, "checks_green");
+    assert_eq!(report.next_skill, "human_review");
+}
+
+#[test]
+fn issue_watch_routes_closed_completed_issue_to_closeout() {
+    let mut issue = open_issue(4397);
+    issue.state = "closed".to_string();
+    issue.closed_at = Some("2026-06-22T00:00:00Z".to_string());
+    let report = build_issue_watch_report(&issue, true, "ready", None);
+    assert_eq!(report.classification, "closeout_needed");
+    assert_eq!(report.next_skill, "pr-closeout");
+}

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -187,7 +187,7 @@ pub(super) fn list_open_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>>
     with_octocrab("pr.list.open_wave", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        let page = block_on_octocrab(runtime, "pr.list.open_wave", || async {
+        let mut page = block_on_octocrab(runtime, "pr.list.open_wave", || async {
             octo.pulls(&owner, &name)
                 .list()
                 .state(octocrab::params::State::Open)
@@ -195,27 +195,37 @@ pub(super) fn list_open_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>>
                 .send()
                 .await
         })?;
-        Ok(page
-            .items
-            .into_iter()
-            .map(|pr| OpenPullRequest {
-                number: pr.number.unwrap_or_default() as u32,
-                title: pr.title.unwrap_or_default(),
-                url: pr.html_url.map(|url| url.to_string()).unwrap_or_default(),
-                head_ref_name: pr
-                    .head
-                    .as_ref()
-                    .map(|head| head.ref_field.clone())
-                    .unwrap_or_default(),
-                base_ref_name: pr
-                    .base
-                    .as_ref()
-                    .map(|base| base.ref_field.clone())
-                    .unwrap_or_default(),
-                is_draft: pr.draft.unwrap_or(false),
-                queue: None,
-            })
-            .collect())
+        let mut open_prs = Vec::new();
+        loop {
+            open_prs.extend(page.items.into_iter().map(|pr| {
+                OpenPullRequest {
+                    number: pr.number.unwrap_or_default() as u32,
+                    title: pr.title.unwrap_or_default(),
+                    url: pr.html_url.map(|url| url.to_string()).unwrap_or_default(),
+                    head_ref_name: pr
+                        .head
+                        .as_ref()
+                        .map(|head| head.ref_field.clone())
+                        .unwrap_or_default(),
+                    base_ref_name: pr
+                        .base
+                        .as_ref()
+                        .map(|base| base.ref_field.clone())
+                        .unwrap_or_default(),
+                    is_draft: pr.draft.unwrap_or(false),
+                    queue: None,
+                }
+            }));
+            let Some(next) = page.next.clone() else {
+                break;
+            };
+            page = block_on_octocrab(runtime, "pr.list.open_wave", || async {
+                octo.get_page::<octocrab::models::pulls::PullRequest>(&Some(next.clone()))
+                    .await
+            })?
+            .ok_or_else(|| anyhow!("GitHub advertised a next PR page but did not return it"))?;
+        }
+        Ok(open_prs)
     })
 }
 

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -182,22 +182,22 @@ pub(super) fn current_pr_url_octocrab(repo: &str, branch: &str) -> Result<Option
     })
 }
 
-pub(super) fn list_open_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
+pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
     let repo_parts = parse_repo(repo)?;
-    with_octocrab("pr.list.open_wave", |runtime, octo| {
+    with_octocrab("pr.list.wave", |runtime, octo| {
         let owner = repo_parts.owner.clone();
         let name = repo_parts.name.clone();
-        let mut page = block_on_octocrab(runtime, "pr.list.open_wave", || async {
+        let mut page = block_on_octocrab(runtime, "pr.list.wave", || async {
             octo.pulls(&owner, &name)
                 .list()
-                .state(octocrab::params::State::Open)
+                .state(octocrab::params::State::All)
                 .per_page(100)
                 .send()
                 .await
         })?;
-        let mut open_prs = Vec::new();
+        let mut prs = Vec::new();
         loop {
-            open_prs.extend(page.items.into_iter().map(|pr| {
+            prs.extend(page.items.into_iter().map(|pr| {
                 OpenPullRequest {
                     number: pr.number.unwrap_or_default() as u32,
                     title: pr.title.unwrap_or_default(),
@@ -213,19 +213,69 @@ pub(super) fn list_open_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>>
                         .map(|base| base.ref_field.clone())
                         .unwrap_or_default(),
                     is_draft: pr.draft.unwrap_or(false),
+                    state: pr
+                        .state
+                        .map(|state| format!("{state:?}").to_uppercase())
+                        .unwrap_or_else(|| "OPEN".to_string()),
                     queue: None,
                 }
             }));
             let Some(next) = page.next.clone() else {
                 break;
             };
-            page = block_on_octocrab(runtime, "pr.list.open_wave", || async {
+            page = block_on_octocrab(runtime, "pr.list.wave", || async {
                 octo.get_page::<octocrab::models::pulls::PullRequest>(&Some(next.clone()))
                     .await
             })?
             .ok_or_else(|| anyhow!("GitHub advertised a next PR page but did not return it"))?;
         }
-        Ok(open_prs)
+        Ok(prs)
+    })
+}
+
+pub(super) fn list_prs_by_head_ref_octocrab(
+    repo: &str,
+    head_ref_name: &str,
+) -> Result<Vec<OpenPullRequest>> {
+    let repo_parts = parse_repo(repo)?;
+    let head = format!("{}:{head_ref_name}", repo_parts.owner);
+    with_octocrab("pr.list.head_ref", |runtime, octo| {
+        let owner = repo_parts.owner.clone();
+        let name = repo_parts.name.clone();
+        let page = block_on_octocrab(runtime, "pr.list.head_ref", || async {
+            octo.pulls(&owner, &name)
+                .list()
+                .state(octocrab::params::State::All)
+                .head(head.clone())
+                .per_page(20)
+                .send()
+                .await
+        })?;
+        Ok(page
+            .items
+            .into_iter()
+            .map(|pr| OpenPullRequest {
+                number: pr.number.unwrap_or_default() as u32,
+                title: pr.title.unwrap_or_default(),
+                url: pr.html_url.map(|url| url.to_string()).unwrap_or_default(),
+                head_ref_name: pr
+                    .head
+                    .as_ref()
+                    .map(|head| head.ref_field.clone())
+                    .unwrap_or_default(),
+                base_ref_name: pr
+                    .base
+                    .as_ref()
+                    .map(|base| base.ref_field.clone())
+                    .unwrap_or_default(),
+                is_draft: pr.draft.unwrap_or(false),
+                state: pr
+                    .state
+                    .map(|state| format!("{state:?}").to_uppercase())
+                    .unwrap_or_else(|| "OPEN".to_string()),
+                queue: None,
+            })
+            .collect())
     })
 }
 

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -104,6 +104,15 @@ pub(crate) struct ValidationArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WatchArgs {
+    pub(crate) issue_ref: String,
+    pub(crate) repo: Option<String>,
+    pub(crate) slug: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ClosingLinkageArgs {
     pub(crate) event_name: Option<String>,
     pub(crate) event_path: Option<PathBuf>,
@@ -682,6 +691,43 @@ pub(crate) fn parse_validation_args(args: &[String]) -> Result<ValidationArgs> {
             other => bail!("validation: unknown arg: {other}"),
         }
         i += 1;
+    }
+    Ok(parsed)
+}
+
+pub(crate) fn parse_watch_args(args: &[String]) -> Result<WatchArgs> {
+    let issue_ref = args
+        .first()
+        .ok_or_else(|| anyhow!("watch: missing <issue-number-or-url>"))?
+        .to_string();
+    let mut parsed = WatchArgs {
+        issue_ref,
+        repo: None,
+        slug: None,
+        version: None,
+        json: false,
+    };
+    let mut i = 1usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(args, i, "watch", args[i].as_str())?);
+                i += 2;
+            }
+            "--slug" => {
+                parsed.slug = Some(require_value(args, i, "watch", "--slug")?);
+                i += 2;
+            }
+            "--version" => {
+                parsed.version = Some(require_value(args, i, "watch", "--version")?);
+                i += 2;
+            }
+            "--json" => {
+                parsed.json = true;
+                i += 1;
+            }
+            other => bail!("watch: unknown arg: {other}"),
+        }
     }
     Ok(parsed)
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -11,6 +11,9 @@ use crate::cli::pr_cmd_prompt::{
 };
 use adl::control_plane::IssueRef;
 use std::env;
+use std::thread;
+use std::time::Duration;
+use tiny_http::{Header, Response, Server};
 
 fn spawn_issue_octocrab_test_server(
     expected_requests: usize,
@@ -113,6 +116,92 @@ fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
     }
 }
 
+fn bind_pr_validation_test_server(context: &str) -> (String, Server) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect(context);
+    let addr = listener.local_addr().expect("local addr");
+    let server = Server::from_listener(listener, None).expect("construct validation server");
+    (format!("http://{addr}"), server)
+}
+
+fn pr_validation_json_response(body: impl Into<String>) -> Response<std::io::Cursor<Vec<u8>>> {
+    let mut response = Response::from_string(body.into()).with_status_code(200);
+    if let Ok(header) = Header::from_bytes("Content-Type", "application/json") {
+        response = response.with_header(header);
+    }
+    response
+}
+
+fn pr_validation_graphql_response(
+    status: &str,
+    conclusion: Option<&str>,
+    check_name: &str,
+    is_draft: bool,
+) -> String {
+    serde_json::json!({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "number": 1159,
+                    "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "state": "OPEN",
+                    "isDraft": is_draft,
+                    "statusCheckRollup": {
+                        "contexts": {
+                            "nodes": [
+                                {
+                                    "__typename": "CheckRun",
+                                    "name": check_name,
+                                    "status": status,
+                                    "conclusion": conclusion,
+                                    "databaseId": 991,
+                                    "checkSuite": {
+                                        "workflowRun": {
+                                            "databaseId": 8801
+                                        }
+                                    }
+                                }
+                            ],
+                            "pageInfo": {
+                                "hasNextPage": false,
+                                "endCursor": null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+fn spawn_pr_validation_status_once_server(
+    status: &'static str,
+    conclusion: Option<&'static str>,
+    check_name: &'static str,
+    is_draft: bool,
+) -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_pr_validation_test_server("bind validation status server");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        let Some(mut request) = server
+            .recv_timeout(Duration::from_secs(5))
+            .expect("validation status server receive")
+        else {
+            return seen;
+        };
+        let method = request.method().as_str().to_string();
+        let url = request.url().to_string();
+        let mut body = String::new();
+        let _ = request.as_reader().read_to_string(&mut body);
+        seen.push(format!("{method} {url} {body}"));
+        let _ = request.respond(pr_validation_json_response(pr_validation_graphql_response(
+            status, conclusion, check_name, is_draft,
+        )));
+        seen
+    });
+    (base_uri, handle)
+}
+
 #[test]
 fn render_generated_issue_prompt_preserves_bootstrap_contract() {
     let content = render_generated_issue_prompt(
@@ -204,6 +293,142 @@ fn parse_validation_args_accepts_repo_watch_and_json_flags() {
     let err = parse_validation_args(&["3849".to_string(), "--bogus".to_string()])
         .expect_err("unknown validation arg");
     assert!(err.to_string().contains("validation: unknown arg"));
+}
+
+#[test]
+fn real_pr_validation_supports_watch_json_success_path() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-validation-watch-json");
+    init_git_repo(&repo);
+    let (base_uri, server) =
+        spawn_pr_validation_status_once_server("COMPLETED", Some("SUCCESS"), "adl-ci", false);
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    unsafe {
+        env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    real_pr_validation(&[
+        "1159".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+        "--watch".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("validation watch json");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1);
+    assert!(seen[0].starts_with("POST /graphql "));
+}
+
+#[test]
+fn real_pr_validation_reports_failed_checks_and_returns_error() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-validation-failure");
+    init_git_repo(&repo);
+    let (base_uri, server) = spawn_pr_validation_status_once_server(
+        "COMPLETED",
+        Some("FAILURE"),
+        "adl-coverage",
+        false,
+    );
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    unsafe {
+        env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    let err = real_pr_validation(&[
+        "1159".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+    ])
+    .expect_err("failed validation should return error");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    assert!(err.to_string().contains("validation: PR #1159 is failed"));
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1);
+    assert!(seen[0].starts_with("POST /graphql "));
+}
+
+#[test]
+fn parse_watch_args_accepts_repo_slug_version_and_json_flags() {
+    let parsed = parse_watch_args(&[
+        "https://github.com/example/repo/issues/4397".to_string(),
+        "-R".to_string(),
+        "example/repo".to_string(),
+        "--slug".to_string(),
+        "watch-target".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse watch");
+    assert_eq!(
+        parsed.issue_ref,
+        "https://github.com/example/repo/issues/4397"
+    );
+    assert_eq!(parsed.repo.as_deref(), Some("example/repo"));
+    assert_eq!(parsed.slug.as_deref(), Some("watch-target"));
+    assert_eq!(parsed.version.as_deref(), Some("v0.91.6"));
+    assert!(parsed.json);
+
+    let err = parse_watch_args(&["4397".to_string(), "--bogus".to_string()])
+        .expect_err("unknown watch arg");
+    assert!(err.to_string().contains("watch: unknown arg"));
+}
+
+#[test]
+fn parse_projection_map_args_accepts_json_and_rejects_unknown_args() {
+    let parsed =
+        parse_projection_map_args(&["--json".to_string()]).expect("parse projection-map");
+    assert!(parsed.json);
+
+    let err = parse_projection_map_args(&["--bogus".to_string()])
+        .expect_err("unknown projection-map arg");
+    assert!(err.to_string().contains("projection-map: unknown arg"));
+}
+
+#[test]
+fn projection_map_report_lists_expected_github_and_csdlc_surfaces() {
+    let report = projection_map_report_v1();
+    assert_eq!(report.schema_version, "adl.github_csdlc_projection_map.v1");
+    assert_eq!(report.issue, "#4047");
+    assert!(report.surfaces.len() >= 10);
+    assert!(report
+        .surfaces
+        .iter()
+        .any(|surface| surface.surface == "github.pr.validation_checks"
+            && surface.primary_command == "adl/tools/pr.sh validation"
+            && surface.projection_policy == "linked_surface_only"));
+    assert!(report
+        .surfaces
+        .iter()
+        .any(|surface| surface.surface == "csdlc.cards.sip_stp_spp_srp_sor"
+            && surface.primary_command
+                == "adl-csdlc tooling prompt-template ...; card editor skills; pr doctor"
+            && surface.projection_policy == "card_local_only"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -2100,7 +2100,7 @@ fn same_checkout_root_handles_equivalent_and_missing_paths() {
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
     assert!(err.to_string().contains(
-        "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | closing-linkage | issue | projection-map | closeout"
+        "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | watch | closing-linkage | issue | projection-map | closeout"
     ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -202,6 +202,106 @@ fn spawn_pr_validation_status_once_server(
     (base_uri, handle)
 }
 
+fn spawn_pr_watch_once_server(linked_pr: bool) -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_pr_validation_test_server("bind watch server");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        let expected_requests = if linked_pr { 5 } else { 4 };
+        for _ in 0..expected_requests {
+            let Some(mut request) = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("watch server receive")
+            else {
+                break;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            let mut body = String::new();
+            let _ = request.as_reader().read_to_string(&mut body);
+            seen.push(format!("{method} {url} {body}"));
+            let path = url.split('?').next().unwrap_or(url.as_str());
+            let response = match (method.as_str(), path) {
+                ("GET", "/repos/owner/repo/issues/4397") => pr_validation_json_response(
+                    serde_json::json!({
+                        "number": 4397,
+                        "title": "[v0.91.6][tools] Repo-native sprint watcher",
+                        "state": "open",
+                        "state_reason": serde_json::Value::Null,
+                        "html_url": "https://github.com/owner/repo/issues/4397",
+                        "closed_at": serde_json::Value::Null,
+                        "body": "Watcher issue body",
+                        "labels": [{
+                            "id": 1,
+                            "node_id": "MDU6TGFiZWwx",
+                            "url": "https://api.github.com/repos/owner/repo/labels/area:tools",
+                            "name": "area:tools",
+                            "color": "ededed",
+                            "default": false,
+                            "description": serde_json::Value::Null
+                        }],
+                        "milestone": serde_json::Value::Null
+                    })
+                    .to_string(),
+                ),
+                ("GET", "/repos/owner/repo/pulls") if linked_pr => {
+                    pr_validation_json_response(
+                        serde_json::json!([
+                            {
+                                "number": 4427,
+                                "title": "[v0.91.6][tools] Prove repo-native sprint watcher",
+                                "html_url": "https://github.com/owner/repo/pull/4427",
+                                "head": {"ref": "codex/4397-v0-91-6-watch-target", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                                "base": {"ref": "main", "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                                "draft": false,
+                                "state": "open"
+                            }
+                        ])
+                        .to_string(),
+                    )
+                }
+                ("GET", "/repos/owner/repo/pulls") => {
+                    pr_validation_json_response(serde_json::json!([]).to_string())
+                }
+                ("POST", "/graphql") if body.contains("closingIssuesReferences") => {
+                    pr_validation_json_response(
+                        serde_json::json!({
+                            "data": {
+                                "repository": {
+                                    "pullRequest": {
+                                        "closingIssuesReferences": {
+                                            "nodes": [{"number": 4397}]
+                                        }
+                                    }
+                                }
+                            }
+                        })
+                        .to_string(),
+                    )
+                }
+                ("POST", "/graphql") if body.contains("statusCheckRollup") => {
+                    pr_validation_json_response(pr_validation_graphql_response(
+                        "COMPLETED",
+                        Some("SUCCESS"),
+                        "adl-ci",
+                        false,
+                    ))
+                }
+                _ => panic!("unexpected watch request: {method} {url} {body}"),
+            };
+            request.respond(response).expect("respond");
+        }
+        seen
+    });
+    (base_uri, handle)
+}
+
+fn write_watch_state_fixture(bin_dir: &std::path::Path) {
+    write_executable(
+        &bin_dir.join("gh"),
+        "#!/usr/bin/env bash\n# ADL_GITHUB_TEST_FIXTURE\nset -euo pipefail\nif [ \"$1 $2\" = 'issue view' ] && printf '%s ' \"$@\" | grep -q 'state,stateReason'; then\n  printf '{\"state\":\"OPEN\",\"stateReason\":null}\\n'\n  exit 0\nfi\nexit 1\n",
+    );
+}
+
 #[test]
 fn render_generated_issue_prompt_preserves_bootstrap_contract() {
     let content = render_generated_issue_prompt(
@@ -330,6 +430,112 @@ fn real_pr_validation_supports_watch_json_success_path() {
     let seen = server.join().expect("server join");
     assert_eq!(seen.len(), 1);
     assert!(seen[0].starts_with("POST /graphql "));
+}
+
+#[test]
+fn real_pr_watch_reports_json_for_linked_green_pr() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-watch-linked-green");
+    init_git_repo(&repo);
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    write_watch_state_fixture(&bin_dir);
+    let (base_uri, server) = spawn_pr_watch_once_server(true);
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_path = env::var_os("PATH");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    let mut path_entries = vec![bin_dir.clone()];
+    path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
+    unsafe {
+        env::set_var("PATH", env::join_paths(path_entries).expect("join PATH"));
+        env::set_var("ADL_GITHUB_CLIENT", "auto");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    real_pr_watch(&[
+        "4397".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+        "--slug".to_string(),
+        "watch-target".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("watch linked green pr");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("PATH", old_path);
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    let seen = server.join().expect("server join");
+    assert!(seen.len() >= 4);
+    assert!(seen[0].starts_with("GET /repos/owner/repo/issues/4397 "));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("/repos/owner/repo/pulls")));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("closingIssuesReferences")));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("statusCheckRollup")));
+}
+
+#[test]
+fn real_pr_watch_reports_json_without_linked_pr() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-watch-no-linked-pr");
+    init_git_repo(&repo);
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    write_watch_state_fixture(&bin_dir);
+    let (base_uri, server) = spawn_pr_watch_once_server(false);
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_path = env::var_os("PATH");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    let mut path_entries = vec![bin_dir.clone()];
+    path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
+    unsafe {
+        env::set_var("PATH", env::join_paths(path_entries).expect("join PATH"));
+        env::set_var("ADL_GITHUB_CLIENT", "auto");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    real_pr_watch(&[
+        "4397".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+        "--slug".to_string(),
+        "watch-target".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("watch without linked pr");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("PATH", old_path);
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    let seen = server.join().expect("server join");
+    assert!(seen.len() >= 3);
+    assert!(seen[0].starts_with("GET /repos/owner/repo/issues/4397 "));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("/repos/owner/repo/pulls")));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -337,12 +337,8 @@ fn real_pr_validation_reports_failed_checks_and_returns_error() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-validation-failure");
     init_git_repo(&repo);
-    let (base_uri, server) = spawn_pr_validation_status_once_server(
-        "COMPLETED",
-        Some("FAILURE"),
-        "adl-coverage",
-        false,
-    );
+    let (base_uri, server) =
+        spawn_pr_validation_status_once_server("COMPLETED", Some("FAILURE"), "adl-coverage", false);
     let previous_dir = env::current_dir().expect("cwd");
     let old_client = env::var_os("ADL_GITHUB_CLIENT");
     let old_token = env::var_os("GITHUB_TOKEN");
@@ -401,8 +397,7 @@ fn parse_watch_args_accepts_repo_slug_version_and_json_flags() {
 
 #[test]
 fn parse_projection_map_args_accepts_json_and_rejects_unknown_args() {
-    let parsed =
-        parse_projection_map_args(&["--json".to_string()]).expect("parse projection-map");
+    let parsed = parse_projection_map_args(&["--json".to_string()]).expect("parse projection-map");
     assert!(parsed.json);
 
     let err = parse_projection_map_args(&["--bogus".to_string()])
@@ -422,13 +417,11 @@ fn projection_map_report_lists_expected_github_and_csdlc_surfaces() {
         .any(|surface| surface.surface == "github.pr.validation_checks"
             && surface.primary_command == "adl/tools/pr.sh validation"
             && surface.projection_policy == "linked_surface_only"));
-    assert!(report
-        .surfaces
-        .iter()
-        .any(|surface| surface.surface == "csdlc.cards.sip_stp_spp_srp_sor"
-            && surface.primary_command
-                == "adl-csdlc tooling prompt-template ...; card editor skills; pr doctor"
-            && surface.projection_policy == "card_local_only"));
+    assert!(report.surfaces.iter().any(|surface| surface.surface
+        == "csdlc.cards.sip_stp_spp_srp_sor"
+        && surface.primary_command
+            == "adl-csdlc tooling prompt-template ...; card editor skills; pr doctor"
+        && surface.projection_policy == "card_local_only"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs
@@ -128,6 +128,7 @@ fn format_open_pr_wave_marks_draft_and_unknown_queue() {
             .to_string(),
         base_ref_name: "main".to_string(),
         is_draft: true,
+        state: "OPEN".to_string(),
         queue: Some("docs".to_string()),
     };
     let rendered = format_open_pr_wave(&[pr.clone()]);

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2634,6 +2634,16 @@ cmd_validation() {
   delegate_pr_command_to_rust validation "$@"
 }
 
+cmd_watch() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_watch
+    return 0
+  fi
+  adl_obs_event "pr.sh" "watch" "started" "issue" "${1:-}"
+  require_rust_pr_delegate watch
+  delegate_pr_command_to_rust watch "$@"
+}
+
 cmd_closing_linkage() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     note "Usage: adl/tools/pr.sh closing-linkage [--event-name <event>] [--event-path <path>] [--head-ref <branch>] [-R owner/repo]"
@@ -2731,6 +2741,7 @@ Commands:
   doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
   validation <pr-number-or-url> [-R owner/repo] [--watch] [--json]
+  watch   <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
   closing-linkage [--event-name <event>] [--event-path <path>] [--head-ref <branch>] [-R owner/repo]
   issue   <list|search|view|create|comment|edit|close> ...
   projection-map [--json]
@@ -2769,6 +2780,7 @@ Notes:
 - `pr init <issue> ...` bootstraps the same local root bundle for an issue that already exists.
 - `pr run <issue> ...` is the preferred public execution-context binder for issue work.
 - `pr doctor <issue> ...` is the preferred public readiness and drift diagnostic surface.
+- `pr watch <issue> ...` is the typed tracked-issue lifecycle watcher for issue/PR wait states.
 - `pr closeout <issue> ...` finalizes a closed issue locally and safely prunes its execution worktree when possible.
 - `pr closing-linkage ...` is the Rust-owned CI/linkage guard and prefers live PR metadata over stale event payloads when token context exists.
 - `pr start <issue> ...` remains only as a legacy alias over the same Rust binding path and is no longer part of the taught public flow.
@@ -2967,6 +2979,21 @@ Behavior:
 EOF
 }
 
+usage_watch() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh watch <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
+
+Behavior:
+- delegates to the Rust-owned tracked-issue lifecycle watcher
+- classifies one tracked issue into ready-for-run, PR-open, checks-running, checks-failed, checks-green, closeout-needed, or blocked-adjacent states
+- uses typed GitHub transport plus local doctor readiness; does not fall back to raw `gh`
+- keeps the JSON report compact enough to feed a future local watcher agent while ADL remains the authoritative classifier
+- emits explicit authority metadata so local watcher agents stay advisory-only
+- emits a JSON watcher report when --json is set
+EOF
+}
+
 usage_issue() {
   cat <<'EOF'
 Usage:
@@ -3040,6 +3067,7 @@ main() {
     preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;
     validation) cmd_validation "$@" ;;
+    watch) cmd_watch "$@" ;;
     closing-linkage) cmd_closing_linkage "$@" ;;
     issue) cmd_issue "$@" ;;
     projection-map) cmd_projection_map "$@" ;;

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json
@@ -4,9 +4,50 @@
   "issue_state": "OPEN",
   "authoritative_classifier": "adl",
   "advisory_agent_mode": "local_agent_advisory_only",
-  "classification": "ready_for_run",
-  "next_skill": "pr-run",
+  "classification": "pr_open",
+  "next_skill": "issue-watcher",
   "continuation": "continue",
-  "reason": "issue_ready_without_linked_pr",
-  "linked_pr": null
+  "reason": "linked_pr_draft",
+  "local_readiness": {
+    "status": "failed",
+    "pr_run_readiness": "unknown",
+    "reason": "doctor: sor failed validation: /Users/daniel/git/agent-design-language/.adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/sor.md: bash failed with status Some(1)"
+  },
+  "linked_pr": {
+    "number": 4427,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/4427",
+    "head_ref_name": "codex/4397-v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher",
+    "base_ref_name": "main",
+    "is_draft": true,
+    "state": "OPEN",
+    "validation": {
+      "pr_number": 4427,
+      "commit_sha": "176c0198197c221893537d105985481704b99ffe",
+      "pr_state": "OPEN",
+      "is_draft": true,
+      "disposition": "pending",
+      "checks": [
+        {
+          "name": "adl-ci",
+          "status": "COMPLETED",
+          "conclusion": "SUCCESS",
+          "job_run_id": "27978473405"
+        },
+        {
+          "name": "adl-slow-proof",
+          "status": "COMPLETED",
+          "conclusion": "SKIPPED",
+          "job_run_id": "27978473405"
+        },
+        {
+          "name": "adl-coverage",
+          "status": "COMPLETED",
+          "conclusion": "SUCCESS",
+          "job_run_id": "27978473405"
+        }
+      ],
+      "failed_checks": [],
+      "pending_checks": []
+    }
+  }
 }

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json
@@ -1,0 +1,12 @@
+{
+  "schema": "adl.pr.watch.v1",
+  "issue": 4397,
+  "issue_state": "OPEN",
+  "authoritative_classifier": "adl",
+  "advisory_agent_mode": "local_agent_advisory_only",
+  "classification": "ready_for_run",
+  "next_skill": "pr-run",
+  "continuation": "continue",
+  "reason": "issue_ready_without_linked_pr",
+  "linked_pr": null
+}

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
@@ -84,6 +84,9 @@ becomes the source of truth.
 ## Recommended near-term usage
 
 - Keep `adl pr watch --json` as the single authoritative state packet.
+- Plan the first production watcher-agent integration around a local agent that
+  reads that packet after ADL emits it, rather than polling GitHub or
+  classifying lifecycle state on its own.
 - Allow a local watcher agent to summarize or restate the packet only after ADL
   emits it.
 - Route all lifecycle action off ADL fields such as `classification`,

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
@@ -1,0 +1,93 @@
+# Local Watcher Agent Proof for #4397
+
+## Scope
+
+This note records the bounded local-agent experiment required by `#4397`.
+
+It proves that the repo-native watcher JSON can be consumed by a local model in
+an advisory-only mode while ADL remains the authoritative classifier.
+
+It does not grant the local model authority to merge PRs, close issues,
+override ADL classification, or mutate repository state.
+
+## Deterministic state packet
+
+The deterministic watcher packet used for this experiment is:
+
+- `docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json`
+
+That packet came from:
+
+```bash
+ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token \
+  cargo run --manifest-path adl/Cargo.toml --bin adl -- pr watch 4397 --json
+```
+
+Observed authoritative result:
+
+- `classification`: `ready_for_run`
+- `next_skill`: `pr-run`
+- `continuation`: `continue`
+- `authoritative_classifier`: `adl`
+- `advisory_agent_mode`: `local_agent_advisory_only`
+
+## Local agent experiment
+
+Tested local model:
+
+- `ollama:gemma4:31b`
+
+Execution surface:
+
+- Rust provider adapter via `adl-provider-adapter`
+- local Ollama HTTP endpoint at `http://127.0.0.1:11434`
+
+Prompt contract used:
+
+- consume only the supplied watcher packet
+- return one classification from:
+  `ready_for_run`, `pr_open`, `checks_running`, `checks_failed`,
+  `checks_green`, `closeout_needed`, `blocked`, `closed`, `unknown`
+- return `unknown` when evidence is insufficient
+- state explicitly that ADL remains authoritative
+
+Observed provider result:
+
+```md
+# Classification
+ready_for_run
+
+# Evidence
+The packet specifies `classification` as "ready_for_run", `issue_state` as "OPEN", and the `reason` as "issue_ready_without_linked_pr".
+
+# Boundary
+ADL remains authoritative and I have no merge, closeout, or repo-mutation authority.
+```
+
+Observed runtime notes:
+
+- one local attempt completed successfully
+- bounded provider-adapter heartbeats were emitted during execution
+- total local-model duration was about 26 seconds
+
+## Conclusion
+
+The local-agent experiment passed for the bounded `ready_for_run` watcher case.
+
+`gemma4:31b` correctly echoed the authoritative ADL classification, cited only
+supplied evidence, and preserved the advisory boundary.
+
+That is sufficient to plan near-term watcher assistance around a local model,
+provided the local agent consumes the typed `adl.pr.watch.v1` packet and never
+becomes the source of truth.
+
+## Recommended near-term usage
+
+- Keep `adl pr watch --json` as the single authoritative state packet.
+- Allow a local watcher agent to summarize or restate the packet only after ADL
+  emits it.
+- Route all lifecycle action off ADL fields such as `classification`,
+  `next_skill`, and `continuation`, not off the model's prose.
+- Expand local-model coverage later to `checks_running`, `checks_failed`,
+  `checks_green`, and `closeout_needed` packets before depending on it for
+  broader sprint execution assistance.

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md
@@ -47,7 +47,8 @@ Prompt contract used:
 - consume only the supplied watcher packet
 - return one classification from:
   `ready_for_run`, `pr_open`, `checks_running`, `checks_failed`,
-  `checks_green`, `closeout_needed`, `blocked`, `closed`, `unknown`
+  `checks_green`, `merged_pending_closeout`, `closeout_needed`, `blocked`,
+  `closed`, `unknown`
 - return `unknown` when evidence is insufficient
 - state explicitly that ADL remains authoritative
 
@@ -92,5 +93,5 @@ becomes the source of truth.
 - Route all lifecycle action off ADL fields such as `classification`,
   `next_skill`, and `continuation`, not off the model's prose.
 - Expand local-model coverage later to `checks_running`, `checks_failed`,
-  `checks_green`, and `closeout_needed` packets before depending on it for
-  broader sprint execution assistance.
+  `checks_green`, `merged_pending_closeout`, and `closeout_needed` packets
+  before depending on it for broader sprint execution assistance.


### PR DESCRIPTION
Closes #4397

## Summary
Implemented a repo-native tracked-issue watcher surface for `#4397` by adding
`adl pr watch` plus the `adl/tools/pr.sh watch` delegate, proving watcher
classification for ready, draft-PR, checks-running, failed-check, green-check,
and closeout-needed states, following open-PR pagination across REST pages, and
adding explicit authority metadata so future local watcher agents stay
advisory-only. Also captured a bounded local-model experiment with
`ollama:gemma4:31b` against the typed watcher packet and recorded that proof in
a tracked sprint-execution packet.

## Artifacts
- Updated tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/tests.rs`
  - `adl/src/cli/pr_cmd/github/tests/watch.rs`
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr.sh`
- Updated tracked proof artifacts:
  - `docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4397_LOCAL_WATCHER_STATE_PACKET.json`
  - `docs/milestones/v0.91.6/review/sprint_execution_packets/WATCHER_LOCAL_AGENT_PROOF_4397.md`
- Updated local issue records:
  - `.adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/spp.md`
  - `.adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/srp.md`
  - `.adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl issue_watch_routes -- --nocapture`
    `Verified the focused watcher-state classification tests after the authority-metadata and `checks_running` proof additions.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl list_open_prs_octocrab_paginates_rest_results -- --nocapture`
    `Verified the transport-level open-PR pagination fix.`
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token cargo run --manifest-path adl/Cargo.toml --bin adl -- pr watch 4397 --json`
    `Verified the live typed watcher path and current issue-state classification.`
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh watch 4397 --json`
    `Verified wrapper delegation to the Rust watcher path.`
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl-provider-adapter -- --request <temp-request> --out <temp-result> --log <temp-log>`
    `Verified one bounded local-agent advisory experiment through the Rust provider adapter using local Ollama.`
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4397__v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher/sor.md
- Idempotency-Key: v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-rs-adl-src-cli-pr-cmd-github-tests-watch-rs-adl-src-cli-pr-cmd-github-tests-transport-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-sh-docs-milestones-v0-91-6-review-sprint-execution-packets-issue-4397-local-watcher-state-packet-json-docs-milestones-v0-91-6-review-sprint-execution-packets-watcher-local-agent-proof-4397-md-adl-v0-91-6-tasks-issue-4397-v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher-sip-md-adl-v0-91-6-tasks-issue-4397-v0-91-6-tools-watcher-prove-or-implement-repo-native-sprint-watcher-sor-md