### PR TITLE
[v0.91.6][tools][quality] Route #4396 and add retained sprint review for #4388

### DIFF
--- a/docs/milestones/v0.91.6/review/V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md
+++ b/docs/milestones/v0.91.6/review/V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md
@@ -1,0 +1,103 @@
+# v0.91.6 C-SDLC Control-Plane Reliability Route
+
+Issue: `#4396`
+Status: `retained_route_packet`
+Date: 2026-06-23
+Parent sprint: `#4388`
+
+## Scope
+
+This packet records the truthful routed disposition for the bounded
+`#4396` reliability lane inside the `#4388` C-SDLC integration control-plane
+sprint.
+
+`#4396` did not land as one standalone merged implementation slice. Instead,
+the remaining reliability rough edges were split into concrete late
+control-plane owner issues and then consumed by v0.91.7 planning as explicit
+closeout input.
+
+## Route Result
+
+`#4396` is satisfiable as a routed reliability lane.
+
+The bounded acceptance bar for `#4396` was:
+
+- fix remaining rough edges in-scope where practical; or
+- route them into concrete follow-on owners with evidence and sprint routing.
+
+The repository now has that second form of completion. The remaining rough-edge
+surface is explicitly routed through the late v0.91.6 / early v0.91.7
+control-plane stream rather than left as unowned residue.
+
+## Routed Reliability Surfaces
+
+The reliability surface named by `#4396` is now distributed across these
+tracked owner issues:
+
+| Surface | Routed owner(s) | Why this satisfies `#4396` |
+| --- | --- | --- |
+| Root-checkout and multi-session safety | `#4405` | Records the root-checkout and session-coordination guardrails needed for reliable multi-session execution. |
+| Session ledger and cross-session lifecycle continuity | `#4412` | Owns the durable session-ledger and cross-session coordination command surface instead of leaving it implicit. |
+| Lifecycle delegate stalls and long-running command liveness | `#4413` | Owns the lifecycle-liveness defect class that showed up in `pr run` / doctor behavior and other long-running control-plane calls. |
+| Validation throughput, path ownership, and lifecycle automation | `#4417`-`#4421` | Own the validation-manager and lifecycle-automation reliability slices that were too broad to hide inside `#4396`. |
+| Generated VPP planning from ownership/validation facts | `#4425` | Owns turning validation planning into generated truth instead of chat-memory policy. |
+| Forward issue-goal metrics capture | `#4431` | Owns durable time/token capture for issue execution rather than leaving reliability accounting as manual memory. |
+| Bounded v0.91.6 metrics backfill | `#4441` | Owns the limited backfill needed to normalize v0.91.6 process truth without overclaiming archaeology precision. |
+| Operational adoption of watcher/VPP/shepherd defaults | `#4433`-`#4438` | Own the operational-adoption slices required to make the control plane reliably used rather than merely available. |
+| Goal snapshots and lifecycle shepherding | `#4442`, `#4443` | Own the remaining v0.91.7-facing lifecycle reliability and shepherding surfaces above watcher/janitor/closeout. |
+
+## Evidence
+
+The routing above is already reflected in tracked planning truth:
+
+- `docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md`
+- `docs/milestones/v0.91.7/WBS_v0.91.7.md`
+- `docs/milestones/v0.91.7/SPRINT_PLAN_v0.91.7.md`
+- `docs/milestones/v0.91.7/README.md`
+- `docs/milestones/v0.91.7/FEATURE_DOCS_v0.91.7.md`
+- `docs/milestones/v0.91.7/MILESTONE_CHECKLIST_v0.91.7.md`
+
+Those planning surfaces already treat `#4388` plus the late input wave
+`#4405`, `#4412`-`#4413`, `#4417`-`#4421`, `#4425`, `#4431`, `#4441`,
+`#4433`-`#4438`, and `#4442`-`#4443` as the required truth-consumption stream
+for reliable sprint-scale execution.
+
+## Findings
+
+No new P1/P2/P3 findings remain inside the bounded `#4396` route packet.
+
+Residual caveat:
+
+- `#4396` itself is still open in GitHub at the time this packet is written.
+  This packet establishes the retained evidence needed to close it truthfully
+  as a routed lane rather than a missing implementation.
+
+## Validation And Evidence
+
+Focused local checks for this repair:
+
+```text
+git diff --check
+```
+
+Live/tracked evidence consumed:
+
+- live GitHub issue state for `#4396`;
+- tracked sprint packet
+  `.adl/v0.91.6/sprints/issue-4388__csdlc-integration-control-plane/SPRINT_EXECUTION_PACKET.md`;
+- tracked v0.91.7 planning and handoff surfaces listed above.
+
+## Non-Claims
+
+- This packet does not claim every routed owner issue is already closed.
+- This packet does not claim `#4396` produced one merged implementation PR.
+- This packet does not claim the whole control-plane reliability program is
+  complete; it claims the `#4396` lane is no longer unowned.
+- This packet does not replace issue-local review or closeout on the routed
+  owner issues themselves.
+
+## Closeout Position
+
+`#4396` can be closed truthfully after this retained route packet lands because
+its remaining reliability rough edges are now explicitly routed to concrete
+owner issues instead of remaining as unresolved sprint residue.

