### PR TITLE
[v0.91.6][tools][finish] Classify version metadata Cargo.toml/Cargo.lock updates

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1649,6 +1649,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if changed_paths.is_empty() {
         bail!("finish: no changed tracked paths available for validation profile selection");
     }
+    if finish_paths_are_version_metadata_update(changed_paths) {
+        return Ok(build_version_metadata_validation_plan());
+    }
     if finish_issue_needs_tokio_manifest_runtime_validation(issue_number, changed_paths) {
         return Ok(build_tokio_manifest_runtime_validation_plan());
     }
@@ -1713,6 +1716,35 @@ fn profile_backed_finish_validation_plan(
         mode: FinishValidationMode::DocsOnly,
         commands,
     })
+}
+
+fn finish_paths_are_version_metadata_update(changed_paths: &[String]) -> bool {
+    let mut has_manifest = false;
+    let mut has_lockfile = false;
+    let mut has_current_docs = false;
+    for path in changed_paths {
+        match path.trim().trim_matches('/') {
+            "README.md" => has_current_docs = true,
+            "adl/Cargo.toml" => has_manifest = true,
+            "adl/Cargo.lock" => has_lockfile = true,
+            _ => return false,
+        }
+    }
+    has_manifest && has_lockfile && has_current_docs
+}
+
+fn build_version_metadata_validation_plan() -> FinishValidationPlan {
+    FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1"
+                .to_string(),
+            "cargo metadata --manifest-path adl/Cargo.toml --locked --no-deps --format-version 1"
+                .to_string(),
+        ],
+    }
 }
 
 fn finish_issue_needs_unity_observatory_scaffold_validation(
@@ -3187,6 +3219,33 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl-pr-finish",
                             "cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+                        ],
+                    )?;
+                }
+                "cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "metadata",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--no-deps",
+                            "--format-version",
+                            "1",
+                        ],
+                    )?;
+                }
+                "cargo metadata --manifest-path adl/Cargo.toml --locked --no-deps --format-version 1" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "metadata",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--locked",
+                            "--no-deps",
+                            "--format-version",
+                            "1",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3533,15 +3533,99 @@ fn finish_tokio_wave_paths_run_new_focused_validation_commands() {
 }
 
 #[test]
-fn finish_validation_profile_does_not_special_case_tokio_manifest_paths_for_other_issues() {
+fn finish_validation_profile_classifies_version_metadata_paths_without_issue_special_case() {
+    let changed_paths = vec![
+        "README.md".to_string(),
+        "adl/Cargo.toml".to_string(),
+        "adl/Cargo.lock".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(5000, &requested_paths, &changed_paths)
+        .expect("version metadata profile plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo metadata --manifest-path adl/Cargo.toml --locked --no-deps --format-version 1"
+            .to_string()
+    ));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo nextest")));
+
     let err = select_finish_validation_plan_for_finish(
         5000,
         ".",
         &["adl/Cargo.toml".to_string(), "adl/Cargo.lock".to_string()],
     )
-    .expect_err("non-Tokio manifest-only issues should stay unclassified");
-
+    .expect_err("manifest-only issues should stay unclassified");
     assert!(err.to_string().contains("changed paths are not classified"));
+}
+
+#[test]
+fn finish_validation_runner_executes_version_metadata_commands() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-version-metadata-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.91.6'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let changed_paths = vec![
+        "README.md".to_string(),
+        "adl/Cargo.toml".to_string(),
+        "adl/Cargo.lock".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+    let plan = select_finish_validation_plan_for_finish(5000, &requested_paths, &changed_paths)
+        .expect("version metadata profile plan");
+    run_finish_validation_rust(&repo, &plan).expect("version metadata validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("metadata --manifest-path"));
+    assert!(cargo_calls.contains("--no-deps --format-version 1"));
+    assert!(cargo_calls.contains("--locked --no-deps --format-version 1"));
+    assert!(!cargo_calls.contains("test --manifest-path"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4450

## Summary
Implemented a focused `pr finish` validation path for version-metadata updates that touch `README.md`, `adl/Cargo.toml`, and `adl/Cargo.lock`. The fix keeps the validation manager from escalating on `adl/Cargo.toml`, adds a general non-issue-specific finish plan for this path set, and proves the plan selects Cargo metadata checks instead of broad Rust validation.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.6/tasks/issue-4450__v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_version_metadata_paths_without_issue_special_case -- --exact --nocapture`
    Verified the finish classifier accepts the complete version-metadata path set, rejects manifest-only changes, and does not select broad Rust validation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_runner_executes_version_metadata_commands -- --exact --nocapture`
    Verified `run_finish_validation_rust` dispatches both Cargo metadata checks selected by the plan.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4450__v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4450__v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates/sor.md
- Idempotency-Key: v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4450-v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates-sip-md-adl-v0-91-6-tasks-issue-4450-v0-91-6-tools-finish-classify-version-metadata-cargo-toml-cargo-lock-updates-sor-md