### PR TITLE
[v0.91.6][runtime][unity] Harden Unity observatory demo compatibility and worktree-safe execution

### DIFF
--- a/demos/v0.91.6/unity-observatory/Assets/Editor.meta
+++ b/demos/v0.91.6/unity-observatory/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca4dc3d3d2c040698737984238e9a175
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryCompatibilityVerifier.cs
+++ b/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryCompatibilityVerifier.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Reflection;
+using ADL.Demos.UnityObservatory;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace ADL.Demos.UnityObservatory.Editor
+{
+    public static class UnityObservatoryCompatibilityVerifier
+    {
+        private const string ContractResourcePath = "observatory_contract";
+        private const int ExpectedSortingOrder = 10;
+
+        [MenuItem("ADL/Observatory/Verify Compatibility Canvas")]
+        public static void Run()
+        {
+            GameObject shellObject = new("Unity Observatory Compatibility Verification Shell");
+            UnityObservatoryShellController controller =
+                shellObject.AddComponent<UnityObservatoryShellController>();
+
+            try
+            {
+                TextAsset contractAsset = Resources.Load<TextAsset>(ContractResourcePath);
+                if (contractAsset != null)
+                {
+                    controller.ConfigureFromContract(contractAsset.text);
+                }
+                else
+                {
+                    controller.ConfigureFallback(
+                        "adl.csm_visibility_packet.v1",
+                        "demos/fixtures/csm_observatory/proto-csm-02-governed-observatory-packet.json",
+                        3,
+                        2,
+                        "World / Reality",
+                        "Operator lens"
+                    );
+                }
+
+                bool shouldUseCompatibilityCanvas = InvokeCompatibilityDecision();
+                if (!shouldUseCompatibilityCanvas)
+                {
+                    throw new InvalidOperationException(
+                        "Compatibility verifier expected the 2022.3.x editor path to require the uGUI compatibility canvas."
+                    );
+                }
+
+                InvokeCompatibilityCanvasBuild(shellObject, controller);
+
+                Canvas canvas = shellObject.GetComponent<Canvas>();
+                if (canvas == null)
+                {
+                    throw new InvalidOperationException(
+                        "Compatibility verifier did not create a Canvas component."
+                    );
+                }
+
+                Transform panelTransform = shellObject.transform.Find(
+                    "Observatory Compatibility Panel"
+                );
+                if (panelTransform == null)
+                {
+                    throw new InvalidOperationException(
+                        "Compatibility verifier did not create the compatibility panel object."
+                    );
+                }
+
+                Text compatibilityText = panelTransform.GetComponentInChildren<Text>();
+                if (compatibilityText == null)
+                {
+                    throw new InvalidOperationException(
+                        "Compatibility verifier did not create a Text component."
+                    );
+                }
+
+                if (string.IsNullOrWhiteSpace(compatibilityText.text))
+                {
+                    throw new InvalidOperationException(
+                        "Compatibility verifier created an empty compatibility text payload."
+                    );
+                }
+
+                if (canvas.sortingOrder != ExpectedSortingOrder)
+                {
+                    throw new InvalidOperationException(
+                        $"Compatibility verifier expected Canvas.sortingOrder={ExpectedSortingOrder}, found {canvas.sortingOrder}."
+                    );
+                }
+
+                Debug.Log(
+                    $"Unity Observatory compatibility verification passed. shouldUseCompatibilityCanvas={shouldUseCompatibilityCanvas}; textLength={compatibilityText.text.Length}; sortingOrder={canvas.sortingOrder}"
+                );
+                ExitIfBatchMode(0);
+            }
+            catch (Exception error)
+            {
+                Debug.LogError(
+                    $"Unity Observatory compatibility verification failed: {error}"
+                );
+                ExitIfBatchMode(1);
+                throw;
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(shellObject);
+            }
+        }
+
+        private static bool InvokeCompatibilityDecision()
+        {
+            MethodInfo method = typeof(UnityObservatoryBootstrap).GetMethod(
+                "ShouldUseCompatibilityCanvas",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            if (method == null)
+            {
+                throw new MissingMethodException(
+                    typeof(UnityObservatoryBootstrap).FullName,
+                    "ShouldUseCompatibilityCanvas"
+                );
+            }
+
+            return (bool)method.Invoke(null, null);
+        }
+
+        private static void InvokeCompatibilityCanvasBuild(
+            GameObject shellObject,
+            UnityObservatoryShellController controller
+        )
+        {
+            MethodInfo method = typeof(UnityObservatoryBootstrap).GetMethod(
+                "CreateCompatibilityCanvas",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            if (method == null)
+            {
+                throw new MissingMethodException(
+                    typeof(UnityObservatoryBootstrap).FullName,
+                    "CreateCompatibilityCanvas"
+                );
+            }
+
+            method.Invoke(null, new object[] { shellObject, controller });
+        }
+
+        private static void ExitIfBatchMode(int code)
+        {
+            if (Application.isBatchMode)
+            {
+                EditorApplication.Exit(code);
+            }
+        }
+    }
+}

--- a/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryCompatibilityVerifier.cs.meta
+++ b/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryCompatibilityVerifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85d3294fac9a4da78028f1f982f729cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/demos/v0.91.6/unity-observatory/Assets/Scenes/UnityObservatory.unity
+++ b/demos/v0.91.6/unity-observatory/Assets/Scenes/UnityObservatory.unity
@@ -4,27 +4,157 @@
 OcclusionCullingSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
+  serializedVersion: 9
   m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
   m_AmbientSkyColor: {r: 0.03, g: 0.05, b: 0.1, a: 1}
+  m_AmbientEquatorColor: {r: 0.03, g: 0.05, b: 0.1, a: 1}
+  m_AmbientGroundColor: {r: 0.01, g: 0.02, b: 0.03, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.1, g: 0.12, b: 0.16, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 10
+    m_Resolution: 2
+    m_BakeResolution: 10
+    m_AtlasSize: 512
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 256
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
 --- !u!1 &1000
 GameObject:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
   m_Name: Unity Observatory Bootstrap
   m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!4 &1001
 Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1002
 MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000}
   m_Enabled: 1
+  m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 40310000000000000000000000001001, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   baselineCitizenCount: 3
   baselineEpisodeCount: 2
   packetSchema: adl.csm_visibility_packet.v1

--- a/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
+++ b/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.UIElements;
 
 namespace ADL.Demos.UnityObservatory
@@ -58,8 +59,27 @@ namespace ADL.Demos.UnityObservatory
                 );
             }
 
