### PR TITLE
[v0.91.6][review][docs] Make release and bridge documents consume issue truth mechanically before closeout

### DIFF
--- a/docs/milestones/v0.91.6/README.md
+++ b/docs/milestones/v0.91.6/README.md
@@ -75,6 +75,26 @@ only as one of:
 The milestone is successful only if `v0.92` can consume first-tranche bridge
 truth without rediscovering the plan.
 
+## Canonical Issue-Truth Sources
+
+Release-facing and bridge-facing docs in this milestone should not reconstruct
+issue state by re-reading scattered issue threads or historical packets.
+
+Use these tracked sources as the current issue-truth surfaces:
+
+- Closed bridge umbrellas and retained review/closeout evidence:
+  [review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md](review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md)
+- Ordered open release-tail sequencing and wait-state policy:
+  [CLOSEOUT_TAIL_SPRINT_v0.91.6.md](CLOSEOUT_TAIL_SPRINT_v0.91.6.md)
+
+Use [review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md](review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md)
+as the bounded audit of this consumption rule and the remaining manual
+boundary, not as a third current-state ledger.
+
+Historical feature docs, sprint packets, and closeout packets remain source
+evidence, but they are not the default current-state ledger for release or
+bridge consumption.
+
 ## First-Tranche Feature Docs
 
 | Surface | Required v0.91.6 output | v0.92 consumption rule |

--- a/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
+++ b/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
@@ -12,9 +12,25 @@
 Use this as the release-tail checklist once `v0.91.6` execution begins. This
 planning package does not publish a release by itself.
 
+Current issue truth for release consumption must be read from:
+
+- [review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md](review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md)
+  for closed bridge umbrellas and retained evidence posture
+- [CLOSEOUT_TAIL_SPRINT_v0.91.6.md](CLOSEOUT_TAIL_SPRINT_v0.91.6.md)
+  for the ordered open release-tail issue wave
+
+Use [review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md](review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md)
+as the bounded audit of this rule and the remaining manual boundary, not as a
+third current-state ledger.
+
+This release plan is a checklist surface, not the canonical per-issue status
+ledger.
+
 ## 0. Release-Tail Convergence
 
-- [ ] Bridge ledger refreshed from first-tranche outcomes.
+- [ ] Bridge ledger refreshed from first-tranche outcomes, consuming the
+  retained-evidence matrix for closed bridge umbrellas and the closeout-tail
+  sprint surface for open ordered release-tail work.
 - [ ] Feature docs reviewed and updated for final truth.
 - [ ] Open residuals routed to `v0.91.7`, `v0.92`, or later milestones.
 - [ ] Tooling reliability issues have complete, blocked, deferred, or routed

--- a/docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md
+++ b/docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md
@@ -17,6 +17,16 @@ WP-05 `#3970`, WP-06 `#3971`, WP-07 `#3972`, WP-08 `#3973`, WP-09 `#3974`,
 and WP-10 `#3975`, while open downstream runtime and closeout-tail work
 remains explicitly routed.
 
+Current issue truth for this sprint should be consumed from:
+
+- [review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md](review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md)
+  for closed bridge umbrellas and their retained evidence posture
+- [CLOSEOUT_TAIL_SPRINT_v0.91.6.md](CLOSEOUT_TAIL_SPRINT_v0.91.6.md)
+  for the ordered open release-tail issue wave
+
+This sprint plan may summarize those surfaces, but it is not the canonical
+per-issue current-state ledger.
+
 ## Sprint Overview
 
 Complete the first bridge tranche before `v0.92` activation refresh. The sprint
@@ -96,16 +106,6 @@ No runnable demo is required for this docs tranche. Review should inspect:
 
 The milestone closeout tail is now treated as one ordered sprint surface rather than a set of unrelated mini-sprints. For the standard sequence, dependency gates, watcher expectations, remediation routing, and automation guidance, use [CLOSEOUT_TAIL_SPRINT_v0.91.6.md](CLOSEOUT_TAIL_SPRINT_v0.91.6.md).
 
-For `v0.91.6`, the ordered closeout-tail issue wave is:
-
-1. `#3976` demo convergence
-2. `#3977` quality gate
-3. `#3978` docs and review alignment
-4. `#3979` internal review
-5. `#3980` external review
-6. `#3981` remediation and final preflight
-7. `#3982` next milestone planning
-8. `#3983` next milestone review
-9. `#3984` release ceremony
-
-Every issue in this closeout tail should have active watcher coverage whenever it is waiting on checks, review, mergeability, or an upstream dependency, with polling no slower than every 30 seconds while blocked.
+For current release-tail issue truth, read the canonical ordered issue wave in
+[CLOSEOUT_TAIL_SPRINT_v0.91.6.md](CLOSEOUT_TAIL_SPRINT_v0.91.6.md) rather than
+maintaining a second hand-updated list here.

