### PR TITLE
[v0.91.6][tools][observability] Preserve machine-readable stdout while moving compatibility observability fully to stderr/log sinks

### DIFF
--- a/adl/tools/test_pr_json_observability.sh
+++ b/adl/tools/test_pr_json_observability.sh
@@ -37,6 +37,30 @@ case "$mode" in
     printf 'adl_event schema=adl.observability.event.v1 command=adl stage=%s result=started\n' "$mode" >&2
     printf '{\n  "schema": "adl.pr.doctor.v1",\n  "mode": "%s"\n}\n' "$mode"
     ;;
+  validation)
+    printf 'adl_event schema=adl.observability.event.v1 command=adl stage=validation result=started\n' >&2
+    printf '{\n  "pr_number": 1152,\n  "disposition": "success",\n  "projection_status": "ready_to_merge_or_review",\n  "pending_checks": []\n}\n'
+    ;;
+  issue)
+    printf 'adl_event schema=adl.observability.event.v1 command=adl stage=issue result=started\n' >&2
+    submode="${3:-}"
+    case "$submode" in
+      search)
+        printf '[\n  {"number": 1152, "title": "validation manager", "state": "OPEN"}\n]\n'
+        ;;
+      view)
+        printf '{\n  "number": 1152,\n  "title": "validation manager",\n  "state": "OPEN"\n}\n'
+        ;;
+      *)
+        echo "unexpected issue mode: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  projection-map)
+    printf 'adl_event schema=adl.observability.event.v1 command=adl stage=projection-map result=started\n' >&2
+    printf '{\n  "schema": "adl.pr.projection_map.v1",\n  "issue_projection_owner": "github",\n  "pr_projection_owner": "github"\n}\n'
+    ;;
   *)
     echo "unexpected mode: $mode" >&2
     exit 1
@@ -91,6 +115,10 @@ PY
 run_json_command ready ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
 run_json_command preflight preflight 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
 run_json_command doctor doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json
+run_json_command validation validation 1152 --json
+run_json_command issue-search issue search --query "validation manager" --state open --json
+run_json_command issue-view issue view 1152 --json
+run_json_command projection-map projection-map --json
 
 args="$(cat "$TMP_DELEGATE_ARGS")"
 [[ "$args" == *"pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json"* ]] || {
@@ -105,6 +133,26 @@ args="$(cat "$TMP_DELEGATE_ARGS")"
 }
 [[ "$args" == *"pr doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json"* ]] || {
   echo "expected doctor delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr validation 1152 --json"* ]] || {
+  echo "expected validation delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr issue search --query validation manager --state open --json"* ]] || {
+  echo "expected issue search delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr issue view 1152 --json"* ]] || {
+  echo "expected issue view delegation args" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"pr projection-map --json"* ]] || {
+  echo "expected projection-map delegation args" >&2
   echo "$args" >&2
   exit 1
 }

