### PR TITLE
[v0.91.6][tools][github] Restore operator-default token discovery for repo-native workflow commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,10 @@ These rules are mandatory for ADL issue work.
    - GitHub operations should use the shared token resolver. When an explicit
      token-file source is needed, use
      `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token`. Never print, copy,
-     commit, or expose the token contents.
+     commit, or expose the token contents. When no explicit override is set,
+     repo-native GitHub commands may also discover the operator-approved
+     default token file at `$HOME/keys/github.token`; explicit environment
+     sources still take precedence.
    - Provider credentials, when available, may also be sourced from
      operator-approved files outside the repo under `$HOME/keys/`. Do not scan,
      print, copy, commit, or expose that directory or file contents. Map the

--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -385,7 +385,11 @@ mod tests {
 
     fn temp_home_dir() -> PathBuf {
         let unique = TEMP_HOME_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!("adl-github-token-test-{}-{}", std::process::id(), unique));
+        let path = std::env::temp_dir().join(format!(
+            "adl-github-token-test-{}-{}",
+            std::process::id(),
+            unique
+        ));
         let _ = std::fs::remove_dir_all(&path);
         std::fs::create_dir_all(&path).expect("temp home dir");
         path

--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -10,6 +10,7 @@ pub(crate) const GH_TOKEN_ENV: &str = "GH_TOKEN";
 pub(crate) const ADL_GITHUB_TOKEN_FILE_ENV: &str = "ADL_GITHUB_TOKEN_FILE";
 pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE";
 pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT";
+pub(crate) const DEFAULT_GITHUB_TOKEN_FILE_RELATIVE_PATH: &str = "keys/github.token";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GithubTokenSource {
@@ -17,6 +18,7 @@ pub(crate) enum GithubTokenSource {
     GhToken,
     TokenFile,
     Keychain,
+    DefaultTokenFile,
 }
 
 impl GithubTokenSource {
@@ -26,6 +28,7 @@ impl GithubTokenSource {
             Self::GhToken => GH_TOKEN_ENV,
             Self::TokenFile => ADL_GITHUB_TOKEN_FILE_ENV,
             Self::Keychain => ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV,
+            Self::DefaultTokenFile => "$HOME/keys/github.token",
         }
     }
 
@@ -75,6 +78,7 @@ struct TokenResolutionKey {
     token_file: Option<String>,
     keychain_service: Option<String>,
     keychain_account: Option<String>,
+    implicit_default_token_file: Option<String>,
 }
 
 #[derive(Clone)]
@@ -116,14 +120,64 @@ fn resolve_github_token_from_env(reader: &dyn TokenReader) -> Result<Option<Reso
 
 impl TokenResolutionKey {
     fn from_env() -> Self {
+        let github_token = std::env::var(GITHUB_TOKEN_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let gh_token = std::env::var(GH_TOKEN_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let token_file = std::env::var(ADL_GITHUB_TOKEN_FILE_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let keychain_service = std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let keychain_account = std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
         Self {
-            github_token: std::env::var(GITHUB_TOKEN_ENV).ok(),
-            gh_token: std::env::var(GH_TOKEN_ENV).ok(),
-            token_file: std::env::var(ADL_GITHUB_TOKEN_FILE_ENV).ok(),
-            keychain_service: std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV).ok(),
-            keychain_account: std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV).ok(),
+            github_token,
+            gh_token,
+            token_file,
+            keychain_service,
+            keychain_account,
+            implicit_default_token_file: default_github_token_file_path()
+                .filter(|_| {
+                    std::env::var(GITHUB_TOKEN_ENV)
+                        .ok()
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                        .is_none()
+                        && std::env::var(GH_TOKEN_ENV)
+                            .ok()
+                            .map(|value| value.trim().to_string())
+                            .filter(|value| !value.is_empty())
+                            .is_none()
+                        && std::env::var(ADL_GITHUB_TOKEN_FILE_ENV)
+                            .ok()
+                            .map(|value| value.trim().to_string())
+                            .filter(|value| !value.is_empty())
+                            .is_none()
+                        && std::env::var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV)
+                            .ok()
+                            .map(|value| value.trim().to_string())
+                            .filter(|value| !value.is_empty())
+                            .is_none()
+                })
+                .map(|path| path.display().to_string()),
         }
     }
+}
+
+fn default_github_token_file_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let path = PathBuf::from(home).join(DEFAULT_GITHUB_TOKEN_FILE_RELATIVE_PATH);
+    path.is_file().then_some(path)
 }
 
 fn resolve_uncached(
@@ -170,6 +224,18 @@ fn resolve_uncached(
                 .filter(|v| !v.is_empty()),
         )?;
         return Ok(ResolvedGithubToken::new(value, GithubTokenSource::Keychain));
+    }
+    if let Some(path) = key
+        .implicit_default_token_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        let value = reader.read_token_file(&PathBuf::from(path))?;
+        return Ok(ResolvedGithubToken::new(
+            value,
+            GithubTokenSource::DefaultTokenFile,
+        ));
     }
     Ok(None)
 }