--- a/docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md
+++ b/docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md
@@ -1,0 +1,96 @@
+# v0.91.6 Release And Bridge Doc Truth Consumption Review
+
+Status: `retained_review_packet`
+Owner issue: `#4522`
+Date: 2026-06-25
+
+## Summary
+
+The C-SDLC adoption audit identified a remaining release/docs gap: milestone
+and bridge documents still depended too much on humans re-reading issue state
+from scattered packets instead of consuming one bounded current-state surface.
+
+This review does not invent a new lifecycle authority. It narrows release and
+bridge truth consumption onto the existing tracked canonicals for `v0.91.6`:
+
+- `docs/milestones/v0.91.6/review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md`
+  for closed bridge umbrellas and retained evidence posture
+- `docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md` for the ordered
+  open release-tail issue wave
+
+## Targeted Docs
+
+The bounded docs updated by `#4522` are:
+
+- `docs/milestones/v0.91.6/README.md`
+- `docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md`
+- `docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md`
+- `docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md`
+- `docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md`
+
+## What Is Now Mechanical
+
+For the targeted release-facing and bridge-facing docs, current issue truth is
+now consumed through explicit references to the same bounded tracked sources
+instead of duplicated ad hoc lists.
+
+### Closed bridge umbrellas
+
+Consume from
+`docs/milestones/v0.91.6/review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md`.
+
+This gives one current tracked answer for:
+
+- whether the closed umbrella has a local bundle
+- what retained review/closeout packet should be read first
+- whether the retained evidence is final, repaired, or caveated
+
+### Open ordered release-tail work
+
+Consume from `docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md`.
+
+This gives one current tracked answer for:
+
+- the ordered issue wave
+- dependency sequencing
+- watcher expectations
+- remediation routing
+- wait-state handling
+
+## What Remains Manual
+
+`#4522` intentionally does not claim full automatic issue-state projection into
+Markdown milestone docs.
+
+Manual boundary that still remains:
+
+- the retained-evidence matrix must still be refreshed when closed umbrella
+  truth changes
+- the closeout-tail sprint surface must still be refreshed when the ordered
+  release-tail wave changes
+- historical feature docs, sprint packets, and closeout packets still require
+  reviewer judgment as evidence surfaces; they are not auto-reduced to one
+  machine-generated milestone ledger here
+
+That boundary is acceptable for this issue because the targeted docs now point
+to the tracked current-state canonicals rather than silently reconstructing
+status from scattered packet families.
+
+## Non-Claims
+
+- This review does not claim repo-wide automatic release-state generation.
+- This review does not replace issue-local `SIP`, `STP`, `SPP`, `SRP`, or
+  `SOR` truth.
+- This review does not make historical packets current-state ledgers.
+- This review does not approve `v0.91.6` release readiness or `v0.92`
+  activation readiness.
+
+## Validation
+
+Focused validation for `#4522` should confirm:
+
+- `git diff --check` passes
+- the targeted docs all reference the same canonical current-state surfaces
+- no added lines introduce host-local paths or secret markers
+- the docs continue to preserve the difference between current issue-truth
+  surfaces and historical evidence packets

--- a/docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md
+++ b/docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md
@@ -29,8 +29,8 @@ It must answer three questions before `v0.92` opens:
 | Source | Planning use | Required v0.91.7 handling |
 | --- | --- | --- |
 | `docs/milestones/v0.91.5/PRE_V092_BRIDGE_FEATURE_DOC_LEDGER_v0.91.5.md` | Pre-`v0.92` bridge ledger / `#3778` source | Consume as upstream bridge authority; do not let v0.91.7 contradict the ledger without an explicit decision. |
-| `docs/milestones/v0.91.6/` | First bridge tranche, runtime/tooling/provider/security/observability evidence | Consume closeout truth; do not duplicate completed work. |
-| `docs/milestones/v0.91.6/review/` | Sprint reviews, remediation, proof packets, and retained evidence | Convert residual findings into explicit v0.91.7 routes or deferrals. |
+| `docs/milestones/v0.91.6/` | First bridge tranche, runtime/tooling/provider/security/observability evidence | Consume closeout truth from the milestone's canonical issue-truth surfaces; do not duplicate completed work. |
+| `docs/milestones/v0.91.6/review/` | Sprint reviews, remediation, proof packets, and retained evidence | Read current closed-umbrella truth from `V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md`, then convert residual findings into explicit v0.91.7 routes or deferrals. |
 | `docs/milestones/v0.91.6/RUNTIME_FIRE_UP_PLAN_v0.91.6.md` | Runtime fire-up and soak continuity | Carry into runtime Soak #2 / integrated runtime proof. |
 | `docs/milestones/v0.91.6/features/COGNITIVE_SCHEDULER_v0.91.6.md` | Scheduler v1 bridge | Preserve as scheduler/economics input, not just docs residue. |
 | `docs/milestones/v0.91.6/review/scheduler/` | Scheduler proof and economics inputs | Feed v0.91.7 scheduler execution or closeout route. |