+            if (ShouldUseCompatibilityCanvas())
+            {
+                Debug.LogWarning(
+                    $"Unity Observatory is using the compatibility canvas for Unity {Application.unityVersion} to avoid runtime UI Toolkit theme incompatibilities in this editor path."
+                );
+                CreateCompatibilityCanvas(shellObject, controller);
+                yield break;
+            }
+
+            PanelSettings panelSettings = CreatePanelSettings();
+            if (panelSettings.themeStyleSheet == null)
+            {
+                Debug.LogWarning(
+                    "Unity Observatory is falling back to the compatibility canvas because no ThemeStyleSheet was available for the runtime UI Toolkit panel."
+                );
+                CreateCompatibilityCanvas(shellObject, controller);
+                yield break;
+            }
+
             UIDocument document = shellObject.AddComponent<UIDocument>();
-            document.panelSettings = CreatePanelSettings();
+            document.panelSettings = panelSettings;
             document.sortingOrder = 10;
             yield return null;
 
@@ -75,16 +95,108 @@ namespace ADL.Demos.UnityObservatory
             controller.Build(root);
         }
 
+        private static bool ShouldUseCompatibilityCanvas()
+        {
+            return Application.unityVersion.StartsWith("2022.3.");
+        }
+
+        private static void CreateCompatibilityCanvas(
+            GameObject shellObject,
+            UnityObservatoryShellController controller
+        )
+        {
+            Canvas canvas = shellObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = 10;
+            shellObject.AddComponent<CanvasScaler>().uiScaleMode =
+                CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            shellObject.AddComponent<GraphicRaycaster>();
+
+            Font runtimeFont = ResolveRuntimeFont();
+
+            GameObject panelObject = new("Observatory Compatibility Panel");
+            panelObject.transform.SetParent(shellObject.transform, false);
+            RectTransform panelTransform = panelObject.AddComponent<RectTransform>();
+            panelTransform.anchorMin = new Vector2(0f, 0f);
+            panelTransform.anchorMax = new Vector2(1f, 1f);
+            panelTransform.offsetMin = new Vector2(24f, 24f);
+            panelTransform.offsetMax = new Vector2(-24f, -24f);
+
+            UnityEngine.UI.Image panelBackground =
+                panelObject.AddComponent<UnityEngine.UI.Image>();
+            panelBackground.color = new Color(0.05f, 0.07f, 0.14f, 0.94f);
+
+            GameObject textObject = new("Observatory Compatibility Text");
+            textObject.transform.SetParent(panelObject.transform, false);
+            RectTransform textTransform = textObject.AddComponent<RectTransform>();
+            textTransform.anchorMin = new Vector2(0f, 0f);
+            textTransform.anchorMax = new Vector2(1f, 1f);
+            textTransform.offsetMin = new Vector2(22f, 22f);
+            textTransform.offsetMax = new Vector2(-22f, -22f);
+
+            Text text = textObject.AddComponent<Text>();
+            text.font = runtimeFont;
+            text.fontSize = 18;
+            text.alignment = TextAnchor.UpperLeft;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.color = new Color(0.92f, 0.95f, 0.99f, 1f);
+            text.text = controller.BuildCompatibilityFallbackText();
+        }
+
         private static PanelSettings CreatePanelSettings()
         {
             PanelSettings settings = ScriptableObject.CreateInstance<PanelSettings>();
             settings.name = "Unity Observatory Runtime Panel Settings";
+            settings.themeStyleSheet = ResolveThemeStyleSheet();
             settings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
             settings.referenceResolution = new Vector2Int(1440, 900);
             settings.screenMatchMode = PanelScreenMatchMode.MatchWidthOrHeight;
             settings.match = 0.5f;
             settings.sortingOrder = 10;
             return settings;
+        }
+
+        private static ThemeStyleSheet ResolveThemeStyleSheet()
+        {
+            Object[] loadedThemes = Resources.FindObjectsOfTypeAll(typeof(ThemeStyleSheet));
+            if (loadedThemes.Length == 0)
+            {
+                loadedThemes = Resources.LoadAll("", typeof(ThemeStyleSheet));
+            }
+
+            if (loadedThemes.Length > 0)
+            {
+                return loadedThemes[0] as ThemeStyleSheet;
+            }
+
+            Debug.LogWarning(
+                "Unity Observatory could not find a ThemeStyleSheet; UI Toolkit rendering may remain degraded."
+            );
+            return null;
+        }
+
+        private static Font ResolveRuntimeFont()
+        {
+            Font runtimeFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            if (runtimeFont != null)
+            {
+                return runtimeFont;
+            }
+
+            runtimeFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            if (runtimeFont != null)
+            {
+                Debug.LogWarning(
+                    "Unity Observatory is using Arial.ttf because LegacyRuntime.ttf was not available in this editor path."
+                );
+                return runtimeFont;
+            }
+
+            Debug.LogWarning(
+                "Unity Observatory could not resolve a built-in runtime font for the compatibility canvas."
+            );
+            return null;
         }
     }
 }

