### PR TITLE
[v0.91.6][tools] Fix pr init version inference before remote mutation

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -14,6 +14,7 @@ use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use crate::cli::tokio_runtime::with_current_thread_runtime;
 use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -1500,14 +1501,76 @@ fn helper_command_path(repo_root: &Path, relative: &str) -> String {
 }
 
 pub(super) fn issue_version(issue: u32, repo: &str) -> Result<Option<String>> {
-    for label in gh_issue_label_names(issue, repo)? {
-        if let Some(version) = label.strip_prefix("version:") {
-            return Ok(Some(version.trim().to_string()));
-        }
+    let label_versions = gh_issue_label_names(issue, repo)?
+        .into_iter()
+        .filter_map(|label| {
+            label
+                .strip_prefix("version:")
+                .map(|version| version.trim().to_string())
+                .filter(|version| !version.is_empty())
+        })
+        .collect::<BTreeSet<_>>();
+    if label_versions.len() > 1 {
+        bail!(
+            "issue_version: conflicting version labels for issue #{}: {}",
+            issue,
+            label_versions.into_iter().collect::<Vec<_>>().join(", ")
+        );
     }
 
-    let title = gh_issue_title(issue, repo)?;
-    Ok(title.and_then(|title| version_from_title(&title)))
+    let title_version = gh_issue_title(issue, repo)?.and_then(|title| version_from_title(&title));
+    let body_version = match gh_issue_body(issue, repo)? {
+        Some(body) => explicit_issue_body_version(&body)?,
+        None => None,
+    };
+
+    let mut evidence = BTreeMap::new();
+    if let Some(version) = label_versions.iter().next().cloned() {
+        evidence.insert("label", version);
+    }
+    if let Some(version) = title_version {
+        evidence.insert("title", version);
+    }
+    if let Some(version) = body_version {
+        evidence.insert("body", version);
+    }
+
+    let unique_versions = evidence.values().cloned().collect::<BTreeSet<_>>();
+    if unique_versions.len() > 1 {
+        let sources = evidence
+            .into_iter()
+            .map(|(source, version)| format!("{source}={version}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "issue_version: conflicting version evidence for issue #{}: {}",
+            issue,
+            sources
+        );
+    }
+
+    Ok(unique_versions.into_iter().next())
+}
+
+fn explicit_issue_body_version(body: &str) -> Result<Option<String>> {
+    let mut versions = std::collections::BTreeSet::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        let value = trimmed
+            .strip_prefix("Version:")
+            .or_else(|| trimmed.strip_prefix("version:"))
+            .map(str::trim);
+        if let Some(version) = value.filter(|value| !value.is_empty()) {
+            versions.insert(version.to_string());
+        }
+    }
+    if versions.len() > 1 {
+        bail!(
+            "issue_version: conflicting explicit body version evidence: {}",
+            versions.into_iter().collect::<Vec<_>>().join(", ")
+        );
+    }
+    Ok(versions.into_iter().next())
 }
 
 pub(super) fn gh_issue_create(

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -447,6 +447,98 @@ fn github_helpers_cover_fallback_and_spawn_failure_paths() {
 }
 
 #[test]
+fn issue_version_prefers_consistent_label_title_and_body_evidence_and_fails_closed_on_conflict() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-github-issue-version-evidence");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let title_file = temp.join("title.txt");
+    let labels_file = temp.join("labels.txt");
+    let body_file = temp.join("body.md");
+    let github_cli_fixture = bin_dir.join("github-cli-fixture");
+
+    write_executable(
+        &github_cli_fixture,
+        &format!(
+            r#"#!/usr/bin/env python3
+import pathlib
+import sys
+
+title = pathlib.Path({title:?})
+labels = pathlib.Path({labels:?})
+body = pathlib.Path({body:?})
+args = sys.argv[1:]
+
+if args[:2] == ["issue", "view"]:
+    if "labels" in args:
+        print(labels.read_text(encoding="utf-8"), end="")
+        sys.exit(0)
+    if "title" in args:
+        print(title.read_text(encoding="utf-8"), end="")
+        sys.exit(0)
+    if "body" in args:
+        print(body.read_text(encoding="utf-8"), end="")
+        sys.exit(0)
+sys.exit(9)
+"#,
+            title = title_file.display().to_string(),
+            labels = labels_file.display().to_string(),
+            body = body_file.display().to_string(),
+        ),
+    );
+
+    let old_path = std::env::var("PATH").ok();
+    let mut path_entries = vec![bin_dir.clone()];
+    path_entries.extend(std::env::split_paths(old_path.as_deref().unwrap_or("")));
+    unsafe {
+        std::env::set_var("ADL_TEST_GITHUB_CLI_FIXTURE", &github_cli_fixture);
+        std::env::set_var(
+            "PATH",
+            std::env::join_paths(path_entries).expect("join PATH"),
+        );
+    }
+
+    fs::write(&labels_file, "track:roadmap\nversion:v0.91.6\n").expect("labels");
+    fs::write(&title_file, "[v0.91.6][adr] Create and route v0.91.6 ADR candidates\n")
+        .expect("title");
+    fs::write(
+        &body_file,
+        "## Summary\nObserved repair failure: `pr init 4383` inferred `v0.91.7` for a `v0.91.6` issue.\n\nVersion: v0.91.6\n",
+    )
+    .expect("body");
+
+    assert_eq!(
+        issue_version(4383, "owner/repo").expect("consistent inferred version"),
+        Some("v0.91.6".to_string())
+    );
+
+    fs::write(
+        &body_file,
+        "## Summary\nObserved repair failure: `pr init 4383` inferred `v0.91.7` for a `v0.91.6` issue.\n\nVersion: v0.91.7\n",
+    )
+    .expect("conflicting body");
+
+    let err = issue_version(4383, "owner/repo").expect_err("conflicting metadata should fail");
+    assert!(err
+        .to_string()
+        .contains("conflicting version evidence for issue #4383"));
+
+    fs::write(
+        &body_file,
+        "## Summary\nObserved repair failure cites [v0.91.7][tools] but the issue remains in the v0.91.6 wave.\n",
+    )
+    .expect("non-authoritative body");
+    assert_eq!(
+        issue_version(4383, "owner/repo").expect("non-authoritative body should not conflict"),
+        Some("v0.91.6".to_string())
+    );
+
+    restore_env("PATH", old_path);
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
 fn issue_metadata_helpers_preserve_create_body_title_and_label_parity() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -500,8 +500,11 @@ sys.exit(9)
     }
 
     fs::write(&labels_file, "track:roadmap\nversion:v0.91.6\n").expect("labels");
-    fs::write(&title_file, "[v0.91.6][adr] Create and route v0.91.6 ADR candidates\n")
-        .expect("title");
+    fs::write(
+        &title_file,
+        "[v0.91.6][adr] Create and route v0.91.6 ADR candidates\n",
+    )
+    .expect("title");
     fs::write(
         &body_file,
         "## Summary\nObserved repair failure: `pr init 4383` inferred `v0.91.7` for a `v0.91.6` issue.\n\nVersion: v0.91.6\n",

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -214,6 +214,65 @@ fn real_pr_init_requires_explicit_or_inferable_version_for_issue() {
 }
 
 #[test]
+fn real_pr_init_fails_closed_on_conflicting_issue_version_metadata_before_remote_mutation() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-init-conflicting-version-metadata");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json title --jq .title\"* ]]; then\n  printf '[v0.91.6][runtime] Metadata conflict gate\\n'\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json labels --jq .labels[].name\"* ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:runtime\\nversion:v0.91.6\\n'\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json body --jq .body\"* ]]; then\n  cat <<'EOF'\n## Summary\n\nConflicting issue metadata regression fixture.\n\nVersion: v0.91.7\nEOF\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* || \"$*\" == *\"issue create -R owner/repo\"* ]]; then\n  exit 97\nfi\nexit 1\n",
+            gh_log.display(),
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "init".to_string(),
+        "1153".to_string(),
+        "--slug".to_string(),
+        "runtime-conflicting-version-metadata".to_string(),
+    ])
+    .expect_err("conflicting version metadata should fail init before mutation");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let err_text = err.to_string();
+    assert!(err_text.contains("conflicting version evidence for issue #1153"));
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_log.contains("issue view 1153 -R owner/repo --json title --jq .title"));
+    assert!(gh_log.contains("issue view 1153 -R owner/repo --json labels --jq .labels[].name"));
+    assert!(gh_log.contains("issue view 1153 -R owner/repo --json body --jq .body"));
+    assert!(!gh_log.contains("issue edit 1153 -R owner/repo"));
+    assert!(!gh_log.contains("issue create -R owner/repo"));
+}
+
+#[test]
 fn current_pr_url_filters_empty_and_null_results() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-current-url");


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4474 remains open.