@@ -139,3 +139,7 @@ Local `.adl/docs/TBD/` files are ignored planning inputs, not tracked proof. The
 - This ledger does not approve v0.92 activation.
 - This ledger does not require every cited future idea to become v0.91.7 implementation.
 - This ledger does require every cited pre-v0.92 input to be complete, blocked, deferred, or routed before `v0.92` starts.
+
+Current `v0.91.6` closeout and release-tail issue truth should be consumed from
+the retained-evidence matrix and the closeout-tail sprint surface, not
+reconstructed manually from scattered historical packets.

--- a/docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md
+++ b/docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md
@@ -34,6 +34,18 @@ Tracked sources:
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `docs/planning/FEATURE_DOC_PRODUCTION_MINI_SPRINT_v0.91.5.md`
 
+When this ledger consumes `v0.91.6` bridge state, the current issue-truth
+surfaces are:
+
+- `docs/milestones/v0.91.6/review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md`
+  for closed bridge umbrellas and retained evidence posture
+- `docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md` for the ordered
+  open release-tail issue wave
+
+Use `docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md`
+as the bounded audit of this consumption rule and its remaining manual
+boundary, not as a third current-state ledger.
+
 ## Consumption States
 
 - `complete`: reviewed feature doc and proof/review evidence are present.
@@ -134,6 +146,10 @@ behavior:
 - identity/continuity and capability-selector bridge accounting
 - AEE completion, Memory/ObsMem handoff, ACP/cognitive profile accounting
 - Observatory/Unity consumption classification
+
+`v0.92` should consume current `v0.91.6` bridge closure truth from the retained
+evidence matrix and current open release-tail truth from the closeout-tail
+sprint surface rather than reconstructing state from individual issue histories.
 
 `v0.91.7` must resolve or route:
 


### PR DESCRIPTION
Closes #4522

## Summary
Implemented the bounded docs-only `#4522` fix in the bound issue worktree by
making release-facing and bridge-facing milestone docs consume two canonical
current-state surfaces instead of duplicating per-issue status lists:

- `docs/milestones/v0.91.6/review/V0916_COMPLETED_SPRINT_RETAINED_EVIDENCE_MATRIX_4251.md`
- `docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md`

Added `docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md`
as the retained audit packet describing what is now mechanically consumed and
what manual boundary remains.

## Artifacts
- `docs/milestones/v0.91.6/README.md`
- `docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md`
- `docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md`
- `docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md`
- `docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md`
- `docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the tracked docs patch has no whitespace or patch-shape errors.
  - `rg -n "<host-path-or-secret-markers>" docs/milestones/v0.91.6/README.md docs/milestones/v0.91.6/SPRINT_PLAN_v0.91.6.md docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md docs/milestones/v0.91.7/PLANNING_SOURCE_CAPTURE_v0.91.7.md docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md docs/milestones/v0.91.6/review/V0916_RELEASE_AND_BRIDGE_DOC_TRUTH_CONSUMPTION_REVIEW_4522.md`
    Verified the touched docs do not contain host-local path leakage or obvious secret markers; the exact literal search alternation is omitted here to avoid copying absolute host path markers into the SOR.
  - `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
    Checked milestone-doc consistency. The command failed on the pre-existing `FEATURE_DOCS_v0.91.6.md` versus `features/README.md` mismatch, not on any `#4522`-touched surface.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh ready 4522`
    Verified issue readiness from the workflow control plane and confirmed `READY=PASS` after the docs implementation, with `pr finish` still blocked only by scaffolded lifecycle-card truth before this SOR/SRP repair.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS: `git diff --check`
  - PASS: touched-doc host-path and secret-marker scan
  - FAIL (pre-existing, unrelated to touched paths): milestone staleness check reports `feature index and feature directory links match`
  - PASS: `pr.sh ready 4522`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4522__v0-91-6-review-docs-make-release-and-bridge-documents-consume-issue-truth-mechanically-before-closeout/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4522__v0-91-6-review-docs-make-release-and-bridge-documents-consume-issue-truth-mechanically-before-closeout/sor.md
- Idempotency-Key: v0-91-6-review-docs-make-release-and-bridge-documents-consume-issue-truth-mechanically-before-closeout-adl-v0-91-6-tasks-issue-4522-v0-91-6-review-docs-make-release-and-bridge-documents-consume-issue-truth-mechanically-before-closeout-sip-md-adl-v0-91-6-tasks-issue-4522-v0-91-6-review-docs-make-release-and-bridge-documents-consume-issue-truth-mechanically-before-closeout-sor-md