### PR TITLE
[v0.91.6][tools][goals] Allow nested fresh-issue goal accounting during operational proof and sprint execution

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1365,6 +1365,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         &worktree_source,
     )?;
     ensure_worktree_task_bundle_materialized(&worktree_path, &issue_ref)?;
+    record_bound_execution_goal_metrics_stage(&repo_root, &issue_ref, "issue_start")?;
 
     println!("• Agent:");
     println!("  STP    {}", worktree_stp.display());
@@ -1438,6 +1439,25 @@ pub(super) fn record_readiness_prep_goal_metrics_stage(
     issue_ref: &IssueRef,
     capture_stage: &str,
 ) -> Result<()> {
+    record_issue_goal_metrics_stage(repo_root, issue_ref, capture_stage)
+        .with_context(|| format!("failed to record readiness-prep metrics stage '{capture_stage}'"))
+}
+
+pub(super) fn record_bound_execution_goal_metrics_stage(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    capture_stage: &str,
+) -> Result<()> {
+    record_issue_goal_metrics_stage(repo_root, issue_ref, capture_stage).with_context(|| {
+        format!("failed to record bound-execution metrics stage '{capture_stage}'")
+    })
+}
+
+fn record_issue_goal_metrics_stage(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    capture_stage: &str,
+) -> Result<()> {
     let script_path = repo_root.join(
         "adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py",
     );
@@ -1468,10 +1488,10 @@ pub(super) fn record_readiness_prep_goal_metrics_stage(
         issue_goal_ref.as_str(),
         "--metrics-confidence",
         "high",
+        "--fallback-data-source",
+        "derived_sprint_state",
     ];
-    run_capture("python3", &args).with_context(|| {
-        format!("failed to record readiness-prep metrics stage '{capture_stage}'")
-    })?;
+    run_capture("python3", &args)?;
     Ok(())
 }
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4499,6 +4499,13 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_sprint_conductor_helpers.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
+                "bash adl/tools/test_sprint_conductor_helpers.sh && bash adl/tools/test_install_adl_operational_skills.sh" => {
+                    let sprint_helpers = repo_root.join("adl/tools/test_sprint_conductor_helpers.sh");
+                    let install_helpers =
+                        repo_root.join("adl/tools/test_install_adl_operational_skills.sh");
+                    run_finish_validation_status("bash", &[path_str(&sprint_helpers)?])?;
+                    run_finish_validation_status("bash", &[path_str(&install_helpers)?])?;
+                }
                 other => bail!("finish: unsupported focused validation command '{other}'"),
             }
         }

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -261,15 +261,22 @@ fn init_doctor_and_start_record_readiness_prep_goal_metric_stages() {
             "card_repair",
             "doctor_readiness",
             "execution_ready",
-            "issue_init"
+            "issue_init",
+            "issue_start"
         ])
     );
     assert_eq!(
         summary["segments_recorded"],
-        serde_json::json!(["readiness_prep"])
+        serde_json::json!(["bound_execution", "readiness_prep"])
     );
-    assert_eq!(summary["selected_stage"], "execution_ready");
-    assert_eq!(summary["selected_segment"], "readiness_prep");
+    assert_eq!(summary["selected_stage"], "issue_start");
+    assert_eq!(summary["selected_segment"], "bound_execution");
+    assert_eq!(summary["data_source"], "derived_sprint_state");
+    assert_eq!(summary["elapsed_availability"], "unknown");
+    assert_eq!(summary["active_work_availability"], "unknown");
+    assert_eq!(summary["token_usage"]["total_availability"], "unknown");
+    assert_eq!(summary["thread_id"], "thread-1154-prep");
+    assert_eq!(summary["session_ref"], "codex-thread:thread-1154-prep");
 }
 
 #[test]
@@ -486,6 +493,188 @@ fn real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage() {
     );
     assert_eq!(summary["selected_stage"], "doctor_readiness");
     assert_eq!(summary["selected_segment"], "readiness_prep");
