### PR TITLE
[v0.91.6][tools][validation] Distinguish green draft PRs from pending checks in repo-native validation

### DIFF
--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -1,64 +1,146 @@
 use super::*;
 use crate::cli::pr_cmd::github::transport::pr_validation_report_from_snapshot_with_disposition;
+use crate::cli::pr_cmd::github::transport::pr_validation_wait_disposition_is_terminal;
 
 #[test]
 fn pr_validation_wait_classifies_pending_failed_successful_and_skipped_states() {
-    let snapshot = |checks: Vec<PrValidationCheckSnapshot>| PrValidationSnapshot {
+    let snapshot = |is_draft: bool, checks: Vec<PrValidationCheckSnapshot>| PrValidationSnapshot {
         pr_number: 1159,
         commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
         state: "OPEN".to_string(),
-        is_draft: false,
+        is_draft,
         checks,
     };
 
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(vec![PrValidationCheckSnapshot {
-            name: "adl-ci".to_string(),
-            status: "IN_PROGRESS".to_string(),
-            conclusion: "UNKNOWN".to_string(),
-            job_run_id: "8801".to_string(),
-        }])),
+        classify_pr_validation_snapshot(&snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8801".to_string(),
+            }]
+        )),
         PrValidationDisposition::Pending
     );
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(vec![PrValidationCheckSnapshot {
-            name: "adl-ci".to_string(),
-            status: "COMPLETED".to_string(),
-            conclusion: "FAILURE".to_string(),
-            job_run_id: "8801".to_string(),
-        }])),
+        classify_pr_validation_snapshot(&snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "FAILURE".to_string(),
+                job_run_id: "8801".to_string(),
+            }]
+        )),
         PrValidationDisposition::Failed
     );
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(vec![PrValidationCheckSnapshot {
-            name: "adl-ci".to_string(),
-            status: "COMPLETED".to_string(),
-            conclusion: "SUCCESS".to_string(),
-            job_run_id: "8801".to_string(),
-        }])),
+        classify_pr_validation_snapshot(&snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "8801".to_string(),
+            }]
+        )),
         PrValidationDisposition::Success
     );
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(Vec::new())),
+        classify_pr_validation_snapshot(&snapshot(false, Vec::new())),
         PrValidationDisposition::Pending
     );
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(vec![PrValidationCheckSnapshot {
-            name: "optional-lane".to_string(),
-            status: "COMPLETED".to_string(),
-            conclusion: "SKIPPED".to_string(),
-            job_run_id: "8803".to_string(),
-        }])),
+        classify_pr_validation_snapshot(&snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "optional-lane".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SKIPPED".to_string(),
+                job_run_id: "8803".to_string(),
+            }]
+        )),
         PrValidationDisposition::Skipped
     );
     assert_eq!(
-        classify_pr_validation_snapshot(&snapshot(vec![PrValidationCheckSnapshot {
-            name: "adl-ci".to_string(),
-            status: "COMPLETED".to_string(),
-            conclusion: "CANCELLED".to_string(),
-            job_run_id: "8801".to_string(),
-        }])),
+        classify_pr_validation_snapshot(&snapshot(
+            false,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "CANCELLED".to_string(),
+                job_run_id: "8801".to_string(),
+            }]
+        )),
         PrValidationDisposition::Cancelled
