### PR TITLE
[v0.91.6][tools][metrics] Restore authoritative workflow time and token accounting

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1466,6 +1466,13 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_sprint_conductor_helper_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            commands.push("bash adl/tools/test_sprint_conductor_helpers.sh".to_string());
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_unity_observatory_baseline_validation(0, path))
         {
             commands.push("bash adl/tools/test_v0916_unity_observatory_baseline.sh".to_string());
@@ -2063,6 +2070,7 @@ fn finish_path_is_larger_binary_focused(path: &str) -> bool {
         || trimmed.starts_with("adl/src/agent_comms/")
         || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
         || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
+        || trimmed.starts_with("adl/tools/skills/sprint-conductor/scripts/")
         || trimmed == "adl/src/runtime_v2/tests.rs"
         || trimmed.starts_with("adl/src/runtime_v2/tests/")
         || trimmed.starts_with("adl/tests/fixtures/scheduler/")
@@ -2560,6 +2568,11 @@ fn finish_path_needs_validation_inventory_focused_validation(path: &str) -> bool
             | "adl/tools/validation_inventory.sh"
             | "adl/tools/test_validation_inventory.sh"
     )
+}
+
+fn finish_path_needs_sprint_conductor_helper_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed.starts_with("adl/tools/skills/sprint-conductor/scripts/")
 }
 
 fn parsed_issue_is_4031_unity_observatory_scaffold_path(issue: u32, path: &str) -> bool {
@@ -3445,6 +3458,10 @@ pub(super) fn run_finish_validation_rust(
                 "bash adl/tools/run_owner_validation_lane.sh all --build" => {
                     let script = repo_root.join("adl/tools/run_owner_validation_lane.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?, "all", "--build"])?;
+                }
+                "bash adl/tools/test_sprint_conductor_helpers.sh" => {
+                    let script = repo_root.join("adl/tools/test_sprint_conductor_helpers.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
                 other => bail!("finish: unsupported focused validation command '{other}'"),
             }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2834,6 +2834,56 @@ fn finish_validation_profile_classifies_validation_inventory_slice_as_small_bina
 }
 
 #[test]
+fn finish_validation_profile_runs_sprint_conductor_helper_validation_for_metrics_scripts() {
+    let plan = select_finish_validation_plan(
+        "adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py,adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py,adl/tools/test_sprint_conductor_helpers.sh,docs/default_workflow.md",
+    )
+    .expect("sprint conductor helper metrics plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_sprint_conductor_helpers.sh".to_string()));
+}
+
+#[test]
+fn finish_helper_paths_run_sprint_conductor_helper_validation() {
+    let repo = unique_temp_dir("adl-pr-finish-sprint-conductor-helper-validation");
+    let tools = repo.join("adl/tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    write_executable(
+        &tools.join("check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\n",
+    );
+    write_executable(
+        &tools.join("test_sprint_conductor_helpers.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nrepo_root=\"$(cd \"$(dirname \"$0\")/../..\" && pwd)\"\necho sprint-conductor-ran > \"$repo_root/sprint-conductor-ran.txt\"\n",
+    );
+    assert!(Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&repo)
+        .status()
+        .expect("git init")
+        .success());
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "bash adl/tools/test_sprint_conductor_helpers.sh".to_string(),
+        ],
+    };
+    run_finish_validation_rust(&repo, &plan).expect("sprint conductor helper validation");
+    assert_eq!(
+        fs::read_to_string(repo.join("sprint-conductor-ran.txt"))
+            .expect("runner marker")
+            .trim(),
+        "sprint-conductor-ran"
+    );
+}
+
+#[test]
 fn finish_validation_profile_classifies_slow_proof_family_split_slice() {
     let plan = select_finish_validation_plan_for_finish(
         4219,

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -121,6 +121,7 @@ execution:
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py --state <path> --out <path> --summary-out <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/record_child_issue_closeout.py --state <path> --issue-number <n> --issue-closed true --pr-state <merged|closed_no_merge|not_applicable> --root-sor-status <done|failed> --worktree-status <pruned|retained_with_reason|not_applicable>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py --goal-state <saved-get-goal.json> --issue-number <n> --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --issue-goal-ref goal:<version>:issue:<n>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py --state <path> --issue-number <n> --sink <jsonl> --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --data-source <codex_goal_tool|manual_entry|derived_sprint_state|unknown>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py --state <path> --out <path>"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -76,7 +76,15 @@ Optional:
      implementation unless nested-goal support is explicitly proven later
 9. Run only the selected downstream lifecycle or editor skill.
 9a. When issue-goal metrics are available from the active session or closeout handoff, record them in the local JSONL sink:
-   - use `record_issue_goal_metrics.py`
+   - for ordinary issue lifecycle captures from saved Codex goal payloads, use
+     `record_issue_goal_stage_artifacts.py`
+   - write the artifacts into the issue task bundle's
+     `artifacts/goal_metrics/` directory rather than an ad hoc temp-only path
+   - rerunning the same issue/stage should replace the prior row for that stage
+     instead of appending duplicates
+   - preserve `unknown` / `not_available` for missing elapsed or token data;
+     do not substitute zero
+   - for sprint-state rollups, use `record_issue_goal_metrics.py`
    - capture stage should be one of `issue_start`, `pr_publication`,
      `review_handoff`, `merge_closeout`, or `sprint_closeout`
    - preserve `unknown` / `not_available` for missing elapsed or token data;
@@ -127,6 +135,9 @@ Preferred child-closeout advancement helper:
 
 Preferred issue-goal metrics helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py --state <path> --issue-number <n> --sink <jsonl> --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --data-source <codex_goal_tool|manual_entry|derived_sprint_state|unknown>`
+
+Preferred ordinary issue artifact helper:
+- `python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py --goal-state <saved-get-goal.json> --issue-number <n> --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics --capture-stage <issue_start|pr_publication|review_handoff|merge_closeout|sprint_closeout> --issue-goal-ref goal:<version>:issue:<n>`
 
 ## Editor-Skill Rule
 

--- a/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
@@ -38,9 +38,72 @@ STAGE_PRIORITY = {
     "sprint_closeout": 5,
 }
 
+CODEX_GOAL_STATUS_TO_COMPLETION_STATE = {
+    "active": "unknown",
+    "completed": "completed",
+    "complete": "completed",
+    "blocked": "blocked",
+    "budgetlimited": "deferred",
+    "budget_limited": "deferred",
+}
+
+TERMINAL_COMPLETION_STATES = {"completed", "blocked", "failed", "cancelled", "deferred"}
+
 
 def iso_now_utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def epoch_seconds_to_iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def parse_codex_goal_tool_snapshot(path: str) -> dict[str, Any]:
+    import json
+    from pathlib import Path
+
+    payload = json.loads(Path(path).read_text())
+    goal = payload.get("goal")
+    if not isinstance(goal, dict):
+        raise ValueError("goal snapshot does not contain an active goal object")
+
+    created_at_raw = goal.get("createdAt")
+    updated_at_raw = goal.get("updatedAt")
+    status_raw = str(goal.get("status") or "unknown")
+    normalized_status = status_raw.strip().lower()
+    completion_state = CODEX_GOAL_STATUS_TO_COMPLETION_STATE.get(normalized_status, "unknown")
+
+    started_at = epoch_seconds_to_iso(created_at_raw)
+    completed_at = epoch_seconds_to_iso(updated_at_raw) if completion_state in TERMINAL_COMPLETION_STATES else None
+    elapsed_seconds_raw = None
+    if (
+        isinstance(created_at_raw, int)
+        and isinstance(updated_at_raw, int)
+        and updated_at_raw >= created_at_raw
+    ):
+        elapsed_seconds_raw = str(updated_at_raw - created_at_raw)
+
+    tokens_used_raw = goal.get("tokensUsed")
+    time_used_raw = goal.get("timeUsedSeconds")
+
+    return {
+        "thread_id": goal.get("threadId"),
+        "objective": goal.get("objective"),
+        "recorded_at": epoch_seconds_to_iso(updated_at_raw) or iso_now_utc(),
+        "status": normalized_status,
+        "completion_state": completion_state,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "elapsed_seconds_raw": elapsed_seconds_raw,
+        "active_work_seconds_raw": str(time_used_raw) if isinstance(time_used_raw, int) else "unknown",
+        "total_tokens_raw": str(tokens_used_raw) if isinstance(tokens_used_raw, int) else "unknown",
+    }
 
 
 def default_goal_metrics_summary() -> dict[str, Any]:
@@ -201,6 +264,53 @@ def build_issue_goal_metrics_record(
         "session_ref": session_ref,
         "thread_id": thread_id,
     }
+
+
+def build_issue_goal_metrics_record_from_codex_goal_snapshot(
+    *,
+    issue_number: int,
+    capture_stage: str,
+    goal_state_path: str,
+    raw_log_path: str,
+    issue_goal_ref: str | None,
+    sprint_goal_ref: str | None,
+    goal_metrics_rollup_ref: str | None,
+    metrics_confidence: str,
+    completion_state_override: str | None,
+    model_ref: str | None,
+    session_ref: str | None,
+) -> dict[str, Any]:
+    snapshot = parse_codex_goal_tool_snapshot(goal_state_path)
+    completion_state = completion_state_override or snapshot["completion_state"]
+    thread_id = snapshot.get("thread_id")
+    return build_issue_goal_metrics_record(
+        sprint_issue_number=None,
+        issue_number=issue_number,
+        capture_stage=capture_stage,
+        data_source="codex_goal_tool",
+        raw_log_path=raw_log_path,
+        recorded_at=snapshot.get("recorded_at"),
+        issue_goal_ref=issue_goal_ref,
+        sprint_goal_ref=sprint_goal_ref,
+        goal_metrics_rollup_ref=goal_metrics_rollup_ref,
+        goal_id=None,
+        goal_id_state="not_available",
+        started_at=snapshot.get("started_at"),
+        completed_at=snapshot.get("completed_at"),
+        elapsed_seconds_raw=snapshot.get("elapsed_seconds_raw"),
+        active_work_seconds_raw=snapshot.get("active_work_seconds_raw"),
+        validation_seconds_raw="unknown",
+        pr_wait_seconds_raw="unknown",
+        ci_wait_seconds_raw="unknown",
+        total_tokens_raw=snapshot.get("total_tokens_raw"),
+        prompt_tokens_raw="unknown",
+        completion_tokens_raw="unknown",
+        metrics_confidence=metrics_confidence,
+        completion_state=completion_state,
+        model_ref=model_ref,
+        session_ref=session_ref or (f"codex-thread:{thread_id}" if isinstance(thread_id, str) else None),
+        thread_id=thread_id if isinstance(thread_id, str) else None,
+    )
 
 
 def summarize_issue_goal_metrics(records: list[dict[str, Any]], raw_log_path: str | None) -> dict[str, Any]:

--- a/adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from issue_goal_metrics import (
+    CAPTURE_STAGES,
+    COMPLETION_STATE_VALUES,
+    METRICS_CONFIDENCE_VALUES,
+    build_issue_goal_metrics_record_from_codex_goal_snapshot,
+)
+
+# Keep this script standalone and avoid importing sprint-state machinery. It
+# writes a durable per-issue goal-metrics sink plus a summary artifact that
+# ordinary issue workflows can reference after live goal state disappears.
+from issue_goal_metrics import summarize_issue_goal_metrics
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        rows.append(json.loads(stripped))
+    return rows
+
+
+def append_jsonl(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--goal-state", required=True)
+    parser.add_argument("--issue-number", type=int, required=True)
+    parser.add_argument("--sink", required=True)
+    parser.add_argument("--summary-out", required=True)
+    parser.add_argument("--capture-stage", required=True, choices=sorted(CAPTURE_STAGES))
+    parser.add_argument("--issue-goal-ref")
+    parser.add_argument("--sprint-goal-ref")
+    parser.add_argument("--goal-metrics-rollup-ref")
+    parser.add_argument(
+        "--metrics-confidence",
+        default="high",
+        choices=sorted(METRICS_CONFIDENCE_VALUES),
+    )
+    parser.add_argument(
+        "--completion-state",
+        choices=sorted(COMPLETION_STATE_VALUES),
+        help="Optional override when the saved goal snapshot should be treated as terminal issue truth.",
+    )
+    parser.add_argument("--model-ref")
+    parser.add_argument("--session-ref")
+    parser.add_argument("--print-json", action="store_true")
+    args = parser.parse_args()
+
+    sink_path = Path(args.sink)
+    summary_path = Path(args.summary_out)
+
+    record = build_issue_goal_metrics_record_from_codex_goal_snapshot(
+        issue_number=args.issue_number,
+        capture_stage=args.capture_stage,
+        goal_state_path=args.goal_state,
+        raw_log_path=str(sink_path),
+        issue_goal_ref=args.issue_goal_ref,
+        sprint_goal_ref=args.sprint_goal_ref,
+        goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+        metrics_confidence=args.metrics_confidence,
+        completion_state_override=args.completion_state,
+        model_ref=args.model_ref,
+        session_ref=args.session_ref,
+    )
+    append_jsonl(sink_path, record)
+
+    issue_rows = [row for row in read_jsonl(sink_path) if row.get("issue_number") == args.issue_number]
+    summary = summarize_issue_goal_metrics(issue_rows, str(sink_path))
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    result = {
+        "recorded": record,
+        "summary": summary,
+        "sink_path": str(sink_path),
+        "summary_path": str(summary_path),
+    }
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(str(summary_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from issue_goal_metrics import (
+    CAPTURE_STAGES,
+    METRICS_CONFIDENCE_VALUES,
+    build_issue_goal_metrics_record_from_codex_goal_snapshot,
+    summarize_issue_goal_metrics,
+)
+
+
+STAGE_SNAPSHOT_SUFFIX = {
+    "issue_start": "",
+    "pr_publication": "-pr-publication",
+    "review_handoff": "-review-handoff",
+    "merge_closeout": "-merge-closeout",
+    "sprint_closeout": "-sprint-closeout",
+}
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        rows.append(json.loads(stripped))
+    return rows
+
+
+def write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def snapshot_name(issue_number: int, capture_stage: str) -> str:
+    return f"issue-{issue_number}-goal-state{STAGE_SNAPSHOT_SUFFIX[capture_stage]}.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--goal-state", required=True, help="Path to a saved get_goal JSON payload.")
+    parser.add_argument("--issue-number", type=int, required=True)
+    parser.add_argument("--artifacts-dir", required=True)
+    parser.add_argument("--capture-stage", required=True, choices=sorted(CAPTURE_STAGES))
+    parser.add_argument("--issue-goal-ref")
+    parser.add_argument("--sprint-goal-ref")
+    parser.add_argument("--goal-metrics-rollup-ref")
+    parser.add_argument(
+        "--metrics-confidence",
+        default="high",
+        choices=sorted(METRICS_CONFIDENCE_VALUES),
+    )
+    parser.add_argument("--model-ref")
+    parser.add_argument("--session-ref")
+    parser.add_argument("--completion-state")
+    parser.add_argument("--print-json", action="store_true")
+    args = parser.parse_args()
+
+    artifacts_dir = Path(args.artifacts_dir)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    snapshot_path = artifacts_dir / snapshot_name(args.issue_number, args.capture_stage)
+    sink_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics.jsonl"
+    summary_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics-summary.json"
+
+    shutil.copyfile(args.goal_state, snapshot_path)
+
+    record = build_issue_goal_metrics_record_from_codex_goal_snapshot(
+        issue_number=args.issue_number,
+        capture_stage=args.capture_stage,
+        goal_state_path=str(snapshot_path),
+        raw_log_path=str(sink_path),
+        issue_goal_ref=args.issue_goal_ref,
+        sprint_goal_ref=args.sprint_goal_ref,
+        goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+        metrics_confidence=args.metrics_confidence,
+        completion_state_override=args.completion_state,
+        model_ref=args.model_ref,
+        session_ref=args.session_ref,
+    )
+
+    rows = [
+        row
+        for row in read_jsonl(sink_path)
+        if not (
+            row.get("issue_number") == args.issue_number
+            and row.get("capture_stage") == args.capture_stage
+        )
+    ]
+    rows.append(record)
+    rows.sort(key=lambda row: ((row.get("issue_number") or 0), row.get("recorded_at") or "", row.get("capture_stage") or ""))
+    write_jsonl(sink_path, rows)
+
+    issue_rows = [row for row in rows if row.get("issue_number") == args.issue_number]
+    summary = summarize_issue_goal_metrics(issue_rows, str(sink_path))
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    result = {
+        "recorded": record,
+        "summary": summary,
+        "snapshot_path": str(snapshot_path),
+        "sink_path": str(sink_path),
+        "summary_path": str(summary_path),
+    }
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(str(summary_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1520,3 +1520,86 @@ grep -Fq '## Planned Vs Actual Parallelism' "${ready_artifact}"
 grep -Fq 'planned summary: `Expected one safe docs lane plus one serial gate.`' "${ready_artifact}"
 grep -Fq 'actual summary: `The docs lane stayed serial because both issues touched the same tracker file.`' "${ready_artifact}"
 grep -Fq 'lane=`docs-lane` issues=`5002, 5003` why_wrong=Both child issues mutated the same tracker path during review preparation. corrective_action=Keep the lane serial until tracker writes are split.' "${ready_artifact}"
+
+codex_goal_snapshot="${tmpdir}/codex-goal-state.json"
+cat >"${codex_goal_snapshot}" <<'JSON'
+{
+  "goal": {
+    "threadId": "thread-4431",
+    "objective": "Issue #4431: restore authoritative workflow time and token accounting",
+    "status": "active",
+    "tokensUsed": 39238,
+    "timeUsedSeconds": 55,
+    "createdAt": 1782153534,
+    "updatedAt": 1782153590
+  },
+  "remainingTokens": null,
+  "completionBudgetReport": null
+}
+JSON
+codex_goal_sink="${tmpdir}/issue-4431-goal-metrics.jsonl"
+codex_goal_summary="${tmpdir}/issue-4431-goal-metrics-summary.json"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py" \
+  --goal-state "${codex_goal_snapshot}" \
+  --issue-number 4431 \
+  --sink "${codex_goal_sink}" \
+  --summary-out "${codex_goal_summary}" \
+  --capture-stage issue_start \
+  --issue-goal-ref "goal:v0.91.6:issue:4431" \
+  --metrics-confidence high \
+  --model-ref "gpt-5-codex" >/dev/null
+python3 - "${codex_goal_sink}" "${codex_goal_summary}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+rows = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+assert len(rows) == 1
+record = rows[0]
+assert record["data_source"] == "codex_goal_tool"
+assert record["issue_goal_ref"] == "goal:v0.91.6:issue:4431"
+assert record["thread_id"] == "thread-4431"
+assert record["active_work_seconds"] == 55
+assert record["active_work_availability"] == "known"
+assert record["elapsed_seconds"] == 56
+assert record["elapsed_availability"] == "known"
+assert record["token_usage"]["total_tokens"] == 39238
+assert record["token_usage"]["total_availability"] == "known"
+assert record["goal_id_availability"] == "not_available"
+summary = json.loads(Path(sys.argv[2]).read_text())
+assert summary["status"] == "recorded"
+assert summary["selected_stage"] == "issue_start"
+assert summary["thread_id"] == "thread-4431"
+assert summary["active_work_seconds"] == 55
+assert summary["token_usage"]["total_tokens"] == 39238
+assert summary["elapsed_seconds"] == 56
+assert summary["elapsed_availability"] == "known"
+assert summary["metrics_confidence"] == "high"
+PY
+
+codex_budgetlimited_snapshot="${tmpdir}/codex-goal-budgetlimited-state.json"
+cat >"${codex_budgetlimited_snapshot}" <<'JSON'
+{
+  "goal": {
+    "threadId": "thread-4431-budgetlimited",
+    "objective": "Issue #4431: budget limited session",
+    "status": "budgetLimited",
+    "tokensUsed": 41000,
+    "timeUsedSeconds": 91,
+    "createdAt": 1782153534,
+    "updatedAt": 1782153625
+  }
+}
+JSON
+python3 - "${repo_root}" "${codex_budgetlimited_snapshot}" <<'PY'
+import sys
+
+sys.path.insert(0, sys.argv[1] + "/adl/tools/skills/sprint-conductor/scripts")
+from issue_goal_metrics import parse_codex_goal_tool_snapshot
+
+snapshot = parse_codex_goal_tool_snapshot(sys.argv[2])
+assert snapshot["status"] == "budgetlimited"
+assert snapshot["completion_state"] == "deferred"
+assert snapshot["completed_at"] == "2026-06-22T18:40:25Z"
+assert snapshot["elapsed_seconds_raw"] == "91"
+PY

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1603,3 +1603,106 @@ assert snapshot["completion_state"] == "deferred"
 assert snapshot["completed_at"] == "2026-06-22T18:40:25Z"
 assert snapshot["elapsed_seconds_raw"] == "91"
 PY
+
+goal_stage_artifacts_dir="${tmpdir}/issue-4431-artifacts/goal_metrics"
+goal_stage_issue_start_a="${tmpdir}/issue-4431-stage-issue-start-a.json"
+cat >"${goal_stage_issue_start_a}" <<'JSON'
+{
+  "goal": {
+    "threadId": "thread-4431-stage",
+    "objective": "Issue #4431 stage helper",
+    "status": "active",
+    "tokensUsed": 1000,
+    "timeUsedSeconds": 10,
+    "createdAt": 1782153534,
+    "updatedAt": 1782153544
+  }
+}
+JSON
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py" \
+  --goal-state "${goal_stage_issue_start_a}" \
+  --issue-number 4431 \
+  --artifacts-dir "${goal_stage_artifacts_dir}" \
+  --capture-stage issue_start \
+  --issue-goal-ref "goal:v0.91.6:issue:4431" \
+  --metrics-confidence high \
+  --model-ref "gpt-5-codex" >/dev/null
+
+goal_stage_issue_start_b="${tmpdir}/issue-4431-stage-issue-start-b.json"
+cat >"${goal_stage_issue_start_b}" <<'JSON'
+{
+  "goal": {
+    "threadId": "thread-4431-stage",
+    "objective": "Issue #4431 stage helper",
+    "status": "active",
+    "tokensUsed": 2000,
+    "timeUsedSeconds": 20,
+    "createdAt": 1782153534,
+    "updatedAt": 1782153554
+  }
+}
+JSON
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py" \
+  --goal-state "${goal_stage_issue_start_b}" \
+  --issue-number 4431 \
+  --artifacts-dir "${goal_stage_artifacts_dir}" \
+  --capture-stage issue_start \
+  --issue-goal-ref "goal:v0.91.6:issue:4431" \
+  --metrics-confidence high \
+  --model-ref "gpt-5-codex" >/dev/null
+
+goal_stage_pr_publication="${tmpdir}/issue-4431-stage-pr-publication.json"
+cat >"${goal_stage_pr_publication}" <<'JSON'
+{
+  "goal": {
+    "threadId": "thread-4431-stage",
+    "objective": "Issue #4431 stage helper",
+    "status": "complete",
+    "tokensUsed": 3000,
+    "timeUsedSeconds": 30,
+    "createdAt": 1782153534,
+    "updatedAt": 1782153564
+  }
+}
+JSON
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py" \
+  --goal-state "${goal_stage_pr_publication}" \
+  --issue-number 4431 \
+  --artifacts-dir "${goal_stage_artifacts_dir}" \
+  --capture-stage pr_publication \
+  --issue-goal-ref "goal:v0.91.6:issue:4431" \
+  --metrics-confidence high \
+  --model-ref "gpt-5-codex" >/dev/null
+
+python3 - "${goal_stage_artifacts_dir}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+artifacts_dir = Path(sys.argv[1])
+issue_start_snapshot = artifacts_dir / "issue-4431-goal-state.json"
+pr_publication_snapshot = artifacts_dir / "issue-4431-goal-state-pr-publication.json"
+assert issue_start_snapshot.exists()
+assert pr_publication_snapshot.exists()
+
+rows = [
+    json.loads(line)
+    for line in (artifacts_dir / "issue-4431-goal-metrics.jsonl").read_text().splitlines()
+    if line.strip()
+]
+assert len(rows) == 2
+issue_start_rows = [row for row in rows if row["capture_stage"] == "issue_start"]
+assert len(issue_start_rows) == 1
+assert issue_start_rows[0]["token_usage"]["total_tokens"] == 2000
+assert issue_start_rows[0]["elapsed_seconds"] == 20
+pr_rows = [row for row in rows if row["capture_stage"] == "pr_publication"]
+assert len(pr_rows) == 1
+assert pr_rows[0]["token_usage"]["total_tokens"] == 3000
+summary = json.loads((artifacts_dir / "issue-4431-goal-metrics-summary.json").read_text())
+assert summary["record_count"] == 2
+assert summary["phases_recorded"] == ["issue_start", "pr_publication"]
+assert summary["selected_stage"] == "pr_publication"
+assert summary["token_usage"]["total_tokens"] == 3000
+assert summary["elapsed_seconds"] == 30
+assert summary["completion_state"] == "completed"
+PY

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -155,6 +155,27 @@ Use `update_goal` only for truthful terminal state:
 - `blocked` only when the repeated blocking threshold is met and meaningful
   progress cannot continue without user input or an external state change
 
+When issue-local time/token accounting matters, preserve a durable local goal
+snapshot before the live goal disappears:
+
+1. save the `get_goal` tool payload to an issue-local path such as
+   `.adl/tmp/goals/issue-<n>-goal-state.json`
+2. normalize it into durable issue metrics artifacts:
+
+```bash
+python3 adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py \
+  --goal-state .adl/tmp/goals/issue-<n>-goal-state.json \
+  --issue-number <n> \
+  --sink .adl/tmp/goals/issue-<n>-goal-metrics.jsonl \
+  --summary-out .adl/tmp/goals/issue-<n>-goal-metrics-summary.json \
+  --capture-stage issue_start \
+  --issue-goal-ref "goal:<version>:issue:<n>"
+```
+
+Use the resulting summary artifact as the preferred `SOR` source ref when
+`Goal metrics data source` is `codex_goal_tool`. If no authoritative snapshot
+exists, keep the metrics fields `unknown` rather than fabricating values.
+
 ## 5) Implement
 
 Read the active issue cards, stay inside the issue edit fence, and make the tracked repo changes.

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -158,23 +158,37 @@ Use `update_goal` only for truthful terminal state:
 When issue-local time/token accounting matters, preserve a durable local goal
 snapshot before the live goal disappears:
 
-1. save the `get_goal` tool payload to an issue-local path such as
-   `.adl/tmp/goals/issue-<n>-goal-state.json`
-2. normalize it into durable issue metrics artifacts:
+1. save the `get_goal` tool payload to a temporary local path
+2. normalize it into the issue task bundle's canonical goal-metrics artifact
+   set immediately after the lifecycle event you are recording:
 
 ```bash
-python3 adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py \
-  --goal-state .adl/tmp/goals/issue-<n>-goal-state.json \
+python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py \
+  --goal-state /tmp/issue-<n>-goal-state.json \
   --issue-number <n> \
-  --sink .adl/tmp/goals/issue-<n>-goal-metrics.jsonl \
-  --summary-out .adl/tmp/goals/issue-<n>-goal-metrics-summary.json \
+  --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics \
   --capture-stage issue_start \
   --issue-goal-ref "goal:<version>:issue:<n>"
 ```
 
-Use the resulting summary artifact as the preferred `SOR` source ref when
-`Goal metrics data source` is `codex_goal_tool`. If no authoritative snapshot
-exists, keep the metrics fields `unknown` rather than fabricating values.
+Record the same artifact set again at later lifecycle checkpoints such as
+`pr_publication`:
+
+```bash
+python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py \
+  --goal-state /tmp/issue-<n>-goal-state-pr-publication.json \
+  --issue-number <n> \
+  --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics \
+  --capture-stage pr_publication \
+  --issue-goal-ref "goal:<version>:issue:<n>"
+```
+
+This helper uses canonical stage-specific snapshot filenames under the task
+bundle, rewrites the summary in place, and replaces any older row for the same
+issue/stage instead of appending duplicates. Use the resulting summary artifact
+as the preferred `SOR` source ref when `Goal metrics data source` is
+`codex_goal_tool`. If no authoritative snapshot exists, keep the metrics fields
+`unknown` rather than fabricating values.
 
 ## 5) Implement
 


### PR DESCRIPTION
Closes #4431

## Summary
Implemented a bounded durable accounting bridge for ordinary issue workflows by
extending the existing issue-goal metrics substrate with Codex goal snapshot
ingest, adding a standalone normalizer and then a canonical stage-based helper
that writes durable per-issue metrics artifacts into the task-bundle
`artifacts/goal_metrics/` directory, correcting active-snapshot elapsed-time
and `budgetLimited` truth handling after bounded review, documenting the
workflow step in `docs/default_workflow.md`, and teaching `pr finish`
validation-lane selection to validate the touched sprint-conductor metrics
scripts instead of stalling at publication time. The issue-local goal metrics
artifact set now records both the original `issue_start` capture and the later
`pr_publication` capture, and rerunning the same lifecycle stage replaces that
stage's row instead of appending duplicates.

## Artifacts
- Updated worktree-local execution record at `.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/sor.md`
- Durable local goal artifacts:
  - `.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-state.json`
  - `.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-state-pr-publication.json`
  - `.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics.jsonl`
  - `.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics-summary.json`
- Tracked implementation artifacts:
  - `adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py`
  - `adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py`
  - `adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py`
  - `adl/tools/skills/sprint-conductor/references/conductor-playbook.md`
  - `adl/tools/skills/sprint-conductor/adl-skill.yaml`
  - `adl/tools/test_sprint_conductor_helpers.sh`
  - `docs/default_workflow.md`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py`
    `Verified Python syntax for the shared helper, the Codex goal snapshot ingest script, and the canonical stage-based artifact helper.`
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    `Verified the helper suite, including the regression coverage for deterministic issue-stage replacement and post-publication selection in the durable issue-local metrics artifact set.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_runs_sprint_conductor_helper_validation_for_metrics_scripts -- --exact --nocapture`
    `Verified the finish-path classifier recognizes the metrics-script slice and schedules the focused sprint-conductor helper validation command.`
  - `git diff --check`
    `Verified patch hygiene for the tracked diff.`
  - `env GOAL_STATE_PATH=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-state.json GOAL_METRICS_SINK=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics.jsonl GOAL_METRICS_SUMMARY=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics-summary.json bash -lc 'python3 adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py --goal-state \"$GOAL_STATE_PATH\" --issue-number 4431 --sink \"$GOAL_METRICS_SINK\" --summary-out \"$GOAL_METRICS_SUMMARY\" --capture-stage issue_start --issue-goal-ref goal:v0.91.6:issue:4431 --metrics-confidence high --model-ref gpt-5-codex --print-json'`
    `Verified the live issue goal can be transformed into durable repo-relative metrics artifacts that keep elapsed, total-token, and active-work values after the transient live goal slot is gone.`
  - `env GOAL_STATE_PATH=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-state-pr-publication.json GOAL_METRICS_SINK=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics.jsonl GOAL_METRICS_SUMMARY=.adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/artifacts/goal_metrics/issue-4431-goal-metrics-summary.json bash -lc 'python3 adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py --goal-state \"$GOAL_STATE_PATH\" --issue-number 4431 --sink \"$GOAL_METRICS_SINK\" --summary-out \"$GOAL_METRICS_SUMMARY\" --capture-stage pr_publication --issue-goal-ref goal:v0.91.6:issue:4431 --metrics-confidence high --model-ref gpt-5-codex --print-json'`
    `Verified the post-publication issue-session snapshot records elapsed seconds 1203 and total tokens 652773 in the durable repo-relative metrics summary.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4431__restore-authoritative-workflow-time-and-token-accounting/sor.md
- Idempotency-Key: v0-91-6-tools-metrics-restore-authoritative-workflow-time-and-token-accounting-adl-tools-skills-sprint-conductor-adl-skill-yaml-adl-tools-skills-sprint-conductor-references-conductor-playbook-md-adl-tools-skills-sprint-conductor-scripts-record-issue-goal-stage-artifacts-py-adl-tools-test-sprint-conductor-helpers-sh-docs-default-workflow-md-adl-v0-91-6-tasks-issue-4431-restore-authoritative-workflow-time-and-token-accounting-sip-md-adl-v0-91-6-tasks-issue-4431-restore-authoritative-workflow-time-and-token-accounting-sor-md