### PR TITLE
[v0.91.6][tools][workflow] Keep demo publication independent from finish-lane plumbing

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -220,6 +220,35 @@
       "reason": "portable_html_observatory_surface_requires_governed_demo_smoke"
     },
     {
+      "id": "unity_observatory_contract_surface",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "demo_contract",
+      "requirement_ids": [
+        "unity_observatory_contract_surface"
+      ],
+      "path_selectors": [
+        "adl/tools/test_v0916_unity_observatory_baseline.sh",
+        "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
+        "demos/v0.91.6/unity-observatory/Assets/**",
+        "demos/v0.91.6/unity-observatory/Packages/**",
+        "demos/v0.91.6/unity-observatory/ProjectSettings/**"
+      ],
+      "path_hints": [
+        "adl/tools/test_v0916_unity_observatory_baseline.sh",
+        "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
+        "demos/v0.91.6/unity-observatory/Assets/**",
+        "demos/v0.91.6/unity-observatory/Packages/**",
+        "demos/v0.91.6/unity-observatory/ProjectSettings/**"
+      ],
+      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
+    },
+    {
       "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2264,6 +2264,20 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_paths_need_github_projection_watch_validation(changed_paths) {
         return Ok(build_github_projection_watch_validation_plan());
     }
+
+    let changed_paths_need_finish_rust_validation = changed_paths
+        .iter()
+        .any(|path| finish_path_needs_pr_finish_rust_focused_validation(path));
+    let finish_profile_result =
+        load_finish_validation_profile_for_execution(&repo_root()?, changed_paths);
+    if !changed_paths_need_finish_rust_validation {
+        if let Ok(finish_profile) = &finish_profile_result {
+            if let Some(plan) = profile_backed_finish_validation_plan(finish_profile) {
+                return Ok(plan);
+            }
+        }
+    }
+
     if finish_issue_needs_unity_observatory_scaffold_validation(issue_number, changed_paths) {
         return Ok(build_unity_observatory_scaffold_validation_plan(
             changed_paths,
@@ -2277,8 +2291,7 @@ pub(super) fn select_finish_validation_plan_for_finish(
     if finish_issue_needs_html_observatory_validation(issue_number, changed_paths) {
         return Ok(build_html_observatory_validation_plan(changed_paths));
     }
-    let finish_profile =
-        load_finish_validation_profile_for_execution(&repo_root()?, changed_paths)?;
+    let finish_profile = finish_profile_result?;
     if let Some(plan) = profile_backed_finish_validation_plan(&finish_profile) {
         return Ok(plan);
     }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2689,8 +2689,8 @@ fn finish_validation_profile_does_not_treat_behavioral_tooling_as_docs_only() {
 }
 
 #[test]
-fn finish_validation_profile_classifies_unity_observatory_guardrail_script_as_small_binary_focused()
-{
+fn finish_validation_profile_classifies_unity_observatory_guardrail_script_as_larger_binary_focused(
+) {
     let plan = select_finish_validation_plan_for_finish(
         4030,
         ".",
@@ -2701,7 +2701,7 @@ fn finish_validation_profile_classifies_unity_observatory_guardrail_script_as_sm
     )
     .expect("unity observatory guardrail plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
         .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
@@ -2709,7 +2709,8 @@ fn finish_validation_profile_classifies_unity_observatory_guardrail_script_as_sm
 }
 
 #[test]
-fn finish_validation_profile_classifies_unity_observatory_scaffold_slice_as_small_binary_focused() {
+fn finish_validation_profile_classifies_unity_observatory_scaffold_slice_as_larger_binary_focused()
+{
     let plan = select_finish_validation_plan_for_finish(
         4031,
         ".",
@@ -2722,32 +2723,44 @@ fn finish_validation_profile_classifies_unity_observatory_scaffold_slice_as_smal
     )
     .expect("unity observatory scaffold plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
         .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
     assert!(plan.commands.contains(&"git diff --check".to_string()));
     assert!(plan
         .commands
-        .contains(&"bash adl/tools/test_v0916_unity_observatory_baseline.sh".to_string()));
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
 }
 
 #[test]
-fn finish_validation_profile_keeps_unity_observatory_scaffold_lane_issue_local() {
-    let err = select_finish_validation_plan_for_finish(
+fn finish_validation_profile_covers_unity_observatory_scaffold_lane_from_manifest() {
+    let plan = select_finish_validation_plan_for_finish(
         4032,
         ".",
         &["demos/v0.91.6/unity-observatory/Assets/Scenes/UnityObservatory.unity".to_string()],
     )
-    .expect_err("future observatory issue should fail closed until it declares its own lane");
+    .expect("unity observatory scaffold path should be manifest-covered");
 
-    assert!(err
-        .to_string()
-        .contains("selector left changed paths without validation-lane coverage"));
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(plan
+        .commands
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
+    assert!(plan
+        .commands
+        .iter()
+        .any(|command| command.contains("csm_observatory_cli_writes_unity_contract_bundle")));
 }
 
 #[test]
-fn finish_validation_profile_classifies_unity_observatory_contract_slice_as_small_binary_focused() {
+fn finish_validation_profile_classifies_unity_observatory_contract_slice_as_larger_binary_focused()
+{
     let plan = select_finish_validation_plan_for_finish(
         4032,
         ".",
@@ -2761,16 +2774,27 @@ fn finish_validation_profile_classifies_unity_observatory_contract_slice_as_smal
     )
     .expect("unity observatory contract plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
-        .contains(&"bash adl/tools/test_v0916_unity_observatory_contract.sh".to_string()));
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_unity65_smoke.sh")));
+    assert!(plan
+        .commands
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_baseline.sh")));
+    assert!(plan
+        .commands
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
     assert!(plan.commands.iter().any(|command| command
         .contains("csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource")));
+    assert!(!plan.commands.iter().any(|command| command
+        .contains("finish_validation_profile_classifies_unity_observatory_contract_slice")));
 }
 
 #[test]
-fn finish_validation_profile_classifies_inhabitant_readiness_slice_as_small_binary_focused() {
+fn finish_validation_profile_classifies_inhabitant_readiness_slice_as_larger_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4033,
         ".",
@@ -2784,16 +2808,17 @@ fn finish_validation_profile_classifies_inhabitant_readiness_slice_as_small_bina
     )
     .expect("unity observatory inhabitant-readiness plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
-        .contains(&"bash adl/tools/test_v0916_unity_observatory_contract.sh".to_string()));
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
     assert!(plan.commands.iter().any(|command| command
         .contains("csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource")));
 }
 
 #[test]
-fn finish_validation_profile_classifies_observability_consumption_slice_as_small_binary_focused() {
+fn finish_validation_profile_classifies_observability_consumption_slice_as_larger_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4034,
         ".",
@@ -2807,16 +2832,17 @@ fn finish_validation_profile_classifies_observability_consumption_slice_as_small
     )
     .expect("unity observatory observability-consumption plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
-        .contains(&"bash adl/tools/test_v0916_unity_observatory_contract.sh".to_string()));
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
     assert!(plan.commands.iter().any(|command| command
         .contains("csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource")));
 }
 
 #[test]
-fn finish_validation_profile_classifies_unity_observatory_repair_slice_as_small_binary_focused() {
+fn finish_validation_profile_classifies_unity_observatory_repair_slice_as_larger_binary_focused() {
     let plan = select_finish_validation_plan_for_finish(
         4416,
         ".",
@@ -2832,10 +2858,11 @@ fn finish_validation_profile_classifies_unity_observatory_repair_slice_as_small_
     )
     .expect("unity observatory repair plan");
 
-    assert_eq!(plan.mode, FinishValidationMode::SmallBinaryFocused);
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
     assert!(plan
         .commands
-        .contains(&"bash adl/tools/test_v0916_unity_observatory_contract.sh".to_string()));
+        .iter()
+        .any(|command| command.contains("test_v0916_unity_observatory_contract.sh")));
     assert!(plan.commands.iter().any(|command| command
         .contains("csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource")));
 }

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -445,4 +445,31 @@ assert lane["proof_role"] == "demo_contract"
 assert lane["owner"] == "review"
 PY
 
+unity_observatory="$TMP/unity-observatory.txt"
+cat >"$unity_observatory" <<'EOF'
+M	adl/tools/test_v0916_unity_observatory_contract.sh
+M	adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
+M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json
+M	demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
+EOF
+bash "$SCRIPT" --changed-files "$unity_observatory" --json >"$TMP/unity-observatory.json"
+python3 - <<'PY' "$TMP/unity-observatory.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert set(profile["lanes"].keys()) == {"unity_observatory_contract_surface"}
+lane = profile["lanes"]["unity_observatory_contract_surface"]
+assert lane["status"] == "selected"
+assert lane["proof_role"] == "demo_contract"
+assert lane["owner"] == "review"
+assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in lane["command"]
+assert "test_v0916_unity_observatory_baseline.sh" in lane["command"]
+assert "test_v0916_unity_observatory_contract.sh" in lane["command"]
+assert "csm_observatory_cli_writes_unity_contract_bundle" in lane["command"]
+PY
+
 echo "PASS test_select_validation_lanes"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -64,6 +64,36 @@ assert surface["resource_class"] == "small"
 assert profile["validation_dag"]["nodes"][0]["proof_role"] == "ci_contract"
 PY
 
+unity_observatory="$TMP/unity-observatory.txt"
+cat >"$unity_observatory" <<'EOF'
+M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json
+M	demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
+M	adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
+EOF
+bash "$SCRIPT" --changed-files "$unity_observatory" --json >"$TMP/unity-observatory.json"
+python3 - <<'PY' "$TMP/unity-observatory.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "unity_observatory_contract_surface_profile"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert [item["lane_id"] for item in profile["run"]] == ["unity_observatory_contract_surface"]
+surface = profile["behavior_surfaces"][0]
+assert surface["id"] == "demo_contract_unity_observatory_contract_surface"
+assert surface["owner"] == "review"
+assert surface["proof_role"] == "demo_contract"
+assert surface["resource_class"] == "small"
+assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in profile["run"][0]["command"]
+assert "test_v0916_unity_observatory_baseline.sh" in profile["run"][0]["command"]
+assert "test_v0916_unity_observatory_contract.sh" in profile["run"][0]["command"]
+assert "csm_observatory_cli_writes_unity_contract_bundle" in profile["run"][0]["command"]
+assert profile["diagnostics"] == []
+assert profile["escalation"]["required"] is False
+PY
+
 runtime="$TMP/runtime.txt"
 printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$runtime"
 bash "$SCRIPT" --changed-files "$runtime" --json >"$TMP/runtime.json"


### PR DESCRIPTION
Closes #4558

## Summary
Bounded implementation is complete and ready for PR publication. The work diagnosed the Unity/demo publication-lane defect, added a manifest-backed Unity Observatory validation lane, moved `pr finish` toward manager-backed lane truth before demo-specific fallbacks, preserved finish-owned Rust validation behavior, and added focused regression coverage. The first session goal hit its token budget before final proof; the replacement goal continued through successful focused proof and pre-PR review. PR publication and green-check shepherding remain the active goal tail, not completed closeout.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.6/tasks/issue-4558__v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing/sor.md`
- Tracked implementation artifacts in progress:
  - `adl/config/validation_lane_selector.v0.91.6.json`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `adl/tools/test_select_validation_lanes.sh`
  - `adl/tools/test_validation_manager.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.6/tasks/issue-4558__v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing/sor.md`
    Verified bootstrap SOR contract compliance for the local output scaffold.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified validation-lane selector behavior, including the newly manifest-backed Unity Observatory lane.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager profile generation, including the newly manifest-backed Unity Observatory lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish unity_observatory -- --nocapture`
    Verified focused Rust finish-selector behavior for Unity Observatory publication lanes after assertion repair and review fixes.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting after review fixes.
  - `git diff --check`
    Verified diff whitespace hygiene after the rebase-aware update.
  - `./adl/tools/pr.sh finish 4558 --title "[v0.91.6][tools][workflow] Keep demo publication independent from finish-lane plumbing"`
    Ran the repo-native finish publication gate. Validation subprocesses passed through C-SDLC owner validation and focused PR-fast finish-selector proof; the first finish run then failed only because this SOR still reported `Status: IN_PROGRESS`, which has now been repaired to `DONE` for rerun.
- Results:
  - PASS: `bash adl/tools/test_select_validation_lanes.sh`
  - PASS: `bash adl/tools/test_validation_manager.sh`
  - PASS: `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish unity_observatory -- --nocapture`
  - PASS: `cargo fmt --manifest-path adl/Cargo.toml --all --check`
  - PASS: `git diff --check`
  - PASS_THEN_SOR_TRUTH_REPAIR_REQUIRED: first `pr.sh finish` validation subprocesses passed, then SOR completed-phase validation rejected `Status: IN_PROGRESS`; SOR status normalized to `DONE` for rerun.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4558__v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4558__v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing/sor.md
- Idempotency-Key: v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing-adl-v0-91-6-tasks-issue-4558-v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing-sip-md-adl-v0-91-6-tasks-issue-4558-v0-91-6-tools-workflow-keep-demo-publication-independent-from-finish-lane-plumbing-sor-md