### PR TITLE
[v0.91.6][tools][validation] Implement operational Nessus remote-validation lane

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -144,25 +144,29 @@
       "path_selectors": [
         "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
+        "adl/tools/run_nessus_remote_validation.sh",
         "adl/tools/select_validation_lanes.py",
         "adl/tools/test_select_validation_lanes.sh",
         "adl/tools/validation_manager.py",
         "adl/tools/test_ci_path_policy.sh",
+        "adl/tools/test_run_nessus_remote_validation.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
       ],
       "path_hints": [
         "adl/config/validation_lane_selector.v0.91.6.json",
         "adl/tools/ci_path_policy.sh",
+        "adl/tools/run_nessus_remote_validation.sh",
         "adl/tools/select_validation_lanes.py",
         "adl/tools/test_select_validation_lanes.sh",
         "adl/tools/validation_manager.py",
         "adl/tools/test_ci_path_policy.sh",
+        "adl/tools/test_run_nessus_remote_validation.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**"
       ],
-      "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh",
-      "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh",
+      "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
+      "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
       "reason": "ci_policy_surface_requires_path_policy_contract_checks"
     },
     {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4315,7 +4315,7 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
-                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh" => {
+                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh" => {
                     let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");
                     run_finish_validation_status("bash", &[path_str(&ci_path_policy)?])?;
                     let select_validation_lanes =
@@ -4324,6 +4324,9 @@ pub(super) fn run_finish_validation_rust(
                     let validation_manager =
                         repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&validation_manager)?])?;
