### PR TITLE
[v0.91.6][csdlc][adoption] Make card readiness and SOR fact capture operational by default

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -892,19 +892,27 @@ fn bullet_lines_from_markdown_section(text: &str, heading: &str) -> Vec<String> 
 }
 
 fn normalize_sor_emitted_facts_text(text: &str, facts: &SorFacts) -> Result<String> {
+    let facts_value = serde_yaml::to_value(facts)
+        .context("finish: failed to serialize emitted SOR facts into YAML")?;
     let Some(summary_body) = markdown_section_body_local(text, "Verification Summary") else {
-        return Ok(text.to_string());
+        let summary_body = append_standalone_sor_facts_block("", facts_value)?;
+        let mut updated = text.trim_end().to_string();
+        if !updated.is_empty() {
+            updated.push_str("\n\n");
+        }
+        updated.push_str("## Verification Summary\n\n");
+        updated.push_str(summary_body.trim_end());
+        updated.push('\n');
+        return Ok(updated);
     };
-    let updated_summary = update_verification_summary_yaml(&summary_body, facts)?;
+    let updated_summary = update_verification_summary_yaml(&summary_body, facts_value)?;
     Ok(
         replace_markdown_section_body(text, "Verification Summary", &updated_summary)
             .unwrap_or_else(|_| text.to_string()),
     )
 }
 
-fn update_verification_summary_yaml(body: &str, facts: &SorFacts) -> Result<String> {
-    let facts_value = serde_yaml::to_value(facts)
-        .context("finish: failed to serialize emitted SOR facts into YAML")?;
+fn update_verification_summary_yaml(body: &str, facts_value: Value) -> Result<String> {
     let Some(yaml) = extract_fenced_yaml_block(body) else {
         return append_standalone_sor_facts_block(body, facts_value);
     };

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -627,6 +627,49 @@ review_results:
 }
 
 #[test]
+fn sor_emitted_facts_creates_verification_summary_when_missing() {
+    let output = r#"## Summary
+
+Execution summary without a verification section yet.
+"#;
+    let review = r#"---
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- No material findings.
+
+## Dispositions
+
+- No fixes required.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["docs/example.md".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: Some("https://example.test/pr/2"),
+            integration_state: "pr_open",
+            closing_linkage_repaired: false,
+        },
+    )
+    .expect("normalize with missing verification summary");
+
+    assert!(normalized.contains("## Summary"));
+    assert!(normalized.contains("## Verification Summary"));
+    assert!(normalized.contains("Machine-readable SOR facts:"));
+    assert!(normalized.contains("schema_version: adl.sor_facts.v1"));
+}
+
+#[test]
 fn sor_emitted_facts_fallback_replaces_existing_machine_readable_block_instead_of_appending() {
     let output = r#"## Verification Summary
 


### PR DESCRIPTION
Closes #4437

## Summary
Implemented a bounded finish-path robustness fix so SOR fact emission creates a `Verification Summary` section when it is missing, and added a focused regression test for that path. Independent pre-PR review completed with no findings. PR publication was attempted and then paused only to normalize the SRP/SOR lifecycle truth surfaces.

## Artifacts
- Updated `adl/src/cli/pr_cmd/finish_support.rs` to create `Verification Summary` when absent before appending machine-readable SOR facts.
- Added `sor_emitted_facts_creates_verification_summary_when_missing` coverage in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`.
- Updated issue-local review/output records for truthful pre-PR publication.

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified there were no whitespace or patch-format defects in the tracked implementation diff.
  - `cargo test --manifest-path adl/Cargo.toml sor_emitted_facts_creates_verification_summary_when_missing -- --nocapture`
    Verified the new missing-`Verification Summary` regression path passes in the local Rust test surface.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the bounded C-SDLC owner validation lane for the touched workflow/control-plane surface.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    Verified the focused finish-support / arg-render fast test lane selected by `pr.sh finish`.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4437__v0-91-6-csdlc-adoption-make-card-readiness-and-sor-fact-capture-operational-by-default/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4437__v0-91-6-csdlc-adoption-make-card-readiness-and-sor-fact-capture-operational-by-default/sor.md
- Idempotency-Key: v0-91-6-csdlc-adoption-make-card-readiness-and-sor-fact-capture-operational-by-default-adl-v0-91-6-tasks-issue-4437-v0-91-6-csdlc-adoption-make-card-readiness-and-sor-fact-capture-operational-by-default-sip-md-adl-v0-91-6-tasks-issue-4437-v0-91-6-csdlc-adoption-make-card-readiness-and-sor-fact-capture-operational-by-default-sor-md