### PR TITLE
[v0.91.6][observatory][unity] Prove live runtime consumption after Unity baseline migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,9 @@ jobs:
 
       - name: tracked proof-validation lane contract
         if: steps.path-policy.outputs.ci_contracts_required == 'true'
+        env:
+          RUSTFLAGS: ""
+          RUST_LINK_ACCEL: system
         run: bash adl/tools/test_run_v0913_proof_validation_lane.sh
         working-directory: .
 

--- a/adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
+++ b/adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROJECT_PATH="${ROOT_DIR}/demos/v0.91.6/unity-observatory"
+DEFAULT_EDITOR="/Applications/Unity/Hub/Editor/6000.5.1f1/Unity.app/Contents/MacOS/Unity"
+UNITY_EDITOR_BIN="${UNITY_6_5_EDITOR_BIN:-${UNITY_EDITOR_BIN:-$DEFAULT_EDITOR}}"
+LOG_DIR="${ROOT_DIR}/.adl/tmp/unity-observatory-4548"
+LOG_PATH="${LOG_DIR}/unity-local-runtime-consumption.log"
+TIMEOUT_SECS="${UNITY_6_5_SMOKE_TIMEOUT_SECS:-60}"
+RUNTIME_ROOT="$(mktemp -d /tmp/adl-uo-4548.XXXXXX)"
+STAGE_ROOT="${RUNTIME_ROOT}/project-stage"
+STAGED_PROJECT_PATH="${STAGE_ROOT}/unity-observatory"
+HOME_ROOT="${RUNTIME_ROOT}/home"
+TMP_ROOT="${RUNTIME_ROOT}/tmp"
+GEN_OUT_DIR="${RUNTIME_ROOT}/generated-contract"
+RUNTIME_PACKET="${ROOT_DIR}/adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
+STAGED_CONTRACT_PATH="${STAGED_PROJECT_PATH}/Assets/Resources/observatory_contract.json"
+
+mkdir -p "${LOG_DIR}"
+rm -f "${LOG_PATH}"
+mkdir -p \
+  "${HOME_ROOT}/Library/Application Support" \
+  "${HOME_ROOT}/Library/Application Support/Unity" \
+  "${HOME_ROOT}/Library/Application Support/Unity/Asset Store-5.x" \
+  "${HOME_ROOT}/Library/Caches" \
+  "${HOME_ROOT}/Library/Logs" \
+  "${HOME_ROOT}/Library/Preferences" \
+  "${HOME_ROOT}/Library/Unity" \
+  "${TMP_ROOT}" \
+  "${GEN_OUT_DIR}"
+
+if [[ ! -x "${UNITY_EDITOR_BIN}" ]]; then
+  echo "missing Unity 6.5 editor binary: ${UNITY_EDITOR_BIN}" >&2
+  exit 2
+fi
+
+if [[ ! -d "${PROJECT_PATH}" ]]; then
+  echo "missing Unity Observatory project: ${PROJECT_PATH}" >&2
+  exit 2
+fi
+
+if [[ ! -f "${RUNTIME_PACKET}" ]]; then
+  echo "missing runtime observatory packet fixture: ${RUNTIME_PACKET}" >&2
+  exit 2
+fi
+
+mkdir -p "${STAGE_ROOT}"
+rsync -a \
+  --exclude 'Library/' \
+  --exclude 'Logs/' \
+  --exclude 'Temp/' \
+  --exclude 'UserSettings/' \
+  "${PROJECT_PATH}/" \
+  "${STAGED_PROJECT_PATH}/"
+
+cargo run --manifest-path "${ROOT_DIR}/adl/Cargo.toml" --bin adl -- \
+  csm observatory \
+  --packet "${RUNTIME_PACKET}" \
+  --format bundle \
+  --out "${GEN_OUT_DIR}" >/dev/null
+
+cp "${GEN_OUT_DIR}/unity_observatory_contract.json" "${STAGED_CONTRACT_PATH}"
+
+EXPECTED_TITLE="Prototype CSM 01"
+EXPECTED_PACKET_REF="adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
+EXPECTED_ARTIFACT_ROOT="runtime_v2"
+EXPECTED_REPORT_REF="runtime_v2/observatory/operator_report.md"
+EXPECTED_EVIDENCE_LEVEL="artifact_backed_fixture"
+
+chmod -R u+rwX "${RUNTIME_ROOT}"
+
+ADL_UNITY_EXPECTED_TITLE="${EXPECTED_TITLE}" \
+ADL_UNITY_EXPECTED_PACKET_REF="${EXPECTED_PACKET_REF}" \
+ADL_UNITY_EXPECTED_ARTIFACT_ROOT="${EXPECTED_ARTIFACT_ROOT}" \
+ADL_UNITY_EXPECTED_REPORT_REF="${EXPECTED_REPORT_REF}" \
+ADL_UNITY_EXPECTED_EVIDENCE_LEVEL="${EXPECTED_EVIDENCE_LEVEL}" \
+HOME="${HOME_ROOT}" \
+TMPDIR="${TMP_ROOT}" \
+XDG_CACHE_HOME="${HOME_ROOT}/Library/Caches" \
+XDG_CONFIG_HOME="${HOME_ROOT}/Library/Application Support" \
+"${UNITY_EDITOR_BIN}" \
+  -projectPath "${STAGED_PROJECT_PATH}" \
+  -batchmode \
+  -executeMethod ADL.Demos.UnityObservatory.Editor.UnityObservatoryBatchValidator.ValidateScene \
+  -quit \
+  -logFile "${LOG_PATH}" &
+unity_pid="$!"
+
+cleanup_child() {
+  if kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -INT "${unity_pid}" 2>/dev/null || true
+    sleep 1
+  fi
+  if kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -TERM "${unity_pid}" 2>/dev/null || true
+    sleep 1
+  fi
+  if kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -KILL "${unity_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${RUNTIME_ROOT}" || true
+}
+
+report_known_batch_blocker() {
+  local readonly_msg="attempt to write a readonly database"
+  local headless_msg="com.unity.editor.headless"
+
+  if [[ -f "${LOG_PATH}" ]] && grep -Fq "${readonly_msg}" "${LOG_PATH}"; then
+    echo "Unity local-runtime consumption proof blocked: readonly-database failure against the staged project copy." >&2
+    echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+    exit 3
+  fi
+
+  if [[ -f "${LOG_PATH}" ]] && grep -Fq "${headless_msg}" "${LOG_PATH}"; then
+    echo "Unity local-runtime consumption proof blocked: headless entitlement unavailable for the current Unity seat." >&2
+    echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+    exit 4
+  fi
+}
+
+trap cleanup_child EXIT
+
+deadline=$((SECONDS + TIMEOUT_SECS))
+while kill -0 "${unity_pid}" 2>/dev/null; do
+  if (( SECONDS >= deadline )); then
+    cleanup_child
+    wait "${unity_pid}" 2>/dev/null || true
+    report_known_batch_blocker
+    echo "Unity local-runtime consumption proof timed out after ${TIMEOUT_SECS}s." >&2
+    echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+    exit 124
+  fi
+  sleep 1
+done
+
+set +e
+wait "${unity_pid}"
+unity_status="$?"
+set -e
+trap - EXIT
+
+if [[ "${unity_status}" -ne 0 ]]; then
+  report_known_batch_blocker
+  echo "Unity local-runtime consumption proof failed with exit ${unity_status}." >&2
+  echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+  exit "${unity_status}"
+fi
+
+report_known_batch_blocker
+
+if ! grep -Fq "Unity Observatory compatibility verification passed." "${LOG_PATH}"; then
+  echo "Unity local-runtime consumption proof failed: validator success marker missing from log." >&2
+  echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+  exit 5
+fi
+
+for expected in \
+  "title=${EXPECTED_TITLE}" \
+  "packetRef=${EXPECTED_PACKET_REF}" \
+  "artifactRoot=${EXPECTED_ARTIFACT_ROOT}" \
+  "reportRef=${EXPECTED_REPORT_REF}"; do
+  if ! grep -Fq "${expected}" "${LOG_PATH}"; then
+    echo "Unity local-runtime consumption proof failed: expected log marker '${expected}' missing." >&2
+    echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log" >&2
+    exit 6
+  fi
+done
+
+rm -rf "${RUNTIME_ROOT}" || true
+
+echo "Unity local-runtime consumption proof passed."
+echo "log: .adl/tmp/unity-observatory-4548/unity-local-runtime-consumption.log"