@@ -264,6 +330,9 @@ mod tests {
     use crate::cli::tests::env_lock as cli_env_lock;
     use std::cell::Cell;
     use std::cell::RefCell;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEMP_HOME_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     struct StubReader {
         file_value: &'static str,
@@ -312,6 +381,14 @@ mod tests {
             std::env::remove_var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV);
         }
         *TOKEN_CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap() = None;
+    }
+
+    fn temp_home_dir() -> PathBuf {
+        let unique = TEMP_HOME_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("adl-github-token-test-{}-{}", std::process::id(), unique));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("temp home dir");
+        path
     }
 
     #[test]
@@ -407,5 +484,98 @@ mod tests {
         assert!(text.contains("ordinary"));
         assert!(text.contains("{\"token\":\"<redacted>\"}"));
         assert!(text.contains("\"<redacted>\""));
+    }
+
+    #[test]
+    fn resolver_uses_default_token_file_when_no_explicit_source_is_configured() {
+        let _guard = env_lock();
+        clear_env();
+        let temp_home = temp_home_dir();
+        let original_home = std::env::var_os("HOME");
+        let keys_dir = temp_home.join("keys");
+        std::fs::create_dir_all(&keys_dir).expect("keys dir");
+        let token_path = keys_dir.join("github.token");
+        std::fs::write(&token_path, "default-token\n").expect("token file");
+        let reader = StubReader::new("default-file-token", "keychain-token");
+        unsafe {
+            std::env::set_var("HOME", &temp_home);
+        }
+
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "default-file-token");
+        assert_eq!(token.source(), GithubTokenSource::DefaultTokenFile);
+        assert_eq!(reader.file_reads.get(), 1);
+        assert_eq!(reader.keychain_reads.get(), 0);
+        clear_env();
+        unsafe {
+            match original_home {
+                Some(ref value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(temp_home);
+    }
+
+    #[test]
+    fn resolver_prefers_explicit_keychain_over_implicit_default_file() {
+        let _guard = env_lock();
+        clear_env();
+        let temp_home = temp_home_dir();
+        let original_home = std::env::var_os("HOME");
+        let keys_dir = temp_home.join("keys");
+        std::fs::create_dir_all(&keys_dir).expect("keys dir");
+        std::fs::write(keys_dir.join("github.token"), "default-token\n").expect("token file");
+        let reader = StubReader::new("default-file-token", "keychain-token");
+        unsafe {
+            std::env::set_var("HOME", &temp_home);
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "adl-github-token");
+        }
+
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "keychain-token");
+        assert_eq!(token.source(), GithubTokenSource::Keychain);
+        assert_eq!(reader.file_reads.get(), 0);
+        assert_eq!(reader.keychain_reads.get(), 1);
+        clear_env();
+        unsafe {
+            match original_home {
+                Some(ref value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(temp_home);
+    }
+
+    #[test]
+    fn resolver_treats_blank_explicit_values_as_absent_and_falls_back_to_default_file() {
+        let _guard = env_lock();
+        clear_env();
+        let temp_home = temp_home_dir();
+        let original_home = std::env::var_os("HOME");
+        let keys_dir = temp_home.join("keys");
+        std::fs::create_dir_all(&keys_dir).expect("keys dir");
+        std::fs::write(keys_dir.join("github.token"), "default-token\n").expect("token file");
+        let reader = StubReader::new("default-file-token", "keychain-token");
+        unsafe {
+            std::env::set_var("HOME", &temp_home);
+            std::env::set_var(GITHUB_TOKEN_ENV, "   ");
+            std::env::set_var(GH_TOKEN_ENV, "");
+            std::env::set_var(ADL_GITHUB_TOKEN_FILE_ENV, " ");
+            std::env::set_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, "");
+        }
+
+        let token = resolve_github_token_from_env(&reader).unwrap().unwrap();
+        assert_eq!(token.value(), "default-file-token");
+        assert_eq!(token.source(), GithubTokenSource::DefaultTokenFile);
+        assert_eq!(reader.file_reads.get(), 1);
+        assert_eq!(reader.keychain_reads.get(), 0);
+        clear_env();
+        unsafe {
+            match original_home {
+                Some(ref value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(temp_home);
     }
 }

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -621,7 +621,7 @@ fn github_credential_preflight_hint(
     config: &crate::cli::pr_cmd::github_client::AdlGithubClientConfig,
 ) -> String {
     match config.token_source {
-        None => "credential_status=missing_token; configure GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE before live C-SDLC GitHub operations; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
+        None => "credential_status=missing_token; configure GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE before live C-SDLC GitHub operations, or provide the approved default token file at $HOME/keys/github.token; load the token from an operator-approved secret source and pass it only to the ADL command environment without echoing it; do not fall back to direct gh commands".to_string(),
         Some(source) => format!(
             "credential_status=token_present source={}; ADL_GITHUB_CLIENT=gh is not a supported read or mutation fallback for covered operations; use ADL_GITHUB_CLIENT=auto or ADL_GITHUB_CLIENT=octocrab",
             source.env_name()

--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -231,7 +231,7 @@ fn parse_disable_gh_fallback(raw: Option<&str>) -> Result<bool, AdlGithubClientE
 }
 
 fn missing_token_message() -> &'static str {
-    "octocrab GitHub transport requires GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, or ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE"
+    "octocrab GitHub transport requires GITHUB_TOKEN, GH_TOKEN, ADL_GITHUB_TOKEN_FILE, ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE, or an approved default token file at $HOME/keys/github.token"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -64,7 +64,10 @@ Minimum init contract:
 ## 2) Confirm GitHub Issue Exists And Inspect Live Issue Truth
 
 Live GitHub issue operations use the ADL typed GitHub transport. Configure one
-shared token source for the ADL command environment without printing the token:
+shared token source for the ADL command environment without printing the token.
+When no explicit environment override is present, the resolver also accepts the
+operator-approved default token file at `$HOME/keys/github.token`. Explicit
+environment sources remain higher-precedence. Supported explicit sources:
 `GITHUB_TOKEN`, `GH_TOKEN`, `ADL_GITHUB_TOKEN_FILE`, or
 `ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`. The keychain source uses the macOS
 `security find-generic-password` command; when using it, optionally set


### PR DESCRIPTION
## Summary
- restore operator-default GitHub token discovery through the shared resolver by auto-discovering the approved `$HOME/keys/github.token` file when no explicit override is configured
- keep precedence deterministic and treat blank explicit env vars as absent so they do not suppress the default-file fallback
- update diagnostics and workflow docs so the implicit default-file source is reported truthfully

## Validation
- `cargo test --manifest-path adl/Cargo.toml --bin adl 'cli::github_token::tests::' -- --nocapture --test-threads=1`
- `bash adl/tools/pr.sh issue view 4454 --json`
- `bash adl/tools/pr.sh issue edit 4454 --title "[v0.91.6][tools][github] Restore operator-default token discovery for repo-native workflow commands" --json`

## Notes
- `pr.sh init 4454 --slug restore-operator-default-token-discovery --version v0.91.6` still enters the separate repeated-read liveness problem already under repair in the lifecycle-hang tranche. I used a manual issue worktree bind for this issue and kept that limitation explicit rather than broadening this fix.

## Issue
- Closes #4454
