### PR TITLE
[v0.91.6][tools][metrics] Add native host-integrated goal snapshot capture for lifecycle accounting

### DIFF
--- a/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
 from typing import Any
 
 
@@ -65,9 +68,6 @@ def epoch_seconds_to_iso(value: Any) -> str | None:
 
 
 def parse_codex_goal_tool_snapshot(path: str) -> dict[str, Any]:
-    import json
-    from pathlib import Path
-
     payload = json.loads(Path(path).read_text())
     goal = payload.get("goal")
     if not isinstance(goal, dict):
@@ -104,6 +104,135 @@ def parse_codex_goal_tool_snapshot(path: str) -> dict[str, Any]:
         "active_work_seconds_raw": str(time_used_raw) if isinstance(time_used_raw, int) else "unknown",
         "total_tokens_raw": str(tokens_used_raw) if isinstance(tokens_used_raw, int) else "unknown",
     }
+
+
+def extract_first_json_object(raw: str) -> dict[str, Any] | None:
+    text = raw.strip()
+    if not text:
+        return None
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def extract_issue_numbers_from_text(raw: str | None) -> set[int]:
+    if not isinstance(raw, str):
+        return set()
+    return {
+        int(match.group(1))
+        for match in re.finditer(r"(?<!\w)(?:issue\s*)?#(\d+)\b", raw, flags=re.IGNORECASE)
+    }
+
+
+def codex_goal_payload_matches_issue_number(payload: dict[str, Any], issue_number: int | None) -> bool:
+    if issue_number is None:
+        return True
+    goal = payload.get("goal")
+    if not isinstance(goal, dict):
+        return False
+    objective_issue_numbers = extract_issue_numbers_from_text(goal.get("objective"))
+    return issue_number in objective_issue_numbers
+
+
+def find_codex_session_transcript(
+    thread_id: str | None,
+    session_root: str,
+    *,
+    issue_number: int | None = None,
+) -> str | None:
+    root = Path(session_root).expanduser()
+    if not root.exists():
+        return None
+    if thread_id:
+        candidates = sorted(root.rglob(f"*{thread_id}*.jsonl"), key=lambda path: path.stat().st_mtime, reverse=True)
+    else:
+        candidates = sorted(root.rglob("*.jsonl"), key=lambda path: path.stat().st_mtime, reverse=True)
+    for candidate in candidates:
+        payload = load_codex_goal_payload_from_session_transcript(
+            str(candidate),
+            thread_id=thread_id,
+            issue_number=issue_number,
+        )
+        if payload is not None:
+            return str(candidate)
+    return None
+
+
+def load_codex_goal_payload_from_session_transcript(
+    transcript_path: str,
+    *,
+    thread_id: str | None = None,
+    issue_number: int | None = None,
+) -> dict[str, Any] | None:
+    transcript = Path(transcript_path)
+    if not transcript.exists():
+        return None
+
+    goal_call_ids: set[str] = set()
+    latest_payload: dict[str, Any] | None = None
+    for raw_line in transcript.read_text().splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            line = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        payload = line.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        item = payload.get("item")
+        if isinstance(item, dict):
+            item_type = item.get("type")
+            if item_type == "function_call" and item.get("name") == "get_goal":
+                call_id = item.get("call_id")
+                if isinstance(call_id, str):
+                    goal_call_ids.add(call_id)
+                continue
+            if item_type == "function_call_output":
+                call_id = item.get("call_id")
+                if goal_call_ids and call_id not in goal_call_ids:
+                    continue
+                output_text = item.get("output")
+                if not isinstance(output_text, str):
+                    output_text = payload.get("output")
+                if not isinstance(output_text, str):
+                    continue
+                candidate = extract_first_json_object(output_text)
+                if not isinstance(candidate, dict):
+                    continue
+                goal = candidate.get("goal")
+                if not isinstance(goal, dict):
+                    continue
+                if thread_id is not None and goal.get("threadId") not in {thread_id, None}:
+                    continue
+                if not codex_goal_payload_matches_issue_number(candidate, issue_number):
+                    continue
+                latest_payload = candidate
+                continue
+
+        output_text = payload.get("output")
+        if not isinstance(output_text, str):
+            continue
+        candidate = extract_first_json_object(output_text)
+        if not isinstance(candidate, dict):
+            continue
+        goal = candidate.get("goal")
+        if not isinstance(goal, dict):
+            continue
+        if thread_id is not None and goal.get("threadId") not in {thread_id, None}:
+            continue
+        if not codex_goal_payload_matches_issue_number(candidate, issue_number):
+            continue
+        latest_payload = candidate
+    return latest_payload
 
 
 def default_goal_metrics_summary() -> dict[str, Any]:
@@ -310,6 +439,50 @@ def build_issue_goal_metrics_record_from_codex_goal_snapshot(
         model_ref=model_ref,
         session_ref=session_ref or (f"codex-thread:{thread_id}" if isinstance(thread_id, str) else None),
         thread_id=thread_id if isinstance(thread_id, str) else None,
+    )
+
+
+def build_unknown_issue_goal_metrics_record(
+    *,
+    issue_number: int,
+    capture_stage: str,
+    raw_log_path: str,
+    issue_goal_ref: str | None,
+    sprint_goal_ref: str | None,
+    goal_metrics_rollup_ref: str | None,
+    metrics_confidence: str,
+    completion_state: str,
+    model_ref: str | None,
+    session_ref: str | None,
+    thread_id: str | None,
+) -> dict[str, Any]:
+    return build_issue_goal_metrics_record(
+        sprint_issue_number=None,
+        issue_number=issue_number,
+        capture_stage=capture_stage,
+        data_source="unknown",
+        raw_log_path=raw_log_path,
+        recorded_at=iso_now_utc(),
+        issue_goal_ref=issue_goal_ref,
+        sprint_goal_ref=sprint_goal_ref,
+        goal_metrics_rollup_ref=goal_metrics_rollup_ref,
+        goal_id=None,
+        goal_id_state="not_available",
+        started_at=None,
+        completed_at=None,
+        elapsed_seconds_raw="unknown",
+        active_work_seconds_raw="unknown",
+        validation_seconds_raw="unknown",
+        pr_wait_seconds_raw="unknown",
+        ci_wait_seconds_raw="unknown",
+        total_tokens_raw="unknown",
+        prompt_tokens_raw="unknown",
+        completion_tokens_raw="unknown",
+        metrics_confidence=metrics_confidence,
+        completion_state=completion_state,
+        model_ref=model_ref,
+        session_ref=session_ref,
+        thread_id=thread_id,
     )
 
 

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from issue_goal_metrics import (
+    build_issue_goal_metrics_record_from_codex_goal_snapshot,
+    build_unknown_issue_goal_metrics_record,
+    find_codex_session_transcript,
+    load_codex_goal_payload_from_session_transcript,
+    summarize_issue_goal_metrics,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture canonical issue goal-metrics artifacts from the host Codex session transcript."
+    )
+    parser.add_argument("--issue-number", type=int, required=True)
+    parser.add_argument("--artifacts-dir", required=True)
+    parser.add_argument("--capture-stage", required=True)
+    parser.add_argument("--issue-goal-ref")
+    parser.add_argument("--sprint-goal-ref")
+    parser.add_argument("--goal-metrics-rollup-ref")
+    parser.add_argument("--metrics-confidence", default="unknown")
+    parser.add_argument("--completion-state-override")
+    parser.add_argument("--model-ref")
+    parser.add_argument("--session-ref")
+    parser.add_argument("--thread-id", default=os.environ.get("CODEX_THREAD_ID"))
+    parser.add_argument("--session-root", default=os.path.expanduser("~/.codex/sessions"))
+    parser.add_argument("--transcript-path")
+    return parser.parse_args()
+
+
+def snapshot_filename(issue_number: int, capture_stage: str) -> str:
+    if capture_stage == "issue_start":
+        return f"issue-{issue_number}-goal-state.json"
+    return f"issue-{issue_number}-goal-state-{capture_stage}.json"
+
+
+def load_existing_records(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def main() -> int:
+    args = parse_args()
+    artifacts_dir = Path(args.artifacts_dir)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    transcript_path = args.transcript_path
+    if transcript_path is None:
+        transcript_path = find_codex_session_transcript(
+            args.thread_id,
+            args.session_root,
+            issue_number=args.issue_number,
+        )
+
+    goal_payload = None
+    if transcript_path is not None:
+        goal_payload = load_codex_goal_payload_from_session_transcript(
+            transcript_path,
+            thread_id=args.thread_id,
+            issue_number=args.issue_number,
+        )
+
+    raw_log_path = transcript_path or args.session_root
+    if goal_payload is not None:
+        snapshot_path = artifacts_dir / snapshot_filename(args.issue_number, args.capture_stage)
+        snapshot_path.write_text(json.dumps(goal_payload, indent=2) + "\n")
+        with NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            json.dump(goal_payload, handle)
+            handle.write("\n")
+            temp_snapshot_path = handle.name
+        try:
+            record = build_issue_goal_metrics_record_from_codex_goal_snapshot(
+                issue_number=args.issue_number,
+                capture_stage=args.capture_stage,
+                goal_state_path=temp_snapshot_path,
+                raw_log_path=raw_log_path,
+                issue_goal_ref=args.issue_goal_ref,
+                sprint_goal_ref=args.sprint_goal_ref,
+                goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+                metrics_confidence=args.metrics_confidence,
+                completion_state_override=args.completion_state_override,
+                model_ref=args.model_ref,
+                session_ref=args.session_ref,
+            )
+        finally:
+            os.unlink(temp_snapshot_path)
+    else:
+        record = build_unknown_issue_goal_metrics_record(
+            issue_number=args.issue_number,
+            capture_stage=args.capture_stage,
+            raw_log_path=raw_log_path,
+            issue_goal_ref=args.issue_goal_ref,
+            sprint_goal_ref=args.sprint_goal_ref,
+            goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+            metrics_confidence=args.metrics_confidence,
+            completion_state=args.completion_state_override or "unknown",
+            model_ref=args.model_ref,
+            session_ref=args.session_ref,
+            thread_id=args.thread_id,
+        )
+
+    jsonl_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics.jsonl"
+    records = [
+        existing
+        for existing in load_existing_records(jsonl_path)
+        if existing.get("capture_stage") != args.capture_stage
+    ]
+    records.append(record)
+    records.sort(key=lambda existing: (existing.get("capture_stage") or "", existing.get("recorded_at") or ""))
+    jsonl_path.write_text("".join(json.dumps(existing, sort_keys=True) + "\n" for existing in records))
+
+    summary = summarize_issue_goal_metrics(records, raw_log_path)
+    summary_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics-summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    print(
+        json.dumps(
+            {
+                "status": "recorded",
+                "issue_number": args.issue_number,
+                "capture_stage": args.capture_stage,
+                "transcript_path": transcript_path,
+                "summary_path": str(summary_path),
+                "data_source": record["data_source"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1706,3 +1706,166 @@ assert summary["token_usage"]["total_tokens"] == 3000
 assert summary["elapsed_seconds"] == 30
 assert summary["completion_state"] == "completed"
 PY
+
+codex_session_root="${tmpdir}/codex-sessions"
+mkdir -p "${codex_session_root}/2026/06/23"
+codex_session_transcript="${codex_session_root}/2026/06/23/rollout-2026-06-23T00-00-00-thread-4442.jsonl"
+cat >"${codex_session_transcript}" <<'JSONL'
+{"type":"response_item","payload":{"item":{"type":"function_call","name":"get_goal","call_id":"call_goal_4442"}}}
+{"type":"response_item","payload":{"item":{"type":"function_call_output","call_id":"call_goal_4442","output":"{\"goal\":{\"threadId\":\"thread-4442\",\"objective\":\"Issue #4442 session\",\"status\":\"active\",\"tokensUsed\":12345,\"timeUsedSeconds\":67,\"createdAt\":1782230400,\"updatedAt\":1782230468}}"}}}
+JSONL
+
+codex_session_artifacts_dir="${tmpdir}/issue-4442-artifacts/goal_metrics"
+codex_session_result="$(env -u CODEX_THREAD_ID python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4442 \
+  --artifacts-dir "${codex_session_artifacts_dir}" \
+  --capture-stage issue_start \
+  --issue-goal-ref "goal:v0.91.6:issue:4442" \
+  --metrics-confidence high \
+  --model-ref "gpt-5-codex" \
+  --session-root "${codex_session_root}")"
+python3 - "${codex_session_result}" "${codex_session_artifacts_dir}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(sys.argv[1])
+assert result["status"] == "recorded"
+assert result["data_source"] == "codex_goal_tool"
+artifacts_dir = Path(sys.argv[2])
+snapshot = json.loads((artifacts_dir / "issue-4442-goal-state.json").read_text())
+assert snapshot["goal"]["threadId"] == "thread-4442"
+rows = [
+    json.loads(line)
+    for line in (artifacts_dir / "issue-4442-goal-metrics.jsonl").read_text().splitlines()
+    if line.strip()
+]
+assert len(rows) == 1
+record = rows[0]
+assert record["capture_stage"] == "issue_start"
+assert record["data_source"] == "codex_goal_tool"
+assert record["thread_id"] == "thread-4442"
+assert record["active_work_seconds"] == 67
+assert record["token_usage"]["total_tokens"] == 12345
+summary = json.loads((artifacts_dir / "issue-4442-goal-metrics-summary.json").read_text())
+assert summary["selected_stage"] == "issue_start"
+assert summary["data_source"] == "codex_goal_tool"
+assert summary["thread_id"] == "thread-4442"
+assert summary["active_work_seconds"] == 67
+assert summary["token_usage"]["total_tokens"] == 12345
+PY
+
+codex_mismatch_root="${tmpdir}/codex-sessions-mismatch"
+mkdir -p "${codex_mismatch_root}/2026/06/23"
+codex_mismatch_transcript="${codex_mismatch_root}/2026/06/23/rollout-2026-06-23T00-00-00-thread-4442-mismatch.jsonl"
+cat >"${codex_mismatch_transcript}" <<'JSONL'
+{"type":"response_item","payload":{"item":{"type":"function_call","name":"get_goal","call_id":"call_goal_4442_mismatch"}}}
+{"type":"response_item","payload":{"item":{"type":"function_call_output","call_id":"call_goal_4442_mismatch","output":"{\"goal\":{\"threadId\":\"thread-4442\",\"objective\":\"Issue #9999 session\",\"status\":\"active\",\"tokensUsed\":12345,\"timeUsedSeconds\":67,\"createdAt\":1782230400,\"updatedAt\":1782230468}}"}}}
+JSONL
+
+codex_mismatch_artifacts_dir="${tmpdir}/issue-4442-mismatch-artifacts/goal_metrics"
+codex_mismatch_result="$(python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4442 \
+  --artifacts-dir "${codex_mismatch_artifacts_dir}" \
+  --capture-stage pr_publication \
+  --issue-goal-ref "goal:v0.91.6:issue:4442" \
+  --metrics-confidence high \
+  --thread-id "thread-4442" \
+  --session-root "${codex_mismatch_root}")"
+python3 - "${codex_mismatch_result}" "${codex_mismatch_artifacts_dir}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(sys.argv[1])
+assert result["status"] == "recorded"
+assert result["data_source"] == "unknown"
+artifacts_dir = Path(sys.argv[2])
+rows = [
+    json.loads(line)
+    for line in (artifacts_dir / "issue-4442-goal-metrics.jsonl").read_text().splitlines()
+    if line.strip()
+]
+assert len(rows) == 1
+record = rows[0]
+assert record["capture_stage"] == "pr_publication"
+assert record["data_source"] == "unknown"
+assert record["thread_id"] == "thread-4442"
+PY
+
+codex_sep_root="${tmpdir}/codex-sessions-sep"
+mkdir -p "${codex_sep_root}/2026/06/23"
+codex_sep_transcript="${codex_sep_root}/2026/06/23/rollout-2026-06-23T00-00-00-thread-4442-sep.jsonl"
+cat >"${codex_sep_transcript}" <<'JSONL'
+{"type":"response_item","payload":{"item":{"type":"function_call","name":"get_goal","call_id":"call_goal_4442_sep"}}}
+{"type":"response_item","payload":{"item":{"type":"function_call_output","call_id":"call_goal_4442_sep","output":"{\"goal\":{\"threadId\":\"thread-4442-sep\",\"objective\":\"#3001 #4442 child session objective\",\"status\":\"active\",\"tokensUsed\":4442,\"timeUsedSeconds\":44,\"createdAt\":1782230400,\"updatedAt\":1782230444}}"}}}
+JSONL
+
+codex_sep_artifacts_dir="${tmpdir}/issue-4442-sep-artifacts/goal_metrics"
+codex_sep_result="$(env -u CODEX_THREAD_ID python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4442 \
+  --artifacts-dir "${codex_sep_artifacts_dir}" \
+  --capture-stage review_handoff \
+  --issue-goal-ref "goal:v0.91.6:issue:4442" \
+  --metrics-confidence high \
+  --session-root "${codex_sep_root}")"
+python3 - "${codex_sep_result}" "${codex_sep_artifacts_dir}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(sys.argv[1])
+assert result["status"] == "recorded"
+assert result["data_source"] == "codex_goal_tool"
+artifacts_dir = Path(sys.argv[2])
+rows = [
+    json.loads(line)
+    for line in (artifacts_dir / "issue-4442-goal-metrics.jsonl").read_text().splitlines()
+    if line.strip()
+]
+assert len(rows) == 1
+record = rows[0]
+assert record["capture_stage"] == "review_handoff"
+assert record["data_source"] == "codex_goal_tool"
+assert record["thread_id"] == "thread-4442-sep"
+assert record["active_work_seconds"] == 44
+assert record["token_usage"]["total_tokens"] == 4442
+PY
+
+codex_unknown_artifacts_dir="${tmpdir}/issue-4443-artifacts/goal_metrics"
+codex_unknown_result="$(python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4443 \
+  --artifacts-dir "${codex_unknown_artifacts_dir}" \
+  --capture-stage pr_publication \
+  --issue-goal-ref "goal:v0.91.6:issue:4443" \
+  --metrics-confidence unknown \
+  --thread-id "thread-missing" \
+  --session-root "${tmpdir}/missing-codex-sessions")"
+python3 - "${codex_unknown_result}" "${codex_unknown_artifacts_dir}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(sys.argv[1])
+assert result["status"] == "recorded"
+assert result["data_source"] == "unknown"
+artifacts_dir = Path(sys.argv[2])
+rows = [
+    json.loads(line)
+    for line in (artifacts_dir / "issue-4443-goal-metrics.jsonl").read_text().splitlines()
+    if line.strip()
+]
+assert len(rows) == 1
+record = rows[0]
+assert record["capture_stage"] == "pr_publication"
+assert record["data_source"] == "unknown"
+assert record["elapsed_availability"] == "unknown"
+assert record["active_work_availability"] == "unknown"
+assert record["token_usage"]["total_availability"] == "unknown"
+summary = json.loads((artifacts_dir / "issue-4443-goal-metrics-summary.json").read_text())
+assert summary["selected_stage"] == "pr_publication"
+assert summary["data_source"] == "unknown"
+assert summary["thread_id"] == "thread-missing"
+assert summary["active_work_availability"] == "unknown"
+assert summary["token_usage"]["total_availability"] == "unknown"
+PY

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -156,15 +156,12 @@ Use `update_goal` only for truthful terminal state:
   progress cannot continue without user input or an external state change
 
 When issue-local time/token accounting matters, preserve a durable local goal
-snapshot before the live goal disappears:
-
-1. save the `get_goal` tool payload to a temporary local path
-2. normalize it into the issue task bundle's canonical goal-metrics artifact
-   set immediately after the lifecycle event you are recording:
+snapshot from the host Codex session transcript before the live goal disappears.
+Use the transcript-backed collector immediately after the lifecycle event you
+are recording:
 
 ```bash
-python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py \
-  --goal-state /tmp/issue-<n>-goal-state.json \
+python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py \
   --issue-number <n> \
   --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics \
   --capture-stage issue_start \
@@ -175,20 +172,24 @@ Record the same artifact set again at later lifecycle checkpoints such as
 `pr_publication`:
 
 ```bash
-python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py \
-  --goal-state /tmp/issue-<n>-goal-state-pr-publication.json \
+python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py \
   --issue-number <n> \
   --artifacts-dir .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics \
   --capture-stage pr_publication \
   --issue-goal-ref "goal:<version>:issue:<n>"
 ```
 
-This helper uses canonical stage-specific snapshot filenames under the task
-bundle, rewrites the summary in place, and replaces any older row for the same
-issue/stage instead of appending duplicates. Use the resulting summary artifact
-as the preferred `SOR` source ref when `Goal metrics data source` is
-`codex_goal_tool`. If no authoritative snapshot exists, keep the metrics fields
-`unknown` rather than fabricating values.
+The transcript-backed helper uses canonical stage-specific snapshot filenames
+under the task bundle when a durable `get_goal` payload is available, rewrites
+the summary in place, and replaces any older row for the same issue/stage
+instead of appending duplicates. Use the resulting summary artifact as the
+preferred `SOR` source ref when `Goal metrics data source` is
+`codex_goal_tool`. If no authoritative transcript-backed snapshot exists, the
+helper still writes the canonical metrics record with `data_source: unknown`
+and preserves metric fields as `unknown` rather than fabricating values.
+The helper validates that the discovered goal objective matches the target
+issue number and falls back to `unknown` instead of attaching a snapshot from a
+different issue or sprint thread.
 
 ## 5) Implement
 


### PR DESCRIPTION
## Summary
- add a transcript-backed helper that captures canonical issue goal-metrics artifacts directly from Codex session transcripts
- fail closed when the discovered goal objective does not match the target issue, while still preserving truthful `unknown` metrics records
- support documented SEP-style sprint-plus-child objectives and replace the manual temp-file workflow in the default docs

## Validation
- `bash adl/tools/test_sprint_conductor_helpers.sh`
- `env -u CODEX_THREAD_ID python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py --issue-number 4442 --artifacts-dir \"$(mktemp -d)/goal_metrics\" --capture-stage issue_start --issue-goal-ref \"goal:v0.91.6:issue:4442\" --metrics-confidence high --model-ref \"gpt-5-codex\"`

## Issue
- Closes #4442