+                    let nessus_remote_runner =
+                        repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
+                    run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
                 }
                 "bash adl/tools/test_validation_inventory.sh" => {
                     let script = repo_root.join("adl/tools/test_validation_inventory.sh");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4400,6 +4400,10 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
         &repo.join("adl/tools/test_validation_manager.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' validation-manager >> \"$FOCUSED_LOG\"\n",
     );
+    write_executable(
+        &repo.join("adl/tools/test_run_nessus_remote_validation.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' nessus-remote-runner >> \"$FOCUSED_LOG\"\n",
+    );
     init_git_repo(&repo);
 
     let bin_dir = temp.join("bin");
@@ -4423,7 +4427,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     let plan = FinishValidationPlan {
         mode: FinishValidationMode::SmallBinaryFocused,
         commands: vec![
-            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh".to_string(),
+            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
         ],
     };
     run_finish_validation_rust(&repo, &plan).expect("combined ci-policy selector validation");
@@ -4445,6 +4449,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     assert!(focused_calls.contains("ci-path-policy"));
     assert!(focused_calls.contains("select-validation-lanes"));
     assert!(focused_calls.contains("validation-manager"));
+    assert!(focused_calls.contains("nessus-remote-runner"));
 }
 
 #[test]

--- a/adl/tools/run_nessus_remote_validation.sh
+++ b/adl/tools/run_nessus_remote_validation.sh
@@ -1,0 +1,544 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  adl/tools/run_nessus_remote_validation.sh --command <shell-command> [options]
+
+Options:
+  --command <shell-command>        Command to run inside the remote ADL checkout. Required.
+  --executor <ssh|local>           Execution transport. Defaults to ssh. local is for bounded contract tests.
+  --host <host>                    Remote host. Defaults to nessus.local.
+  --ssh-user <user>                SSH login user. Defaults to danie.
+  --wsl-user <user>                WSL Linux user. Defaults to root.
+  --remote-root <path>             Remote workspace root. Defaults to /root/adl-remote-runner.
+  --repo-url <url>                 Git remote used to materialize/refresh the checkout.
+  --git-ref <ref>                  Git ref to fetch and check out. Defaults to origin/main.
+  --run-id <id>                    Deterministic run id. Defaults to UTC timestamp.
+  --local-artifact-dir <path>      Optional local artifact directory for fetched summary + log tarball.
+  --summary-name <name>            Remote summary filename. Defaults to summary.json.
+  --help                           Show this help.
+
+Environment overrides:
+  ADL_NESSUS_REMOTE_EXECUTOR
+  ADL_NESSUS_REMOTE_HOST
+  ADL_NESSUS_REMOTE_SSH_USER
+  ADL_NESSUS_REMOTE_WSL_USER
+  ADL_NESSUS_REMOTE_ROOT
+  ADL_NESSUS_REMOTE_REPO_URL
+  ADL_NESSUS_REMOTE_GIT_REF
+  ADL_NESSUS_REMOTE_ARTIFACT_DIR
+  ADL_NESSUS_APT_SOURCES_LIST
+  ADL_NESSUS_APT_KUBERNETES_LIST
+  SSH_BIN
+EOF
+}
+
+timestamp_id() {
+  date -u +"%Y%m%d-%H%M%S"
+}
+
+quote_remote_single() {
+  printf "%s" "$1" | sed "s/'/'\"'\"'/g"
+}
+
+COMMAND_STRING=""
+EXECUTOR="${ADL_NESSUS_REMOTE_EXECUTOR:-ssh}"
+HOST="${ADL_NESSUS_REMOTE_HOST:-nessus.local}"
+SSH_USER="${ADL_NESSUS_REMOTE_SSH_USER:-danie}"
+WSL_USER="${ADL_NESSUS_REMOTE_WSL_USER:-root}"
+REMOTE_ROOT="${ADL_NESSUS_REMOTE_ROOT:-/root/adl-remote-runner}"
+REPO_URL="${ADL_NESSUS_REMOTE_REPO_URL:-https://github.com/danielbaustin/agent-design-language.git}"
+GIT_REF="${ADL_NESSUS_REMOTE_GIT_REF:-origin/main}"
+RUN_ID=""
+LOCAL_ARTIFACT_DIR="${ADL_NESSUS_REMOTE_ARTIFACT_DIR:-}"
+SUMMARY_NAME="summary.json"
+SSH_BIN="${SSH_BIN:-ssh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --command)
+      COMMAND_STRING="${2:-}"
+      shift 2
+      ;;
+    --executor)
+      EXECUTOR="${2:-}"
+      shift 2
+      ;;
+    --host)
+      HOST="${2:-}"
+      shift 2
+      ;;
+    --ssh-user)
+      SSH_USER="${2:-}"
+      shift 2
+      ;;
+    --wsl-user)
+      WSL_USER="${2:-}"
+      shift 2
+      ;;
+    --remote-root)
+      REMOTE_ROOT="${2:-}"
+      shift 2
+      ;;
+    --repo-url)
+      REPO_URL="${2:-}"
+      shift 2
+      ;;
+    --git-ref)
+      GIT_REF="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --local-artifact-dir)
+      LOCAL_ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --summary-name)
+      SUMMARY_NAME="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "run_nessus_remote_validation: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$COMMAND_STRING" ]]; then
+  echo "run_nessus_remote_validation: --command is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ "$EXECUTOR" != "ssh" && "$EXECUTOR" != "local" ]]; then
+  echo "run_nessus_remote_validation: unsupported --executor '$EXECUTOR' (expected ssh or local)" >&2
+  exit 2
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$(timestamp_id)"
+fi
+
+COMMAND_B64="$(printf "%s" "$COMMAND_STRING" | base64 | tr -d '\n')"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/adl-nessus-remote-validation.XXXXXX")"
+REMOTE_SCRIPT="$TMP_DIR/remote_runner.sh"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$REMOTE_SCRIPT" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE_ROOT="$1"
+REPO_URL="$2"
+GIT_REF="$3"
+RUN_ID="$4"
+COMMAND_B64="$5"
+SUMMARY_NAME="$6"
+APT_SOURCES_LIST="${ADL_NESSUS_APT_SOURCES_LIST:-/etc/apt/sources.list}"
+APT_KUBERNETES_LIST="${ADL_NESSUS_APT_KUBERNETES_LIST:-/etc/apt/sources.list.d/kubernetes.list}"
+COMMAND_STRING="$(printf '%s' "$COMMAND_B64" | base64 -d)"
+RUN_ROOT="$REMOTE_ROOT/logs/$RUN_ID"
+REPO_DIR="$REMOTE_ROOT/agent-design-language"
+CACHE_ROOT="$REMOTE_ROOT/cache"
+TARGET_DIR="$CACHE_ROOT/target"
+SCCACHE_DIR="$CACHE_ROOT/sccache"
+SUMMARY_PATH="$RUN_ROOT/$SUMMARY_NAME"
+WINDOWS_IDENTITY_FILE="$RUN_ROOT/windows-identity.txt"
+WSL_IDENTITY_FILE="$RUN_ROOT/wsl-identity.txt"
+STATUS="failed"
+RESOLVED_COMMIT="unknown"
+COMMAND_EXIT=1
+APT_MASKED=false
+HASHICORP_MASKED=false
+KUBERNETES_BACKUP=""
+SOURCES_BACKUP=""
+START_EPOCH="$(date +%s)"
+START_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$RUN_ROOT" "$CACHE_ROOT" "$TARGET_DIR" "$SCCACHE_DIR"
+
+restore_apt_sources() {
+  if [[ -n "$KUBERNETES_BACKUP" && -f "$KUBERNETES_BACKUP" ]]; then
+    mv "$KUBERNETES_BACKUP" "$APT_KUBERNETES_LIST"
+  fi
+  if [[ -n "$SOURCES_BACKUP" && -f "$SOURCES_BACKUP" ]]; then
+    mv "$SOURCES_BACKUP" "$APT_SOURCES_LIST"
+  fi
+}
+
+write_summary() {
+  local exit_code="$1"
+  local end_epoch elapsed end_iso
+  end_epoch="$(date +%s)"
+  elapsed="$((end_epoch - START_EPOCH))"
+  end_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  python3 - <<'PY' \
+    "$SUMMARY_PATH" "$RUN_ID" "$STATUS" "$exit_code" "$START_ISO" "$end_iso" "$elapsed" \
+    "$REPO_URL" "$GIT_REF" "$RESOLVED_COMMIT" "$COMMAND_STRING" "$REMOTE_ROOT" "$RUN_ROOT" \
+    "$REPO_DIR" "$TARGET_DIR" "$SCCACHE_DIR" "$APT_SOURCES_LIST" "$APT_KUBERNETES_LIST"
+import json
+import os
+import sys
+from pathlib import Path
+
+(
+    summary_path,
+    run_id,
+    status,
+    exit_code,
+    started_at,
+    finished_at,
+    elapsed_seconds,
+    repo_url,
+    git_ref,
+    resolved_commit,
+    command,
+    remote_root,
+    run_root,
+    repo_dir,
+    target_dir,
+    sccache_dir,
+    apt_sources_list,
+    apt_kubernetes_list,
+) = sys.argv[1:]
+
+run_root_path = Path(run_root)
+sccache_stats_path = run_root_path / "sccache-stats.log"
+cache_status = {
+    "target_dir": target_dir,
+    "sccache_dir": sccache_dir,
+    "sccache_stats_log": str(sccache_stats_path),
+}
+if sccache_stats_path.exists():
+    for raw_line in sccache_stats_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        normalized = " ".join(raw_line.split())
+        if normalized.startswith("Compile requests "):
+            cache_status["compile_requests"] = normalized.split()[-1]
+        elif normalized.startswith("Compile requests executed "):
+            cache_status["compile_requests_executed"] = normalized.split()[-1]
+        elif normalized.startswith("Cache hits ") and not normalized.startswith("Cache hits rate "):
+            cache_status["cache_hits"] = normalized.split()[-1]
+        elif normalized.startswith("Cache misses ") and not normalized.startswith("Cache misses ("):
+            cache_status["cache_misses"] = normalized.split()[-1]
+
+payload = {
+    "schema_version": "adl.remote_validation_run.v1",
+    "runner": "nessus",
+    "run_id": run_id,
+    "status": status,
+    "exit_code": int(exit_code),
+    "started_at": started_at,
+    "finished_at": finished_at,
+    "elapsed_seconds": int(elapsed_seconds),
+    "repo_url": repo_url,
+    "git_ref": git_ref,
+    "resolved_commit": resolved_commit,
+    "command": command,
+    "remote_root": remote_root,
+    "run_root": run_root,
+    "repo_dir": repo_dir,
+    "target_dir": target_dir,
+    "sccache_dir": sccache_dir,
+    "cache_status": cache_status,
+    "apt_sources_list": apt_sources_list,
+    "apt_kubernetes_list": apt_kubernetes_list,
+    "logs": {
+        "host_facts": os.path.join(run_root, "host-facts.log"),
+        "rustc_version": os.path.join(run_root, "rustc-version.log"),
+        "cargo_version": os.path.join(run_root, "cargo-version.log"),
+        "sccache_version": os.path.join(run_root, "sccache-version.log"),
+        "apt_update": os.path.join(run_root, "apt-update.log"),
+        "git_fetch": os.path.join(run_root, "git-fetch.log"),
+        "git_checkout": os.path.join(run_root, "git-checkout.log"),
+        "command": os.path.join(run_root, "command.log"),
+        "sccache_stats": os.path.join(run_root, "sccache-stats.log"),
+        "windows_identity": os.path.join(run_root, "windows-identity.txt"),
+        "wsl_identity": os.path.join(run_root, "wsl-identity.txt"),
+    },
+}
+
+with open(summary_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+}
+
+finish() {
+  local exit_code="$1"
+  set +e
+  if command -v sccache >/dev/null 2>&1; then
+    sccache --show-stats >"$RUN_ROOT/sccache-stats.log" 2>&1
+  fi
+  restore_apt_sources
+  write_summary "$exit_code"
+  exit "$exit_code"
+}
+
+trap 'finish $?' EXIT
+
+printf '%s\n' "${ADL_NESSUS_WINDOWS_IDENTITY:-unknown}" >"$WINDOWS_IDENTITY_FILE"
+whoami >"$WSL_IDENTITY_FILE"
+{
+  echo "whoami=$(whoami)"
+  echo "uname=$(uname -s)"
+  echo "kernel=$(uname -r)"
+  if command -v nproc >/dev/null 2>&1; then
+    echo "cpus=$(nproc)"
+  fi
+  if command -v free >/dev/null 2>&1; then
+    free -h
+  fi
+} >"$RUN_ROOT/host-facts.log" 2>&1
+
+if [[ -f "$HOME/.cargo/env" ]]; then
+  # Non-login WSL shells need the Cargo toolchain path restored explicitly.
+  # The proven interactive path already had rust/cargo/sccache available.
+  # The wrapper preserves that truth for automation without assuming systemwide
+  # installation.
+  # shellcheck disable=SC1090
+  . "$HOME/.cargo/env"
+fi
+
+command -v git >/dev/null 2>&1
+command -v rustc >/dev/null 2>&1
+command -v cargo >/dev/null 2>&1
+command -v sccache >/dev/null 2>&1
+
+rustc --version >"$RUN_ROOT/rustc-version.log" 2>&1
+cargo --version >"$RUN_ROOT/cargo-version.log" 2>&1
+sccache --version >"$RUN_ROOT/sccache-version.log" 2>&1
+sccache --zero-stats >/dev/null 2>&1 || true
+
+if [[ -f "$APT_KUBERNETES_LIST" ]]; then
+  KUBERNETES_BACKUP="$RUN_ROOT/kubernetes.list.backup"
+  mv "$APT_KUBERNETES_LIST" "$KUBERNETES_BACKUP"
+  APT_MASKED=true
+fi
+if [[ -f "$APT_SOURCES_LIST" ]] && grep -q 'apt.releases.hashicorp.com' "$APT_SOURCES_LIST"; then
+  SOURCES_BACKUP="$RUN_ROOT/sources.list.backup"
+  cp "$APT_SOURCES_LIST" "$SOURCES_BACKUP"
+  python3 - <<'PY' "$APT_SOURCES_LIST"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines()
+rewritten = []
+for line in lines:
+    if "apt.releases.hashicorp.com" in line and not line.lstrip().startswith("#"):
+        rewritten.append(f"# ADL-temporarily-masked {line}")
+    else:
+        rewritten.append(line)
+path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+PY
+  HASHICORP_MASKED=true
+fi
+apt-get update >"$RUN_ROOT/apt-update.log" 2>&1
+
+mkdir -p "$REMOTE_ROOT"
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  git clone "$REPO_URL" "$REPO_DIR" >"$RUN_ROOT/git-clone.log" 2>&1
+fi
+
+git -C "$REPO_DIR" reset --hard HEAD >"$RUN_ROOT/git-reset.log" 2>&1
+git -C "$REPO_DIR" clean -fd >"$RUN_ROOT/git-clean.log" 2>&1
+git -C "$REPO_DIR" fetch origin --prune >"$RUN_ROOT/git-fetch.log" 2>&1
+git -C "$REPO_DIR" checkout --detach "$GIT_REF" >"$RUN_ROOT/git-checkout.log" 2>&1
+RESOLVED_COMMIT="$(git -C "$REPO_DIR" rev-parse HEAD)"
+
+export CARGO_TARGET_DIR="$TARGET_DIR"
+export SCCACHE_DIR
+export RUSTC_WRAPPER="sccache"
+
+if bash -lc "cd '$REPO_DIR' && $COMMAND_STRING" >"$RUN_ROOT/command.log" 2>&1; then
+  COMMAND_EXIT=0
+  STATUS="passed"
+else
+  COMMAND_EXIT=$?
+  STATUS="failed"
+fi
+
+exit "$COMMAND_EXIT"
+EOF
+chmod +x "$REMOTE_SCRIPT"
+
+REMOTE_SUMMARY_PATH="$REMOTE_ROOT/logs/$RUN_ID/$SUMMARY_NAME"
+REMOTE_RUN_ROOT="$REMOTE_ROOT/logs/$RUN_ID"
+LOCAL_SUMMARY_PATH=""
+
+run_remote() {
+  if [[ "$EXECUTOR" == "ssh" ]]; then
+    local remote_cmd
+    remote_cmd="wsl.exe -u $WSL_USER -- bash -s -- '$(quote_remote_single "$REMOTE_ROOT")' '$(quote_remote_single "$REPO_URL")' '$(quote_remote_single "$GIT_REF")' '$(quote_remote_single "$RUN_ID")' '$(quote_remote_single "$COMMAND_B64")' '$(quote_remote_single "$SUMMARY_NAME")'"
+    "$SSH_BIN" -o BatchMode=yes -o ConnectTimeout=15 "${SSH_USER}@${HOST}" "$remote_cmd" <"$REMOTE_SCRIPT"
+  else
+    ADL_NESSUS_WINDOWS_IDENTITY="local-executor" bash "$REMOTE_SCRIPT" \
+      "$REMOTE_ROOT" "$REPO_URL" "$GIT_REF" "$RUN_ID" "$COMMAND_B64" "$SUMMARY_NAME"
+  fi
+}
+
+fetch_summary() {
+  local destination="$1"
+  if [[ "$EXECUTOR" == "ssh" ]]; then
+    local remote_cmd
+    remote_cmd="wsl.exe -u $WSL_USER -- bash -lc 'cat '\''$(quote_remote_single "$REMOTE_SUMMARY_PATH")'\'''"
+    "$SSH_BIN" -o BatchMode=yes -o ConnectTimeout=15 "${SSH_USER}@${HOST}" "$remote_cmd" >"$destination"
+  else
+    cp "$REMOTE_SUMMARY_PATH" "$destination"
+  fi
+}
+
+fetch_logs_tarball() {
+  local destination="$1"
+  if [[ "$EXECUTOR" == "ssh" ]]; then
+    local remote_cmd
+    remote_cmd="wsl.exe -u $WSL_USER -- bash -lc 'tar -C '\''$(quote_remote_single "$REMOTE_RUN_ROOT")'\'' -czf - .'"
+    "$SSH_BIN" -o BatchMode=yes -o ConnectTimeout=15 "${SSH_USER}@${HOST}" "$remote_cmd" >"$destination"
+  else
+    tar -C "$REMOTE_RUN_ROOT" -czf "$destination" .
+  fi
+}
+
+write_transport_failure_summary() {
+  local destination="$1"
+  python3 - <<'PY' \
+    "$destination" "$RUN_ID" "$RUN_EXIT" "$COMMAND_STRING" "$EXECUTOR" "$HOST" "$SSH_USER" \
+    "$REMOTE_ROOT" "$REMOTE_SUMMARY_PATH" "$REMOTE_RUN_ROOT" "$REPO_URL" "$GIT_REF"
+import json
+import sys
+
+(
+    destination,
+    run_id,
+    exit_code,
+    command,
+    executor,
+    host,
+    ssh_user,
+    remote_root,
+    remote_summary_path,
+    remote_run_root,
+    repo_url,
+    git_ref,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": "adl.remote_validation_run.v1",
+    "runner": "nessus",
+    "run_id": run_id,
+    "status": "failed",
+    "exit_code": int(exit_code),
+    "command": command,
+    "repo_url": repo_url,
+    "git_ref": git_ref,
+    "resolved_commit": "unknown",
+    "remote_root": remote_root,
+    "run_root": remote_run_root,
+    "repo_dir": f"{remote_root}/agent-design-language",
+    "target_dir": f"{remote_root}/cache/target",
+    "sccache_dir": f"{remote_root}/cache/sccache",
+    "started_at": "unknown",
+    "finished_at": "unknown",
+    "elapsed_seconds": 0,
+    "transport_failure": {
+        "executor": executor,
+        "host": host,
+        "ssh_user": ssh_user,
+        "summary_fetch_failed": True,
+        "expected_remote_summary_path": remote_summary_path,
+    },
+    "logs": {
+        "host_facts": "not_available",
+        "rustc_version": "not_available",
+        "cargo_version": "not_available",
+        "sccache_version": "not_available",
+        "apt_update": "not_available",
+        "git_fetch": "not_available",
+        "git_checkout": "not_available",
+        "command": "not_available",
+        "sccache_stats": "not_available",
+        "windows_identity": "not_available",
+        "wsl_identity": "not_available",
+    },
+    "cache_status": {
+        "target_dir": f"{remote_root}/cache/target",
+        "sccache_dir": f"{remote_root}/cache/sccache",
+        "sccache_stats_log": "not_available",
+    },
+    "apt_sources_list": "unknown",
+    "apt_kubernetes_list": "unknown",
+}
+
+with open(destination, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+}
+
+set +e
+run_remote
+RUN_EXIT=$?
+set -e
+
+SUMMARY_FETCH_OK=true
+if [[ -n "$LOCAL_ARTIFACT_DIR" ]]; then
+  mkdir -p "$LOCAL_ARTIFACT_DIR"
+  LOCAL_SUMMARY_PATH="$LOCAL_ARTIFACT_DIR/$SUMMARY_NAME"
+else
+  LOCAL_SUMMARY_PATH="$TMP_DIR/$SUMMARY_NAME"
+fi
+
+set +e
+fetch_summary "$LOCAL_SUMMARY_PATH"
+SUMMARY_FETCH_RC=$?
+set -e
+if [[ "$SUMMARY_FETCH_RC" -ne 0 ]]; then
+  SUMMARY_FETCH_OK=false
+  if [[ "$RUN_EXIT" -ne 0 ]]; then
+    write_transport_failure_summary "$LOCAL_SUMMARY_PATH"
+  else
+    echo "run_nessus_remote_validation: failed to fetch remote summary from $REMOTE_SUMMARY_PATH" >&2
+    exit "$SUMMARY_FETCH_RC"
+  fi
+fi
+
+if [[ -n "$LOCAL_ARTIFACT_DIR" ]]; then
+  set +e
+  fetch_logs_tarball "$LOCAL_ARTIFACT_DIR/run-logs.tar.gz"
+  LOG_FETCH_RC=$?
+  set -e
+  if [[ "$LOG_FETCH_RC" -ne 0 && "$RUN_EXIT" -eq 0 ]]; then
+    echo "run_nessus_remote_validation: failed to fetch remote log tarball from $REMOTE_RUN_ROOT" >&2
+    exit "$LOG_FETCH_RC"
+  fi
+fi
+
+python3 - <<'PY' "$LOCAL_SUMMARY_PATH"
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+print(json.dumps(summary, indent=2, sort_keys=True))
+PY
+
+if [[ "$RUN_EXIT" -ne 0 ]]; then
+  if [[ "$SUMMARY_FETCH_OK" == true ]]; then
+    echo "run_nessus_remote_validation: remote command failed (see summary above)" >&2
+  else
+    echo "run_nessus_remote_validation: transport failed before remote summary was available; fallback summary written locally" >&2
+  fi
+fi
+
+exit "$RUN_EXIT"

--- a/adl/tools/test_run_nessus_remote_validation.sh
+++ b/adl/tools/test_run_nessus_remote_validation.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/run_nessus_remote_validation.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "expected file to exist: $path" >&2
+    exit 1
+  fi
+}
+
+origin_src="$TMP/origin-src"
+origin_bare="$TMP/origin.git"
+mkdir -p "$origin_src"
+git -C "$origin_src" init -q
+git -C "$origin_src" branch -M main
+cat >"$origin_src/README.md" <<'EOF'
+# remote validation fixture
+EOF
+git -C "$origin_src" add README.md
+git -C "$origin_src" -c user.name=Codex -c user.email=codex@example.com commit -q -m "fixture"
+git clone -q --bare "$origin_src" "$origin_bare"
+
+fake_bin="$TMP/fake-bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "rustc 1.96.0 (fixture)"
+  exit 0
+fi
+echo "unexpected rustc invocation: $*" >&2
+exit 1
+EOF
+cat >"$fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "cargo 1.96.0 (fixture)"
+  exit 0
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 1
+EOF
+cat >"$fake_bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --version)
+    echo "sccache 0.16.0"
+    ;;
+  --zero-stats)
+    exit 0
+    ;;
+  --show-stats)
+    cat <<'STATS'
+Compile requests                      3
+Compile requests executed             1
+Cache hits                            2
+Cache misses                          1
+STATS
+    ;;
+  *)
+    echo "unexpected sccache invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+cat >"$fake_bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAIL_APT:-0}" == "1" ]]; then
+  echo "apt-get fixture failure" >&2
+  exit 1
+fi
+echo "apt-get update fixture ok"
+EOF
+chmod +x "$fake_bin/"*
+
+sources_list="$TMP/sources.list"
+kubernetes_list="$TMP/kubernetes.list"
+cat >"$sources_list" <<'EOF'
+deb https://apt.releases.hashicorp.com focal main
+EOF
+cat >"$kubernetes_list" <<'EOF'
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+PATH="$fake_bin:$PATH" \
+ADL_NESSUS_APT_SOURCES_LIST="$sources_list" \
+ADL_NESSUS_APT_KUBERNETES_LIST="$kubernetes_list" \
+bash "$SCRIPT" \
+  --executor local \
+  --repo-url "$origin_bare" \
+  --git-ref origin/main \
+  --remote-root "$TMP/remote-root-pass" \
+  --run-id fixture-pass \
+  --command "printf remote-ok" \
+  --local-artifact-dir "$TMP/artifacts-pass" \
+  >"$TMP/pass.json"
+
+assert_file "$TMP/artifacts-pass/summary.json"
+assert_file "$TMP/artifacts-pass/run-logs.tar.gz"
+python3 - <<'PY' "$TMP/artifacts-pass/summary.json"
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+assert summary["schema_version"] == "adl.remote_validation_run.v1"
+assert summary["runner"] == "nessus"
+assert summary["status"] == "passed"
+assert summary["resolved_commit"] != "unknown"
+assert summary["command"] == "printf remote-ok"
+assert summary["logs"]["command"].endswith("command.log")
+PY
+
+grep -F "apt.releases.hashicorp.com" "$sources_list" >/dev/null
+assert_file "$kubernetes_list"
+
+if PATH="$fake_bin:$PATH" \
+  FAIL_APT=1 \
+  ADL_NESSUS_APT_SOURCES_LIST="$sources_list" \
+  ADL_NESSUS_APT_KUBERNETES_LIST="$kubernetes_list" \
+  bash "$SCRIPT" \
+    --executor local \
+    --repo-url "$origin_bare" \
+    --git-ref origin/main \
+    --remote-root "$TMP/remote-root-fail" \
+    --run-id fixture-fail \
+    --command "printf should-not-run" \
+    --local-artifact-dir "$TMP/artifacts-fail" \
+    >"$TMP/fail.json" 2>"$TMP/fail.err"; then
+  echo "expected apt failure path to fail closed" >&2
+  exit 1
+fi
+
+assert_file "$TMP/artifacts-fail/summary.json"
+python3 - <<'PY' "$TMP/artifacts-fail/summary.json"
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+assert summary["status"] == "failed"
+assert summary["exit_code"] != 0
+assert summary["command"] == "printf should-not-run"
+PY
+
+cat >"$fake_bin/ssh-fail" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "ssh fixture failure" >&2
+exit 255
+EOF
+chmod +x "$fake_bin/ssh-fail"
+
+if SSH_BIN="$fake_bin/ssh-fail" \
+  bash "$SCRIPT" \
+    --executor ssh \
+    --host fixture.invalid \
+    --ssh-user fixture \
+    --run-id fixture-transport-fail \
+    --command "printf no-transport" \
+    --local-artifact-dir "$TMP/artifacts-transport-fail" \
+    >"$TMP/transport-fail.json" 2>"$TMP/transport-fail.err"; then
+  echo "expected transport failure path to fail closed" >&2
+  exit 1
+fi
+
+assert_file "$TMP/artifacts-transport-fail/summary.json"
+python3 - <<'PY' "$TMP/artifacts-transport-fail/summary.json"
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+assert summary["status"] == "failed"
+assert summary["transport_failure"]["summary_fetch_failed"] is True
+assert summary["transport_failure"]["executor"] == "ssh"
+assert summary["command"] == "printf no-transport"
+PY
+grep -F "fallback summary written locally" "$TMP/transport-fail.err" >/dev/null
+
+echo "PASS test_run_nessus_remote_validation"

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -76,6 +76,13 @@ assert_has "$TMP/metric-backfill-tool.out" "aggregate_status=selected"
 assert_has "$TMP/metric-backfill-tool.out" "csdlc_owner_lane status=selected"
 assert_not_has "$TMP/metric-backfill-tool.out" "unmapped_change_surface"
 
