### PR TITLE
[v0.91.6][tools][vpp] Generate and validate VPPs from ownership and validation profile facts

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1015,6 +1015,7 @@ fn with_octocrab<T>(
 }
 
 fn run_octocrab_capture(operation: &str, args: &[&str]) -> Result<String> {
+    let _client = github_client(operation)?;
     match operation {
         "pr.list.current_branch" => {
             let repo = arg_after(args, "-R")?;
@@ -1062,6 +1063,7 @@ fn run_octocrab_capture(operation: &str, args: &[&str]) -> Result<String> {
 }
 
 fn run_octocrab_status(operation: &str, args: &[&str]) -> Result<()> {
+    let _client = github_client(operation)?;
     match operation {
         "pr.edit.body_file" => {
             let repo = arg_after(args, "-R")?;

--- a/adl/src/cli/pr_cmd/github/tests/policy.rs
+++ b/adl/src/cli/pr_cmd/github/tests/policy.rs
@@ -5,6 +5,7 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
     let temp = unique_temp_dir("adl-github-disabled-fallback");
+    let old_home = std::env::var("HOME").ok();
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
@@ -23,6 +24,7 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
             "PATH",
             std::env::join_paths(path_entries).expect("join PATH"),
         );
+        std::env::set_var("HOME", &temp);
         std::env::set_var("ADL_GITHUB_DISABLE_GH_FALLBACK", "1");
     }
 
@@ -42,6 +44,7 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
     );
 
     restore_env("PATH", old_path);
+    restore_env("HOME", old_home);
     restore_github_policy_env(policy_env);
 }
 
@@ -99,7 +102,10 @@ fn live_github_policy_blocks_explicit_gh_fallback_before_spawn() {
 fn live_github_policy_explains_missing_token_before_spawn() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-github-missing-token");
+    let old_home = std::env::var("HOME").ok();
     unsafe {
+        std::env::set_var("HOME", &temp);
         std::env::set_var("ADL_GITHUB_CLIENT", "gh");
     }
 
@@ -116,5 +122,6 @@ fn live_github_policy_explains_missing_token_before_spawn() {
     assert!(err_debug.contains("do not fall back to direct gh commands"));
     assert!(err_debug.contains("credential values are never printed"));
 
+    restore_env("HOME", old_home);
     restore_github_policy_env(policy_env);
 }

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -2119,7 +2119,9 @@ mod tests {
 
     #[test]
     fn extract_declared_repo_paths_ignores_local_adl_and_urls() {
-        let repo_root = Path::new("/Users/daniel/git/agent-design-language");
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("adl crate should live under the repo root");
         let prompt = r#"
 ## Repo Inputs
 
@@ -2127,7 +2129,7 @@ mod tests {
 - `.adl/v0.91.6/tasks/issue-4425__/`
 - `adl/src/cli/pr_cmd_cards/cards.rs`
 - `docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md`
-- `.github/workflows/adl-ci.yml`
+- `.github/workflows/ci.yaml`
 
 ## Target Files / Surfaces
 
@@ -2140,7 +2142,7 @@ mod tests {
         assert!(paths.contains(&"AGENTS.md".to_string()));
         assert!(paths.contains(&"adl/src/cli/pr_cmd_cards/cards.rs".to_string()));
         assert!(paths.contains(&"adl/tools/validation_manager.py".to_string()));
-        assert!(paths.contains(&".github/workflows/adl-ci.yml".to_string()));
+        assert!(paths.contains(&".github/workflows/ci.yaml".to_string()));
         assert!(paths
             .contains(&"docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md".to_string()));
         assert!(!paths.iter().any(|path| path.starts_with(".adl/")));

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -2,8 +2,10 @@ use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use serde_json::Value;
 use serde_yaml::Value as YamlValue;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use super::super::pr_cmd_prompt::{
     infer_initial_pvf_lane, infer_initial_pvf_lane_source, infer_planned_pvf_lane,
@@ -1553,18 +1555,39 @@ fn render_bootstrap_validation_plan_card(
     let planned_pvf_lane = resolved_planned_pvf_lane(&initial_pvf_lane);
     let planned_pvf_lane_source =
         resolved_planned_pvf_lane_source(&initial_pvf_lane, &initial_pvf_lane_source);
-    let failure_policy = if planned_pvf_lane == NEEDS_PLANNING_PVF_LANE {
-        "fail_closed_until_validation_lane_is_selected"
+    let fallback_failure_policy = if planned_pvf_lane == NEEDS_PLANNING_PVF_LANE {
+        "fail_closed_until_validation_lane_is_selected".to_string()
     } else {
-        "fail_closed"
+        "fail_closed".to_string()
     };
-    let validation_strategy = issue_prompt_section(&prompt, "Validation Plan")
+    let fallback_validation_strategy = issue_prompt_section(&prompt, "Validation Plan")
         .or_else(|| issue_prompt_section(&prompt, "Tooling Notes"))
         .map(|value| one_line_summary(&value))
         .unwrap_or_else(|| {
             "Select the smallest proving validation lane before execution proceeds.".to_string()
         });
-    let validation_command = yaml_inline(&validation_strategy);
+    let fallback_validation_command = yaml_inline(&fallback_validation_strategy);
+    let generated_vpp =
+        generate_vpp_plan_from_prompt(repo_root, &prompt, &planned_pvf_lane).unwrap_or_else(
+            |err| GeneratedVppPlan {
+                selected_lanes_inline: planned_pvf_lane.clone(),
+                parallel_groups_inline: "unknown".to_string(),
+                validation_runtime_class: "unknown".to_string(),
+                validation_resource_profile: "unknown".to_string(),
+                validation_family: "unknown".to_string(),
+                validation_size_split: "unknown".to_string(),
+                expected_proof_cost: "unknown".to_string(),
+                planned_validation_seconds: "unknown".to_string(),
+                planned_validation_tokens: "unknown".to_string(),
+                validation_commands_inline: fallback_validation_command.clone(),
+                failure_policy: fallback_failure_policy.clone(),
+                notes_risks_inline: format!(
+                    "Generated from {} template; lane source: {planned_pvf_lane_source}. Validation-profile derivation fallback used: {}",
+                    active_prompt_template_set_label(repo_root),
+                    one_line_summary(&err.to_string())
+                ),
+            },
+        );
     let mut text = read_prompt_template(repo_root, "vpp", &[])?;
     let issue_url = format!(
         "https://github.com/{}/issues/{}",
@@ -1576,9 +1599,18 @@ fn render_bootstrap_validation_plan_card(
         &mut text,
         &[
             ("<issue>", issue_ref.issue_number().to_string()),
-            ("<issue_padded>", issue_ref.padded_issue_number().to_string()),
-            ("<task_id>", format!("issue-{}", issue_ref.padded_issue_number())),
-            ("<run_id>", format!("issue-{}", issue_ref.padded_issue_number())),
+            (
+                "<issue_padded>",
+                issue_ref.padded_issue_number().to_string(),
+            ),
+            (
+                "<task_id>",
+                format!("issue-{}", issue_ref.padded_issue_number()),
+            ),
+            (
+                "<run_id>",
+                format!("issue-{}", issue_ref.padded_issue_number()),
+            ),
             ("<version>", issue_ref.scope().to_string()),
             ("<slug>", issue_ref.slug().to_string()),
             ("<title>", title.to_string()),
@@ -1597,27 +1629,48 @@ fn render_bootstrap_validation_plan_card(
                 "docs/validation/pvf_lanes.json".to_string(),
             ),
             ("<lane_registry_template_set>", "vpp.lane.v1".to_string()),
-            ("<validation_runtime_class>", "unknown".to_string()),
-            ("<validation_resource_profile>", "unknown".to_string()),
-            ("<validation_family>", "unknown".to_string()),
-            ("<validation_size_split>", "unknown".to_string()),
-            ("<expected_proof_cost>", "unknown".to_string()),
-            ("<planned_validation_seconds>", "unknown".to_string()),
-            ("<planned_validation_tokens>", "unknown".to_string()),
-            ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
+            (
+                "<validation_runtime_class>",
+                generated_vpp.validation_runtime_class,
+            ),
+            (
+                "<validation_resource_profile>",
+                generated_vpp.validation_resource_profile,
+            ),
+            ("<validation_family>", generated_vpp.validation_family),
+            (
+                "<validation_size_split>",
+                generated_vpp.validation_size_split,
+            ),
+            ("<expected_proof_cost>", generated_vpp.expected_proof_cost),
+            (
+                "<planned_validation_seconds>",
+                generated_vpp.planned_validation_seconds,
+            ),
+            (
+                "<planned_validation_tokens>",
+                generated_vpp.planned_validation_tokens,
+            ),
+            (
+                "<issue_goal_ref>",
+                format!("issue-{}", issue_ref.issue_number()),
+            ),
             ("<sprint_goal_ref>", "unknown".to_string()),
             ("<goal_metrics_rollup_ref>", "unknown".to_string()),
-            ("<selected_lanes_inline>", planned_pvf_lane),
-            ("<parallel_groups_inline>", "unknown".to_string()),
-            ("<validation_commands_inline>", validation_command),
-            ("<failure_policy>", failure_policy.to_string()),
             (
-                "<notes_risks_inline>",
-                format!(
-                    "Generated from {} template; confirm lane selection before relying on this plan. Lane source: {planned_pvf_lane_source}.",
-                    active_prompt_template_set_label(repo_root)
-                ),
+                "<selected_lanes_inline>",
+                generated_vpp.selected_lanes_inline,
             ),
+            (
+                "<parallel_groups_inline>",
+                generated_vpp.parallel_groups_inline,
+            ),
+            (
+                "<validation_commands_inline>",
+                generated_vpp.validation_commands_inline,
+            ),
+            ("<failure_policy>", generated_vpp.failure_policy),
+            ("<notes_risks_inline>", generated_vpp.notes_risks_inline),
             (
                 "<plan_summary>",
                 format!(
@@ -1627,6 +1680,282 @@ fn render_bootstrap_validation_plan_card(
         ],
     );
     Ok(text)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GeneratedVppPlan {
+    selected_lanes_inline: String,
+    parallel_groups_inline: String,
+    validation_runtime_class: String,
+    validation_resource_profile: String,
+    validation_family: String,
+    validation_size_split: String,
+    expected_proof_cost: String,
+    planned_validation_seconds: String,
+    planned_validation_tokens: String,
+    validation_commands_inline: String,
+    failure_policy: String,
+    notes_risks_inline: String,
+}
+
+fn generate_vpp_plan_from_prompt(
+    repo_root: &Path,
+    prompt: &str,
+    planned_pvf_lane: &str,
+) -> Result<GeneratedVppPlan> {
+    let declared_paths = extract_declared_repo_paths(repo_root, prompt);
+    if declared_paths.is_empty() {
+        return Ok(GeneratedVppPlan {
+            selected_lanes_inline: planned_pvf_lane.to_string(),
+            parallel_groups_inline: "unknown".to_string(),
+            validation_runtime_class: "unknown".to_string(),
+            validation_resource_profile: "unknown".to_string(),
+            validation_family: "unknown".to_string(),
+            validation_size_split: "unknown".to_string(),
+            expected_proof_cost: "unknown".to_string(),
+            planned_validation_seconds: "unknown".to_string(),
+            planned_validation_tokens: "unknown".to_string(),
+            validation_commands_inline: yaml_inline(
+                "Select the smallest proving validation lane before execution proceeds.",
+            ),
+            failure_policy: "fail_closed".to_string(),
+            notes_risks_inline: "Generated from prompt metadata only; declare repo-relative target surfaces to derive a fact-backed VPP.".to_string(),
+        });
+    }
+
+    let temp_file = std::env::temp_dir().join(format!(
+        "adl-vpp-paths-{}-{}.txt",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&temp_file, declared_paths.join("\n") + "\n").with_context(|| {
+        format!(
+            "failed to write temporary changed-files list at {}",
+            temp_file.display()
+        )
+    })?;
+    let output = Command::new("python3")
+        .arg(repo_root.join("adl/tools/validation_manager.py"))
+        .arg("--changed-files")
+        .arg(&temp_file)
+        .arg("--json")
+        .current_dir(repo_root)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to invoke validation_manager.py for {}",
+                temp_file.display()
+            )
+        });
+    let _ = fs::remove_file(&temp_file);
+    let output = output?;
+    if !output.status.success() {
+        bail!(
+            "validation manager returned non-zero status: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let profile: Value = serde_json::from_slice(&output.stdout)
+        .context("validation manager returned invalid JSON for VPP generation")?;
+    Ok(generated_vpp_plan_from_profile_json(&profile))
+}
+
+fn generated_vpp_plan_from_profile_json(profile: &Value) -> GeneratedVppPlan {
+    let selected_profile = profile
+        .get("selected_profile")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown_profile");
+    let status = profile
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let publication_sufficient = profile
+        .get("pr_publication_sufficient")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let run_items = profile
+        .get("run")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let not_run_items = profile
+        .get("not_run")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let escalation_reasons = profile
+        .get("escalation")
+        .and_then(|value| value.get("reasons"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let selected_lanes = run_items
+        .iter()
+        .filter_map(|item| item.get("lane_id").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let selected_lanes_inline = if selected_lanes.is_empty() {
+        "none_selected".to_string()
+    } else {
+        selected_lanes.join(", ")
+    };
+
+    let mut parallel_groups = BTreeSet::new();
+    for item in &run_items {
+        if let Some(group) = item
+            .get("vpp_record")
+            .and_then(|value| value.get("parallel_group"))
+            .and_then(Value::as_str)
+        {
+            if !group.trim().is_empty() {
+                parallel_groups.insert(group.trim().to_string());
+            }
+        }
+    }
+    if parallel_groups.is_empty() {
+        parallel_groups.insert("local".to_string());
+    }
+
+    let mut command_items = run_items
+        .iter()
+        .filter_map(|item| item.get("command").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if command_items.is_empty() {
+        command_items.push(format!(
+            "validation profile `{selected_profile}` is not runnable; review escalation before execution"
+        ));
+    }
+    command_items.extend(not_run_items.iter().take(4).filter_map(|item| {
+        let surface = item.get("surface").and_then(Value::as_str)?;
+        let reason = item.get("reason").and_then(Value::as_str)?;
+        Some(format!("deferred {surface}: {reason}"))
+    }));
+    command_items.extend(escalation_reasons.iter().filter_map(|item| {
+        let lane_id = item.get("lane_id").and_then(Value::as_str)?;
+        let reason = item.get("reason").and_then(Value::as_str)?;
+        Some(format!("escalation {lane_id}: {reason}"))
+    }));
+
+    let selected_count = run_items.len();
+    let size_split = match selected_count {
+        0 => "not_applicable",
+        1 => "small_only",
+        _ => "mixed",
+    };
+    let runtime_class = profile
+        .get("estimated_cost")
+        .and_then(|value| value.get("runtime_class"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let proof_cost = profile
+        .get("estimated_cost")
+        .and_then(|value| value.get("token_review_cost"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let notes = if escalation_reasons.is_empty() {
+        format!(
+            "Generated from validation profile {selected_profile} (status={status}, pr_publication_sufficient={publication_sufficient})."
+        )
+    } else {
+        format!(
+            "Generated from validation profile {selected_profile} (status={status}, pr_publication_sufficient={publication_sufficient}); escalation remains explicit in this VPP."
+        )
+    };
+
+    GeneratedVppPlan {
+        selected_lanes_inline,
+        parallel_groups_inline: parallel_groups.into_iter().collect::<Vec<_>>().join(", "),
+        validation_runtime_class: runtime_class.to_string(),
+        validation_resource_profile: "local".to_string(),
+        validation_family: selected_profile.to_string(),
+        validation_size_split: size_split.to_string(),
+        expected_proof_cost: proof_cost.to_string(),
+        planned_validation_seconds: "unknown".to_string(),
+        planned_validation_tokens: "unknown".to_string(),
+        validation_commands_inline: yaml_inline(&command_items.join("; ")),
+        failure_policy: "fail_closed".to_string(),
+        notes_risks_inline: notes,
+    }
+}
+
+fn extract_declared_repo_paths(repo_root: &Path, prompt: &str) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+    for heading in ["Repo Inputs", "Target Files / Surfaces"] {
+        let Some(section) = issue_prompt_section(prompt, heading) else {
+            continue;
+        };
+        for candidate in extract_paths_from_section(repo_root, &section) {
+            paths.insert(candidate);
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn extract_paths_from_section(repo_root: &Path, section: &str) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+    for line in section.lines() {
+        let trimmed = line.trim().trim_start_matches("- ").trim();
+        for candidate in extract_backtick_paths(trimmed) {
+            if let Some(path) = normalize_declared_repo_path(repo_root, &candidate) {
+                paths.insert(path);
+            }
+        }
+        for token in trimmed
+            .split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | ',' | '(' | ')' | '[' | ']'))
+        {
+            if let Some(path) = normalize_declared_repo_path(repo_root, token) {
+                paths.insert(path);
+            }
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn extract_backtick_paths(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut remainder = text;
+    while let Some(start) = remainder.find('`') {
+        let after_start = &remainder[start + 1..];
+        let Some(end) = after_start.find('`') else {
+            break;
+        };
+        out.push(after_start[..end].to_string());
+        remainder = &after_start[end + 1..];
+    }
+    out
+}
+
+fn normalize_declared_repo_path(repo_root: &Path, raw: &str) -> Option<String> {
+    let candidate = raw
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '`' | '"' | '\'' | ':'));
+    if candidate.is_empty()
+        || candidate.starts_with("http://")
+        || candidate.starts_with("https://")
+        || candidate.starts_with('#')
+        || candidate.starts_with(".adl/")
+    {
+        return None;
+    }
+    let supported_root_file = matches!(
+        candidate,
+        "AGENTS.md" | "README.md" | "Cargo.toml" | "Cargo.lock"
+    );
+    let supported_prefix = candidate.starts_with("adl/")
+        || candidate.starts_with("docs/")
+        || candidate.starts_with(".github/");
+    if !(supported_root_file || supported_prefix) {
+        return None;
+    }
+    let path = repo_root.join(candidate);
+    if path.exists() {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
 }
 
 fn issue_prompt_section(text: &str, heading: &str) -> Option<String> {
@@ -1758,4 +2087,126 @@ fn render_bootstrap_review_policy_card(
         ],
     );
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extract_declared_repo_paths_ignores_local_adl_and_urls() {
+        let repo_root = Path::new("/Users/daniel/git/agent-design-language");
+        let prompt = r#"
+## Repo Inputs
+
+- https://github.com/example/repo/issues/4425
+- `.adl/v0.91.6/tasks/issue-4425__/`
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md`
+- `.github/workflows/adl-ci.yml`
+
+## Target Files / Surfaces
+
+- `AGENTS.md`
+- adl/tools/validation_manager.py
+- not/a/real/path.txt
+"#;
+
+        let paths = extract_declared_repo_paths(repo_root, prompt);
+        assert!(paths.contains(&"AGENTS.md".to_string()));
+        assert!(paths.contains(&"adl/src/cli/pr_cmd_cards/cards.rs".to_string()));
+        assert!(paths.contains(&"adl/tools/validation_manager.py".to_string()));
+        assert!(paths.contains(&".github/workflows/adl-ci.yml".to_string()));
+        assert!(paths
+            .contains(&"docs/tooling/FINISH_VALIDATION_PATH_OWNERSHIP_REGISTRY.md".to_string()));
+        assert!(!paths.iter().any(|path| path.starts_with(".adl/")));
+        assert!(!paths.iter().any(|path| path.starts_with("http")));
+    }
+
+    #[test]
+    fn generated_vpp_plan_from_profile_json_carries_run_and_skip_rationale() {
+        let profile = json!({
+            "selected_profile": "selected_2_lane_profile",
+            "status": "ready_to_run",
+            "pr_publication_sufficient": true,
+            "estimated_cost": {
+                "runtime_class": "normal",
+                "token_review_cost": "medium"
+            },
+            "run": [
+                {
+                    "lane_id": "docs_diff_check",
+                    "command": "git diff --check",
+                    "vpp_record": {
+                        "parallel_group": "docs_hygiene"
+                    }
+                },
+                {
+                    "lane_id": "csdlc_owner_lane",
+                    "command": "bash adl/tools/run_owner_validation_lane.sh csdlc"
+                }
+            ],
+            "not_run": [
+                {
+                    "surface": "full_workspace_nextest",
+                    "reason": "not selected by validation profile"
+                }
+            ],
+            "escalation": {
+                "reasons": []
+            }
+        });
+
+        let plan = generated_vpp_plan_from_profile_json(&profile);
+        assert_eq!(
+            plan.selected_lanes_inline,
+            "docs_diff_check, csdlc_owner_lane"
+        );
+        assert_eq!(plan.parallel_groups_inline, "docs_hygiene");
+        assert_eq!(plan.validation_runtime_class, "normal");
+        assert_eq!(plan.validation_resource_profile, "local");
+        assert_eq!(plan.validation_family, "selected_2_lane_profile");
+        assert_eq!(plan.validation_size_split, "mixed");
+        assert_eq!(plan.expected_proof_cost, "medium");
+        assert!(plan.validation_commands_inline.contains("git diff --check"));
+        assert!(plan
+            .validation_commands_inline
+            .contains("deferred full_workspace_nextest: not selected by validation profile"));
+    }
+
+    #[test]
+    fn generated_vpp_plan_from_profile_json_records_escalation_when_not_runnable() {
+        let profile = json!({
+            "selected_profile": "escalated_profile",
+            "status": "not_runnable",
+            "pr_publication_sufficient": false,
+            "estimated_cost": {
+                "runtime_class": "escalated",
+                "token_review_cost": "high"
+            },
+            "run": [],
+            "not_run": [],
+            "escalation": {
+                "reasons": [
+                    {
+                        "lane_id": "release_gate_review",
+                        "reason": "release-gate disposition required"
+                    }
+                ]
+            }
+        });
+
+        let plan = generated_vpp_plan_from_profile_json(&profile);
+        assert_eq!(plan.selected_lanes_inline, "none_selected");
+        assert!(plan
+            .validation_commands_inline
+            .contains("validation profile `escalated_profile` is not runnable"));
+        assert!(plan
+            .validation_commands_inline
+            .contains("escalation release_gate_review: release-gate disposition required"));
+        assert!(plan
+            .notes_risks_inline
+            .contains("escalation remains explicit"));
+    }
 }

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -1821,7 +1821,7 @@ fn generated_vpp_plan_from_profile_json(profile: &Value) -> GeneratedVppPlan {
     let mut command_items = run_items
         .iter()
         .filter_map(|item| item.get("command").and_then(Value::as_str))
-        .map(ToOwned::to_owned)
+        .map(sanitize_vpp_validation_command)
         .collect::<Vec<_>>();
     if command_items.is_empty() {
         command_items.push(format!(
@@ -2031,6 +2031,29 @@ fn yaml_inline(text: &str) -> String {
     text.replace('\\', "\\\\").replace('"', "'")
 }
 
+fn sanitize_vpp_validation_command(command: &str) -> String {
+    let mut sanitized = Vec::new();
+    let mut replace_next_changed_files = false;
+    for token in command.split_whitespace() {
+        if replace_next_changed_files {
+            sanitized.push("<changed-files>".to_string());
+            replace_next_changed_files = false;
+            continue;
+        }
+        if token == "--changed-files" {
+            sanitized.push(token.to_string());
+            replace_next_changed_files = true;
+            continue;
+        }
+        if token.starts_with('/') {
+            sanitized.push("<path>".to_string());
+        } else {
+            sanitized.push(token.to_string());
+        }
+    }
+    sanitized.join(" ")
+}
+
 fn render_bootstrap_review_policy_card(
     repo_root: &Path,
     issue_ref: &IssueRef,
@@ -2127,7 +2150,7 @@ mod tests {
     #[test]
     fn generated_vpp_plan_from_profile_json_carries_run_and_skip_rationale() {
         let profile = json!({
-            "selected_profile": "selected_2_lane_profile",
+            "selected_profile": "selected_3_lane_profile",
             "status": "ready_to_run",
             "pr_publication_sufficient": true,
             "estimated_cost": {
@@ -2145,6 +2168,10 @@ mod tests {
                 {
                     "lane_id": "csdlc_owner_lane",
                     "command": "bash adl/tools/run_owner_validation_lane.sh csdlc"
+                },
+                {
+                    "lane_id": "rust_pr_fast",
+                    "command": "bash adl/tools/run_pr_fast_test_lane.sh --changed-files /private/tmp/changed-files.txt"
                 }
             ],
             "not_run": [
@@ -2161,15 +2188,21 @@ mod tests {
         let plan = generated_vpp_plan_from_profile_json(&profile);
         assert_eq!(
             plan.selected_lanes_inline,
-            "docs_diff_check, csdlc_owner_lane"
+            "docs_diff_check, csdlc_owner_lane, rust_pr_fast"
         );
         assert_eq!(plan.parallel_groups_inline, "docs_hygiene");
         assert_eq!(plan.validation_runtime_class, "normal");
         assert_eq!(plan.validation_resource_profile, "local");
-        assert_eq!(plan.validation_family, "selected_2_lane_profile");
+        assert_eq!(plan.validation_family, "selected_3_lane_profile");
         assert_eq!(plan.validation_size_split, "mixed");
         assert_eq!(plan.expected_proof_cost, "medium");
         assert!(plan.validation_commands_inline.contains("git diff --check"));
+        assert!(plan
+            .validation_commands_inline
+            .contains("bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>"));
+        assert!(!plan
+            .validation_commands_inline
+            .contains("/private/tmp/changed-files.txt"));
         assert!(plan
             .validation_commands_inline
             .contains("deferred full_workspace_nextest: not selected by validation profile"));

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1325,6 +1325,7 @@ fn fetch_issue_body_respects_github_fallback_policy() {
     let old_token_file = env::var_os("ADL_GITHUB_TOKEN_FILE");
     let old_keychain_service = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
     let old_keychain_account = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
+    let old_home = env::var_os("HOME");
 
     let mut path_entries = vec![bin_dir.clone()];
     path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
@@ -1337,6 +1338,7 @@ fn fetch_issue_body_respects_github_fallback_policy() {
         env::remove_var("ADL_GITHUB_TOKEN_FILE");
         env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
         env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
+        env::set_var("HOME", &temp);
     }
 
     assert_eq!(
@@ -1363,6 +1365,7 @@ fn fetch_issue_body_respects_github_fallback_policy() {
     restore_env_var("ADL_GITHUB_DISABLE_GH_FALLBACK", old_disable);
     restore_env_var("GITHUB_TOKEN", old_github_token);
     restore_env_var("GH_TOKEN", old_gh_token);
+    restore_env_var("HOME", old_home);
     restore_env_var("ADL_GITHUB_TOKEN_FILE", old_token_file);
     restore_env_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE", old_keychain_service);
     restore_env_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT", old_keychain_account);

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -222,6 +222,119 @@ fn versioned_bootstrap_bundle_from_issue_prompt_includes_valid_six_cards_without
 }
 
 #[test]
+fn versioned_bootstrap_vpp_derives_fact_backed_validation_profile_fields() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-vpp-derived-facts");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4425,
+        "v0.91.6".to_string(),
+        "tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts"
+            .to_string(),
+    )
+    .expect("issue ref");
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+    fs::write(
+        &source_path,
+        r#"---
+title: "[v0.91.6][tools][vpp] Generate and validate VPPs from ownership and validation profile facts"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.91.6"
+issue_number: 4425
+---
+
+# [v0.91.6][tools][vpp] Generate and validate VPPs from ownership and validation profile facts
+
+## Summary
+
+Use fact sources that already exist in the repo to derive a concrete VPP.
+
+## Goal
+
+Generate reviewable validation-planning truth from the validation manager output.
+
+## Required Outcome
+
+Bootstrap VPP generation should name selected lanes, commands, and deferred rationale.
+
+## Deliverables
+
+- generated validation-planning truth
+
+## Acceptance Criteria
+
+- VPP names selected lanes and commands from the validation manager profile
+- VPP records deferred proof surfaces explicitly
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/tools/validation_manager.py`
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- broad prompt-template redesign
+
+## Issue-Graph Notes
+
+- test fixture
+
+## Notes
+
+- generated inside unit tests
+
+## Tooling Notes
+
+- run focused bootstrap coverage only
+"#,
+    )
+    .expect("write source");
+    let title =
+        "[v0.91.6][tools][vpp] Generate and validate VPPs from ownership and validation profile facts";
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    ensure_bootstrap_cards(
+        &repo,
+        &issue_ref,
+        title,
+        "codex/4425-vpp-derived-facts",
+        &source_path,
+    )
+    .expect("bootstrap cards");
+
+    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
+        .expect("read generated vpp");
+    assert!(vpp.contains("selected_3_lane_profile"));
+    assert!(vpp.contains("ci_path_policy_contracts, csdlc_owner_lane, rust_pr_fast"));
+    assert!(vpp.contains("Validation runtime class: `normal`"));
+    assert!(vpp.contains("Validation resource profile: `local`"));
+    assert!(vpp.contains("Validation family: `selected_3_lane_profile`"));
+    assert!(vpp.contains("Validation size split: `mixed`"));
+    assert!(vpp.contains("Expected proof cost: `medium`"));
+    assert!(vpp.contains("bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh"));
+    assert!(vpp.contains("bash adl/tools/run_owner_validation_lane.sh csdlc"));
+    assert!(vpp.contains("bash adl/tools/run_pr_fast_test_lane.sh --changed-files"));
+    assert!(vpp.contains("deferred full_workspace_nextest: not selected by validation profile"));
+    assert!(vpp.contains(
+        "Generated from validation profile selected_3_lane_profile (status=ready_to_run, pr_publication_sufficient=true)."
+    ));
+}
+
+#[test]
 fn versioned_bootstrap_refreshes_existing_template_placeholder_cards() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-versioned-refresh-placeholder-cards");

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -228,6 +228,14 @@ fn versioned_bootstrap_vpp_derives_fact_backed_validation_profile_fields() {
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
     copy_versioned_prompt_templates(&repo);
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+    let cards_src = workspace_root.join("adl/src/cli/pr_cmd_cards/cards.rs");
+    let cards_dst = repo.join("adl/src/cli/pr_cmd_cards/cards.rs");
+    fs::create_dir_all(cards_dst.parent().expect("cards parent")).expect("mkdir cards");
+    fs::copy(cards_src, cards_dst).expect("copy cards source");
 
     let issue_ref = IssueRef::new(
         4425,


### PR DESCRIPTION
Closes #4425

## Summary
Implemented the bounded VPP fact-generation seam for `#4425` in the bound
issue worktree by generating plan fields from ownership/profile inputs instead
of bootstrap placeholders. Focused local validation passed, independent review
findings were fixed on-branch, and publication is now being resumed through the
normal `pr.sh finish` path.

## Artifacts
- `adl/src/cli/pr_cmd_cards/cards.rs`
- `adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the touched Rust sources remain formatted.
  - `cargo check --manifest-path adl/Cargo.toml --tests -j 1`
    Verified the touched Rust code and targeted test surfaces compile cleanly.
  - `bash adl/tools/test_validation_manager.sh`
    Verified the validation-manager contract that feeds generated VPP facts.
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`
    Verified the prompt-template workflow integration surface remains healthy.
  - `git diff --check`
    Verified whitespace hygiene across the branch changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4425__v0-91-6-tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4425__v0-91-6-tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts/sor.md
- Idempotency-Key: v0-91-6-tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts-adl-v0-91-6-tasks-issue-4425-v0-91-6-tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts-sip-md-adl-v0-91-6-tasks-issue-4425-v0-91-6-tools-vpp-generate-and-validate-vpps-from-ownership-and-validation-profile-facts-sor-md