### PR TITLE
[v0.91.6][tools][finish] Support prompt-template workflow focused validation

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4256,6 +4256,11 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_select_validation_lanes.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
+                "bash adl/tools/test_prompt_template_workflow_integration.sh" => {
+                    let script =
+                        repo_root.join("adl/tools/test_prompt_template_workflow_integration.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
                 "bash adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh" => {
                     let script =
                         repo_root.join("adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4315,6 +4315,70 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
 }
 
 #[test]
+fn finish_runner_executes_prompt_template_workflow_integration_command() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-prompt-template-workflow-integration-command");
+
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_prompt_template_workflow_integration.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' prompt-template-workflow >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec!["bash adl/tools/test_prompt_template_workflow_integration.sh".to_string()],
+    };
+    run_finish_validation_rust(&repo, &plan)
+        .expect("prompt-template workflow integration validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "prompt-template workflow command should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("prompt-template-workflow"));
+}
+
+#[test]
 fn finish_helper_paths_run_validation_inventory_validation() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-validation-inventory-validation");

--- a/docs/milestones/v0.91.6/review/workflow_tools/PR_SH_STABLE_SHIM_ARCHITECTURE_4481.md
+++ b/docs/milestones/v0.91.6/review/workflow_tools/PR_SH_STABLE_SHIM_ARCHITECTURE_4481.md
@@ -135,6 +135,13 @@ combined CI-policy command while the runner only knew the component commands.
 This issue fixes that specific gap by decomposing the combined command into
 the already-supported component checks.
 
+The rebased publication path exposed a second runner parity gap for the
+prompt-template workflow integration command. That command was already a
+declared focused validation surface, but `pr finish` did not yet execute it
+directly. This issue also adds that exact runner mapping and regression
+coverage so the tailored prompt-template lane can complete through the normal
+finish path.
+
 ## Failure Modes To Design Out
 
 The target design should remove these recurring failure classes from shell


### PR DESCRIPTION
Closes #4507

## Summary
Implemented the missing `pr finish` focused-validation runner mapping for the prompt-template workflow integration proof command. This remediates the local fix that was discovered during #4481 publication but did not make it into merged PR #4500 after a rebased-branch push rejection.

The change is deliberately narrow: `pr finish` now executes `bash adl/tools/test_prompt_template_workflow_integration.sh` through the focused validation runner, a Rust regression proves that exact command path, and the #4481 architecture packet records why the follow-up exists.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `docs/milestones/v0.91.6/review/workflow_tools/PR_SH_STABLE_SHIM_ARCHITECTURE_4481.md`
- Updated local SPP/VPP/SOR truth cards for #4507.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`
    Verified the prompt-template workflow proof command selected by the focused profile still passes.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_executes`
    Verified the finish runner executes both the combined CI-policy selector command and the prompt-template workflow integration command without falling back to cargo.
  - `git diff --check`
    Verified whitespace hygiene.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --phase bootstrap --input .adl/v0.91.6/tasks/issue-4507__v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation/spp.md`
    Verified SPP structure after budget repair.
  - `bash adl/tools/validate_structured_prompt.sh --type vpp --phase bootstrap --input .adl/v0.91.6/tasks/issue-4507__v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation/vpp.md`
    Verified VPP structure after validation budget repair.
- Results:
  - PASS for all listed local validation commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4507__v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4507__v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation/sor.md
- Idempotency-Key: v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-milestones-v0-91-6-review-workflow-tools-pr-sh-stable-shim-architecture-4481-md-adl-v0-91-6-tasks-issue-4507-v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation-sip-md-adl-v0-91-6-tasks-issue-4507-v0-91-6-tools-finish-support-prompt-template-workflow-focused-validation-sor-md