### PR TITLE
[v0.91.6][tools] Focus finish validation profiles

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2195,6 +2195,9 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_native_gws_runtime_validation(issue_number, changed_paths) {
         return Ok(build_native_gws_runtime_validation_plan());
     }
+    if finish_paths_need_github_projection_watch_validation(changed_paths) {
+        return Ok(build_github_projection_watch_validation_plan());
+    }
     if finish_issue_needs_unity_observatory_scaffold_validation(issue_number, changed_paths) {
         return Ok(build_unity_observatory_scaffold_validation_plan(
             changed_paths,
@@ -2336,6 +2339,43 @@ fn build_version_metadata_validation_plan() -> FinishValidationPlan {
                 .to_string(),
             "cargo metadata --manifest-path adl/Cargo.toml --locked --no-deps --format-version 1"
                 .to_string(),
+        ],
+    }
+}
+
+fn finish_paths_need_github_projection_watch_validation(changed_paths: &[String]) -> bool {
+    let mut has_github_projection_surface = false;
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            if matches!(
+                trimmed,
+                "adl/src/cli/pr_cmd/github.rs"
+                    | "adl/src/cli/pr_cmd/github/transport.rs"
+                    | "adl/src/cli/pr_cmd/github/tests/watch.rs"
+                    | "adl/src/cli/pr_cmd/github/tests/validation.rs"
+            ) || trimmed.starts_with("adl/src/cli/pr_cmd/github/")
+            {
+                has_github_projection_surface = true;
+                return true;
+            }
+            matches!(
+                trimmed,
+                "adl/src/cli/pr_cmd.rs" | "adl/src/cli/tests/pr_cmd_inline/basics.rs"
+            ) || finish_path_is_docs_only(trimmed)
+        })
+        && has_github_projection_surface
+}
+
+fn build_github_projection_watch_validation_plan() -> FinishValidationPlan {
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml --bin adl validation_disposition_blocks_pending_and_terminal_failures -- --nocapture".to_string(),
         ],
     }
 }
@@ -3556,6 +3596,36 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl",
                             "cli::pr_cmd",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "cli::pr_cmd::github::tests",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl validation_disposition_blocks_pending_and_terminal_failures -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "validation_disposition_blocks_pending_and_terminal_failures",
+                            "--",
+                            "--nocapture",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3040,6 +3040,42 @@ fn finish_validation_profile_keeps_finish_support_changes_narrow() {
 }
 
 #[test]
+fn finish_validation_profile_keeps_github_projection_watch_slice_focused() {
+    let plan = select_finish_validation_plan_for_finish(
+        4488,
+        ".",
+        &[
+            "adl/src/cli/pr_cmd.rs".to_string(),
+            "adl/src/cli/pr_cmd/github.rs".to_string(),
+            "adl/src/cli/pr_cmd/github/transport.rs".to_string(),
+            "adl/src/cli/pr_cmd/github/tests/watch.rs".to_string(),
+            "adl/src/cli/pr_cmd/github/tests/validation.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/basics.rs".to_string(),
+        ],
+    )
+    .expect("github projection/watch focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl validation_disposition_blocks_pending_and_terminal_failures -- --nocapture"
+            .to_string()
+    ));
+    assert!(
+        !plan.commands.contains(
+            &"cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd".to_string()
+        ),
+        "github projection/watch slices should not fall back to the full pr_cmd lane"
+    );
+}
+
+#[test]
 fn finish_validation_profile_classifies_process_status_helper_surfaces() {
     let plan = select_finish_validation_plan_for_finish(
         0,


### PR DESCRIPTION
Closes #4489

## Summary
Implemented the #4489 finish-profile correction for GitHub projection/watch changes. `pr.sh finish` now recognizes #4488-style changed paths in `adl/src/cli/pr_cmd/github*`, shared `adl/src/cli/pr_cmd.rs`, and `adl/src/cli/tests/pr_cmd_inline/basics.rs` as a focused GitHub projection/watch slice instead of falling back to the full `cargo test ... cli::pr_cmd` lane.

The selected profile is path-based, not issue-number based. It remains self-contained on the current `main` base by using existing GitHub test namespaces and the existing validation-disposition regression. It intentionally does not depend on #4488-only tests until #4488 merges.

## Artifacts
- Updated finish profile selection in `adl/src/cli/pr_cmd/finish_support.rs`.
- Added command dispatch support for the new focused validation commands in `adl/src/cli/pr_cmd/finish_support.rs`.
- Added regression coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`.
- Updated issue-local SRP and SOR cards for #4489.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_validation_profile_keeps_github_projection_watch_slice_focused -- --nocapture`
    Verified the new GitHub projection/watch path slice selects focused validation and rejects full `cli::pr_cmd` fallback.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests -- --nocapture`
    Verified the selected GitHub PR/watch/validation test namespace.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl validation_disposition_blocks_pending_and_terminal_failures -- --nocapture`
    Verified the selected validation-disposition regression.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_validation_profile_keeps_finish_support_changes_narrow -- --nocapture`
    Verified existing finish-support profile behavior remained narrow.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_validation_profile_classifies_lifecycle_inline_tests -- --nocapture`
    Verified unrelated lifecycle inline test paths still select their expected profile.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4489__v0-91-6-tools-pr-sh-correct-finish-validation-profiles-and-focused-proof-selection/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4489__v0-91-6-tools-pr-sh-correct-finish-validation-profiles-and-focused-proof-selection/sor.md
- Idempotency-Key: v0-91-6-tools-focus-finish-validation-profiles-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-6-tasks-issue-4489-v0-91-6-tools-pr-sh-correct-finish-validation-profiles-and-focused-proof-selection-sip-md-adl-v0-91-6-tasks-issue-4489-v0-91-6-tools-pr-sh-correct-finish-validation-profiles-and-focused-proof-selection-sor-md