### PR TITLE
[v0.91.6][csdlc][goals] Enforce issue-bound goal terminal-state truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,13 @@ These rules are mandatory for ADL issue work.
      objective so token accounting, completion, and blocked-state reporting stay
      tied to the tracked issue.
    - Use `update_goal` only for truthful terminal state changes:
-     `complete` when the current session's bounded objective is actually
-     achieved, including a truthful handoff into review/wait state after
-     publication when that was the session goal, or `blocked` only when the
-     repeated blocking threshold is met and meaningful progress cannot continue.
+     `complete` when the current session's declared terminal boundary is
+     actually satisfied. Handoff-only completion is allowed only when the goal
+     explicitly declares a handoff boundary such as setup-only or review-only
+     publication. Default tracked implementation goals stay active while the PR
+     is red, pending, conflicted, draft, missing required checks, or missing
+     current SRP/SOR truth. Use `blocked` only when the repeated blocking
+     threshold is met and meaningful progress cannot continue.
 5. Always review work with a subagent before opening the PR.
    - Run a bounded review subagent over the changed work product.
    - Fix all actionable findings immediately before publication.

--- a/adl/tools/check_issue_goal_terminal_state.py
+++ b/adl/tools/check_issue_goal_terminal_state.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent / "skills" / "sprint-conductor" / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from issue_goal_metrics import evaluate_goal_terminal_state
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate whether an issue-bound goal may truthfully be marked complete."
+    )
+    parser.add_argument("--goal-kind")
+    parser.add_argument("--goal-boundary")
+    parser.add_argument("--issue-state")
+    parser.add_argument("--pr-state")
+    parser.add_argument("--checks-state")
+    parser.add_argument("--review-truth")
+    parser.add_argument("--closeout-truth")
+    parser.add_argument("--watch-target-status")
+    parser.add_argument("--sprint-rollup-status")
+    parser.add_argument("--merge-conflicts", action="store_true")
+    parser.add_argument("--no-merge-conflicts", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = evaluate_goal_terminal_state(
+        goal_kind=args.goal_kind,
+        declared_boundary=args.goal_boundary,
+        issue_state=args.issue_state,
+        pr_state=args.pr_state,
+        checks_state=args.checks_state,
+        review_truth=args.review_truth,
+        closeout_truth=args.closeout_truth,
+        merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+        watch_target_status=args.watch_target_status,
+        sprint_rollup_status=args.sprint_rollup_status,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("completion_allowed") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -84,6 +84,8 @@ The normal workflow is:
    - actionable PR blockers route here for bounded remediation
    - the repo finish path may auto-attach the janitor hook after PR publication when blocker monitoring is needed
 9. truthful `update_goal` terminal state, then `pr-closeout` after the PR outcome or explicit non-PR closure disposition is settled
+   - default tracked implementation goals stay active until their declared terminal boundary is satisfied
+   - handoff-only completion is reserved for goals that explicitly declare that narrower boundary
 
 The first-class issue-lifecycle shepherd contract above those phases lives at:
 

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -193,6 +193,8 @@ After bind/readiness succeeds and before implementation starts:
 - treat goal creation as mandatory workflow state for tracked issue execution, not a nice-to-have reminder
 - if the current environment cannot create the session goal, stop and report that blocked state truthfully instead of proceeding as though the requirement was satisfied
 - reserve `update_goal status=complete` and `update_goal status=blocked` for truthful session-terminal states only
+- keep default tracked implementation goals active while the PR is red, pending, conflicted, draft, missing required checks, or missing current SRP/SOR truth
+- allow early completion only when the goal explicitly declares a handoff-only terminal boundary such as setup-only or review-only publication
 
 ### 4. Execute The Issue
 

--- a/adl/tools/skills/pr-run/references/run-playbook.md
+++ b/adl/tools/skills/pr-run/references/run-playbook.md
@@ -99,6 +99,7 @@ Then:
 - perform only the work required by the issue
 - keep edits bounded to the issue's acceptance criteria
 - record follow-on discoveries instead of silently expanding scope
+- evaluate goal terminal-state truth before `update_goal status=complete` when PR or issue lifecycle state is involved
 
 ## Validation Checklist
 

--- a/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
@@ -51,6 +51,42 @@ CODEX_GOAL_STATUS_TO_COMPLETION_STATE = {
 }
 
 TERMINAL_COMPLETION_STATES = {"completed", "blocked", "failed", "cancelled", "deferred"}
+GOAL_KIND_VALUES = {
+    "tracked_issue",
+    "setup_only",
+    "implementation",
+    "watcher",
+    "janitor",
+    "review_only",
+    "sprint_child",
+    "sprint_umbrella",
+}
+GOAL_BOUNDARY_VALUES = {
+    "handoff_only",
+    "pr_green",
+    "merged",
+    "closed_no_pr",
+    "closed_out",
+    "watch_target_reached",
+    "sprint_rollup_settled",
+}
+ISSUE_STATE_VALUES = {"open", "closed", "unknown", "not_applicable"}
+PR_STATE_VALUES = {"not_opened", "open", "draft", "merged", "closed", "unknown", "not_applicable"}
+CHECKS_STATE_VALUES = {"green", "pending", "red", "missing", "skipped", "unknown", "not_applicable"}
+RECORD_TRUTH_VALUES = {"current", "missing", "stale", "unknown", "not_applicable"}
+TARGET_STATE_VALUES = {"reached", "not_reached", "blocked", "unknown", "not_applicable"}
+TERMINAL_TRUTH_STATUS_VALUES = {"satisfied", "not_satisfied", "unknown"}
+
+DEFAULT_BOUNDARY_BY_GOAL_KIND = {
+    "tracked_issue": "pr_green",
+    "setup_only": "handoff_only",
+    "implementation": "pr_green",
+    "watcher": "watch_target_reached",
+    "janitor": "watch_target_reached",
+    "review_only": "handoff_only",
+    "sprint_child": "closed_out",
+    "sprint_umbrella": "sprint_rollup_settled",
+}
 
 
 def iso_now_utc() -> str:
@@ -275,7 +311,239 @@ def default_goal_metrics_summary() -> dict[str, Any]:
         "model_ref": None,
         "session_ref": None,
         "thread_id": None,
+        "goal_terminal_state": default_goal_terminal_state_summary(),
     }
+
+
+def default_goal_terminal_state_summary() -> dict[str, Any]:
+    return {
+        "goal_kind": "tracked_issue",
+        "declared_boundary": "pr_green",
+        "boundary_source": "default_from_goal_kind",
+        "issue_state": "unknown",
+        "pr_state": "unknown",
+        "checks_state": "unknown",
+        "review_truth": "unknown",
+        "closeout_truth": "unknown",
+        "merge_conflicts": "unknown",
+        "watch_target_status": "unknown",
+        "sprint_rollup_status": "unknown",
+        "completion_allowed": False,
+        "truth_status": "unknown",
+        "reason": "goal terminal-state truth was not evaluated",
+    }
+
+
+def normalize_choice(
+    value: str | None,
+    *,
+    default: str,
+    allowed: set[str],
+    field_name: str,
+) -> str:
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered not in allowed:
+        raise ValueError(f"invalid {field_name}: {value}")
+    return lowered
+
+
+def default_boundary_for_goal_kind(goal_kind: str) -> str:
+    return DEFAULT_BOUNDARY_BY_GOAL_KIND.get(goal_kind, "pr_green")
+
+
+def evaluate_goal_terminal_state(
+    *,
+    goal_kind: str | None,
+    declared_boundary: str | None,
+    issue_state: str | None,
+    pr_state: str | None,
+    checks_state: str | None,
+    review_truth: str | None,
+    closeout_truth: str | None,
+    merge_conflicts: bool | None,
+    watch_target_status: str | None,
+    sprint_rollup_status: str | None,
+) -> dict[str, Any]:
+    normalized_goal_kind = normalize_choice(
+        goal_kind,
+        default="tracked_issue",
+        allowed=GOAL_KIND_VALUES,
+        field_name="goal kind",
+    )
+    if declared_boundary is None:
+        normalized_boundary = default_boundary_for_goal_kind(normalized_goal_kind)
+        boundary_source = "default_from_goal_kind"
+    else:
+        normalized_boundary = normalize_choice(
+            declared_boundary,
+            default="pr_green",
+            allowed=GOAL_BOUNDARY_VALUES,
+            field_name="goal boundary",
+        )
+        boundary_source = "explicit"
+
+    normalized_issue_state = normalize_choice(
+        issue_state,
+        default="unknown",
+        allowed=ISSUE_STATE_VALUES,
+        field_name="issue state",
+    )
+    normalized_pr_state = normalize_choice(
+        pr_state,
+        default="unknown",
+        allowed=PR_STATE_VALUES,
+        field_name="PR state",
+    )
+    normalized_checks_state = normalize_choice(
+        checks_state,
+        default="unknown",
+        allowed=CHECKS_STATE_VALUES,
+        field_name="checks state",
+    )
+    normalized_review_truth = normalize_choice(
+        review_truth,
+        default="unknown",
+        allowed=RECORD_TRUTH_VALUES,
+        field_name="review truth",
+    )
+    normalized_closeout_truth = normalize_choice(
+        closeout_truth,
+        default="unknown",
+        allowed=RECORD_TRUTH_VALUES,
+        field_name="closeout truth",
+    )
+    normalized_watch_target_status = normalize_choice(
+        watch_target_status,
+        default="unknown",
+        allowed=TARGET_STATE_VALUES,
+        field_name="watch target status",
+    )
+    normalized_sprint_rollup_status = normalize_choice(
+        sprint_rollup_status,
+        default="unknown",
+        allowed=TARGET_STATE_VALUES,
+        field_name="sprint rollup status",
+    )
+    merge_conflicts_value = "unknown" if merge_conflicts is None else str(bool(merge_conflicts)).lower()
+
+    result = {
+        "goal_kind": normalized_goal_kind,
+        "declared_boundary": normalized_boundary,
+        "boundary_source": boundary_source,
+        "issue_state": normalized_issue_state,
+        "pr_state": normalized_pr_state,
+        "checks_state": normalized_checks_state,
+        "review_truth": normalized_review_truth,
+        "closeout_truth": normalized_closeout_truth,
+        "merge_conflicts": merge_conflicts_value,
+        "watch_target_status": normalized_watch_target_status,
+        "sprint_rollup_status": normalized_sprint_rollup_status,
+        "completion_allowed": False,
+        "truth_status": "unknown",
+        "reason": "",
+    }
+
+    def satisfied(reason: str) -> dict[str, Any]:
+        result["completion_allowed"] = True
+        result["truth_status"] = "satisfied"
+        result["reason"] = reason
+        return result
+
+    def not_satisfied(reason: str) -> dict[str, Any]:
+        result["completion_allowed"] = False
+        result["truth_status"] = "not_satisfied"
+        result["reason"] = reason
+        return result
+
+    def unknown(reason: str) -> dict[str, Any]:
+        result["completion_allowed"] = False
+        result["truth_status"] = "unknown"
+        result["reason"] = reason
+        return result
+
+    if normalized_boundary == "handoff_only":
+        return satisfied(
+            "goal explicitly declares handoff-only completion; terminal completion may be recorded at the documented handoff boundary"
+        )
+
+    if normalized_boundary == "watch_target_reached":
+        if normalized_watch_target_status == "reached":
+            return satisfied("watch/janitor target state is reached")
+        if normalized_watch_target_status in {"not_reached", "blocked"}:
+            return not_satisfied("watch/janitor target state has not reached its declared terminal condition")
+        return unknown("watch/janitor target state is not yet known")
+
+    if normalized_boundary == "sprint_rollup_settled":
+        if normalized_sprint_rollup_status == "reached":
+            return satisfied("sprint child-issue rollup is settled")
+        if normalized_sprint_rollup_status in {"not_reached", "blocked"}:
+            return not_satisfied("sprint child-issue rollup is not settled")
+        return unknown("sprint child-issue rollup state is not yet known")
+
+    if merge_conflicts is True:
+        return not_satisfied("merge conflicts are still present")
+    if normalized_pr_state == "draft":
+        return not_satisfied("PR is still draft")
+    if normalized_pr_state == "open" and normalized_checks_state == "pending":
+        return not_satisfied("required checks are still pending")
+    if normalized_pr_state == "open" and normalized_checks_state == "red":
+        return not_satisfied("required checks are failing")
+    if normalized_pr_state == "open" and normalized_checks_state == "missing":
+        return not_satisfied("required checks are missing")
+    if normalized_review_truth in {"missing", "stale"}:
+        return not_satisfied("SRP/SOR review truth is not current")
+
+    if normalized_boundary == "pr_green":
+        if normalized_pr_state != "open":
+            return not_satisfied("PR must be open and reviewable for the default tracked-issue terminal boundary")
+        if normalized_checks_state in {"green", "skipped"}:
+            return satisfied("PR checks are green or explicitly skipped and review truth is current")
+        if normalized_checks_state == "unknown":
+            return unknown("PR checks state is not known")
+        return not_satisfied("PR has not reached a green-or-skipped checks state")
+
+    if normalized_boundary == "merged":
+        if normalized_pr_state == "merged":
+            return satisfied("PR is merged")
+        if normalized_pr_state in {"open", "draft"}:
+            return not_satisfied("PR is not merged yet")
+        if normalized_pr_state == "unknown":
+            return unknown("PR merge state is not known")
+        return not_satisfied("PR is not in a merged state")
+
+    if normalized_boundary == "closed_no_pr":
+        if normalized_issue_state == "closed" and normalized_pr_state in {"not_applicable", "not_opened", "closed"}:
+            return satisfied("issue is closed without an active PR requirement")
+        if normalized_issue_state == "unknown":
+            return unknown("issue closure state is not known")
+        return not_satisfied("issue is not closed in a no-PR terminal state")
+
+    if normalized_boundary == "closed_out":
+        if normalized_closeout_truth in {"missing", "stale"}:
+            return not_satisfied("closeout truth is not current")
+        if normalized_issue_state == "closed" and normalized_closeout_truth == "current":
+            return satisfied("issue is closed and closeout truth is current")
+        if normalized_issue_state == "unknown" or normalized_closeout_truth == "unknown":
+            return unknown("closed-out terminal state cannot be confirmed yet")
+        return not_satisfied("issue is not yet closed out")
+
+    return unknown("goal terminal-state boundary could not be evaluated")
+
+
+def validate_terminal_completion_allowed(record: dict[str, Any]) -> None:
+    completion_state = str(record.get("completion_state") or "unknown").strip().lower()
+    if completion_state not in {"completed", "completed_with_follow_on"}:
+        return
+    terminal_truth = record.get("goal_terminal_state") or {}
+    if terminal_truth.get("completion_allowed") is True:
+        return
+    reason = terminal_truth.get("reason") or "goal terminal-state truth is not satisfied"
+    raise ValueError(
+        "issue goal cannot be recorded as completed before the declared terminal state is satisfied: "
+        f"{reason}"
+    )
 
 
 def parse_availability_int(raw: str | None) -> tuple[str, int | None]:
@@ -326,6 +594,16 @@ def build_issue_goal_metrics_record(
     model_ref: str | None,
     session_ref: str | None,
     thread_id: str | None,
+    goal_kind: str | None = None,
+    goal_boundary: str | None = None,
+    issue_state: str | None = None,
+    pr_state: str | None = None,
+    checks_state: str | None = None,
+    review_truth: str | None = None,
+    closeout_truth: str | None = None,
+    merge_conflicts: bool | None = None,
+    watch_target_status: str | None = None,
+    sprint_rollup_status: str | None = None,
 ) -> dict[str, Any]:
     if capture_stage not in CAPTURE_STAGES:
         raise ValueError(f"invalid capture stage: {capture_stage}")
@@ -351,6 +629,18 @@ def build_issue_goal_metrics_record(
         else "not_available"
         if all(value == "not_available" for value in (total_availability, prompt_availability, completion_availability))
         else "unknown"
+    )
+    goal_terminal_state = evaluate_goal_terminal_state(
+        goal_kind=goal_kind,
+        declared_boundary=goal_boundary,
+        issue_state=issue_state,
+        pr_state=pr_state,
+        checks_state=checks_state,
+        review_truth=review_truth,
+        closeout_truth=closeout_truth,
+        merge_conflicts=merge_conflicts,
+        watch_target_status=watch_target_status,
+        sprint_rollup_status=sprint_rollup_status,
     )
 
     return {
@@ -392,6 +682,7 @@ def build_issue_goal_metrics_record(
         "model_ref": model_ref,
         "session_ref": session_ref,
         "thread_id": thread_id,
+        "goal_terminal_state": goal_terminal_state,
     }
 
 
@@ -408,6 +699,16 @@ def build_issue_goal_metrics_record_from_codex_goal_snapshot(
     completion_state_override: str | None,
     model_ref: str | None,
     session_ref: str | None,
+    goal_kind: str | None = None,
+    goal_boundary: str | None = None,
+    issue_state: str | None = None,
+    pr_state: str | None = None,
+    checks_state: str | None = None,
+    review_truth: str | None = None,
+    closeout_truth: str | None = None,
+    merge_conflicts: bool | None = None,
+    watch_target_status: str | None = None,
+    sprint_rollup_status: str | None = None,
 ) -> dict[str, Any]:
     snapshot = parse_codex_goal_tool_snapshot(goal_state_path)
     completion_state = completion_state_override or snapshot["completion_state"]
@@ -439,6 +740,16 @@ def build_issue_goal_metrics_record_from_codex_goal_snapshot(
         model_ref=model_ref,
         session_ref=session_ref or (f"codex-thread:{thread_id}" if isinstance(thread_id, str) else None),
         thread_id=thread_id if isinstance(thread_id, str) else None,
+        goal_kind=goal_kind,
+        goal_boundary=goal_boundary,
+        issue_state=issue_state,
+        pr_state=pr_state,
+        checks_state=checks_state,
+        review_truth=review_truth,
+        closeout_truth=closeout_truth,
+        merge_conflicts=merge_conflicts,
+        watch_target_status=watch_target_status,
+        sprint_rollup_status=sprint_rollup_status,
     )
 
 
@@ -455,6 +766,16 @@ def build_unknown_issue_goal_metrics_record(
     model_ref: str | None,
     session_ref: str | None,
     thread_id: str | None,
+    goal_kind: str | None = None,
+    goal_boundary: str | None = None,
+    issue_state: str | None = None,
+    pr_state: str | None = None,
+    checks_state: str | None = None,
+    review_truth: str | None = None,
+    closeout_truth: str | None = None,
+    merge_conflicts: bool | None = None,
+    watch_target_status: str | None = None,
+    sprint_rollup_status: str | None = None,
 ) -> dict[str, Any]:
     return build_issue_goal_metrics_record(
         sprint_issue_number=None,
@@ -483,6 +804,16 @@ def build_unknown_issue_goal_metrics_record(
         model_ref=model_ref,
         session_ref=session_ref,
         thread_id=thread_id,
+        goal_kind=goal_kind,
+        goal_boundary=goal_boundary,
+        issue_state=issue_state,
+        pr_state=pr_state,
+        checks_state=checks_state,
+        review_truth=review_truth,
+        closeout_truth=closeout_truth,
+        merge_conflicts=merge_conflicts,
+        watch_target_status=watch_target_status,
+        sprint_rollup_status=sprint_rollup_status,
     )
 
 
@@ -532,6 +863,9 @@ def summarize_issue_goal_metrics(records: list[dict[str, Any]], raw_log_path: st
     summary["model_ref"] = selected.get("model_ref")
     summary["session_ref"] = selected.get("session_ref")
     summary["thread_id"] = selected.get("thread_id")
+    summary["goal_terminal_state"] = deepcopy(
+        selected.get("goal_terminal_state") or default_goal_terminal_state_summary()
+    )
     return summary
 
 
@@ -562,6 +896,7 @@ def compute_goal_metrics_rollup(issue_records: list[dict[str, Any]]) -> dict[str
         "data_source_counts": {source: 0 for source in sorted(DATA_SOURCE_VALUES)},
         "goal_id_availability_counts": {availability: 0 for availability in sorted(AVAILABILITY_VALUES)},
         "completion_state_counts": {state: 0 for state in sorted(COMPLETION_STATE_VALUES)},
+        "terminal_truth_status_counts": {state: 0 for state in sorted(TERMINAL_TRUTH_STATUS_VALUES)},
         "elapsed_availability_counts": availability_counts(),
         "active_work_availability_counts": availability_counts(),
         "validation_availability_counts": availability_counts(),
@@ -591,6 +926,12 @@ def compute_goal_metrics_rollup(issue_records: list[dict[str, Any]]) -> dict[str
         if completion_state not in rollup["completion_state_counts"]:
             rollup["completion_state_counts"][completion_state] = 0
         rollup["completion_state_counts"][completion_state] += 1
+
+        terminal_truth = summary.get("goal_terminal_state") or default_goal_terminal_state_summary()
+        truth_status = terminal_truth.get("truth_status") or "unknown"
+        if truth_status not in rollup["terminal_truth_status_counts"]:
+            rollup["terminal_truth_status_counts"][truth_status] = 0
+        rollup["terminal_truth_status_counts"][truth_status] += 1
 
         elapsed_availability = summary.get("elapsed_availability") or "unknown"
         if elapsed_availability not in rollup["elapsed_availability_counts"]:

--- a/adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py
@@ -10,6 +10,7 @@ from issue_goal_metrics import (
     COMPLETION_STATE_VALUES,
     METRICS_CONFIDENCE_VALUES,
     build_issue_goal_metrics_record_from_codex_goal_snapshot,
+    validate_terminal_completion_allowed,
 )
 
 # Keep this script standalone and avoid importing sprint-state machinery. It
@@ -58,6 +59,17 @@ def main() -> int:
     )
     parser.add_argument("--model-ref")
     parser.add_argument("--session-ref")
+    parser.add_argument("--goal-kind")
+    parser.add_argument("--goal-boundary")
+    parser.add_argument("--issue-state")
+    parser.add_argument("--pr-state")
+    parser.add_argument("--checks-state")
+    parser.add_argument("--review-truth")
+    parser.add_argument("--closeout-truth")
+    parser.add_argument("--watch-target-status")
+    parser.add_argument("--sprint-rollup-status")
+    parser.add_argument("--merge-conflicts", action="store_true")
+    parser.add_argument("--no-merge-conflicts", action="store_true")
     parser.add_argument("--print-json", action="store_true")
     args = parser.parse_args()
 
@@ -76,7 +88,18 @@ def main() -> int:
         completion_state_override=args.completion_state,
         model_ref=args.model_ref,
         session_ref=args.session_ref,
+        goal_kind=args.goal_kind,
+        goal_boundary=args.goal_boundary,
+        issue_state=args.issue_state,
+        pr_state=args.pr_state,
+        checks_state=args.checks_state,
+        review_truth=args.review_truth,
+        closeout_truth=args.closeout_truth,
+        merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+        watch_target_status=args.watch_target_status,
+        sprint_rollup_status=args.sprint_rollup_status,
     )
+    validate_terminal_completion_allowed(record)
     append_jsonl(sink_path, record)
 
     issue_rows = [row for row in read_jsonl(sink_path) if row.get("issue_number") == args.issue_number]

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py
@@ -13,6 +13,7 @@ from issue_goal_metrics import (
     compute_goal_metrics_rollup,
     default_goal_metrics_summary,
     summarize_issue_goal_metrics,
+    validate_terminal_completion_allowed,
 )
 
 
@@ -92,6 +93,17 @@ def main() -> int:
     parser.add_argument("--model-ref")
     parser.add_argument("--session-ref")
     parser.add_argument("--thread-id")
+    parser.add_argument("--goal-kind")
+    parser.add_argument("--goal-boundary")
+    parser.add_argument("--issue-state")
+    parser.add_argument("--pr-state")
+    parser.add_argument("--checks-state")
+    parser.add_argument("--review-truth")
+    parser.add_argument("--closeout-truth")
+    parser.add_argument("--watch-target-status")
+    parser.add_argument("--sprint-rollup-status")
+    parser.add_argument("--merge-conflicts", action="store_true")
+    parser.add_argument("--no-merge-conflicts", action="store_true")
     parser.add_argument("--print-json", action="store_true")
     args = parser.parse_args()
 
@@ -129,7 +141,18 @@ def main() -> int:
         model_ref=args.model_ref,
         session_ref=args.session_ref,
         thread_id=args.thread_id,
+        goal_kind=args.goal_kind,
+        goal_boundary=args.goal_boundary,
+        issue_state=args.issue_state,
+        pr_state=args.pr_state,
+        checks_state=args.checks_state,
+        review_truth=args.review_truth,
+        closeout_truth=args.closeout_truth,
+        merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+        watch_target_status=args.watch_target_status,
+        sprint_rollup_status=args.sprint_rollup_status,
     )
+    validate_terminal_completion_allowed(record)
     append_jsonl(sink_path, record)
 
     all_rows = read_jsonl(sink_path)

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py
@@ -11,6 +11,7 @@ from issue_goal_metrics import (
     METRICS_CONFIDENCE_VALUES,
     build_issue_goal_metrics_record_from_codex_goal_snapshot,
     summarize_issue_goal_metrics,
+    validate_terminal_completion_allowed,
 )
 
 
@@ -63,6 +64,17 @@ def main() -> int:
     parser.add_argument("--model-ref")
     parser.add_argument("--session-ref")
     parser.add_argument("--completion-state")
+    parser.add_argument("--goal-kind")
+    parser.add_argument("--goal-boundary")
+    parser.add_argument("--issue-state")
+    parser.add_argument("--pr-state")
+    parser.add_argument("--checks-state")
+    parser.add_argument("--review-truth")
+    parser.add_argument("--closeout-truth")
+    parser.add_argument("--watch-target-status")
+    parser.add_argument("--sprint-rollup-status")
+    parser.add_argument("--merge-conflicts", action="store_true")
+    parser.add_argument("--no-merge-conflicts", action="store_true")
     parser.add_argument("--print-json", action="store_true")
     args = parser.parse_args()
 
@@ -87,7 +99,18 @@ def main() -> int:
         completion_state_override=args.completion_state,
         model_ref=args.model_ref,
         session_ref=args.session_ref,
+        goal_kind=args.goal_kind,
+        goal_boundary=args.goal_boundary,
+        issue_state=args.issue_state,
+        pr_state=args.pr_state,
+        checks_state=args.checks_state,
+        review_truth=args.review_truth,
+        closeout_truth=args.closeout_truth,
+        merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+        watch_target_status=args.watch_target_status,
+        sprint_rollup_status=args.sprint_rollup_status,
     )
+    validate_terminal_completion_allowed(record)
 
     rows = [
         row

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
@@ -13,6 +13,7 @@ from issue_goal_metrics import (
     find_codex_session_transcript,
     load_codex_goal_payload_from_session_transcript,
     summarize_issue_goal_metrics,
+    validate_terminal_completion_allowed,
 )
 
 
@@ -30,6 +31,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--completion-state-override")
     parser.add_argument("--model-ref")
     parser.add_argument("--session-ref")
+    parser.add_argument("--goal-kind")
+    parser.add_argument("--goal-boundary")
+    parser.add_argument("--issue-state")
+    parser.add_argument("--pr-state")
+    parser.add_argument("--checks-state")
+    parser.add_argument("--review-truth")
+    parser.add_argument("--closeout-truth")
+    parser.add_argument("--watch-target-status")
+    parser.add_argument("--sprint-rollup-status")
+    parser.add_argument("--merge-conflicts", action="store_true")
+    parser.add_argument("--no-merge-conflicts", action="store_true")
     parser.add_argument("--thread-id", default=os.environ.get("CODEX_THREAD_ID"))
     parser.add_argument("--session-root", default=os.path.expanduser("~/.codex/sessions"))
     parser.add_argument("--transcript-path")
@@ -90,6 +102,16 @@ def main() -> int:
                 completion_state_override=args.completion_state_override,
                 model_ref=args.model_ref,
                 session_ref=args.session_ref,
+                goal_kind=args.goal_kind,
+                goal_boundary=args.goal_boundary,
+                issue_state=args.issue_state,
+                pr_state=args.pr_state,
+                checks_state=args.checks_state,
+                review_truth=args.review_truth,
+                closeout_truth=args.closeout_truth,
+                merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+                watch_target_status=args.watch_target_status,
+                sprint_rollup_status=args.sprint_rollup_status,
             )
         finally:
             os.unlink(temp_snapshot_path)
@@ -106,7 +128,18 @@ def main() -> int:
             model_ref=args.model_ref,
             session_ref=args.session_ref,
             thread_id=args.thread_id,
+            goal_kind=args.goal_kind,
+            goal_boundary=args.goal_boundary,
+            issue_state=args.issue_state,
+            pr_state=args.pr_state,
+            checks_state=args.checks_state,
+            review_truth=args.review_truth,
+            closeout_truth=args.closeout_truth,
+            merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+            watch_target_status=args.watch_target_status,
+            sprint_rollup_status=args.sprint_rollup_status,
         )
+    validate_terminal_completion_allowed(record)
 
     jsonl_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics.jsonl"
     records = [

--- a/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
+++ b/adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py
@@ -100,6 +100,14 @@ def main() -> int:
             f"`completion_state={goal_metrics.get('completion_state') or 'unknown'}, "
             f"metrics_confidence={goal_metrics.get('metrics_confidence') or 'unknown'}`"
         )
+        terminal_truth = goal_metrics.get('goal_terminal_state') or {}
+        lines.append(
+            "  - goal terminal boundary: "
+            f"`kind={terminal_truth.get('goal_kind') or 'unknown'}, "
+            f"boundary={terminal_truth.get('declared_boundary') or 'unknown'}, "
+            f"allowed={terminal_truth.get('completion_allowed')}, "
+            f"truth_status={terminal_truth.get('truth_status') or 'unknown'}`"
+        )
         if goal_metrics.get('raw_log_path'):
             lines.append(f"  - goal metrics log: `{goal_metrics['raw_log_path']}`")
 
@@ -152,6 +160,7 @@ def main() -> int:
     lines.append(f"- data sources: `{goal_metrics_rollup['data_source_counts']}`")
     lines.append(f"- goal-id availability: `{goal_metrics_rollup['goal_id_availability_counts']}`")
     lines.append(f"- completion states: `{goal_metrics_rollup['completion_state_counts']}`")
+    lines.append(f"- terminal truth states: `{goal_metrics_rollup['terminal_truth_status_counts']}`")
     lines.append(
         f"- elapsed seconds: `known_sum={goal_metrics_rollup['total_elapsed_seconds_known_sum']}, "
         f"known_issue_count={goal_metrics_rollup['issues_with_known_elapsed']}, "

--- a/adl/tools/test_issue_goal_terminal_state_truth.sh
+++ b/adl/tools/test_issue_goal_terminal_state_truth.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+check_script="${repo_root}/adl/tools/check_issue_goal_terminal_state.py"
+record_script="${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py"
+state_path="${tmpdir}/state.json"
+sink_path="${tmpdir}/goal-metrics.jsonl"
+
+cat >"${state_path}" <<'JSON'
+{
+  "sprint_issue_number": 9000,
+  "ordered_issue_numbers": [4470],
+  "issue_records": [
+    {
+      "issue_number": 4470,
+      "status": "in_progress",
+      "artifact_paths": []
+    }
+  ]
+}
+JSON
+
+python3 - "${check_script}" <<'PY'
+import json
+import subprocess
+import sys
+
+check_script = sys.argv[1]
+
+def run(*args, expect=0):
+    proc = subprocess.run(
+        ["python3", check_script, *args],
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != expect:
+        raise SystemExit(
+            f"unexpected exit {proc.returncode} for {args}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+pending = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "pending",
+    "--review-truth", "current",
+    expect=1,
+)
+assert pending["truth_status"] == "not_satisfied"
+assert "pending" in pending["reason"]
+
+red = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "red",
+    "--review-truth", "current",
+    expect=1,
+)
+assert "failing" in red["reason"]
+
+draft = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "draft",
+    "--checks-state", "green",
+    "--review-truth", "current",
+    expect=1,
+)
+assert "draft" in draft["reason"]
+
+missing_checks = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "missing",
+    "--review-truth", "current",
+    expect=1,
+)
+assert "missing" in missing_checks["reason"]
+
+conflicted = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "green",
+    "--review-truth", "current",
+    "--merge-conflicts",
+    expect=1,
+)
+assert "conflicts" in conflicted["reason"]
+
+stale_review = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "green",
+    "--review-truth", "stale",
+    expect=1,
+)
+assert "current" in stale_review["reason"]
+
+green = run(
+    "--goal-kind", "implementation",
+    "--pr-state", "open",
+    "--checks-state", "green",
+    "--review-truth", "current",
+    expect=0,
+)
+assert green["completion_allowed"] is True
+
+setup = run(
+    "--goal-kind", "setup_only",
+    expect=0,
+)
+assert setup["declared_boundary"] == "handoff_only"
+assert setup["completion_allowed"] is True
+PY
+
+if python3 "${record_script}" \
+  --state "${state_path}" \
+  --issue-number 4470 \
+  --sink "${sink_path}" \
+  --capture-stage review_handoff \
+  --data-source manual_entry \
+  --completion-state completed \
+  --goal-kind implementation \
+  --pr-state open \
+  --checks-state pending \
+  --review-truth current >/dev/null 2>&1; then
+  echo "expected completed goal metrics record to fail when terminal state is pending" >&2
+  exit 1
+fi
+
+python3 "${record_script}" \
+  --state "${state_path}" \
+  --issue-number 4470 \
+  --sink "${sink_path}" \
+  --capture-stage review_handoff \
+  --data-source manual_entry \
+  --completion-state completed \
+  --goal-kind implementation \
+  --pr-state open \
+  --checks-state green \
+  --review-truth current >/dev/null
+
+python3 - "${state_path}" "${sink_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+rows = [json.loads(line) for line in Path(sys.argv[2]).read_text().splitlines() if line.strip()]
+assert len(rows) == 1
+record = rows[0]
+assert record["goal_terminal_state"]["completion_allowed"] is True
+assert record["goal_terminal_state"]["declared_boundary"] == "pr_green"
+summary = state["issue_records"][0]["goal_metrics"]
+assert summary["goal_terminal_state"]["truth_status"] == "satisfied"
+assert state["closeout"]["goal_metrics_rollup"]["terminal_truth_status_counts"]["satisfied"] == 1
+PY
+
+echo "PASS test_issue_goal_terminal_state_truth"

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1207,6 +1207,11 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goa
   --total-tokens 325020 \
   --metrics-confidence high \
   --completion-state completed \
