### PR TITLE
[v0.91.6][tools] Fix PR delegate build-lock stale recovery

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -404,6 +404,72 @@ rust_pr_cargo_delegate_build_lock_timeout_secs() {
   fi
 }
 
+rust_pr_delegate_pid_alive() {
+  local pid="${1:-}"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+rust_pr_delegate_build_lock_age_secs() {
+  local lock_dir="$1" created_at now
+  created_at="$(cat "$lock_dir/created_at_epoch" 2>/dev/null || true)"
+  if [[ "$created_at" =~ ^[0-9]+$ ]]; then
+    now="$(date +%s)"
+    printf '%s\n' "$(( now - created_at ))"
+  else
+    printf 'unknown\n'
+  fi
+}
+
+rust_pr_delegate_build_lock_cleanup() {
+  local lock_dir="$1"
+  rm -f \
+    "$lock_dir/owner_pid" \
+    "$lock_dir/created_at_epoch" \
+    "$lock_dir/subcommand" \
+    "$lock_dir/delegate_bin" \
+    "$lock_dir/cwd" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+rust_pr_delegate_write_build_lock_metadata() {
+  local lock_dir="$1" subcommand="$2" delegate_bin="$3"
+  printf '%s\n' "$$" >"$lock_dir/owner_pid" || return 1
+  date +%s >"$lock_dir/created_at_epoch" || return 1
+  printf '%s\n' "$subcommand" >"$lock_dir/subcommand" || return 1
+  printf '%s\n' "$delegate_bin" >"$lock_dir/delegate_bin" || return 1
+  pwd >"$lock_dir/cwd" || return 1
+}
+
+rust_pr_delegate_recover_stale_build_lock() {
+  local lock_dir="$1" subcommand="$2" delegate_bin="$3"
+  local owner_pid lock_subcommand lock_delegate_bin lock_age_secs
+  [[ -d "$lock_dir" ]] || return 1
+  owner_pid="$(cat "$lock_dir/owner_pid" 2>/dev/null || true)"
+  [[ -n "$owner_pid" ]] || return 1
+  if rust_pr_delegate_pid_alive "$owner_pid"; then
+    return 1
+  fi
+  lock_subcommand="$(cat "$lock_dir/subcommand" 2>/dev/null || true)"
+  lock_delegate_bin="$(cat "$lock_dir/delegate_bin" 2>/dev/null || true)"
+  lock_age_secs="$(rust_pr_delegate_build_lock_age_secs "$lock_dir")"
+  rust_pr_delegate_build_lock_cleanup "$lock_dir"
+  if [[ -d "$lock_dir" ]]; then
+    return 1
+  fi
+  adl_obs_event "pr.sh" "rust_delegate_wait" "recovered" \
+    "subcommand" "$subcommand" \
+    "delegate" "cargo" \
+    "bin" "$delegate_bin" \
+    "reason_code" "stale_build_lock_recovered" \
+    "lock_dir" "$lock_dir" \
+    "lock_owner_pid" "$owner_pid" \
+    "lock_subcommand" "${lock_subcommand:-unknown}" \
+    "lock_delegate_bin" "${lock_delegate_bin:-unknown}" \
+    "lock_age_secs" "$lock_age_secs"
+  return 0
+}
+
 terminate_rust_pr_delegate_pid() {
   local pid="$1"
   kill "$pid" 2>/dev/null || true
@@ -422,21 +488,32 @@ acquire_rust_pr_delegate_build_lock() {
   last_heartbeat="$start"
   while ! mkdir "$lock_dir" 2>/dev/null; do
     now="$(date +%s)"
+    if rust_pr_delegate_recover_stale_build_lock "$lock_dir" "$subcommand" "$delegate_bin"; then
+      continue
+    fi
     if (( timeout_secs >= 0 && now - start >= timeout_secs )); then
+      local owner_pid lock_age_secs
+      owner_pid="$(cat "$lock_dir/owner_pid" 2>/dev/null || true)"
+      lock_age_secs="$(rust_pr_delegate_build_lock_age_secs "$lock_dir")"
       adl_obs_event "pr.sh" "rust_delegate_wait" "timeout" \
         "subcommand" "$subcommand" \
         "delegate" "cargo" \
         "bin" "$delegate_bin" \
         "reason_code" "build_lock_timeout" \
         "lock_dir" "$lock_dir" \
+        "lock_owner_pid" "${owner_pid:-unknown}" \
+        "lock_age_secs" "$lock_age_secs" \
+        "recovery_hint" "run_adl/tools/run_owner_validation_lane.sh_csdlc_--build" \
         "timeout_secs" "$timeout_secs"
       cat >&2 <<EOF
 ERROR: Rust PR delegate cargo fallback is already busy for too long.
 subcommand=$subcommand
 delegate_bin=$delegate_bin
 lock_dir=$lock_dir
+lock_owner_pid=${owner_pid:-unknown}
+lock_age_seconds=$lock_age_secs
 timeout_seconds=$timeout_secs
-hint=build the direct adl-pr-* binaries first or wait for the active cargo delegate to finish
+hint=run bash adl/tools/run_owner_validation_lane.sh csdlc --build, or wait for the active cargo delegate to finish
 EOF
       return 75
     fi
@@ -451,6 +528,16 @@ EOF
     fi
     adl_obs_sleep_ms "$heartbeat_interval_ms"
   done
+  if ! rust_pr_delegate_write_build_lock_metadata "$lock_dir" "$subcommand" "$delegate_bin"; then
+    rust_pr_delegate_build_lock_cleanup "$lock_dir"
+    adl_obs_event "pr.sh" "rust_delegate_wait" "failed" \
+      "subcommand" "$subcommand" \
+      "delegate" "cargo" \
+      "bin" "$delegate_bin" \
+      "reason_code" "build_lock_metadata_write_failed" \
+      "lock_dir" "$lock_dir"
+    return 75
+  fi
   ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD="$lock_dir"
   return 0
 }
@@ -484,14 +571,15 @@ run_rust_pr_delegate_with_liveness() {
         "manifest" "$manifest" \
         "timeout_secs" "$timeout_secs" \
         "elapsed_ms" "$elapsed_ms" \
-        "reason_code" "cargo_delegate_timeout"
+        "reason_code" "cargo_delegate_timeout" \
+        "recovery_hint" "run_adl/tools/run_owner_validation_lane.sh_csdlc_--build"
       cat >&2 <<EOF
 ERROR: Rust PR delegate cargo fallback timed out.
 subcommand=$subcommand
 delegate_bin=$delegate_bin
 manifest=$manifest
 timeout_seconds=$timeout_secs
-hint=build the direct adl-pr-* binaries first or increase ADL_PR_CARGO_DELEGATE_TIMEOUT_SECS for an intentionally long compile
+hint=run bash adl/tools/run_owner_validation_lane.sh csdlc --build, or increase ADL_PR_CARGO_DELEGATE_TIMEOUT_SECS for an intentionally long compile
 EOF
       return 124
     fi
@@ -554,24 +642,24 @@ delegate_pr_command_to_rust() {
   if direct_bin="$(rust_pr_subcommand_binary_name "$subcommand" || true)"; [[ -n "$direct_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "$direct_bin" "lock_mode" "locked"
     acquire_rust_pr_delegate_build_lock "$build_lock_dir" "$subcommand" "$direct_bin" || exit "$?"
-    trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rmdir "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD" 2>/dev/null || true; fi' EXIT
+    trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rust_pr_delegate_build_lock_cleanup "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD"; fi' EXIT
     set +e
     run_rust_pr_delegate_with_liveness "$subcommand" "$manifest" "$direct_bin" "$@"
     local status="$?"
     set -e
-    rmdir "$build_lock_dir" 2>/dev/null || true
+    rust_pr_delegate_build_lock_cleanup "$build_lock_dir"
     ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD=""
     trap - EXIT
     exit "$status"
   fi
   adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "cargo" "manifest" "$manifest" "bin" "adl" "lock_mode" "locked"
   acquire_rust_pr_delegate_build_lock "$build_lock_dir" "$subcommand" "adl" || exit "$?"
-  trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rmdir "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD" 2>/dev/null || true; fi' EXIT
+  trap 'if [[ -n "${ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD:-}" ]]; then rust_pr_delegate_build_lock_cleanup "$ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD"; fi' EXIT
   set +e
   run_rust_pr_delegate_with_liveness "$subcommand" "$manifest" "adl" pr "$subcommand" "$@"
   local status="$?"
   set -e
-  rmdir "$build_lock_dir" 2>/dev/null || true
+  rust_pr_delegate_build_lock_cleanup "$build_lock_dir"
   ADL_PR_RUST_DELEGATE_BUILD_LOCK_HELD=""
   trap - EXIT
   exit "$status"

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -87,6 +87,7 @@ build_owner_bins() {
       --bin adl-pr-run --bin adl-pr-doctor --bin adl-pr-ready \
       --bin adl-pr-preflight --bin adl-pr-finish --bin adl-pr-validation \
       --bin adl-pr-closing-linkage \
+      --bin adl-issue \
       --bin adl-pr-closeout
   if [[ "$PRINT_PLAN" == "1" ]]; then
     return 0
@@ -108,6 +109,8 @@ run_csdlc_lane() {
     bash adl/tools/test_pr_run_ambiguity_policy.sh
   run_command "C-SDLC PR small-binary delegation" \
     bash adl/tools/test_pr_small_binary_delegation.sh
+  run_command "C-SDLC PR delegate cargo fallback liveness" \
+    bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
   run_command "C-SDLC PR locked Cargo fallback" \
     bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
   run_command "C-SDLC control-plane observability contract" \

--- a/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
+++ b/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
@@ -121,6 +121,10 @@ grep -F "reason_code=cargo_delegate_timeout" "$timeout_log" >/dev/null || {
 lock_log="$tmpdir/lock.log"
 lock_dir="$repo/adl/target/.adl-pr-rust-delegate-build.lock"
 mkdir -p "$lock_dir"
+printf '%s\n' "$$" >"$lock_dir/owner_pid"
+date +%s >"$lock_dir/created_at_epoch"
+printf '%s\n' "doctor" >"$lock_dir/subcommand"
+printf '%s\n' "adl-pr-doctor" >"$lock_dir/delegate_bin"
 set +e
 run_from_repo \
   env \
@@ -132,6 +136,7 @@ run_from_repo \
     "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full >/dev/null
 lock_status="$?"
 set -e
+rm -f "$lock_dir/owner_pid" "$lock_dir/created_at_epoch" "$lock_dir/subcommand" "$lock_dir/delegate_bin"
 rmdir "$lock_dir"
 [[ "$lock_status" == "75" ]] || {
   echo "assertion failed: build-lock timeout should exit 75, got $lock_status" >&2
@@ -143,6 +148,47 @@ grep -F "stage=rust_delegate_wait result=timeout" "$lock_log" >/dev/null || {
 }
 grep -F "reason_code=build_lock_timeout" "$lock_log" >/dev/null || {
   echo "assertion failed: build-lock timeout should classify lock timeout reason" >&2
+  exit 1
+}
+grep -F "recovery_hint=run_adl/tools/run_owner_validation_lane.sh_csdlc_--build" "$lock_log" >/dev/null || {
+  echo "assertion failed: build-lock timeout should point to the delegate binary build helper" >&2
+  exit 1
+}
+grep -F "lock_owner_pid=$$" "$lock_log" >/dev/null || {
+  echo "assertion failed: build-lock timeout should report active owner pid" >&2
+  exit 1
+}
+
+stale_log="$tmpdir/stale.log"
+stale_args="$tmpdir/stale.args"
+mkdir -p "$lock_dir"
+printf '%s\n' "999999" >"$lock_dir/owner_pid"
+date +%s >"$lock_dir/created_at_epoch"
+printf '%s\n' "finish" >"$lock_dir/subcommand"
+printf '%s\n' "adl-pr-finish" >"$lock_dir/delegate_bin"
+run_from_repo \
+  env \
+    ADL_OBSERVABILITY_LOG="$stale_log" \
+    ADL_OBSERVABILITY_STDERR=0 \
+    ADL_OBSERVABILITY_HEARTBEAT_MS=25 \
+    ADL_PR_CARGO_DELEGATE_BUILD_LOCK_TIMEOUT_SECS=0 \
+    ADL_TEST_CARGO_MODE=heartbeat \
+    ADL_TEST_CARGO_ARGS="$stale_args" \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+grep -F "reason_code=stale_build_lock_recovered" "$stale_log" >/dev/null || {
+  echo "assertion failed: stale build lock should be recovered before cargo fallback" >&2
+  exit 1
+}
+grep -F "lock_owner_pid=999999" "$stale_log" >/dev/null || {
+  echo "assertion failed: stale build-lock recovery should report dead owner pid" >&2
+  exit 1
+}
+grep -F -- "--bin adl-pr-doctor -- 4413 --slug demo --no-fetch-issue --version v0.91.6 --mode full" "$stale_args" >/dev/null || {
+  echo "assertion failed: stale build-lock recovery should continue into cargo fallback" >&2
+  exit 1
+}
+[[ ! -d "$lock_dir" ]] || {
+  echo "assertion failed: recovered cargo fallback should remove the build lock" >&2
   exit 1
 }
 


### PR DESCRIPTION
Closes #4483

## Summary
Implemented the bounded `#4483` lifecycle reliability fix in the issue worktree. `pr.sh` cargo fallback locks now write owner metadata, recover stale locks owned by dead PIDs, report active-lock owner/age in timeout evidence, clean up metadata on normal exit, and keep the existing trap-based cleanup path for interrupted wrapper exits. The recovery hint now points to the existing owner-lane build command, `bash adl/tools/run_owner_validation_lane.sh csdlc --build`, and liveness proof coverage now covers active locks, stale locks, recovery hints, cargo timeout, and cargo fallback continuation after recovery.

## Artifacts
- `adl/tools/pr.sh`
- `adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
- `adl/tools/run_owner_validation_lane.sh`
- Local output-card truth update at `.adl/v0.91.6/tasks/issue-4483__v0-91-6-tools-lifecycle-fix-rust-pr-delegate-build-lock-timeout-and-stale-lock-recovery/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
    Verified the lock/liveness behavior changed by this issue.
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified direct small-binary delegation did not regress.
  - `bash -n adl/tools/pr.sh adl/tools/test_pr_delegate_cargo_fallback_liveness.sh adl/tools/run_owner_validation_lane.sh`
    Verified shell syntax for changed shell surfaces.
  - `git diff --check`
    Verified diff whitespace hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the actual selected owner lane includes the focused delegate fallback liveness proof.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4483__v0-91-6-tools-lifecycle-fix-rust-pr-delegate-build-lock-timeout-and-stale-lock-recovery/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4483__v0-91-6-tools-lifecycle-fix-rust-pr-delegate-build-lock-timeout-and-stale-lock-recovery/sor.md
- Idempotency-Key: v0-91-6-tools-fix-pr-delegate-build-lock-stale-recovery-adl-tools-pr-sh-adl-tools-test-pr-delegate-cargo-fallback-liveness-sh-adl-tools-run-owner-validation-lane-sh-adl-v0-91-6-tasks-issue-4483-v0-91-6-tools-lifecycle-fix-rust-pr-delegate-build-lock-timeout-and-stale-lock-recovery-sip-md-adl-v0-91-6-tasks-issue-4483-v0-91-6-tools-lifecycle-fix-rust-pr-delegate-build-lock-timeout-and-stale-lock-recovery-sor-md