+    );
+    assert_eq!(
+        classify_pr_validation_snapshot(&snapshot(
+            true,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "SUCCESS".to_string(),
+                job_run_id: "8805".to_string(),
+            }]
+        )),
+        PrValidationDisposition::Success
+    );
+    assert_eq!(
+        classify_pr_validation_snapshot(&snapshot(
+            true,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8806".to_string(),
+            }]
+        )),
+        PrValidationDisposition::Pending
+    );
+    assert_eq!(
+        classify_pr_validation_snapshot(&snapshot(
+            true,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "FAILURE".to_string(),
+                job_run_id: "8807".to_string(),
+            }]
+        )),
+        PrValidationDisposition::Failed
+    );
+    assert!(
+        !pr_validation_wait_disposition_is_terminal(
+            &snapshot(
+                true,
+                vec![PrValidationCheckSnapshot {
+                    name: "adl-ci".to_string(),
+                    status: "COMPLETED".to_string(),
+                    conclusion: "SUCCESS".to_string(),
+                    job_run_id: "8808".to_string(),
+                }]
+            ),
+            PrValidationDisposition::Success,
+        ),
+        "green draft PRs must stay non-terminal for validation wait paths"
+    );
+    assert!(
+        pr_validation_wait_disposition_is_terminal(
+            &snapshot(
+                false,
+                vec![PrValidationCheckSnapshot {
+                    name: "adl-ci".to_string(),
+                    status: "COMPLETED".to_string(),
+                    conclusion: "SUCCESS".to_string(),
+                    job_run_id: "8809".to_string(),
+                }]
+            ),
+            PrValidationDisposition::Success,
+        ),
+        "ready PRs with green checks should stay terminal"
     );
 
     let merged_success = PrValidationSnapshot {
@@ -69,7 +151,7 @@ fn pr_validation_wait_classifies_pending_failed_successful_and_skipped_states() 
             conclusion: "SUCCESS".to_string(),
             job_run_id: "8804".to_string(),
         }],