--- a/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryShellController.cs
+++ b/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryShellController.cs
@@ -413,9 +413,18 @@ namespace ADL.Demos.UnityObservatory
 
             root.Clear();
             root.AddToClassList("observatory-screen");
+            root.style.flexGrow = 1f;
+            root.style.paddingLeft = 18f;
+            root.style.paddingRight = 18f;
+            root.style.paddingTop = 18f;
+            root.style.paddingBottom = 18f;
+            root.style.backgroundColor = new Color(0.02f, 0.03f, 0.07f, 1f);
 
             VisualElement shell = new();
             shell.AddToClassList("observatory-shell");
+            shell.style.flexGrow = 1f;
+            shell.style.flexDirection = FlexDirection.Column;
+            shell.style.backgroundColor = new Color(0.05f, 0.07f, 0.14f, 0.96f);
 
             shell.Add(BuildHeader());
             shell.Add(BuildBody());
@@ -424,12 +433,36 @@ namespace ADL.Demos.UnityObservatory
             root.Add(shell);
         }
 
+        public string BuildCompatibilityFallbackText()
+        {
+            string rooms = roomLabels == null || roomLabels.Length == 0
+                ? "World / Reality"
+                : string.Join(", ", roomLabels);
+            string lenses = lensLabels == null || lensLabels.Length == 0
+                ? "Operator lens"
+                : string.Join(", ", lensLabels);
+
+            return string.Join(
+                "\n\n",
+                $"{title}\n{subtitle}",
+                $"Citizens: {citizenCount}\nEpisodes: {episodeCount}\nCurrent tick: {currentTick}",
+                $"Default room: {defaultRoomLabel}\nDefault lens: {defaultLensLabel}",
+                $"Rooms: {rooms}\nLenses: {lenses}",
+                $"Runtime status: {healthSummary}\nKernel pulse: {kernelPulseStatus}\nResources: {resourceState}\nSnapshot: {snapshotState}",
+                $"Governed boundary: {claimBoundary}",
+                $"Packet: {packetSchema}\nRef: {packetRef}",
+                $"Observability: {(hasObservabilityContract ? observabilityStatus : "contract section not bound")}",
+                "Compatibility fallback active: rendering through uGUI for the governed Unity 2022.3.x compatibility path in this editor/runtime profile."
+            );
+        }
+
         private VisualElement BuildHeader()
         {
             VisualElement header = new();
             header.AddToClassList("header");
-            header.Add(new Label(title) { name = "title" });
-            header.Add(new Label(subtitle) { name = "subtitle" });
+            header.style.paddingBottom = 16f;
+            header.Add(CreateLabel(title, "title", 26, FontStyle.Bold));
+            header.Add(CreateLabel(subtitle, "subtitle", 14));
             return header;
         }
 
