### PR TITLE
[v0.91.6][csdlc][adoption] Enforce issue-start gates in pr-ready and pr-run

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1311,14 +1311,13 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         chrono::Utc::now(),
     )?;
     emit_start_session_ledger_notes(&session_assessment);
-    if session_assessment.status == "BLOCK" {
-        bail!(
-            "start: session ledger active conflict for issue #{} before worktree binding. {}\n{}",
-            parsed.issue,
-            session_assessment.guidance,
-            format_session_claims_for_error(&session_assessment.relevant_claims)
-        );
-    }
+    ensure_start_session_claim_ready(
+        &repo_root,
+        parsed.issue,
+        &branch,
+        &worktree_path,
+        &session_assessment,
+    )?;
 
     eprintln!("• Target branch: {branch}");
     eprintln!("• Target worktree: {}", worktree_path.display());
@@ -1489,6 +1488,66 @@ fn emit_start_session_ledger_notes(assessment: &adl::session_ledger::TargetClaim
         }
         _ => {}
     }
+}
+
+fn ensure_start_session_claim_ready(
+    repo_root: &Path,
+    issue_number: u32,
+    branch: &str,
+    worktree_path: &Path,
+    assessment: &adl::session_ledger::TargetClaimAssessment,
+) -> Result<()> {
+    if assessment.block_kind == "session_self_claim" {
+        return Ok(());
+    }
+    let route = suggested_session_claim_command(repo_root, issue_number, branch, worktree_path);
+    match assessment.block_kind {
+        "session_active_conflict" => bail!(
+            "start: session ledger active conflict for issue #{} before worktree binding. {}\n{}\nSuggested next step:\n  {}",
+            issue_number,
+            assessment.guidance,
+            format_session_claims_for_error(&assessment.relevant_claims),
+            route
+        ),
+        "session_stale_claim_manual_inspection" | "session_nonblocking_live_claim" => bail!(
+            "start: session claim gate blocked for issue #{} before worktree binding. {}\n{}\nAfter inspection, create or refresh the active claim explicitly:\n  {}",
+            issue_number,
+            assessment.guidance,
+            format_session_claims_for_error(&assessment.relevant_claims),
+            route
+        ),
+        _ => bail!(
+            "start: missing active self-claim for issue #{} before worktree binding. {}\nCreate the claim explicitly, then rerun `pr run`:\n  {}",
+            issue_number,
+            assessment.guidance,
+            route
+        ),
+    }
+}
+
+fn suggested_session_claim_command(
+    repo_root: &Path,
+    issue_number: u32,
+    branch: &str,
+    worktree_path: &Path,
+) -> String {
+    let session_id = std::env::var("CODEX_SESSION_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "<session-id>".to_string());
+    let worktree_ref = if worktree_path.is_absolute() {
+        worktree_path
+            .strip_prefix(repo_root)
+            .ok()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| worktree_path.display().to_string())
+    } else {
+        worktree_path.display().to_string()
+    };
+    format!(
+        "adl session claim --session-id {} --owner codex --resource csdlc_issue:{} --purpose \"issue-mode execution ownership\" --issue {} --branch {} --worktree {} --policy-ref AGENTS.md --lifecycle-phase pr_run --mode active --json",
+        session_id, issue_number, issue_number, branch, worktree_ref
+    )
 }
 
 fn format_session_claims_for_error(claims: &[adl::session_ledger::TargetClaimMatch]) -> String {

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -70,10 +70,11 @@ pub(super) fn run_doctor_preflight(
             })
             .collect(),
     };