+  --goal-kind sprint_child \
+  --goal-boundary closed_out \
+  --issue-state closed \
+  --closeout-truth current \
+  --pr-state not_applicable \
   --model-ref "gpt-5-codex" \
   --session-ref "codex-session-7002" \
   --thread-id "thread-7002" >/dev/null
@@ -1247,6 +1252,8 @@ assert record_7002["goal_metrics"]["pr_wait_seconds"] == 142
 assert record_7002["goal_metrics"]["pr_wait_availability"] == "known"
 assert record_7002["goal_metrics"]["ci_wait_availability"] == "not_applicable"
 assert record_7002["goal_metrics"]["completion_state"] == "completed"
+assert record_7002["goal_metrics"]["goal_terminal_state"]["completion_allowed"] is True
+assert record_7002["goal_metrics"]["goal_terminal_state"]["declared_boundary"] == "closed_out"
 assert record_7002["goal_metrics"]["metrics_confidence"] == "high"
 assert record_7002["goal_metrics"]["token_usage"]["total_tokens"] == 325020
 assert record_7002["goal_metrics"]["token_usage"]["total_availability"] == "known"
@@ -1280,6 +1287,8 @@ assert rollup["elapsed_availability_counts"]["not_collected"] == 1
 assert rollup["ci_wait_availability_counts"]["not_applicable"] == 1
 assert rollup["completion_state_counts"]["completed"] == 1
 assert rollup["completion_state_counts"]["unknown"] == 1