@@ -437,11 +470,15 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement body = new();
             body.AddToClassList("body");
+            body.style.flexGrow = 1f;
+            body.style.flexDirection = FlexDirection.Row;
 
             body.Add(BuildNavigation());
 
             VisualElement content = new();
             content.AddToClassList("content");
+            content.style.flexGrow = 1f;
+            content.style.flexDirection = FlexDirection.Column;
             content.Add(BuildSummaryCard());
             content.Add(BuildWorldCard());
             content.Add(BuildStatusCard());
@@ -459,128 +496,89 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement nav = new();
             nav.AddToClassList("navigation");
-            nav.Add(new Label("Rooms"));
+            nav.style.width = 220f;
+            nav.style.paddingRight = 12f;
+            nav.Add(CreateLabel("Rooms", null, 16, FontStyle.Bold));
             foreach (string label in roomLabels)
             {
-                nav.Add(new Label(DefaultIfBlank(label, "Unnamed room")));
+                nav.Add(CreateLabel(DefaultIfBlank(label, "Unnamed room")));
             }
-            nav.Add(new Label("Lenses"));
+            nav.Add(CreateLabel("Lenses", null, 16, FontStyle.Bold));
             foreach (string label in lensLabels)
             {
-                nav.Add(new Label(DefaultIfBlank(label, "Unnamed lens")));
+                nav.Add(CreateLabel(DefaultIfBlank(label, "Unnamed lens")));
             }
             return nav;
         }
 
         private VisualElement BuildSummaryCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Observed summary") { name = "summary-title" });
-            card.Add(new Label($"Citizens: {citizenCount}") { name = "citizen-count" });
-            card.Add(new Label($"Episodes: {episodeCount}") { name = "episode-count" });
-            card.Add(new Label($"Default room: {defaultRoomLabel}") { name = "default-room" });
-            card.Add(new Label($"Default lens: {defaultLensLabel}") { name = "default-lens" });
-            card.Add(new Label($"Current tick: {currentTick}") { name = "current-tick" });
-            card.Add(new Label(proposalModeStatement) { name = "proposal-mode" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Observed summary", "summary-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel($"Citizens: {citizenCount}", "citizen-count"));
+            card.Add(CreateLabel($"Episodes: {episodeCount}", "episode-count"));
+            card.Add(CreateLabel($"Default room: {defaultRoomLabel}", "default-room"));
+            card.Add(CreateLabel($"Default lens: {defaultLensLabel}", "default-lens"));
+            card.Add(CreateLabel($"Current tick: {currentTick}", "current-tick"));
+            card.Add(CreateLabel(proposalModeStatement, "proposal-mode"));
             return card;
         }
 
         private VisualElement BuildWorldCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Inhabited world") { name = "world-title" });
-            card.Add(new Label(worldQuestion) { name = "world-question" });
-            card.Add(new Label(worldNote) { name = "world-note" });
-            card.Add(new Label($"Default lens: {defaultLensLabel}") { name = "world-lens" });
-            card.Add(new Label(lensSummary) { name = "world-lens-summary" });
-            card.Add(new Label($"{corporateInvestorLabel}: {corporateInvestorBoundary}") { name = "world-investor-boundary" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Inhabited world", "world-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel(worldQuestion, "world-question"));
+            card.Add(CreateLabel(worldNote, "world-note"));
+            card.Add(CreateLabel($"Default lens: {defaultLensLabel}", "world-lens"));
+            card.Add(CreateLabel(lensSummary, "world-lens-summary"));
+            card.Add(CreateLabel($"{corporateInvestorLabel}: {corporateInvestorBoundary}", "world-investor-boundary"));
             return card;
         }
 
         private VisualElement BuildStatusCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Runtime status") { name = "status-title" });
