### PR TITLE
[v0.91.6][tools][validation] Add path ownership registry for finish validation

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1098,6 +1098,116 @@ pub(super) struct FinishValidationProfileEscalationReason {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FinishPathOwnerBinary {
+    Adl,
+    Csdlc,
+    OwnerValidationLane,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FinishPathProofRole {
+    OwnerBinaryRustSlice,
+    OwnerLaneContract,
+    CsdlcOwnerLane,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FinishPathOwnershipRule {
+    owner_binary: FinishPathOwnerBinary,
+    validation_lane: FinishValidationMode,
+    proof_role: FinishPathProofRole,
+    publication_sufficient: bool,
+    exact_paths: &'static [&'static str],
+    prefix_paths: &'static [&'static str],
+}
+
+const FINISH_PATH_OWNERSHIP_RULES: &[FinishPathOwnershipRule] = &[
+    FinishPathOwnershipRule {
+        owner_binary: FinishPathOwnerBinary::Adl,
+        validation_lane: FinishValidationMode::LargerBinaryFocused,
+        proof_role: FinishPathProofRole::OwnerBinaryRustSlice,
+        publication_sufficient: true,
+        exact_paths: &[
+            "adl/src/control_plane.rs",
+            "adl/src/lib.rs",
+            "adl/src/session_ledger.rs",
+            "adl/src/cli/session_cmd.rs",
+            "adl/src/cli/tests.rs",
+            "adl/src/csdlc_prompt_editor.rs",
+            "adl/src/cli/run_artifacts_types.rs",
+        ],
+        prefix_paths: &[
+            "adl/src/csdlc_prompt_editor/",
+            "adl/src/cli/run_artifacts_types/",
+        ],
+    },
+    FinishPathOwnershipRule {
+        owner_binary: FinishPathOwnerBinary::OwnerValidationLane,
+        validation_lane: FinishValidationMode::LargerBinaryFocused,
+        proof_role: FinishPathProofRole::OwnerLaneContract,
+        publication_sufficient: true,
+        exact_paths: &[
+            "adl/tools/run_owner_validation_lane.sh",
+            "adl/tools/test_owner_validation_lane.sh",
+            "adl/tools/test_control_plane_observability.sh",
+            "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md",
+            "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md",
+        ],
+        prefix_paths: &[],
+    },
+    FinishPathOwnershipRule {
+        owner_binary: FinishPathOwnerBinary::Csdlc,
+        validation_lane: FinishValidationMode::LargerBinaryFocused,
+        proof_role: FinishPathProofRole::CsdlcOwnerLane,
+        publication_sufficient: true,
+        exact_paths: &[
+            "adl/tools/run_owner_validation_lane.sh",
+            "adl/tools/test_owner_validation_lane.sh",
+            "adl/tools/test_cli_wrapper_migration_contract.sh",
+            "adl/tools/test_pr_run_ambiguity_policy.sh",
+            "adl/tools/test_control_plane_observability.sh",
+            "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md",
+            "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md",
+        ],
+        prefix_paths: &[],
+    },
+];
+
+fn finish_path_matches_ownership_rule(path: &str, rule: &FinishPathOwnershipRule) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    !trimmed.is_empty()
+        && (rule.exact_paths.contains(&trimmed)
+            || rule
+                .prefix_paths
+                .iter()
+                .any(|prefix| trimmed.starts_with(prefix)))
+}
+
+fn finish_path_matches_registry_proof_role(path: &str, role: FinishPathProofRole) -> bool {
+    FINISH_PATH_OWNERSHIP_RULES.iter().any(|rule| {
+        finish_path_matches_ownership_rule(path, rule)
+            && rule.proof_role == role
+            && rule.publication_sufficient
+    })
+}
+
+fn finish_path_matches_registry_lane(path: &str, lane: FinishValidationMode) -> bool {
+    FINISH_PATH_OWNERSHIP_RULES.iter().any(|rule| {
+        finish_path_matches_ownership_rule(path, rule)
+            && rule.validation_lane == lane
+            && rule.publication_sufficient
+    })
+}
+
+fn finish_path_matches_registry_owner(path: &str, owner: FinishPathOwnerBinary) -> bool {
+    FINISH_PATH_OWNERSHIP_RULES.iter().any(|rule| {
+        finish_path_matches_ownership_rule(path, rule)
+            && rule.owner_binary == owner
+            && rule.publication_sufficient
+    })
+}
+
 fn finish_validation_guard(repo_root: &Path) -> Result<()> {
     let tracked_residue_guard =
         repo_root.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh");
@@ -1920,6 +2030,9 @@ fn finish_path_has_docs_artifact_extension(path: &str) -> bool {
 
 fn finish_path_is_small_binary_focused(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
+    if finish_path_matches_registry_lane(trimmed, FinishValidationMode::SmallBinaryFocused) {
+        return true;
+    }
     matches!(
         trimmed,
         "adl/tools/pr.sh"
@@ -1945,6 +2058,9 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
 
 fn finish_path_is_larger_binary_focused(path: &str) -> bool {
     let trimmed = path.trim().trim_matches('/');
+    if finish_path_matches_registry_lane(trimmed, FinishValidationMode::LargerBinaryFocused) {
+        return true;
+    }
     matches!(
         trimmed,
         ".github/workflows/ci.yaml"
@@ -2123,16 +2239,7 @@ fn finish_path_needs_github_token_focused_validation(path: &str) -> bool {
 }
 
 fn finish_path_needs_owner_binary_rust_slice_validation(path: &str) -> bool {
-    let trimmed = path.trim().trim_matches('/');
-    trimmed == "adl/src/control_plane.rs"
-        || trimmed == "adl/src/lib.rs"
-        || trimmed == "adl/src/session_ledger.rs"
-        || trimmed == "adl/src/cli/session_cmd.rs"
-        || trimmed == "adl/src/cli/tests.rs"
-        || trimmed == "adl/src/csdlc_prompt_editor.rs"
-        || trimmed.starts_with("adl/src/csdlc_prompt_editor/")
-        || trimmed == "adl/src/cli/run_artifacts_types.rs"
-        || trimmed.starts_with("adl/src/cli/run_artifacts_types/")
+    finish_path_matches_registry_proof_role(path, FinishPathProofRole::OwnerBinaryRustSlice)
 }
 
 fn finish_path_needs_process_status_focused_validation(path: &str) -> bool {
@@ -2733,15 +2840,7 @@ fn finish_path_needs_locked_cargo_fallback_validation(path: &str) -> bool {
 }
 
 fn finish_path_needs_owner_lane_contract_validation(path: &str) -> bool {
-    let trimmed = path.trim().trim_matches('/');
-    matches!(
-        trimmed,
-        "adl/tools/run_owner_validation_lane.sh"
-            | "adl/tools/test_owner_validation_lane.sh"
-            | "adl/tools/test_control_plane_observability.sh"
-            | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
-            | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
-    )
+    finish_path_matches_registry_proof_role(path, FinishPathProofRole::OwnerLaneContract)
 }
 
 fn finish_path_needs_repo_quality_staleness_validation(path: &str) -> bool {
@@ -2784,17 +2883,8 @@ fn finish_path_needs_private_endpoint_fixture_sanitation_validation(path: &str) 
 }
 
 fn finish_path_needs_csdlc_owner_lane_validation(path: &str) -> bool {
-    let trimmed = path.trim().trim_matches('/');
-    matches!(
-        trimmed,
-        "adl/tools/run_owner_validation_lane.sh"
-            | "adl/tools/test_owner_validation_lane.sh"
-            | "adl/tools/test_cli_wrapper_migration_contract.sh"
-            | "adl/tools/test_pr_run_ambiguity_policy.sh"
-            | "adl/tools/test_control_plane_observability.sh"
-            | "docs/milestones/v0.91.5/VALIDATION_LANE_SPLIT_3610.md"
-            | "docs/milestones/v0.91.5/LOCAL_VS_CI_VALIDATION_POLICY_3607.md"
-    )
+    finish_path_matches_registry_proof_role(path, FinishPathProofRole::CsdlcOwnerLane)
+        || finish_path_matches_registry_owner(path, FinishPathOwnerBinary::Csdlc)
 }
 
 fn finish_path_needs_runtime_owner_lane_validation(path: &str) -> bool {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3845,6 +3845,41 @@ fn finish_owner_binary_paths_run_owner_binary_focused_validation() {
 }
 
 #[test]
+fn finish_path_ownership_registry_classifies_owner_binary_slice() {
+    let plan = select_finish_validation_plan("adl/src/session_ledger.rs")
+        .expect("owner binary registry plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.iter().any(|cmd| cmd.contains("--bin adl")));
+}
+
+#[test]
+fn finish_path_ownership_registry_classifies_csdlc_owner_lane_contract() {
+    let plan = select_finish_validation_plan("adl/tools/test_pr_run_ambiguity_policy.sh")
+        .expect("csdlc owner lane registry plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .iter()
+        .any(|cmd| cmd == "bash adl/tools/run_owner_validation_lane.sh csdlc"));
+}
+
+#[test]
+fn finish_path_ownership_registry_preserves_shared_owner_lane_overlap() {
+    let plan = select_finish_validation_plan("adl/tools/run_owner_validation_lane.sh")
+        .expect("shared owner lane registry plan");
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_owner_validation_lane.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh all --build".to_string()));
+}
+
+#[test]
 fn finish_prompt_template_paths_run_prompt_template_focused_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-prompt-template-focused-validation");

--- a/docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md
+++ b/docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md
@@ -1,0 +1,56 @@
+# Finish Validation Path Ownership Registry
+
+`pr finish` still fails closed for unknown changed paths.
+
+That behavior is intentional. What changed in `#4418` is where known path
+ownership is declared.
+
+## Purpose
+
+The finish-validation selector needs one bounded place to answer four questions
+for a changed path:
+
+- which owner binary or owner lane owns the surface
+- which focused validation lane applies
+- which proof role the path triggers
+- whether the known classification is publication-sufficient
+
+## Current Registry Surface
+
+The registry currently lives in
+`adl/src/cli/pr_cmd/finish_support.rs` as `FINISH_PATH_OWNERSHIP_RULES`.
+
+Each rule declares:
+
+- exact paths and optional path prefixes
+- `owner_binary`
+- `validation_lane`
+- `proof_role`
+- `publication_sufficient`
+
+Matching is additive for registry queries. If more than one
+`FINISH_PATH_OWNERSHIP_RULES` entry matches the same path, every matching
+publication-sufficient rule contributes its owner/proof-role classification.
+Shared paths must therefore either agree on the validation lane or carry an
+explicit regression test proving the intended combined behavior.
+
+## How To Declare A New Command Surface
+
+When a new command or control-plane surface should be recognized by
+`pr finish`:
+
+1. Add the new exact path or prefix to `FINISH_PATH_OWNERSHIP_RULES`.
+2. Set the owner binary or owner lane that is responsible for the surface.
+3. Set the focused validation lane that should run when the path changes.
+4. Set the proof role that should be triggered by the path.
+5. Add or update a regression test in
+   `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`.
+
+If a path does not belong to any known rule, leave it unclassified and let
+finish fail closed.
+
+## Non-goals
+
+- This registry does not replace the future validation manager.
+- This registry does not auto-classify unknown paths.
+- This registry does not make docs-only or wider owner-lane policy optional.


### PR DESCRIPTION
Closes #4418

## Summary
Implemented a bounded finish-validation path ownership registry that moves
known path ownership, focused lane choice, proof-role mapping, and
publication-sufficiency classification into one declared rule set. The slice
preserves fail-closed behavior for unknown paths, documents the registry
surface, and fixes an owner-lane overlap regression before publication by
making shared-path classification additive and directly covered by tests.

## Artifacts
- Updated local ignored output record at `.adl/v0.91.6/tasks/issue-4418__v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml finish_path_ownership_registry_classifies_owner_binary_slice -- --nocapture`
    Verified the registry maps a known owner-binary Rust surface to the expected focused finish plan.
  - `cargo test --manifest-path adl/Cargo.toml finish_owner_binary_paths_run_owner_binary_focused_validation -- --nocapture`
    Verified the existing owner-binary finish validation path still works after the registry migration.
  - `cargo test --manifest-path adl/Cargo.toml finish_path_ownership_registry_classifies_csdlc_owner_lane_contract -- --nocapture`
    Verified a C-SDLC owner-lane path is classified by the new registry.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_plan_classifies_owner_validation_lanes -- --nocapture`
    Verified the owner-lane plan for shared validation-lane paths still includes both required lane commands after the overlap fix.
  - `cargo test --manifest-path adl/Cargo.toml finish_path_ownership_registry_preserves_shared_owner_lane_overlap -- --nocapture`
    Verified a single shared owner-lane path preserves the dual-command overlap contract directly.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified formatting.
  - `git diff --check`
    Verified patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4418__v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.91.6/tasks/issue-4418__v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation/sor.md
- Idempotency-Key: v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-tooling-finish-validation-path-ownership-registry-md-adl-v0-91-6-tasks-issue-4418-v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation-sip-md-users-daniel-git-agent-design-language-adl-v0-91-6-tasks-issue-4418-v0-91-6-tools-validation-add-path-ownership-registry-for-finish-validation-sor-md