+assert rollup["terminal_truth_status_counts"]["satisfied"] == 1
+assert rollup["terminal_truth_status_counts"]["not_satisfied"] == 1
 PY
 
 goal_metrics_default_state_path="${tmpdir}/goal-metrics-default-state.json"
@@ -1369,9 +1378,11 @@ grep -Fq '## Goal Metrics Rollup' "${goal_metrics_artifact}"
 grep -Fq 'issues with recorded metrics: `2/2`' "${goal_metrics_artifact}"
 grep -Fq "goal refs: \`issue=goal:v0.91.6:sprint:7001:issue:7002, sprint=goal:v0.91.6:sprint:7001, rollup=.adl/v0.91.6/sprints/issue-7001__sample/goal-metrics.jsonl\`" "${goal_metrics_artifact}"
 grep -Fq 'goal timing buckets: `active_work=1220, validation=200, pr_wait=142, ci_wait=not_applicable`' "${goal_metrics_artifact}"
+grep -Fq 'goal terminal boundary: `kind=sprint_child, boundary=closed_out, allowed=True, truth_status=satisfied`' "${goal_metrics_artifact}"
 grep -Fq "data sources: \`{'codex_goal_tool': 1, 'derived_sprint_state': 0, 'manual_entry': 1, 'unknown': 0}\`" "${goal_metrics_artifact}"
 grep -Fq "goal-id availability: \`{'known': 1, 'not_applicable': 0, 'not_available': 1, 'not_collected': 0, 'unknown': 0}\`" "${goal_metrics_artifact}"
 grep -Fq "completion states: \`{'blocked': 0, 'cancelled': 0, 'completed': 1, 'completed_with_follow_on': 0, 'deferred': 0, 'failed': 0, 'unknown': 1}\`" "${goal_metrics_artifact}"