## Summary
Fixed `pr init` version inference so labels, title, and body evidence are reconciled deterministically and conflicting version evidence fails closed before remote-mutation paths continue. Added focused regression coverage for the `#4383`-style metadata shape and preserved existing fallback/helper behavior.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.6/tasks/issue-4474__v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation/sor.md`
- Tracked implementation artifacts: `adl/src/cli/pr_cmd/github.rs`; `adl/src/cli/pr_cmd/github/tests/helpers.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml issue_version_prefers_consistent_label_title_and_body_evidence_and_fails_closed_on_conflict -- --nocapture`
    Verified deterministic version inference across labels, title, and body evidence and fail-closed behavior on conflicting metadata.
  - `cargo test --manifest-path adl/Cargo.toml github_helpers_cover_fallback_and_spawn_failure_paths -- --nocapture`
    Verified existing helper fallback behavior remains intact after the issue-version inference change.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4474__v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4474__v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation/sor.md
- Idempotency-Key: v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-helpers-rs-adl-src-cli-tests-pr-cmd-inline-repo-helpers-bootstrap-rs-adl-v0-91-6-tasks-issue-4474-v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation-sip-md-adl-v0-91-6-tasks-issue-4474-v0-91-6-tools-fix-pr-init-version-inference-before-remote-mutation-sor-md