### PR TITLE
[v0.91.6][tools][lifecycle] Fix PR lifecycle delegate stalls and command liveness

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1920,7 +1920,10 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
     matches!(
         trimmed,
         "adl/tools/pr.sh"
+            | "adl/tools/observability.sh"
             | "adl/tools/polis_status_for_ssm_windows.ps1"
+            | "adl/tools/test_pr_delegate_cargo_fallback_liveness.sh"
+            | "adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh"
             | "adl/tools/test_pr_small_binary_delegation.sh"
             | "adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh"
             | "adl/tools/validate_polis_status_for_ssm_windows.py"
@@ -2649,7 +2652,13 @@ fn parsed_issue_is_html_observatory_path(issue: u32, path: &str) -> bool {
 
 fn finish_path_needs_small_binary_delegation_validation(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
-    matches!(trimmed, "adl/tools/test_pr_small_binary_delegation.sh")
+    matches!(
+        trimmed,
+        "adl/tools/observability.sh"
+            | "adl/tools/test_pr_delegate_cargo_fallback_liveness.sh"
+            | "adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh"
+            | "adl/tools/test_pr_small_binary_delegation.sh"
+    )
 }
 
 fn finish_path_needs_locked_cargo_fallback_validation(path: &str) -> bool {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2522,6 +2522,34 @@ fn finish_validation_profile_classifies_issue_small_binary_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_delegate_liveness_small_binary_slice() {
+    let plan = select_finish_validation_plan_for_finish(
+        4413,
+        ".",
+        &[
+            "adl/tools/observability.sh".to_string(),
+            "adl/tools/pr.sh".to_string(),
+            "adl/tools/test_pr_delegate_cargo_fallback_liveness.sh".to_string(),
+            "adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh".to_string(),
+        ],
+    )
+    .expect("delegate liveness small binary focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_pr_small_binary_delegation.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo nextest")));
+}
+
+#[test]
 fn finish_validation_profile_classifies_closing_linkage_small_binary_slice() {
     let plan = select_finish_validation_plan_for_finish(
         4286,

--- a/adl/tools/observability.sh
+++ b/adl/tools/observability.sh
@@ -89,3 +89,24 @@ adl_obs_stage_done() {
   elapsed=$((now - started_ms))
   adl_obs_event "$command" "$stage" "$result" "elapsed_ms" "$elapsed" "$@"
 }
+
+adl_obs_heartbeat_interval_ms() {
+  local value
+  value="${ADL_OBSERVABILITY_HEARTBEAT_MS:-5000}"
+  if [[ "$value" =~ ^[0-9]+$ ]] && (( value > 0 )); then
+    printf '%s\n' "$value"
+  else
+    printf '5000\n'
+  fi
+}
+
+adl_obs_sleep_ms() {
+  local millis="$1"
+  python3 - "$millis" <<'PY'
+import sys
+import time
+
+millis = int(sys.argv[1])
+time.sleep(max(millis, 0) / 1000.0)
+PY
+}

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -205,7 +205,15 @@ rust_pr_delegate_available() {
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
   fi
+  cached_bin="$(rust_pr_subcommand_primary_cached_bin "${1:-}" || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
   cached_bin="$(rust_pr_delegate_cached_bin || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
+  cached_bin="$(rust_pr_delegate_primary_cached_bin || true)"
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
   fi
@@ -225,12 +233,55 @@ rust_pr_delegate_root() {
   repo_root
 }
 
+rust_pr_delegate_primary_root() {
+  local root
+  root="$(rust_pr_delegate_root)"
+  if [[ -n "${ADL_PRIMARY_CHECKOUT_ROOT:-}" && -f "${ADL_PRIMARY_CHECKOUT_ROOT}/adl/Cargo.toml" ]]; then
+    printf '%s\n' "${ADL_PRIMARY_CHECKOUT_ROOT}"
+    return 0
+  fi
+  case "$root" in
+    */.worktrees/*)
+      printf '%s\n' "${root%%/.worktrees/*}"
+      ;;
+    *)
+      printf '%s\n' "$root"
+      ;;
+  esac
+}
+
+rust_pr_worktree_inputs_are_newer_than_bin() {
+  local root="$1" candidate="$2"
+  [[ -f "$root/adl/Cargo.toml" && "$root/adl/Cargo.toml" -nt "$candidate" ]] && return 0
+  [[ -f "$root/adl/Cargo.lock" && "$root/adl/Cargo.lock" -nt "$candidate" ]] && return 0
+  [[ -f "$root/adl/build.rs" && "$root/adl/build.rs" -nt "$candidate" ]] && return 0
+  if [[ -d "$root/adl/src" ]] && find "$root/adl/src" -type f -newer "$candidate" -print -quit | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
 rust_pr_delegate_cached_bin() {
-  local root candidate
+  local root primary_root candidate
   root="$(rust_pr_delegate_root)"
   candidate="$root/adl/target/debug/adl"
   [[ -x "$candidate" ]] || return 1
   rust_pr_delegate_bin_is_fresh "$root" "$candidate" || return 1
+  printf '%s\n' "$candidate"
+  return 0
+}
+
+rust_pr_delegate_primary_cached_bin() {
+  local root primary_root candidate
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$primary_root" != "$root" ]] || return 1
+  candidate="$primary_root/adl/target/debug/adl"
+  [[ -x "$candidate" ]] || return 1
+  rust_pr_delegate_bin_is_fresh "$primary_root" "$candidate" || return 1
+  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate"; then
+    return 1
+  fi
   printf '%s\n' "$candidate"
 }
 
@@ -306,9 +357,152 @@ rust_pr_subcommand_cached_bin() {
   printf '%s\n' "$candidate"
 }
 
+rust_pr_subcommand_primary_cached_bin() {
+  local subcommand="$1"
+  local root primary_root binary_name candidate
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$primary_root" != "$root" ]] || return 1
+  binary_name="$(rust_pr_subcommand_binary_name "$subcommand" || true)"
+  [[ -n "$binary_name" ]] || return 1
+  candidate="$primary_root/adl/target/debug/$binary_name"
+  [[ -x "$candidate" ]] || return 1
+  rust_pr_delegate_bin_is_fresh "$primary_root" "$candidate" || return 1
+  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate"; then
+    return 1
+  fi
+  printf '%s\n' "$candidate"
+}
+
+rust_pr_cargo_delegate_timeout_secs() {
+  local value
+  value="${ADL_PR_CARGO_DELEGATE_TIMEOUT_SECS:-180}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '180\n'
+  fi
+}
+
+rust_pr_cargo_delegate_build_lock_timeout_secs() {
+  local value
+  value="${ADL_PR_CARGO_DELEGATE_BUILD_LOCK_TIMEOUT_SECS:-15}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '15\n'
+  fi
+}
+
+terminate_rust_pr_delegate_pid() {
+  local pid="$1"
+  kill "$pid" 2>/dev/null || true
+  adl_obs_sleep_ms 200
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+}
+
+acquire_rust_pr_delegate_build_lock() {
+  local lock_dir="$1" subcommand="$2" delegate_bin="$3"
+  local timeout_secs start now last_heartbeat heartbeat_interval_ms
+  timeout_secs="$(rust_pr_cargo_delegate_build_lock_timeout_secs)"
+  heartbeat_interval_ms="$(adl_obs_heartbeat_interval_ms)"
+  start="$(date +%s)"
+  last_heartbeat="$start"
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    now="$(date +%s)"
+    if (( timeout_secs >= 0 && now - start >= timeout_secs )); then
+      adl_obs_event "pr.sh" "rust_delegate_wait" "timeout" \
+        "subcommand" "$subcommand" \
+        "delegate" "cargo" \
+        "bin" "$delegate_bin" \
+        "reason_code" "build_lock_timeout" \
+        "lock_dir" "$lock_dir" \
+        "timeout_secs" "$timeout_secs"
+      cat >&2 <<EOF
+ERROR: Rust PR delegate cargo fallback is already busy for too long.
+subcommand=$subcommand
+delegate_bin=$delegate_bin
+lock_dir=$lock_dir
+timeout_seconds=$timeout_secs
+hint=build the direct adl-pr-* binaries first or wait for the active cargo delegate to finish
+EOF
+      return 75
+    fi
+    if (( now > last_heartbeat )); then
+      adl_obs_event "pr.sh" "rust_delegate_wait" "heartbeat" \
+        "subcommand" "$subcommand" \
+        "delegate" "cargo" \
+        "bin" "$delegate_bin" \
+        "lock_dir" "$lock_dir" \
+        "elapsed_ms" "$(( (now - start) * 1000 ))"
+      last_heartbeat="$now"
+    fi
+    adl_obs_sleep_ms "$heartbeat_interval_ms"
+  done
+  ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD="$lock_dir"
+  return 0
+}
+
+run_rust_pr_delegate_with_liveness() {
+  local subcommand="$1" manifest="$2" delegate_bin="$3"
+  shift 3 || true
+  local timeout_secs heartbeat_interval_ms elapsed_ms status pid
+  timeout_secs="$(rust_pr_cargo_delegate_timeout_secs)"
+  heartbeat_interval_ms="$(adl_obs_heartbeat_interval_ms)"
+  set +e
+  cargo run --quiet --locked --manifest-path "$manifest" --bin "$delegate_bin" -- "$@" &
+  pid="$!"
+  set -e
+  trap 'terminate_rust_pr_delegate_pid "$pid"' INT TERM
+  elapsed_ms=0
+  while kill -0 "$pid" 2>/dev/null; do
+    adl_obs_sleep_ms "$heartbeat_interval_ms"
+    elapsed_ms=$((elapsed_ms + heartbeat_interval_ms))
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    if (( timeout_secs > 0 && elapsed_ms >= timeout_secs * 1000 )); then
+      terminate_rust_pr_delegate_pid "$pid"
+      wait "$pid" 2>/dev/null || true
+      trap - INT TERM
+      adl_obs_event "pr.sh" "rust_delegate" "timeout" \
+        "subcommand" "$subcommand" \
+        "delegate" "cargo" \
+        "bin" "$delegate_bin" \
+        "manifest" "$manifest" \
+        "timeout_secs" "$timeout_secs" \
+        "elapsed_ms" "$elapsed_ms" \
+        "reason_code" "cargo_delegate_timeout"
+      cat >&2 <<EOF
+ERROR: Rust PR delegate cargo fallback timed out.
+subcommand=$subcommand
+delegate_bin=$delegate_bin
+manifest=$manifest
+timeout_seconds=$timeout_secs
+hint=build the direct adl-pr-* binaries first or increase ADL_PR_CARGO_DELEGATE_TIMEOUT_SECS for an intentionally long compile
+EOF
+      return 124
+    fi
+    adl_obs_event "pr.sh" "rust_delegate" "heartbeat" \
+      "subcommand" "$subcommand" \
+      "delegate" "cargo" \
+      "bin" "$delegate_bin" \
+      "manifest" "$manifest" \
+      "elapsed_ms" "$elapsed_ms"
+  done
+  set +e
+  wait "$pid"
+  status="$?"
+  set -e
+  trap - INT TERM
+  return "$status"
+}
+
 delegate_pr_command_to_rust() {
   local subcommand="$1"; shift || true
-  local root manifest cached_bin override_bin direct_bin
+  local root manifest cached_bin override_bin direct_bin build_lock_dir
   root="$(rust_pr_delegate_root)"
   manifest="$root/adl/Cargo.toml"
   # These Rust-owned delegated paths intentionally install no shell-level
@@ -329,17 +523,48 @@ delegate_pr_command_to_rust() {
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin"
     exec "$direct_bin" "$@"
   fi
+  direct_bin="$(rust_pr_subcommand_primary_cached_bin "$subcommand" || true)"
+  if [[ -n "$direct_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin"
+    exec "$direct_bin" "$@"
+  fi
   cached_bin="$(rust_pr_delegate_cached_bin || true)"
   if [[ -n "$cached_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
     exec "$cached_bin" pr "$subcommand" "$@"
   fi
+  cached_bin="$(rust_pr_delegate_primary_cached_bin || true)"
+  if [[ -n "$cached_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
+    exec "$cached_bin" pr "$subcommand" "$@"
+  fi
+  build_lock_dir="${ADL_PR_CARGO_DELEGATE_BUILD_LOCK_DIR:-$root/adl/target/.adl-pr-rust-delegate-build.lock}"
+  mkdir -p "$(dirname "$build_lock_dir")"
+  ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD=""
   if direct_bin="$(rust_pr_subcommand_binary_name "$subcommand" || true)"; [[ -n "$direct_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "$direct_bin" "lock_mode" "locked"
-    exec cargo run --quiet --locked --manifest-path "$manifest" --bin "$direct_bin" -- "$@"
+    acquire_rust_pr_delegate_build_lock "$build_lock_dir" "$subcommand" "$direct_bin" || exit "$?"
+    trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rmdir "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD" 2>/dev/null || true; fi' EXIT
+    set +e
+    run_rust_pr_delegate_with_liveness "$subcommand" "$manifest" "$direct_bin" "$@"
+    local status="$?"
+    set -e
+    rmdir "$build_lock_dir" 2>/dev/null || true
+    ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD=""
+    trap - EXIT
+    exit "$status"
   fi
   adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "adl" "lock_mode" "locked"
-  exec cargo run --quiet --locked --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
+  acquire_rust_pr_delegate_build_lock "$build_lock_dir" "$subcommand" "adl" || exit "$?"
+  trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rmdir "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD" 2>/dev/null || true; fi' EXIT
+  set +e
+  run_rust_pr_delegate_with_liveness "$subcommand" "$manifest" "adl" pr "$subcommand" "$@"
+  local status="$?"
+  set -e
+  rmdir "$build_lock_dir" 2>/dev/null || true
+  ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD=""
+  trap - EXIT
+  exit "$status"
 }
 
 require_rust_pr_delegate() {

--- a/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
+++ b/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+OBS_SRC="$ROOT_DIR/adl/tools/observability.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$mockbin" "$repo/adl/target"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+cp "$OBS_SRC" "$repo/adl/tools/observability.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+cat >"$mockbin/cargo" <<'EOF_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+mode="${ADL_TEST_CARGO_MODE:-heartbeat}"
+printf '%s\n' "$*" >"${ADL_TEST_CARGO_ARGS}"
+case "$mode" in
+  heartbeat)
+    sleep 0.15
+    ;;
+  timeout)
+    trap 'exit 88' TERM INT
+    sleep 30
+    ;;
+  *)
+    echo "unknown ADL_TEST_CARGO_MODE=$mode" >&2
+    exit 97
+    ;;
+esac
+EOF_CARGO
+chmod +x "$mockbin/cargo"
+
+run_from_repo() {
+  (
+    cd "$repo"
+    PATH="$mockbin:$PATH" "$@"
+  )
+}
+
+heartbeat_log="$tmpdir/heartbeat.log"
+heartbeat_args="$tmpdir/heartbeat.args"
+run_from_repo \
+  env \
+    ADL_OBSERVABILITY_LOG="$heartbeat_log" \
+    ADL_OBSERVABILITY_STDERR=0 \
+    ADL_OBSERVABILITY_HEARTBEAT_MS=25 \
+    ADL_TEST_CARGO_MODE=heartbeat \
+    ADL_TEST_CARGO_ARGS="$heartbeat_args" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+grep -F "stage=rust_delegate result=heartbeat" "$heartbeat_log" >/dev/null || {
+  echo "assertion failed: cargo delegate fallback should emit heartbeat events" >&2
+  exit 1
+}
+grep -F -- "--bin adl-pr-doctor -- 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full" "$heartbeat_args" >/dev/null || {
+  echo "assertion failed: doctor fallback should execute the direct small binary through cargo" >&2
+  exit 1
+}
+
+issue_log="$tmpdir/issue.log"
+issue_args="$tmpdir/issue.args"
+run_from_repo \
+  env \
+    ADL_OBSERVABILITY_LOG="$issue_log" \
+    ADL_OBSERVABILITY_STDERR=0 \
+    ADL_OBSERVABILITY_HEARTBEAT_MS=25 \
+    ADL_TEST_CARGO_MODE=heartbeat \
+    ADL_TEST_CARGO_ARGS="$issue_args" \
+    "$BASH_BIN" adl/tools/pr.sh issue search --query "validation manager" --state open --json >/dev/null
+grep -F -- "--bin adl-issue -- search --query validation manager --state open --json" "$issue_args" >/dev/null || {
+  echo "assertion failed: issue fallback should execute the adl-issue binary through cargo" >&2
+  exit 1
+}
+
+timeout_log="$tmpdir/timeout.log"
+timeout_args="$tmpdir/timeout.args"
+set +e
+run_from_repo \
+  env \
+    ADL_OBSERVABILITY_LOG="$timeout_log" \
+    ADL_OBSERVABILITY_STDERR=0 \
+    ADL_OBSERVABILITY_HEARTBEAT_MS=25 \
+    ADL_PR_CARGO_DELEGATE_TIMEOUT_SECS=1 \
+    ADL_TEST_CARGO_MODE=timeout \
+    ADL_TEST_CARGO_ARGS="$timeout_args" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+timeout_status="$?"
+set -e
+[[ "$timeout_status" == "124" ]] || {
+  echo "assertion failed: cargo delegate timeout should exit 124, got $timeout_status" >&2
+  exit 1
+}
+grep -F "stage=rust_delegate result=timeout" "$timeout_log" >/dev/null || {
+  echo "assertion failed: cargo delegate timeout should emit timeout event" >&2
+  exit 1
+}
+grep -F "reason_code=cargo_delegate_timeout" "$timeout_log" >/dev/null || {
+  echo "assertion failed: cargo delegate timeout should classify timeout reason" >&2
+  exit 1
+}
+
+lock_log="$tmpdir/lock.log"
+lock_dir="$repo/adl/target/.adl-pr-rust-delegate-build.lock"
+mkdir -p "$lock_dir"
+set +e
+run_from_repo \
+  env \
+    ADL_OBSERVABILITY_LOG="$lock_log" \
+    ADL_OBSERVABILITY_STDERR=0 \
+    ADL_PR_CARGO_DELEGATE_BUILD_LOCK_TIMEOUT_SECS=0 \
+    ADL_TEST_CARGO_MODE=heartbeat \
+    ADL_TEST_CARGO_ARGS="$tmpdir/lock.args" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+lock_status="$?"
+set -e
+rmdir "$lock_dir"
+[[ "$lock_status" == "75" ]] || {
+  echo "assertion failed: build-lock timeout should exit 75, got $lock_status" >&2
+  exit 1
+}
+grep -F "stage=rust_delegate_wait result=timeout" "$lock_log" >/dev/null || {
+  echo "assertion failed: build-lock timeout should emit wait-timeout event" >&2
+  exit 1
+}
+grep -F "reason_code=build_lock_timeout" "$lock_log" >/dev/null || {
+  echo "assertion failed: build-lock timeout should classify lock timeout reason" >&2
+  exit 1
+}
+
+echo "pr.sh cargo fallback liveness: ok"

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+OBS_SRC="$ROOT_DIR/adl/tools/observability.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+worktree="$repo/.worktrees/issue-4413"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$repo/adl/target/debug" "$mockbin"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+cp "$OBS_SRC" "$repo/adl/tools/observability.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+sleep 1
+
+cat >"$repo/adl/target/debug/adl-pr-doctor" <<'EOF_ADL'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"${TMP_ADL_ARGS}"
+EOF_ADL
+chmod +x "$repo/adl/target/debug/adl-pr-doctor"
+
+cat >"$mockbin/cargo" <<'EOF_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"${TMP_CARGO_ARGS}"
+exit 0
+EOF_CARGO
+chmod +x "$mockbin/cargo"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md adl/tools/pr.sh adl/tools/card_paths.sh adl/tools/observability.sh adl/Cargo.toml
+  git commit -q -m "init"
+  git worktree add -q -b codex/4413 "$worktree" HEAD
+)
+
+TMP_ADL_ARGS="$tmpdir/adl_args.txt"
+TMP_CARGO_ARGS="$tmpdir/cargo_args.txt"
+export TMP_ADL_ARGS
+export TMP_CARGO_ARGS
+export PATH="$mockbin:$PATH"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == *"4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full"* ]] || {
+  echo "assertion failed: expected worktree doctor delegation through the primary checkout direct binary" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ ! -s "$TMP_CARGO_ARGS" ]] || {
+  echo "assertion failed: cargo should not run when the primary checkout binary is fresh for the worktree" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+
+sleep 1
+touch "$worktree/adl/Cargo.toml"
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+)
+
+[[ ! -s "$TMP_ADL_ARGS" ]] || {
+  echo "assertion failed: stale worktree Cargo.toml should block reuse of the primary checkout direct binary" >&2
+  cat "$TMP_ADL_ARGS" >&2
+  exit 1
+}
+grep -F -- "--bin adl-pr-doctor -- 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full" "$TMP_CARGO_ARGS" >/dev/null || {
+  echo "assertion failed: stale worktree Cargo.toml should force cargo fallback" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+
+echo "pr.sh worktree prefers primary checkout built binary: ok"


### PR DESCRIPTION
Closes #4413

## Summary
Implemented bounded shell-side delegate liveness hardening for `adl/tools/pr.sh` and added focused proof for both cargo-fallback supervision and primary-checkout binary reuse from bound worktrees.

## Artifacts
- `adl/tools/pr.sh`
- `adl/tools/observability.sh`
- `adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
- `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
- Updated execution-planning and review records under `.adl/v0.91.6/tasks/issue-4413__v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness/`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
    Verified heartbeat, timeout, and build-lock timeout behavior for cargo delegate fallback.
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified primary-checkout small-binary reuse from a real Git worktree plus stale-worktree fallback through `Cargo.toml`.
  - `bash adl/tools/test_pr_doctor_prefers_built_binary.sh`
    Verified the built direct doctor binary still takes precedence over cargo fallback.
  - `bash adl/tools/test_pr_ready_prefers_built_binary.sh`
    Verified the built direct ready binary still takes precedence over cargo fallback.
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified small-binary delegation argv and override precedence remain correct across the delegated lifecycle subcommands.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token adl/tools/pr.sh doctor 4413 --json`
    Verified live structured doctor output in the bound worktree and confirmed primary-checkout binary reuse on the real issue path.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4413__v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4413__v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness/sor.md
- Idempotency-Key: v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness-adl-tools-pr-sh-adl-tools-observability-sh-adl-tools-test-pr-delegate-cargo-fallback-liveness-sh-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4413-v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness-sip-md-adl-v0-91-6-tasks-issue-4413-v0-91-6-tools-lifecycle-fix-pr-lifecycle-delegate-stalls-and-command-liveness-sor-md