+grep -Fq "terminal truth states: \`{'not_satisfied': 1, 'satisfied': 1, 'unknown': 0}\`" "${goal_metrics_artifact}"
 grep -Fq "elapsed seconds: \`known_sum=1562, known_issue_count=1, unknown_issue_count=0, availability_counts={'known': 1, 'not_applicable': 0, 'not_available': 0, 'not_collected': 1, 'unknown': 0}\`" "${goal_metrics_artifact}"
 grep -Fq "active work seconds: \`known_sum=1220, known_issue_count=1, unknown_issue_count=1, availability_counts={'known': 1, 'not_applicable': 0, 'not_available': 0, 'not_collected': 0, 'unknown': 1}\`" "${goal_metrics_artifact}"
 grep -Fq "validation seconds: \`known_sum=200, known_issue_count=1, unknown_issue_count=1, availability_counts={'known': 1, 'not_applicable': 0, 'not_available': 0, 'not_collected': 0, 'unknown': 1}\`" "${goal_metrics_artifact}"
@@ -1671,6 +1682,8 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goa
   --artifacts-dir "${goal_stage_artifacts_dir}" \
   --capture-stage pr_publication \
   --issue-goal-ref "goal:v0.91.6:issue:4431" \
+  --goal-kind review_only \
+  --goal-boundary handoff_only \
   --metrics-confidence high \
   --model-ref "gpt-5-codex" >/dev/null
 