+remote_validation_tool="$TMP/remote-validation-tool.txt"
+printf 'M\tadl/tools/run_nessus_remote_validation.sh\n' >"$remote_validation_tool"
+bash "$SCRIPT" --changed-files "$remote_validation_tool" >"$TMP/remote-validation-tool.out"
+assert_has "$TMP/remote-validation-tool.out" "aggregate_status=selected"
+assert_has "$TMP/remote-validation-tool.out" "ci_path_policy_contracts status=selected"
+assert_not_has "$TMP/remote-validation-tool.out" "unmapped_change_surface"
+
 release_gate="$TMP/release-gate.txt"
 printf 'M\t.github/workflows/ci.yaml\n' >"$release_gate"
 bash "$SCRIPT" --changed-files "$release_gate" >"$TMP/release.out"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -497,4 +497,156 @@ if bash "$SCRIPT" --manifest "$bad_guardrail_manifest" --changed-files "$runtime
 fi
 assert_has "$TMP/bad-guardrail.err" "validation_manager: manager guardrail pr_fast.max_filter_token_count must be an integer"
 
+remote_origin_src="$TMP/remote-origin-src"
+remote_origin_bare="$TMP/remote-origin.git"
+mkdir -p "$remote_origin_src"
+git -C "$remote_origin_src" init -q
+git -C "$remote_origin_src" branch -M main
+cat >"$remote_origin_src/README.md" <<'EOF'
+# validation manager remote fixture
+EOF
+git -C "$remote_origin_src" add README.md
+git -C "$remote_origin_src" -c user.name=Codex -c user.email=codex@example.com commit -q -m "fixture"
+git clone -q --bare "$remote_origin_src" "$remote_origin_bare"
+
+remote_fake_bin="$TMP/remote-fake-bin"
+mkdir -p "$remote_fake_bin"
+cat >"$remote_fake_bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "rustc 1.96.0 (fixture)"
+  exit 0
+fi
+echo "unexpected rustc invocation: $*" >&2
+exit 1
+EOF
+cat >"$remote_fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "cargo 1.96.0 (fixture)"
+  exit 0
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 1
+EOF
+cat >"$remote_fake_bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --version)
+    echo "sccache 0.16.0"
+    ;;
+  --zero-stats)
+    exit 0
+    ;;
+  --show-stats)
+    cat <<'STATS'
+Compile requests                      5
+Compile requests executed             2
+Cache hits                            3
+Cache misses                          2
+STATS
+    ;;
+  *)
+    echo "unexpected sccache invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+cat >"$remote_fake_bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "apt-get update fixture ok"
+EOF
+chmod +x "$remote_fake_bin/"*
+
+remote_sources="$TMP/remote-sources.list"
+remote_kubernetes="$TMP/remote-kubernetes.list"
+cat >"$remote_sources" <<'EOF'
+deb https://apt.releases.hashicorp.com focal main
+EOF
+cat >"$remote_kubernetes" <<'EOF'
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+remote_profile_changed="$TMP/remote-profile.txt"
+printf 'M\tadl/src/provider_communication.rs\n' >"$remote_profile_changed"
+ADL_NESSUS_REMOTE_EXECUTOR=local \
+ADL_NESSUS_REMOTE_ROOT="$TMP/validation-manager-remote-root" \
+ADL_NESSUS_REMOTE_REPO_URL="$remote_origin_bare" \
+ADL_NESSUS_REMOTE_GIT_REF=origin/main \
+ADL_NESSUS_APT_SOURCES_LIST="$remote_sources" \
+ADL_NESSUS_APT_KUBERNETES_LIST="$remote_kubernetes" \
+PATH="$remote_fake_bin:$PATH" \
+bash "$SCRIPT" \
+  --changed-files "$remote_profile_changed" \
+  --remote-runner nessus \
+  --remote-command "printf remote-manager-ok" \
+  --remote-artifact-dir "$TMP/remote-manager-artifacts" \
+  --json >"$TMP/remote-manager.json"
+python3 - <<'PY' "$TMP/remote-manager.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["remote_runner"]["requested"] == "nessus"
+assert profile["remote_runner"]["decision"] == "selected"
+assert "run_nessus_remote_validation.sh" in profile["remote_runner"]["command"]
+assert profile["run"][0]["lane_id"] == "nessus_remote_validation"
+assert profile["status"] == "ready_to_run"
+PY
+
+ADL_NESSUS_REMOTE_EXECUTOR=local \
+ADL_NESSUS_REMOTE_ROOT="$TMP/validation-manager-remote-root-run" \
+ADL_NESSUS_REMOTE_REPO_URL="$remote_origin_bare" \
+ADL_NESSUS_REMOTE_GIT_REF=origin/main \
+ADL_NESSUS_APT_SOURCES_LIST="$remote_sources" \
+ADL_NESSUS_APT_KUBERNETES_LIST="$remote_kubernetes" \
+PATH="$remote_fake_bin:$PATH" \
+bash "$SCRIPT" \
+  --changed-files "$remote_profile_changed" \
+  --remote-runner nessus \
+  --remote-command "printf remote-manager-ok" \
+  --remote-artifact-dir "$TMP/remote-manager-artifacts-run" \
+  --run \
+  --report-out "$TMP/remote-manager-run-report.json" >/dev/null
+python3 - <<'PY' "$TMP/remote-manager-run-report.json" "$TMP/remote-manager-artifacts-run/summary.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+summary = json.load(open(sys.argv[2]))
+assert profile["run_status"] == "passed"
+assert profile["remote_runner"]["decision"] == "selected"
+assert summary["status"] == "passed"
+assert summary["command"] == "printf remote-manager-ok"
+PY
+
+bash "$SCRIPT" \
+  --changed-files "$docs_only" \
+  --remote-runner nessus \
+  --remote-command "printf no-remote-docs" \
+  --json >"$TMP/remote-docs.json"
+python3 - <<'PY' "$TMP/remote-docs.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["remote_runner"]["decision"] == "rejected"
+assert "runtime_class tiny" in profile["remote_runner"]["reason"]
+assert profile["status"] == "ready_to_run"
+PY
+
+if bash "$SCRIPT" \
+  --changed-files "$docs_only" \
+  --remote-runner nessus \
+  --remote-command "printf no-remote-docs" \
+  --run >"$TMP/remote-docs-run.out" 2>"$TMP/remote-docs-run.err"; then
+  echo "expected docs-only remote-runner request to be rejected" >&2
+  exit 1
+fi
+assert_has "$TMP/remote-docs-run.err" "requested remote runner is not eligible"
+
 echo "PASS test_validation_manager"

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SELECTOR = ROOT / "adl/tools/select_validation_lanes.sh"
 SLOW_PROOF_FAMILIES = ROOT / "adl/config/slow_proof_families.v0.91.6.json"
 DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