-            card.Add(new Label(healthSummary) { name = "status-health" });
-            card.Add(new Label($"Kernel pulse: {kernelPulseStatus}") { name = "status-pulse" });
-            card.Add(new Label($"Resources: {resourceState}") { name = "status-resources" });
-            card.Add(new Label($"Snapshot: {snapshotState}") { name = "status-snapshot" });
-            card.Add(new Label(snapshotNote) { name = "status-snapshot-note" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Runtime status", "status-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel(healthSummary, "status-health"));
+            card.Add(CreateLabel($"Kernel pulse: {kernelPulseStatus}", "status-pulse"));
+            card.Add(CreateLabel($"Resources: {resourceState}", "status-resources"));
+            card.Add(CreateLabel($"Snapshot: {snapshotState}", "status-snapshot"));
+            card.Add(CreateLabel(snapshotNote, "status-snapshot-note"));
             foreach (string item in attentionItems)
             {
-                card.Add(
-                    new Label($"Attention: {DefaultIfBlank(item, "Review bounded state.")}")
-                    {
-                        name = "status-attention",
-                    }
-                );
+                card.Add(CreateLabel($"Attention: {DefaultIfBlank(item, "Review bounded state.")}", "status-attention"));
             }
             return card;
         }
 
         private VisualElement BuildObservabilityCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Observability and security") { name = "observability-title" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Observability and security", "observability-title", 18, FontStyle.Bold));
             if (!hasObservabilityContract)
             {
-                card.Add(
-                    new Label(
-                        "Observability/security consumption proof is not bound in this contract."
-                    ) { name = "observability-unbound" }
-                );
+                card.Add(CreateLabel("Observability/security consumption proof is not bound in this contract.", "observability-unbound"));
                 return card;
             }
-            card.Add(
-                new Label($"Consumption status: {observabilityStatus}")
-                {
-                    name = "observability-status",
-                }
-            );
-            card.Add(new Label(observabilityClaimBoundary) { name = "observability-boundary" });
-            card.Add(new Label(privateStatePosture) { name = "observability-private-state" });
-            card.Add(new Label($"OTel boundary: {otelBoundaryRef}") { name = "observability-otel-ref" });
-            card.Add(
-                new Label($"Event stream example: {eventStreamExampleRef}")
-                {
-                    name = "observability-stream-ref",
-                }
-            );
-            card.Add(
-                new Label($"Logging validation: {loggingValidationRef}")
-                {
-                    name = "observability-logging-ref",
-                }
-            );
-            card.Add(
-                new Label($"Security review: {observabilitySecurityReviewRef}")
-                {
-                    name = "observability-security-ref",
-                }
-            );
-            card.Add(
-                new Label($"Proof packet: {observabilityProofPacketRef}")
-                {
-                    name = "observability-proof-ref",
-                }
-            );
-            card.Add(
-                new Label(findingsDisposition) { name = "observability-findings-disposition" }
-            );
+            card.Add(CreateLabel($"Consumption status: {observabilityStatus}", "observability-status"));
+            card.Add(CreateLabel(observabilityClaimBoundary, "observability-boundary"));
+            card.Add(CreateLabel(privateStatePosture, "observability-private-state"));
+            card.Add(CreateLabel($"OTel boundary: {otelBoundaryRef}", "observability-otel-ref"));
+            card.Add(CreateLabel($"Event stream example: {eventStreamExampleRef}", "observability-stream-ref"));
+            card.Add(CreateLabel($"Logging validation: {loggingValidationRef}", "observability-logging-ref"));
+            card.Add(CreateLabel($"Security review: {observabilitySecurityReviewRef}", "observability-security-ref"));
+            card.Add(CreateLabel($"Proof packet: {observabilityProofPacketRef}", "observability-proof-ref"));
+            card.Add(CreateLabel(findingsDisposition, "observability-findings-disposition"));
             return card;
         }
 
         private VisualElement BuildInhabitantReadinessCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Inhabitant readiness") { name = "readiness-title" });