--- a/adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
+++ b/adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
@@ -71,7 +71,7 @@ cleanup_child() {
   if kill -0 "${unity_pid}" 2>/dev/null; then
     kill -KILL "${unity_pid}" 2>/dev/null || true
   fi
-  rm -rf "${RUNTIME_ROOT}"
+  rm -rf "${RUNTIME_ROOT}" || true
 }
 
 trap cleanup_child EXIT
@@ -127,7 +127,7 @@ if ! grep -Fq "Unity Observatory compatibility verification passed." "${LOG_PATH
   exit 5
 fi
 
-rm -rf "${RUNTIME_ROOT}"
+rm -rf "${RUNTIME_ROOT}" || true
 
 echo "Unity 6.5 smoke passed."
 echo "log: .adl/tmp/unity-observatory-4529/unity-6000.5.1f1-batch.log"

--- a/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryBatchValidator.cs
+++ b/demos/v0.91.6/unity-observatory/Assets/Editor/UnityObservatoryBatchValidator.cs
@@ -17,6 +17,11 @@ namespace ADL.Demos.UnityObservatory.Editor
         private const string ThemeResourcePath = "UnityDefaultRuntimeTheme";
         private const string RuntimeStyleSheetResourcePath = "ObservatoryShellRuntime";
         private const string ShellObjectName = "Unity Observatory Shell";