+NESSUS_REMOTE_RUNNER = "bash adl/tools/run_nessus_remote_validation.sh"
 
 
 def fail(message: str) -> None:
@@ -590,6 +592,71 @@ def build_profile(plan: dict[str, Any], guardrails: dict[str, Any], manifest_pat
     }
 
 
+def shell_quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def remote_runner_decision(profile: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
+    if not args.remote_runner and not args.remote_command:
+        return None
+    if bool(args.remote_runner) != bool(args.remote_command):
+        fail("remote runner selection requires both --remote-runner and --remote-command")
+    if args.remote_runner != "nessus":
+        fail(f"unsupported remote runner: {args.remote_runner}")
+
+    selected_lane_count = int(profile["estimated_cost"]["selected_lane_count"])
+    runtime_class = str(profile["estimated_cost"]["runtime_class"])
+    behavior_surfaces = profile.get("behavior_surfaces", [])
+    allowed_determinism = {"deterministic", "evidence_bound"}
+    unsupported_determinism = [
+        surface.get("determinism_posture", "unknown")
+        for surface in behavior_surfaces
+        if surface.get("determinism_posture", "unknown") not in allowed_determinism
+    ]
+
+    if profile["status"] != "ready_to_run":
+        return {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": f"validation profile status {profile['status']} is not remote-runnable",
+        }
+    if profile["escalation"]["required"]:
+        return {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": "validation profile already requires escalation",
+        }
+    if selected_lane_count != 1:
+        return {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": f"remote runner requires exactly 1 selected lane, observed {selected_lane_count}",
+        }
+    if runtime_class in {"none", "tiny", "escalated"}:
+        return {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": f"runtime_class {runtime_class} is not eligible for Nessus remote execution",
+        }
+    if unsupported_determinism:
+        return {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": "remote runner supports deterministic or evidence-bound lanes only",
+            "unsupported_determinism": unsupported_determinism,
+        }
+
+    remote_command = f"{NESSUS_REMOTE_RUNNER} --command {shell_quote(args.remote_command)}"
+    if args.remote_artifact_dir:
+        remote_command += f" --local-artifact-dir {shell_quote(str(args.remote_artifact_dir.resolve()))}"
+    return {
+        "requested": "nessus",
+        "decision": "selected",
+        "reason": "single-lane non-tiny deterministic profile is eligible for Nessus remote execution",
+        "command": remote_command,
+    }
+
+
 def print_text(profile: dict[str, Any]) -> None:
     print("Validation profile")
     print(f"  selected_profile={profile['selected_profile']}")
@@ -603,6 +670,14 @@ def print_text(profile: dict[str, Any]) -> None:
             print(f"      command={item['command']}")
     else:
         print("  run: []")
+    if profile.get("remote_runner"):
+        remote = profile["remote_runner"]
+        print("  remote_runner:")
+        print(f"    requested={remote['requested']}")
+        print(f"    decision={remote['decision']}")
+        print(f"    reason={remote['reason']}")
+        if remote.get("command"):
+            print(f"    command={remote['command']}")
     if profile["escalation"]["required"]:
         print("  escalation:")
         for reason in profile["escalation"]["reasons"]:
@@ -645,6 +720,11 @@ def write_report(path: Path, profile: dict[str, Any]) -> None:
 
 
 def run_profile(profile: dict[str, Any]) -> int:
+    remote_runner = profile.get("remote_runner")
+    if remote_runner and remote_runner.get("decision") != "selected":
+        print_text(profile)
+        print("validation_manager: refusing --run because the requested remote runner is not eligible", file=sys.stderr)
+        return 1
     if profile["status"] not in {"ready_to_run", "no_validation_needed"}:
         print_text(profile)
         print("validation_manager: refusing --run for non-runnable profile", file=sys.stderr)
@@ -672,6 +752,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--report-out", type=Path)
     parser.add_argument("--run", action="store_true")
+    parser.add_argument("--remote-runner", choices=["nessus"])
+    parser.add_argument("--remote-command")
+    parser.add_argument("--remote-artifact-dir", type=Path)
     return parser.parse_args(argv)
 
 
@@ -681,6 +764,20 @@ def main(argv: list[str]) -> int:
     manifest_path = args.manifest.resolve() if args.manifest else DEFAULT_MANIFEST
     guardrails = manager_guardrails(load_manifest(manifest_path), args.max_selected_lanes)
     profile = build_profile(plan, guardrails, manifest_path)
+    remote = remote_runner_decision(profile, args)
+    if remote:
+        profile["remote_runner"] = remote
+        if remote["decision"] == "selected":
+            profile["run"] = [
+                {
+                    "lane_id": "nessus_remote_validation",
+                    "command": remote["command"],
+                    "reason": remote["reason"],
+                    "matched_paths": profile["changed_paths"],
+                    "vpp_record": None,
+                    "local_run": profile["run"],
+                }
+            ]
     exit_code = 0
     if args.run:
         exit_code = run_profile(profile)

--- a/docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md
+++ b/docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md
@@ -1,0 +1,146 @@
+# Nessus Remote Validation Lane Proof for `#4553`
+
+Status: `integrated_proven_for_issue_scope`
+Issue: `#4553`
+Date: 2026-06-26
+
+## Scope
+
+This packet records the bounded proof that ADL now has an operational
+Nessus-backed remote validation lane rather than only prerequisite evidence.
+
+This issue proves:
+
+- a repo-native command can run one declared validation command on
+  `nessus.local` through the proven `danie@nessus.local` plus explicit
+  `wsl.exe -u root` path
+- the validation manager can choose the Nessus runner for an eligible
+  single-lane deterministic Rust profile
+- the remote runner fails closed when preflight fails
+- the remote runner emits a stable summary artifact plus retained remote log
+  paths
+- repeated runs against the same remote root record warm-path behavior
+
+This issue does not prove:
+
+- that every validation lane should run remotely
+- that provider/model credentialed lanes are remote-safe
+- that GitHub CI should move to Nessus
+- that CodeBuild is no longer deferred
+
+## Implemented surfaces
+
+- `adl/tools/run_nessus_remote_validation.sh`
+- `adl/tools/validation_manager.py --remote-runner nessus --remote-command ...`
+- selector classification for the new remote-runner contract surfaces in
+  `adl/config/validation_lane_selector.v0.91.6.json`
+
+## Manager-routed proof
+
+The first live run used the validation-manager route for the eligible focused
+Rust profile produced by the changed-path set:
+
+- changed path: `adl/src/provider_communication.rs`
+- selected profile: `rust_pr_fast_profile`
+- remote runner decision: `selected`
+- remote command:
+  `cargo test --manifest-path adl/Cargo.toml --locked provider_communication -- --nocapture`
+
+Observed result:
+
+- status: `passed`
+- run id: `20260626-174605`
+- commit: `abf3945ab363c54e43437b0124826b9fcafe916a`
+- elapsed seconds: `181`
+- remote run root: `/root/adl-remote-runner/logs/20260626-174605`
+
+The remote command log shows the focused lane passed on Nessus:
+
+- `21 passed; 0 failed`
+- filtered binary harnesses remained `0 failed`
+
+## Warm-path proof
+
+The same remote command was run again against the same remote root without
+clearing the retained target/cache directories.
+
+Observed result:
+
+- status: `passed`
+- run id: `20260626-175020`
+- commit: `abf3945ab363c54e43437b0124826b9fcafe916a`
+- elapsed seconds: `8`
+- remote run root: `/root/adl-remote-runner/logs/20260626-175020`
+
+Interpretation:
+
+- the first run paid the expected compile/setup cost
+- the second run completed on the warm path with no additional compile work
+  recorded by `sccache`
+- this is sufficient to classify the Nessus runner as operational for this
+  bounded focused Rust lane
+
+## Cache and artifact truth
+
+First run cache facts:
+
+- compile requests: `134`
+- compile requests executed: `33`
+- cache misses: `32`
+- cache hits: `0`
+- `sccache` stats log:
+  `/root/adl-remote-runner/logs/20260626-174605/sccache-stats.log`
+
+Second run cache facts:
+
+- compile requests: `0`
+- compile requests executed: `0`
+- cache misses: `0`
+- cache hits: `0`
+- `sccache` stats log:
+  `/root/adl-remote-runner/logs/20260626-175020/sccache-stats.log`
+
+Stable remote summary artifacts:
+
+- `/root/adl-remote-runner/logs/20260626-174605/summary.json`
+- `/root/adl-remote-runner/logs/20260626-175020/summary.json`
+
+Each summary records:
+
+- host/runner identity
+- requested Git ref and resolved commit
+- declared command
+- exit status and elapsed seconds
+- stable remote log paths
+- retained target and `sccache` roots
+
+## Failure-mode proof
+
+The issue-local contract tests prove fail-closed behavior for:
+
+- apt-source hygiene failure
+- invalid remote-runner selection requests from the validation manager
+- unmapped selector surfaces and ordinary validation-manager escalation gates
+
+Focused proving commands:
+
+- `bash adl/tools/test_run_nessus_remote_validation.sh`
+- `bash adl/tools/test_select_validation_lanes.sh`
+- `bash adl/tools/test_validation_manager.sh`
+
+## CodeBuild disposition
+
+`#4316` remains the truthful CodeBuild position:
+
+- CodeBuild stays deferred
+- Nessus is the current operational remote-runner path
+- a future CodeBuild pilot still needs its own bounded issue with AWS/OIDC and
+  security truth
+
+## Non-claims
+
+- This packet does not claim release-wide remote validation routing.
+- This packet does not claim provider-credentialed or network-bound validation
+  commands are eligible for Nessus by default.
+- This packet does not claim the remote runner replaces local focused proof for
+  normal narrow tooling issues.


### PR DESCRIPTION
Closes #4553

## Summary
Implemented a real operational Nessus remote-validation lane for bounded Rust proof, then proved it two ways: first through the validation-manager remote-runner route for a focused `provider_communication` profile, and second through a repeated direct Nessus rerun against the same retained cache root. The issue added a fail-closed `adl/tools/run_nessus_remote_validation.sh` wrapper, validation-manager remote-runner eligibility/selection support, selector coverage for the new remote-runner contract surfaces, focused shell-test coverage for local/selector/manager behavior, and a durable proof note at `docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md`. The first live manager-routed Nessus run passed in `181` seconds on commit `abf3945ab363c54e43437b0124826b9fcafe916a`; the second repeated Nessus run passed in `8` seconds against the same remote root, which is sufficient issue-scope evidence that the warm path is operational rather than prerequisite-only.

## Artifacts
- Tracked implementation artifacts:
  - `adl/tools/run_nessus_remote_validation.sh`
  - `adl/tools/test_run_nessus_remote_validation.sh`
  - `adl/tools/validation_manager.py`
  - `adl/tools/test_validation_manager.sh`
  - `adl/config/validation_lane_selector.v0.91.6.json`
  - `adl/tools/test_select_validation_lanes.sh`
  - `docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md`
- Remote retained proof artifacts:
  - `/root/adl-remote-runner/logs/20260626-174605/summary.json`
  - `/root/adl-remote-runner/logs/20260626-175020/summary.json`
  - `/root/adl-remote-runner/logs/20260626-174605/sccache-stats.log`
  - `/root/adl-remote-runner/logs/20260626-175020/sccache-stats.log`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_nessus_remote_validation.sh`
    Verified the new Nessus wrapper contract locally, including pass/fail-closed behavior and the SSH transport fallback summary.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector coverage for the new remote-runner surfaces and preserved existing focused-lane behavior.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager remote-runner selection, execution, and rejection behavior with focused fixtures.
  - `python3 adl/tools/validation_manager.py --changed-files <temp manifest containing adl/src/provider_communication.rs> --remote-runner nessus --remote-command 'cargo test --manifest-path adl/Cargo.toml --locked provider_communication -- --nocapture' --run --json`
    Verified that the validation manager selected the Nessus runner for an eligible single-lane deterministic Rust profile and executed the focused remote validation successfully on `nessus.local`.
  - `bash adl/tools/run_nessus_remote_validation.sh --command 'cargo test --manifest-path adl/Cargo.toml --locked provider_communication -- --nocapture'`
    Re-ran the same focused remote validation directly against the same remote root to record warm-path behavior and retained cache/target reuse.
- Results:
  - PASS: `test_run_nessus_remote_validation.sh`
  - PASS: `test_select_validation_lanes.sh`
  - PASS: `test_validation_manager.sh`
  - PASS: first live manager-routed Nessus run on commit `abf3945ab363c54e43437b0124826b9fcafe916a` in `181` seconds
  - PASS: second repeated Nessus run on the same commit in `8` seconds

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4553__v0-91-6-tools-validation-implement-operational-nessus-remote-validation-lane/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4553__v0-91-6-tools-validation-implement-operational-nessus-remote-validation-lane/sor.md
- Idempotency-Key: v0-91-6-tools-validation-implement-operational-nessus-remote-validation-lane-adl-v0-91-6-tasks-issue-4553-v0-91-6-tools-validation-implement-operational-nessus-remote-validation-lane-sip-md-adl-v0-91-6-tasks-issue-4553-v0-91-6-tools-validation-implement-operational-nessus-remote-validation-lane-sor-md