### PR TITLE
[v0.91.6][csdlc][workflow] Add prep-scout lane for next-issue readiness during closeout waits

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -87,6 +87,24 @@ The normal workflow is:
    - default tracked implementation goals stay active until their declared terminal boundary is satisfied
    - handoff-only completion is reserved for goals that explicitly declare that narrower boundary
 
+Closeout-wait prep lane:
+
+- while one issue is in `pr_waiting`, `janitor_active`, or
+  `merged_needs_closeout`, a separate prep-scout lane may inspect and classify
+  the next issue from clean root `main`
+- this is a preparation-only lane routed through `workflow-conductor`, not a
+  second execution lane
+- the lane may use repo-native issue inspection and readiness commands, but it
+  must stop before `pr run`, implementation binding, or PR publication
+- if preparation would require mutation and no first-class prep-only repo-native
+  surface exists, record `needs_operator` or a tooling gap instead of
+  normalizing a manual fallback
+
+See:
+
+- `docs/tooling/PREP_SCOUT_NEXT_ISSUE_READINESS_LANE.md`
+- `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`
+
 The first-class issue-lifecycle shepherd contract above those phases lives at:
 
 - `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -211,6 +211,29 @@ The helper validates that the discovered goal objective matches the target
 issue number and falls back to `unknown` instead of attaching a snapshot from a
 different issue or sprint thread.
 
+## 4.5) Prep-Scout Lane During Closeout Waits
+
+When the active issue is waiting on PR checks, review, janitor work, or
+closeout, a separate prep-scout lane may prepare the next issue without
+starting implementation early.
+
+Use the prep-scout lane only from clean root `main` and keep it preparation-only:
+
+- allowed: `workflow-conductor`, repo-native issue list/view/search, session
+  collision inspection, and `pr.sh doctor --mode ready --json` for already
+  bootstrapped candidate issues
+- prohibited: `pr run`, implementation binding, tracked product/tooling/docs
+  edits for the candidate issue, PR publication, or raw `gh`
+
+Current repo-native tooling supports read-only scouting and truthful handoff
+classification. It does not yet provide a first-class prep-only mutation/bind
+surface, so prep-time card or metadata mutation should be routed as
+`needs_operator` rather than normalized through manual fallback.
+
+Reference:
+
+- `docs/tooling/PREP_SCOUT_NEXT_ISSUE_READINESS_LANE.md`
+
 ## 5) Implement
 
 Read the active issue cards, stay inside the issue edit fence, and make the tracked repo changes.

--- a/docs/templates/sprints/1.0.0/sprint_execution_packet.md
+++ b/docs/templates/sprints/1.0.0/sprint_execution_packet.md
@@ -112,6 +112,18 @@ Allowed `classification` values:
 - `speculative_risky`
 - `blocked_until_dependency`
 
+## Prep-Scout / Next-Issue Readiness
+
+- Candidate issue queue: `{{prep_scout_candidate_queue}}`
+- Current wait-state owner: `{{prep_scout_current_wait_owner}}`
+- Scout owner or watcher: `{{prep_scout_owner}}`
+- Lane posture: `{{prep_scout_lane_posture}}`
+- Promotion rule: `{{prep_scout_promotion_rule}}`
+- Current tooling boundary: `{{prep_scout_tooling_boundary}}`
+- Handoff contract: prep scouting must end in `ready`, `blocked`, `collision`,
+  or `needs_operator`, and must include the exact next lifecycle command when
+  the candidate is `ready`.
+
 ## Serial Gates
 
 | Gate | Blocks | Exit condition | Owner |

--- a/docs/tooling/PREP_SCOUT_NEXT_ISSUE_READINESS_LANE.md
+++ b/docs/tooling/PREP_SCOUT_NEXT_ISSUE_READINESS_LANE.md
@@ -1,0 +1,155 @@
+# Prep-Scout Next-Issue Readiness Lane
+
+## Purpose
+
+The prep-scout lane exists so one session can prepare the next issue while the
+current issue is in PR wait, review wait, CI wait, janitor wait, or
+merge-needs-closeout wait.
+
+The lane is preparation-only. It reduces cold-start time for the next issue,
+but it does not start implementation early.
+
+## When To Use It
+
+Use the lane when all of the following are true:
+
+- the current issue is already in a truthful wait state such as
+  `pr_waiting`, `janitor_active`, or `merged_needs_closeout`
+- the operator wants the next issue prepared without widening the current
+  closeout lane
+- the primary checkout is clean on `main`
+- the next issue is a concrete candidate rather than a vague backlog browse
+
+Do not use the lane when:
+
+- the current issue still needs implementation work
+- the next issue has already been bound for execution by another session
+- the operator is really asking to begin the next issue, not just prepare it
+
+## Allowed Surfaces
+
+The prep scout may use:
+
+- `workflow-conductor` for routing truth
+- repo-native `bash adl/tools/pr.sh issue list|view|search`
+- repo-native `bash adl/tools/pr.sh doctor <issue> --mode ready --json`
+- root-checkout inspection commands while the root checkout remains clean on
+  `main`
+- issue/task-bundle reads for the candidate issue
+- session-ledger reads to detect collisions
+
+The prep scout may also note that a candidate would need:
+
+- `pr init` because the task bundle is missing
+- card-editor repair because readiness defects are present
+- operator judgment because candidate choice or dependency truth is ambiguous
+
+## Prohibited Actions
+
+The prep scout must not:
+
+- run `pr run` for the candidate issue
+- bind or create an implementation worktree for the candidate issue
+- start product, tooling, docs, or test implementation for the candidate issue
+- publish or update a PR for the candidate issue
+- hide a tooling limitation behind manual git surgery or raw `gh`
+
+## Current Tooling Boundary
+
+Current repo-native tooling cleanly supports read-only scouting and readiness
+classification.
+
+Current repo-native tooling does not yet provide a first-class prep-only bind
+surface for card repair that preserves:
+
+- clean-root `main` discipline
+- no-implementation-start semantics
+- no-hidden-manual-worktree fallback
+
+Because that surface is missing, a prep scout should treat prep-time mutation as
+`needs_operator` unless the operator explicitly promotes the candidate into the
+normal execution path.
+
+## Standard Flow
+
+1. Confirm the current issue is in a wait-capable state.
+2. Confirm `git status --short --branch` is clean on root `main`.
+3. Use `workflow-conductor` to route the current issue and preserve the waiting
+   lane truth separately from the prep lane.
+4. Inspect candidate issues with repo-native issue commands.
+5. Check for collision evidence in the shared session ledger and existing
+   worktree/PR state.
+6. Run `pr.sh doctor --mode ready --json` for the candidate when a task bundle
+   already exists.
+7. Emit one bounded handoff result and stop.
+
+## Handoff States
+
+Use one of these terminal handoff states:
+
+- `ready`
+  - The candidate is structurally ready for normal execution.
+  - Include the exact next command, normally
+    `bash adl/tools/pr.sh run <issue>`.
+- `blocked`
+  - The candidate is not executable yet because readiness defects or hard
+    dependencies are present.
+  - Include the blocking evidence and the next repair route.
+- `collision`
+  - Another session, worktree, branch, or PR state already owns the candidate.
+  - Include the owning evidence and the do-not-touch route.
+- `needs_operator`
+  - More than one candidate is plausible, or prep would require mutation that
+    current repo-native tooling cannot express safely as preparation-only work.
+
+## Suggested Handoff Shape
+
+```yaml
+prep_scout_handoff:
+  candidate_issue: 0
+  state: ready | blocked | collision | needs_operator
+  current_issue_wait_state: pr_waiting | janitor_active | merged_needs_closeout
+  evidence:
+    - "repo-native issue view/list result"
+    - "doctor/readiness result"
+    - "session-ledger or worktree collision result"
+  next_command: "bash adl/tools/pr.sh run <issue>"
+  notes:
+    - "record any tooling gap explicitly"
+```
+
+## Observed Proof Examples
+
+This issue proved the handoff contract against live repo-native readiness
+surfaces without starting implementation for the candidate issues:
+
+- `#4438` -> `collision`
+  - another session already owns the active claim and bound worktree, so the
+    prep scout must stop instead of duplicating ownership
+- `#4534` -> `blocked`
+  - stale session-claim residue requires manual inspection before execution can
+    resume truthfully
+- `#4530` -> `ready`
+  - the issue is structurally ready for normal execution; the next step is the
+    standard session claim plus `bash adl/tools/pr.sh run 4530`, not early
+    implementation from the prep lane
+
+These examples are intentionally workflow-level proof only. They do not claim
+merge, closeout, or autonomous issue execution.
+
+## Sprint Execution Packet Integration
+
+When a sprint or mini-sprint expects closeout-wait compression, its Sprint
+Execution Packet should name:
+
+- the candidate next-issue queue
+- whether the prep lane is read-only or blocked pending tooling support
+- the owner or watcher responsible for the prep handoff
+- the promotion rule from prep to normal `pr run`
+
+## Non-Claims
+
+- This lane is not autonomous issue execution.
+- This lane does not weaken issue-start gates from `#4435`.
+- This lane does not authorize tracked work on `main`.
+- This lane does not claim a prep-only mutation surface already exists.