+        private const string ExpectedTitleEnvVar = "ADL_UNITY_EXPECTED_TITLE";
+        private const string ExpectedPacketRefEnvVar = "ADL_UNITY_EXPECTED_PACKET_REF";
+        private const string ExpectedArtifactRootEnvVar = "ADL_UNITY_EXPECTED_ARTIFACT_ROOT";
+        private const string ExpectedReportRefEnvVar = "ADL_UNITY_EXPECTED_REPORT_REF";
+        private const string ExpectedEvidenceLevelEnvVar = "ADL_UNITY_EXPECTED_EVIDENCE_LEVEL";
 
         public static void ValidateScene()
         {
@@ -136,8 +141,45 @@ namespace ADL.Demos.UnityObservatory.Editor
 
                 string title = root.Q<Label>("title")?.text ?? "unknown";
                 string packetSchema = root.Q<Label>("packet-schema")?.text ?? "unknown";
+                string packetRef = root.Q<Label>("packet-ref")?.text ?? "unknown";
+                string artifactRoot = root.Q<Label>("artifact-root")?.text ?? "unknown";
+                string reportRef = root.Q<Label>("report-ref")?.text ?? "unknown";
+                string packetNote = root.Q<Label>("packet-note")?.text ?? "unknown";
+
+                AssertMatchesExpectation(
+                    "title",
+                    title,
+                    Environment.GetEnvironmentVariable(ExpectedTitleEnvVar)
+                );
+                AssertMatchesExpectation(
+                    "packet-ref",
+                    packetRef,
+                    Environment.GetEnvironmentVariable(ExpectedPacketRefEnvVar)
+                );
+                AssertMatchesExpectation(
+                    "artifact-root",
+                    artifactRoot,
+                    Environment.GetEnvironmentVariable(ExpectedArtifactRootEnvVar)
+                );
+                AssertMatchesExpectation(
+                    "report-ref",
+                    reportRef,
+                    Environment.GetEnvironmentVariable(ExpectedReportRefEnvVar)
+                );
+
+                string expectedEvidenceLevel = Environment.GetEnvironmentVariable(
+                    ExpectedEvidenceLevelEnvVar
+                );
+                if (!string.IsNullOrWhiteSpace(expectedEvidenceLevel) &&
+                    !packetNote.Contains(expectedEvidenceLevel, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Unity Observatory validation expected packet-note to contain '{expectedEvidenceLevel}' but observed '{packetNote}'."
+                    );
+                }
+
                 Debug.Log(
-                    $"Unity Observatory compatibility verification passed. rootChildren={root.childCount}; title={title}; packetSchema={packetSchema}"
+                    $"Unity Observatory compatibility verification passed. rootChildren={root.childCount}; title={title}; packetSchema={packetSchema}; packetRef={packetRef}; artifactRoot={artifactRoot}; reportRef={reportRef}"
                 );
             }
             finally
@@ -147,6 +189,21 @@ namespace ADL.Demos.UnityObservatory.Editor
                 {
                     UnityEngine.Object.DestroyImmediate(shellObject);
                 }
+            }
+        }
+
+        private static void AssertMatchesExpectation(
+            string label,
+            string observed,
+            string expected
+        )
+        {
+            if (!string.IsNullOrWhiteSpace(expected) &&
+                !string.Equals(observed, expected, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Unity Observatory validation expected {label} '{expected}' but observed '{observed}'."
+                );
             }
         }
 

