### PR TITLE
[v0.91.6][tools] Harden PR projection and watcher state

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -445,11 +445,12 @@ fn real_pr_validation(args: &[String]) -> Result<()> {
             );
         }
     }
-    if validation_disposition_blocks_shell_success(&report.disposition) {
+    if validation_report_blocks_shell_success(&report.disposition, &report.projection_status) {
         bail!(
-            "validation: PR #{} is {}",
+            "validation: PR #{} is {} ({})",
             report.pr_number,
-            report.disposition
+            report.disposition,
+            report.projection_status
         );
     }
     Ok(())
@@ -461,9 +462,23 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
     let repo = parsed
         .repo
         .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+        .or_else(|| repo_from_pr_ref(&parsed.issue_ref))
         .unwrap_or(default_repo(&repo_root)?);
-    let issue = parse_issue_ref_number("watch", &parsed.issue_ref)?;
-    let issue_record = github::gh_issue_view(&repo, issue)?;
+    let requested_number = parse_issue_ref_number("watch", &parsed.issue_ref)?;
+    let (issue, issue_record, direct_pr) = match github::gh_issue_view(&repo, requested_number) {
+        Ok(issue_record) => (requested_number, issue_record, None),
+        Err(err)
+            if err
+                .to_string()
+                .contains("GitHub returned a pull request instead of an issue") =>
+        {
+            let pr = github::pr_metadata_for_watch(&repo, &parsed.issue_ref)?;
+            let issue = github::issue_number_for_pr_watch(&repo, &pr)?;
+            let issue_record = github::gh_issue_view(&repo, issue)?;
+            (issue, issue_record, Some(pr))
+        }
+        Err(err) => return Err(err),
+    };
     let closed_completed = github::gh_issue_is_closed_completed(issue, &repo)?;
     let version = resolve_version_for_existing_issue(
         &repo_root,
@@ -479,21 +494,29 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
         .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
         .unwrap_or_else(|| sanitize_slug(&issue_record.title));
     let issue_ref = IssueRef::new(issue, version, slug)?;
-    let linked_prs =
-        github::linked_prs_for_issue(&repo, issue, Some(issue_ref.branch_name("codex").as_str()))?;
-    let linked_pr = match linked_prs.len() {
-        0 => None,
-        1 => {
-            let pr = linked_prs
-                .into_iter()
-                .next()
-                .expect("single linked PR should exist");
-            let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
-            Some((pr, validation))
+    let linked_pr = if let Some(pr) = direct_pr {
+        let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
+        Some((pr, validation))
+    } else {
+        let linked_prs = github::linked_prs_for_issue(
+            &repo,
+            issue,
+            Some(issue_ref.branch_name("codex").as_str()),
+        )?;
+        match linked_prs.len() {
+            0 => None,
+            1 => {
+                let pr = linked_prs
+                    .into_iter()
+                    .next()
+                    .expect("single linked PR should exist");
+                let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
+                Some((pr, validation))
+            }
+            count => bail!(
+                "watch: issue #{issue} has {count} linked PRs; watcher requires a single unambiguous lifecycle target"
+            ),
         }
-        count => bail!(
-            "watch: issue #{issue} has {count} linked PRs; watcher requires a single unambiguous lifecycle target"
-        ),
     };
     let local_readiness = doctor::run_doctor_ready(
         &repo_root,
@@ -540,6 +563,11 @@ fn validation_disposition_blocks_shell_success(disposition: &str) -> bool {
         disposition,
         "pending" | "failed" | "cancelled" | "timed_out"
     )
+}
+
+fn validation_report_blocks_shell_success(disposition: &str, projection_status: &str) -> bool {
+    validation_disposition_blocks_shell_success(disposition)
+        || projection_status == "checks_green_but_draft"
 }
 
 fn real_pr_issue(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -153,6 +153,7 @@ pub(super) struct PrValidationReport {
     pub(super) pr_state: String,
     pub(super) is_draft: bool,
     pub(super) disposition: String,
+    pub(super) projection_status: String,
     pub(super) checks: Vec<PrValidationCheckReport>,
     pub(super) failed_checks: Vec<PrValidationCheckReport>,
     pub(super) pending_checks: Vec<PrValidationCheckReport>,
@@ -416,6 +417,60 @@ pub(super) fn pr_validation_report(repo: &str, pr_ref: &str) -> Result<PrValidat
     transport::pr_validation_report(repo, pr_ref)
 }
 
+pub(super) fn pr_validation_projection_status(
+    pr_state: &str,
+    is_draft: bool,
+    disposition: &str,
+) -> &'static str {
+    if pr_state.eq_ignore_ascii_case("MERGED") {
+        return "merged";
+    }
+    match disposition {
+        "pending" => "checks_pending",
+        "failed" | "cancelled" | "timed_out" => "checks_failed",
+        "success" | "skipped" if is_draft => "checks_green_but_draft",
+        "success" | "skipped" => "ready_to_merge_or_review",
+        _ if is_draft => "checks_pending",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn pr_metadata_for_watch(repo: &str, pr_ref: &str) -> Result<OpenPullRequest> {
+    transport::pr_metadata_octocrab(repo, pr_ref)
+}
+
+pub(crate) fn issue_number_for_pr_watch(repo: &str, pr: &OpenPullRequest) -> Result<u32> {
+    let linked = pr_closing_issue_numbers_octocrab(repo, &pr.number.to_string())?;
+    issue_number_from_pr_metadata_for_watch(pr, &linked)
+}
+
+pub(crate) fn issue_number_from_pr_metadata_for_watch(
+    pr: &OpenPullRequest,
+    linked: &[u32],
+) -> Result<u32> {
+    if linked.len() == 1 {
+        return Ok(linked[0]);
+    }
+    if linked.len() > 1 {
+        bail!(
+            "watch: PR #{} closes multiple issues {}; pass the issue number explicitly",
+            pr.number,
+            linked
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    issue_number_from_codex_branch(&pr.head_ref_name).ok_or_else(|| {
+        anyhow!(
+            "watch: PR #{} has no closing issue metadata and head branch '{}' does not start with a codex issue number",
+            pr.number,
+            pr.head_ref_name
+        )
+    })
+}
+
 pub(crate) fn linked_prs_for_issue(
     repo: &str,
     issue: u32,
@@ -549,6 +604,13 @@ pub(crate) fn build_issue_watch_report(
             "pr-closeout",
             "action_required",
             "linked_pr_merged_closeout_pending",
+        )
+    } else if validation.projection_status == "checks_green_but_draft" {
+        (
+            "checks_green_but_draft",
+            "pr-janitor",
+            "action_required",
+            "linked_pr_checks_green_but_draft",
         )
     } else if validation.is_draft {
         ("pr_open", "issue-watcher", "continue", "linked_pr_draft")

--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -78,6 +78,56 @@ fn pr_validation_wait_classifies_pending_failed_successful_and_skipped_states() 
 }
 
 #[test]
+fn pr_validation_report_exposes_projection_status_for_pr_lifecycle_states() {
+    let snapshot = |is_draft: bool, checks: Vec<PrValidationCheckSnapshot>| PrValidationSnapshot {
+        pr_number: 1159,
+        commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        state: "OPEN".to_string(),
+        is_draft,
+        checks,
+    };
+    let completed = |conclusion: &str| PrValidationCheckSnapshot {
+        name: "adl-ci".to_string(),
+        status: "COMPLETED".to_string(),
+        conclusion: conclusion.to_string(),
+        job_run_id: "8801".to_string(),
+    };
+
+    let pending = pr_validation_report_from_snapshot_with_disposition(
+        &snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8801".to_string(),
+            }],
+        ),
+        PrValidationDisposition::Pending,
+    );
+    assert_eq!(pending.disposition, "pending");
+    assert_eq!(pending.projection_status, "checks_pending");
+
+    let failed = pr_validation_report_from_snapshot_with_disposition(
+        &snapshot(false, vec![completed("FAILURE")]),
+        PrValidationDisposition::Failed,
+    );
+    assert_eq!(failed.projection_status, "checks_failed");
+
+    let green_draft = pr_validation_report_from_snapshot_with_disposition(
+        &snapshot(true, vec![completed("SUCCESS")]),
+        PrValidationDisposition::Success,
+    );
+    assert_eq!(green_draft.projection_status, "checks_green_but_draft");
+
+    let green_ready = pr_validation_report_from_snapshot_with_disposition(
+        &snapshot(false, vec![completed("SUCCESS")]),
+        PrValidationDisposition::Success,
+    );
+    assert_eq!(green_ready.projection_status, "ready_to_merge_or_review");
+}
+
+#[test]
 fn pr_validation_classification_uses_latest_logical_check_state() {
     let snapshot = |checks: Vec<PrValidationCheckSnapshot>| PrValidationSnapshot {
         pr_number: 3933,

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -42,6 +42,13 @@ fn linked_pr(number: u32, is_draft: bool) -> OpenPullRequest {
     }
 }
 
+fn linked_pr_with_head(number: u32, head_ref_name: &str) -> OpenPullRequest {
+    OpenPullRequest {
+        head_ref_name: head_ref_name.to_string(),
+        ..linked_pr(number, false)
+    }
+}
+
 fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
     let failed_checks = if disposition == "failed" {
         vec![PrValidationCheckReport {
@@ -69,6 +76,8 @@ fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
         pr_state: "OPEN".to_string(),
         is_draft,
         disposition: disposition.to_string(),
+        projection_status: pr_validation_projection_status("OPEN", is_draft, disposition)
+            .to_string(),
         checks: failed_checks
             .iter()
             .chain(pending_checks.iter())
@@ -86,6 +95,7 @@ fn merged_validation_report() -> PrValidationReport {
         pr_state: "MERGED".to_string(),
         is_draft: false,
         disposition: "success".to_string(),
+        projection_status: "merged".to_string(),
         checks: vec![],
         failed_checks: vec![],
         pending_checks: vec![],
@@ -113,6 +123,50 @@ fn issue_watch_routes_draft_pr_to_issue_watcher() {
     );
     assert_eq!(report.classification, "pr_open");
     assert_eq!(report.next_skill, "issue-watcher");
+}
+
+#[test]
+fn issue_watch_routes_all_green_draft_pr_to_janitor() {
+    let pr = linked_pr(77, true);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        readiness_ready(),
+        Some((pr, validation_report("success", true))),
+    );
+    assert_eq!(report.classification, "checks_green_but_draft");
+    assert_eq!(report.next_skill, "pr-janitor");
+    assert_eq!(report.continuation, "action_required");
+    assert_eq!(report.reason, "linked_pr_checks_green_but_draft");
+    assert_eq!(
+        report
+            .linked_pr
+            .as_ref()
+            .expect("linked PR")
+            .validation
+            .projection_status,
+        "checks_green_but_draft"
+    );
+}
+
+#[test]
+fn issue_watch_pr_number_resolution_routes_missing_closing_linkage_by_codex_branch() {
+    let pr = linked_pr_with_head(4495, "codex/4487-worktree-safe-truth");
+    assert_eq!(
+        issue_number_from_pr_metadata_for_watch(&pr, &[]).expect("codex branch issue fallback"),
+        4487
+    );
+
+    let missing = linked_pr_with_head(4496, "feature/no-issue-prefix");
+    let err = issue_number_from_pr_metadata_for_watch(&missing, &[])
+        .expect_err("missing closing refs and non-codex branch should fail");
+    assert!(err.to_string().contains("has no closing issue metadata"));
+
+    let ambiguous = issue_number_from_pr_metadata_for_watch(&pr, &[4487, 4488])
+        .expect_err("multiple closing issues should require explicit issue");
+    assert!(ambiguous
+        .to_string()
+        .contains("closes multiple issues 4487, 4488"));
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -1,6 +1,6 @@
 use super::{
-    block_on_octocrab, parse_pr_number, parse_repo, with_octocrab, OpenPullRequest,
-    PrValidationCheckReport, PrValidationReport,
+    block_on_octocrab, parse_pr_number, parse_repo, pr_validation_projection_status, with_octocrab,
+    OpenPullRequest, PrValidationCheckReport, PrValidationReport,
 };
 #[cfg(test)]
 use super::{run_gh_status_shell, test_gh_fixture_fallback_allowed};
@@ -295,6 +295,39 @@ pub(super) fn list_prs_by_head_ref_octocrab(
                 queue: None,
             })
             .collect())
+    })
+}
+
+pub(super) fn pr_metadata_octocrab(repo: &str, pr_ref: &str) -> Result<OpenPullRequest> {
+    let repo_parts = parse_repo(repo)?;
+    let number = parse_pr_number(pr_ref)? as u64;
+    with_octocrab("pr.view.metadata", |runtime, octo| {
+        let owner = repo_parts.owner.clone();
+        let name = repo_parts.name.clone();
+        let pr = block_on_octocrab(runtime, "pr.view.metadata", || async {
+            octo.pulls(&owner, &name).get(number).await
+        })?;
+        Ok(OpenPullRequest {
+            number: pr.number.unwrap_or(number) as u32,
+            title: pr.title.unwrap_or_default(),
+            url: pr.html_url.map(|url| url.to_string()).unwrap_or_default(),
+            head_ref_name: pr
+                .head
+                .as_ref()
+                .map(|head| head.ref_field.clone())
+                .unwrap_or_default(),
+            base_ref_name: pr
+                .base
+                .as_ref()
+                .map(|base| base.ref_field.clone())
+                .unwrap_or_default(),
+            is_draft: pr.draft.unwrap_or(false),
+            state: pr
+                .state
+                .map(|state| format!("{state:?}").to_uppercase())
+                .unwrap_or_else(|| "OPEN".to_string()),
+            queue: None,
+        })
     })
 }
 
@@ -922,6 +955,12 @@ pub(super) fn pr_validation_report_from_snapshot_with_disposition(
         pr_state: snapshot.state.clone(),
         is_draft: snapshot.is_draft,
         disposition: disposition.as_event_result().to_string(),
+        projection_status: pr_validation_projection_status(
+            &snapshot.state,
+            snapshot.is_draft,
+            disposition.as_event_result(),
+        )
+        .to_string(),
         checks,
         failed_checks,
         pending_checks,

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -295,6 +295,108 @@ fn spawn_pr_watch_once_server(linked_pr: bool) -> (String, thread::JoinHandle<Ve
     (base_uri, handle)
 }
 
+fn spawn_pr_watch_pr_ref_server() -> (String, thread::JoinHandle<Vec<String>>) {
+    let (base_uri, server) = bind_pr_validation_test_server("bind PR-ref watch server");
+    let handle = thread::spawn(move || {
+        let mut seen = Vec::new();
+        for _ in 0..5 {
+            let Some(mut request) = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("PR-ref watch server receive")
+            else {
+                break;
+            };
+            let method = request.method().as_str().to_string();
+            let url = request.url().to_string();
+            let mut body = String::new();
+            let _ = request.as_reader().read_to_string(&mut body);
+            seen.push(format!("{method} {url} {body}"));
+            let path = url.split('?').next().unwrap_or(url.as_str());
+            let response = match (method.as_str(), path) {
+                ("GET", "/repos/owner/repo/issues/4427") => pr_validation_json_response(
+                    serde_json::json!({
+                        "number": 4427,
+                        "title": "[v0.91.6][tools] PR-like issue",
+                        "state": "open",
+                        "state_reason": serde_json::Value::Null,
+                        "html_url": "https://github.com/owner/repo/pull/4427",
+                        "closed_at": serde_json::Value::Null,
+                        "body": "Pull request issue endpoint payload",
+                        "labels": [],
+                        "milestone": serde_json::Value::Null,
+                        "pull_request": {
+                            "url": "https://api.github.test/repos/owner/repo/pulls/4427"
+                        }
+                    })
+                    .to_string(),
+                ),
+                ("GET", "/repos/owner/repo/pulls/4427") => pr_validation_json_response(
+                    serde_json::json!({
+                        "number": 4427,
+                        "title": "[v0.91.6][tools] Prove repo-native sprint watcher",
+                        "html_url": "https://github.com/owner/repo/pull/4427",
+                        "head": {"ref": "codex/4397-v0-91-6-watch-target", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                        "base": {"ref": "main", "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                        "draft": false,
+                        "state": "open"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/graphql") if body.contains("closingIssuesReferences") => {
+                    pr_validation_json_response(
+                        serde_json::json!({
+                            "data": {
+                                "repository": {
+                                    "pullRequest": {
+                                        "closingIssuesReferences": {
+                                            "nodes": [{"number": 4397}]
+                                        }
+                                    }
+                                }
+                            }
+                        })
+                        .to_string(),
+                    )
+                }
+                ("GET", "/repos/owner/repo/issues/4397") => pr_validation_json_response(
+                    serde_json::json!({
+                        "number": 4397,
+                        "title": "[v0.91.6][tools] Repo-native sprint watcher",
+                        "state": "open",
+                        "state_reason": serde_json::Value::Null,
+                        "html_url": "https://github.com/owner/repo/issues/4397",
+                        "closed_at": serde_json::Value::Null,
+                        "body": "Watcher issue body",
+                        "labels": [{
+                            "id": 1,
+                            "node_id": "MDU6TGFiZWwx",
+                            "url": "https://api.github.com/repos/owner/repo/labels/area:tools",
+                            "name": "area:tools",
+                            "color": "ededed",
+                            "default": false,
+                            "description": serde_json::Value::Null
+                        }],
+                        "milestone": serde_json::Value::Null
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/graphql") if body.contains("statusCheckRollup") => {
+                    pr_validation_json_response(pr_validation_graphql_response(
+                        "COMPLETED",
+                        Some("SUCCESS"),
+                        "adl-ci",
+                        false,
+                    ))
+                }
+                _ => panic!("unexpected PR-ref watch request: {method} {url} {body}"),
+            };
+            request.respond(response).expect("respond");
+        }
+        seen
+    });
+    (base_uri, handle)
+}
+
 fn write_watch_state_fixture(bin_dir: &std::path::Path) {
     write_executable(
         &bin_dir.join("gh"),
@@ -483,6 +585,65 @@ fn real_pr_watch_reports_json_for_linked_green_pr() {
     assert!(seen
         .iter()
         .any(|request| request.contains("closingIssuesReferences")));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("statusCheckRollup")));
+}
+
+#[test]
+fn real_pr_watch_accepts_direct_pr_ref_and_resolves_backing_issue() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-watch-direct-pr-ref");
+    init_git_repo(&repo);
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    write_watch_state_fixture(&bin_dir);
+    let (base_uri, server) = spawn_pr_watch_pr_ref_server();
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_path = env::var_os("PATH");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    let mut path_entries = vec![bin_dir.clone()];
+    path_entries.extend(env::split_paths(old_path.as_deref().unwrap_or_default()));
+    unsafe {
+        env::set_var("PATH", env::join_paths(path_entries).expect("join PATH"));
+        env::set_var("ADL_GITHUB_CLIENT", "auto");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    real_pr_watch(&[
+        "https://github.com/owner/repo/pull/4427".to_string(),
+        "--version".to_string(),
+        "v0.91.6".to_string(),
+        "--slug".to_string(),
+        "watch-target".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("watch direct PR ref");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("PATH", old_path);
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    let seen = server.join().expect("server join");
+    assert!(
+        seen[0].starts_with("GET /repos/owner/repo/issues/4427 "),
+        "first request should probe issue endpoint and hit PR-like issue response: {seen:#?}"
+    );
+    assert!(seen
+        .iter()
+        .any(|request| request.starts_with("GET /repos/owner/repo/pulls/4427 ")));
+    assert!(seen
+        .iter()
+        .any(|request| request.contains("closingIssuesReferences")));
+    assert!(seen
+        .iter()
+        .any(|request| request.starts_with("GET /repos/owner/repo/issues/4397 ")));
     assert!(seen
         .iter()
         .any(|request| request.contains("statusCheckRollup")));
@@ -1028,6 +1189,15 @@ fn validation_disposition_blocks_pending_and_terminal_failures() {
     assert!(validation_disposition_blocks_shell_success("failed"));
     assert!(validation_disposition_blocks_shell_success("cancelled"));
     assert!(validation_disposition_blocks_shell_success("timed_out"));
+
+    assert!(!validation_report_blocks_shell_success(
+        "success",
+        "ready_to_merge_or_review"
+    ));
+    assert!(validation_report_blocks_shell_success(
+        "success",
+        "checks_green_but_draft"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4488

## Summary
Implemented the #4488 PR metadata and projection hardening slice. `adl pr validation` now reports a machine-readable `projection_status` alongside the existing disposition and treats a green draft PR as a shell-blocking state. `adl pr watch` now accepts a direct PR reference by detecting the pull-request issue shape, fetching typed PR metadata, resolving the backing issue through closing references or codex branch ownership, and then producing the normal issue watch report.

The review found two issues: green draft PR validation did not yet fail shell success, and the direct PR watch path needed command-level coverage. Both were fixed before publication. A separate cross-worktree local-readiness polish issue and a session-goal blocking problem were captured as residual workflow/tooling evidence, not hidden inside this implementation.

## Artifacts
- Updated PR validation/watch implementation in `adl/src/cli/pr_cmd.rs`.
- Updated GitHub metadata helpers in `adl/src/cli/pr_cmd/github.rs` and `adl/src/cli/pr_cmd/github/transport.rs`.
- Added/updated focused tests in `adl/src/cli/pr_cmd/github/tests/watch.rs`, `adl/src/cli/pr_cmd/github/tests/validation.rs`, and `adl/src/cli/tests/pr_cmd_inline/basics.rs`.
- Updated issue-local SRP and SOR cards for #4488.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl pr_validation_report_exposes_projection_status_for_pr_lifecycle_states -- --nocapture`
    Verified projection status mapping for PR lifecycle states.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl issue_watch_routes_all_green_draft_pr_to_janitor -- --nocapture`
    Verified watcher routing for green draft PRs.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl issue_watch_pr_number_resolution_routes_missing_closing_linkage_by_codex_branch -- --nocapture`
    Verified fallback issue ownership inference from codex branch names.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl validation_disposition_blocks_pending_and_terminal_failures -- --nocapture`
    Verified shell-blocking validation behavior, including green draft projection status.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_watch_accepts_direct_pr_ref_and_resolves_backing_issue -- --nocapture`
    Verified the command-level direct PR watch fallback path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture`
    Verified the focused GitHub PR/watch/validation unit-test surface.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- pr watch 4495 --json`
    Verified live direct PR watch fallback against PR #4495 without exposing token contents.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4488__v0-91-6-tools-pr-sh-harden-github-projection-validation-and-pr-metadata-janitor/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4488__v0-91-6-tools-pr-sh-harden-github-projection-validation-and-pr-metadata-janitor/sor.md
- Idempotency-Key: v0-91-6-tools-harden-pr-projection-and-watcher-state-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-watch-rs-adl-src-cli-pr-cmd-github-tests-validation-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-v0-91-6-tasks-issue-4488-v0-91-6-tools-pr-sh-harden-github-projection-validation-and-pr-metadata-janitor-sip-md-adl-v0-91-6-tasks-issue-4488-v0-91-6-tools-pr-sh-harden-github-projection-validation-and-pr-metadata-janitor-sor-md