@@ -1705,6 +1718,7 @@ assert summary["selected_stage"] == "pr_publication"
 assert summary["token_usage"]["total_tokens"] == 3000
 assert summary["elapsed_seconds"] == 30
 assert summary["completion_state"] == "completed"
+assert summary["goal_terminal_state"]["declared_boundary"] == "handoff_only"
 PY
 
 codex_session_root="${tmpdir}/codex-sessions"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -149,11 +149,25 @@ the child issue number, and the concrete bounded session objective.
 
 Use `update_goal` only for truthful terminal state:
 
-- `complete` when the current session objective is actually achieved, including
-  publication-to-review handoff when opening or updating the PR was the bounded
-  session objective
+- `complete` when the current session objective's declared terminal boundary is
+  actually satisfied
+- handoff-only completion is allowed only when the goal explicitly declares a
+  setup-only, review-only, or similar handoff boundary
+- default tracked implementation goals stay active while the PR is red,
+  pending, conflicted, draft, missing required checks, or missing current
+  SRP/SOR truth
 - `blocked` only when the repeated blocking threshold is met and meaningful
   progress cannot continue without user input or an external state change
+
+When the completion boundary matters, evaluate and record it explicitly with:
+
+```bash
+python3 adl/tools/check_issue_goal_terminal_state.py \
+  --goal-kind implementation \
+  --pr-state open \
+  --checks-state green \
+  --review-truth current
+```
 
 When issue-local time/token accounting matters, preserve a durable local goal
 snapshot from the host Codex session transcript before the live goal disappears.