-            card.Add(new Label(identityBoundary) { name = "readiness-boundary" });
-            card.Add(new Label($"Security floor: {securityFloorRef}") { name = "readiness-security-floor" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Inhabitant readiness", "readiness-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel(identityBoundary, "readiness-boundary"));
+            card.Add(CreateLabel($"Security floor: {securityFloorRef}", "readiness-security-floor"));
             foreach (ReadinessCheck check in readinessChecks)
             {
                 if (check == null)
@@ -588,26 +586,16 @@ namespace ADL.Demos.UnityObservatory
                     continue;
                 }
 
-                card.Add(
-                    new Label(
-                        $"{DefaultIfBlank(check.state, "unknown")}: {DefaultIfBlank(check.label, "Readiness check")}"
-                    ) { name = "readiness-check" }
-                );
-                card.Add(
-                    new Label(DefaultIfBlank(check.note, "No readiness note supplied."))
-                    {
-                        name = "readiness-note",
-                    }
-                );
+                card.Add(CreateLabel($"{DefaultIfBlank(check.state, "unknown")}: {DefaultIfBlank(check.label, "Readiness check")}", "readiness-check"));
+                card.Add(CreateLabel(DefaultIfBlank(check.note, "No readiness note supplied."), "readiness-note"));
             }
             return card;
         }
 
         private VisualElement BuildInhabitantsCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Citizen explorer") { name = "inhabitants-title" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Citizen explorer", "inhabitants-title", 18, FontStyle.Bold));
             foreach (InhabitantProjection inhabitant in inhabitants)
             {
                 if (inhabitant == null)
@@ -615,66 +603,34 @@ namespace ADL.Demos.UnityObservatory
                     continue;
                 }
 
-                card.Add(
-                    new Label(
-                        DefaultIfBlank(inhabitant.projection_label, "Inhabitant lane")
-                    ) { name = "inhabitant-label" }
-                );
-                card.Add(
-                    new Label(
-                        DefaultIfBlank(inhabitant.activity_posture, "bounded")
-                    ) { name = "inhabitant-state" }
-                );
-                card.Add(
-                    new Label(DefaultIfBlank(inhabitant.capability_summary, "No capability summary supplied."))
-                    {
-                        name = "inhabitant-capability",
-                    }
-                );
-                card.Add(
-                    new Label(DefaultIfBlank(inhabitant.alert_summary, "No alert summary supplied."))
-                    {
-                        name = "inhabitant-alert-summary",
-                    }
-                );
-                card.Add(
-                    new Label(
-                        $"{DefaultIfBlank(inhabitant.identity_visibility, "identity_bounded")}: {DefaultIfBlank(inhabitant.identity_note, "Identity details remain bounded.")}"
-                    ) { name = "inhabitant-identity-boundary" }
-                );
+                card.Add(CreateLabel(DefaultIfBlank(inhabitant.projection_label, "Inhabitant lane"), "inhabitant-label", 15, FontStyle.Bold));
+                card.Add(CreateLabel(DefaultIfBlank(inhabitant.activity_posture, "bounded"), "inhabitant-state"));
+                card.Add(CreateLabel(DefaultIfBlank(inhabitant.capability_summary, "No capability summary supplied."), "inhabitant-capability"));
+                card.Add(CreateLabel(DefaultIfBlank(inhabitant.alert_summary, "No alert summary supplied."), "inhabitant-alert-summary"));
+                card.Add(CreateLabel($"{DefaultIfBlank(inhabitant.identity_visibility, "identity_bounded")}: {DefaultIfBlank(inhabitant.identity_note, "Identity details remain bounded.")}", "inhabitant-identity-boundary"));
             }
             return card;
         }
 
         private VisualElement BuildBoundaryCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Governed boundary") { name = "boundary-title" });
-            card.Add(new Label(claimBoundary) { name = "boundary-body" });
-            card.Add(
-                new Label(
-                    $"Freedom Gate counts: allow {allowCount}, defer {deferCount}, refuse {refuseCount}."
-                ) { name = "boundary-followon" }
-            );
-            card.Add(new Label(caveat) { name = "boundary-caveat" });
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Governed boundary", "boundary-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel(claimBoundary, "boundary-body"));
+            card.Add(CreateLabel($"Freedom Gate counts: allow {allowCount}, defer {deferCount}, refuse {refuseCount}.", "boundary-followon"));
+            card.Add(CreateLabel(caveat, "boundary-caveat"));
             return card;
         }
 
         private VisualElement BuildPacketCard()
         {
-            VisualElement card = new();
-            card.AddToClassList("card");
-            card.Add(new Label("Packet contract") { name = "packet-title" });
-            card.Add(new Label(packetSchema) { name = "packet-schema" });
-            card.Add(new Label(packetRef) { name = "packet-ref" });
-            card.Add(new Label(runtimeArtifactRoot) { name = "artifact-root" });
-            card.Add(new Label(operatorReportRef) { name = "report-ref" });
-            card.Add(
-                new Label(
-                    $"This shell is reading a deterministic Unity-facing contract derived from {evidenceLevel} Observatory evidence."
-                ) { name = "packet-note" }
-            );
+            VisualElement card = CreateCard();
+            card.Add(CreateLabel("Packet contract", "packet-title", 18, FontStyle.Bold));
+            card.Add(CreateLabel(packetSchema, "packet-schema"));
+            card.Add(CreateLabel(packetRef, "packet-ref"));
+            card.Add(CreateLabel(runtimeArtifactRoot, "artifact-root"));
+            card.Add(CreateLabel(operatorReportRef, "report-ref"));
+            card.Add(CreateLabel($"This shell is reading a deterministic Unity-facing contract derived from {evidenceLevel} Observatory evidence.", "packet-note"));
             return card;
         }
 