--- a/demos/v0.91.6/unity-observatory/PROOF_PACKET.md
+++ b/demos/v0.91.6/unity-observatory/PROOF_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Current through ADL issue `#4529`.
+Current through ADL issue `#4548`.
 
 ## Project Surface
 
@@ -34,6 +34,11 @@ The Unity-facing contract seed now lives at:
 This seed is the checked-in reference copy of the same bounded contract family
 that ADL emits as `unity_observatory_contract.json` in the Observatory CLI
 bundle.
+
+For `#4548`, the proof lane now also stages one explicitly local runtime-derived
+bundle into a disposable Unity project copy before batch validation. The
+checked-in seed remains the normal project baseline; the runtime-derived swap is
+proof-only.
 
 ## Launch Wiring
 
@@ -93,6 +98,26 @@ checked-in Unity contract resource, and executes
 `UnityObservatoryBootstrap` and that the Observatory shell builds the expected
 title, packet-contract, and observability surfaces.
 
+Deterministic Unity 6.5 local-runtime consumption proof: passed by
+`bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh`,
+which:
+
+- generates a fresh Observatory bundle from
+  `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+- stages `unity_observatory_contract.json` into a disposable Unity project copy
+- runs the Unity batch validator against that staged project
+- asserts the runtime shell renders:
+  - title `Prototype CSM 01`
+  - packet ref
+    `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+  - artifact root `runtime_v2`
+  - report ref `runtime_v2/observatory/operator_report.md`
+  - evidence-level note `artifact_backed_fixture`
+
+This proof shows the Unity shell consumes an explicitly local runtime-derived
+contract instead of only the older canned checked-in seed, while still stopping
+short of live runtime/network ingestion claims.
+
 Observability/security consumption proof: carried by the contract and reviewed
 in
 `docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md`.
@@ -121,9 +146,11 @@ C# compiler validation outside Unity: not run.
 
 ## Known Limitations
 
-- The shell loads a checked-in Unity-facing contract seed rather than parsing
-  the full governed packet directly inside Unity.
-- No live Runtime v2 or ADL runtime API integration is claimed.
+- The shell still loads a Unity-facing contract bundle rather than parsing the
+  full governed packet directly inside Unity.
+- The `#4548` proof swaps in a freshly generated local runtime-derived contract
+  only inside a disposable staged project; it does not claim direct live
+  Runtime v2 or ADL runtime API integration inside the checked-in scene.
 - No live OpenTelemetry collector or exporter integration is claimed.
 - No inhabitant-safe identity/profile closure beyond redacted lane projections is claimed.
 - The working-scene proof is limited to the checked-in scene and shell surface;

--- a/demos/v0.91.6/unity-observatory/README.md
+++ b/demos/v0.91.6/unity-observatory/README.md
@@ -23,14 +23,22 @@ This bounded scaffold still does not claim:
 - identity-safe inhabitant/profile closure
 - production Observatory readiness
 
-Those remain owned by downstream runtime/demo integration work. WP-09 closeout
-truth itself is now complete through `#3974`.
+Direct live runtime/network ingestion remains owned by downstream runtime/demo
+integration work. WP-09 closeout truth itself is now complete through `#3974`.
 
 Update for `#4032`: the scaffold now includes one deterministic Unity-facing
 contract seed at `Assets/Resources/observatory_contract.json`, derived from the
 same governed Observatory packet family and loaded through Unity `Resources`
 instead of private machine-local paths. The same contract is emitted by the ADL
 Observatory bundle as `unity_observatory_contract.json`.
+
+Update for `#4548`: the Unity 6.5 proof lane now also verifies one explicitly
+local runtime-derived contract path by generating a fresh
+`unity_observatory_contract.json` from
+`adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`, staging it
+into a disposable Unity project copy, and proving the runtime shell renders the
+runtime-derived title, packet ref, artifact root, report ref, and evidence
+level instead of the older canned seeded contract.
 
 ## Purpose
 
@@ -116,9 +124,11 @@ security-consumption posture explicit through repository-relative proof refs for
 - the issue-owned reviewer packet
   `docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md`
 
-The current checked-in contract and Unity shell now render this as a governed
+The checked-in contract and Unity shell now render this as a governed
 observability/security card when that contract section is actually present, so
 reviewers can inspect the non-claim boundary without opening raw runtime logs.