-    let (status, block_kind, guidance) = doctor_preflight_status(
+    let (status, block_kind, guidance) = doctor_preflight_status_with_session_block(
         open_prs.is_empty(),
         card_run_readiness,
         session_ledger.status,
+        session_ledger.block_kind,
         allow_open_pr_wave,
     );
     if open_prs.is_empty() && card_run_readiness != Some("blocked") {
@@ -121,47 +122,79 @@ pub(super) fn doctor_preflight_status(
     session_status: &'static str,
     open_pr_wave_skipped: bool,
 ) -> (&'static str, &'static str, &'static str) {
+    doctor_preflight_status_with_session_block(
+        open_pr_wave_empty,
+        card_run_readiness,
+        session_status,
+        session_status,
+        open_pr_wave_skipped,
+    )
+}
+
+fn doctor_preflight_status_with_session_block(
+    open_pr_wave_empty: bool,
+    card_run_readiness: Option<&'static str>,
+    session_status: &'static str,
+    session_block_kind: &'static str,
+    open_pr_wave_skipped: bool,
+) -> (&'static str, &'static str, &'static str) {
     let card_blocked = card_run_readiness == Some("blocked");
     match (
         open_pr_wave_empty,
         card_blocked,
         session_status,
+        session_block_kind,
         open_pr_wave_skipped,
     ) {
-        (true, false, "BLOCK", _) => (
+        (true, false, "BLOCK", "session_active_conflict", _) => (
             "BLOCK",
             "session_active_conflict",
             "Session-ledger ownership is actively claimed by another session. Resolve the claim before execution binding.",
         ),
-        (true, false, "WARN", _) => (
-            "WARN",
-            "session_manual_inspection",
-            "Session-ledger history needs manual inspection before execution, but there is no active ownership conflict.",
-        ),
-        (true, false, _, true) => (
+        (true, false, _, "session_self_claim", true) => (
             "WARN",
             "open_pr_wave_override",
             "Open PR wave scan was explicitly skipped by --allow-open-pr-wave; record why the queue override is unrelated or intentionally sequenced.",
         ),
-        (true, false, _, false) => (
+        (true, false, _, "session_self_claim", false) => (
             "PASS",
             "none",
             "No preflight queue or card-readiness blockers detected.",
         ),
-        (false, false, _, _) => (
+        (true, false, _, "none" | "session_released_history", _) => (
             "BLOCK",
-            "open_pr_wave",
-            "Issue-local readiness may proceed only under an explicit queue override such as --allow-open-pr-wave after recording why the open PR wave is unrelated or intentionally sequenced.",
+            "session_claim_required",
+            "Create an active session claim with `adl session claim` before execution binding so issue ownership is explicit.",
         ),
-        (true, true, _, _) => (
+        (true, false, _, "session_stale_claim_manual_inspection", _) => (
+            "BLOCK",
+            "session_stale_claim_manual_inspection",
+            "Stale session claims exist for this issue/worktree. Inspect `adl session status`, then create, heartbeat, or release a claim deliberately before execution.",
+        ),
+        (true, false, _, "session_nonblocking_live_claim", _) => (
+            "BLOCK",
+            "session_nonblocking_live_claim",
+            "A relevant watching or paused session claim exists. Inspect `adl session status` and make active ownership explicit before execution binding.",
+        ),
+        (true, true, _, _, _) => (
             "BLOCK",
             "card_run_readiness",
             "Repair issue-local SIP/STP/SPP/VPP/SRP/SOR readiness before execution; do not override this as queue pressure.",
         ),
-        (false, true, _, _) => (
+        (false, true, _, _, _) => (
             "BLOCK",
             "open_pr_wave_and_card_run_readiness",
             "Repair issue-local card readiness before execution; open PR queue pressure remains a separate scheduling gate.",
+        ),
+        (true, false, _, _, _) => (
+            "BLOCK",
+            "session_claim_manual_inspection",
+            "Session-ledger state is not execution-ready. Inspect `adl session status` and make active ownership explicit before execution binding.",
+        ),
+        (false, false, _, _, _) => (
+            "BLOCK",
+            "open_pr_wave",
+            "Issue-local readiness may proceed only under an explicit queue override such as --allow-open-pr-wave after recording why the open PR wave is unrelated or intentionally sequenced.",
         ),
     }
 }

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -116,6 +116,7 @@ pub(super) fn run_doctor_preflight(
     }
 }
 
+#[cfg(test)]
 pub(super) fn doctor_preflight_status(
     open_pr_wave_empty: bool,
     card_run_readiness: Option<&'static str>,

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -123,11 +123,17 @@ pub(super) fn doctor_preflight_status(
     session_status: &'static str,
     open_pr_wave_skipped: bool,
 ) -> (&'static str, &'static str, &'static str) {
+    let session_block_kind = match session_status {
+        "PASS" => "session_self_claim",
+        "WARN" => "session_manual_inspection",
+        "BLOCK" => "session_active_conflict",
+        _ => session_status,
+    };
     doctor_preflight_status_with_session_block(
         open_pr_wave_empty,
         card_run_readiness,
         session_status,
-        session_status,
+        session_block_kind,
         open_pr_wave_skipped,
     )
 }

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -308,13 +308,13 @@ fn doctor_preflight_blocks_on_active_session_conflict() {
 }
 
 #[test]
-fn doctor_preflight_warns_on_stale_session_history() {
+fn doctor_preflight_blocks_on_stale_session_history() {
     let (preflight_status, block_kind, guidance) =
         doctor_preflight_status(true, Some("ready"), "WARN", true);
 
-    assert_eq!(preflight_status, "WARN");
-    assert_eq!(block_kind, "session_manual_inspection");
-    assert!(guidance.contains("manual inspection"));
+    assert_eq!(preflight_status, "BLOCK");
+    assert_eq!(block_kind, "session_claim_manual_inspection");
+    assert!(guidance.contains("make active ownership explicit"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -1,4 +1,53 @@
 use super::*;
+use adl::session_ledger::{
+    default_ledger_path, save_ledger, ClaimInput, ClaimMode, GithubRef, ResourceRef, SessionLedger,
+    DEFAULT_TTL_SECS,
+};
+
+fn write_session_claim(
+    repo: &std::path::Path,
+    issue: u64,
+    session_id: &str,
+    branch: &str,
+    worktree_path: &std::path::Path,
+) {
+    let mut ledger = SessionLedger::empty(chrono::Utc::now());
+    ledger
+        .claim(
+            ClaimInput {
+                session_id: session_id.to_string(),
+                owner: "codex".to_string(),
+                resource: ResourceRef {
+                    kind: "csdlc_issue".to_string(),
+                    id: issue.to_string(),
+                },
+                purpose: "test ownership".to_string(),
+                mode: ClaimMode::Active,
+                lifecycle_phase: Some("pr_run".to_string()),
+                policy_ref: Some("AGENTS.md".to_string()),
+                github: GithubRef {
+                    issue: Some(issue),
+                    pull_request: None,
+                    repository: Some("owner/repo".to_string()),
+                    last_state: Some("open".to_string()),
+                },
+                branch: Some(branch.to_string()),
+                worktree_path: Some(
+                    worktree_path
+                        .strip_prefix(repo)
+                        .unwrap_or(worktree_path)
+                        .display()
+                        .to_string(),
+                ),
+                do_not_touch_paths: Vec::new(),
+                blockers: Vec::new(),
+                ttl_secs: DEFAULT_TTL_SECS,
+            },
+            chrono::Utc::now(),
+        )
+        .expect("claim");
+    save_ledger(&default_ledger_path(repo), &ledger).expect("save ledger");
+}
 
 #[test]
 fn real_pr_doctor_full_reports_pre_run_ready_without_worktree() {
@@ -597,15 +646,28 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1197, "v0.86", "doctor-worktree-cwd").expect("issue ref");
+    let branch = "codex/1197-doctor-worktree-cwd";
+    let session_id = "thread-self";
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Doctor worktree cwd");
     write_design_time_ready_cards(
         &repo,
         &issue_ref,
         "[v0.86][tools] Doctor worktree cwd",
-        "codex/1197-doctor-worktree-cwd",
+        branch,
     );
+    write_session_claim(
+        &repo,
+        1197,
+        session_id,
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", session_id);
+    }
     real_pr(&[
         "start".to_string(),
         "1197".to_string(),
@@ -652,6 +714,10 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     doctor.expect("doctor from worktree");
 }
 
@@ -731,12 +797,24 @@ fn real_pr_doctor_full_succeeds_with_worktree_only_card_bundle() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1198, "v0.86", "doctor-worktree-only-cards").expect("issue ref");
     let title = "[v0.86][tools] Doctor worktree-only cards";
     let branch = "codex/1198-doctor-worktree-only-cards";
+    let session_id = "thread-self";
     write_authored_issue_prompt(&repo, &issue_ref, title);
     write_design_time_ready_cards(&repo, &issue_ref, title, branch);
+    write_session_claim(
+        &repo,
+        1198,
+        session_id,
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", session_id);
+    }
     real_pr(&[
         "start".to_string(),
         "1198".to_string(),
@@ -787,6 +865,10 @@ fn real_pr_doctor_full_succeeds_with_worktree_only_card_bundle() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     doctor.expect("doctor with worktree-only card bundle");
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -213,6 +213,14 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     ])
     .expect("real_pr doctor ready");
 
+    write_session_claim(
+        &repo,
+        1154,
+        "thread-self",
+        "codex/1154-readiness-prep-metrics",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+
     real_pr(&[
         "start".to_string(),
         "1154".to_string(),

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -853,7 +853,12 @@ fn real_pr_start_requires_an_active_self_claim_before_binding_worktree() {
     let issue_ref = IssueRef::new(1157, "v0.86", "requires-self-claim").expect("issue ref");
     let branch = "codex/1157-requires-self-claim";
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Requires self claim");
-    write_design_time_ready_cards(&repo, &issue_ref, "[v0.86][tools] Requires self claim", branch);
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Requires self claim",
+        branch,
+    );
 
     let prev_dir = env::current_dir().expect("cwd");
     let old_session = env::var("CODEX_SESSION_ID").ok();

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -162,6 +162,10 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Readiness prep metrics");
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     real_pr(&[
         "init".to_string(),
@@ -223,6 +227,10 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     .expect("real_pr start");
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
+        match old_session {
+            Some(value) => env::set_var("CODEX_SESSION_ID", value),
+            None => env::remove_var("CODEX_SESSION_ID"),
+        }
         match old_home {
             Some(value) => env::set_var("HOME", value),
             None => env::remove_var("HOME"),
@@ -344,9 +352,11 @@ fn real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage() {
         1782230477,
     );
     let old_home = env::var_os("HOME");
+    let old_env_session = env::var_os("CODEX_SESSION_ID");
     let old_thread_id = env::var_os("CODEX_THREAD_ID");
     unsafe {
         env::set_var("HOME", &home);
+        env::set_var("CODEX_SESSION_ID", "thread-1155-prep");
         env::set_var("CODEX_THREAD_ID", "thread-1155-prep");
     }
 
@@ -359,6 +369,9 @@ fn real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage() {
     );
 
     let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     real_pr(&[
         "init".to_string(),
@@ -378,6 +391,13 @@ fn real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage() {
         &issue_ref,
         "[v0.86][tools] Readiness prep start failure",
         "not bound yet",
+    );
+    write_session_claim(
+        &repo,
+        1155,
+        "thread-self",
+        "codex/1155-readiness-prep-start-failure",
+        &issue_ref.default_worktree_path(&repo, None),
     );
 
     real_pr(&[
@@ -430,6 +450,10 @@ fn real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage() {
         match old_home {
             Some(value) => env::set_var("HOME", value),
             None => env::remove_var("HOME"),
+        }
+        match old_env_session {
+            Some(value) => env::set_var("CODEX_SESSION_ID", value),
+            None => env::remove_var("CODEX_SESSION_ID"),
         }
         match old_thread_id {
             Some(value) => env::set_var("CODEX_THREAD_ID", value),
@@ -502,6 +526,10 @@ fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
     fs::write(repo.join("README.md"), "tracked drift on main\n").expect("dirty readme");
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let err = real_pr(&[
         "start".to_string(),
@@ -516,6 +544,10 @@ fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
     ])
     .expect_err("tracked dirty primary main should block issue-mode run");
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     let err = err.to_string();
     assert!(err.contains("unsafe_root_checkout_execution"));
@@ -599,6 +631,10 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1152, "v0.86", "rust-start-ready-test").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust start ready test");
@@ -607,6 +643,13 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
         &issue_ref,
         "[v0.86][tools] Rust start ready test",
         "codex/1152-rust-start-ready-test",
+    );
+    write_session_claim(
+        &repo,
+        1152,
+        "thread-self",
+        "codex/1152-rust-start-ready-test",
+        &issue_ref.default_worktree_path(&repo, None),
     );
     let local_templates = repo.join("docs/templates");
     fs::create_dir_all(local_templates.join("nested")).expect("create local templates");
@@ -667,6 +710,10 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     ready.expect("real_pr ready");
 
     assert!(worktree.is_dir());
@@ -718,6 +765,116 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     assert!(card_review_policy_path(&root_cards, 1152)
         .symlink_metadata()
         .is_ok());
+}
+
+#[test]
+fn real_pr_start_requires_an_active_self_claim_before_binding_worktree() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-requires-self-claim");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "missing self claim\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let issue_ref = IssueRef::new(1157, "v0.86", "requires-self-claim").expect("issue ref");
+    let branch = "codex/1157-requires-self-claim";
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Requires self claim");
+    write_design_time_ready_cards(&repo, &issue_ref, "[v0.86][tools] Requires self claim", branch);
+
+    let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var("CODEX_SESSION_ID").ok();
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let err = real_pr(&[
+        "start".to_string(),
+        "1157".to_string(),
+        "--slug".to_string(),
+        "requires-self-claim".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Requires self claim".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("missing self claim should block run binding");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
+
+    let err_text = err.to_string();
+    assert!(err_text.contains("missing active self-claim"));
+    assert!(err_text.contains("adl session claim"));
+    assert!(!issue_ref.default_worktree_path(&repo, None).exists());
 }
 
 #[test]
@@ -1054,15 +1211,27 @@ fn real_pr_start_rejects_invocation_from_existing_issue_worktree() {
         .success());
 
     let issue_ref = IssueRef::new(3819, "v0.91.5", "nested-worktree-guard").expect("issue ref");
+    let branch = "codex/3819-v0-91-5-tools-nested-worktree-guard";
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.91.5][tools] Nested worktree guard");
     write_design_time_ready_cards(
         &repo,
         &issue_ref,
         "[v0.91.5][tools] Nested worktree guard",
-        "codex/3819-v0-91-5-tools-nested-worktree-guard",
+        branch,
+    );
+    write_session_claim(
+        &repo,
+        3819,
+        "thread-self",
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
     );
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir repo");
     real_pr(&[
         "start".to_string(),
@@ -1092,6 +1261,10 @@ fn real_pr_start_rejects_invocation_from_existing_issue_worktree() {
     ])
     .expect_err("issue worktree invocation should fail clearly");
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     let err = err.to_string();
     assert!(err.contains("must be invoked from the primary checkout"));
@@ -1179,6 +1352,10 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1153, "v0.86", "repair-worktree-bundle").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Repair worktree bundle");
@@ -1189,6 +1366,13 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
         "codex/1153-repair-worktree-bundle",
     );
     let branch = "codex/1153-repair-worktree-bundle";
+    write_session_claim(
+        &repo,
+        1153,
+        "thread-self",
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
+    );
     let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
         .args([
@@ -1219,6 +1403,10 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
     .expect("real_pr start");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     assert_nonempty_materialized_file(issue_ref.issue_prompt_path(&worktree));
     assert_nonempty_materialized_file(issue_ref.worktree_task_bundle_stp_path(&worktree));
@@ -1308,6 +1496,10 @@ fn real_pr_start_updates_existing_root_spp_and_srp_branch() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref =
         IssueRef::new(1154, "v0.86", "update-root-plan-review-branch").expect("issue ref");
@@ -1344,6 +1536,20 @@ fn real_pr_start_updates_existing_root_spp_and_srp_branch() {
         &issue_ref,
         "[v0.86][tools] Update root plan and review branch",
         "not bound yet",
+    );
+    write_session_claim(
+        &repo,
+        1154,
+        "thread-self",
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+    write_session_claim(
+        &repo,
+        1154,
+        "thread-self",
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
     );
 
     real_pr(&[
@@ -1391,6 +1597,10 @@ fn real_pr_start_updates_existing_root_spp_and_srp_branch() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     ready.expect("real_pr ready");
     assert!(fs::read_to_string(issue_ref.task_bundle_plan_path(&repo))
@@ -1489,6 +1699,10 @@ fn real_pr_ready_blocks_invalid_worktree_srp() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1917, "v0.86", "ready-invalid-worktree-srp").expect("issue ref");
     write_authored_issue_prompt(
@@ -1556,6 +1770,10 @@ fn real_pr_ready_blocks_invalid_worktree_srp() {
     .expect_err("ready should reject invalid worktree srp");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     let err = err.to_string();
     assert!(err.contains("ready: srp failed validation"));
     assert!(err.contains("status must be one of: draft, ready, approved"));
@@ -1637,6 +1855,10 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1199, "v0.86", "start-rewrites-unbound").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Start rewrites unbound");
@@ -1658,6 +1880,13 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
         "[v0.86][tools] Start rewrites unbound",
         "not bound yet",
     );
+    write_session_claim(
+        &repo,
+        1199,
+        "thread-self",
+        "codex/1199-start-rewrites-unbound",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
 
     let root_sip = issue_ref.task_bundle_input_path(&repo);
     assert_eq!(
@@ -1678,6 +1907,10 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     start.expect("real_pr start after unbound root card");
     assert_eq!(
         field_line_value(&root_sip, "Branch").expect("root branch"),
@@ -1790,7 +2023,18 @@ fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
         "[v0.86][tools] Canonical bind slug issue",
         "not bound yet",
     );
+    write_session_claim(
+        &repo,
+        1288,
+        "thread-self",
+        "codex/1288-canonical-bind-slug",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
 
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     real_pr(&[
         "start".to_string(),
         "1288".to_string(),
@@ -1803,6 +2047,10 @@ fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
     .expect("start should honor canonical local slug");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(worktree.is_dir());
@@ -2312,6 +2560,13 @@ fn real_pr_start_allow_open_pr_wave_skips_wave_scan_before_binding() {
     )
     .expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Preflight override");
+    write_session_claim(
+        &repo,
+        1174,
+        "thread-self",
+        "codex/1174-v0-86-tools-preflight-override",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
 
     let bin_dir = repo.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -2326,9 +2581,11 @@ fn real_pr_start_allow_open_pr_wave_skips_wave_scan_before_binding() {
     );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_session = env::var_os("CODEX_SESSION_ID");
     let old_disable_default_token_file = env::var_os("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE");
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", "1");
     }
@@ -2350,6 +2607,10 @@ fn real_pr_start_allow_open_pr_wave_skips_wave_scan_before_binding() {
 
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
+        match old_session {
+            Some(value) => env::set_var("CODEX_SESSION_ID", value),
+            None => env::remove_var("CODEX_SESSION_ID"),
+        }
         env::set_var("PATH", old_path);
         match old_disable_default_token_file {
             Some(value) => env::set_var("ADL_TEST_DISABLE_DEFAULT_GITHUB_TOKEN_FILE", value),

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -162,10 +162,6 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Readiness prep metrics");
 
     let prev_dir = env::current_dir().expect("cwd");
-    let old_session = env::var_os("CODEX_SESSION_ID");
-    unsafe {
-        env::set_var("CODEX_SESSION_ID", "thread-self");
-    }
     env::set_current_dir(&repo).expect("chdir");
     real_pr(&[
         "init".to_string(),
@@ -235,10 +231,6 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     .expect("real_pr start");
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
-        match old_session {
-            Some(value) => env::set_var("CODEX_SESSION_ID", value),
-            None => env::remove_var("CODEX_SESSION_ID"),
-        }
         match old_home {
             Some(value) => env::set_var("HOME", value),
             None => env::remove_var("HOME"),
@@ -534,10 +526,6 @@ fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
     fs::write(repo.join("README.md"), "tracked drift on main\n").expect("dirty readme");
 
     let prev_dir = env::current_dir().expect("cwd");
-    let old_session = env::var_os("CODEX_SESSION_ID");
-    unsafe {
-        env::set_var("CODEX_SESSION_ID", "thread-self");
-    }
     env::set_current_dir(&repo).expect("chdir");
     let err = real_pr(&[
         "start".to_string(),
@@ -552,10 +540,6 @@ fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
     ])
     .expect_err("tracked dirty primary main should block issue-mode run");
     env::set_current_dir(prev_dir).expect("restore cwd");
-    match old_session {
-        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
-        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
-    }
 
     let err = err.to_string();
     assert!(err.contains("unsafe_root_checkout_execution"));
@@ -1729,6 +1713,13 @@ fn real_pr_ready_blocks_invalid_worktree_srp() {
         "[v0.86][tools] Ready invalid worktree srp",
         "codex/1917-ready-invalid-worktree-srp",
     );
+    write_session_claim(
+        &repo,
+        1917,
+        "thread-self",
+        "codex/1917-ready-invalid-worktree-srp",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
 
     real_pr(&[
         "start".to_string(),
@@ -2010,6 +2001,10 @@ fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref =
         IssueRef::new(1288, "v0.86", "canonical-bind-slug").expect("canonical issue ref");
@@ -2162,6 +2157,10 @@ fn real_pr_start_still_fails_closed_when_real_duplicate_bundle_exists() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1289, "v0.86", "canonical-duplicate-bind").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Canonical duplicate bind");
@@ -2274,6 +2273,10 @@ fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1198, "v0.86", "ready-worktree-cwd").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Ready worktree cwd");
@@ -2282,6 +2285,13 @@ fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
         &issue_ref,
         "[v0.86][tools] Ready worktree cwd",
         "codex/1198-ready-worktree-cwd",
+    );
+    write_session_claim(
+        &repo,
+        1198,
+        "thread-self",
+        "codex/1198-ready-worktree-cwd",
+        &issue_ref.default_worktree_path(&repo, None),
     );
     real_pr(&[
         "start".to_string(),
@@ -2327,6 +2337,10 @@ fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     ready.expect("ready from worktree");
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -152,6 +152,7 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
         1782230488,
     );
     let old_home = env::var_os("HOME");
+    let old_env_session = env::var_os("CODEX_SESSION_ID");
     let old_thread_id = env::var_os("CODEX_THREAD_ID");
     unsafe {
         env::set_var("HOME", &home);
@@ -212,10 +213,13 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
     write_session_claim(
         &repo,
         1154,
-        "thread-self",
+        "thread-1154-prep",
         "codex/1154-readiness-prep-metrics",
         &issue_ref.default_worktree_path(&repo, None),
     );
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-1154-prep");
+    }
 
     real_pr(&[
         "start".to_string(),
@@ -234,6 +238,10 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
         match old_home {
             Some(value) => env::set_var("HOME", value),
             None => env::remove_var("HOME"),
+        }
+        match old_env_session {
+            Some(value) => env::set_var("CODEX_SESSION_ID", value),
+            None => env::remove_var("CODEX_SESSION_ID"),
         }
         match old_thread_id {
             Some(value) => env::set_var("CODEX_THREAD_ID", value),
@@ -2001,10 +2009,6 @@ fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
         .success());
 
     let prev_dir = env::current_dir().expect("cwd");
-    let old_session = env::var_os("CODEX_SESSION_ID");
-    unsafe {
-        env::set_var("CODEX_SESSION_ID", "thread-self");
-    }
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref =
         IssueRef::new(1288, "v0.86", "canonical-bind-slug").expect("canonical issue ref");
@@ -2191,6 +2195,10 @@ fn real_pr_start_still_fails_closed_when_real_duplicate_bundle_exists() {
     .expect_err("real duplicate should still fail closed");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     let text = err.to_string();
     assert!(text.contains("duplicate local task-bundle identities detected"));

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -808,6 +808,17 @@ fn real_pr_ready_accepts_started_issue_when_output_branch_is_bootstrap_placehold
         "[v0.86][tools] Ready branch placeholder",
         "codex/1198-ready-branch-placeholder",
     );
+    write_session_claim(
+        &repo,
+        1198,
+        "thread-self",
+        "codex/1198-ready-branch-placeholder",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
 
     real_pr(&[
         "start".to_string(),
@@ -866,6 +877,10 @@ fn real_pr_ready_accepts_started_issue_when_output_branch_is_bootstrap_placehold
     ]);
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
     ready.expect("ready should accept placeholder output branch");
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -1,5 +1,54 @@
 use super::*;
 use crate::cli::pr_cmd::github::current_pr_url;
+use adl::session_ledger::{
+    default_ledger_path, save_ledger, ClaimInput, ClaimMode, GithubRef, ResourceRef, SessionLedger,
+    DEFAULT_TTL_SECS,
+};
+
+fn write_session_claim(
+    repo: &std::path::Path,
+    issue: u64,
+    session_id: &str,
+    branch: &str,
+    worktree_path: &std::path::Path,
+) {
+    let mut ledger = SessionLedger::empty(chrono::Utc::now());
+    ledger
+        .claim(
+            ClaimInput {
+                session_id: session_id.to_string(),
+                owner: "codex".to_string(),
+                resource: ResourceRef {
+                    kind: "csdlc_issue".to_string(),
+                    id: issue.to_string(),
+                },
+                purpose: "test ownership".to_string(),
+                mode: ClaimMode::Active,
+                lifecycle_phase: Some("pr_run".to_string()),
+                policy_ref: Some("AGENTS.md".to_string()),
+                github: GithubRef {
+                    issue: Some(issue),
+                    pull_request: None,
+                    repository: Some("owner/repo".to_string()),
+                    last_state: Some("open".to_string()),
+                },
+                branch: Some(branch.to_string()),
+                worktree_path: Some(
+                    worktree_path
+                        .strip_prefix(repo)
+                        .unwrap_or(worktree_path)
+                        .display()
+                        .to_string(),
+                ),
+                do_not_touch_paths: Vec::new(),
+                blockers: Vec::new(),
+                ttl_secs: DEFAULT_TTL_SECS,
+            },
+            chrono::Utc::now(),
+        )
+        .expect("claim");
+    save_ledger(&default_ledger_path(repo), &ledger).expect("save ledger");
+}
 
 #[test]
 fn real_pr_start_requires_explicit_version_when_no_fetch_issue_has_no_local_bundle() {
@@ -118,8 +167,19 @@ fn real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready() {
         .status()
         .expect("git remote set-url")
         .success());
+    write_session_claim(
+        &repo,
+        1154,
+        "thread-self",
+        "codex/1154-v0-86-tools-design-time-card-gate",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
 
     let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
     env::set_current_dir(&repo).expect("chdir");
 
     let err = real_pr(&[
@@ -136,6 +196,10 @@ fn real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready() {
     .expect_err("start should block before worktree binding when root SPP is not ready");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
 
     let err_text = err.to_string();
     assert!(


### PR DESCRIPTION
Closes #4435

## Summary
Implemented stricter issue-start gating for `pr ready` / `pr run` so execution binding now requires an active self-claim and fail-closed preflight ownership truth instead of relying on ambient session memory.

## Artifacts
- Updated issue-local execution record at `.adl/v0.91.6/tasks/issue-4435__v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/doctor/preflight.rs`
  - `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
  - `adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --check --cached`
    Verified staged patch hygiene for the four tracked issue surfaces.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_start_requires_an_active_self_claim_before_binding_worktree -- --nocapture`
    Verified fail-closed start binding when no active self-claim exists.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
    Verified successful binding and ready-state proof when the current session owns the active self-claim.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4435__v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4435__v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run/sor.md
- Idempotency-Key: v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run-adl-v0-91-6-tasks-issue-4435-v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run-sip-md-adl-v0-91-6-tasks-issue-4435-v0-91-6-csdlc-adoption-enforce-issue-start-gates-in-pr-ready-and-pr-run-sor-md