### PR TITLE
[v0.91.6][csdlc][readiness] Enforce pre-start card completeness and issue token-budget gates

### DIFF
--- a/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+++ b/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
@@ -89,6 +89,34 @@ fn classify_vpp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             ),
         );
     }
+    if !has_explicit_vpp_validation_budget(&text) {
+        return card_stage(
+            repo_root,
+            "VPP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("vpp-editor"),
+                "VPP must record explicit validation seconds and token budgets before execution binding.",
+            ),
+        );
+    }
+    if !has_issue_specific_vpp_validation_plan(&text) {
+        return card_stage(
+            repo_root,
+            "VPP",
+            path,
+            stage_truth(
+                "scaffold",
+                false,
+                false,
+                Some("vpp-editor"),
+                "VPP validation commands are still generic planning guidance and must be issue-specific before execution binding.",
+            ),
+        );
+    }
     if ["ready", "reviewed", "approved"].contains(&status.trim_matches('"')) {
         return card_stage(
             repo_root,
@@ -285,6 +313,20 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             ),
         );
     }
+    if !has_explicit_spp_execution_budget(&text) {
+        return card_stage(
+            repo_root,
+            "SPP",
+            path,
+            stage_truth(
+                "active",
+                false,
+                false,
+                Some("spp-editor"),
+                "SPP must record explicit elapsed-seconds and total-token estimates before execution binding.",
+            ),
+        );
+    }
     if ["ready", "reviewed", "approved"].contains(&status.trim_matches('"')) {
         return card_stage(
             repo_root,
@@ -360,6 +402,53 @@ fn has_generic_vpp_design_time_scaffold(text: &str) -> bool {
         || unresolved_failure_policy
         || MARKERS.iter().any(|marker| text.contains(marker))
         || has_truncation_sentinel_line(text)
+}
+
+fn has_explicit_spp_execution_budget(text: &str) -> bool {
+    has_known_metric_field(text, "estimate_elapsed_seconds:")
+        && has_known_metric_field(text, "estimate_total_tokens:")
+}
+
+fn has_explicit_vpp_validation_budget(text: &str) -> bool {
+    has_known_metric_field(text, "planned_validation_seconds:")
+        && has_known_metric_field(text, "planned_validation_tokens:")
+}
+
+fn has_issue_specific_vpp_validation_plan(text: &str) -> bool {
+    let validation_commands =
+        markdown_section_body(text, "Validation Commands").unwrap_or_default();
+    if validation_commands.trim().is_empty() {
+        return false;
+    }
+    let generic_markers = [
+        "Use `workflow-conductor` and the active prompt-template renderer/schema path.",
+        "Use the session ledger before execution and avoid active claimed worktrees.",
+        "Use focused validation, not broad test reflexes, unless touched code requires broader proof.",
+    ];
+    !generic_markers
+        .iter()
+        .any(|marker| validation_commands.contains(marker))
+}
+
+fn has_known_metric_field(text: &str, prefix: &str) -> bool {
+    line_value_after_prefix(text, prefix)
+        .map(|value| {
+            let normalized = value.trim().trim_matches('"');
+            !normalized.is_empty()
+                && !matches!(
+                    normalized,
+                    "unknown" | "not_recorded_yet" | "not_applicable" | "none"
+                )
+        })
+        .unwrap_or(false)
+}
+
+fn markdown_section_body<'a>(text: &'a str, heading: &str) -> Option<&'a str> {
+    let marker = format!("## {heading}");
+    let start = text.find(&marker)?;
+    let rest = &text[start + marker.len()..];
+    let next_heading = rest.find("\n## ").unwrap_or(rest.len());
+    Some(rest[..next_heading].trim())
 }
 
 fn has_truncation_sentinel_line(text: &str) -> bool {

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -112,7 +112,7 @@ fn card_lifecycle_marks_legacy_srp_policy_as_not_finish_ready() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n\n## Review Summary\n\npolicy only\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -138,7 +138,7 @@ fn card_lifecycle_does_not_treat_placeholder_srp_results_as_final() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\nreview_results:\n  findings_status: \"not_run | findings_present | no_findings\"\n  recommended_outcome: \"pass | block | needs_followup | not_run\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- <pass, block, needs_followup, or not_run>\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -162,7 +162,7 @@ fn card_lifecycle_does_not_treat_unknown_srp_result_values_as_final() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"todo\"\n  recommended_outcome: \"ship_it\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- ship_it\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -185,7 +185,7 @@ fn card_lifecycle_allows_explicit_srp_policy_exception() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results_exception: \"explicit policy exception: docs-only no-op review\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\nexplicit policy exception recorded\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -207,7 +207,7 @@ fn card_lifecycle_accepts_pre_review_srp_prompt_without_final_results() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -237,7 +237,7 @@ fn card_lifecycle_does_not_treat_pre_execution_srp_absence_as_final_exception() 
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent until implementation exists\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -260,7 +260,7 @@ fn card_lifecycle_accepts_terminal_structured_review_prompt_exception() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results_exception: \"explicit policy exception: docs-only no-op review\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\nexplicit policy exception recorded\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -299,7 +299,7 @@ fn closed_ready_validation_is_read_only_and_reports_truth_drift() {
             "- stale closeout truth causes a blocking validation error\n- no bundle files are mutated on failure",
         );
     let spp_text = format!(
-            "---\nschema_version: \"0.1\"\nartifact_type: \"structured_planning_prompt\"\nname: \"fixture-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: v0.91.2\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\nstatus: \"reviewed\"\nactivation_state: \"reviewed\"\nplan_revision: 1\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nscope:\n  files:\n    - \".adl/v0.91.2/tasks/{bundle}/sip.md\"\nconstraints:\n  - \"read_only_until_execution_is_approved\"\nconfidence: \"medium\"\nplan_summary: \"Fixture plan for closed-ready validation.\"\nassumptions:\n  - \"The canonical bundle already exists.\"\nproposed_steps:\n  - id: \"step-1\"\n    description: \"Validate closed-ready truth without mutation.\"\n    expected_output: \".adl/v0.91.2/tasks/{bundle}/spp.md\"\n    allowed_mode: \"execution_after_approval\"\ncodex_plan:\n  - step: \"Validate closed-ready truth without mutation.\"\n    status: \"pending\"\naffected_areas:\n  - \"doctor\"\ninvariants_to_preserve:\n  - \"Do not mutate stale closeout truth during validation.\"\nrisks_and_edge_cases:\n  - \"Closed issue bundles can still drift.\"\ntest_strategy:\n  - \"Run the focused doctor regression test.\"\nexecution_handoff: \"Use this artifact as the durable plan-of-record before execution.\"\nrequired_permissions:\n  - \"workspace-write after execution approval\"\nstop_conditions:\n  - \"Stop if validation would mutate the stale bundle.\"\nalternatives_considered:\n  - description: \"Use transient planning only.\"\n    reason_not_chosen: \"That would not leave durable reviewable plan truth.\"\nreview_hooks:\n  - \"Check read-only behavior.\"\nnotes: \"fixture\"\n---\n\n# Structured Plan Prompt\n\n## Plan Summary\n\nFixture plan.\n\n## Codex Plan\n\n1. [pending] Validate closed-ready truth without mutation.\n",
+            "---\nschema_version: \"0.1\"\nartifact_type: \"structured_planning_prompt\"\nname: \"fixture-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: v0.91.2\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\nstatus: \"reviewed\"\nactivation_state: \"reviewed\"\nplan_revision: 1\nestimate_elapsed_seconds: \"60\"\nestimate_total_tokens: \"1200\"\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nscope:\n  files:\n    - \".adl/v0.91.2/tasks/{bundle}/sip.md\"\nconstraints:\n  - \"read_only_until_execution_is_approved\"\nconfidence: \"medium\"\nplan_summary: \"Fixture plan for closed-ready validation.\"\nassumptions:\n  - \"The canonical bundle already exists.\"\nproposed_steps:\n  - id: \"step-1\"\n    description: \"Validate closed-ready truth without mutation.\"\n    expected_output: \".adl/v0.91.2/tasks/{bundle}/spp.md\"\n    allowed_mode: \"execution_after_approval\"\ncodex_plan:\n  - step: \"Validate closed-ready truth without mutation.\"\n    status: \"pending\"\naffected_areas:\n  - \"doctor\"\ninvariants_to_preserve:\n  - \"Do not mutate stale closeout truth during validation.\"\nrisks_and_edge_cases:\n  - \"Closed issue bundles can still drift.\"\ntest_strategy:\n  - \"Run the focused doctor regression test.\"\nexecution_handoff: \"Use this artifact as the durable plan-of-record before execution.\"\nrequired_permissions:\n  - \"workspace-write after execution approval\"\nstop_conditions:\n  - \"Stop if validation would mutate the stale bundle.\"\nalternatives_considered:\n  - description: \"Use transient planning only.\"\n    reason_not_chosen: \"That would not leave durable reviewable plan truth.\"\nreview_hooks:\n  - \"Check read-only behavior.\"\nnotes: \"fixture\"\n---\n\n# Structured Plan Prompt\n\n## Plan Summary\n\nFixture plan.\n\n## Codex Plan\n\n1. [pending] Validate closed-ready truth without mutation.\n",
             issue = issue_ref.issue_number(),
             task_id = issue_ref.task_issue_id(),
             bundle = issue_ref.task_bundle_dir_name(),
@@ -311,7 +311,7 @@ fn closed_ready_validation_is_read_only_and_reports_truth_drift() {
             bundle = issue_ref.task_bundle_dir_name(),
         );
     let vpp_text = format!(
-        "---\nschema_version: \"0.1\"\nartifact_type: \"structured_validation_planning_prompt\"\nname: \"fixture-validation-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: \"v0.91.2\"\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"unknown\"\nplanned_validation_tokens: \"unknown\"\nissue_goal_ref: \"issue-{issue}\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"fixture\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Lane Registry Inputs\n\n- Registry path: `docs/validation/pvf_lanes.json`\n- Registry template set: `vpp.lane.v1`\n- Initial PVF lane from issue creation: `tooling`\n- Planned PVF lane for execution: `tooling`\n\n## Selected Validation Lanes\n\n- tooling\n\n## Parallelization Plan\n\n- Parallel groups: local\n- Validation runtime class: `tiny`\n- Validation resource profile: `local`\n\n## Goal Accounting Hooks\n\n- Issue goal ref: `issue-{issue}`\n- Sprint goal ref: `unknown`\n- Goal metrics rollup ref: `unknown`\n\n## Proof Cost / Runtime Expectations\n\n- Expected proof cost: `small`\n- Planned validation seconds: `unknown`\n- Planned validation tokens: `unknown`\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\n\n## Failure Semantics\n\n- fail_closed\n\n## Handoff\n\nUse this fixture VPP as the validation plan.\n\n## Notes\n\nfixture\n",
+        "---\nschema_version: \"0.1\"\nartifact_type: \"structured_validation_planning_prompt\"\nname: \"fixture-validation-plan\"\nissue: {issue}\ntask_id: \"{task_id}\"\nrun_id: \"{task_id}\"\nversion: \"v0.91.2\"\ntitle: \"Fixture\"\nbranch: \"codex/1410-fixture\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"30\"\nplanned_validation_tokens: \"800\"\nissue_goal_ref: \"issue-{issue}\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nsource_refs:\n  - kind: \"issue\"\n    ref: \"https://github.com/example/repo/issues/{issue}\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"fixture\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Lane Registry Inputs\n\n- Registry path: `docs/validation/pvf_lanes.json`\n- Registry template set: `vpp.lane.v1`\n- Initial PVF lane from issue creation: `tooling`\n- Planned PVF lane for execution: `tooling`\n\n## Selected Validation Lanes\n\n- tooling\n\n## Parallelization Plan\n\n- Parallel groups: local\n- Validation runtime class: `tiny`\n- Validation resource profile: `local`\n\n## Goal Accounting Hooks\n\n- Issue goal ref: `issue-{issue}`\n- Sprint goal ref: `unknown`\n- Goal metrics rollup ref: `unknown`\n\n## Proof Cost / Runtime Expectations\n\n- Expected proof cost: `small`\n- Planned validation seconds: `30`\n- Planned validation tokens: `800`\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\n\n## Failure Semantics\n\n- fail_closed\n\n## Handoff\n\nUse this fixture VPP as the validation plan.\n\n## Notes\n\nfixture\n",
         issue = issue_ref.issue_number(),
         task_id = issue_ref.task_issue_id(),
     );
@@ -348,7 +348,7 @@ fn card_lifecycle_allows_ellipsis_in_reviewed_spp_prose() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n\n## Validation\n\nInspect provider output like `downloading... done` without treating it as truncation.\n",
+                spp: Box::leak(format!("{}{}", reviewed_spp_frontmatter(), "\n# Structured Plan Prompt\n\n## Validation\n\nInspect provider output like `downloading... done` without treating it as truncation.\n").into_boxed_str()),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -360,6 +360,55 @@ fn card_lifecycle_allows_ellipsis_in_reviewed_spp_prose() {
 
     assert_eq!(lifecycle.pr_run_readiness, "ready");
     assert_stage(&lifecycle, "SPP", "complete", true, false);
+}
+
+#[test]
+fn card_lifecycle_blocks_spp_without_explicit_execution_budget() {
+    let repo = lifecycle_temp_repo("spp-missing-explicit-budget");
+    let paths = write_lifecycle_fixture(
+        &repo,
+        LifecycleFixture {
+            sip: "Branch: codex/3065-test\n",
+            stp: complete_stp_fixture(),
+            spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\nestimate_elapsed_seconds: \"unknown\"\nestimate_total_tokens: \"unknown\"\n---\n",
+            srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n",
+            sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+        },
+    );
+
+    let lifecycle = build_doctor_card_lifecycle(
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
+    );
+
+    assert_eq!(lifecycle.pr_run_readiness, "blocked");
+    assert_stage(&lifecycle, "SPP", "active", false, false);
+}
+
+#[test]
+fn card_lifecycle_blocks_vpp_without_explicit_validation_budget() {
+    let repo = lifecycle_temp_repo("vpp-missing-explicit-budget");
+    let paths = write_lifecycle_fixture(
+        &repo,
+        LifecycleFixture {
+            sip: "Branch: codex/3065-test\n",
+            stp: complete_stp_fixture(),
+            spp: reviewed_spp_frontmatter(),
+            srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n",
+            sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+        },
+    );
+    fs::write(
+        &paths.vpp,
+        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nplanned_validation_seconds: \"unknown\"\nplanned_validation_tokens: \"unknown\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml card_lifecycle_blocks_vpp_without_explicit_validation_budget -- --nocapture\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml card_lifecycle_blocks_vpp_without_explicit_validation_budget -- --nocapture\n",
+    )
+    .expect("overwrite vpp");
+
+    let lifecycle = build_doctor_card_lifecycle(
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
+    );
+
+    assert_eq!(lifecycle.pr_run_readiness, "blocked");
+    assert_stage(&lifecycle, "VPP", "active", false, false);
 }
 
 #[test]
@@ -469,7 +518,7 @@ fn card_lifecycle_blocks_draft_design_time_card_status_before_execution() {
             LifecycleFixture {
                 sip: "Card Status: draft\nBranch: not bound yet\n",
                 stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
-                spp: "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n",
+                spp: Box::leak(format!("{}{}", reviewed_ready_spp_frontmatter("not bound yet"), "\n# Structured Plan Prompt\n").into_boxed_str()),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
                 sor: "Branch: not bound yet\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -500,7 +549,7 @@ fn card_lifecycle_blocks_completed_srp_without_review_results() {
             LifecycleFixture {
                 sip: "Card Status: ready\nBranch: codex/3065-test\n",
                 stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
-                spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_ready_spp_frontmatter("codex/3065-test"),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- Not run yet.\n",
                 sor: "# output\n\nBranch: codex/3065-test\nCard Status: ready\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -522,7 +571,7 @@ fn card_lifecycle_blocks_completed_sor_before_terminal_closeout() {
             LifecycleFixture {
                 sip: "Card Status: ready\nBranch: codex/3065-test\n",
                 stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
-                spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"approved\"\n---\n",
+                spp: approved_ready_spp_frontmatter("codex/3065-test"),
                 srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nCard Status: completed\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -559,12 +608,12 @@ fn preflight_card_readiness_reports_blocked_for_draft_design_time_card() {
         .expect("write stp");
     fs::write(
         issue_ref.task_bundle_plan_path(&repo),
-        "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+        reviewed_ready_spp_frontmatter("not bound yet"),
     )
     .expect("write spp");
     fs::write(
         issue_ref.task_bundle_validation_plan_path(&repo),
-        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"ready\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n",
+        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nplanned_validation_seconds: \"30\"\nplanned_validation_tokens: \"800\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml preflight_card_readiness_reports_blocked_for_draft_design_time_card -- --nocapture\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml preflight_card_readiness_reports_blocked_for_draft_design_time_card -- --nocapture\n",
     )
     .expect("write vpp");
     fs::write(
@@ -607,7 +656,7 @@ fn preflight_card_readiness_reports_blocked_when_vpp_is_missing() {
     .expect("write stp");
     fs::write(
         issue_ref.task_bundle_plan_path(&repo),
-        "---\nbranch: \"not bound yet\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\n---\n",
+        reviewed_ready_spp_frontmatter("not bound yet"),
     )
     .expect("write spp");
     fs::write(
@@ -635,7 +684,7 @@ fn card_lifecycle_treats_ready_vpp_as_design_time_complete() {
         LifecycleFixture {
             sip: "Card Status: ready\nBranch: codex/3065-test\n",
             stp: complete_stp_fixture(),
-            spp: "---\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"approved\"\n---\n",
+            spp: approved_ready_spp_frontmatter("codex/3065-test"),
             srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
             sor: "Branch: codex/3065-test\nCard Status: draft\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
         },
@@ -688,7 +737,7 @@ fn card_lifecycle_blocks_run_readiness_for_incomplete_active_stp() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: "## Required Outcome\n\nready\n",
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
                 sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -712,7 +761,7 @@ fn card_lifecycle_blocks_sparse_stp_before_execution() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
                 sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -736,7 +785,7 @@ fn card_lifecycle_does_not_treat_embedded_heading_text_as_complete_stp() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: "## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\n```md\n## Tooling Notes\n```\n",
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                spp: reviewed_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Policy\n",
                 sor: "Branch: codex/3065-test\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
             },
@@ -760,7 +809,7 @@ fn card_lifecycle_reports_final_review_and_output_truth() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
+                spp: approved_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: none\n- Integration state: merged\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -785,7 +834,7 @@ fn card_lifecycle_accepts_terminal_sor_with_retained_dirty_worktree_truth() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
+                spp: approved_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: issue worktree retained: adl-wp-3065\n- Worktree prune result: retained_with_reason: dirty stale worktree retained: adl-wp-3065\n- Integration state: merged\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
             },
@@ -809,7 +858,7 @@ fn card_lifecycle_blocks_final_sor_with_contradictory_status_and_result() {
             LifecycleFixture {
                 sip: "Branch: codex/3065-test\n",
                 stp: complete_stp_fixture(),
-                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\n---\n",
+                spp: approved_spp_frontmatter(),
                 srp: "---\nartifact_type: \"structured_review_policy\"\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n### Recommended Outcome\n\n- pass\n",
                 sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: none\n- Integration state: merged\n- Result: FAIL\n\n## Validation\n- focused validation failed\n",
             },
@@ -842,13 +891,13 @@ fn card_lifecycle_accepts_tracked_csdlc_bundle() {
         &bundle.join("sor.md"),
     );
 
-    assert_eq!(lifecycle.active_stage, "SOR");
-    assert_eq!(lifecycle.next_required_stage, None);
-    assert_eq!(lifecycle.pr_run_readiness, "ready");
+    assert_eq!(lifecycle.active_stage, "SPP");
+    assert_eq!(lifecycle.next_required_stage, Some("SPP"));
+    assert_eq!(lifecycle.pr_run_readiness, "blocked");
     assert_eq!(lifecycle.pr_finish_readiness, "ready");
     assert_stage(&lifecycle, "SIP", "complete", true, false);
     assert_stage(&lifecycle, "STP", "complete", true, false);
-    assert_stage(&lifecycle, "SPP", "complete", true, false);
+    assert_stage(&lifecycle, "SPP", "active", false, false);
     assert_stage(&lifecycle, "SRP", "final", true, true);
     assert_stage(&lifecycle, "SOR", "final", true, true);
 }
@@ -899,7 +948,7 @@ fn write_lifecycle_fixture(repo: &Path, fixture: LifecycleFixture<'_>) -> Lifecy
     fs::write(&paths.spp, fixture.spp).expect("write spp");
     fs::write(
         &paths.vpp,
-        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"ready\"\ninitial_pvf_lane: \"needs_planning_lane_assignment\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"unknown\"\nplanned_validation_tokens: \"unknown\"\nissue_goal_ref: \"issue-3065\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml closed_ready_validation_is_read_only_and_reports_truth_drift -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"Generated from docs/templates/prompts/1.0.3/vpp.md template; confirm lane selection before relying on this plan. Lane source: initial_pvf_lane.\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n",
+        "---\nartifact_type: \"structured_validation_planning_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\ninitial_pvf_lane: \"tooling\"\nplanned_pvf_lane: \"tooling\"\nlane_registry_path: \"docs/validation/pvf_lanes.json\"\nlane_registry_template_set: \"vpp.lane.v1\"\nvalidation_runtime_class: \"tiny\"\nvalidation_resource_profile: \"local\"\nexpected_proof_cost: \"small\"\nplanned_validation_seconds: \"45\"\nplanned_validation_tokens: \"900\"\nissue_goal_ref: \"issue-3065\"\nsprint_goal_ref: \"unknown\"\ngoal_metrics_rollup_ref: \"unknown\"\nselected_lanes:\n  - \"tooling\"\nparallel_groups:\n  - \"local\"\nvalidation_commands:\n  - \"cargo test --manifest-path adl/Cargo.toml doctor_ready_uses_bound_worktree_root_for_validation_once_bundle_exists -- --nocapture\"\nfailure_policy: \"fail_closed\"\nnotes: \"Fixture validation plan with explicit lane and budget truth.\"\n---\n\n# Validation Planning Prompt\n\n## Validation Planning Summary\n\nFixture validation plan.\n\n## Validation Commands\n\n- cargo test --manifest-path adl/Cargo.toml doctor_ready_uses_bound_worktree_root_for_validation_once_bundle_exists -- --nocapture\n",
     )
     .expect("write vpp");
     fs::write(&paths.srp, fixture.srp).expect("write srp");
@@ -922,6 +971,32 @@ fn complete_stp_fixture_with(required_outcome: &str, acceptance_criteria: &str) 
             )
             .into_boxed_str(),
         )
+}
+
+fn reviewed_spp_frontmatter() -> &'static str {
+    "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\nestimate_elapsed_seconds: \"120\"\nestimate_total_tokens: \"4000\"\n---\n"
+}
+
+fn approved_spp_frontmatter() -> &'static str {
+    "---\nbranch: \"codex/3065-test\"\nstatus: \"approved\"\nestimate_elapsed_seconds: \"120\"\nestimate_total_tokens: \"4000\"\n---\n"
+}
+
+fn reviewed_ready_spp_frontmatter(branch: &str) -> &'static str {
+    Box::leak(
+        format!(
+            "---\nbranch: \"{branch}\"\ncard_status: \"ready\"\nstatus: \"reviewed\"\nestimate_elapsed_seconds: \"120\"\nestimate_total_tokens: \"4000\"\n---\n"
+        )
+        .into_boxed_str(),
+    )
+}
+
+fn approved_ready_spp_frontmatter(branch: &str) -> &'static str {
+    Box::leak(
+        format!(
+            "---\nbranch: \"{branch}\"\ncard_status: \"ready\"\nstatus: \"approved\"\nestimate_elapsed_seconds: \"120\"\nestimate_total_tokens: \"4000\"\n---\n"
+        )
+        .into_boxed_str(),
+    )
 }
 
 fn assert_stage(

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -478,6 +478,8 @@ scope:
 constraints:
   - "read_only_until_execution_is_approved"
 confidence: "medium"
+estimate_elapsed_seconds: "30"
+estimate_total_tokens: "800"
 plan_summary: "Authored planning surface for finish-path tests."
 assumptions:
   - "The linked STP and SIP remain canonical."
@@ -525,12 +527,12 @@ test
 
 ## Estimate Plan
 
-- Estimated elapsed seconds: `unknown`
-- Estimated total tokens: `unknown`
-- Estimated validation seconds: `unknown`
-- Estimate confidence: `unknown`
-- Estimate data source: `unknown`
-- Estimate source ref: `unknown`
+- Estimated elapsed seconds: `30`
+- Estimated total tokens: `800`
+- Estimated validation seconds: `30`
+- Estimate confidence: `medium`
+- Estimate data source: `fixture`
+- Estimate source ref: `inline-authored-spp`
 - Unknown-value rule: record `unknown`, never `0`, when the estimate is unavailable or intentionally deferred.
 
 ## Codex Plan
@@ -583,6 +585,119 @@ test
         spp_rel = spp_rel,
     );
     fs::write(path, content).expect("write authored spp");
+}
+
+pub(crate) fn write_authored_vpp(
+    path: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    repo_root: &Path,
+) {
+    let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
+    let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
+    let content = format!(
+        r#"---
+schema_version: "0.1"
+artifact_type: "structured_validation_planning_prompt"
+name: "{slug}-validation-plan"
+issue: {issue}
+task_id: "{task_id}"
+run_id: "{task_id}"
+version: v0.86
+title: "{title}"
+branch: "{branch}"
+card_status: "ready"
+status: "reviewed"
+initial_pvf_lane: "tooling"
+planned_pvf_lane: "tooling"
+lane_registry_path: "docs/validation/pvf_lanes.json"
+lane_registry_template_set: "vpp.lane.v1"
+validation_runtime_class: "tiny"
+validation_resource_profile: "local"
+expected_proof_cost: "small"
+planned_validation_seconds: "30"
+planned_validation_tokens: "800"
+issue_goal_ref: "issue-{issue}"
+sprint_goal_ref: "unknown"
+goal_metrics_rollup_ref: "unknown"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/example/repo/issues/{issue}"
+  - kind: "stp"
+    ref: "{stp_rel}"
+  - kind: "sip"
+    ref: "{sip_rel}"
+selected_lanes:
+  - "tooling"
+parallel_groups:
+  - "local"
+validation_commands:
+  - "cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::lifecycle -- --nocapture"
+failure_policy: "fail_closed"
+notes: "test note"
+---
+
+# Validation Planning Prompt
+
+## Validation Planning Summary
+
+Issue-specific validation plan for lifecycle fixture execution.
+
+## Lane Registry Inputs
+
+- Registry path: `docs/validation/pvf_lanes.json`
+- Registry template set: `vpp.lane.v1`
+- Initial PVF lane from issue creation: `tooling`
+- Planned PVF lane for execution: `tooling`
+
+## Selected Validation Lanes
+
+- tooling
+
+## Parallelization Plan
+
+- Parallel groups: local
+- Validation runtime class: `tiny`
+- Validation resource profile: `local`
+
+## Goal Accounting Hooks
+
+- Issue goal ref: `issue-{issue}`
+- Sprint goal ref: `unknown`
+- Goal metrics rollup ref: `unknown`
+
+## Proof Cost / Runtime Expectations
+
+- Expected proof cost: `small`
+- Planned validation seconds: `30`
+- Planned validation tokens: `800`
+
+## Validation Commands
+
+- cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::lifecycle -- --nocapture
+
+## Failure Semantics
+
+- fail_closed
+
+## Handoff
+
+Use this authored VPP as the validation plan-of-record for lifecycle fixtures.
+
+## Notes
+
+test
+"#,
+        slug = issue_ref.slug(),
+        issue = issue_ref.issue_number(),
+        task_id = issue_ref.task_issue_id(),
+        title = title,
+        branch = branch,
+        stp_rel = stp_rel,
+        sip_rel = sip_rel,
+    );
+    fs::write(path, content).expect("write authored vpp");
 }
 
 pub(crate) fn write_authored_srp(
@@ -737,6 +852,13 @@ pub(crate) fn write_design_time_ready_cards(
     );
     write_authored_spp(
         &issue_ref.task_bundle_plan_path(repo),
+        issue_ref,
+        title,
+        branch,
+        repo,
+    );
+    write_authored_vpp(
+        &issue_ref.task_bundle_validation_plan_path(repo),
         issue_ref,
         title,
         branch,

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -108,9 +108,37 @@ def design_time_card_status_defect(card_name: str, text: str) -> str | None:
     status = card_status_value(text)
     if not status:
         return None
-    if card_name in {'sip.md', 'stp.md', 'spp.md'} and status not in {'ready', 'approved'}:
+    if card_name in {'sip.md', 'stp.md', 'spp.md', 'vpp.md'} and status not in {'ready', 'approved'}:
         return f'{card_name} card_status must be ready or approved before execution binding'
     return None
+
+
+def has_known_metric(text: str, prefix: str) -> bool:
+    value = line_value_after_prefix(text, prefix)
+    return bool(value) and value not in {'unknown', 'not_recorded_yet', 'not_applicable', 'none'}
+
+
+def has_generic_vpp_design_time_scaffold(text: str) -> bool:
+    unresolved_planned_lane = line_value_after_prefix(text, 'planned_pvf_lane:') == 'needs_planning_lane_assignment'
+    unresolved_selected_lane = '- "needs_planning_lane_assignment"' in text or '- needs_planning_lane_assignment' in text
+    unresolved_failure_policy = (
+        line_value_after_prefix(text, 'failure_policy:') == 'fail_closed_until_validation_lane_is_selected'
+        or 'fail_closed_until_validation_lane_is_selected' in text
+    )
+    return (
+        unresolved_planned_lane
+        or unresolved_selected_lane
+        or unresolved_failure_policy
+        or 'selected_lanes_inline: needs_planning_lane_assignment' in text
+        or has_truncation_sentinel_line(text)
+    )
+
+
+def markdown_section_body(text: str, heading: str) -> str:
+    marker = f'## {heading}'
+    if marker not in text:
+        return ''
+    return text.split(marker, 1)[1].split('\n## ', 1)[0].strip()
 
 
 def completed_srp_without_review_results(text: str) -> bool:
@@ -163,8 +191,27 @@ def design_time_defect(card_name: str, text: str) -> str | None:
         status = line_value_after_prefix(text, 'status:')
         if contains_any(text, GENERIC_SPP_MARKERS) or has_truncation_sentinel_line(text):
             return 'generic or truncated design-time SPP scaffold'
+        if not has_known_metric(text, 'estimate_elapsed_seconds:') or not has_known_metric(text, 'estimate_total_tokens:'):
+            return 'SPP missing explicit elapsed-seconds or total-token estimate budget'
         if status not in {'reviewed', 'approved'}:
             return 'SPP is not reviewed or approved for design-time execution'
+    if card_name == 'vpp.md':
+        status = line_value_after_prefix(text, 'status:')
+        if has_generic_vpp_design_time_scaffold(text):
+            return 'generic or incomplete design-time VPP scaffold'
+        if not has_known_metric(text, 'planned_validation_seconds:') or not has_known_metric(text, 'planned_validation_tokens:'):
+            return 'VPP missing explicit validation-seconds or validation-token budget'
+        validation_commands = markdown_section_body(text, 'Validation Commands')
+        if not validation_commands:
+            return 'VPP missing validation commands section content'
+        if contains_any(validation_commands, [
+            'Use `workflow-conductor` and the active prompt-template renderer/schema path.',
+            'Use the session ledger before execution and avoid active claimed worktrees.',
+            'Use focused validation, not broad test reflexes, unless touched code requires broader proof.',
+        ]):
+            return 'VPP validation commands are still generic planning guidance'
+        if status not in {'ready', 'reviewed', 'approved'}:
+            return 'VPP is not ready, reviewed, or approved for design-time execution'
     if card_name == 'srp.md':
         if '# Structured Review Policy' in text or 'artifact_type: "structured_review_policy"' in text:
             return 'legacy SRP policy scaffold'
@@ -182,6 +229,7 @@ def inspect_issue(
     repo_root: Path,
     issue_number: int,
     require_spp: bool,
+    require_vpp: bool,
     require_srp: bool,
 ) -> dict:
     bundle_dir, notes = find_bundle_dir(repo_root, issue_number)
@@ -204,6 +252,8 @@ def inspect_issue(
     }
     if require_spp:
         required_cards['spp.md'] = 'spp-editor'
+    if require_vpp:
+        required_cards['vpp.md'] = 'vpp-editor'
     if require_srp:
         required_cards['srp.md'] = 'srp-editor'
 
@@ -263,6 +313,8 @@ def main() -> int:
     parser.add_argument('--state')
     parser.add_argument('--require-spp', dest='require_spp', action='store_true', default=True)
     parser.add_argument('--skip-spp', dest='require_spp', action='store_false')
+    parser.add_argument('--require-vpp', dest='require_vpp', action='store_true', default=True)
+    parser.add_argument('--skip-vpp', dest='require_vpp', action='store_false')
     parser.add_argument('--require-srp', dest='require_srp', action='store_true', default=True)
     parser.add_argument('--skip-srp', dest='require_srp', action='store_false')
     parser.add_argument('--print-json', action='store_true')
@@ -271,7 +323,7 @@ def main() -> int:
     repo_root = Path(args.repo_root)
     ordered = parse_csv_ints(args.ordered_issues)
     issue_results = [
-        inspect_issue(repo_root, issue, args.require_spp, args.require_srp)
+        inspect_issue(repo_root, issue, args.require_spp, args.require_vpp, args.require_srp)
         for issue in ordered
     ]
 
@@ -285,6 +337,7 @@ def main() -> int:
         'status': overall_status,
         'required_card_types': ['stp.md', 'sip.md', 'sor.md'] +
         (['spp.md'] if args.require_spp else []) +
+        (['vpp.md'] if args.require_vpp else []) +
         (['srp.md'] if args.require_srp else []),
         'issue_results': issue_results,
         'notes': [

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -658,10 +658,10 @@ def main() -> int:
             'follow_up_issues': [],
             'structured_prompt_preflight': {
                 'status': 'not_run',
-                'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'srp.md'],
+                'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'vpp.md', 'srp.md'],
                 'issue_results': [],
                 'notes': [
-                    'Run sprint-wide structured prompt preflight before starting issue execution, including SPP and SRP design-time readiness.',
+                    'Run sprint-wide structured prompt preflight before starting issue execution, including SPP, VPP, and SRP design-time readiness.',
                 ],
             },
             'readiness_sweep': {

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -61,10 +61,10 @@ def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, A
         'issue_records': default_issue_records(ordered),
         'structured_prompt_preflight': {
             'status': 'not_run',
-            'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'srp.md'],
+            'required_card_types': ['stp.md', 'sip.md', 'sor.md', 'spp.md', 'vpp.md', 'srp.md'],
             'issue_results': [],
             'notes': [
-                'Run sprint-wide structured prompt preflight before starting issue execution, including SPP and SRP design-time readiness.',
+                'Run sprint-wide structured prompt preflight before starting issue execution, including SPP, VPP, and SRP design-time readiness.',
             ],
         },
         'truth_check': {

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -150,6 +150,14 @@ Status: NOT_STARTED
 EOF2
 cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/spp.md" <<'EOF2'
 issue: 3001
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/vpp.md" <<'EOF2'
+issue: 3001
+planned_pvf_lane: "tooling"
+planned_validation_seconds: "30"
+planned_validation_tokens: "800"
 EOF2
 cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/srp.md" <<'EOF2'
 issue: 3001
@@ -184,6 +192,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/spp.md" <<'EOF2'
 ---
 issue: 2827
 status: approved
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 # Structured Plan Prompt
@@ -191,6 +201,23 @@ status: approved
 ## Codex Plan
 
 1. [pending] Execute the bounded WP-05 task.
+EOF2
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/vpp.md" <<'EOF2'
+---
+artifact_type: "structured_validation_planning_prompt"
+issue: 2827
+status: approved
+card_status: ready
+planned_pvf_lane: "tooling"
+planned_validation_seconds: "30"
+planned_validation_tokens: "800"
+---
+
+# Validation Planning Prompt
+
+## Validation Commands
+
+- cargo test --manifest-path adl/Cargo.toml doctor_full_warns_when_only_open_wave_blocks_ready_issue -- --nocapture
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/srp.md" <<'EOF2'
 ---
@@ -231,6 +258,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
 ---
 issue: 2828
 status: approved
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 # Structured Plan Prompt
@@ -239,6 +268,23 @@ status: approved
 
 1. [pending] Execute the bounded WP-06 task.
 2. [pending] Inspect provider output such as `downloading... done` without treating prose ellipsis as truncation.
+EOF2
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/vpp.md" <<'EOF2'
+---
+artifact_type: "structured_validation_planning_prompt"
+issue: 2828
+status: approved
+card_status: ready
+planned_pvf_lane: "tooling"
+planned_validation_seconds: "30"
+planned_validation_tokens: "800"
+---
+
+# Validation Planning Prompt
+
+## Validation Commands
+
+- cargo test --manifest-path adl/Cargo.toml card_lifecycle_accepts_pre_review_srp_prompt_without_final_results -- --nocapture
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'
 ---
@@ -346,7 +392,8 @@ assert state["current_issue_number"] == 2827
 assert state["execution_mode"] == "hybrid"
 assert state["execution_packet_path"].endswith("issue-3001__sprint-1-management-trial-sprint/SPRINT_EXECUTION_PACKET.md")
 assert len(state["issue_records"]) == 2
-assert state["structured_prompt_preflight"]["required_card_types"] == ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"]
+assert set(state["structured_prompt_preflight"]["required_card_types"]) == {"stp.md", "sip.md", "sor.md", "spp.md", "vpp.md", "srp.md"}
+assert any("SPP, VPP, and SRP" in note for note in state["structured_prompt_preflight"]["notes"])
 assert state["readiness_sweep"]["execution_packet"]["status"] == "present"
 assert state["readiness_sweep"]["review_paths"]["status"] == "declared"
 assert state["readiness_sweep"]["activity_log_paths"]["status"] == "declared"
@@ -394,7 +441,7 @@ from pathlib import Path
 state = json.loads(Path(sys.argv[1]).read_text())
 preflight = state["structured_prompt_preflight"]
 assert preflight["status"] == "ready"
-assert preflight["required_card_types"] == ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"]
+assert set(preflight["required_card_types"]) == {"stp.md", "sip.md", "sor.md", "spp.md", "vpp.md", "srp.md"}
 assert len(preflight["issue_results"]) == 2
 assert all(result["status"] == "ready" for result in preflight["issue_results"])
 assert all(result["canonical_slug"] for result in preflight["issue_results"])
@@ -583,6 +630,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
 ---
 issue: 2828
 status: draft
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 Design-time generated SPP; review before execution.
@@ -610,6 +659,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
 ---
 issue: 2828
 status: approved
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 # Structured Plan Prompt
@@ -623,6 +674,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
 ---
 issue: 2828
 status: approved
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 # Structured Plan Prompt
@@ -662,6 +715,8 @@ cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
 ---
 issue: 2828
 status: approved
+estimate_elapsed_seconds: "120"
+estimate_total_tokens: "4000"
 ---
 
 # Structured Plan Prompt


### PR DESCRIPTION
## Summary
- require explicit SPP execution budgets and VPP validation budgets before execution binding
- reject generic VPP validation guidance in both doctor and sprint preflight paths
- keep sprint bootstrap state aligned with the required `vpp.md` card set

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all --check
- cargo test --manifest-path adl/Cargo.toml doctor::tests -- --nocapture
- cargo test --manifest-path adl/Cargo.toml doctor::tests::card_lifecycle_treats_ready_vpp_as_design_time_complete -- --nocapture
- cargo test --manifest-path adl/Cargo.toml doctor::tests::card_lifecycle_blocks_vpp_without_explicit_validation_budget -- --nocapture
- bash adl/tools/test_sprint_conductor_helpers.sh

Closes #4457