+}
+
+#[test]
+fn real_pr_start_uses_derived_issue_start_when_thread_goal_targets_other_issue() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-derived-issue-start");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    let home = temp.join("home");
+    fs::create_dir_all(&repo).expect("repo dir");
+    fs::create_dir_all(&home).expect("home dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("gitignore");
+    fs::write(repo.join("README.md"), "derived issue start\n").expect("readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    seed_codex_goal_transcript(
+        &home,
+        9999,
+        "thread-1156-derived",
+        7777,
+        99,
+        1782230400,
+        1782230499,
+    );
+    let old_home = env::var_os("HOME");
+    let old_env_session = env::var_os("CODEX_SESSION_ID");
+    let old_thread_id = env::var_os("CODEX_THREAD_ID");
+    unsafe {
+        env::set_var("HOME", &home);
+        env::set_var("CODEX_THREAD_ID", "thread-1156-derived");
+    }
+
+    let issue_ref = IssueRef::new(1156, "v0.86", "derived-issue-start").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Derived issue start");
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    real_pr(&[
+        "init".to_string(),
+        "1156".to_string(),
+        "--slug".to_string(),
+        "derived-issue-start".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Derived issue start".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Derived issue start",
+        "not bound yet",
+    );
+    write_session_claim(
+        &repo,
+        1156,
+        "thread-1156-derived",
+        "codex/1156-derived-issue-start",
+        &issue_ref.default_worktree_path(&repo, None),
+    );
+    unsafe {
+        env::set_var("CODEX_SESSION_ID", "thread-1156-derived");
+    }
+
+    real_pr(&[
+        "start".to_string(),
+        "1156".to_string(),
+        "--slug".to_string(),
+        "derived-issue-start".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Derived issue start".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        match old_home {
+            Some(value) => env::set_var("HOME", value),
+            None => env::remove_var("HOME"),
+        }
+        match old_env_session {
+            Some(value) => env::set_var("CODEX_SESSION_ID", value),
+            None => env::remove_var("CODEX_SESSION_ID"),
+        }
+        match old_thread_id {
+            Some(value) => env::set_var("CODEX_THREAD_ID", value),
+            None => env::remove_var("CODEX_THREAD_ID"),
+        }
+    }
+
+    let summary_path = issue_ref
+        .task_bundle_dir_path(&repo)
+        .join("artifacts/goal_metrics/issue-1156-goal-metrics-summary.json");
+    let summary: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(summary_path).expect("read goal summary"))
+            .expect("parse goal summary");
+    assert_eq!(
+        summary["phases_recorded"],
+        serde_json::json!(["execution_ready", "issue_init", "issue_start"])
+    );
+    assert_eq!(
+        summary["segments_recorded"],
+        serde_json::json!(["bound_execution", "readiness_prep"])
+    );
+    assert_eq!(summary["selected_stage"], "issue_start");
+    assert_eq!(summary["selected_segment"], "bound_execution");
+    assert_eq!(summary["data_source"], "derived_sprint_state");
+    assert_eq!(summary["elapsed_availability"], "unknown");
+    assert_eq!(summary["active_work_availability"], "unknown");
+    assert_eq!(summary["token_usage"]["total_availability"], "unknown");
+    assert_eq!(summary["thread_id"], "thread-1156-derived");
+    assert_eq!(summary["session_ref"], "codex-thread:thread-1156-derived");
 }
 
 #[test]

