### PR TITLE
[v0.91.6][csdlc][adoption] Make watcher and shepherd states mandatory for PR tail work

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -788,6 +788,8 @@ fn print_issue_watch_report(report: &github::IssueWatchReport) {
         report.issue, report.classification, report.next_skill, report.reason
     );
     println!("state: {}", report.issue_state);
+    println!("tail_owner: {}", report.tail_owner);
+    println!("shepherd_state: {}", report.shepherd_state);
     println!("continuation: {}", report.continuation);
     println!(
         "local_readiness: status={} pr_run_readiness={} reason={}",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -15,7 +15,7 @@ use super::git_support::{
     run_status_allow_failure,
 };
 use super::github::{
-    attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
+    attach_issue_watcher, attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
     ensure_or_repair_pr_closing_linkage, pr_create_finish, pr_edit_finish_existing,
     pr_merge_finish, pr_ready_finish_allow_failure, pr_ready_finish_merge_allow_failure,
     pr_view_base_ref_finish_existing, wait_for_pr_validation_finish,
@@ -309,6 +309,26 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         if parsed.ready { "ready" } else { "draft" },
     )?;
     attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &pr_url)?;
+    let initial_watcher_state = if parsed.ready {
+        ("checks_running", "issue-watcher", "watcher_owned_checks_running")
+    } else {
+        ("pr_open", "issue-watcher", "watcher_owned_pr_open")
+    };
+    if let Err(err) = attach_issue_watcher(
+        &repo_root,
+        &repo,
+        parsed.issue,
+        &branch,
+        &pr_url,
+        if parsed.ready { "ready" } else { "draft" },
+        initial_watcher_state.0,
+        initial_watcher_state.1,
+        initial_watcher_state.2,
+    ) {
+        eprintln!(
+            "warning: issue watcher auto-attach failed after PR publication; PR remains published and other tail attachments succeeded. Resolve watcher setup separately: {err}"
+        );
+    }
 
     println!("{pr_url}");
     if !parsed.no_open {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -18,7 +18,7 @@ use super::github::{
     attach_issue_watcher, attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
     ensure_or_repair_pr_closing_linkage, pr_create_finish, pr_edit_finish_existing,
     pr_merge_finish, pr_ready_finish_allow_failure, pr_ready_finish_merge_allow_failure,
-    pr_view_base_ref_finish_existing, wait_for_pr_validation_finish,
+    pr_view_base_ref_finish_existing, wait_for_pr_validation_finish, IssueWatcherAttachRequest,
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
@@ -318,17 +318,17 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     } else {
         ("pr_open", "issue-watcher", "watcher_owned_pr_open")
     };
-    if let Err(err) = attach_issue_watcher(
-        &repo_root,
-        &repo,
-        parsed.issue,
-        &branch,
-        &pr_url,
-        if parsed.ready { "ready" } else { "draft" },
-        initial_watcher_state.0,
-        initial_watcher_state.1,
-        initial_watcher_state.2,
-    ) {
+    if let Err(err) = attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo_root,
+        repo: &repo,
+        issue: parsed.issue,
+        branch: &branch,
+        pr_url: &pr_url,
+        expected_pr_state: if parsed.ready { "ready" } else { "draft" },
+        classification: initial_watcher_state.0,
+        tail_owner: initial_watcher_state.1,
+        shepherd_state: initial_watcher_state.2,
+    }) {
         eprintln!(
             "warning: issue watcher auto-attach failed after PR publication; PR remains published and other tail attachments succeeded. Resolve watcher setup separately: {err}"
         );

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -310,7 +310,11 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     )?;
     attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &pr_url)?;
     let initial_watcher_state = if parsed.ready {
-        ("checks_running", "issue-watcher", "watcher_owned_checks_running")
+        (
+            "checks_running",
+            "issue-watcher",
+            "watcher_owned_checks_running",
+        )
     } else {
         ("pr_open", "issue-watcher", "watcher_owned_pr_open")
     };

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -635,6 +635,18 @@ pub(crate) fn build_issue_watch_report(
             "action_required",
             "linked_pr_checks_green_but_draft",
         )