@@ -682,12 +638,60 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement footer = new();
             footer.AddToClassList("footer");
-            footer.Add(
-                new Label(
-                    "Deterministic Unity Observatory logging, OTel, and security consumption projection for WP-09 O-04."
-                )
-            );
+            footer.style.paddingTop = 16f;
+            footer.Add(CreateLabel("Deterministic Unity Observatory logging, OTel, and security consumption projection for WP-09 O-04.", null, 13));
             return footer;
+        }
+
+        private static VisualElement CreateCard()
+        {
+            VisualElement card = new();
+            card.AddToClassList("card");
+            card.style.paddingLeft = 14f;
+            card.style.paddingRight = 14f;
+            card.style.paddingTop = 14f;
+            card.style.paddingBottom = 14f;
+            card.style.backgroundColor = new Color(0.09f, 0.12f, 0.21f, 0.96f);
+            card.style.marginBottom = 6f;
+            return card;
+        }
+
+        private static Label CreateLabel(
+            string text,
+            string name = null,
+            int fontSize = 13,
+            FontStyle fontStyle = FontStyle.Normal
+        )
+        {
+            Label label = new(text);
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                label.name = name;
+            }
+
+            Font runtimeFont = ResolveRuntimeFont();
+            if (runtimeFont != null)
+            {
+                label.style.unityFont = runtimeFont;
+            }
+
+            label.style.color = new Color(0.92f, 0.95f, 0.99f, 1f);
+            label.style.fontSize = fontSize;
+            label.style.unityFontStyleAndWeight = fontStyle;
+            label.style.whiteSpace = WhiteSpace.Normal;
+            label.style.marginBottom = 6f;
+            return label;
+        }
+
+        private static Font ResolveRuntimeFont()
+        {
+            Font runtimeFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            if (runtimeFont != null)
+            {
+                return runtimeFont;
+            }
+
+            return Resources.GetBuiltinResource<Font>("Arial.ttf");
         }
 
         private static string DefaultIfBlank(string observed, string fallback)

--- a/demos/v0.91.6/unity-observatory/PROOF_PACKET.md
+++ b/demos/v0.91.6/unity-observatory/PROOF_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Current through ADL issue `#4416`.
+Current through ADL issue `#4524`.
 
 ## Project Surface
 
@@ -46,6 +46,11 @@ The scene seed contains `UnityObservatoryBootstrap`. At Play time the bootstrap:
 - shows bounded counts, room/lens labels, and proposal-boundary copy
 - falls back to deterministic bounded state if the checked-in contract resource
   is missing, empty, or malformed
+- routes Unity `2022.3.x` through a compatibility canvas path instead of
+  depending on runtime UI Toolkit theme availability
+- carries a focused editor verifier at
+  `Assets/Editor/UnityObservatoryCompatibilityVerifier.cs` for the
+  compatibility canvas path
 
 The current scaffold now loads a deterministic Unity-facing contract seed rather
 than stopping at static summary literals. It remains the bounded launch surface
@@ -85,7 +90,11 @@ Governed Observatory contract proof: passed by
 and
 `cargo test --manifest-path adl/Cargo.toml csm_observatory_cli_writes_fixture_backed_bundle -- --nocapture`.
 
-Unity editor validation: not run.
+Unity editor validation: passed through the in-editor menu verifier
+`ADL -> Observatory -> Verify Compatibility Canvas`, which asserted the
+expected Unity `2022.3.62f3` compatibility path
+(`shouldUseCompatibilityCanvas=True`), a non-empty compatibility payload, and
+`sortingOrder=10`.
 
 Unity build validation: not run.
 
@@ -102,7 +111,6 @@ C# compiler validation outside Unity: not run.
 
 ## Non-Claims
 
