### PR TITLE
[v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -302,7 +302,8 @@ impl SourcePromptMetadata {
                 out.initial_pvf_lane_source = yaml_string_field(mapping, "initial_pvf_lane_source");
             }
             if out.estimate_elapsed_seconds.is_none() {
-                out.estimate_elapsed_seconds = yaml_string_field(mapping, "estimate_elapsed_seconds");
+                out.estimate_elapsed_seconds =
+                    yaml_string_field(mapping, "estimate_elapsed_seconds");
             }
             if out.estimate_total_tokens.is_none() {
                 out.estimate_total_tokens = yaml_string_field(mapping, "estimate_total_tokens");

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -242,6 +242,21 @@ struct SourcePromptMetadata {
     demo_required: Option<bool>,
     initial_pvf_lane: Option<String>,
     initial_pvf_lane_source: Option<String>,
+    estimate_elapsed_seconds: Option<String>,
+    estimate_total_tokens: Option<String>,
+    estimate_validation_seconds: Option<String>,
+    issue_goal_token_budget: Option<String>,
+    estimate_confidence: Option<String>,
+    estimate_data_source: Option<String>,
+    estimate_source_ref: Option<String>,
+    goal_metrics_rollup_ref: Option<String>,
+    validation_runtime_class: Option<String>,
+    validation_resource_profile: Option<String>,
+    validation_family: Option<String>,
+    validation_size_split: Option<String>,
+    expected_proof_cost: Option<String>,
+    planned_validation_seconds: Option<String>,
+    planned_validation_tokens: Option<String>,
 }
 
 impl SourcePromptMetadata {
@@ -286,9 +301,63 @@ impl SourcePromptMetadata {
             if out.initial_pvf_lane_source.is_none() {
                 out.initial_pvf_lane_source = yaml_string_field(mapping, "initial_pvf_lane_source");
             }
+            if out.estimate_elapsed_seconds.is_none() {
+                out.estimate_elapsed_seconds = yaml_string_field(mapping, "estimate_elapsed_seconds");
+            }
+            if out.estimate_total_tokens.is_none() {
+                out.estimate_total_tokens = yaml_string_field(mapping, "estimate_total_tokens");
+            }
+            if out.estimate_validation_seconds.is_none() {
+                out.estimate_validation_seconds =
+                    yaml_string_field(mapping, "estimate_validation_seconds");
+            }
+            if out.issue_goal_token_budget.is_none() {
+                out.issue_goal_token_budget = yaml_string_field(mapping, "issue_goal_token_budget");
+            }
+            if out.estimate_confidence.is_none() {
+                out.estimate_confidence = yaml_string_field(mapping, "estimate_confidence");
+            }
+            if out.estimate_data_source.is_none() {
+                out.estimate_data_source = yaml_string_field(mapping, "estimate_data_source");
+            }
+            if out.estimate_source_ref.is_none() {
+                out.estimate_source_ref = yaml_string_field(mapping, "estimate_source_ref");
+            }
+            if out.goal_metrics_rollup_ref.is_none() {
+                out.goal_metrics_rollup_ref = yaml_string_field(mapping, "goal_metrics_rollup_ref");
+            }
+            if out.validation_runtime_class.is_none() {
+                out.validation_runtime_class =
+                    yaml_string_field(mapping, "validation_runtime_class");
+            }
+            if out.validation_resource_profile.is_none() {
+                out.validation_resource_profile =
+                    yaml_string_field(mapping, "validation_resource_profile");
+            }
+            if out.validation_family.is_none() {
+                out.validation_family = yaml_string_field(mapping, "validation_family");
+            }
+            if out.validation_size_split.is_none() {
+                out.validation_size_split = yaml_string_field(mapping, "validation_size_split");
+            }
+            if out.expected_proof_cost.is_none() {
+                out.expected_proof_cost = yaml_string_field(mapping, "expected_proof_cost");
+            }
+            if out.planned_validation_seconds.is_none() {
+                out.planned_validation_seconds =
+                    yaml_string_field(mapping, "planned_validation_seconds");
+            }
+            if out.planned_validation_tokens.is_none() {
+                out.planned_validation_tokens =
+                    yaml_string_field(mapping, "planned_validation_tokens");
+            }
         }
         out
     }
+}
+
+fn metadata_value_or_unknown(value: &Option<String>) -> String {
+    value.clone().unwrap_or_else(|| "unknown".to_string())
 }
 
 fn resolved_initial_pvf_lane(metadata: &SourcePromptMetadata, title: &str, prompt: &str) -> String {
@@ -384,8 +453,16 @@ fn yaml_front_matter_documents(text: &str) -> Vec<YamlValue> {
 fn yaml_string_field(mapping: &serde_yaml::Mapping, key: &str) -> Option<String> {
     mapping
         .get(YamlValue::String(key.to_string()))
-        .and_then(YamlValue::as_str)
-        .map(ToString::to_string)
+        .and_then(yaml_scalar_to_string)
+}
+
+fn yaml_scalar_to_string(value: &YamlValue) -> Option<String> {
+    match value {
+        YamlValue::String(value) => Some(value.clone()),
+        YamlValue::Number(value) => Some(value.to_string()),
+        YamlValue::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
 }
 
 fn yaml_bool_field(mapping: &serde_yaml::Mapping, key: &str) -> Option<bool> {
@@ -402,22 +479,6 @@ fn yaml_string_sequence_field(mapping: &serde_yaml::Mapping, key: &str) -> Vec<S
         return sequence.iter().filter_map(yaml_scalar_to_string).collect();
     }
     yaml_scalar_to_string(value).into_iter().collect()
-}
-
-fn yaml_scalar_to_string(value: &YamlValue) -> Option<String> {
-    if let Some(value) = value.as_str() {
-        return Some(value.to_string());
-    }
-    if let Some(value) = value.as_i64() {
-        return Some(value.to_string());
-    }
-    if let Some(value) = value.as_u64() {
-        return Some(value.to_string());
-    }
-    if let Some(value) = value.as_bool() {
-        return Some(value.to_string());
-    }
-    None
 }
 
 fn merge_strings(target: &mut Vec<String>, values: Vec<String>) {
@@ -1163,28 +1224,64 @@ fn render_bootstrap_output_card(
             ("<planned_pvf_lane>", planned_pvf_lane.clone()),
             ("<final_pvf_lane>", "not_recorded_yet".to_string()),
             ("<lane_change_reason>", "not_recorded_yet".to_string()),
-            ("<expected_runtime_class>", "unknown".to_string()),
-            ("<estimate_elapsed_seconds>", "unknown".to_string()),
-            ("<estimated_elapsed_seconds>", "unknown".to_string()),
+            (
+                "<expected_runtime_class>",
+                metadata_value_or_unknown(&metadata.validation_runtime_class),
+            ),
+            (
+                "<estimate_elapsed_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_elapsed_seconds),
+            ),
+            (
+                "<estimated_elapsed_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_elapsed_seconds),
+            ),
             ("<actual_elapsed_seconds>", "unknown".to_string()),
             ("<actual_active_work_seconds>", "unknown".to_string()),
-            ("<estimate_total_tokens>", "unknown".to_string()),
-            ("<estimated_total_tokens>", "unknown".to_string()),
+            (
+                "<estimate_total_tokens>",
+                metadata_value_or_unknown(&metadata.estimate_total_tokens),
+            ),
+            (
+                "<estimated_total_tokens>",
+                metadata_value_or_unknown(&metadata.estimate_total_tokens),
+            ),
             ("<actual_total_tokens>", "unknown".to_string()),
-            ("<estimate_validation_seconds>", "unknown".to_string()),
-            ("<estimated_validation_seconds>", "unknown".to_string()),
+            (
+                "<estimate_validation_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_validation_seconds),
+            ),
+            (
+                "<estimated_validation_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_validation_seconds),
+            ),
             ("<actual_validation_seconds>", "unknown".to_string()),
-            ("<budget_source>", "unknown".to_string()),
+            (
+                "<budget_source>",
+                metadata_value_or_unknown(&metadata.estimate_data_source),
+            ),
             ("<actual_pr_wait_seconds>", "unknown".to_string()),
             ("<actual_ci_wait_seconds>", "unknown".to_string()),
-            ("<actual_metrics_data_source>", "unknown".to_string()),
-            ("<actual_metrics_source_ref>", "unknown".to_string()),
-            ("<actual_metrics_confidence>", "unknown".to_string()),
+            (
+                "<actual_metrics_data_source>",
+                metadata_value_or_unknown(&metadata.estimate_data_source),
+            ),
+            (
+                "<actual_metrics_source_ref>",
+                metadata_value_or_unknown(&metadata.estimate_source_ref),
+            ),
+            (
+                "<actual_metrics_confidence>",
+                metadata_value_or_unknown(&metadata.estimate_confidence),
+            ),
             ("<estimate_error_percent>", "unknown".to_string()),
             ("<completion_state>", "unknown".to_string()),
             ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
             ("<sprint_goal_ref>", "unknown".to_string()),
-            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+            (
+                "<goal_metrics_rollup_ref>",
+                metadata_value_or_unknown(&metadata.goal_metrics_rollup_ref),
+            ),
             ("<vpp_card>", vpp_rel),
             ("<variance_analysis_required>", "not_applicable".to_string()),
             ("<variance_analysis_completed>", "not_applicable".to_string()),
@@ -1517,20 +1614,53 @@ fn render_bootstrap_plan_card(
             ("<planned_pvf_lane>", planned_pvf_lane.clone()),
             ("<planned_pvf_lane_source>", planned_pvf_lane_source.clone()),
             ("<expected_runtime_class>", "unknown".to_string()),
-            ("<estimate_elapsed_seconds>", "unknown".to_string()),
-            ("<estimated_elapsed_seconds>", "unknown".to_string()),
-            ("<estimate_total_tokens>", "unknown".to_string()),
-            ("<estimated_total_tokens>", "unknown".to_string()),
-            ("<estimate_validation_seconds>", "unknown".to_string()),
-            ("<estimated_validation_seconds>", "unknown".to_string()),
-            ("<issue_goal_token_budget>", "unknown".to_string()),
+            (
+                "<estimate_elapsed_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_elapsed_seconds),
+            ),
+            (
+                "<estimated_elapsed_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_elapsed_seconds),
+            ),
+            (
+                "<estimate_total_tokens>",
+                metadata_value_or_unknown(&metadata.estimate_total_tokens),
+            ),
+            (
+                "<estimated_total_tokens>",
+                metadata_value_or_unknown(&metadata.estimate_total_tokens),
+            ),
+            (
+                "<estimate_validation_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_validation_seconds),
+            ),
+            (
+                "<estimated_validation_seconds>",
+                metadata_value_or_unknown(&metadata.estimate_validation_seconds),
+            ),
+            (
+                "<issue_goal_token_budget>",
+                metadata_value_or_unknown(&metadata.issue_goal_token_budget),
+            ),
             ("<variance_threshold_percent>", "10".to_string()),
-            ("<estimate_confidence>", "unknown".to_string()),
-            ("<estimate_data_source>", "unknown".to_string()),
-            ("<estimate_source_ref>", "unknown".to_string()),
+            (
+                "<estimate_confidence>",
+                metadata_value_or_unknown(&metadata.estimate_confidence),
+            ),
+            (
+                "<estimate_data_source>",
+                metadata_value_or_unknown(&metadata.estimate_data_source),
+            ),
+            (
+                "<estimate_source_ref>",
+                metadata_value_or_unknown(&metadata.estimate_source_ref),
+            ),
             ("<issue_goal_ref>", format!("issue-{}", issue_ref.issue_number())),
             ("<sprint_goal_ref>", "unknown".to_string()),
-            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+            (
+                "<goal_metrics_rollup_ref>",
+                metadata_value_or_unknown(&metadata.goal_metrics_rollup_ref),
+            ),
         ],
     );
     Ok(text)
@@ -1589,6 +1719,37 @@ fn render_bootstrap_validation_plan_card(
                 ),
             },
         );
+    let generated_vpp = GeneratedVppPlan {
+        validation_runtime_class: metadata
+            .validation_runtime_class
+            .clone()
+            .unwrap_or(generated_vpp.validation_runtime_class),
+        validation_resource_profile: metadata
+            .validation_resource_profile
+            .clone()
+            .unwrap_or(generated_vpp.validation_resource_profile),
+        validation_family: metadata
+            .validation_family
+            .clone()
+            .unwrap_or(generated_vpp.validation_family),
+        validation_size_split: metadata
+            .validation_size_split
+            .clone()
+            .unwrap_or(generated_vpp.validation_size_split),
+        expected_proof_cost: metadata
+            .expected_proof_cost
+            .clone()
+            .unwrap_or(generated_vpp.expected_proof_cost),
+        planned_validation_seconds: metadata
+            .planned_validation_seconds
+            .clone()
+            .unwrap_or(generated_vpp.planned_validation_seconds),
+        planned_validation_tokens: metadata
+            .planned_validation_tokens
+            .clone()
+            .unwrap_or(generated_vpp.planned_validation_tokens),
+        ..generated_vpp
+    };
     let mut text = read_prompt_template(repo_root, "vpp", &[])?;
     let issue_url = format!(
         "https://github.com/{}/issues/{}",
@@ -1657,7 +1818,10 @@ fn render_bootstrap_validation_plan_card(
                 format!("issue-{}", issue_ref.issue_number()),
             ),
             ("<sprint_goal_ref>", "unknown".to_string()),
-            ("<goal_metrics_rollup_ref>", "unknown".to_string()),
+            (
+                "<goal_metrics_rollup_ref>",
+                metadata_value_or_unknown(&metadata.goal_metrics_rollup_ref),
+            ),
             (
                 "<selected_lanes_inline>",
                 generated_vpp.selected_lanes_inline,
@@ -2037,7 +2201,7 @@ fn sanitize_vpp_validation_command(command: &str) -> String {
     let mut replace_next_changed_files = false;
     for token in command.split_whitespace() {
         if replace_next_changed_files {
-            sanitized.push("<changed-files>".to_string());
+            sanitized.push(".adl/generated-vpp-changed-files.txt".to_string());
             replace_next_changed_files = false;
             continue;
         }

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -336,11 +336,563 @@ Bootstrap VPP generation should name selected lanes, commands, and deferred rati
     assert!(vpp.contains("Expected proof cost: `medium`"));
     assert!(vpp.contains("bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh"));
     assert!(vpp.contains("bash adl/tools/run_owner_validation_lane.sh csdlc"));
-    assert!(vpp.contains("bash adl/tools/run_pr_fast_test_lane.sh --changed-files"));
+    assert!(vpp.contains(
+        "bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/generated-vpp-changed-files.txt"
+    ));
+    assert!(!vpp.contains("<changed-files>"));
     assert!(vpp.contains("deferred full_workspace_nextest: not selected by validation profile"));
     assert!(vpp.contains(
         "Generated from validation profile selected_3_lane_profile (status=ready_to_run, pr_publication_sufficient=true)."
     ));
+}
+
+#[test]
+fn versioned_bootstrap_uses_source_prompt_metric_metadata_in_rendered_cards() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-source-prompt-metric-metadata");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4552,
+        "v0.91.6".to_string(),
+        "tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets"
+            .to_string(),
+    )
+    .expect("issue ref");
+    let title =
+        "[v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets";
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+    fs::write(
+        &source_path,
+        r#"---
+title: "[v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets"
+labels:
+  - "track:roadmap"
+  - "type:bug"
+  - "area:tools"
+  - "version:v0.91.6"
+issue_number: 4552
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd_cards/cards.rs"
+  - "adl/src/cli/tooling_cmd/prompt_template.rs"
+demo_required: false
+initial_pvf_lane: "prompt_template"
+initial_pvf_lane_source: "configured_policy_from_title_labels_and_body_inference"
+estimate_elapsed_seconds: "9000"
+estimate_total_tokens: "400000"
+estimate_validation_seconds: "3000"
+issue_goal_token_budget: "400000"
+estimate_confidence: "medium"
+estimate_data_source: "manual_entry"
+estimate_source_ref: "docs/milestones/v0.91.6/features/PER_ISSUE_EXECUTION_METRICS_FOUNDATION_v0.91.6.md"
+goal_metrics_rollup_ref: "docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md"
+validation_runtime_class: "normal"
+validation_resource_profile: "local"
+validation_family: "prompt_template_card_profile"
+validation_size_split: "all_card_kind_fixture"
+expected_proof_cost: "medium"
+planned_validation_seconds: "3000"
+planned_validation_tokens: "80000"
+---
+
+# [v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets
+
+## Summary
+
+Fix the bootstrap generator/editor path.
+
+## Goal
+
+Keep freshly initialized issue bundles validator-clean without manual card surgery.
+
+## Required Outcome
+
+The generated pre-execution card bundle is complete and deterministic.
+
+## Deliverables
+
+- deterministic bootstrap cards
+- focused regression coverage
+
+## Acceptance Criteria
+
+- SPP, VPP, and SOR render the seeded planning metrics truthfully
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/src/cli/tooling_cmd/prompt_template.rs`
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- no runtime behavior changes
+
+## Issue-Graph Notes
+
+- regression fixture
+
+## Notes
+
+- seeded planning metrics fixture
+
+## Tooling Notes
+
+- run focused bootstrap coverage only
+"#,
+    )
+    .expect("write source prompt");
+
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    let (_stp, _sip, sor_path) =
+        ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path)
+            .expect("pre-run bootstrap cards");
+
+    let spp = fs::read_to_string(issue_ref.task_bundle_plan_path(&repo)).expect("read spp");
+    assert!(spp.contains("estimate_elapsed_seconds: \"9000\""));
+    assert!(spp.contains("estimate_total_tokens: \"400000\""));
+    assert!(spp.contains("issue_goal_token_budget: \"400000\""));
+    assert!(spp.contains("goal_metrics_rollup_ref: \"docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md\""));
+    assert!(spp.contains("- Estimated elapsed seconds: `9000`"));
+    assert!(spp.contains("- Estimated total tokens: `400000`"));
+    assert!(spp.contains("- Issue goal token budget: `400000`"));
+    assert!(spp.contains("- Estimate data source: `manual_entry`"));
+
+    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
+        .expect("read vpp");
+    assert!(vpp.contains("validation_family: \"prompt_template_card_profile\""));
+    assert!(vpp.contains("validation_size_split: \"all_card_kind_fixture\""));
+    assert!(vpp.contains("planned_validation_seconds: \"3000\""));
+    assert!(vpp.contains("planned_validation_tokens: \"80000\""));
+    assert!(vpp.contains("goal_metrics_rollup_ref: \"docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md\""));
+    assert!(vpp.contains("- Validation family: `prompt_template_card_profile`"));
+    assert!(vpp.contains("- Validation size split: `all_card_kind_fixture`"));
+    assert!(vpp.contains("- Planned validation seconds: `3000`"));
+    assert!(vpp.contains("- Planned validation token budget: `80000`"));
+    assert!(vpp.contains("- Goal metrics rollup ref: `docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md`"));
+
+    let sor = fs::read_to_string(&sor_path).expect("read sor");
+    assert!(sor.contains("- Estimated elapsed seconds: `9000`"));
+    assert!(sor.contains("- Estimated total tokens: `400000`"));
+    assert!(sor.contains("- Estimated validation seconds: `3000`"));
+    assert!(sor.contains("- Budget source: `manual_entry`"));
+    assert!(sor.contains("- Goal metrics source ref: `docs/milestones/v0.91.6/features/PER_ISSUE_EXECUTION_METRICS_FOUNDATION_v0.91.6.md`"));
+    assert!(sor.contains("- Goal metrics rollup ref: `docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md`"));
+}
+
+#[test]
+fn versioned_bootstrap_uses_unquoted_numeric_source_prompt_metadata_in_rendered_cards() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-source-prompt-unquoted-metric-metadata");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4553,
+        "v0.91.6".to_string(),
+        "tools-validation-implement-operational-nessus-remote-validation-lane".to_string(),
+    )
+    .expect("issue ref");
+    let title =
+        "[v0.91.6][tools][validation] Implement operational Nessus remote-validation lane";
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+    fs::write(
+        &source_path,
+        r#"---
+title: "[v0.91.6][tools][validation] Implement operational Nessus remote-validation lane"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.91.6"
+issue_number: 4553
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd_cards/cards.rs"
+  - "adl/tools/validation_manager.py"
+demo_required: false
+initial_pvf_lane: "prompt_template"
+initial_pvf_lane_source: "configured_policy_from_title_labels_and_body_inference"
+estimate_elapsed_seconds: 9000
+estimate_total_tokens: 400000
+estimate_validation_seconds: 3000
+issue_goal_token_budget: 400000
+estimate_confidence: "medium"
+estimate_data_source: "manual_entry"
+estimate_source_ref: "docs/milestones/v0.91.6/features/PER_ISSUE_EXECUTION_METRICS_FOUNDATION_v0.91.6.md"
+goal_metrics_rollup_ref: "docs/milestones/v0.91.6/features/FIRST_CLASS_NESTED_GOAL_ACCOUNTING_v0.91.6.md"
+validation_runtime_class: "normal"
+validation_resource_profile: "local"
+validation_family: "prompt_template_card_profile"
+validation_size_split: "all_card_kind_fixture"
+expected_proof_cost: "medium"
+planned_validation_seconds: 3000
+planned_validation_tokens: 80000
+---
+
+# [v0.91.6][tools][validation] Implement operational Nessus remote-validation lane
+
+## Summary
+
+Keep unquoted numeric planning metadata deterministic across bootstrap cards.
+
+## Goal
+
+Allow ordinary YAML numeric values to survive source-prompt bootstrap unchanged.
+
+## Required Outcome
+
+Bootstrap cards render numeric planning metadata truthfully whether the source prompt quotes those scalars or not.
+
+## Deliverables
+
+- scalar-tolerant bootstrap metadata parsing
+
+## Acceptance Criteria
+
+- SPP, VPP, and SOR render unquoted numeric metrics truthfully
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/tools/validation_manager.py`
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- no runtime behavior changes
+
+## Issue-Graph Notes
+
+- regression fixture
+
+## Notes
+
+- unquoted numeric metadata fixture
+
+## Tooling Notes
+
+- run focused bootstrap coverage only
+"#,
+    )
+    .expect("write source prompt");
+
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    let (_stp, _sip, sor_path) =
+        ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path)
+            .expect("pre-run bootstrap cards");
+
+    let spp = fs::read_to_string(issue_ref.task_bundle_plan_path(&repo)).expect("read spp");
+    assert!(spp.contains("estimate_elapsed_seconds: \"9000\""));
+    assert!(spp.contains("estimate_total_tokens: \"400000\""));
+    assert!(spp.contains("issue_goal_token_budget: \"400000\""));
+    assert!(spp.contains("- Estimated elapsed seconds: `9000`"));
+    assert!(spp.contains("- Estimated total tokens: `400000`"));
+
+    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
+        .expect("read vpp");
+    assert!(vpp.contains("planned_validation_seconds: \"3000\""));
+    assert!(vpp.contains("planned_validation_tokens: \"80000\""));
+    assert!(vpp.contains("- Planned validation seconds: `3000`"));
+    assert!(vpp.contains("- Planned validation token budget: `80000`"));
+
+    let sor = fs::read_to_string(&sor_path).expect("read sor");
+    assert!(sor.contains("- Estimated elapsed seconds: `9000`"));
+    assert!(sor.contains("- Estimated total tokens: `400000`"));
+    assert!(sor.contains("- Estimated validation seconds: `3000`"));
+}
+
+#[test]
+fn versioned_bootstrap_stp_supports_edit_rendered_round_trip() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-bootstrap-edit-rendered-stp");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4552,
+        "v0.91.6".to_string(),
+        "tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets"
+            .to_string(),
+    )
+    .expect("issue ref");
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+    fs::write(
+        &source_path,
+        r#"---
+title: "[v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets"
+wp: "unassigned"
+labels:
+  - "track:roadmap"
+  - "type:bug"
+  - "area:tools"
+  - "version:v0.91.6"
+issue_number: 4552
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd_cards/cards.rs"
+  - "adl/src/cli/tooling_cmd/prompt_template.rs"
+demo_required: false
+initial_pvf_lane: "prompt_template"
+initial_pvf_lane_source: "configured_policy_from_title_labels_and_body_inference"
+---
+
+# [v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets
+
+## Summary
+
+Fix the C-SDLC prompt-card generator/editor path so newly prepared issues can be made execution-ready without manual Markdown cleanup.
+
+## Goal
+
+A freshly created and initialized issue with complete source-prompt metadata must be be editable through the rendered-card round trip.
+
+## Required Outcome
+
+The active card bootstrap path produces complete, schema-valid pre-execution card bundles for authored issues without manual Markdown surgery.
+
+## Deliverables
+
+- deterministic card bootstrap behavior
+- repaired `edit-rendered --kind stp` behavior
+
+## Acceptance Criteria
+
+- `edit-rendered --kind stp` works on a freshly generated STP
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/src/cli/tooling_cmd/prompt_template.rs`
+
+## Dependencies
+
+- Active prompt-template registry remains authoritative.
+- No `gh` fallback.
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- no runtime/product changes
+
+## Issue-Graph Notes
+
+- regression fixture
+
+## Notes
+
+- generated in focused test
+
+## Tooling Notes
+
+- run focused prompt-template coverage only
+"#,
+    )
+    .expect("write source");
+
+    let stp = ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("bootstrap stp");
+    let edited = repo.join("edited-stp.md");
+    let values_out = repo.join("edited-stp.values.yaml");
+    let repo_root_for_tooling = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+
+    crate::cli::tooling_cmd::real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-rendered".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tooling.to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+        stp.to_string_lossy().to_string(),
+        "--set".to_string(),
+        "summary=Deterministic bootstrap regression.".to_string(),
+        "--values-out".to_string(),
+        values_out.to_string_lossy().to_string(),
+        "--out".to_string(),
+        edited.to_string_lossy().to_string(),
+    ])
+    .expect("edit-rendered should accept freshly bootstrapped stp");
+
+    let edited_text = fs::read_to_string(&edited).expect("edited stp");
+    assert!(edited_text.contains("Deterministic bootstrap regression."));
+
+    crate::cli::tooling_cmd::real_tooling(&[
+        "prompt-template".to_string(),
+        "validate-structure".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tooling.to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+        edited.to_string_lossy().to_string(),
+    ])
+    .expect("edited bootstrap stp should remain structure-valid");
+}
+
+#[test]
+fn versioned_bootstrap_stp_edit_rendered_fails_closed_for_template_text_drift() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-versioned-bootstrap-edit-rendered-stp-drift");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    copy_versioned_prompt_templates(&repo);
+
+    let issue_ref = IssueRef::new(
+        4552,
+        "v0.91.6".to_string(),
+        "tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets"
+            .to_string(),
+    )
+    .expect("issue ref");
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+    fs::write(
+        &source_path,
+        r#"---
+title: "[v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets"
+wp: "unassigned"
+labels:
+  - "track:roadmap"
+  - "type:bug"
+  - "area:tools"
+  - "version:v0.91.6"
+issue_number: 4552
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd_cards/cards.rs"
+  - "adl/src/cli/tooling_cmd/prompt_template.rs"
+demo_required: false
+initial_pvf_lane: "prompt_template"
+initial_pvf_lane_source: "configured_policy_from_title_labels_and_body_inference"
+---
+
+# [v0.91.6][tools][cards] Make card bootstrap and edit-rendered deterministic for execution budgets
+
+## Summary
+
+Fix the C-SDLC prompt-card generator/editor path so newly prepared issues can be made execution-ready without manual Markdown cleanup.
+
+## Goal
+
+A freshly created and initialized issue with complete source-prompt metadata must be be editable through the rendered-card round trip.
+
+## Required Outcome
+
+The active card bootstrap path produces complete, schema-valid pre-execution card bundles for authored issues without manual Markdown surgery.
+
+## Deliverables
+
+- deterministic card bootstrap behavior
+- repaired `edit-rendered --kind stp` behavior
+
+## Acceptance Criteria
+
+- `edit-rendered --kind stp` works on a freshly generated STP
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/src/cli/tooling_cmd/prompt_template.rs`
+
+## Dependencies
+
+- Active prompt-template registry remains authoritative.
+- No `gh` fallback.
+
+## Target Files / Surfaces
+
+- `adl/src/cli/pr_cmd_cards/cards.rs`
+- `adl/src/csdlc_prompt_editor.rs`
+
+## Validation Plan
+
+- focused prompt-template proof only
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- no runtime/product changes
+
+## Issue-Graph Notes
+
+- regression fixture
+
+## Notes
+
+- generated in focused test
+
+## Tooling Notes
+
+- run focused prompt-template coverage only
+"#,
+    )
+    .expect("write source");
+
+    let stp = ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("bootstrap stp");
+    let drifted = repo.join("drifted-stp.md");
+    let original = fs::read_to_string(&stp).expect("read stp");
+    fs::write(
+        &drifted,
+        original.replace("Canonical Template Source:", "Canonical Template Drift:"),
+    )
+    .expect("write drifted stp");
+
+    let repo_root_for_tooling = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+
+    let err = crate::cli::tooling_cmd::real_tooling(&[
+        "prompt-template".to_string(),
+        "edit-rendered".to_string(),
+        "--repo-root".to_string(),
+        repo_root_for_tooling.to_string_lossy().to_string(),
+        "--kind".to_string(),
+        "stp".to_string(),
+        "--input".to_string(),
+        drifted.to_string_lossy().to_string(),
+        "--set".to_string(),
+        "summary=This edit should fail closed.".to_string(),
+        "--out".to_string(),
+        repo.join("should-not-render.md").to_string_lossy().to_string(),
+    ])
+    .expect_err("stp edit-rendered should fail closed for template prose drift");
+    assert!(err.to_string().contains("locked template text drifted"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs
@@ -470,8 +470,8 @@ The generated pre-execution card bundle is complete and deterministic.
     assert!(spp.contains("- Issue goal token budget: `400000`"));
     assert!(spp.contains("- Estimate data source: `manual_entry`"));
 
-    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
-        .expect("read vpp");
+    let vpp =
+        fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo)).expect("read vpp");
     assert!(vpp.contains("validation_family: \"prompt_template_card_profile\""));
     assert!(vpp.contains("validation_size_split: \"all_card_kind_fixture\""));
     assert!(vpp.contains("planned_validation_seconds: \"3000\""));
@@ -506,8 +506,7 @@ fn versioned_bootstrap_uses_unquoted_numeric_source_prompt_metadata_in_rendered_
         "tools-validation-implement-operational-nessus-remote-validation-lane".to_string(),
     )
     .expect("issue ref");
