### PR TITLE
[v0.91.6][tools] Bound pr.sh PR-wave bind scans

### DIFF
--- a/adl/src/cli/github_token.rs
+++ b/adl/src/cli/github_token.rs
@@ -11,6 +11,9 @@ pub(crate) const ADL_GITHUB_TOKEN_FILE_ENV: &str = "ADL_GITHUB_TOKEN_FILE";
 pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE";
 pub(crate) const ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV: &str = "ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT";
 pub(crate) const DEFAULT_GITHUB_TOKEN_FILE_RELATIVE_PATH: &str = "keys/github.token";
+#[cfg(test)]
+pub(crate) const ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE_ENV: &str =
+    "ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GithubTokenSource {
@@ -78,6 +81,7 @@ struct TokenResolutionKey {
     token_file: Option<String>,
     keychain_service: Option<String>,
     keychain_account: Option<String>,
+    default_token_file_disabled_for_test: bool,
     implicit_default_token_file: Option<String>,
 }
 
@@ -140,19 +144,22 @@ impl TokenResolutionKey {
             .ok()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+        let default_token_file_disabled_for_test = default_github_token_file_disabled_for_test();
         Self {
             github_token,
             gh_token,
             token_file,
             keychain_service,
             keychain_account,
+            default_token_file_disabled_for_test,
             implicit_default_token_file: default_github_token_file_path()
                 .filter(|_| {
-                    std::env::var(GITHUB_TOKEN_ENV)
-                        .ok()
-                        .map(|value| value.trim().to_string())
-                        .filter(|value| !value.is_empty())
-                        .is_none()
+                    !default_token_file_disabled_for_test
+                        && std::env::var(GITHUB_TOKEN_ENV)
+                            .ok()
+                            .map(|value| value.trim().to_string())
+                            .filter(|value| !value.is_empty())
+                            .is_none()
                         && std::env::var(GH_TOKEN_ENV)
                             .ok()
                             .map(|value| value.trim().to_string())
@@ -172,6 +179,19 @@ impl TokenResolutionKey {
                 .map(|path| path.display().to_string()),
         }
     }
+}
+
+#[cfg(test)]
+fn default_github_token_file_disabled_for_test() -> bool {
+    std::env::var(ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE_ENV)
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+#[cfg(not(test))]
+fn default_github_token_file_disabled_for_test() -> bool {
+    false
 }
 
 fn default_github_token_file_path() -> Option<PathBuf> {
@@ -379,6 +399,7 @@ mod tests {
             std::env::remove_var(ADL_GITHUB_TOKEN_FILE_ENV);
             std::env::remove_var(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV);
             std::env::remove_var(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV);
+            std::env::remove_var(ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE_ENV);
         }
         *TOKEN_CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap() = None;
     }

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1246,8 +1246,6 @@ fn real_pr_start(args: &[String]) -> Result<()> {
             source: "inferred",
         }
     };
-    let unresolved =
-        unresolved_milestone_pr_wave(&repo, &version, &target_queue.queue, Some(&branch))?;
     let sprint_wave_override = std::env::var("ADL_SPRINT_ALLOW_OPEN_PR_WAVE")
         .map(|value| {
             matches!(
@@ -1256,7 +1254,13 @@ fn real_pr_start(args: &[String]) -> Result<()> {
             )
         })
         .unwrap_or(false);
-    if !(parsed.allow_open_pr_wave || sprint_wave_override || unresolved.is_empty()) {
+    let open_pr_wave_override = parsed.allow_open_pr_wave || sprint_wave_override;
+    let unresolved = if open_pr_wave_override {
+        Vec::new()
+    } else {
+        unresolved_milestone_pr_wave(&repo, &version, &target_queue.queue, Some(&branch))?
+    };
+    if !open_pr_wave_override && !unresolved.is_empty() {
         bail!(
             "start: unresolved open PR queue detected for {} [{}:{}]. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
             version,

--- a/adl/src/cli/pr_cmd/github/tests.rs
+++ b/adl/src/cli/pr_cmd/github/tests.rs
@@ -58,6 +58,7 @@ fn clear_github_policy_env() -> Vec<(&'static str, Option<String>)> {
         "ADL_GITHUB_DISABLE_GH_FALLBACK",
         "ADL_GITHUB_OCTOCRAB_BASE_URI",
         "ADL_TEST_GITHUB_CLI_FIXTURE",
+        "ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE",
         "GITHUB_TOKEN",
         "GH_TOKEN",
         "ADL_GITHUB_TOKEN_FILE",

--- a/adl/src/cli/pr_cmd/github/tests/policy.rs
+++ b/adl/src/cli/pr_cmd/github/tests/policy.rs
@@ -5,7 +5,6 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
     let temp = unique_temp_dir("adl-github-disabled-fallback");
-    let old_home = std::env::var("HOME").ok();
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
@@ -24,7 +23,7 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
             "PATH",
             std::env::join_paths(path_entries).expect("join PATH"),
         );
-        std::env::set_var("HOME", &temp);
+        std::env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
         std::env::set_var("ADL_GITHUB_DISABLE_GH_FALLBACK", "1");
     }
 
@@ -44,7 +43,6 @@ fn live_gh_policy_guard_blocks_disabled_fallback_before_spawn() {
     );
 
     restore_env("PATH", old_path);
-    restore_env("HOME", old_home);
     restore_github_policy_env(policy_env);
 }
 
@@ -102,10 +100,8 @@ fn live_github_policy_blocks_explicit_gh_fallback_before_spawn() {
 fn live_github_policy_explains_missing_token_before_spawn() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();
-    let temp = unique_temp_dir("adl-github-missing-token");
-    let old_home = std::env::var("HOME").ok();
     unsafe {
-        std::env::set_var("HOME", &temp);
+        std::env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
         std::env::set_var("ADL_GITHUB_CLIENT", "gh");
     }
 
@@ -122,6 +118,5 @@ fn live_github_policy_explains_missing_token_before_spawn() {
     assert!(err_debug.contains("do not fall back to direct gh commands"));
     assert!(err_debug.contains("credential values are never printed"));
 
-    restore_env("HOME", old_home);
     restore_github_policy_env(policy_env);
 }

--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
+++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
@@ -475,6 +475,10 @@ fn list_prs_octocrab_paginates_rest_results() {
     let seen = server.join().expect("server join");
     assert_eq!(seen.len(), 2, "unexpected pagination calls: {seen:#?}");
     assert!(seen[0].contains("/repos/owner/repo/pulls?"));
+    assert!(
+        seen[0].contains("state=open"),
+        "first PR-wave list must request only open PRs: {seen:#?}"
+    );
     assert!(seen[1].contains("/repos/owner/repo/pulls?page=2"));
 
     unsafe {
@@ -501,6 +505,10 @@ fn list_prs_octocrab_fails_closed_on_repeated_next_page_urls() {
     let seen = server.join().expect("server join");
     assert_eq!(seen.len(), 2, "unexpected pagination calls: {seen:#?}");
     assert!(seen[0].contains("/repos/owner/repo/pulls?"));
+    assert!(
+        seen[0].contains("state=open"),
+        "repeated-page PR-wave list must request only open PRs: {seen:#?}"
+    );
     assert!(seen[1].contains("/repos/owner/repo/pulls?page=2"));
 
     unsafe {
@@ -528,6 +536,10 @@ fn list_prs_octocrab_times_out_promptly_when_github_stalls() {
 
     let seen = server.join().expect("server join");
     assert_eq!(seen.len(), 1, "unexpected slow-server calls: {seen:#?}");
+    assert!(
+        seen[0].contains("state=open"),
+        "slow PR-wave list must request only open PRs: {seen:#?}"
+    );
 
     unsafe {
         std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -191,7 +191,7 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
         let mut page = block_on_octocrab(runtime, "pr.list.wave", || async {
             octo.pulls(&owner, &name)
                 .list()
-                .state(octocrab::params::State::All)
+                .state(octocrab::params::State::Open)
                 .per_page(100)
                 .send()
                 .await

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -1325,7 +1325,7 @@ fn fetch_issue_body_respects_github_fallback_policy() {
     let old_token_file = env::var_os("ADL_GITHUB_TOKEN_FILE");
     let old_keychain_service = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
     let old_keychain_account = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
-    let old_home = env::var_os("HOME");
+    let old_disable_default_token_file = env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
 
     let mut path_entries = vec![bin_dir.clone()];
     path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
@@ -1333,12 +1333,12 @@ fn fetch_issue_body_respects_github_fallback_policy() {
         env::set_var("PATH", env::join_paths(path_entries).expect("join PATH"));
         env::remove_var("ADL_GITHUB_CLIENT");
         env::remove_var("ADL_GITHUB_DISABLE_GH_FALLBACK");
+        env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
         env::remove_var("GITHUB_TOKEN");
         env::remove_var("GH_TOKEN");
         env::remove_var("ADL_GITHUB_TOKEN_FILE");
         env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
         env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
-        env::set_var("HOME", &temp);
     }
 
     assert_eq!(
@@ -1365,10 +1365,13 @@ fn fetch_issue_body_respects_github_fallback_policy() {
     restore_env_var("ADL_GITHUB_DISABLE_GH_FALLBACK", old_disable);
     restore_env_var("GITHUB_TOKEN", old_github_token);
     restore_env_var("GH_TOKEN", old_gh_token);
-    restore_env_var("HOME", old_home);
     restore_env_var("ADL_GITHUB_TOKEN_FILE", old_token_file);
     restore_env_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE", old_keychain_service);
     restore_env_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT", old_keychain_account);
+    restore_env_var(
+        "ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE",
+        old_disable_default_token_file,
+    );
 }
 
 #[test]
@@ -1448,6 +1451,7 @@ fn ensure_source_issue_prompt_uses_default_labels_and_generated_prompt_when_gith
     let old_client = env::var_os("ADL_GITHUB_CLIENT");
     let old_disable = env::var_os("ADL_GITHUB_DISABLE_GH_FALLBACK");
     let old_fixture = env::var_os("ADL_TEST_GITHUB_CLI_FIXTURE");
+    let old_disable_default_token_file = env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
     let mut path_entries = vec![bin_dir.clone()];
     path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
     unsafe {
@@ -1455,6 +1459,7 @@ fn ensure_source_issue_prompt_uses_default_labels_and_generated_prompt_when_gith
         env::remove_var("ADL_GITHUB_CLIENT");
         env::remove_var("ADL_GITHUB_DISABLE_GH_FALLBACK");
         env::remove_var("ADL_TEST_GITHUB_CLI_FIXTURE");
+        env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
     }
 
     let issue_ref = IssueRef::new(
@@ -1478,6 +1483,10 @@ fn ensure_source_issue_prompt_uses_default_labels_and_generated_prompt_when_gith
     restore_env_var("ADL_GITHUB_CLIENT", old_client);
     restore_env_var("ADL_GITHUB_DISABLE_GH_FALLBACK", old_disable);
     restore_env_var("ADL_TEST_GITHUB_CLI_FIXTURE", old_fixture);
+    restore_env_var(
+        "ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE",
+        old_disable_default_token_file,
+    );
 
     let prompt = fs::read_to_string(ensured).expect("read prompt");
     assert!(prompt.contains("  - \"track:roadmap\""));

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -1768,9 +1768,23 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_github_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_github_token = env::var_os("GITHUB_TOKEN");
+    let old_gh_token = env::var_os("GH_TOKEN");
+    let old_token_file = env::var_os("ADL_GITHUB_TOKEN_FILE");
+    let old_keychain_service = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
+    let old_keychain_account = env::var_os("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
+    let old_disable_default_token_file = env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::remove_var("ADL_GITHUB_CLIENT");
+        env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
+        env::remove_var("GITHUB_TOKEN");
+        env::remove_var("GH_TOKEN");
+        env::remove_var("ADL_GITHUB_TOKEN_FILE");
+        env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE");
+        env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT");
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -1790,11 +1804,173 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
+        match old_github_client {
+            Some(value) => env::set_var("ADL_GITHUB_CLIENT", value),
+            None => env::remove_var("ADL_GITHUB_CLIENT"),
+        }
+        match old_github_token {
+            Some(value) => env::set_var("GITHUB_TOKEN", value),
+            None => env::remove_var("GITHUB_TOKEN"),
+        }
+        match old_gh_token {
+            Some(value) => env::set_var("GH_TOKEN", value),
+            None => env::remove_var("GH_TOKEN"),
+        }
+        match old_token_file {
+            Some(value) => env::set_var("ADL_GITHUB_TOKEN_FILE", value),
+            None => env::remove_var("ADL_GITHUB_TOKEN_FILE"),
+        }
+        match old_keychain_service {
+            Some(value) => env::set_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE", value),
+            None => env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE"),
+        }
+        match old_keychain_account {
+            Some(value) => env::set_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT", value),
+            None => env::remove_var("ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT"),
+        }
+        match old_disable_default_token_file {
+            Some(value) => env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", value),
+            None => env::remove_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE"),
+        }
     }
     assert!(err
         .to_string()
         .contains("start: unresolved open PR queue detected for v0.86 [tools:inferred]"));
     assert!(err.to_string().contains("#1169 [draft]"));
+}
+
+#[test]
+fn real_pr_start_allow_open_pr_wave_skips_wave_scan_before_binding() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-open-wave-override-skips-scan");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "override branch placeholder\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+    let issue_ref = IssueRef::new(
+        1174,
+        "v0.86".to_string(),
+        "v0-86-tools-preflight-override".to_string(),
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Preflight override");
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    let pr_list_marker = repo.join("pr-list-called.marker");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  printf called > '{}'\n  printf 'pr list must not be called when --allow-open-pr-wave is explicit\\n' >&2\n  exit 42\nfi\nexit 0\n",
+            pr_list_marker.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_disable_default_token_file = env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "start".to_string(),
+        "1174".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-preflight-override".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Preflight override".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--allow-open-pr-wave".to_string(),
+    ])
+    .expect_err("fixture cards may still block after the wave override is honored");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        match old_disable_default_token_file {
+            Some(value) => env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", value),
+            None => env::remove_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE"),
+        }
+    }
+    assert!(err
+        .to_string()
+        .contains("design-time card completion gate failed"));
+    assert!(
+        !pr_list_marker.exists(),
+        "explicit --allow-open-pr-wave must skip pr list before binding/card gates"
+    );
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/support.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/support.rs
@@ -24,6 +24,7 @@ pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
 
 pub(crate) struct GithubCliFixtureGuard {
     old_fixture: Option<std::ffi::OsString>,
+    old_disable_default_token_file: Option<std::ffi::OsString>,
 }
 
 impl Drop for GithubCliFixtureGuard {
@@ -33,6 +34,10 @@ impl Drop for GithubCliFixtureGuard {
                 Some(value) => env::set_var("ADL_TEST_GITHUB_CLI_FIXTURE", value),
                 None => env::remove_var("ADL_TEST_GITHUB_CLI_FIXTURE"),
             }
+            match &self.old_disable_default_token_file {
+                Some(value) => env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", value),
+                None => env::remove_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE"),
+            }
         }
     }
 }
@@ -40,10 +45,16 @@ impl Drop for GithubCliFixtureGuard {
 impl GithubCliFixtureGuard {
     pub(crate) fn set(path: &Path) -> Self {
         let old_fixture = env::var_os("ADL_TEST_GITHUB_CLI_FIXTURE");
+        let old_disable_default_token_file =
+            env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
         unsafe {
             env::set_var("ADL_TEST_GITHUB_CLI_FIXTURE", path);
+            env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
         }
-        Self { old_fixture }
+        Self {
+            old_fixture,
+            old_disable_default_token_file,
+        }
     }
 }
 
@@ -70,6 +81,7 @@ pub(crate) fn force_gh_cli_transport_env() -> GithubTransportEnvGuard {
         "ADL_GITHUB_DISABLE_GH_FALLBACK",
         "ADL_GITHUB_OCTOCRAB_BASE_URI",
         "ADL_TEST_GITHUB_CLI_FIXTURE",
+        "ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE",
         "GITHUB_TOKEN",
         "GH_TOKEN",
         "ADL_GITHUB_TOKEN_FILE",
@@ -84,6 +96,7 @@ pub(crate) fn force_gh_cli_transport_env() -> GithubTransportEnvGuard {
         for key in keys {
             env::remove_var(key);
         }
+        env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
     }
     GithubTransportEnvGuard { old_values }
 }

--- a/adl/src/cli/tooling_cmd/github_release.rs
+++ b/adl/src/cli/tooling_cmd/github_release.rs
@@ -266,19 +266,14 @@ fn build_octocrab() -> Result<octocrab::Octocrab> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::tests as cli_tests;
     use std::net::TcpListener;
-    use std::sync::{Mutex, OnceLock};
     use std::thread;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tiny_http::{Header, Response, Server};
 
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+        cli_tests::env_lock()
     }
 
     fn json_response(body: String) -> Response<std::io::Cursor<Vec<u8>>> {


### PR DESCRIPTION
Closes #4485

## Summary
Implemented the bounded PR-wave bind-scan fix for `#4485`. The run/start path now honors explicit open-wave overrides before fetching the milestone PR wave, and the Octocrab PR-wave transport now requests open PRs instead of all historical PRs. Focused lifecycle and transport regressions cover both the override path and the open-only PR-wave request. A finish-lane validation blocker was also repaired by making GitHub policy tests hermetic against the operator-approved default token file.

## Artifacts
- Tracked implementation change in `adl/src/cli/pr_cmd.rs`
- Tracked implementation change in `adl/src/cli/pr_cmd/github/transport.rs`
- Test-only token resolver guard in `adl/src/cli/github_token.rs`
- Shared GitHub transport test guard update in `adl/src/cli/pr_cmd/github/tests.rs`
- Shared GitHub release test lock update in `adl/src/cli/tooling_cmd/github_release.rs`
- Focused regression updates in `adl/src/cli/pr_cmd/github/tests/transport.rs`
- Focused policy-test hermeticity update in `adl/src/cli/pr_cmd/github/tests/policy.rs`
- Shared inline PR test fixture guard update in `adl/src/cli/tests/pr_cmd_inline/support.rs`
- Legacy inline PR env-guard updates in `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- Focused lifecycle regression in `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- Local ignored output-card update at `.adl/v0.91.6/tasks/issue-4485__v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified formatting for touched Rust files.
  - `cargo test --manifest-path adl/Cargo.toml list_prs_octocrab -- --nocapture`
    Verified PR-wave transport regressions, including open-only PR listing.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_blocks_when_open_milestone_pr_wave_exists -- --nocapture`
    Verified existing fail-closed behavior for open PR wave without override.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_allow_open_pr_wave_skips_wave_scan_before_binding -- --nocapture`
    Verified explicit override avoids `pr list` before binding/card gates.
  - `cargo test --manifest-path adl/Cargo.toml live_gh_policy_guard_blocks_disabled_fallback_before_spawn -- --nocapture && cargo test --manifest-path adl/Cargo.toml live_github_policy_explains_missing_token_before_spawn -- --nocapture`
    Verified fallback-disabled and missing-token policy tests remain deterministic on machines with an approved default token file.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl -- --nocapture`
    Verified the broader main-binary PR command and finish validation profile tests after hermetic test-harness repair; result was `892 passed, 0 failed, 1 ignored`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl github_token -- --nocapture`
    Verified the exact token/release lane that had failed in `pr.sh finish`; result was `10 passed, 0 failed`.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.6/tasks/issue-4485__v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans/spp.md && bash adl/tools/validate_structured_prompt.sh --type vpp --input .adl/v0.91.6/tasks/issue-4485__v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans/vpp.md`
    Verified local ignored SPP/VPP readiness after budget repair.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4485__v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4485__v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans/sor.md
- Idempotency-Key: v0-91-6-tools-bound-pr-sh-pr-wave-bind-scans-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-transport-rs-adl-src-cli-pr-cmd-github-tests-policy-rs-adl-src-cli-pr-cmd-github-tests-rs-adl-src-cli-github-token-rs-adl-src-cli-tooling-cmd-github-release-rs-adl-src-cli-tests-pr-cmd-inline-support-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-v0-91-6-tasks-issue-4485-v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans-sip-md-adl-v0-91-6-tasks-issue-4485-v0-91-6-tools-pr-sh-bound-doctor-run-pr-wave-preflight-and-bind-scans-sor-md