### PR TITLE
[v0.91.6][tools][review-fix] Close out 4417 sprint review findings

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2093,7 +2093,7 @@ pub(super) fn load_finish_validation_profile(
     load_finish_validation_profile_with_retention(repo_root, changed_paths, false)
 }
 
-fn load_finish_validation_profile_for_execution(
+pub(super) fn load_finish_validation_profile_for_execution(
     repo_root: &Path,
     changed_paths: &[String],
 ) -> Result<FinishValidationProfile> {
@@ -2137,6 +2137,14 @@ fn load_finish_validation_profile_with_retention(
             return Err(err).context("finish: validation manager returned invalid profile JSON");
         }
     };
+    if retain_changed_file_for_execution {
+        if let Err(err) =
+            validate_manager_backed_retained_changed_file(&profile, &changed_file_path_str)
+        {
+            let _ = fs::remove_file(&changed_file_path);
+            return Err(err);
+        }
+    }
     if !retain_changed_file_for_execution {
         for item in &mut profile.run {
             item.command = sanitize_validation_profile_command(&item.command);
@@ -2150,6 +2158,32 @@ fn load_finish_validation_profile_with_retention(
         let _ = fs::remove_file(&changed_file_path);
     }
     Ok(profile)
+}
+
+fn validate_manager_backed_retained_changed_file(
+    profile: &FinishValidationProfile,
+    expected_changed_file: &str,
+) -> Result<()> {
+    for item in &profile.run {
+        if item
+            .command
+            .starts_with("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")
+        {
+            let changed_file = manager_backed_pr_fast_changed_files_arg(&item.command)?;
+            let changed_file_cmp =
+                fs::canonicalize(&changed_file).unwrap_or_else(|_| PathBuf::from(&changed_file));
+            let expected_changed_file_cmp = fs::canonicalize(expected_changed_file)
+                .unwrap_or_else(|_| PathBuf::from(expected_changed_file));
+            if changed_file_cmp != expected_changed_file_cmp {
+                bail!(
+                    "finish: validation manager returned unsupported changed-files manifest '{}'; expected ADL-created retained manifest '{}'",
+                    changed_file,
+                    expected_changed_file
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn select_finish_validation_plan_for_finish(
@@ -4317,11 +4351,7 @@ pub(super) fn run_finish_validation_rust(
                 other if other.starts_with(
                     "bash adl/tools/run_pr_fast_test_lane.sh --changed-files ",
                 ) => {
-                    let Some(changed_files) =
-                        manager_backed_pr_fast_changed_files_arg(other)
-                    else {
-                        bail!("finish: unsupported focused validation command '{other}'");
-                    };
+                    let changed_files = manager_backed_pr_fast_changed_files_arg(other)?;
                     let script = repo_root.join("adl/tools/run_pr_fast_test_lane.sh");
                     let result = run_finish_validation_status(
                         "bash",
@@ -4430,14 +4460,28 @@ pub(super) fn run_finish_validation_rust(
     bail!("finish: unsupported validation mode")
 }
 
-fn manager_backed_pr_fast_changed_files_arg(command: &str) -> Option<String> {
-    let changed_files = command
-        .strip_prefix("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")?
-        .trim();
+fn manager_backed_pr_fast_changed_files_arg(command: &str) -> Result<String> {
+    let Some(changed_files) =
+        command.strip_prefix("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")
+    else {
+        bail!("finish: unsupported focused validation command '{command}'");
+    };
+    let changed_files = changed_files.trim();
     if changed_files.is_empty() {
-        return None;
+        bail!("finish: unsupported focused validation command '{command}'");
     }
-    Some(changed_files.trim_matches('\'').to_string())
+    let changed_files = changed_files.trim_matches('\'');
+    let file_name = Path::new(changed_files)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if !file_name.starts_with("finish-validation-profile-") || !file_name.ends_with(".txt") {
+        bail!(
+            "finish: validation manager returned unsupported changed-files manifest '{}'; expected ADL-created finish-validation-profile-*.txt",
+            changed_files
+        );
+    }
+    Ok(changed_files.to_string())
 }
 
 const FINISH_VALIDATION_SANITIZED_ENVS: &[&str] = &[

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4,8 +4,9 @@ use crate::cli::pr_cmd::finish_support::{
     ensure_no_staged_issue_bundle_mutations, extra_pr_body_looks_like_issue_template,
     extract_markdown_section, finish_declared_paths_for_validation, finish_inputs_fingerprint,
     issue_bundle_issue_number_from_repo_relative, load_finish_validation_profile,
-    non_closing_lifecycle_line, normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture,
-    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, real_pr_finish,
+    load_finish_validation_profile_for_execution, non_closing_lifecycle_line,
+    normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture, open_pr_url_nonblocking,
+    open_pr_url_nonblocking_with_timeout, real_pr_finish,
     reject_local_issue_bundle_paths_in_finish_paths, render_default_finish_validation,
     resolve_finish_issue_scope_and_slug, restage_finish_output_truth_paths,
     run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
@@ -1482,6 +1483,75 @@ fn load_finish_validation_profile_cleans_tempfile_on_invalid_manager_json() {
         fs::read_dir(&tmpdir).expect("read temp dir").count(),
         0,
         "temporary changed-file manifests should be cleaned up on parse failure"
+    );
+}
+
+#[test]
+fn load_finish_validation_profile_rejects_retained_changed_file_substitution() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-finish-load-profile-substituted-retained-file");
+    let tmpdir = repo.join("tmp");
+    let wrong_dir = repo.join("wrong");
+    fs::create_dir_all(repo.join("adl/tools")).expect("tools dir");
+    fs::create_dir_all(&tmpdir).expect("tmp dir");
+    fs::create_dir_all(&wrong_dir).expect("wrong dir");
+    let substituted = wrong_dir.join("finish-validation-profile-substituted.txt");
+    write_executable(
+        &repo.join("adl/tools/validation_manager.py"),
+        &format!(
+            r#"#!/usr/bin/env python3
+import json
+
+print(json.dumps({{
+    "selected_profile": "csdlc_owner_profile",
+    "status": "ready_to_run",
+    "pr_publication_sufficient": False,
+    "run": [
+        {{
+            "lane_id": "pr_fast",
+            "command": "bash adl/tools/run_pr_fast_test_lane.sh --changed-files {substituted}",
+            "reason": "substituted changed-files path",
+        }}
+    ],
+    "not_run": [],
+    "deferred": [],
+    "behavior_surfaces": ["csdlc"],
+    "validation_dag": [],
+    "estimated_cost": "small",
+    "escalation": {{
+        "required": False,
+        "reasons": [],
+    }},
+    "selector_plan": [],
+}}))
+"#,
+            substituted = substituted.display()
+        ),
+    );
+
+    let old_tmpdir = env::var("TMPDIR").ok();
+    unsafe {
+        env::set_var("TMPDIR", &tmpdir);
+    }
+
+    let err = load_finish_validation_profile_for_execution(
+        &repo,
+        &["adl/src/cli/pr_cmd/doctor.rs".to_string()],
+    )
+    .expect_err("manager-backed profile must reject substituted retained changed-file path");
+
+    match old_tmpdir {
+        Some(value) => unsafe { env::set_var("TMPDIR", value) },
+        None => unsafe { env::remove_var("TMPDIR") },
+    }
+
+    assert!(err
+        .to_string()
+        .contains("expected ADL-created retained manifest"));
+    assert_eq!(
+        fs::read_dir(&tmpdir).expect("read temp dir").count(),
+        0,
+        "real retained tempfile should be cleaned when manager substitutes the changed-file path"
     );
 }
 
@@ -4005,7 +4075,7 @@ fn finish_helper_paths_run_manager_backed_owner_and_pr_fast_validation() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let cargo_log = temp.join("cargo.log");
     let focused_log = temp.join("focused.log");
-    let changed_files = temp.join("changed-files.txt");
+    let changed_files = temp.join("finish-validation-profile-safe.txt");
     fs::write(&changed_files, "M\tadl/src/cli/pr_cmd/doctor.rs\n").expect("changed files");
     write_executable(
         &bin_dir.join("cargo"),
@@ -4054,6 +4124,54 @@ fn finish_helper_paths_run_manager_backed_owner_and_pr_fast_validation() {
     assert!(
         !changed_files.exists(),
         "manager-backed pr-fast helper execution should clean up the changed-file manifest"
+    );
+}
+
+#[test]
+fn finish_helper_rejects_manager_backed_pr_fast_changed_files_substitution() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-manager-rejects-substituted-changed-files");
+
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("manifest");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/run_pr_fast_test_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let substituted = temp.join("not-adl-created.txt");
+    fs::write(&substituted, "M\tadl/src/cli/pr_cmd/doctor.rs\n")
+        .expect("substituted changed files");
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            format!(
+                "bash adl/tools/run_pr_fast_test_lane.sh --changed-files {}",
+                substituted.display()
+            ),
+        ],
+    };
+
+    let err = run_finish_validation_rust(&repo, &plan)
+        .expect_err("substituted changed-files manifest should be refused");
+    assert!(err
+        .to_string()
+        .contains("expected ADL-created finish-validation-profile-*.txt"));
+    assert!(
+        substituted.exists(),
+        "refused substituted manifest must not be deleted"
     );
 }
 

--- a/docs/milestones/v0.91.6/review/V0916_VALIDATION_THROUGHPUT_LIFECYCLE_AUTOMATION_SPRINT_REVIEW_4417.md
+++ b/docs/milestones/v0.91.6/review/V0916_VALIDATION_THROUGHPUT_LIFECYCLE_AUTOMATION_SPRINT_REVIEW_4417.md
@@ -1,0 +1,172 @@
+# v0.91.6 Sprint Review: #4417 Validation Throughput And Lifecycle Automation
+
+Status: reviewed with remediation in #4499
+Date: 2026-06-24
+Scope: #4417 umbrella and child issues #4418, #4419, #4420, #4421
+
+## Findings Reviewed
+
+### P1 Retained dirty worktree carried real Rust changes
+
+The retained `.worktrees/adl-wp-4417` worktree was not disposable residue. It was 30 commits behind `origin/main` and contained modified Rust GitHub transport files:
+
+- `adl/src/cli/pr_cmd/github.rs`
+- `adl/src/cli/pr_cmd/github/transport.rs`
+- `adl/src/cli/pr_cmd/github/tests/transport.rs`
+
+The diff changed PR-list semantics so `pr.list.open_wave` uses open-only PR listing while `pr.list.wave` can still request all-state PR listing. This was preserved below before the stale worktree was pruned.
+
+Disposition: routed into the active `pr.sh`/GitHub wave-liveness hardening stream. The patch is retained in this review packet as evidence and migration input; the stale worktree must not remain the only copy.
+
+### P1 Umbrella SRP still claimed review had not run
+
+The local `#4417` SRP still recorded `findings_status: not_run` after the sprint review was complete.
+
+Disposition: repaired in the local root-authoritative `#4417` SRP during #4499 closeout cleanup.
+
+### P2 Sprint review was local ignored evidence only
+
+The sprint review existed under ignored `.adl` state but did not have a tracked milestone review packet.
+
+Disposition: this tracked review packet is the durable review surface.
+
+### P2 Manager-backed changed-files execution could delete a substituted path
+
+The finish-validation path parsed manager-emitted `run_pr_fast_test_lane.sh --changed-files <path>` commands and removed the parsed path after execution without checking that it was the ADL-created retained temp manifest.
+
+Disposition: #4499 hardens the manager-backed profile loader to require the exact ADL-created retained manifest path before execution, rejects same-pattern substituted paths, and adds focused regression coverage for both malformed and wrong-path substitution.
+
+### P3 Child issue goal metrics remain incomplete
+
+Child issue token/time splits are still mostly unknown because the active goal substrate exposed only umbrella-level metrics during execution.
+
+Disposition: accepted as truthful residual risk for #4417; broader issue/sprint metrics work remains in the C-SDLC metrics stream.
+
+## Retained Worktree Diff Summary
+
+The retained `adl-wp-4417` diff was preserved before worktree cleanup. Summary:
+
+```diff
+diff --git a/adl/src/cli/pr_cmd/github.rs b/adl/src/cli/pr_cmd/github.rs
+index d71c0d20..274f72c3 100644
+--- a/adl/src/cli/pr_cmd/github.rs
++++ b/adl/src/cli/pr_cmd/github.rs
+@@ -424,12 +424,12 @@ pub(crate) fn linked_prs_for_issue(
+     let prs = if let Some(branch_hint) = branch_hint {
+         let prs = list_prs_by_head_ref_octocrab(repo, branch_hint)?;
+         if prs.is_empty() {
+-            list_prs_octocrab(repo)?
++            list_prs_octocrab(repo, octocrab::params::State::All, "pr.list.wave")?
+         } else {
+             prs
+         }
+     } else {
+-        list_prs_octocrab(repo)?
++        list_prs_octocrab(repo, octocrab::params::State::All, "pr.list.wave")?
+     };
+     for pr in prs {
+         let pr_ref = pr.number.to_string();
+@@ -979,9 +979,14 @@ fn run_octocrab_capture(operation: &str, args: &[&str]) -> Result<String> {
+             let branch = arg_after(args, "--head")?;
+             current_pr_url_octocrab(repo, branch).map(|url| url.unwrap_or_default())
+         }
+-        "pr.list.open_wave" | "pr.list.wave" => {
++        "pr.list.open_wave" => {
+             let repo = arg_after(args, "-R")?;
+-            let prs = list_prs_octocrab(repo)?;
++            let prs = list_prs_octocrab(repo, octocrab::params::State::Open, operation)?;
++            serde_json::to_string(&prs).context("failed to serialize octocrab PR list")
++        }
++        "pr.list.wave" => {
++            let repo = arg_after(args, "-R")?;
++            let prs = list_prs_octocrab(repo, octocrab::params::State::All, operation)?;
+             serde_json::to_string(&prs).context("failed to serialize octocrab PR list")
+         }
+         "pr.view.body" => {
+@@ -1162,6 +1167,7 @@ pub(super) fn unresolved_milestone_pr_wave(
+     let prs: Vec<OpenPullRequest> =
+         serde_json::from_str(&out).with_context(|| "failed to parse GitHub PR list JSON")?;
+     prs.into_iter()
++        .filter(|pr| pr.state == "OPEN")
+         .filter(|pr| {
+             pr_matches_main_version_wave(
+                 &PullRequestMetadataSnapshot::new(
+diff --git a/adl/src/cli/pr_cmd/github/tests/transport.rs b/adl/src/cli/pr_cmd/github/tests/transport.rs
+index 9c938974..8870494b 100644
+--- a/adl/src/cli/pr_cmd/github/tests/transport.rs
++++ b/adl/src/cli/pr_cmd/github/tests/transport.rs
+@@ -240,6 +240,11 @@ fn octocrab_transport_covers_pr_and_issue_operations_against_mock_github() {
+ 
+     let seen = server.join().expect("server join");
+     assert_eq!(seen.len(), 27, "unexpected mock GitHub calls: {seen:#?}");
++    assert!(seen.iter().any(|call| {
++        call.starts_with("GET /repos/owner/repo/pulls?")
++            && call.contains("state=open")
++            && call.contains("per_page=100")
++    }));
+     assert!(seen
+         .iter()
+         .any(|call| call.starts_with("POST /repos/owner/repo/pulls ")));
+@@ -467,7 +472,12 @@ fn list_prs_octocrab_paginates_rest_results() {
+         std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+     }
+ 
+-    let prs = list_prs_octocrab("owner/repo").expect("paginated PRs");
++    let prs = list_prs_octocrab(
++        "owner/repo",
++        octocrab::params::State::Open,
++        "pr.list.open_wave",
++    )
++    .expect("paginated PRs");
+     assert_eq!(prs.len(), 2);
+     assert_eq!(prs[0].number, 2101);
+     assert_eq!(prs[1].number, 2102);
+diff --git a/adl/src/cli/pr_cmd/github/transport.rs b/adl/src/cli/pr_cmd/github/transport.rs
+index 57cf6dc8..b1556e78 100644
+--- a/adl/src/cli/pr_cmd/github/transport.rs
++++ b/adl/src/cli/pr_cmd/github/transport.rs
+@@ -182,15 +182,19 @@ pub(super) fn current_pr_url_octocrab(repo: &str, branch: &str) -> Result<Option
+     })
+ }
+ 
+-pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
++pub(super) fn list_prs_octocrab(
++    repo: &str,
++    state: octocrab::params::State,
++    operation: &str,
++) -> Result<Vec<OpenPullRequest>> {
+     let repo_parts = parse_repo(repo)?;
+-    with_octocrab("pr.list.wave", |runtime, octo| {
++    with_octocrab(operation, |runtime, octo| {
+         let owner = repo_parts.owner.clone();
+         let name = repo_parts.name.clone();
+-        let mut page = block_on_octocrab(runtime, "pr.list.wave", || async {
++        let mut page = block_on_octocrab(runtime, operation, || async {
+             octo.pulls(&owner, &name)
+                 .list()
+-                .state(octocrab::params::State::All)
++                .state(state.clone())
+                 .per_page(100)
+                 .send()
+                 .await
+@@ -223,7 +227,7 @@ pub(super) fn list_prs_octocrab(repo: &str) -> Result<Vec<OpenPullRequest>> {
+             let Some(next) = page.next.clone() else {
+                 break;
+             };
+-            page = block_on_octocrab(runtime, "pr.list.wave", || async {
++            page = block_on_octocrab(runtime, operation, || async {
+                 octo.get_page::<octocrab::models::pulls::PullRequest>(&Some(next.clone()))
+                     .await
+             })?
+```
+
+## Review Result
+
+The sprint delivered meaningful validation-throughput and lifecycle automation improvements, but it was not closeout-clean until #4499 resolved the review findings above.
+
+After #4499 remediation, the required closure bar is:
+
+- retained dirty worktree diff preserved and stale worktree removed
+- local #4417 SRP/SOR truth normalized
+- tracked review packet present
+- manager-backed changed-files hardening implemented and covered by focused tests


### PR DESCRIPTION
Closes #4499

## Summary
Resolved the `#4417` sprint-review closeout findings by creating remediation issue `#4499`, preserving the retained dirty `adl-wp-4417` GitHub transport diff in a tracked sprint-review packet, pruning the stale retained worktree, normalizing local `#4417` SRP/SOR/sprint-review truth, and hardening manager-backed finish validation so substituted `--changed-files` paths are refused rather than executed and deleted.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `docs/milestones/v0.91.6/review/V0916_VALIDATION_THROUGHPUT_LIFECYCLE_AUTOMATION_SPRINT_REVIEW_4417.md`
- Local ignored `#4417` SRP/SOR/sprint-review truth repairs under `.adl/`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_manager_backed_owner_and_pr_fast_validation -- --exact --nocapture`
    Verified manager-backed focused validation still accepts and deletes the ADL-created retained changed-files manifest.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::load_finish_validation_profile_rejects_retained_changed_file_substitution -- --exact --nocapture`
    Verified manager-backed validation profile loading rejects same-pattern wrong-path retained manifest substitution and cleans up the real retained manifest.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_rejects_manager_backed_pr_fast_changed_files_substitution -- --exact --nocapture`
    Verified manager-substituted changed-files paths are refused and not deleted.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified formatting.
  - `git diff --check`
    Verified whitespace hygiene.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.91.6/tasks/issue-4417__v0-91-6-tools-mini-sprint-validation-throughput-and-lifecycle-automation/sor.md`
    Verified #4417 closeout SOR truth remains structurally valid after remediation.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4499__v0-91-6-tools-review-fix-close-out-4417-sprint-review-findings/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4499__v0-91-6-tools-review-fix-close-out-4417-sprint-review-findings/sor.md
- Idempotency-Key: v0-91-6-tools-review-fix-close-out-4417-sprint-review-findings-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-milestones-v0-91-6-review-v0916-validation-throughput-lifecycle-automation-sprint-review-4417-md-adl-v0-91-6-tasks-issue-4499-v0-91-6-tools-review-fix-close-out-4417-sprint-review-findings-sip-md-adl-v0-91-6-tasks-issue-4499-v0-91-6-tools-review-fix-close-out-4417-sprint-review-findings-sor-md