-    let title =
-        "[v0.91.6][tools][validation] Implement operational Nessus remote-validation lane";
+    let title = "[v0.91.6][tools][validation] Implement operational Nessus remote-validation lane";
     let source_path = issue_ref.issue_prompt_path(&repo);
     fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
     fs::write(
@@ -611,8 +610,8 @@ Bootstrap cards render numeric planning metadata truthfully whether the source p
     assert!(spp.contains("- Estimated elapsed seconds: `9000`"));
     assert!(spp.contains("- Estimated total tokens: `400000`"));
 
-    let vpp = fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo))
-        .expect("read vpp");
+    let vpp =
+        fs::read_to_string(issue_ref.task_bundle_validation_plan_path(&repo)).expect("read vpp");
     assert!(vpp.contains("planned_validation_seconds: \"3000\""));
     assert!(vpp.contains("planned_validation_tokens: \"80000\""));
     assert!(vpp.contains("- Planned validation seconds: `3000`"));
@@ -889,7 +888,9 @@ The active card bootstrap path produces complete, schema-valid pre-execution car
         "--set".to_string(),
         "summary=This edit should fail closed.".to_string(),
         "--out".to_string(),
-        repo.join("should-not-render.md").to_string_lossy().to_string(),
+        repo.join("should-not-render.md")
+            .to_string_lossy()
+            .to_string(),
     ])
     .expect_err("stp edit-rendered should fail closed for template prose drift");
     assert!(err.to_string().contains("locked template text drifted"));

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -708,6 +708,7 @@ fn prompt_template_cli_edit_rendered_card_uses_values_roundtrip_default_path() {
     .expect("edit-rendered output should remain structure-valid");
 }
 