-        ..snapshot(Vec::new())
+        ..snapshot(false, Vec::new())
     };
     assert_eq!(
         classify_pr_validation_snapshot(&merged_success),
@@ -116,8 +198,9 @@ fn pr_validation_report_exposes_projection_status_for_pr_lifecycle_states() {
 
     let green_draft = pr_validation_report_from_snapshot_with_disposition(
         &snapshot(true, vec![completed("SUCCESS")]),
-        PrValidationDisposition::Success,
+        classify_pr_validation_snapshot(&snapshot(true, vec![completed("SUCCESS")])),
     );
+    assert_eq!(green_draft.disposition, "success");
     assert_eq!(green_draft.projection_status, "checks_green_but_draft");
 
     let green_ready = pr_validation_report_from_snapshot_with_disposition(
@@ -125,6 +208,29 @@ fn pr_validation_report_exposes_projection_status_for_pr_lifecycle_states() {
         PrValidationDisposition::Success,
     );
     assert_eq!(green_ready.projection_status, "ready_to_merge_or_review");
+
+    let pending_draft = pr_validation_report_from_snapshot_with_disposition(
+        &snapshot(
+            true,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8802".to_string(),
+            }],
+        ),
+        classify_pr_validation_snapshot(&snapshot(
+            true,
+            vec![PrValidationCheckSnapshot {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8802".to_string(),
+            }],
+        )),
+    );
+    assert_eq!(pending_draft.disposition, "pending");
+    assert_eq!(pending_draft.projection_status, "checks_pending");
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -668,10 +668,11 @@ pub(super) fn wait_for_pr_validation_report(
         poll_count += 1;
         let snapshot = pr_validation_status_octocrab(repo, pr_ref)?;
         let disposition = classify_pr_validation_snapshot(&snapshot);
-        let next_delay = if disposition == PrValidationDisposition::Pending {
-            poll_delay
-        } else {
+        let wait_terminal = pr_validation_wait_disposition_is_terminal(&snapshot, disposition);
+        let next_delay = if wait_terminal {
             Duration::ZERO
+        } else {
+            poll_delay
         };
         emit_pr_validation_wait_snapshot(&snapshot, disposition, started, poll_count, next_delay);
         capture_pr_validation_wait_anomaly_best_effort(
@@ -682,35 +683,28 @@ pub(super) fn wait_for_pr_validation_report(
             poll_count,
         );
 
-        match disposition {
-            PrValidationDisposition::Success
-            | PrValidationDisposition::Skipped
-            | PrValidationDisposition::Failed
-            | PrValidationDisposition::Cancelled
-            | PrValidationDisposition::TimedOut => {
-                return Ok(pr_validation_report_from_snapshot_with_disposition(
-                    &snapshot,
-                    disposition,
-                ))
-            }
-            PrValidationDisposition::Pending => {
-                if started.elapsed() >= timeout {
-                    emit_pr_validation_wait_timeout(&snapshot, started, poll_count, Duration::ZERO);
-                    capture_pr_validation_wait_anomaly_best_effort(
-                        repo,
-                        &snapshot,
-                        PrValidationDisposition::TimedOut,
-                        started,
-                        poll_count,
-                    );
-                    return Ok(pr_validation_report_from_snapshot_with_disposition(
-                        &snapshot,
-                        PrValidationDisposition::TimedOut,
-                    ));
-                }
-                std::thread::sleep(poll_delay);
-            }
+        if wait_terminal {
+            return Ok(pr_validation_report_from_snapshot_with_disposition(
+                &snapshot,
+                disposition,
+            ));
         }
+
+        if started.elapsed() >= timeout {
+            emit_pr_validation_wait_timeout(&snapshot, started, poll_count, Duration::ZERO);
+            capture_pr_validation_wait_anomaly_best_effort(
+                repo,
+                &snapshot,
+                PrValidationDisposition::TimedOut,
+                started,
+                poll_count,
+            );
+            return Ok(pr_validation_report_from_snapshot_with_disposition(
+                &snapshot,
+                PrValidationDisposition::TimedOut,
+            ));
+        }
+        std::thread::sleep(poll_delay);
     }
 }
 
@@ -1221,9 +1215,6 @@ pub(super) fn classify_pr_validation_snapshot(
     if snapshot.state == "CLOSED" {
         return PrValidationDisposition::Cancelled;
     }
-    if snapshot.is_draft {
-        return PrValidationDisposition::Pending;
-    }
     if snapshot.checks.is_empty() {
         return PrValidationDisposition::Pending;
     }
@@ -1253,6 +1244,19 @@ pub(super) fn classify_pr_validation_snapshot(
         return PrValidationDisposition::Skipped;
     }
     PrValidationDisposition::Success
+}
+
+pub(super) fn pr_validation_wait_disposition_is_terminal(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+) -> bool {
+    match disposition {
+        PrValidationDisposition::Pending => false,
+        PrValidationDisposition::Success | PrValidationDisposition::Skipped => !snapshot.is_draft,
+        PrValidationDisposition::Failed
+        | PrValidationDisposition::Cancelled
+        | PrValidationDisposition::TimedOut => true,
+    }
 }
 
 fn effective_pr_validation_checks(


### PR DESCRIPTION
Closes #4530

## Summary
Implemented the bounded `#4530` validation-classifier fix so repo-native PR
validation distinguishes draft lifecycle state from actual check outcomes.
Green draft PRs now keep a `success` disposition and project as
`checks_green_but_draft`, while pending and failing checks still classify
truthfully from the latest logical check state.

## Artifacts
- Updated local ignored output record at `.adl/v0.91.6/tasks/issue-4530__v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/github/transport.rs`
  - `adl/src/cli/pr_cmd/github/tests/validation.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_classification_uses_latest_logical_check_state -- --nocapture`
    Verified the classifier keeps using the latest logical check state after removing the draft short-circuit.
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_wait_classifies_pending_failed_successful_and_skipped_states -- --nocapture`
    Verified the focused classification coverage, including draft-success, draft-pending, and draft-failure expectations.
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_report_exposes_projection_status_for_pr_lifecycle_states -- --nocapture`
    Verified projection-status reporting stays truthful for green draft, green ready, and pending draft surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4530__v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4530__v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation/sor.md
- Idempotency-Key: v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-validation-rs-adl-v0-91-6-tasks-issue-4530-v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation-sip-md-adl-v0-91-6-tasks-issue-4530-v0-91-6-tools-validation-distinguish-green-draft-prs-from-pending-checks-in-repo-native-validation-sor-md