--- a/docs/milestones/v0.91.6/features/PER_ISSUE_EXECUTION_METRICS_FOUNDATION_v0.91.6.md
+++ b/docs/milestones/v0.91.6/features/PER_ISSUE_EXECUTION_METRICS_FOUNDATION_v0.91.6.md
@@ -99,6 +99,7 @@ Each issue-local `SOR` should carry the following execution-facing fields:
 | `actual_metrics_confidence` | Confidence in the actual metrics payload. |
 | `estimate_error_percent` | Rolled-up estimate/actual error when computable. |
 | `completion_state` | Truthful issue-local outcome such as `completed`, `completed_with_follow_on`, `blocked`, `failed`, `deferred`, `cancelled`, or `unknown`. |
+| `goal_terminal_state` | Terminal-boundary truth for the selected goal record, including goal kind, declared boundary, issue/PR evidence, whether completion was allowed, and the reason. |
 
 Actual-value rules:
 

--- a/docs/tooling/ISSUE_BOUND_GOAL_TERMINAL_STATE_POLICY.md
+++ b/docs/tooling/ISSUE_BOUND_GOAL_TERMINAL_STATE_POLICY.md
@@ -1,0 +1,90 @@
+# Issue-Bound Goal Terminal-State Policy
+
+This document defines when an issue-bound Codex goal may truthfully be marked
+`complete` in ADL workflow sessions.
+
+## Purpose
+
+Issue-bound goals exist to make token/time accounting, sprint rollups, and
+workflow state truthful. A goal must not be marked complete merely because a
+local session produced a patch, opened a draft PR, or reached a convenient
+pause point.
+
+## Default Rule
+
+Default tracked implementation goals remain active until the declared terminal
+boundary is satisfied.
+
+They must not be marked complete while the issue or PR is:
+
+- red
+- pending
+- conflicted
+- draft
+- missing required checks
+- missing current SRP/SOR truth
+
+## Allowed Goal Kinds
+
+- `setup_only`
+- `implementation`
+- `watcher`
+- `janitor`
+- `review_only`
+- `sprint_child`
+- `sprint_umbrella`
+- `tracked_issue`
+
+## Terminal Boundaries
+
+- `handoff_only`
+  Use only when the goal explicitly declares setup-only, review-only, or
+  equivalent handoff scope.
+- `pr_green`
+  Default tracked implementation boundary. Requires an open non-draft PR,
+  green or explicitly skipped required checks, and current SRP/SOR truth.
+- `merged`
+  Use when the goal declares merge as the terminal state.
+- `closed_no_pr`
+  Use for intentional no-PR closure work.
+- `closed_out`
+  Use when the goal must carry through issue closure and closeout truth.
+- `watch_target_reached`
+  Use for watcher/janitor goals that must wait for an observed target state.
+- `sprint_rollup_settled`
+  Use for sprint umbrella goals that depend on child-issue terminal truth.
+
+## Handoff Rule
+
+Handoff-only completion is never implicit. If a goal is allowed to complete at
+publication or review handoff, that narrower terminal boundary must be explicit
+in the goal objective or the recorded workflow artifact.
+
+## Recording Rule
+
+When goal completion is captured in durable workflow artifacts, also record:
+
+- goal kind
+- declared terminal boundary
+- issue/PR state used for evaluation
+- review truth status
+- closeout truth status when applicable
+- whether completion was allowed
+- the reason for the decision
+
+## Tooling Hook
+
+Use `adl/tools/check_issue_goal_terminal_state.py` for a fail-closed terminal
+state evaluation:
+
+```bash
+python3 adl/tools/check_issue_goal_terminal_state.py \
+  --goal-kind implementation \
+  --pr-state open \
+  --checks-state green \
+  --review-truth current
+```
+
+Goal metrics capture helpers under
+`adl/tools/skills/sprint-conductor/scripts/` may also record and enforce this
+truth when completion is being written into durable issue or sprint artifacts.


### PR DESCRIPTION
## Summary
- add a fail-closed issue-bound goal terminal-state evaluator for tracked issue goal metrics
- wire terminal-boundary truth into the goal metrics capture helpers and sprint closeout rollups
- document when `update_goal complete` is allowed for implementation, handoff-only, watcher/janitor, and sprint goal types

## Validation
- `python3 -m py_compile adl/tools/check_issue_goal_terminal_state.py adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_codex_goal_tool_snapshot.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_artifacts.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py adl/tools/skills/sprint-conductor/scripts/write_sprint_closeout_artifact.py`
- `bash adl/tools/test_issue_goal_terminal_state_truth.sh`
- `bash adl/tools/test_sprint_conductor_helpers.sh`
- `git diff --check`

## Notes
- This change tightens goal-metrics recording so completed issue-bound goals now fail closed unless their declared terminal boundary is satisfied.
- Existing helper fixtures were updated to declare explicit `closed_out` or `handoff_only` boundaries where that was the intended truth.

Closes #4470