+The `#4548` local-runtime proof keeps that same shell path intact while swapping
+in the runtime-derived local contract only inside the disposable staged project.
 
 ### Non-authoritative boundary
 
@@ -172,6 +182,21 @@ Current contract-backed behavior:
   private-state posture from the same contract
 - no live runtime mutation, snapshot, or profile inspection is performed
 
+Current local-runtime proof behavior for `#4548`:
+
+- ADL generates a fresh Unity Observatory contract bundle from
+  `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+- the Unity smoke lane stages that generated contract into a disposable Unity
+  project copy
+- the batch validator proves the runtime shell rendered:
+  - title `Prototype CSM 01`
+  - packet ref `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+  - artifact root `runtime_v2`
+  - operator report ref `runtime_v2/observatory/operator_report.md`
+  - evidence-level note `artifact_backed_fixture`
+- the checked-in project seed remains unchanged; only the staged proof copy is
+  replaced for this validation lane
+
 ## Validation Entry Points
 
 Focused proof that already exists for the bounded Observatory packet contract:
@@ -208,6 +233,12 @@ Focused Unity 6.5 working-scene smoke proof for this issue:
 
 ```bash
 bash adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
+```
+
+Focused Unity 6.5 local-runtime consumption proof for `#4548`:
+
+```bash
+bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
 ```
 
 Focused O-04 review packet inspection:
@@ -258,6 +289,11 @@ This means the checked-in Unity Observatory demo now retains a proved
 Unity `2022.3.x` compatibility fallback while also carrying a focused
 Unity `6000.5.1f1` working-scene migration proof. It still does not claim a
 player build or broader production readiness.
+
+With `#4548`, the bounded Unity 6.5 proof now also shows the runtime shell can
+consume an explicitly local runtime-derived Observatory contract rather than
+only the older canned seed, while still stopping short of live runtime/network
+ingestion claims.
 
 ## Non-Claims
 

--- a/docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md
+++ b/docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md
@@ -1,0 +1,61 @@
+# Unity Observatory Local Runtime Consumption Proof
+
+## Status
+
+Bounded proof for ADL issue `#4548`.
+
+## Purpose
+
+Prove that the Unity 6.5 Observatory shell can consume an explicitly local
+runtime-derived Observatory contract instead of only the older checked-in seed,
+without widening into live runtime/network ingestion claims.
+
+## Bounded Contract Path
+
+Runtime-derived packet source:
+
+- `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+
+Generated bundle artifact used by the proof:
+
+- staged `unity_observatory_contract.json` copied into
+  `Assets/Resources/observatory_contract.json` inside a disposable Unity
+  project copy
+
+Normal checked-in project seed remains:
+
+- `demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json`
+
+## Proof Commands
+
+Contract baseline guardrail:
+
+```bash
+bash adl/tools/test_v0916_unity_observatory_contract.sh
+```
+
+Local runtime-derived consumption proof:
+
+```bash
+bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
+```
+
+## What The Proof Verifies
+
+The local-runtime proof stages a disposable Unity project copy, replaces the
+staged `observatory_contract.json` with a freshly generated runtime-derived
+bundle, runs the Unity batch validator, and asserts the rendered shell surfaces:
+
+- title `Prototype CSM 01`
+- packet ref `adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json`
+- artifact root `runtime_v2`
+- report ref `runtime_v2/observatory/operator_report.md`
+- evidence-level note `artifact_backed_fixture`
+
+## Observed Non-Claims
+
+- No live runtime socket, service, or network ingestion is claimed.
+- No Unity player build is claimed.
+- No direct governed-packet parser inside Unity is claimed.
+- The checked-in project seed is not replaced by this proof; only the staged
+  disposable copy is changed.


### PR DESCRIPTION
## Summary
- add a focused Unity 6.5 proof lane that stages a runtime-derived observatory contract into a disposable project copy
- extend the Unity batch validator to assert runtime-derived rendered fields and harden the two Unity proof scripts against cleanup-only failures
- document the new bounded proof surface and non-claims for issue #4548

## Validation
- bash adl/tools/test_v0916_unity_observatory_contract.sh
- bash adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
- bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
- git diff --check

## Notes
- Repo-native `pr.sh finish` currently refuses publication for this Unity demo surface because `adl/config/validation_lane_selector.v0.91.6.json` leaves the changed Unity/runtime-proof paths unmapped; this PR was published manually so #4548 can proceed while that selector gap is remediated separately.
- Closes #4548