--- a/docs/milestones/v0.91.6/review/V0916_CSDLC_INTEGRATION_CONTROL_PLANE_SPRINT_REVIEW_4388.md
+++ b/docs/milestones/v0.91.6/review/V0916_CSDLC_INTEGRATION_CONTROL_PLANE_SPRINT_REVIEW_4388.md
@@ -1,0 +1,130 @@
+# v0.91.6 C-SDLC Integration Control-Plane Sprint Review
+
+Issue: `#4388`
+Status: `retained_sprint_review`
+Date: 2026-06-23
+
+## Scope
+
+This packet backfills the tracked retained sprint-review surface for the
+v0.91.6 C-SDLC integration control-plane sprint.
+
+The reviewed sprint scope is exactly the ten child lanes named by the sprint
+execution packet:
+
+| Issue | Role | State after retained review |
+| --- | --- | --- |
+| `#4389` | VPP default validation-planning surface | closed |
+| `#4390` | External PVF lane configuration | closed |
+| `#4391` | Sprint execution packet automation | closed |
+| `#4392` | Issue and sprint goal accounting | closed |
+| `#4393` | Octocrab/GitHub convergence | closed |
+| `#4394` | Prompt-card template edge repair | closed |
+| `#4395` | Runtime dependency routing | closed |
+| `#4396` | Tooling reliability rough edges | routed through retained packet `V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md` |
+| `#4397` | Repo-native sprint watcher | closed |
+| `#4398` | FastContext evaluation | closed |
+
+This review does not widen the sprint to the later control-plane ownership
+stream. It consumes that later stream only as routed evidence for the bounded
+`#4396` reliability lane.
+
+## Review Result
+
+`#4388` is review-consumable after this retained packet lands.
+
+The sprint did real issue-local delivery work across VPP, PVF, SEP, goal
+accounting, GitHub convergence, prompt-template repair, runtime dependency
+routing, watcher support, and FastContext evaluation. The one child lane that
+did not land as its own merged implementation slice, `#4396`, now has explicit
+retained route evidence instead of remaining as an unconsumed open rough-edge
+bucket.
+
+## Findings
+
+No P1/P2/P3 retained sprint-review findings remain after the `#4396` routing
+packet is added.
+
+Residual caveat:
+
+- The umbrella issue `#4388` is still open in GitHub at the time this packet is
+  written. This packet fixes the retained-review gap; issue closure truth still
+  needs the normal closeout step after the routed child disposition is applied.
+
+## Child Issue Closure Truth
+
+The bounded sprint result is now:
+
+- nine child lanes closed as standalone issue deliveries; and
+- one child lane, `#4396`, closed-by-routing once the retained route packet
+  lands.
+
+The tracked sprint result therefore becomes:
+
+- VPP default behavior: consumed from `#4389`;
+- PVF externalization: consumed from `#4390`;
+- SEP automation: consumed from `#4391`;
+- goal accounting: consumed from `#4392`;
+- GitHub/octocrab convergence: consumed from `#4393`;
+- prompt-template edge repair: consumed from `#4394`;
+- runtime dependency routing: consumed from `#4395`;
+- tooling reliability rough-edge routing: consumed from `#4396`;
+- repo-native watcher packet/proof: consumed from `#4397`;
+- FastContext evaluation: consumed from `#4398`.
+
+## Evidence Summary
+
+Primary retained evidence for the sprint is now:
+
+- `docs/milestones/v0.91.6/review/V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md`
+- `docs/milestones/v0.91.6/review/context/FASTCONTEXT_EVALUATION_4398.md`
+- the closed child issue set `#4389`-`#4395`, `#4397`, and `#4398`
+- tracked v0.91.7 planning truth that consumes the late reliability/adoption
+  stream needed for `#4396`
+
+Issue `#4388` also has local sprint-state scaffolding under:
+
+- `.adl/v0.91.6/sprints/issue-4388__csdlc-integration-control-plane/`
+
+That local sprint state remains ignored local workflow evidence, not tracked
+retained release evidence. This packet replaces the missing tracked sprint
+review surface.
+
+## Validation And Evidence
+
+Focused local checks for this repair:
+
+```text
+git diff --check
+```
+
+Evidence consumed:
+
+- live GitHub issue state for `#4388` and child issues `#4389`-`#4398`;
+- tracked FastContext evaluation packet
+  `docs/milestones/v0.91.6/review/context/FASTCONTEXT_EVALUATION_4398.md`;
+- tracked retained route packet
+  `docs/milestones/v0.91.6/review/V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md`;
+- tracked v0.91.7 planning surfaces that explicitly consume the late
+  control-plane stream.
+
+## Non-Claims
+
+- This packet does not claim all late control-plane follow-on issues are
+  closed.
+- This packet does not claim `#4388` is already fully closeouted in GitHub.
+- This packet does not convert ignored local sprint cards into tracked release
+  artifacts.
+- This packet does not replace child issue reviews or rerun each child PR's
+  validation in full.
+
+## Closeout Position
+
+`#4388` no longer lacks retained sprint-review consumption once this packet
+lands.
+
+The remaining work is closeout truth, not sprint-review evidence creation:
+
+- apply the normal issue closure path for `#4396` using the routed packet; then
+- close out `#4388` against this retained review surface and the child issue
+  set.


### PR DESCRIPTION
Closes #4396

## Summary
Add the retained routed-evidence packet for #4396 and the retained sprint-review packet for #4388 so the remaining C-SDLC control-plane sprint truth can be closed without stale singleton-review drift.

## Artifacts
- docs/milestones/v0.91.6/review/V0916_CSDLC_CONTROL_PLANE_RELIABILITY_ROUTE_4396.md
- docs/milestones/v0.91.6/review/V0916_CSDLC_INTEGRATION_CONTROL_PLANE_SPRINT_REVIEW_4388.md

## Validation
- `git diff --check`
  Verified the retained review packet edits are structurally clean.