+    } else if matches!(
+        validation.disposition.as_str(),
+        "failed" | "cancelled" | "timed_out"
+    ) {
+        (
+            "checks_failed",
+            "pr-janitor",
+            "janitor_owned_checks_failed",
+            "pr-janitor",
+            "action_required",
+            "linked_pr_checks_failed",
+        )
     } else if validation.is_draft {
         (
             "pr_open",
@@ -654,13 +666,8 @@ pub(crate) fn build_issue_watch_report(
                 "continue",
                 "linked_pr_checks_pending",
             ),
-            "failed" | "cancelled" | "timed_out" => (
-                "checks_failed",
-                "pr-janitor",
-                "janitor_owned_checks_failed",
-                "pr-janitor",
-                "action_required",
-                "linked_pr_checks_failed",
+            "failed" | "cancelled" | "timed_out" => unreachable!(
+                "failed draft and ready PR checks are classified before the non-draft disposition match"
             ),
             "success" | "skipped" => (
                 "checks_green",
@@ -1500,6 +1507,178 @@ pub(super) fn attach_pr_janitor(
             }
         );
     }
+    Ok(())
+}
+
+pub(super) fn attach_issue_watcher(
+    repo_root: &Path,
+    repo: &str,
+    issue: u32,
+    branch: &str,
+    pr_url: &str,
+    expected_pr_state: &str,
+    classification: &str,
+    tail_owner: &str,
+    shepherd_state: &str,
+) -> Result<()> {
+    if std::env::var("ADL_ISSUE_WATCHER_DISABLE")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
+        return Ok(());
+    }
+
+    if let Some(command_path) = std::env::var("ADL_ISSUE_WATCHER_CMD")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        let mut command = helper_command_with_github_context(&command_path);
+        let output = command
+            .arg("--repo-root")
+            .arg(repo_root)
+            .arg("--repo")
+            .arg(repo)
+            .arg("--issue")
+            .arg(issue.to_string())
+            .arg("--branch")
+            .arg(branch)
+            .arg("--pr-url")
+            .arg(pr_url)
+            .arg("--expected-pr-state")
+            .arg(expected_pr_state)
+            .arg("--classification")
+            .arg(classification)
+            .arg("--tail-owner")
+            .arg(tail_owner)
+            .arg("--shepherd-state")
+            .arg(shepherd_state)
+            .output()
+            .with_context(|| {
+                format!("finish: failed to spawn issue watcher command '{command_path}'")
+            })?;
+        if !output.status.success() {
+            let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&output.stderr));
+            let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
+            bail!(
+                "finish: issue watcher auto-attach failed for issue #{} and PR '{}': {}{}",
+                issue,
+                pr_url,
+                stderr.trim(),
+                if stdout.trim().is_empty() {
+                    String::new()
+                } else {
+                    format!(" (stdout: {})", stdout.trim())
+                }
+            );
+        }
+        return Ok(());
+    }
+
+    let install_script = repo_root.join("adl/tools/install_adl_operational_skills.sh");
+    let install_output = helper_command_with_github_context("bash")
+        .arg(&install_script)
+        .output()
+        .with_context(|| {
+            format!(
+                "finish: failed to run watcher skill installer '{}'",
+                install_script.display()
+            )
+        })?;
+    if !install_output.status.success() {
+        let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&install_output.stderr));
+        let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&install_output.stdout));
+        bail!(
+            "finish: issue watcher skill install failed for issue #{}: {}{}",
+            issue,
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" (stdout: {})", stdout.trim())
+            }
+        );
+    }
+
+    let artifact_root = repo_root
+        .join(".adl")
+        .join("logs")
+        .join("issue-watcher")
+        .join(format!("issue-{issue}"));
+    fs::create_dir_all(&artifact_root).with_context(|| {
+        format!(
+            "finish: failed to create issue watcher artifact root '{}'",
+            artifact_root.display()
+        )
+    })?;
+    let input_file = artifact_root.join("input.yaml");
+    let prompt_file = artifact_root.join("prompt.md");
+    let run_log = artifact_root.join("codex.log");
+    let last_message_file = artifact_root.join("last_message.md");
+    let pid_file = artifact_root.join("pid");
+
+    fs::write(
+        &input_file,
+        format!(
+            "skill_input_schema: issue_watcher.v1\nmode: watch_issue_pr_tail\nrepo_root: {}\ntarget:\n  issue_number: {}\n  pr_url: {}\n  branch: {}\n  expected_state: {}\n  expected_pr_state: {}\n  expected_tail_owner: {}\n  expected_shepherd_state: {}\n  expected_checks:\n    - adl-ci\n    - adl-coverage\npolicy:\n  allow_pr_inference: false\n  monitor_checks: true\n  monitor_merge_state: true\n  monitor_closure_state: true\n",
+            repo_root.display(),
+            issue,
+            pr_url,
+            branch,
+            classification,
+            expected_pr_state,
+            tail_owner,
+            shepherd_state,
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "finish: failed to write issue watcher input '{}'",
+            input_file.display()
+        )
+    })?;
+    let prompt = format!(
+        "Use $issue-watcher at {repo_root}/adl/tools/skills/issue-watcher/SKILL.md with this validated input:\n\n```yaml\n{input}\n```\n\nRun one bounded watcher pass for this newly published issue-bound PR tail. Treat the repo-native watcher classifier as authoritative, preserve the initial expected watcher/shepherd/tail-owner state as publication context, route failed-check/conflict/review blockers to $pr-janitor if observed, and stop after writing a concise watcher status summary.\n",
+        repo_root = repo_root.display(),
+        input = fs::read_to_string(&input_file).unwrap_or_default(),
+    );
+    fs::write(&prompt_file, &prompt).with_context(|| {
+        format!(
+            "finish: failed to write issue watcher prompt '{}'",
+            prompt_file.display()
+        )
+    })?;
+
+    let run_log_file = fs::File::create(&run_log)
+        .with_context(|| format!("finish: failed to create watcher log '{}'", run_log.display()))?;
+    let run_log_err = run_log_file
+        .try_clone()
+        .with_context(|| format!("finish: failed to clone watcher log '{}'", run_log.display()))?;
+    let mut command = helper_command_with_github_context("codex");
+    let child = command
+        .arg("exec")
+        .arg("--full-auto")
+        .arg("--sandbox")
+        .arg("workspace-write")
+        .arg("--cd")
+        .arg(repo_root)
+        .arg("--skip-git-repo-check")
+        .arg("--add-dir")
+        .arg(repo_root)
+        .arg("--output-last-message")
+        .arg(&last_message_file)
+        .arg(&prompt)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(run_log_file))
+        .stderr(std::process::Stdio::from(run_log_err))
+        .spawn()
+        .context("finish: failed to launch issue watcher codex exec")?;
+    fs::write(&pid_file, format!("{}\n", child.id())).with_context(|| {
+        format!(
+            "finish: failed to record issue watcher pid '{}'",
+            pid_file.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -618,46 +618,46 @@ pub(crate) fn build_issue_watch_report(
 
     let (classification, tail_owner, shepherd_state, next_skill, continuation, reason) =
         if validation.pr_state == "MERGED" {
-        (
-            "merged_pending_closeout",
-            "pr-closeout",
-            "merged_pending_closeout",
-            "pr-closeout",
-            "action_required",
-            "linked_pr_merged_closeout_pending",
-        )
-    } else if validation.projection_status == "checks_green_but_draft" {
-        (
-            "checks_green_but_draft",
-            "pr-janitor",
-            "green_draft_requires_publication_action",
-            "pr-janitor",
-            "action_required",
-            "linked_pr_checks_green_but_draft",
-        )
-    } else if matches!(
-        validation.disposition.as_str(),
-        "failed" | "cancelled" | "timed_out"
-    ) {
-        (
-            "checks_failed",
-            "pr-janitor",
-            "janitor_owned_checks_failed",
-            "pr-janitor",
-            "action_required",
-            "linked_pr_checks_failed",
-        )
-    } else if validation.is_draft {
-        (
-            "pr_open",
-            "issue-watcher",
-            "watcher_owned_pr_open",
-            "issue-watcher",
-            "continue",
-            "linked_pr_draft",
-        )
-    } else {
-        match validation.disposition.as_str() {
+            (
+                "merged_pending_closeout",
+                "pr-closeout",
+                "merged_pending_closeout",
+                "pr-closeout",
+                "action_required",
+                "linked_pr_merged_closeout_pending",
+            )
+        } else if validation.projection_status == "checks_green_but_draft" {
+            (
+                "checks_green_but_draft",
+                "pr-janitor",
+                "green_draft_requires_publication_action",
+                "pr-janitor",
+                "action_required",
+                "linked_pr_checks_green_but_draft",
+            )
+        } else if matches!(
+            validation.disposition.as_str(),
+            "failed" | "cancelled" | "timed_out"
+        ) {
+            (
+                "checks_failed",
+                "pr-janitor",
+                "janitor_owned_checks_failed",
+                "pr-janitor",
+                "action_required",
+                "linked_pr_checks_failed",
+            )
+        } else if validation.is_draft {
+            (
+                "pr_open",
+                "issue-watcher",
+                "watcher_owned_pr_open",
+                "issue-watcher",
+                "continue",
+                "linked_pr_draft",
+            )
+        } else {
+            match validation.disposition.as_str() {
             "pending" => (
                 "checks_running",
                 "issue-watcher",
@@ -686,7 +686,7 @@ pub(crate) fn build_issue_watch_report(
                 "linked_pr_validation_ambiguous",
             ),
         }
-    };
+        };
 
     IssueWatchReport {
         schema: "adl.pr.watch.v1",
@@ -1521,11 +1521,7 @@ pub(super) fn attach_issue_watcher(
     tail_owner: &str,
     shepherd_state: &str,
 ) -> Result<()> {
-    if std::env::var("ADL_ISSUE_WATCHER_DISABLE")
-        .ok()
-        .as_deref()
-        == Some("1")
-    {
+    if std::env::var("ADL_ISSUE_WATCHER_DISABLE").ok().as_deref() == Some("1") {
         return Ok(());
     }
 
@@ -1649,11 +1645,18 @@ pub(super) fn attach_issue_watcher(
         )
     })?;
 
-    let run_log_file = fs::File::create(&run_log)
-        .with_context(|| format!("finish: failed to create watcher log '{}'", run_log.display()))?;
-    let run_log_err = run_log_file
-        .try_clone()
-        .with_context(|| format!("finish: failed to clone watcher log '{}'", run_log.display()))?;
+    let run_log_file = fs::File::create(&run_log).with_context(|| {
+        format!(
+            "finish: failed to create watcher log '{}'",
+            run_log.display()
+        )
+    })?;
+    let run_log_err = run_log_file.try_clone().with_context(|| {
+        format!(
+            "finish: failed to clone watcher log '{}'",
+            run_log.display()
+        )
+    })?;
     let mut command = helper_command_with_github_context("codex");
     let child = command
         .arg("exec")

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1510,17 +1510,19 @@ pub(super) fn attach_pr_janitor(
     Ok(())
 }
 
-pub(super) fn attach_issue_watcher(
-    repo_root: &Path,
-    repo: &str,
-    issue: u32,
-    branch: &str,
-    pr_url: &str,
-    expected_pr_state: &str,
-    classification: &str,
-    tail_owner: &str,
-    shepherd_state: &str,
-) -> Result<()> {
+pub(super) struct IssueWatcherAttachRequest<'a> {
+    pub repo_root: &'a Path,
+    pub repo: &'a str,
+    pub issue: u32,
+    pub branch: &'a str,
+    pub pr_url: &'a str,
+    pub expected_pr_state: &'a str,
+    pub classification: &'a str,
+    pub tail_owner: &'a str,
+    pub shepherd_state: &'a str,
+}
+
+pub(super) fn attach_issue_watcher(request: IssueWatcherAttachRequest<'_>) -> Result<()> {
     if std::env::var("ADL_ISSUE_WATCHER_DISABLE").ok().as_deref() == Some("1") {
         return Ok(());
     }
@@ -1532,23 +1534,23 @@ pub(super) fn attach_issue_watcher(
         let mut command = helper_command_with_github_context(&command_path);
         let output = command
             .arg("--repo-root")
-            .arg(repo_root)
+            .arg(request.repo_root)
             .arg("--repo")
-            .arg(repo)
+            .arg(request.repo)
             .arg("--issue")
-            .arg(issue.to_string())
+            .arg(request.issue.to_string())
             .arg("--branch")
-            .arg(branch)
+            .arg(request.branch)
             .arg("--pr-url")
-            .arg(pr_url)
+            .arg(request.pr_url)
             .arg("--expected-pr-state")
-            .arg(expected_pr_state)
+            .arg(request.expected_pr_state)
             .arg("--classification")
-            .arg(classification)
+            .arg(request.classification)
             .arg("--tail-owner")
-            .arg(tail_owner)
+            .arg(request.tail_owner)
             .arg("--shepherd-state")
-            .arg(shepherd_state)
+            .arg(request.shepherd_state)
             .output()
             .with_context(|| {
                 format!("finish: failed to spawn issue watcher command '{command_path}'")
@@ -1558,8 +1560,8 @@ pub(super) fn attach_issue_watcher(
             let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
             bail!(
                 "finish: issue watcher auto-attach failed for issue #{} and PR '{}': {}{}",
-                issue,
-                pr_url,
+                request.issue,
+                request.pr_url,
                 stderr.trim(),
                 if stdout.trim().is_empty() {
                     String::new()
@@ -1571,7 +1573,9 @@ pub(super) fn attach_issue_watcher(
         return Ok(());
     }
 
-    let install_script = repo_root.join("adl/tools/install_adl_operational_skills.sh");
+    let install_script = request
+        .repo_root
+        .join("adl/tools/install_adl_operational_skills.sh");
     let install_output = helper_command_with_github_context("bash")
         .arg(&install_script)
         .output()
@@ -1586,7 +1590,7 @@ pub(super) fn attach_issue_watcher(
         let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&install_output.stdout));
         bail!(
             "finish: issue watcher skill install failed for issue #{}: {}{}",
-            issue,
+            request.issue,
             stderr.trim(),
             if stdout.trim().is_empty() {
                 String::new()
@@ -1596,11 +1600,12 @@ pub(super) fn attach_issue_watcher(
         );
     }
 
-    let artifact_root = repo_root
+    let artifact_root = request
+        .repo_root
         .join(".adl")
         .join("logs")
         .join("issue-watcher")
-        .join(format!("issue-{issue}"));
+        .join(format!("issue-{}", request.issue));
     fs::create_dir_all(&artifact_root).with_context(|| {
         format!(
             "finish: failed to create issue watcher artifact root '{}'",
@@ -1617,14 +1622,14 @@ pub(super) fn attach_issue_watcher(
         &input_file,
         format!(
             "skill_input_schema: issue_watcher.v1\nmode: watch_issue_pr_tail\nrepo_root: {}\ntarget:\n  issue_number: {}\n  pr_url: {}\n  branch: {}\n  expected_state: {}\n  expected_pr_state: {}\n  expected_tail_owner: {}\n  expected_shepherd_state: {}\n  expected_checks:\n    - adl-ci\n    - adl-coverage\npolicy:\n  allow_pr_inference: false\n  monitor_checks: true\n  monitor_merge_state: true\n  monitor_closure_state: true\n",
-            repo_root.display(),
-            issue,
-            pr_url,
-            branch,
-            classification,
-            expected_pr_state,
-            tail_owner,
-            shepherd_state,
+            request.repo_root.display(),
+            request.issue,
+            request.pr_url,
+            request.branch,
+            request.classification,
+            request.expected_pr_state,
+            request.tail_owner,
+            request.shepherd_state,
         ),
     )
     .with_context(|| {
@@ -1635,7 +1640,7 @@ pub(super) fn attach_issue_watcher(
     })?;
     let prompt = format!(
         "Use $issue-watcher at {repo_root}/adl/tools/skills/issue-watcher/SKILL.md with this validated input:\n\n```yaml\n{input}\n```\n\nRun one bounded watcher pass for this newly published issue-bound PR tail. Treat the repo-native watcher classifier as authoritative, preserve the initial expected watcher/shepherd/tail-owner state as publication context, route failed-check/conflict/review blockers to $pr-janitor if observed, and stop after writing a concise watcher status summary.\n",
-        repo_root = repo_root.display(),
+        repo_root = request.repo_root.display(),
         input = fs::read_to_string(&input_file).unwrap_or_default(),
     );
     fs::write(&prompt_file, &prompt).with_context(|| {
@@ -1664,10 +1669,10 @@ pub(super) fn attach_issue_watcher(
         .arg("--sandbox")
         .arg("workspace-write")
         .arg("--cd")
-        .arg(repo_root)
+        .arg(request.repo_root)
         .arg("--skip-git-repo-check")
         .arg("--add-dir")
-        .arg(repo_root)
+        .arg(request.repo_root)
         .arg("--output-last-message")
         .arg(&last_message_file)
         .arg(&prompt)

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -189,6 +189,8 @@ pub(crate) struct IssueWatchReport {
     pub(crate) authoritative_classifier: &'static str,
     pub(crate) advisory_agent_mode: &'static str,
     pub(crate) classification: String,
+    pub(crate) tail_owner: String,
+    pub(crate) shepherd_state: String,
     pub(crate) next_skill: String,
     pub(crate) continuation: String,
     pub(crate) reason: String,
@@ -523,6 +525,8 @@ pub(crate) fn build_issue_watch_report(
             authoritative_classifier: "adl",
             advisory_agent_mode: "local_agent_advisory_only",
             classification: "closeout_needed".to_string(),
+            tail_owner: "pr-closeout".to_string(),
+            shepherd_state: "closeout_required".to_string(),
             next_skill: "pr-closeout".to_string(),
             continuation: "action_required".to_string(),
             reason: "issue_closed_completed".to_string(),
@@ -547,6 +551,8 @@ pub(crate) fn build_issue_watch_report(
             authoritative_classifier: "adl",
             advisory_agent_mode: "local_agent_advisory_only",
             classification: "closed".to_string(),
+            tail_owner: "human_review".to_string(),
+            shepherd_state: "closed_without_completed_reason".to_string(),
             next_skill: "human_review".to_string(),
             continuation: "ask_operator".to_string(),
             reason: "issue_closed_without_completed_reason".to_string(),
@@ -564,10 +570,12 @@ pub(crate) fn build_issue_watch_report(
     }
 
     let Some((pr, validation)) = linked_pr else {
-        let (classification, next_skill, continuation, reason) =
+        let (classification, tail_owner, shepherd_state, next_skill, continuation, reason) =
             if local_readiness.pr_run_readiness == "ready" {
                 (
                     "ready_for_run",
+                    "pr-run",
+                    "ready_without_pr",
                     "pr-run",
                     "continue",
                     "issue_ready_without_linked_pr",
@@ -576,12 +584,16 @@ pub(crate) fn build_issue_watch_report(
                 (
                     "blocked",
                     "pr-ready",
+                    "local_readiness_failed",
+                    "pr-ready",
                     "action_required",
                     "issue_local_readiness_failed",
                 )
             } else {
                 (
                     "unknown",
+                    "issue-watcher",
+                    "local_readiness_unknown",
                     "issue-watcher",
                     "ask_operator",
                     "issue_local_readiness_unknown",
@@ -594,6 +606,8 @@ pub(crate) fn build_issue_watch_report(
             authoritative_classifier: "adl",
             advisory_agent_mode: "local_agent_advisory_only",
             classification: classification.to_string(),
+            tail_owner: tail_owner.to_string(),
+            shepherd_state: shepherd_state.to_string(),
             next_skill: next_skill.to_string(),
             continuation: continuation.to_string(),
             reason: reason.to_string(),
@@ -602,8 +616,11 @@ pub(crate) fn build_issue_watch_report(
         };
     };
 
-    let (classification, next_skill, continuation, reason) = if validation.pr_state == "MERGED" {
+    let (classification, tail_owner, shepherd_state, next_skill, continuation, reason) =
+        if validation.pr_state == "MERGED" {
         (
+            "merged_pending_closeout",
+            "pr-closeout",
             "merged_pending_closeout",
             "pr-closeout",
             "action_required",
@@ -613,15 +630,26 @@ pub(crate) fn build_issue_watch_report(
         (
             "checks_green_but_draft",
             "pr-janitor",
+            "green_draft_requires_publication_action",
+            "pr-janitor",
             "action_required",
             "linked_pr_checks_green_but_draft",
         )
     } else if validation.is_draft {
-        ("pr_open", "issue-watcher", "continue", "linked_pr_draft")
+        (
+            "pr_open",
+            "issue-watcher",
+            "watcher_owned_pr_open",
+            "issue-watcher",
+            "continue",
+            "linked_pr_draft",
+        )
     } else {
         match validation.disposition.as_str() {
             "pending" => (
                 "checks_running",
+                "issue-watcher",
+                "watcher_owned_checks_running",
                 "issue-watcher",
                 "continue",
                 "linked_pr_checks_pending",
@@ -629,17 +657,23 @@ pub(crate) fn build_issue_watch_report(
             "failed" | "cancelled" | "timed_out" => (
                 "checks_failed",
                 "pr-janitor",
+                "janitor_owned_checks_failed",
+                "pr-janitor",
                 "action_required",
                 "linked_pr_checks_failed",
             ),
             "success" | "skipped" => (
                 "checks_green",
+                "issue-watcher",
+                "watcher_owned_waiting_for_review",
                 "human_review",
                 "ask_operator",
-                "linked_pr_checks_green",
+                "linked_pr_checks_green_waiting_review",
             ),
             _ => (
                 "blocked",
+                "issue-watcher",
+                "watcher_state_ambiguous",
                 "issue-watcher",
                 "ask_operator",
                 "linked_pr_validation_ambiguous",
@@ -654,6 +688,8 @@ pub(crate) fn build_issue_watch_report(
         authoritative_classifier: "adl",
         advisory_agent_mode: "local_agent_advisory_only",
         classification: classification.to_string(),
+        tail_owner: tail_owner.to_string(),
+        shepherd_state: shepherd_state.to_string(),
         next_skill: next_skill.to_string(),
         continuation: continuation.to_string(),
         reason: reason.to_string(),

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -192,6 +192,23 @@ fn issue_watch_routes_failed_checks_to_pr_janitor() {
 }
 
 #[test]
+fn issue_watch_routes_failed_draft_checks_to_pr_janitor() {
+    let pr = linked_pr(77, true);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        readiness_ready(),
+        Some((pr, validation_report("failed", true))),
+    );
+    assert_eq!(report.classification, "checks_failed");
+    assert_eq!(report.tail_owner, "pr-janitor");
+    assert_eq!(report.shepherd_state, "janitor_owned_checks_failed");
+    assert_eq!(report.next_skill, "pr-janitor");
+    assert_eq!(report.continuation, "action_required");
+    assert_eq!(report.reason, "linked_pr_checks_failed");
+}
+
+#[test]
 fn issue_watch_routes_pending_checks_to_issue_watcher() {
     let pr = linked_pr(77, false);
     let report = build_issue_watch_report(

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -141,7 +141,10 @@ fn issue_watch_routes_all_green_draft_pr_to_janitor() {
     );
     assert_eq!(report.classification, "checks_green_but_draft");
     assert_eq!(report.tail_owner, "pr-janitor");
-    assert_eq!(report.shepherd_state, "green_draft_requires_publication_action");
+    assert_eq!(
+        report.shepherd_state,
+        "green_draft_requires_publication_action"
+    );
     assert_eq!(report.next_skill, "pr-janitor");
     assert_eq!(report.continuation, "action_required");
     assert_eq!(report.reason, "linked_pr_checks_green_but_draft");

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -109,6 +109,8 @@ fn issue_watch_routes_ready_issue_without_pr_to_pr_run() {
     assert_eq!(report.authoritative_classifier, "adl");
     assert_eq!(report.advisory_agent_mode, "local_agent_advisory_only");
     assert_eq!(report.classification, "ready_for_run");
+    assert_eq!(report.tail_owner, "pr-run");
+    assert_eq!(report.shepherd_state, "ready_without_pr");
     assert_eq!(report.next_skill, "pr-run");
     assert_eq!(report.continuation, "continue");
 }
@@ -123,6 +125,8 @@ fn issue_watch_routes_draft_pr_to_issue_watcher() {
         Some((pr, validation_report("pending", true))),
     );
     assert_eq!(report.classification, "pr_open");
+    assert_eq!(report.tail_owner, "issue-watcher");
+    assert_eq!(report.shepherd_state, "watcher_owned_pr_open");
     assert_eq!(report.next_skill, "issue-watcher");
 }
 
@@ -136,6 +140,8 @@ fn issue_watch_routes_all_green_draft_pr_to_janitor() {
         Some((pr, validation_report("success", true))),
     );
     assert_eq!(report.classification, "checks_green_but_draft");
+    assert_eq!(report.tail_owner, "pr-janitor");
+    assert_eq!(report.shepherd_state, "green_draft_requires_publication_action");
     assert_eq!(report.next_skill, "pr-janitor");
     assert_eq!(report.continuation, "action_required");
     assert_eq!(report.reason, "linked_pr_checks_green_but_draft");
@@ -180,6 +186,8 @@ fn issue_watch_routes_failed_checks_to_pr_janitor() {
         Some((pr, validation_report("failed", false))),
     );
     assert_eq!(report.classification, "checks_failed");
+    assert_eq!(report.tail_owner, "pr-janitor");
+    assert_eq!(report.shepherd_state, "janitor_owned_checks_failed");
     assert_eq!(report.next_skill, "pr-janitor");
 }
 
@@ -193,12 +201,14 @@ fn issue_watch_routes_pending_checks_to_issue_watcher() {
         Some((pr, validation_report("pending", false))),
     );
     assert_eq!(report.classification, "checks_running");
+    assert_eq!(report.tail_owner, "issue-watcher");
+    assert_eq!(report.shepherd_state, "watcher_owned_checks_running");
     assert_eq!(report.next_skill, "issue-watcher");
     assert_eq!(report.continuation, "continue");
 }
 
 #[test]
-fn issue_watch_routes_green_checks_to_human_review() {
+fn issue_watch_routes_green_checks_to_issue_watcher() {
     let pr = linked_pr(77, false);
     let report = build_issue_watch_report(
         &open_issue(4397),
@@ -207,7 +217,28 @@ fn issue_watch_routes_green_checks_to_human_review() {
         Some((pr, validation_report("success", false))),
     );
     assert_eq!(report.classification, "checks_green");
+    assert_eq!(report.tail_owner, "issue-watcher");
+    assert_eq!(report.shepherd_state, "watcher_owned_waiting_for_review");
     assert_eq!(report.next_skill, "human_review");
+    assert_eq!(report.continuation, "ask_operator");
+    assert_eq!(report.reason, "linked_pr_checks_green_waiting_review");
+}
+
+#[test]
+fn issue_watch_routes_skipped_checks_to_issue_watcher_owned_review_handoff() {
+    let pr = linked_pr(77, false);
+    let report = build_issue_watch_report(
+        &open_issue(4397),
+        false,
+        readiness_ready(),
+        Some((pr, validation_report("skipped", false))),
+    );
+    assert_eq!(report.classification, "checks_green");
+    assert_eq!(report.tail_owner, "issue-watcher");
+    assert_eq!(report.shepherd_state, "watcher_owned_waiting_for_review");
+    assert_eq!(report.next_skill, "human_review");
+    assert_eq!(report.continuation, "ask_operator");
+    assert_eq!(report.reason, "linked_pr_checks_green_waiting_review");
 }
 
 #[test]
@@ -217,6 +248,8 @@ fn issue_watch_routes_closed_completed_issue_to_closeout() {
     issue.closed_at = Some("2026-06-22T00:00:00Z".to_string());
     let report = build_issue_watch_report(&issue, true, readiness_ready(), None);
     assert_eq!(report.classification, "closeout_needed");
+    assert_eq!(report.tail_owner, "pr-closeout");
+    assert_eq!(report.shepherd_state, "closeout_required");
     assert_eq!(report.next_skill, "pr-closeout");
 }
 
@@ -231,6 +264,8 @@ fn issue_watch_routes_merged_pr_to_merged_pending_closeout() {
         Some((pr, merged_validation_report())),
     );
     assert_eq!(report.classification, "merged_pending_closeout");
+    assert_eq!(report.tail_owner, "pr-closeout");
+    assert_eq!(report.shepherd_state, "merged_pending_closeout");
     assert_eq!(report.next_skill, "pr-closeout");
     assert_eq!(report.continuation, "action_required");
 }
@@ -239,6 +274,8 @@ fn issue_watch_routes_merged_pr_to_merged_pending_closeout() {
 fn issue_watch_routes_failed_local_readiness_without_pr_to_blocked() {
     let report = build_issue_watch_report(&open_issue(4397), false, readiness_failed(), None);
     assert_eq!(report.classification, "blocked");
+    assert_eq!(report.tail_owner, "pr-ready");
+    assert_eq!(report.shepherd_state, "local_readiness_failed");
     assert_eq!(report.next_skill, "pr-ready");
     assert_eq!(
         report.local_readiness.reason,

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -25,7 +25,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     fs::create_dir_all(repo.join("adl/src")).expect("adl src");
     fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
     assert!(Command::new("git")
-        .args(["add", ".gitignore", "adl/src/lib.rs"])
+        .args(["add", "."])
         .current_dir(&repo)
         .status()
         .expect("git add")
@@ -122,10 +122,12 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
+    let watcher_log = temp.join("watcher.log");
     let closeout_log = temp.join("closeout.log");
     let open_log = temp.join("open.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
+    let watcher_path = bin_dir.join("watcher");
     let closeout_path = bin_dir.join("closeout");
     let open_path = bin_dir.join("open");
     write_executable(
@@ -140,6 +142,13 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         &format!(
             "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
             janitor_log.display()
+        ),
+    );
+    write_executable(
+        &watcher_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            watcher_log.display()
         ),
     );
     write_executable(
@@ -160,6 +169,8 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_watcher_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    let old_watcher_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
     let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
     let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
@@ -167,6 +178,8 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_PR_JANITOR_DISABLE", "0");
         env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
         env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
         env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
     }
@@ -198,6 +211,16 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
             env::set_var("ADL_PR_JANITOR_DISABLE", value);
         } else {
             env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_watcher_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+        if let Some(value) = old_watcher_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
         }
         if let Some(value) = old_closeout_cmd {
             env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
@@ -253,6 +276,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         .success());
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
     let janitor_calls = fs::read_to_string(&janitor_log).expect("read janitor log");
+    let watcher_calls = fs::read_to_string(&watcher_log).expect("read watcher log");
     let closeout_calls = fs::read_to_string(&closeout_log).expect("read closeout log");
     let open_calls = fs::read_to_string(&open_log).expect("read open log");
     assert!(gh_calls.contains("pr create"));
@@ -265,6 +289,14 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     assert!(janitor_calls
         .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
     assert!(janitor_calls.contains("--expected-pr-state draft"));
+    assert!(watcher_calls.contains("--issue 1153"));
+    assert!(watcher_calls.contains("--branch codex/1153-rust-finish-test"));
+    assert!(watcher_calls
+        .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
+    assert!(watcher_calls.contains("--expected-pr-state draft"));
+    assert!(watcher_calls.contains("--classification pr_open"));
+    assert!(watcher_calls.contains("--tail-owner issue-watcher"));
+    assert!(watcher_calls.contains("--shepherd-state watcher_owned_pr_open"));
     assert!(closeout_calls.contains("--issue 1153"));
     assert!(closeout_calls.contains("--branch codex/1153-rust-finish-test"));
     assert!(open_calls.contains("https://github.com/danielbaustin/agent-design-language/pull/1159"));
@@ -297,7 +329,7 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     fs::create_dir_all(repo.join("adl/src")).expect("adl src");
     fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
     assert!(Command::new("git")
-        .args(["add", ".gitignore", "adl/src/lib.rs"])
+        .args(["add", "."])
         .current_dir(&repo)
         .status()
         .expect("git add")
@@ -393,7 +425,9 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
+    let watcher_path = bin_dir.join("watcher");
     let closeout_path = bin_dir.join("closeout");
+    let watcher_log = temp.join("watcher.log");
     let pr_body_capture = temp.join("pr-body.md");
     write_executable(
         &gh_path,
@@ -407,6 +441,13 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         "#!/usr/bin/env bash\nset -euo pipefail\necho 'janitor attach failed' >&2\nexit 9\n",
     );
     write_executable(
+        &watcher_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            watcher_log.display()
+        ),
+    );
+    write_executable(
         &closeout_path,
         "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
     );
@@ -414,6 +455,8 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_watcher_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    let old_watcher_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
     let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
     let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
@@ -421,6 +464,8 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_PR_JANITOR_DISABLE", "0");
         env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
         env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
         env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
     }
@@ -453,6 +498,16 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         } else {
             env::remove_var("ADL_PR_JANITOR_DISABLE");
         }
+        if let Some(value) = old_watcher_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+        if let Some(value) = old_watcher_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
         if let Some(value) = old_closeout_cmd {
             env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
         } else {
@@ -473,6 +528,226 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     assert!(captured_body.contains("Non-closing lifecycle PR"));
     assert!(captured_body.contains("issue #1154 remains open"));
     assert!(!captured_body.contains("Closes #1154"));
+    assert!(
+        !watcher_log.exists(),
+        "watcher should not launch when janitor attach fails first"
+    );
+}
+
+#[test]
+fn real_pr_finish_warns_but_succeeds_when_issue_watcher_auto_attach_fails() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-watcher-fail");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("seed gitignore");
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["checkout", "-q", "-b", "codex/1162-rust-finish-test"])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref =
+        IssueRef::new(1162, "v0.86".to_string(), "rust-finish-test".to_string()).expect("ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1162-rust-finish-test",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1162-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1162-rust-finish-test",
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1162-rust-finish-test");
+    fs::write(
+        repo.join("adl/src/lib.rs"),
+        "pub fn placeholder() {}\npub fn changed() {}\n",
+    )
+    .expect("write change");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let gh_path = bin_dir.join("gh");
+    let janitor_path = bin_dir.join("janitor");
+    let watcher_path = bin_dir.join("watcher");
+    let closeout_path = bin_dir.join("closeout");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1162\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1162\\n'\n  else\n    printf 'Closes #1162\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+    write_executable(
+        &janitor_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &watcher_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'watcher attach failed' >&2\nexit 9\n",
+    );
+    write_executable(
+        &closeout_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_watcher_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    let old_watcher_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
+    let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+        env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let result = real_pr(&[
+        "finish".to_string(),
+        "1162".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish test".to_string(),
+        "--paths".to_string(),
+        "adl".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ]);
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        if let Some(value) = old_janitor_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+        if let Some(value) = old_janitor_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_watcher_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+        if let Some(value) = old_watcher_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
+        if let Some(value) = old_closeout_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+        if let Some(value) = old_closeout_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
+        }
+    }
+
+    result.expect("watcher attach failure should not block finish");
+    let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
+    assert!(gh_calls.contains("pr create"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::cli::pr_cmd::github::{attach_issue_watcher, attach_pr_janitor};
+use crate::cli::pr_cmd::github::{
+    attach_issue_watcher, attach_pr_janitor, IssueWatcherAttachRequest,
+};
 
 #[test]
 fn attach_pr_janitor_reports_failure_output() {
@@ -208,17 +210,17 @@ fn attach_issue_watcher_reports_failure_output() {
         env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     }
 
-    let err = attach_issue_watcher(
-        &repo,
-        "owner/repo",
-        1153,
-        "codex/1153-rust-finish-test",
-        "https://github.com/owner/repo/pull/1159",
-        "draft",
-        "pr_open",
-        "issue-watcher",
-        "watcher_owned_pr_open",
-    )
+    let err = attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo,
+        repo: "owner/repo",
+        issue: 1153,
+        branch: "codex/1153-rust-finish-test",
+        pr_url: "https://github.com/owner/repo/pull/1159",
+        expected_pr_state: "draft",
+        classification: "pr_open",
+        tail_owner: "issue-watcher",
+        shepherd_state: "watcher_owned_pr_open",
+    })
     .expect_err("failing watcher helper should bubble up");
 
     unsafe {
@@ -253,17 +255,17 @@ fn attach_issue_watcher_returns_early_when_disabled() {
         env::remove_var("ADL_ISSUE_WATCHER_CMD");
     }
 
-    attach_issue_watcher(
-        &repo,
-        "owner/repo",
-        1153,
-        "codex/1153-rust-finish-test",
-        "https://github.com/owner/repo/pull/1159",
-        "draft",
-        "pr_open",
-        "issue-watcher",
-        "watcher_owned_pr_open",
-    )
+    attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo,
+        repo: "owner/repo",
+        issue: 1153,
+        branch: "codex/1153-rust-finish-test",
+        pr_url: "https://github.com/owner/repo/pull/1159",
+        expected_pr_state: "draft",
+        classification: "pr_open",
+        tail_owner: "issue-watcher",
+        shepherd_state: "watcher_owned_pr_open",
+    })
     .expect("disabled watcher helper should be skipped");
 
     unsafe {
@@ -302,17 +304,17 @@ fn attach_issue_watcher_invokes_helper_successfully() {
         env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     }
 
-    attach_issue_watcher(
-        &repo,
-        "owner/repo",
-        1153,
-        "codex/1153-rust-finish-test",
-        "https://github.com/owner/repo/pull/1159",
-        "draft",
-        "pr_open",
-        "issue-watcher",
-        "watcher_owned_pr_open",
-    )
+    attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo,
+        repo: "owner/repo",
+        issue: 1153,
+        branch: "codex/1153-rust-finish-test",
+        pr_url: "https://github.com/owner/repo/pull/1159",
+        expected_pr_state: "draft",
+        classification: "pr_open",
+        tail_owner: "issue-watcher",
+        shepherd_state: "watcher_owned_pr_open",
+    })
     .expect("watcher helper should succeed");
 
     unsafe {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::cli::pr_cmd::github::attach_pr_janitor;
+use crate::cli::pr_cmd::github::{attach_issue_watcher, attach_pr_janitor};
 
 #[test]
 fn attach_pr_janitor_reports_failure_output() {
@@ -188,4 +188,153 @@ fn attach_pr_janitor_falls_back_when_command_override_is_blank() {
 
     let argv = fs::read_to_string(&argv_log).expect("janitor args");
     assert!(argv.contains("--repo owner/repo"));
+}
+
+#[test]
+fn attach_issue_watcher_reports_failure_output() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-attach-watcher-failure");
+    let repo = temp.join("repo");
+    let watcher_path = temp.join("watcher");
+    write_executable(
+        &watcher_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'watcher stdout'\necho 'watcher stderr' >&2\nexit 17\n",
+    );
+
+    let old_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
+    let old_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    unsafe {
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
+    }
+
+    let err = attach_issue_watcher(
+        &repo,
+        "owner/repo",
+        1153,
+        "codex/1153-rust-finish-test",
+        "https://github.com/owner/repo/pull/1159",
+        "draft",
+        "pr_open",
+        "issue-watcher",
+        "watcher_owned_pr_open",
+    )
+    .expect_err("failing watcher helper should bubble up");
+
+    unsafe {
+        if let Some(value) = old_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
+        if let Some(value) = old_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+    }
+
+    let message = err.to_string();
+    assert!(message.contains("issue watcher auto-attach failed"));
+    assert!(message.contains("watcher stderr"));
+    assert!(message.contains("stdout: watcher stdout"));
+}
+
+#[test]
+fn attach_issue_watcher_returns_early_when_disabled() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-attach-watcher-disabled");
+    let repo = temp.join("repo");
+
+    let old_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
+    let old_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    unsafe {
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "1");
+        env::remove_var("ADL_ISSUE_WATCHER_CMD");
+    }
+
+    attach_issue_watcher(
+        &repo,
+        "owner/repo",
+        1153,
+        "codex/1153-rust-finish-test",
+        "https://github.com/owner/repo/pull/1159",
+        "draft",
+        "pr_open",
+        "issue-watcher",
+        "watcher_owned_pr_open",
+    )
+    .expect("disabled watcher helper should be skipped");
+
+    unsafe {
+        if let Some(value) = old_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
+        if let Some(value) = old_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+    }
+}
+
+#[test]
+fn attach_issue_watcher_invokes_helper_successfully() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-attach-watcher-success");
+    let repo = temp.join("repo");
+    let argv_log = temp.join("watcher-args.log");
+    let watcher_path = temp.join("watcher");
+    write_executable(
+        &watcher_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" > '{}'\n",
+            argv_log.display()
+        ),
+    );
+
+    let old_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
+    let old_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    unsafe {
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
+    }
+
+    attach_issue_watcher(
+        &repo,
+        "owner/repo",
+        1153,
+        "codex/1153-rust-finish-test",
+        "https://github.com/owner/repo/pull/1159",
+        "draft",
+        "pr_open",
+        "issue-watcher",
+        "watcher_owned_pr_open",
+    )
+    .expect("watcher helper should succeed");
+
+    unsafe {
+        if let Some(value) = old_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
+        if let Some(value) = old_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+    }
+
+    let argv = fs::read_to_string(&argv_log).expect("watcher args");
+    assert!(argv.contains("--repo owner/repo"));
+    assert!(argv.contains("--issue 1153"));
+    assert!(argv.contains("--branch codex/1153-rust-finish-test"));
+    assert!(argv.contains("--pr-url https://github.com/owner/repo/pull/1159"));
+    assert!(argv.contains("--expected-pr-state draft"));
+    assert!(argv.contains("--classification pr_open"));
+    assert!(argv.contains("--tail-owner issue-watcher"));
+    assert!(argv.contains("--shepherd-state watcher_owned_pr_open"));
 }


### PR DESCRIPTION
Closes #4436

## Summary
Implemented mandatory watcher/shepherd ownership fields for PR-tail lifecycle state so watcher reports now expose explicit ownership and review/closeout handoff instead of relying on implicit session memory.

## Artifacts
- Updated issue-local execution record at `.adl/v0.91.6/tasks/issue-4436__v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/tests/watch.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified patch hygiene for the tracked watcher/shepherd change set.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl issue_watch_ -- --nocapture`
    Verified focused watcher classification behavior and regression coverage.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token ./adl/tools/pr.sh watch 4435 --version v0.91.6 --json`
    Verified machine-readable watcher output includes explicit ownership fields.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token ./adl/tools/pr.sh watch 4435 --version v0.91.6`
    Verified human-readable watcher output surfaces the same ownership fields.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4436__v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4436__v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work/sor.md
- Idempotency-Key: v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work-adl-adl-v0-91-6-tasks-issue-4436-v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work-sip-md-adl-v0-91-6-tasks-issue-4436-v0-91-6-csdlc-adoption-make-watcher-and-shepherd-states-mandatory-for-pr-tail-work-sor-md