### PR TITLE
[v0.91.6][tools][sessions] Make issue execution reuse the current Codex session identity without manual CODEX_SESSION_ID export (Closes #4537)

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1304,12 +1304,13 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     }
     let managed_root = std::env::var_os("ADL_WORKTREE_ROOT").map(PathBuf::from);
     let worktree_path = issue_ref.default_worktree_path(&repo_root, managed_root.as_deref());
+    let current_session_ids = adl::session_ledger::current_codex_session_ids();
     let session_assessment = load_target_claim_assessment(
         &repo_root,
         issue_ref.issue_number().into(),
         &branch,
         &worktree_path,
-        std::env::var("CODEX_SESSION_ID").ok().as_deref(),
+        &current_session_ids,
         chrono::Utc::now(),
     )?;
     emit_start_session_ledger_notes(&session_assessment);
@@ -1532,9 +1533,7 @@ fn suggested_session_claim_command(
     branch: &str,
     worktree_path: &Path,
 ) -> String {
-    let session_id = std::env::var("CODEX_SESSION_ID")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+    let session_id = adl::session_ledger::current_codex_session_id()
         .unwrap_or_else(|| "<session-id>".to_string());
     let worktree_ref = if worktree_path.is_absolute() {
         worktree_path

--- a/adl/src/cli/pr_cmd/doctor/preflight.rs
+++ b/adl/src/cli/pr_cmd/doctor/preflight.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use super::*;
-use adl::session_ledger::{load_target_claim_assessment, ClaimClassification, ClaimMode};
+use adl::session_ledger::{
+    current_codex_session_ids, load_target_claim_assessment, ClaimClassification, ClaimMode,
+};
 
 pub(super) fn run_doctor_preflight(
     repo_root: &Path,
@@ -29,6 +31,7 @@ pub(super) fn run_doctor_preflight(
         })
         .collect::<Vec<_>>();
     let card_run_readiness = preflight_card_run_readiness(repo_root, issue_ref);
+    let current_session_ids = current_codex_session_ids();
     let session_assessment = load_target_claim_assessment(
         repo_root,
         issue_ref.issue_number().into(),
@@ -39,7 +42,7 @@ pub(super) fn run_doctor_preflight(
                 .map(std::path::PathBuf::from)
                 .as_deref(),
         ),
-        std::env::var("CODEX_SESSION_ID").ok().as_deref(),
+        &current_session_ids,
         chrono::Utc::now(),
     )?;
     let session_ledger = DoctorSessionLedgerJson {

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -1014,6 +1014,142 @@ fn real_pr_start_requires_an_active_self_claim_before_binding_worktree() {
 }
 
 #[test]
+fn real_pr_start_accepts_codex_thread_id_as_self_claim_identity() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-codex-thread-id-self-claim");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    let home = temp.join("home");
+    fs::create_dir_all(&repo).expect("repo dir");
+    fs::create_dir_all(&home).expect("home dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("gitignore");
+    fs::write(repo.join("README.md"), "thread-id self claim\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    seed_codex_goal_transcript(&home, 1158, "thread-self", 5558, 44, 1782230400, 1782230444);
+    let old_home = env::var_os("HOME");
+    let old_session = env::var_os("CODEX_SESSION_ID");
+    let old_thread_id = env::var_os("CODEX_THREAD_ID");
+    unsafe {
+        env::set_var("HOME", &home);
+        env::remove_var("CODEX_SESSION_ID");
+        env::set_var("CODEX_THREAD_ID", "thread-self");
+    }
+
+    let issue_ref = IssueRef::new(1158, "v0.86", "thread-id-self-claim").expect("issue ref");
+    let branch = "codex/1158-thread-id-self-claim";
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Thread id self claim");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Thread id self claim",
+        branch,
+    );
+    write_session_claim(
+        &repo,
+        1158,
+        "thread-self",
+        branch,
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    real_pr(&[
+        "start".to_string(),
+        "1158".to_string(),
+        "--slug".to_string(),
+        "thread-id-self-claim".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Thread id self claim".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start with CODEX_THREAD_ID fallback");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    match old_home {
+        Some(value) => unsafe { env::set_var("HOME", value) },
+        None => unsafe { env::remove_var("HOME") },
+    }
+    match old_session {
+        Some(value) => unsafe { env::set_var("CODEX_SESSION_ID", value) },
+        None => unsafe { env::remove_var("CODEX_SESSION_ID") },
+    }
+    match old_thread_id {
+        Some(value) => unsafe { env::set_var("CODEX_THREAD_ID", value) },
+        None => unsafe { env::remove_var("CODEX_THREAD_ID") },
+    }
+
+    assert!(issue_ref.default_worktree_path(&repo, None).exists());
+}
+
+#[test]
 fn real_pr_start_blocks_when_another_session_claims_the_issue() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-session-ledger-conflict");

--- a/adl/src/session_ledger.rs
+++ b/adl/src/session_ledger.rs
@@ -618,7 +618,10 @@ pub fn load_target_claim_assessment(
         branch,
         worktree_path,
         current_session_id: current_session_ids.first().map(|value| value.as_str()),
-        current_session_aliases: current_session_ids.iter().map(|value| value.as_str()).collect(),
+        current_session_aliases: current_session_ids
+            .iter()
+            .map(|value| value.as_str())
+            .collect(),
         now,
     };
     Ok(assess_target_claims(&ledger, &ledger_path, &query))

--- a/adl/src/session_ledger.rs
+++ b/adl/src/session_ledger.rs
@@ -146,6 +146,7 @@ pub struct TargetClaimQuery<'a> {
     pub branch: &'a str,
     pub worktree_path: &'a Path,
     pub current_session_id: Option<&'a str>,
+    pub current_session_aliases: Vec<&'a str>,
     pub now: DateTime<Utc>,
 }
 
@@ -527,9 +528,9 @@ pub fn assess_target_claims(
                 matches_branch,
                 matches_worktree,
                 self_claim: query
-                    .current_session_id
-                    .map(|session_id| claim.session_id == session_id)
-                    .unwrap_or(false),
+                    .current_session_aliases
+                    .iter()
+                    .any(|session_id| claim.session_id == *session_id),
             })
         })
         .collect::<Vec<_>>();
@@ -606,7 +607,7 @@ pub fn load_target_claim_assessment(
     issue_number: u64,
     branch: &str,
     worktree_path: &Path,
-    current_session_id: Option<&str>,
+    current_session_ids: &[String],
     now: DateTime<Utc>,
 ) -> Result<TargetClaimAssessment> {
     let ledger_path = default_ledger_path(repo_root);
@@ -616,10 +617,30 @@ pub fn load_target_claim_assessment(
         issue_number,
         branch,
         worktree_path,
-        current_session_id,
+        current_session_id: current_session_ids.first().map(|value| value.as_str()),
+        current_session_aliases: current_session_ids.iter().map(|value| value.as_str()).collect(),
         now,
     };
     Ok(assess_target_claims(&ledger, &ledger_path, &query))
+}
+
+pub fn current_codex_session_ids() -> Vec<String> {
+    let mut ids = Vec::new();
+    if let Ok(value) = std::env::var("CODEX_SESSION_ID") {
+        if !value.trim().is_empty() {
+            ids.push(value);
+        }
+    }
+    if let Ok(value) = std::env::var("CODEX_THREAD_ID") {
+        if !value.trim().is_empty() && !ids.iter().any(|existing| existing == &value) {
+            ids.push(value);
+        }
+    }
+    ids
+}
+
+pub fn current_codex_session_id() -> Option<String> {
+    current_codex_session_ids().into_iter().next()
 }
 
 fn claim_status(claim: &OccupancyClaim, now: DateTime<Utc>) -> ClaimStatus {
@@ -865,6 +886,7 @@ mod tests {
             branch: "codex/4419-test",
             worktree_path: &repo_root.join(".worktrees/adl-wp-4419"),
             current_session_id: Some("thread-1"),
+            current_session_aliases: vec!["thread-1"],
             now: now(),
         };
 
@@ -890,6 +912,7 @@ mod tests {
             branch: "codex/4419-test",
             worktree_path: &repo_root.join(".worktrees/adl-wp-4419"),
             current_session_id: Some("thread-1"),
+            current_session_aliases: vec!["thread-1"],
             now: now(),
         };
 
@@ -917,6 +940,7 @@ mod tests {
             branch: "codex/4419-test",
             worktree_path: &repo_root.join(".worktrees/adl-wp-4419"),
             current_session_id: Some("thread-1"),
+            current_session_aliases: vec!["thread-1"],
             now: stale_time,
         };
 
@@ -947,6 +971,33 @@ mod tests {
             branch: "codex/4419-test",
             worktree_path: &repo_root.join(".worktrees/adl-wp-4419"),
             current_session_id: Some("thread-1"),
+            current_session_aliases: vec!["thread-1"],
+            now: now(),
+        };
+
+        let assessment = assess_target_claims(&ledger, &default_ledger_path(&repo_root), &query);
+
+        assert_eq!(assessment.status, "PASS");
+        assert_eq!(assessment.block_kind, "session_self_claim");
+        assert!(assessment.relevant_claims[0].self_claim);
+    }
+
+    #[test]
+    fn target_claim_assessment_treats_thread_and_session_ids_as_same_current_owner() {
+        let repo_root = PathBuf::from("/repo");
+        let mut ledger = SessionLedger::empty(now());
+        let mut mine = input(4419);
+        mine.session_id = "thread-1".to_string();
+        mine.branch = Some("codex/4419-test".to_string());
+        mine.worktree_path = Some(".worktrees/adl-wp-4419".to_string());
+        ledger.claim(mine, now()).expect("claim");
+        let query = TargetClaimQuery {
+            repo_root: &repo_root,
+            issue_number: 4419,
+            branch: "codex/4419-test",
+            worktree_path: &repo_root.join(".worktrees/adl-wp-4419"),
+            current_session_id: Some("session-1"),
+            current_session_aliases: vec!["session-1", "thread-1"],
             now: now(),
         };
 


### PR DESCRIPTION
Closes #4537

## Summary
Implemented the smallest truthful `#4537` fix so repo-native issue execution can reuse the current Codex session identity automatically in normal Codex.app use without requiring manual `CODEX_SESSION_ID` export. The issue-local change adds a shared current-session resolver that falls back from `CODEX_SESSION_ID` to `CODEX_THREAD_ID`, wires that resolver into the `pr run` and doctor session-ledger paths, adds a focused lifecycle regression test for the thread-id fallback, and updates the active session-ledger claim to the current Codex thread identity in the bound worktree.

## Artifacts
- Updated session-identity helper path in `adl/src/session_ledger.rs`
- Updated issue-execution binding path in `adl/src/cli/pr_cmd.rs`
- Updated doctor preflight session-identity lookup in `adl/src/cli/pr_cmd/doctor/preflight.rs`
- Added focused lifecycle regression coverage in `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- Updated issue-local review truth in `srp.md`
- Updated issue-local execution truth in this `sor.md`

## Validation
- Validation commands and their purpose:
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token ./adl/tools/pr.sh doctor 4537 --version v0.91.6 --json`
    Verified doctor preflight, card readiness, bound worktree identity, and active self-claim truth after the `#4537` session-identity fix.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_accepts_codex_thread_id_as_self_claim_identity -- --nocapture`
    Verified the focused lifecycle regression where `pr` execution accepts `CODEX_THREAD_ID` as the active self-claim identity when `CODEX_SESSION_ID` is absent.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4537__v0-91-6-tools-sessions-make-issue-execution-reuse-the-current-codex-session-identity-without-manual-codex-session-id-export/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4537__v0-91-6-tools-sessions-make-issue-execution-reuse-the-current-codex-session-identity-without-manual-codex-session-id-export/sor.md
- Idempotency-Key: v0-91-6-tools-sessions-make-issue-execution-reuse-the-current-codex-session-identity-without-manual-codex-session-id-export-closes-4537-adl-v0-91-6-tasks-issue-4537-v0-91-6-tools-sessions-make-issue-execution-reuse-the-current-codex-session-identity-without-manual-codex-session-id-export-sip-md-adl-v0-91-6-tasks-issue-4537-v0-91-6-tools-sessions-make-issue-execution-reuse-the-current-codex-session-identity-without-manual-codex-session-id-export-sor-md