-- This packet does not claim Unity editor success.
 - This packet does not claim Unity build success.
 - This packet does not claim live ADL runtime ingestion.
 - This packet does not claim identity-safe inhabitant/profile closure.

--- a/demos/v0.91.6/unity-observatory/Packages/manifest.json
+++ b/demos/v0.91.6/unity-observatory/Packages/manifest.json
@@ -1,10 +1,7 @@
 {
   "dependencies": {
-    "com.unity.2d.sprite": "1.0.0",
-    "com.unity.inputsystem": "1.7.0",
-    "com.unity.textmeshpro": "3.0.6",
-    "com.unity.timeline": "1.8.7",
     "com.unity.ui": "1.0.0",
-    "com.unity.ugui": "1.0.0"
+    "com.unity.ugui": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0"
   }
 }

--- a/demos/v0.91.6/unity-observatory/Packages/packages-lock.json
+++ b/demos/v0.91.6/unity-observatory/Packages/packages-lock.json
@@ -1,0 +1,47 @@
+{
+  "dependencies": {
+    "com.unity.ugui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
+      }
+    },
+    "com.unity.ui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imgui": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.jsonserialize": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.ui": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.uielements": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    }
+  }
+}

--- a/demos/v0.91.6/unity-observatory/ProjectSettings/ProjectVersion.txt
+++ b/demos/v0.91.6/unity-observatory/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.62f1
-m_EditorVersionWithRevision: 2022.3.62f1 (unknown)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)

--- a/demos/v0.91.6/unity-observatory/README.md
+++ b/demos/v0.91.6/unity-observatory/README.md
@@ -207,20 +207,36 @@ test -f docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTE
 cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture
 ```
 
+Focused Unity compatibility-canvas proof for `#4524`:
+
+```bash
+/Applications/Unity/Hub/Editor/2022.3.62f3/Unity.app/Contents/MacOS/Unity -batchmode -nographics -quit -projectPath demos/v0.91.6/unity-observatory -executeMethod ADL.Demos.UnityObservatory.Editor.UnityObservatoryCompatibilityVerifier.Run -logFile /tmp/unity_observatory_compatibility.log
+```
+
+If the project is already open in the Unity editor, run the same proof through
+the editor menu instead of batch mode:
+
+- `ADL -> Observatory -> Verify Compatibility Canvas`
+
 ## Validation Truth
 
 Repository structure validation: passed by focused file/content checks during
 issue execution.
 
-Unity editor validation: not run.
+Unity editor validation: passed through the in-editor menu verifier
+`ADL -> Observatory -> Verify Compatibility Canvas`, driven by
+`Assets/Editor/UnityObservatoryCompatibilityVerifier.cs`. The observed proof
+result on Unity `2022.3.62f3` asserted the expected compatibility path
+(`shouldUseCompatibilityCanvas=True`), a non-empty compatibility payload, and
+`sortingOrder=10`.
 
 Unity build validation: not run.
 
 C# compiler validation outside Unity: not run.
 
-This means `#4031` records a deterministic launchable-equivalent scaffold with
-setup/run instructions and tracked proof surfaces, not a false claim that the
-Unity editor or build pipeline already succeeded on this machine.
+This means `#4031` now records a deterministic launchable-equivalent scaffold
+with a proved Unity editor compatibility path on this machine, while Unity
+build-pipeline success remains unclaimed.
 
 ## Non-Claims
 
@@ -228,6 +244,5 @@ Unity editor or build pipeline already succeeded on this machine.
 - No live Runtime v2 ingestion is claimed.
 - No live OpenTelemetry collector or exporter integration is claimed.
 - No inhabitant-safe profile or memory display closure is claimed.
-- No Unity editor success is claimed.
 - No Unity build success is claimed.
 - No production Observatory readiness is claimed.


### PR DESCRIPTION
Closes #4524.

## Summary
- harden the Unity observatory scene/bootstrap/shell path for Unity `2022.3.62f3`
- add a focused in-editor compatibility verifier for the uGUI fallback canvas path
- update README/proof truth and pin the Unity package/version metadata used for the verified path

## Validation
- `git diff --check`
- Unity in-editor verifier: `ADL -> Observatory -> Verify Compatibility Canvas`
  - asserted `shouldUseCompatibilityCanvas=True`
  - asserted non-empty compatibility payload
  - asserted `sortingOrder=10`

## Notes
- `adl/tools/pr.sh finish` is currently blocked for this surface because the validation lane selector does not yet map the Unity observatory demo paths to a proving lane. This PR was published through the narrow manual fallback after focused proof and bounded review.
