### PR TITLE
[v0.91.6][tools][lifecycle] Fix pr.list.wave readiness hangs in doctor and run

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -772,7 +772,10 @@ fn build_sor_facts(
     let validation_commands = if validation_status == "NOT_RUN" {
         Vec::new()
     } else {
-        plan.commands.clone()
+        plan.commands
+            .iter()
+            .map(|command| sanitize_validation_profile_command(command))
+            .collect()
     };
     let fix_notes = if closing_linkage_repaired {
         vec!["repaired missing PR closing linkage".to_string()]

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -831,10 +831,51 @@ where
     let _runtime_guard = runtime.enter();
     let mut attempt = 1usize;
     let max_attempts = octocrab_max_attempts();
+    let request_timeout = octocrab_request_timeout();
     let result = loop {
-        match runtime.block_on(make_future()) {
-            Ok(value) => break value,
-            Err(err)
+        match runtime.block_on(tokio::time::timeout(request_timeout, make_future())) {
+            Ok(Ok(value)) => break value,
+            Err(_elapsed) if attempt < max_attempts && octocrab_operation_allows_retry(operation) => {
+                let attempt_text = attempt.to_string();
+                let max_attempts_text = max_attempts.to_string();
+                let timeout_secs_text = request_timeout.as_secs().to_string();
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "retry",
+                    &[
+                        ("operation", operation),
+                        ("attempt", attempt_text.as_str()),
+                        ("max_attempts", max_attempts_text.as_str()),
+                        ("reason", "timeout"),
+                        ("timeout_secs", timeout_secs_text.as_str()),
+                    ],
+                );
+                std::thread::sleep(octocrab_retry_delay(attempt));
+                attempt += 1;
+            }
+            Err(_elapsed) => {
+                let attempts_text = attempt.to_string();
+                let timeout_secs_text = request_timeout.as_secs().to_string();
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "failed",
+                    &[
+                        ("operation", operation),
+                        ("attempts", attempts_text.as_str()),
+                        ("reason", "timeout"),
+                        ("timeout_secs", timeout_secs_text.as_str()),
+                    ],
+                );
+                return Err(anyhow!(
+                    "github_client.timeout: operation '{}' exceeded the {}s per-attempt timeout after {} attempt(s)",
+                    operation,
+                    request_timeout.as_secs(),
+                    attempt
+                ));
+            }
+            Ok(Err(err))
                 if attempt < max_attempts
                     && octocrab_operation_allows_retry(operation)
                     && octocrab_error_is_retryable(&err) =>
@@ -854,7 +895,7 @@ where
                 std::thread::sleep(octocrab_retry_delay(attempt));
                 attempt += 1;
             }
-            Err(err) => {
+            Ok(Err(err)) => {
                 let attempts_text = attempt.to_string();
                 observability::emit_event(
                     "adl",
@@ -905,6 +946,16 @@ fn octocrab_max_attempts() -> usize {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|attempts| (1..=10).contains(attempts))
         .unwrap_or(3)
+}
+
+fn octocrab_request_timeout() -> Duration {
+    Duration::from_secs(
+        std::env::var("ADL_GITHUB_OCTOCRAB_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|secs| (1..=120).contains(secs))
+            .unwrap_or(10),
+    )
 }
 
 fn octocrab_retry_delay(attempt: usize) -> Duration {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -831,51 +831,38 @@ where
     let _runtime_guard = runtime.enter();
     let mut attempt = 1usize;
     let max_attempts = octocrab_max_attempts();
-    let request_timeout = octocrab_request_timeout();
     let result = loop {
-        match runtime.block_on(tokio::time::timeout(request_timeout, make_future())) {
-            Ok(Ok(value)) => break value,
-            Err(_elapsed) if attempt < max_attempts && octocrab_operation_allows_retry(operation) => {
-                let attempt_text = attempt.to_string();
-                let max_attempts_text = max_attempts.to_string();
-                let timeout_secs_text = request_timeout.as_secs().to_string();
-                observability::emit_event(
-                    "adl",
-                    "github_octocrab",
-                    "retry",
-                    &[
-                        ("operation", operation),
-                        ("attempt", attempt_text.as_str()),
-                        ("max_attempts", max_attempts_text.as_str()),
-                        ("reason", "timeout"),
-                        ("timeout_secs", timeout_secs_text.as_str()),
-                    ],
-                );
-                std::thread::sleep(octocrab_retry_delay(attempt));
-                attempt += 1;
+        let call_result = if let Some(request_timeout) = octocrab_request_timeout(operation) {
+            match runtime.block_on(tokio::time::timeout(request_timeout, make_future())) {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    let attempts_text = attempt.to_string();
+                    let timeout_secs_text = request_timeout.as_secs().to_string();
+                    observability::emit_event(
+                        "adl",
+                        "github_octocrab",
+                        "failed",
+                        &[
+                            ("operation", operation),
+                            ("attempts", attempts_text.as_str()),
+                            ("reason", "timeout"),
+                            ("timeout_secs", timeout_secs_text.as_str()),
+                        ],
+                    );
+                    return Err(anyhow!(
+                        "github_client.timeout: operation '{}' exceeded the {}s per-attempt timeout after {} attempt(s)",
+                        operation,
+                        request_timeout.as_secs(),
+                        attempt
+                    ));
+                }
             }
-            Err(_elapsed) => {
-                let attempts_text = attempt.to_string();
-                let timeout_secs_text = request_timeout.as_secs().to_string();
-                observability::emit_event(
-                    "adl",
-                    "github_octocrab",
-                    "failed",
-                    &[
-                        ("operation", operation),
-                        ("attempts", attempts_text.as_str()),
-                        ("reason", "timeout"),
-                        ("timeout_secs", timeout_secs_text.as_str()),
-                    ],
-                );
-                return Err(anyhow!(
-                    "github_client.timeout: operation '{}' exceeded the {}s per-attempt timeout after {} attempt(s)",
-                    operation,
-                    request_timeout.as_secs(),
-                    attempt
-                ));
-            }
-            Ok(Err(err))
+        } else {
+            runtime.block_on(make_future())
+        };
+        match call_result {
+            Ok(value) => break value,
+            Err(err)
                 if attempt < max_attempts
                     && octocrab_operation_allows_retry(operation)
                     && octocrab_error_is_retryable(&err) =>
@@ -895,7 +882,7 @@ where
                 std::thread::sleep(octocrab_retry_delay(attempt));
                 attempt += 1;
             }
-            Ok(Err(err)) => {
+            Err(err) => {
                 let attempts_text = attempt.to_string();
                 observability::emit_event(
                     "adl",
@@ -948,14 +935,17 @@ fn octocrab_max_attempts() -> usize {
         .unwrap_or(3)
 }
 
-fn octocrab_request_timeout() -> Duration {
-    Duration::from_secs(
+fn octocrab_request_timeout(operation: &str) -> Option<Duration> {
+    if operation != "pr.list.wave" {
+        return None;
+    }
+    Some(Duration::from_secs(
         std::env::var("ADL_GITHUB_OCTOCRAB_TIMEOUT_SECS")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             .filter(|secs| (1..=120).contains(secs))
             .unwrap_or(10),
-    )
+    ))
 }
 
 fn octocrab_retry_delay(attempt: usize) -> Duration {

--- a/adl/src/cli/pr_cmd/github/tests.rs
+++ b/adl/src/cli/pr_cmd/github/tests.rs
@@ -591,6 +591,73 @@ fn spawn_open_prs_paginated_server() -> (String, thread::JoinHandle<Vec<String>>
     (base_uri, handle)
 }
 
+fn spawn_open_prs_repeated_next_server() -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_test_http_server("bind open PR repeated-next server");
+    let repeated_next_url = format!("{base_uri}/repos/owner/repo/pulls?page=2");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        for _ in 0..2 {
+            let Some(request) = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("open PR repeated-next server receive")
+            else {
+                break;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            seen.push(format!("{method} {url}"));
+            let response_body = format!(
+                "[{}]",
+                pr_fixture(
+                    2101,
+                    "[v0.91.6][tools] Repeated page PR",
+                    "Closes #4301",
+                    "codex/4301-repeated-page",
+                    "main"
+                )
+            );
+            let mut response = json_response(response_body);
+            let link = format!(r#"<{repeated_next_url}>; rel="next""#);
+            if let Ok(header) = Header::from_bytes("Link", link) {
+                response = response.with_header(header);
+            }
+            let _ = request.respond(response);
+        }
+        seen
+    });
+    (base_uri, handle)
+}
+
+fn spawn_open_prs_slow_server(delay: Duration) -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_test_http_server("bind open PR slow server");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        let Some(request) = server
+            .recv_timeout(Duration::from_secs(5))
+            .expect("open PR slow server receive")
+        else {
+            return seen;
+        };
+        let method = request.method().as_str().to_string();
+        let url = request.url().to_string();
+        seen.push(format!("{method} {url}"));
+        std::thread::sleep(delay);
+        let response_body = format!(
+            "[{}]",
+            pr_fixture(
+                2103,
+                "[v0.91.6][tools] Slow page PR",
+                "Closes #4303",
+                "codex/4303-slow-page",
+                "main"
+            )
+        );
+        let _ = request.respond(json_response(response_body));
+        seen
+    });
+    (base_uri, handle)
+}
+
 fn spawn_validation_status_once_server(
     status: &'static str,
     conclusion: Option<&'static str>,

--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
+++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
@@ -484,6 +484,62 @@ fn list_prs_octocrab_paginates_rest_results() {
 }
 
 #[test]
+fn list_prs_octocrab_fails_closed_on_repeated_next_page_urls() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let (base_uri, server) = spawn_open_prs_repeated_next_server();
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+
+    let err = list_prs_octocrab("owner/repo").expect_err("repeated next URL should fail closed");
+    assert!(err
+        .to_string()
+        .contains("github_client.pagination_loop"));
+    assert!(err.to_string().contains("pr.list.wave"));
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 2, "unexpected pagination calls: {seen:#?}");
+    assert!(seen[0].contains("/repos/owner/repo/pulls?"));
+    assert!(seen[1].contains("/repos/owner/repo/pulls?page=2"));
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
+fn list_prs_octocrab_times_out_promptly_when_github_stalls() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let (base_uri, server) = spawn_open_prs_slow_server(Duration::from_secs(2));
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_TIMEOUT_SECS", "1");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS", "1");
+    }
+
+    let err = list_prs_octocrab("owner/repo").expect_err("slow GitHub should time out");
+    assert!(err.to_string().contains("github_client.timeout"));
+    assert!(err.to_string().contains("pr.list.wave"));
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1, "unexpected slow-server calls: {seen:#?}");
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_TIMEOUT_SECS");
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
 fn pr_validation_watch_returns_failed_report_without_second_fetch() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
@@ -521,6 +577,7 @@ fn octocrab_retry_policy_blocks_non_idempotent_mutations() {
     assert!(octocrab_operation_allows_retry("pr.validation.status"));
     assert!(octocrab_operation_allows_retry("issue.view.title"));
     assert!(octocrab_operation_allows_retry("issue.close"));
+    assert!(!octocrab_operation_allows_retry("pr.list.wave"));
     assert!(!octocrab_operation_allows_retry("issue.comment"));
     assert!(!octocrab_operation_allows_retry("issue.create"));
     assert!(!octocrab_operation_allows_retry("pr.create.finish"));

--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
+++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
@@ -495,9 +495,7 @@ fn list_prs_octocrab_fails_closed_on_repeated_next_page_urls() {
     }
 
     let err = list_prs_octocrab("owner/repo").expect_err("repeated next URL should fail closed");
-    assert!(err
-        .to_string()
-        .contains("github_client.pagination_loop"));
+    assert!(err.to_string().contains("github_client.pagination_loop"));
     assert!(err.to_string().contains("pr.list.wave"));
 
     let seen = server.join().expect("server join");

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -198,7 +198,6 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
         })?;
         let mut prs = Vec::new();
         let mut seen_next_pages = HashSet::new();
-        let mut page_index = 1usize;
         loop {
             prs.extend(page.items.into_iter().map(|pr| {
                 OpenPullRequest {
@@ -240,22 +239,7 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
                 return Err(anyhow!(
                     "github_client.pagination_loop: operation 'pr.list.wave' received repeated next-page URL '{}' after page {}",
                     next_url,
-                    page_index
-                ));
-            }
-            page_index += 1;
-            if page_index > 50 {
-                observability::emit_event(
-                    "adl",
-                    "github_octocrab",
-                    "failed",
-                    &[
-                        ("operation", "pr.list.wave"),
-                        ("reason", "pagination_page_limit"),
-                    ],
-                );
-                return Err(anyhow!(
-                    "github_client.pagination_limit: operation 'pr.list.wave' exceeded the 50-page safety limit while listing pull requests"
+                    seen_next_pages.len() + 1
                 ));
             }
             page = block_on_octocrab(runtime, "pr.list.wave", || async {

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -7,6 +7,7 @@ use super::{run_gh_status_shell, test_gh_fixture_fallback_allowed};
 use crate::cli::observability;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -196,6 +197,8 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
                 .await
         })?;
         let mut prs = Vec::new();
+        let mut seen_next_pages = HashSet::new();
+        let mut page_index = 1usize;
         loop {
             prs.extend(page.items.into_iter().map(|pr| {
                 OpenPullRequest {
@@ -223,6 +226,38 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
             let Some(next) = page.next.clone() else {
                 break;
             };
+            let next_url = next.to_string();
+            if !seen_next_pages.insert(next_url.clone()) {
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "failed",
+                    &[
+                        ("operation", "pr.list.wave"),
+                        ("reason", "pagination_repeated_next"),
+                    ],
+                );
+                return Err(anyhow!(
+                    "github_client.pagination_loop: operation 'pr.list.wave' received repeated next-page URL '{}' after page {}",
+                    next_url,
+                    page_index
+                ));
+            }
+            page_index += 1;
+            if page_index > 50 {
+                observability::emit_event(
+                    "adl",
+                    "github_octocrab",
+                    "failed",
+                    &[
+                        ("operation", "pr.list.wave"),
+                        ("reason", "pagination_page_limit"),
+                    ],
+                );
+                return Err(anyhow!(
+                    "github_client.pagination_limit: operation 'pr.list.wave' exceeded the 50-page safety limit while listing pull requests"
+                ));
+            }
             page = block_on_octocrab(runtime, "pr.list.wave", || async {
                 octo.get_page::<octocrab::models::pulls::PullRequest>(&Some(next.clone()))
                     .await

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -757,9 +757,8 @@ review_results:
     )
     .expect("normalize with sanitized changed-files command");
 
-    assert!(normalized.contains(
-        "bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>"
-    ));
+    assert!(normalized
+        .contains("bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>"));
     assert!(!normalized.contains("/private/tmp/finish-validation-profile-123.txt"));
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -728,6 +728,42 @@ review_results:
 }
 
 #[test]
+fn sor_emitted_facts_sanitize_manager_backed_changed_files_path() {
+    let output = "## Verification Summary\n";
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["adl/src/cli/pr_cmd/github.rs".to_string()],
+        &["bash adl/tools/run_pr_fast_test_lane.sh --changed-files /private/tmp/finish-validation-profile-123.txt".to_string()],
+        review,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+        },
+    )
+    .expect("normalize with sanitized changed-files command");
+
+    assert!(normalized.contains(
+        "bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>"
+    ));
+    assert!(!normalized.contains("/private/tmp/finish-validation-profile-123.txt"));
+}
+
+#[test]
 fn sor_emitted_facts_default_review_truth_when_srp_front_matter_is_absent() {
     let output = r#"## Verification Summary
 


### PR DESCRIPTION
Closes #4453

## Summary
Bounded fix for `pr.list.wave` readiness hangs completed in the issue worktree. The transport now fails closed on repeated next-page URLs, applies a bounded timeout only to `pr.list.wave`, and avoids turning that timeout into a global GitHub transport behavior change. Focused transport tests passed, and live `doctor` / `run` proofs returned bounded results instead of hanging indefinitely.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.6/tasks/issue-4453__v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/transport.rs`
  - `adl/src/cli/pr_cmd/github/tests.rs`
  - `adl/src/cli/pr_cmd/github/tests/transport.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-doctor transport::list_prs_octocrab -- --nocapture`
    Verified focused transport behavior for healthy pagination, repeated-next detection, and slow-server timeout handling.
  - `python3` wrapper invoking `bash adl/tools/pr.sh doctor 4453 --version v0.91.6 --json` from the issue worktree with `ADL_GITHUB_TOKEN_FILE` set
    Verified the live `doctor` path is bounded and returns timeout classification instead of hanging.
  - `python3` wrapper invoking `bash adl/tools/pr.sh run 4453 --version v0.91.6 --allow-open-pr-wave` from the issue worktree with `ADL_GITHUB_TOKEN_FILE` set
    Verified the live `run` path is bounded and returns the expected wrong-checkout guard instead of hanging.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4453__v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4453__v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run/sor.md
- Idempotency-Key: v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run-adl-v0-91-6-tasks-issue-4453-v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run-sip-md-adl-v0-91-6-tasks-issue-4453-v0-91-6-tools-lifecycle-fix-pr-list-wave-readiness-hangs-in-doctor-and-run-sor-md