--- a/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
+++ b/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
@@ -35,6 +35,8 @@ Allowed primary-checkout uses:
 - read-only inspection
 - issue creation/bootstrap
 - `pr ready` / `pr doctor`
+- prep-scout issue inspection/readiness checks for a separate next-issue lane
+  while the current issue is in a truthful wait state
 - issue-mode `pr run` binding when `main` is clean
 - fast-forwarding `main`
 - checking root/worktree state before routing
@@ -57,6 +59,16 @@ the primary checkout for the same issue, stop and repair the mismatch instead
 of guessing which copy is right. Root-only `.adl` state remains bootstrap,
 coordination, and sprint-truth context rather than a hidden per-issue live
 authority during execution.
+
+Prep-scout exception:
+
+- a prep scout may use the root checkout for read-only next-issue inspection
+  and readiness classification while another issue is waiting
+- the prep scout must not convert that root-checkout preparation pass into
+  tracked implementation or hidden candidate-issue mutation on `main`
+- if a candidate would require mutation before it can be called ready and there
+  is no proven prep-only repo-native bind surface, stop as `needs_operator` and
+  record the tooling gap instead of improvising a manual fallback
 
 ## Required Startup Check
 
@@ -183,6 +195,12 @@ When another session appears to own an issue or worktree:
    repo-native worktree evidence first. Use manual preservation only as a
    bounded fallback to move the work into an issue worktree before restoring
    root to clean `main`.
