### PR TITLE
[v0.91.6][csdlc][readiness] Fail closed on bootstrap stub residue before issue execution

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -18,8 +18,8 @@ use super::pr_cmd_args::{
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
-    ensure_pre_run_bootstrap_cards, ensure_source_issue_prompt, ensure_symlink,
-    ensure_task_bundle_stp, ensure_worktree_task_bundle_materialized, field_line_value,
+    ensure_source_issue_prompt, ensure_symlink, ensure_task_bundle_stp,
+    ensure_worktree_task_bundle_materialized, field_line_value,
     mirror_docs_templates_into_worktree, mirror_scope_sprints_into_worktree, path_relative_to_repo,
     sync_root_task_bundle_into_worktree, validate_bootstrap_stp, validate_initialized_cards,
     validate_issue_body_for_create, validate_ready_cards, write_source_issue_prompt,
@@ -1340,7 +1340,6 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let root_stp = ensure_task_bundle_stp(&repo_root, &issue_ref, &source_path)?;
     validate_authored_prompt_surface("start", &root_stp, PromptSurfaceKind::Stp)?;
 
-    ensure_pre_run_bootstrap_cards(&repo_root, &issue_ref, &title, &source_path)?;
     doctor::ensure_pr_run_design_time_ready(&repo_root, &issue_ref, &branch)?;
     let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
 

--- a/adl/src/cli/pr_cmd/doctor/ready.rs
+++ b/adl/src/cli/pr_cmd/doctor/ready.rs
@@ -367,18 +367,6 @@ pub(super) fn ensure_pr_run_design_time_ready(
     let root_bundle_plan = issue_ref.task_bundle_plan_path(repo_root);
     let root_bundle_validation_plan = issue_ref.task_bundle_validation_plan_path(repo_root);
     let root_bundle_review_policy = issue_ref.task_bundle_review_policy_path(repo_root);
-    validate_initialized_cards(
-        issue_ref.issue_number(),
-        issue_ref.slug(),
-        &root_bundle_input,
-        &root_bundle_output,
-        repo_root,
-        StructuredBundlePaths {
-            plan_path: &root_bundle_plan,
-            validation_plan_path: &root_bundle_validation_plan,
-            review_policy_path: &root_bundle_review_policy,
-        },
-    )?;
     let lifecycle = build_doctor_card_lifecycle(
         repo_root,
         &root_bundle_input,
@@ -389,6 +377,18 @@ pub(super) fn ensure_pr_run_design_time_ready(
         &root_bundle_output,
     );
     if lifecycle.pr_run_readiness == "ready" {
+        validate_initialized_cards(
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            &root_bundle_input,
+            &root_bundle_output,
+            repo_root,
+            StructuredBundlePaths {
+                plan_path: &root_bundle_plan,
+                validation_plan_path: &root_bundle_validation_plan,
+                review_policy_path: &root_bundle_review_policy,
+            },
+        )?;
         return Ok(());
     }
 

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -591,6 +591,7 @@ pub(crate) fn ensure_bootstrap_cards(
     ensure_bootstrap_cards_with_mode(root, issue_ref, title, branch, source_path, true)
 }
 
+#[allow(dead_code)]
 pub(crate) fn ensure_pre_run_bootstrap_cards(
     root: &Path,
     issue_ref: &IssueRef,

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -768,6 +768,137 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 }
 
 #[test]
+fn real_pr_start_fails_closed_before_binding_when_required_cards_are_missing() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-fail-closed-missing-cards");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "missing cards gate\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-self");
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1452, "v0.86", "fail-closed-missing-cards").expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Fail closed when required cards are missing",
+    );
+    ensure_task_bundle_stp(&repo, &issue_ref, &issue_ref.issue_prompt_path(&repo)).expect("stp");
+    write_session_claim(
+        &repo,
+        1452,
+        "thread-self",
+        "codex/1452-fail-closed-missing-cards",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+
+    let err = real_pr(&[
+        "start".to_string(),
+        "1452".to_string(),
+        "--slug".to_string(),
+        "fail-closed-missing-cards".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Fail closed when required cards are missing".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("start should refuse to generate missing cards during execution binding");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
+
+    let err = err.to_string();
+    assert!(err.contains("design-time card completion gate failed"));
+    assert!(
+        !issue_ref.task_bundle_input_path(&repo).exists(),
+        "start should not backfill SIP during execution binding"
+    );
+    assert!(
+        !issue_ref.task_bundle_output_path(&repo).exists(),
+        "start should not backfill SOR during execution binding"
+    );
+    assert!(
+        !issue_ref.default_worktree_path(&repo, None).exists(),
+        "worktree binding should not begin when design-time cards are missing"
+    );
+}
+
+#[test]
 fn real_pr_start_requires_an_active_self_claim_before_binding_worktree() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-requires-self-claim");

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -212,19 +212,23 @@ fn real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready() {
         "design-time card gate should block before worktree creation"
     );
     let branch = "codex/1154-v0-86-tools-design-time-card-gate";
-    let root_sip = fs::read_to_string(issue_ref.task_bundle_input_path(&repo)).expect("read sip");
-    let root_sor = fs::read_to_string(issue_ref.task_bundle_output_path(&repo)).expect("read sor");
+    let root_sip_path = issue_ref.task_bundle_input_path(&repo);
+    let root_sor_path = issue_ref.task_bundle_output_path(&repo);
     let root_spp = fs::read_to_string(issue_ref.task_bundle_plan_path(&repo)).expect("read spp");
-    let root_srp =
-        fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo)).expect("read srp");
-    assert!(root_sip.contains("Branch: not bound yet"));
-    assert!(root_sor.contains("Branch: not bound yet"));
-    assert!(root_sor.contains("Status: NOT_STARTED"));
-    assert!(!root_sor.contains("Status: IN_PROGRESS"));
-    assert!(!root_sip.contains(&format!("Branch: {branch}")));
-    assert!(!root_sor.contains(&format!("Branch: {branch}")));
+    let root_srp_path = issue_ref.task_bundle_review_policy_path(&repo);
+    assert!(
+        !root_sip_path.exists(),
+        "start should not backfill SIP before the design-time gate passes"
+    );
+    assert!(
+        !root_sor_path.exists(),
+        "start should not backfill SOR before the design-time gate passes"
+    );
+    assert!(
+        !root_srp_path.exists(),
+        "start should not backfill SRP before the design-time gate passes"
+    );
     assert!(!root_spp.contains(&format!("branch: \"{branch}\"")));
-    assert!(!root_srp.contains(&format!("branch: \"{branch}\"")));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd_cards::ensure_pre_run_bootstrap_cards;
 use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 
 #[test]


### PR DESCRIPTION
Closes #4534

## Summary
Tightened `pr start` so it fails closed on non-ready design-time cards before root/worktree bootstrap and branch binding. Added focused regressions for missing required cards and aligned the older bootstrap guard test with the new pre-bootstrap gate.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/doctor/ready.rs`
- `adl/src/cli/pr_cmd_cards/cards.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- `adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs`
- `adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the tracked issue diff is free of whitespace and patch-shape errors.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_fails_closed_before_binding_when_required_cards_are_missing -- --nocapture`
    Verified `pr start` fails closed before binding/backfill when required design-time cards are missing.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready -- --nocapture`
    Verified `pr start` blocks before worktree creation and does not backfill bootstrap cards when the design-time gate fails.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the focused C-SDLC owner lane remained green after the readiness-path changes.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files adl/src/cli/pr_cmd.rs,adl/src/cli/pr_cmd/doctor/ready.rs,adl/src/cli/pr_cmd_cards/cards.rs,adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs,adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs,adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`
    Verified the focused `pr_cmd` nextest lane for the touched surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4534__fail-closed-on-bootstrap-stub-residue-before-issue-execution/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4534__fail-closed-on-bootstrap-stub-residue-before-issue-execution/sor.md
- Idempotency-Key: v0-91-6-csdlc-readiness-fail-closed-on-bootstrap-stub-residue-before-issue-execution-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-doctor-ready-rs-adl-src-cli-pr-cmd-cards-cards-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-src-cli-tests-pr-cmd-inline-repo-helpers-bootstrap-rs-adl-src-cli-tests-pr-cmd-inline-versioned-bootstrap-rs-adl-v0-91-6-tasks-issue-4534-fail-closed-on-bootstrap-stub-residue-before-issue-execution-sip-md-adl-v0-91-6-tasks-issue-4534-fail-closed-on-bootstrap-stub-residue-before-issue-execution-sor-md