### PR TITLE
[v0.91.6][tools][workflow] Make canonical .adl lifecycle truth worktree-safe

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -20,7 +20,7 @@ use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
     ensure_pre_run_bootstrap_cards, ensure_source_issue_prompt, ensure_symlink,
     ensure_task_bundle_stp, ensure_worktree_task_bundle_materialized, field_line_value,
-    mirror_docs_templates_into_worktree, path_relative_to_repo,
+    mirror_docs_templates_into_worktree, mirror_scope_sprints_into_worktree, path_relative_to_repo,
     sync_root_task_bundle_into_worktree, validate_bootstrap_stp, validate_initialized_cards,
     validate_issue_body_for_create, validate_ready_cards, write_source_issue_prompt,
 };
@@ -31,7 +31,7 @@ use super::pr_cmd_prompt::{
     infer_required_outcome_type, infer_workflow_queue, normalize_issue_title_for_version,
     normalize_labels_csv, parse_issue_number_from_url, render_generated_issue_body,
     resolve_issue_body, resolve_issue_prompt_path, resolve_issue_prompt_workflow_queue,
-    resolve_issue_scope_and_slug_from_local_state, validate_issue_prompt_exists,
+    resolve_issue_scope_and_slug_from_available_local_state, validate_issue_prompt_exists,
     version_from_labels_csv, version_from_title, WorkflowQueueResolution,
 };
 use super::pr_cmd_validate::{
@@ -130,7 +130,7 @@ fn resolve_version_for_existing_issue(
 
     if no_fetch_issue {
         if let Some((version, _slug)) =
-            resolve_issue_scope_and_slug_from_local_state(repo_root, issue)?
+            resolve_issue_scope_and_slug_from_available_local_state(repo_root, issue)?
         {
             return Ok(version);
         }
@@ -147,7 +147,7 @@ fn resolve_version_for_existing_issue(
 }
 
 fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(String, String)>> {
-    resolve_issue_scope_and_slug_from_local_state(repo_root, issue)
+    resolve_issue_scope_and_slug_from_available_local_state(repo_root, issue)
 }
 
 fn resolve_start_slug(
@@ -1297,6 +1297,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 
     let worktree_source = ensure_local_issue_prompt_copy(&worktree_path, &issue_ref, &source_path)?;
     mirror_docs_templates_into_worktree(&repo_root, &worktree_path)?;
+    mirror_scope_sprints_into_worktree(&repo_root, &worktree_path, &issue_ref)?;
     let worktree_stp = ensure_task_bundle_stp(&worktree_path, &issue_ref, &worktree_source)?;
     validate_authored_prompt_surface("start", &worktree_stp, PromptSurfaceKind::Stp)?;
 
@@ -1429,7 +1430,10 @@ fn real_pr_closeout(args: &[String]) -> Result<()> {
     let repo_root = repo_root()?;
     let primary_root = primary_checkout_root()?;
     let repo = default_repo(&primary_root)?;
-    let inferred = resolve_issue_scope_and_slug_from_local_state(&primary_root, parsed.issue)?
+    let inferred = resolve_issue_scope_and_slug_from_available_local_state(
+        &primary_root,
+        parsed.issue,
+    )?
         .unwrap_or((
             parsed
                 .version

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1430,20 +1430,18 @@ fn real_pr_closeout(args: &[String]) -> Result<()> {
     let repo_root = repo_root()?;
     let primary_root = primary_checkout_root()?;
     let repo = default_repo(&primary_root)?;
-    let inferred = resolve_issue_scope_and_slug_from_available_local_state(
-        &primary_root,
-        parsed.issue,
-    )?
-        .unwrap_or((
-            parsed
-                .version
-                .clone()
-                .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
-            parsed
-                .slug
-                .clone()
-                .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
-        ));
+    let inferred =
+        resolve_issue_scope_and_slug_from_available_local_state(&primary_root, parsed.issue)?
+            .unwrap_or((
+                parsed
+                    .version
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
+                parsed
+                    .slug
+                    .clone()
+                    .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
+            ));
     let issue_ref = IssueRef::new(parsed.issue, inferred.0, inferred.1)?;
     let output_path = issue_ref.task_bundle_output_path(&primary_root);
     lifecycle::ensure_issue_closed_completed_for_closeout(parsed.issue, &repo)?;

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -166,7 +166,7 @@ fn resolve_doctor_scope_and_slug(
     if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
         return Ok((version, slug));
     }
-    let inferred = resolve_issue_scope_and_slug_from_local_state(repo_root, parsed.issue)?;
+    let inferred = resolve_issue_scope_and_slug_from_available_local_state(repo_root, parsed.issue)?;
     let version = parsed
         .version
         .clone()

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -166,7 +166,8 @@ fn resolve_doctor_scope_and_slug(
     if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
         return Ok((version, slug));
     }
-    let inferred = resolve_issue_scope_and_slug_from_available_local_state(repo_root, parsed.issue)?;
+    let inferred =
+        resolve_issue_scope_and_slug_from_available_local_state(repo_root, parsed.issue)?;
     let version = parsed
         .version
         .clone()

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -4,8 +4,8 @@ use crate::cli::pr_cmd::doctor::ready::{
     ready_validation_repo_root, stale_worktree_branch_mismatch_preserves_pre_run,
 };
 use crate::cli::pr_cmd_cards::mirror_scope_sprints_into_worktree;
-use crate::cli::pr_cmd_prompt::resolve_issue_scope_and_slug_from_available_local_state;
 use crate::cli::pr_cmd_cards::StructuredBundlePaths;
+use crate::cli::pr_cmd_prompt::resolve_issue_scope_and_slug_from_available_local_state;
 use crate::cli::tests::env_lock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -34,8 +34,12 @@ fn doctor_issue_prompt_resolution_falls_back_to_bound_worktree_prompt() {
 fn local_issue_identity_resolution_falls_back_to_bound_worktree_bundle_from_nested_path() {
     let _guard = env_lock();
     let repo = lifecycle_temp_repo("doctor-identity-worktree-fallback");
-    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
-        .expect("issue ref");
+    let issue_ref = IssueRef::new(
+        4455,
+        "v0.91.6".to_string(),
+        "worktree-safe-truth".to_string(),
+    )
+    .expect("issue ref");
     let worktree = issue_ref.default_worktree_path(&repo, None);
     let bundle = issue_ref.task_bundle_dir_path(&worktree);
     fs::create_dir_all(&bundle).expect("create worktree bundle");
@@ -60,14 +64,17 @@ fn local_issue_identity_resolution_falls_back_to_bound_worktree_bundle_from_nest
 fn local_issue_identity_resolution_blocks_when_primary_and_worktree_disagree() {
     let _guard = env_lock();
     let repo = lifecycle_temp_repo("doctor-identity-worktree-mismatch");
-    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
-        .expect("issue ref");
+    let issue_ref = IssueRef::new(
+        4455,
+        "v0.91.6".to_string(),
+        "worktree-safe-truth".to_string(),
+    )
+    .expect("issue ref");
     let primary_bundle = issue_ref.task_bundle_dir_path(&repo);
     fs::create_dir_all(&primary_bundle).expect("create primary bundle");
 
     let worktree = issue_ref.default_worktree_path(&repo, None);
-    let worktree_bundle = worktree
-        .join(".adl/v0.91.7/tasks/issue-4455__worktree-safe-truth");
+    let worktree_bundle = worktree.join(".adl/v0.91.7/tasks/issue-4455__worktree-safe-truth");
     fs::create_dir_all(&worktree_bundle).expect("create mismatched worktree bundle");
     fs::create_dir_all(&worktree).expect("create worktree root");
     fs::write(worktree.join(".git"), "gitdir: /tmp/fake-worktree\n").expect("seed git marker");
@@ -89,8 +96,12 @@ fn local_issue_identity_resolution_blocks_when_primary_and_worktree_disagree() {
 #[test]
 fn sprint_packets_are_materialized_into_bound_worktree_without_root_writes() {
     let repo = lifecycle_temp_repo("doctor-sprint-worktree-materialization");
-    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
-        .expect("issue ref");
+    let issue_ref = IssueRef::new(
+        4455,
+        "v0.91.6".to_string(),
+        "worktree-safe-truth".to_string(),
+    )
+    .expect("issue ref");
     let worktree = issue_ref.default_worktree_path(&repo, None);
     let sprint_log = repo
         .join(".adl/v0.91.6/sprints/issue-4417__v0-91-6-tools-mini-sprint-validation-throughput-and-lifecycle-automation/SPRINT_ACTIVITY_LOG.md");

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -3,7 +3,10 @@ use super::*;
 use crate::cli::pr_cmd::doctor::ready::{
     ready_validation_repo_root, stale_worktree_branch_mismatch_preserves_pre_run,
 };
+use crate::cli::pr_cmd_cards::mirror_scope_sprints_into_worktree;
+use crate::cli::pr_cmd_prompt::resolve_issue_scope_and_slug_from_available_local_state;
 use crate::cli::pr_cmd_cards::StructuredBundlePaths;
+use crate::cli::tests::env_lock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -25,6 +28,87 @@ fn doctor_issue_prompt_resolution_falls_back_to_bound_worktree_prompt() {
         resolve_doctor_issue_prompt_path(&repo, &issue_ref).expect("doctor source prompt");
 
     assert_eq!(resolved, source_path);
+}
+
+#[test]
+fn local_issue_identity_resolution_falls_back_to_bound_worktree_bundle_from_nested_path() {
+    let _guard = env_lock();
+    let repo = lifecycle_temp_repo("doctor-identity-worktree-fallback");
+    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
+        .expect("issue ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let bundle = issue_ref.task_bundle_dir_path(&worktree);
+    fs::create_dir_all(&bundle).expect("create worktree bundle");
+    fs::create_dir_all(&worktree).expect("create worktree root");
+    fs::write(worktree.join(".git"), "gitdir: /tmp/fake-worktree\n").expect("seed git marker");
+    let nested = worktree.join("adl/src");
+    fs::create_dir_all(&nested).expect("create nested worktree path");
+
+    let previous = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&nested).expect("chdir nested worktree path");
+    let resolved = resolve_issue_scope_and_slug_from_available_local_state(&repo, 4455)
+        .expect("resolve local identity");
+    std::env::set_current_dir(previous).expect("restore cwd");
+
+    assert_eq!(
+        resolved,
+        Some(("v0.91.6".to_string(), "worktree-safe-truth".to_string()))
+    );
+}
+
+#[test]
+fn local_issue_identity_resolution_blocks_when_primary_and_worktree_disagree() {
+    let _guard = env_lock();
+    let repo = lifecycle_temp_repo("doctor-identity-worktree-mismatch");
+    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
+        .expect("issue ref");
+    let primary_bundle = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&primary_bundle).expect("create primary bundle");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let worktree_bundle = worktree
+        .join(".adl/v0.91.7/tasks/issue-4455__worktree-safe-truth");
+    fs::create_dir_all(&worktree_bundle).expect("create mismatched worktree bundle");
+    fs::create_dir_all(&worktree).expect("create worktree root");
+    fs::write(worktree.join(".git"), "gitdir: /tmp/fake-worktree\n").expect("seed git marker");
+    let nested = worktree.join("adl/src");
+    fs::create_dir_all(&nested).expect("create nested worktree path");
+
+    let previous = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&nested).expect("chdir nested worktree path");
+    let err = resolve_issue_scope_and_slug_from_available_local_state(&repo, 4455)
+        .expect_err("mismatched issue identity should block");
+    std::env::set_current_dir(previous).expect("restore cwd");
+
+    assert!(
+        format!("{err:#}").contains("local issue identity mismatch"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn sprint_packets_are_materialized_into_bound_worktree_without_root_writes() {
+    let repo = lifecycle_temp_repo("doctor-sprint-worktree-materialization");
+    let issue_ref = IssueRef::new(4455, "v0.91.6".to_string(), "worktree-safe-truth".to_string())
+        .expect("issue ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let sprint_log = repo
+        .join(".adl/v0.91.6/sprints/issue-4417__v0-91-6-tools-mini-sprint-validation-throughput-and-lifecycle-automation/SPRINT_ACTIVITY_LOG.md");
+    fs::create_dir_all(sprint_log.parent().expect("sprint parent")).expect("create sprint parent");
+    fs::write(
+        &sprint_log,
+        "# Sprint activity fixture\n\n- should be copied into the worktree once bound.\n",
+    )
+    .expect("write sprint log");
+
+    mirror_scope_sprints_into_worktree(&repo, &worktree, &issue_ref).expect("mirror sprint state");
+
+    let mirrored = worktree
+        .join(".adl/v0.91.6/sprints/issue-4417__v0-91-6-tools-mini-sprint-validation-throughput-and-lifecycle-automation/SPRINT_ACTIVITY_LOG.md");
+    assert_eq!(
+        fs::read_to_string(mirrored).expect("read mirrored sprint log"),
+        "# Sprint activity fixture\n\n- should be copied into the worktree once bound.\n"
+    );
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -560,6 +560,19 @@ pub(crate) fn mirror_docs_templates_into_worktree(
     copy_directory_contents(&source_templates, &target_templates)
 }
 
+pub(crate) fn mirror_scope_sprints_into_worktree(
+    repo_root: &Path,
+    worktree_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let source_sprints = repo_root.join(".adl").join(issue_ref.scope()).join("sprints");
+    if !source_sprints.is_dir() {
+        return Ok(());
+    }
+    let target_sprints = worktree_root.join(".adl").join(issue_ref.scope()).join("sprints");
+    crate::cli::pr_cmd_cards::copy_directory_contents_if_missing(&source_sprints, &target_sprints)
+}
+
 pub(crate) fn ensure_bootstrap_cards(
     root: &Path,
     issue_ref: &IssueRef,

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -565,11 +565,17 @@ pub(crate) fn mirror_scope_sprints_into_worktree(
     worktree_root: &Path,
     issue_ref: &IssueRef,
 ) -> Result<()> {
-    let source_sprints = repo_root.join(".adl").join(issue_ref.scope()).join("sprints");
+    let source_sprints = repo_root
+        .join(".adl")
+        .join(issue_ref.scope())
+        .join("sprints");
     if !source_sprints.is_dir() {
         return Ok(());
     }
-    let target_sprints = worktree_root.join(".adl").join(issue_ref.scope()).join("sprints");
+    let target_sprints = worktree_root
+        .join(".adl")
+        .join(issue_ref.scope())
+        .join("sprints");
     crate::cli::pr_cmd_cards::copy_directory_contents_if_missing(&source_sprints, &target_sprints)
 }
 

--- a/adl/src/cli/pr_cmd_cards/shared.rs
+++ b/adl/src/cli/pr_cmd_cards/shared.rs
@@ -62,6 +62,25 @@ pub(crate) fn copy_directory_contents(source: &Path, target: &Path) -> Result<()
     Ok(())
 }
 
+pub(crate) fn copy_directory_contents_if_missing(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_directory_contents_if_missing(&source_path, &target_path)?;
+        } else if file_type.is_file() && !target_path.exists() {
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&source_path, &target_path)?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn ensure_symlink(link_path: &Path, target: &Path) -> Result<()> {
     if let Some(parent) = link_path.parent() {
         fs::create_dir_all(parent)?;

--- a/adl/src/cli/pr_cmd_prompt.rs
+++ b/adl/src/cli/pr_cmd_prompt.rs
@@ -121,6 +121,52 @@ pub(crate) fn resolve_issue_scope_and_slug_from_local_state(
     Ok(matches.into_iter().next())
 }
 
+pub(crate) fn resolve_issue_scope_and_slug_from_available_local_state(
+    primary_root: &Path,
+    issue: u32,
+) -> Result<Option<(String, String)>> {
+    let checkout_identity = if let Some(cwd_root) = current_checkout_root() {
+        if cwd_root != primary_root {
+            resolve_issue_scope_and_slug_from_local_state(&cwd_root, issue)?
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let primary_identity = resolve_issue_scope_and_slug_from_local_state(primary_root, issue)?;
+    match (checkout_identity, primary_identity) {
+        (Some(checkout), Some(primary)) => {
+            if checkout != primary {
+                bail!(
+                    "local issue identity mismatch for issue #{}: active checkout resolved {}:{} but primary checkout resolved {}:{}",
+                    issue,
+                    checkout.0,
+                    checkout.1,
+                    primary.0,
+                    primary.1
+                );
+            }
+            Ok(Some(checkout))
+        }
+        (Some(checkout), None) => Ok(Some(checkout)),
+        (None, Some(primary)) => Ok(Some(primary)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn current_checkout_root() -> Option<PathBuf> {
+    let mut cursor = std::env::current_dir().ok()?;
+    loop {
+        if cursor.join(".git").exists() {
+            return Some(cursor);
+        }
+        if !cursor.pop() {
+            return None;
+        }
+    }
+}
+
 pub(crate) fn normalize_issue_title_for_version(title: &str, version: &str) -> String {
     let trimmed = title.trim();
     if trimmed.is_empty() {

--- a/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
+++ b/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
@@ -48,6 +48,15 @@ Disallowed primary-checkout uses:
 - parking untracked issue artifacts in root when a bound worktree exists
 
 After an issue is bound, tracked edits happen in the bound issue worktree.
+The bound worktree's local `.adl/<version>/tasks/...` bundle is the active
+issue-local execution surface for normal issue work. Materialized
+`.adl/<version>/sprints/...` packet copies in the worktree are convenience
+mirrors for local context, not silent replacements for the primary checkout's
+canonical sprint record. If the worktree-local issue identity disagrees with
+the primary checkout for the same issue, stop and repair the mismatch instead
+of guessing which copy is right. Root-only `.adl` state remains bootstrap,
+coordination, and sprint-truth context rather than a hidden per-issue live
+authority during execution.
 
 ## Required Startup Check
 


### PR DESCRIPTION
Closes #4455

## Summary
- make local issue identity resolution work from nested bound worktree paths without silently preferring stale worktree truth over primary checkout truth
- materialize sprint packets into bound worktrees for local context while documenting that sprint mirrors are convenience copies, not hidden canonical authority
- add focused regression proof for nested worktree resolution and root/worktree mismatch blocking

## Validation
- cargo test --manifest-path /Users/daniel/git/agent-design-language/.worktrees/adl-wp-4455/adl/Cargo.toml local_issue_identity_resolution_ -- --nocapture
- git -C /Users/daniel/git/agent-design-language/.worktrees/adl-wp-4455 diff --check