--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from issue_goal_metrics import (
+    build_issue_goal_metrics_record,
     build_issue_goal_metrics_record_from_codex_goal_snapshot,
     build_unknown_issue_goal_metrics_record,
     find_codex_session_transcript,
+    iso_now_utc,
     load_codex_goal_payload_from_session_transcript,
     summarize_issue_goal_metrics,
     validate_terminal_completion_allowed,
@@ -45,6 +47,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--thread-id", default=os.environ.get("CODEX_THREAD_ID"))
     parser.add_argument("--session-root", default=os.path.expanduser("~/.codex/sessions"))
     parser.add_argument("--transcript-path")
+    parser.add_argument("--fallback-data-source", choices=["unknown", "derived_sprint_state"])
     return parser.parse_args()
 
 
@@ -65,21 +68,28 @@ def main() -> int:
     artifacts_dir = Path(args.artifacts_dir)
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    transcript_path = args.transcript_path
-    if transcript_path is None:
-        transcript_path = find_codex_session_transcript(
-            args.thread_id,
-            args.session_root,
-            issue_number=args.issue_number,
-        )
+    use_derived_issue_start = (
+        args.capture_stage == "issue_start"
+        and args.fallback_data_source == "derived_sprint_state"
+    )
 
+    transcript_path = None
     goal_payload = None
-    if transcript_path is not None:
-        goal_payload = load_codex_goal_payload_from_session_transcript(
-            transcript_path,
-            thread_id=args.thread_id,
-            issue_number=args.issue_number,
-        )
+    if not use_derived_issue_start:
+        transcript_path = args.transcript_path
+        if transcript_path is None:
+            transcript_path = find_codex_session_transcript(
+                args.thread_id,
+                args.session_root,
+                issue_number=args.issue_number,
+            )
+
+        if transcript_path is not None:
+            goal_payload = load_codex_goal_payload_from_session_transcript(
+                transcript_path,
+                thread_id=args.thread_id,
+                issue_number=args.issue_number,
+            )
 
     raw_log_path = transcript_path or args.session_root
     if goal_payload is not None:
@@ -116,29 +126,73 @@ def main() -> int:
         finally:
             os.unlink(temp_snapshot_path)
     else:
-        record = build_unknown_issue_goal_metrics_record(
-            issue_number=args.issue_number,
-            capture_stage=args.capture_stage,
-            raw_log_path=raw_log_path,
-            issue_goal_ref=args.issue_goal_ref,
-            sprint_goal_ref=args.sprint_goal_ref,
-            goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
-            metrics_confidence=args.metrics_confidence,
-            completion_state=args.completion_state_override or "unknown",
-            model_ref=args.model_ref,
-            session_ref=args.session_ref,
-            thread_id=args.thread_id,
-            goal_kind=args.goal_kind,
-            goal_boundary=args.goal_boundary,
-            issue_state=args.issue_state,
-            pr_state=args.pr_state,
-            checks_state=args.checks_state,
-            review_truth=args.review_truth,
-            closeout_truth=args.closeout_truth,
-            merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
-            watch_target_status=args.watch_target_status,
-            sprint_rollup_status=args.sprint_rollup_status,
-        )
+        if args.fallback_data_source == "derived_sprint_state":
+            recorded_at = iso_now_utc()
+            session_ref = args.session_ref
+            if session_ref is None and args.thread_id:
+                session_ref = f"codex-thread:{args.thread_id}"
+            record = build_issue_goal_metrics_record(
+                sprint_issue_number=None,
+                issue_number=args.issue_number,
+                capture_stage=args.capture_stage,
+                data_source="derived_sprint_state",
+                raw_log_path=raw_log_path,
+                recorded_at=recorded_at,
+                issue_goal_ref=args.issue_goal_ref,
+                sprint_goal_ref=args.sprint_goal_ref,
+                goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+                goal_id=None,
+                goal_id_state="not_available",
+                started_at=recorded_at if args.capture_stage == "issue_start" else None,
+                completed_at=None,
+                elapsed_seconds_raw="unknown",
+                active_work_seconds_raw="unknown",
+                validation_seconds_raw="unknown",
+                pr_wait_seconds_raw="unknown",
+                ci_wait_seconds_raw="unknown",
+                total_tokens_raw="unknown",
+                prompt_tokens_raw="unknown",
+                completion_tokens_raw="unknown",
+                metrics_confidence=args.metrics_confidence,
+                completion_state=args.completion_state_override or "unknown",
+                model_ref=args.model_ref,
+                session_ref=session_ref,
+                thread_id=args.thread_id,
+                goal_kind=args.goal_kind,
+                goal_boundary=args.goal_boundary,
+                issue_state=args.issue_state,
+                pr_state=args.pr_state,
+                checks_state=args.checks_state,
+                review_truth=args.review_truth,
+                closeout_truth=args.closeout_truth,
+                merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+                watch_target_status=args.watch_target_status,
+                sprint_rollup_status=args.sprint_rollup_status,
+            )
+        else:
+            record = build_unknown_issue_goal_metrics_record(
+                issue_number=args.issue_number,
+                capture_stage=args.capture_stage,
+                raw_log_path=raw_log_path,
+                issue_goal_ref=args.issue_goal_ref,
+                sprint_goal_ref=args.sprint_goal_ref,
+                goal_metrics_rollup_ref=args.goal_metrics_rollup_ref,
+                metrics_confidence=args.metrics_confidence,
+                completion_state=args.completion_state_override or "unknown",
+                model_ref=args.model_ref,
+                session_ref=args.session_ref,
+                thread_id=args.thread_id,
+                goal_kind=args.goal_kind,
+                goal_boundary=args.goal_boundary,
+                issue_state=args.issue_state,
+                pr_state=args.pr_state,
+                checks_state=args.checks_state,
+                review_truth=args.review_truth,
+                closeout_truth=args.closeout_truth,
+                merge_conflicts=True if args.merge_conflicts else False if args.no_merge_conflicts else None,
+                watch_target_status=args.watch_target_status,
+                sprint_rollup_status=args.sprint_rollup_status,
+            )
     validate_terminal_completion_allowed(record)
 
     jsonl_path = artifacts_dir / f"issue-{args.issue_number}-goal-metrics.jsonl"


### PR DESCRIPTION
Closes #4538

## Summary
Implemented the bounded `#4538` lifecycle-truth fix so `pr start` records
`issue_start` as an ADL-derived bound-execution stage rather than trusting
transcript goal telemetry that can be absent, stale, or still owned by a
parent sprint/umbrella goal. The start-path proof now preserves readiness-prep
truth on failed binds and records explicit derived child-issue accounting on
successful binds.

## Artifacts
- Updated local ignored output record at `.adl/v0.91.6/tasks/issue-4538__v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution/sor.md`
- Goal-metrics summary artifact at `.adl/v0.91.6/tasks/issue-4538__v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution/artifacts/goal_metrics/issue-4538-goal-metrics-summary.json`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
  - `adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl init_doctor_and_start_record_readiness_prep_goal_metric_stages -- --nocapture`
    Verified successful `pr start` now records a derived `issue_start` stage and promotes the summary to the bound-execution segment.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_start_failure_leaves_doctor_readiness_as_selected_prep_stage -- --nocapture`
    Verified early start failure preserves readiness-prep truth instead of claiming bound execution began.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_start_uses_derived_issue_start_when_thread_goal_targets_other_issue -- --nocapture`
    Verified same-thread transcript residue for another issue does not leak transcript telemetry into the new child issue.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4538__v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4538__v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution/sor.md
- Idempotency-Key: v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution-adl-v0-91-6-tasks-issue-4538-v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution-sip-md-adl-v0-91-6-tasks-issue-4538-v0-91-6-tools-goals-allow-nested-fresh-issue-goal-accounting-during-operational-proof-and-sprint-execution-sor-md