### PR TITLE
[v0.91.6][tools][sor] Emit SOR facts from validation review and finish events

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Mapping, Value};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -139,6 +140,16 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
         record_docs_only_validation_evidence_for_finish(&output_path, &finish_validation_plan)?;
     }
+    record_sor_emitted_facts_for_finish(
+        &output_path,
+        &review_policy_path,
+        &changed_paths,
+        &finish_validation_plan,
+        if parsed.no_checks { "NOT_RUN" } else { "PASS" },
+        None,
+        "worktree_only",
+        false,
+    )?;
     validate_completed_sor(&repo_root, &output_path)?;
 
     let canonical_output = lifecycle::sync_completed_output_surfaces(
@@ -239,6 +250,30 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         parsed.no_close,
         &pr_body_file,
     )?;
+    record_sor_emitted_facts_for_finish(
+        &output_path,
+        &review_policy_path,
+        &changed_paths,
+        &finish_validation_plan,
+        if parsed.no_checks { "NOT_RUN" } else { "PASS" },
+        Some(pr_url.as_str()),
+        "pr_open",
+        _closing_linkage_repaired,
+    )?;
+    validate_completed_sor(&repo_root, &output_path)?;
+    let canonical_output = lifecycle::sync_completed_output_surfaces(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &output_path,
+    )?;
+    restage_finish_output_truth_paths(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &[output_path.clone(), canonical_output.clone()],
+    )?;
+    ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
 
     if parsed.merge_mode {
         if parsed.ready {
@@ -629,6 +664,318 @@ fn record_docs_only_validation_evidence_for_finish(
         })?;
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFacts {
+    schema_version: &'static str,
+    changed_paths: Vec<String>,
+    validation: SorFactValidation,
+    review: SorFactReview,
+    finish: SorFactFinish,
+    integration: SorFactIntegration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFactValidation {
+    status: String,
+    commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFactReview {
+    findings_status: String,
+    recommended_outcome: String,
+    findings: Vec<String>,
+    fixes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFactFinish {
+    pr_url: Option<String>,
+    blocking_notes: Vec<String>,
+    fix_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFactIntegration {
+    state: String,
+    main_repo_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SorReviewEvidence {
+    findings_status: String,
+    recommended_outcome: String,
+    findings: Vec<String>,
+    fixes: Vec<String>,
+}
+
+fn record_sor_emitted_facts_for_finish(
+    output_path: &Path,
+    review_policy_path: &Path,
+    changed_paths: &[String],
+    plan: &FinishValidationPlan,
+    validation_status: &str,
+    pr_url: Option<&str>,
+    integration_state: &str,
+    closing_linkage_repaired: bool,
+) -> Result<()> {
+    let original = fs::read_to_string(output_path).with_context(|| {
+        format!(
+            "finish: failed to read output card {}",
+            output_path.display()
+        )
+    })?;
+    let review = read_sor_review_evidence(review_policy_path)?;
+    let normalized = normalize_sor_emitted_facts_text(
+        &original,
+        &build_sor_facts(
+            changed_paths,
+            plan,
+            validation_status,
+            &review,
+            pr_url,
+            integration_state,
+            closing_linkage_repaired,
+        ),
+    )?;
+    if normalized != original {
+        fs::write(output_path, normalized).with_context(|| {
+            format!(
+                "finish: failed to write emitted SOR facts into output card {}",
+                output_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn build_sor_facts(
+    changed_paths: &[String],
+    plan: &FinishValidationPlan,
+    validation_status: &str,
+    review: &SorReviewEvidence,
+    pr_url: Option<&str>,
+    integration_state: &str,
+    closing_linkage_repaired: bool,
+) -> SorFacts {
+    let fix_notes = if closing_linkage_repaired {
+        vec!["repaired missing PR closing linkage".to_string()]
+    } else {
+        vec!["none".to_string()]
+    };
+    SorFacts {
+        schema_version: "adl.sor_facts.v1",
+        changed_paths: changed_paths.to_vec(),
+        validation: SorFactValidation {
+            status: validation_status.to_string(),
+            commands: plan.commands.clone(),
+        },
+        review: SorFactReview {
+            findings_status: review.findings_status.clone(),
+            recommended_outcome: review.recommended_outcome.clone(),
+            findings: review.findings.clone(),
+            fixes: review.fixes.clone(),
+        },
+        finish: SorFactFinish {
+            pr_url: pr_url.map(str::to_string),
+            blocking_notes: vec!["none".to_string()],
+            fix_notes,
+        },
+        integration: SorFactIntegration {
+            state: integration_state.to_string(),
+            main_repo_paths: changed_paths.to_vec(),
+        },
+    }
+}
+
+fn read_sor_review_evidence(review_policy_path: &Path) -> Result<SorReviewEvidence> {
+    let text = fs::read_to_string(review_policy_path).with_context(|| {
+        format!(
+            "finish: failed to read review policy card {}",
+            review_policy_path.display()
+        )
+    })?;
+    Ok(parse_sor_review_evidence(&text))
+}
+
+fn parse_sor_review_evidence(text: &str) -> SorReviewEvidence {
+    let (findings_status, recommended_outcome) = review_results_from_front_matter(text)
+        .unwrap_or_else(|| ("not_run".to_string(), "not_run".to_string()));
+    let findings = bullet_lines_from_markdown_section(text, "Findings");
+    let fixes = bullet_lines_from_markdown_section(text, "Dispositions");
+    SorReviewEvidence {
+        findings_status,
+        recommended_outcome,
+        findings: if findings.is_empty() {
+            vec!["not_recorded".to_string()]
+        } else {
+            findings
+        },
+        fixes: if fixes.is_empty() {
+            vec!["not_recorded".to_string()]
+        } else {
+            fixes
+        },
+    }
+}
+
+fn review_results_from_front_matter(text: &str) -> Option<(String, String)> {
+    let front_matter = extract_yaml_front_matter(text)?;
+    let yaml: Value = serde_yaml::from_str(front_matter).ok()?;
+    let mapping = yaml.as_mapping()?;
+    let review_results = mapping.get(Value::String("review_results".to_string()))?;
+    let review_mapping = review_results.as_mapping()?;
+    let findings_status = yaml_mapping_string(review_mapping, "findings_status")
+        .unwrap_or_else(|| "not_run".to_string());
+    let recommended_outcome = yaml_mapping_string(review_mapping, "recommended_outcome")
+        .unwrap_or_else(|| "not_run".to_string());
+    Some((findings_status, recommended_outcome))
+}
+
+fn extract_yaml_front_matter(text: &str) -> Option<&str> {
+    let mut cursor = 0usize;
+    let mut lines = text.split_inclusive('\n');
+    let first = lines.next()?;
+    if first.trim_end_matches(['\r', '\n']).trim() != "---" {
+        return None;
+    }
+    let content_start = first.len();
+    cursor += first.len();
+    for line in lines {
+        let trimmed = line.trim_end_matches(['\r', '\n']).trim();
+        if trimmed == "---" {
+            return text.get(content_start..cursor);
+        }
+        cursor += line.len();
+    }
+    None
+}
+
+fn yaml_mapping_string(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn bullet_lines_from_markdown_section(text: &str, heading: &str) -> Vec<String> {
+    markdown_section_body_local(text, heading)
+        .map(|body| {
+            body.lines()
+                .map(str::trim)
+                .filter_map(|line| line.strip_prefix("- "))
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn normalize_sor_emitted_facts_text(text: &str, facts: &SorFacts) -> Result<String> {
+    let Some(summary_body) = markdown_section_body_local(text, "Verification Summary") else {
+        return Ok(text.to_string());
+    };
+    let updated_summary = update_verification_summary_yaml(&summary_body, facts)?;
+    Ok(
+        replace_markdown_section_body(text, "Verification Summary", &updated_summary)
+            .unwrap_or_else(|_| text.to_string()),
+    )
+}
+
+fn update_verification_summary_yaml(body: &str, facts: &SorFacts) -> Result<String> {
+    let facts_value = serde_yaml::to_value(facts)
+        .context("finish: failed to serialize emitted SOR facts into YAML")?;
+    let Some(yaml) = extract_fenced_yaml_block(body) else {
+        return append_standalone_sor_facts_block(body, facts_value);
+    };
+    let mut value: Value = match serde_yaml::from_str(&yaml) {
+        Ok(value) => value,
+        Err(_) => return append_standalone_sor_facts_block(body, facts_value),
+    };
+    let Some(mapping) = value.as_mapping_mut() else {
+        return append_standalone_sor_facts_block(body, facts_value);
+    };
+    mapping.insert(Value::String("sor_facts".to_string()), facts_value);
+    render_yaml_fence(&value)
+}
+
+fn extract_fenced_yaml_block(body: &str) -> Option<String> {
+    let mut lines = body.lines();
+    let first = lines.next()?.trim();
+    if !first.starts_with("```") {
+        return None;
+    }
+    let mut yaml_lines = Vec::new();
+    for line in lines {
+        if line.trim() == "```" {
+            return Some(yaml_lines.join("\n"));
+        }
+        yaml_lines.push(line.to_string());
+    }
+    None
+}
+
+fn append_standalone_sor_facts_block(body: &str, facts_value: Value) -> Result<String> {
+    let mut sor_facts = Mapping::new();
+    sor_facts.insert(Value::String("sor_facts".to_string()), facts_value);
+    let fenced = render_yaml_fence(&Value::Mapping(sor_facts))?;
+    let mut out = strip_existing_standalone_sor_facts_block(body)
+        .trim_end()
+        .to_string();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str("Machine-readable SOR facts:\n\n");
+    out.push_str(&fenced);
+    Ok(out)
+}
+
+fn strip_existing_standalone_sor_facts_block(body: &str) -> &str {
+    if let Some(idx) = body.find("Machine-readable SOR facts:\n") {
+        &body[..idx]
+    } else {
+        body
+    }
+}
+
+fn render_yaml_fence(value: &Value) -> Result<String> {
+    let mut rendered = serde_yaml::to_string(value)
+        .context("finish: failed to render Verification Summary YAML with emitted SOR facts")?;
+    if let Some(stripped) = rendered.strip_prefix("---\n") {
+        rendered = stripped.to_string();
+    }
+    Ok(format!("```yaml\n{rendered}```"))
+}
+
+#[cfg(test)]
+pub(super) fn normalize_sor_emitted_facts_fixture(
+    text: &str,
+    changed_paths: &[String],
+    commands: &[String],
+    review_text: &str,
+    validation_status: &str,
+    pr_url: Option<&str>,
+    integration_state: &str,
+    closing_linkage_repaired: bool,
+) -> Result<String> {
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: commands.to_vec(),
+    };
+    let review = parse_sor_review_evidence(review_text);
+    let facts = build_sor_facts(
+        changed_paths,
+        &plan,
+        validation_status,
+        &review,
+        pr_url,
+        integration_state,
+        closing_linkage_repaired,
+    );
+    normalize_sor_emitted_facts_text(text, &facts)
 }
 
 pub(super) fn restage_finish_output_truth_paths(

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -769,6 +769,11 @@ fn build_sor_facts(
     integration_state: &str,
     closing_linkage_repaired: bool,
 ) -> SorFacts {
+    let validation_commands = if validation_status == "NOT_RUN" {
+        Vec::new()
+    } else {
+        plan.commands.clone()
+    };
     let fix_notes = if closing_linkage_repaired {
         vec!["repaired missing PR closing linkage".to_string()]
     } else {
@@ -779,7 +784,7 @@ fn build_sor_facts(
         changed_paths: changed_paths.to_vec(),
         validation: SorFactValidation {
             status: validation_status.to_string(),
-            commands: plan.commands.clone(),
+            commands: validation_commands,
         },
         review: SorFactReview {
             findings_status: review.findings_status.clone(),

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -145,10 +145,12 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         &review_policy_path,
         &changed_paths,
         &finish_validation_plan,
-        if parsed.no_checks { "NOT_RUN" } else { "PASS" },
-        None,
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: if parsed.no_checks { "NOT_RUN" } else { "PASS" },
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )?;
     validate_completed_sor(&repo_root, &output_path)?;
 
@@ -255,10 +257,12 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         &review_policy_path,
         &changed_paths,
         &finish_validation_plan,
-        if parsed.no_checks { "NOT_RUN" } else { "PASS" },
-        Some(pr_url.as_str()),
-        "pr_open",
-        _closing_linkage_repaired,
+        SorFactEmissionContext {
+            validation_status: if parsed.no_checks { "NOT_RUN" } else { "PASS" },
+            pr_url: Some(pr_url.as_str()),
+            integration_state: "pr_open",
+            closing_linkage_repaired: _closing_linkage_repaired,
+        },
     )?;
     validate_completed_sor(&repo_root, &output_path)?;
     let canonical_output = lifecycle::sync_completed_output_surfaces(
@@ -711,15 +715,20 @@ struct SorReviewEvidence {
     fixes: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SorFactEmissionContext<'a> {
+    pub validation_status: &'a str,
+    pub pr_url: Option<&'a str>,
+    pub integration_state: &'a str,
+    pub closing_linkage_repaired: bool,
+}
+
 fn record_sor_emitted_facts_for_finish(
     output_path: &Path,
     review_policy_path: &Path,
     changed_paths: &[String],
     plan: &FinishValidationPlan,
-    validation_status: &str,
-    pr_url: Option<&str>,
-    integration_state: &str,
-    closing_linkage_repaired: bool,
+    context: SorFactEmissionContext<'_>,
 ) -> Result<()> {
     let original = fs::read_to_string(output_path).with_context(|| {
         format!(
@@ -733,11 +742,11 @@ fn record_sor_emitted_facts_for_finish(
         &build_sor_facts(
             changed_paths,
             plan,
-            validation_status,
+            context.validation_status,
             &review,
-            pr_url,
-            integration_state,
-            closing_linkage_repaired,
+            context.pr_url,
+            context.integration_state,
+            context.closing_linkage_repaired,
         ),
     )?;
     if normalized != original {
@@ -956,10 +965,7 @@ pub(super) fn normalize_sor_emitted_facts_fixture(
     changed_paths: &[String],
     commands: &[String],
     review_text: &str,
-    validation_status: &str,
-    pr_url: Option<&str>,
-    integration_state: &str,
-    closing_linkage_repaired: bool,
+    context: SorFactEmissionContext<'_>,
 ) -> Result<String> {
     let plan = FinishValidationPlan {
         mode: FinishValidationMode::LargerBinaryFocused,
@@ -969,11 +975,11 @@ pub(super) fn normalize_sor_emitted_facts_fixture(
     let facts = build_sor_facts(
         changed_paths,
         &plan,
-        validation_status,
+        context.validation_status,
         &review,
-        pr_url,
-        integration_state,
-        closing_linkage_repaired,
+        context.pr_url,
+        context.integration_state,
+        context.closing_linkage_repaired,
     );
     normalize_sor_emitted_facts_text(text, &facts)
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4,8 +4,8 @@ use crate::cli::pr_cmd::finish_support::{
     ensure_no_staged_issue_bundle_mutations, extra_pr_body_looks_like_issue_template,
     extract_markdown_section, finish_declared_paths_for_validation, finish_inputs_fingerprint,
     issue_bundle_issue_number_from_repo_relative, load_finish_validation_profile,
-    non_closing_lifecycle_line, normalize_docs_only_sor_text, open_pr_url_nonblocking,
-    open_pr_url_nonblocking_with_timeout, real_pr_finish,
+    non_closing_lifecycle_line, normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture,
+    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, real_pr_finish,
     reject_local_issue_bundle_paths_in_finish_paths, render_default_finish_validation,
     resolve_finish_issue_scope_and_slug, restage_finish_output_truth_paths,
     run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
@@ -418,6 +418,350 @@ verification_summary:
     let commands = vec!["git diff --check".to_string()];
     let normalized = normalize_docs_only_sor_text(input, &commands);
     assert_eq!(normalized.matches("git diff --check").count(), 2);
+}
+
+#[test]
+fn sor_emitted_facts_merge_review_validation_and_pr_publication_truth() {
+    let output = r#"## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git diff --check"
+  determinism:
+    status: NOT_RUN
+```
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "findings_present"
+  recommended_outcome: "needs_followup"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- Missing focused regression test for fact merge.
+
+## Dispositions
+
+- Added focused SOR fact merge test coverage.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &[
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        ],
+        &[
+            "git diff --check".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_merge_review_validation_and_pr_publication_truth".to_string(),
+        ],
+        review,
+        "PASS",
+        Some("https://github.com/danielbaustin/agent-design-language/pull/9999"),
+        "pr_open",
+        true,
+    )
+    .expect("normalize sor emitted facts");
+
+    assert!(normalized.contains("sor_facts:"));
+    assert!(normalized.contains("schema_version: adl.sor_facts.v1"));
+    assert!(normalized.contains("findings_status: findings_present"));
+    assert!(normalized.contains("recommended_outcome: needs_followup"));
+    assert!(normalized.contains("Missing focused regression test for fact merge."));
+    assert!(normalized.contains("Added focused SOR fact merge test coverage."));
+    assert!(normalized
+        .contains("pr_url: https://github.com/danielbaustin/agent-design-language/pull/9999"));
+    assert!(normalized.contains("state: pr_open"));
+    assert!(normalized.contains("repaired missing PR closing linkage"));
+}
+
+#[test]
+fn sor_emitted_facts_merge_is_idempotent() {
+    let output = r#"## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git diff --check"
+  determinism:
+    status: NOT_RUN
+```
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+
+## Dispositions
+
+- No fixes required.
+"#;
+    let changed_paths = vec!["docs/example.md".to_string()];
+    let commands = vec!["git diff --check".to_string()];
+
+    let first = normalize_sor_emitted_facts_fixture(
+        output,
+        &changed_paths,
+        &commands,
+        review,
+        "PASS",
+        Some("https://example.test/pr/1"),
+        "pr_open",
+        false,
+    )
+    .expect("first normalize");
+    let second = normalize_sor_emitted_facts_fixture(
+        &first,
+        &changed_paths,
+        &commands,
+        review,
+        "PASS",
+        Some("https://example.test/pr/1"),
+        "pr_open",
+        false,
+    )
+    .expect("second normalize");
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn sor_emitted_facts_record_not_run_validation_truth_when_checks_are_skipped() {
+    let output = r#"## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: NOT_RUN
+```
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "not_run"
+  recommended_outcome: "not_run"
+---
+
+# Structured Review Prompt
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "NOT_RUN",
+        None,
+        "worktree_only",
+        false,
+    )
+    .expect("normalize no-checks sor emitted facts");
+
+    assert!(normalized.contains("status: NOT_RUN"));
+    assert!(normalized.contains("pr_url: null"));
+}
+
+#[test]
+fn sor_emitted_facts_fallback_preserves_non_yaml_summary_and_appends_machine_readable_block() {
+    let output = r#"## Verification Summary
+
+plain-text verification summary that should not become a finish-time parse failure
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+
+## Dispositions
+
+- No fixes required.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        Some("https://example.test/pr/2"),
+        "pr_open",
+        false,
+    )
+    .expect("normalize with fallback");
+
+    assert!(normalized.contains("plain-text verification summary"));
+    assert!(normalized.contains("Machine-readable SOR facts:"));
+    assert!(normalized.contains("sor_facts:"));
+}
+
+#[test]
+fn sor_emitted_facts_fallback_replaces_existing_machine_readable_block_instead_of_appending() {
+    let output = r#"## Verification Summary
+
+plain-text verification summary that should not become a finish-time parse failure
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+
+## Dispositions
+
+- No fixes required.
+"#;
+
+    let first = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        Some("https://example.test/pr/2"),
+        "worktree_only",
+        false,
+    )
+    .expect("first fallback normalize");
+    let second = normalize_sor_emitted_facts_fixture(
+        &first,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        Some("https://example.test/pr/2"),
+        "pr_open",
+        false,
+    )
+    .expect("second fallback normalize");
+
+    assert_eq!(second.matches("Machine-readable SOR facts:").count(), 1);
+    assert!(second.contains("state: pr_open"));
+    assert!(!second.contains("state: worktree_only\n\nMachine-readable SOR facts:"));
+}
+
+#[test]
+fn sor_emitted_facts_fallback_is_idempotent_for_initially_empty_summary_body() {
+    let output = "## Verification Summary\n";
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+"#;
+
+    let first = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        Some("https://example.test/pr/3"),
+        "worktree_only",
+        false,
+    )
+    .expect("first empty-body fallback normalize");
+    let second = normalize_sor_emitted_facts_fixture(
+        &first,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        Some("https://example.test/pr/3"),
+        "pr_open",
+        false,
+    )
+    .expect("second empty-body fallback normalize");
+
+    assert_eq!(second.matches("Machine-readable SOR facts:").count(), 1);
+    assert!(second.contains("state: pr_open"));
+}
+
+#[test]
+fn sor_emitted_facts_default_review_truth_when_srp_front_matter_is_absent() {
+    let output = r#"## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+```
+"#;
+    let review = r#"# Structured Review Prompt
+
+## Findings
+
+- Review packet not finalized yet.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        None,
+        "worktree_only",
+        false,
+    )
+    .expect("normalize without srp front matter");
+
+    assert!(normalized.contains("findings_status: not_run"));
+    assert!(normalized.contains("recommended_outcome: not_run"));
+    assert!(normalized.contains("Review packet not finalized yet."));
+}
+
+#[test]
+fn sor_emitted_facts_parse_review_truth_from_crlf_front_matter() {
+    let output = "## Verification Summary\n\n```yaml\nverification_summary:\n  validation:\n    status: PASS\n```\n";
+    let review = "---\r\nreview_results:\r\n  findings_status: \"no_findings\"\r\n  recommended_outcome: \"pass\"\r\n---\r\n\r\n# Structured Review Prompt\r\n\r\n## Findings\r\n\r\n- No material findings.\r\n";
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        "PASS",
+        None,
+        "worktree_only",
+        false,
+    )
+    .expect("normalize crlf srp front matter");
+
+    assert!(normalized.contains("findings_status: no_findings"));
+    assert!(normalized.contains("recommended_outcome: pass"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -11,7 +11,7 @@ use crate::cli::pr_cmd::finish_support::{
     run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
     FinishValidationPlan, FinishValidationProfile, FinishValidationProfileEscalation,
     FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
-    FinishValidationProfileSurfaceItem, FinishValidationVppRecord,
+    FinishValidationProfileSurfaceItem, FinishValidationVppRecord, SorFactEmissionContext,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 use std::os::unix::fs::PermissionsExt;
@@ -462,10 +462,12 @@ review_results:
             "cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_merge_review_validation_and_pr_publication_truth".to_string(),
         ],
         review,
-        "PASS",
-        Some("https://github.com/danielbaustin/agent-design-language/pull/9999"),
-        "pr_open",
-        true,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://github.com/danielbaustin/agent-design-language/pull/9999"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: true,
+        },
     )
     .expect("normalize sor emitted facts");
 
@@ -519,10 +521,12 @@ review_results:
         &changed_paths,
         &commands,
         review,
-        "PASS",
-        Some("https://example.test/pr/1"),
-        "pr_open",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/1"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("first normalize");
     let second = normalize_sor_emitted_facts_fixture(
@@ -530,10 +534,12 @@ review_results:
         &changed_paths,
         &commands,
         review,
-        "PASS",
-        Some("https://example.test/pr/1"),
-        "pr_open",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/1"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("second normalize");
 
@@ -564,10 +570,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "NOT_RUN",
-        None,
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: "NOT_RUN",
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("normalize no-checks sor emitted facts");
 
@@ -603,10 +611,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        Some("https://example.test/pr/2"),
-        "pr_open",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/2"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("normalize with fallback");
 
@@ -643,10 +653,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        Some("https://example.test/pr/2"),
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/2"),
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("first fallback normalize");
     let second = normalize_sor_emitted_facts_fixture(
@@ -654,10 +666,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        Some("https://example.test/pr/2"),
-        "pr_open",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/2"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("second fallback normalize");
 
@@ -687,10 +701,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        Some("https://example.test/pr/3"),
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/3"),
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("first empty-body fallback normalize");
     let second = normalize_sor_emitted_facts_fixture(
@@ -698,10 +714,12 @@ review_results:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        Some("https://example.test/pr/3"),
-        "pr_open",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/3"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("second empty-body fallback normalize");
 
@@ -731,10 +749,12 @@ verification_summary:
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        None,
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("normalize without srp front matter");
 
@@ -753,10 +773,12 @@ fn sor_emitted_facts_parse_review_truth_from_crlf_front_matter() {
         &["docs/example.md".to_string()],
         &["git diff --check".to_string()],
         review,
-        "PASS",
-        None,
-        "worktree_only",
-        false,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
     )
     .expect("normalize crlf srp front matter");
 


### PR DESCRIPTION
Closes #4420

## Summary
Implemented the `#4420` SOR-fact emission slice inside the native finish path.
The work adds deterministic machine-readable `sor_facts` emission for observed
validation, review, finish, and integration truth while preserving fail-closed
behavior for skipped validation, non-YAML verification-summary bodies, empty
summary bodies, duplicate fallback passes, and SRP front-matter variants.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified formatting on the touched Rust surfaces.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_merge_review_validation_and_pr_publication_truth -- --nocapture`
    Verified emitted SOR facts merge validation, review, PR URL, and
    integration truth in the happy-path case.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_merge_is_idempotent -- --nocapture`
    Verified repeated merge passes preserve stable output.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_record_not_run_validation_truth_when_checks_are_skipped -- --nocapture`
    Verified skipped finish validation emits `NOT_RUN` truth instead of `PASS`.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_fallback_preserves_non_yaml_summary_and_appends_machine_readable_block -- --nocapture`
    Verified non-YAML verification-summary bodies fall back to a machine-readable
    SOR-facts block instead of failing finish-time emission.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_fallback_replaces_existing_machine_readable_block_instead_of_appending -- --nocapture`
    Verified repeated fallback writes replace the machine-readable block rather
    than appending duplicates.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_fallback_is_idempotent_for_initially_empty_summary_body -- --nocapture`
    Verified empty verification-summary bodies stay idempotent across repeated
    fallback emission passes.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_default_review_truth_when_srp_front_matter_is_absent -- --nocapture`
    Verified review facts fall back truthfully when SRP front matter is absent.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_parse_review_truth_from_crlf_front_matter -- --nocapture`
    Verified CRLF SRP front matter still yields truthful review facts.
  - `git diff --check`
    Verified whitespace and patch hygiene.
- Results:
  - PASS: all focused `sor_emitted_facts_*` tests listed above completed
    successfully.
  - PASS: `cargo fmt --manifest-path adl/Cargo.toml --all`.
  - PASS: `git diff --check`.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4420__v0-91-6-tools-sor-emit-sor-facts-from-validation-review-and-finish-events/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4420__v0-91-6-tools-sor-emit-sor-facts-from-validation-review-and-finish-events/sor.md
- Idempotency-Key: v0-91-6-tools-sor-emit-sor-facts-from-validation-review-and-finish-events-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4420-v0-91-6-tools-sor-emit-sor-facts-from-validation-review-and-finish-events-sip-md-adl-v0-91-6-tasks-issue-4420-v0-91-6-tools-sor-emit-sor-facts-from-validation-review-and-finish-events-sor-md