--- a/docs/milestones/v0.91.6/review/V0916_STDOUT_STDERR_OBSERVABILITY_BOUNDARY_4520.md
+++ b/docs/milestones/v0.91.6/review/V0916_STDOUT_STDERR_OBSERVABILITY_BOUNDARY_4520.md
@@ -1,0 +1,81 @@
+# V0.91.6 Stdout/Stderr Observability Boundary Proof for #4520
+
+Issue: `#4520`  
+Title: `[v0.91.6][tools][observability] Preserve machine-readable stdout while moving compatibility observability fully to stderr/log sinks`
+
+## Scope
+
+This proof packet is intentionally bounded to the workflow/tooling command
+surfaces named by `#4520`:
+
+- `adl/tools/pr.sh`
+- `adl/tools/pr_delegate.sh`
+- the Rust-owned `adl pr ...` / `adl issue ...` delegated JSON paths those
+  wrappers expose
+
+It does not claim a repo-wide observability redesign. It only classifies the
+JSON-facing workflow surfaces that matter to the current control-plane contract.
+
+## Command Inventory
+
+| Surface | Current classification | Evidence |
+| --- | --- | --- |
+| `adl/tools/pr.sh ready ... --json` | already safe | `adl/tools/test_pr_json_observability.sh` proves JSON stdout stays parse-safe while `adl_event` remains on stderr |
+| `adl/tools/pr.sh preflight ... --json` | already safe | `adl/tools/test_pr_json_observability.sh` |
+| `adl/tools/pr.sh doctor ... --json` | already safe | `adl/tools/test_pr_json_observability.sh` |
+| `adl/tools/pr.sh validation ... --json` | fixed/proven in `#4520` | expanded `adl/tools/test_pr_json_observability.sh` now enforces the same stdout/stderr split for the validation delegate path |
+| `adl/tools/pr.sh issue search ... --json` | fixed/proven in `#4520` | expanded `adl/tools/test_pr_json_observability.sh` |
+| `adl/tools/pr.sh issue view ... --json` | fixed/proven in `#4520` | expanded `adl/tools/test_pr_json_observability.sh` |
+| `adl/tools/pr.sh projection-map --json` | fixed/proven in `#4520` | expanded `adl/tools/test_pr_json_observability.sh` |
+
+## Out-of-Scope / Deferred
+
+- Human-oriented non-JSON surfaces such as `adl/tools/pr.sh status`, issue-mode
+  `run`, and help/usage text are not treated as machine-readable stdout
+  contracts in this issue.
+- Broader direct CLI families like `adl agent ... --json`, `adl session ...
+  --json`, and `adl process status --json` are outside the repo-input scope of
+  `#4520` and remain separate proof surfaces.
+
+## Validation Run
+
+Command:
+
+```bash
+bash adl/tools/test_pr_json_observability.sh
+```
+
+What it proves:
+
+- the delegated JSON payload remains on stdout and parses successfully
+- `adl_event` compatibility observability does not appear on stdout
+- `adl_event` remains available on stderr for the same invocation
+- the wrapper preserves exact delegated argv for:
+  - `ready`
+  - `preflight`
+  - `doctor`
+  - `validation`
+  - `issue search`
+  - `issue view`
+  - `projection-map`
+
+## Live Command Spot Checks
+
+The retained fixture proof above was also spot-checked against live repo
+commands with stdout/stderr split into separate files and stdout parsed as JSON:
+
+- `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh validation 4525 --json`
+- `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh issue search --query "validation manager" --state open --json`
+- `bash adl/tools/pr.sh projection-map --json`
+
+Those live checks confirmed the same contract on the current repo surfaces:
+
+- stdout remained parse-safe JSON
+- stderr retained `adl_event` observability lines
+- no `adl_event` compatibility output leaked onto stdout
+
+## Result
+
+`#4520` closes the `#4434` audit gap at the workflow-wrapper level by turning
+the stdout/stderr boundary from a partially retained claim into an enforced
+proof surface for the currently in-scope JSON-facing `pr.sh` commands.


### PR DESCRIPTION
Closes #4520

## Summary
Completed the bounded `#4520` observability contract hardening by extending the
retained JSON-wrapper proof for `adl/tools/pr.sh` beyond `ready` / `preflight`
/ `doctor` to cover `validation`, `issue`, and `projection-map`, then writing a
durable v0.91.6 review packet that classifies the in-scope machine-readable
stdout surfaces. The result is an enforced proof surface, not just a retained
claim, for the JSON-facing `pr.sh` wrapper commands named by the issue.

## Artifacts
- `adl/tools/test_pr_json_observability.sh`
- `docs/milestones/v0.91.6/review/V0916_STDOUT_STDERR_OBSERVABILITY_BOUNDARY_4520.md`
- Local issue-record updates in:
  - `.adl/v0.91.6/tasks/issue-4520__v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks/vpp.md`
  - `.adl/v0.91.6/tasks/issue-4520__v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks/srp.md`
  - `.adl/v0.91.6/tasks/issue-4520__v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_json_observability.sh`
    Verified the expanded fixture-backed stdout/stderr contract for the in-scope `pr.sh` JSON wrapper family.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh validation 4525 --json >validation.stdout 2>validation.stderr && python3 -c 'import json, pathlib; json.loads(pathlib.Path("validation.stdout").read_text())'`
    Verified the live delegated validation JSON path stays parse-safe on stdout.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh issue search --query "validation manager" --state open --json >issue.stdout 2>issue.stderr && python3 -c 'import json, pathlib; json.loads(pathlib.Path("issue.stdout").read_text())'`
    Verified the live delegated issue-search JSON path stays parse-safe on stdout.
  - `bash adl/tools/pr.sh projection-map --json >projection.stdout 2>projection.stderr && python3 -c 'import json, pathlib; json.loads(pathlib.Path("projection.stdout").read_text())'`
    Verified the live delegated projection-map JSON path stays parse-safe on stdout.
  - `git diff --check`
    Verified whitespace and patch hygiene for the tracked issue diff before publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4520__v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4520__v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks/sor.md
- Idempotency-Key: v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks-adl-tools-test-pr-json-observability-sh-docs-milestones-v0-91-6-review-v0916-stdout-stderr-observability-boundary-4520-md-adl-v0-91-6-tasks-issue-4520-v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks-sip-md-adl-v0-91-6-tasks-issue-4520-v0-91-6-tools-observability-preserve-machine-readable-stdout-while-moving-compatibility-observability-fully-to-stderr-log-sinks-sor-md