+
+Prep-scout-specific collision rule:
+
+- if the candidate issue already has an active session claim, open PR, or bound
+  worktree owned by another session, classify the handoff as `collision`
+  instead of beginning duplicate preparation
 
 ## Tooling Failure Handling
 


### PR DESCRIPTION
Closes #4535

## Summary
Implemented the prep-scout lane as a bounded workflow-doc and template update,
captured the missing planning references under `.adl/docs/TBD/workflow_tooling/`,
and proved the handoff model with repo-native readiness checks on real open
issues without starting implementation for those candidate issues.

## Artifacts
- `docs/tooling/PREP_SCOUT_NEXT_ISSUE_READINESS_LANE.md`
- `docs/default_workflow.md`
- `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `docs/templates/sprints/1.0.0/sprint_execution_packet.md`
- `.adl/docs/TBD/workflow_tooling/planning/SPRINT_CYCLE_TIME_REDUCTION_PLAN.md`
- `.adl/docs/TBD/workflow_tooling/PARALLEL_EXECUTION_LANES_AND_COMPRESSION_MODEL.md`
- `.adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/artifacts/goal_metrics/issue-4535-goal-metrics-summary.json`
- `.adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/artifacts/goal_metrics/issue-4535-goal-metrics.jsonl`
- `.adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/artifacts/goal_metrics/issue-4535-goal-state.json`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the touched workflow docs, template, and planning paths have a clean patch shape with no whitespace or context corruption.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh issue list --state open --limit 12 --json`
    Verified the prep scout can use repo-native issue discovery from clean root `main` without raw `gh`.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh doctor 4438 --mode ready --json`
    Verified a truthful `collision` handoff when another session already owns the candidate issue/worktree.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh doctor 4534 --mode ready --json`
    Verified a truthful `blocked` handoff when stale session claims require manual inspection.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh doctor 4530 --mode ready --json`
    Verified a structurally ready candidate whose next execution step is the normal session-claim plus `pr run` handoff rather than early implementation from the prep lane.
  - `python3 adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py --issue-number 4535 --artifacts-dir .adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/artifacts/goal_metrics --capture-stage issue_start --issue-goal-ref "goal:v0.91.6:issue:4535" --thread-id 019eec0d-bd4d-7160-b553-f1f1270a722e`
    Recorded a durable issue-goal metrics snapshot for time/token accounting.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4535__v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits/sor.md
- Idempotency-Key: v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits-docs-tooling-prep-scout-next-issue-readiness-lane-md-docs-default-workflow-md-docs-tooling-session-coordination-and-root-checkout-policy-md-adl-tools-skills-docs-operational-skills-guide-md-docs-templates-sprints-1-0-0-sprint-execution-packet-md-adl-v0-91-6-tasks-issue-4535-v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits-sip-md-adl-v0-91-6-tasks-issue-4535-v0-91-6-csdlc-workflow-add-prep-scout-lane-for-next-issue-readiness-during-closeout-waits-sor-md