+
 #[test]
 fn prompt_template_cli_import_values_fails_closed_for_structure_drift() {
     let repo = TempRepo::new("prompt-template-import-values-drift");

--- a/adl/src/cli/tooling_cmd/tests/prompt_template.rs
+++ b/adl/src/cli/tooling_cmd/tests/prompt_template.rs
@@ -708,7 +708,6 @@ fn prompt_template_cli_edit_rendered_card_uses_values_roundtrip_default_path() {
     .expect("edit-rendered output should remain structure-valid");
 }
 
-
 #[test]
 fn prompt_template_cli_import_values_fails_closed_for_structure_drift() {
     let repo = TempRepo::new("prompt-template-import-values-drift");

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -603,9 +603,9 @@ fn import_values_document_from_rendered_card(
         Ok(values) => values,
         Err(err)
             if card.key == "stp"
-                && err
-                    .to_string()
-                    .contains("stp rendered card cannot find post-placeholder literal for title") =>
+                && err.to_string().contains(
+                    "stp rendered card cannot find post-placeholder literal for title",
+                ) =>
         {
             extract_active_stp_values(rendered).with_context(|| err.to_string())?
         }
@@ -634,10 +634,9 @@ fn extract_active_stp_values(rendered: &str) -> Result<BTreeMap<String, String>>
     let version = version_from_rendered_title(&title)
         .or_else(|| mapping_required_scalar(mapping, "milestone_sprint").ok())
         .unwrap_or_else(|| "v0.0.0-imported".to_string());
-    let required_outcome_type = yaml_sequence_summary(
-        mapping.get(Value::String("required_outcome_type".to_string())),
-    )
-    .unwrap_or_else(|| "combination".to_string());
+    let required_outcome_type =
+        yaml_sequence_summary(mapping.get(Value::String("required_outcome_type".to_string())))
+            .unwrap_or_else(|| "combination".to_string());
     let repo_inputs = markdown_section_body_local(rendered, "Repo Inputs")
         .map(|body| body.trim().to_string())
         .filter(|body| !body.is_empty())
@@ -665,16 +664,19 @@ fn extract_active_stp_values(rendered: &str) -> Result<BTreeMap<String, String>>
         "wp".to_string(),
         mapping_required_scalar(mapping, "wp").unwrap_or_else(|_| "unassigned".to_string()),
     );
-    values.insert(
-        "required_outcome_type".to_string(),
-        required_outcome_type,
-    );
+    values.insert("required_outcome_type".to_string(), required_outcome_type);
     values.insert(
         "demo_required".to_string(),
         mapping_required_scalar(mapping, "demo_required").unwrap_or_else(|_| "false".to_string()),
     );
-    values.insert("summary".to_string(), required_markdown_section(rendered, "Summary")?);
-    values.insert("goal".to_string(), required_markdown_section(rendered, "Goal")?);
+    values.insert(
+        "summary".to_string(),
+        required_markdown_section(rendered, "Summary")?,
+    );
+    values.insert(
+        "goal".to_string(),
+        required_markdown_section(rendered, "Goal")?,
+    );
     values.insert(
         "required_outcome".to_string(),
         required_markdown_section(rendered, "Required Outcome")?,

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -599,7 +599,18 @@ fn import_values_document_from_rendered_card(
     template_set: &str,
     rendered: &str,
 ) -> Result<(PromptValuesDocument, Vec<String>)> {
-    let mut extracted = extract_template_values(card, &card.template, rendered)?;
+    let mut extracted = match extract_template_values(card, &card.template, rendered) {
+        Ok(values) => values,
+        Err(err)
+            if card.key == "stp"
+                && err
+                    .to_string()
+                    .contains("stp rendered card cannot find post-placeholder literal for title") =>
+        {
+            extract_active_stp_values(rendered).with_context(|| err.to_string())?
+        }
+        Err(err) => return Err(err),
+    };
     let unrepresented_required_fields =
         populate_unrepresented_required_import_fields(card, &mut extracted)?;
     Ok(prompt_values_document_from_extracted(
@@ -608,6 +619,131 @@ fn import_values_document_from_rendered_card(
         extracted,
         unrepresented_required_fields,
     ))
+}
+
+fn extract_active_stp_values(rendered: &str) -> Result<BTreeMap<String, String>> {
+    let (frontmatter, _) = split_front_matter_local(rendered)?;
+    let doc = serde_yaml::from_str::<Value>(&frontmatter)
+        .context("stp import requires valid YAML front matter")?;
+    let mapping = doc
+        .as_mapping()
+        .ok_or_else(|| anyhow!("stp front matter must be a mapping"))?;
+
+    let issue = mapping_required_scalar(mapping, "issue_number")?;
+    let title = mapping_required_scalar(mapping, "title")?;
+    let version = version_from_rendered_title(&title)
+        .or_else(|| mapping_required_scalar(mapping, "milestone_sprint").ok())
+        .unwrap_or_else(|| "v0.0.0-imported".to_string());
+    let required_outcome_type = yaml_sequence_summary(
+        mapping.get(Value::String("required_outcome_type".to_string())),
+    )
+    .unwrap_or_else(|| "combination".to_string());
+    let repo_inputs = markdown_section_body_local(rendered, "Repo Inputs")
+        .map(|body| body.trim().to_string())
+        .filter(|body| !body.is_empty())
+        .ok_or_else(|| anyhow!("stp import requires Repo Inputs section"))?;
+
+    let mut values = BTreeMap::new();
+    values.insert("issue".to_string(), issue.clone());
+    values.insert("version".to_string(), version);
+    values.insert(
+        "timestamp".to_string(),
+        mapping_required_scalar(mapping, "generated_at")
+            .unwrap_or_else(|_| "legacy_import_unknown_timestamp".to_string()),
+    );
+    values.insert(
+        "card_status".to_string(),
+        mapping_required_scalar(mapping, "card_status").unwrap_or_else(|_| "draft".to_string()),
+    );
+    values.insert(
+        "slug".to_string(),
+        mapping_required_scalar(mapping, "slug")
+            .unwrap_or_else(|_| "imported-rendered-prompt-card".to_string()),
+    );
+    values.insert("title".to_string(), title);
+    values.insert(
+        "wp".to_string(),
+        mapping_required_scalar(mapping, "wp").unwrap_or_else(|_| "unassigned".to_string()),
+    );
+    values.insert(
+        "required_outcome_type".to_string(),
+        required_outcome_type,
+    );
+    values.insert(
+        "demo_required".to_string(),
+        mapping_required_scalar(mapping, "demo_required").unwrap_or_else(|_| "false".to_string()),
+    );
+    values.insert("summary".to_string(), required_markdown_section(rendered, "Summary")?);
+    values.insert("goal".to_string(), required_markdown_section(rendered, "Goal")?);
+    values.insert(
+        "required_outcome".to_string(),
+        required_markdown_section(rendered, "Required Outcome")?,
+    );
+    values.insert(
+        "deliverables".to_string(),
+        required_markdown_section(rendered, "Deliverables")?,
+    );
+    values.insert(
+        "acceptance_criteria".to_string(),
+        required_markdown_section(rendered, "Acceptance Criteria")?,
+    );
+    values.insert("repo_inputs".to_string(), repo_inputs.clone());
+    values.insert(
+        "dependencies".to_string(),
+        required_markdown_section(rendered, "Dependencies")?,
+    );
+    values.insert(
+        "target_files_surfaces".to_string(),
+        required_markdown_section(rendered, "Target Files / Surfaces")?,
+    );
+    values.insert(
+        "validation_plan".to_string(),
+        required_markdown_section(rendered, "Validation Plan")?,
+    );
+    values.insert(
+        "demo_proof_requirements".to_string(),
+        required_markdown_section(rendered, "Demo Expectations")?,
+    );
+    values.insert(
+        "non_goals".to_string(),
+        required_markdown_section(rendered, "Non-goals")?,
+    );
+    values.insert(
+        "issue_graph_notes".to_string(),
+        required_markdown_section(rendered, "Issue-Graph Notes")?,
+    );
+    values.insert(
+        "issue_graph_note".to_string(),
+        values["issue_graph_notes"]
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .map(str::trim)
+            .unwrap_or("not recorded in rendered card")
+            .to_string(),
+    );
+    values.insert(
+        "notes_risks".to_string(),
+        required_markdown_section(rendered, "Notes")?,
+    );
+    values.insert(
+        "tooling_notes".to_string(),
+        required_markdown_section(rendered, "Tooling Notes")?,
+    );
+    Ok(values)
+}
+
+fn required_markdown_section(rendered: &str, heading: &str) -> Result<String> {
+    markdown_section_body_local(rendered, heading)
+        .map(|body| body.trim().to_string())
+        .filter(|body| !body.is_empty())
+        .ok_or_else(|| anyhow!("stp import requires {heading} section"))
+}
+
+fn version_from_rendered_title(title: &str) -> Option<String> {
+    let start = title.find("[v")?;
+    let rest = &title[start + 1..];
+    let end = rest.find(']')?;
+    Some(rest[..end].to_string())
 }
 
 fn import_values_document_from_legacy_rendered_card(


### PR DESCRIPTION
Closes #4552

## Summary
Inherited the bound `#4552` worktree with the in-scope implementation already
staged, verified the staged diff against the issue intent, reran focused prompt
template and versioned-bootstrap proof, and finalized the issue cards for
truthful repo-native publication. The change makes bootstrap card generation
carry source-prompt planning metadata deterministically, replaces the VPP
`<changed-files>` placeholder with a concrete generated path, and lets
freshly bootstrapped STP cards round-trip through `edit-rendered` while still
failing closed for template-text drift.

## Artifacts
- `adl/src/cli/pr_cmd_cards/cards.rs`
- `adl/src/csdlc_prompt_editor.rs`
- `adl/src/cli/tests/pr_cmd_inline/versioned_bootstrap.rs`
- `adl/src/cli/tooling_cmd/tests/prompt_template.rs`

## Validation
- Validation commands and their purpose:
  - `git diff --cached --check`
    Verified the staged `#4552` patch has no whitespace or context corruption.
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`
    Verified the active prompt-template workflow still passes end-to-end render, edit, import, structure, and schema checks after the bootstrap changes.
  - `cargo test --manifest-path adl/Cargo.toml -p adl versioned_bootstrap_ -- --nocapture`
    Verified the focused versioned-bootstrap regression tests covering source-prompt metric metadata carry-through, deterministic VPP changed-files rendering, and active-STP `edit-rendered` behavior.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4552__v0-91-6-tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4552__v0-91-6-tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets/sor.md
- Idempotency-Key: v0-91-6-tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets-adl-src-cli-pr-cmd-cards-cards-rs-adl-src-csdlc-prompt-editor-rs-adl-src-cli-tests-pr-cmd-inline-versioned-bootstrap-rs-adl-src-cli-tooling-cmd-tests-prompt-template-rs-adl-v0-91-6-tasks-issue-4552-v0-91-6-tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets-sip-md-adl-v0-91-6-tasks-issue-4552-v0-91-6-tools-cards-make-card-bootstrap-and-edit-rendered-deterministic-for-execution-budgets-sor-md