### PR TITLE
[v0.91.6][observatory][runtime] Integrate Unity Observatory into the Soak #1 runtime path

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -239,6 +239,7 @@
       "path_selectors": [
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
         "demos/v0.91.6/unity-observatory/Assets/**",
         "demos/v0.91.6/unity-observatory/Packages/**",
@@ -247,13 +248,14 @@
       "path_hints": [
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
         "demos/v0.91.6/unity-observatory/Assets/**",
         "demos/v0.91.6/unity-observatory/Packages/**",
         "demos/v0.91.6/unity-observatory/ProjectSettings/**"
       ],
-      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
-      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
       "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
     },
     {

--- a/adl/src/bin/run_v0916_integrated_runtime_soak.rs
+++ b/adl/src/bin/run_v0916_integrated_runtime_soak.rs
@@ -7,6 +7,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use adl::adl::ProviderSpec;
+use adl::csm_observatory::{write_observatory_outputs, ObservatoryFormat};
 use adl::long_lived_agent::{self, InspectOptions, LeaseRecord, RunOptions};
 use adl::obsmem_transition_memory::build_write_request_from_transition_handoff;
 use adl::remote_exec::{
@@ -139,7 +140,10 @@ fn run(args: Args) -> Result<()> {
     )?;
 
     let scheduler_plan = build_scheduler_plan()?;
-    write_json(&out_dir.join("scheduler/scheduler_plan.json"), &scheduler_plan)?;
+    write_json(
+        &out_dir.join("scheduler/scheduler_plan.json"),
+        &scheduler_plan,
+    )?;
 
     let remote_timeout = run_remote_timeout_probe()?;
     write_json(
@@ -172,6 +176,18 @@ fn run(args: Args) -> Result<()> {
         &completion_classification,
     )?;
 
+    let observatory_bundle = write_observatory_integration_bundle(
+        &out_dir,
+        &run_status,
+        &restart_status,
+        &stop_probe,
+        &timeout_trace,
+        &bulkhead_trace,
+        &degraded_trace,
+        &remote_timeout,
+        &stopped,
+    )?;
+
     let evidence_index = build_evidence_index(&out_dir)?;
     write_json(
         &out_dir.join("integrated_runtime_soak_evidence_index.json"),
@@ -189,6 +205,7 @@ fn run(args: Args) -> Result<()> {
         &bulkhead_trace,
         &degraded_trace,
         &remote_timeout,
+        &observatory_bundle,
         &evidence_index,
     );
     write_json(
@@ -552,6 +569,575 @@ fn build_scheduler_plan() -> Result<Value> {
     serde_json::to_value(plan).context("serialize scheduler plan")
 }
 
+#[allow(clippy::too_many_arguments)]
+fn write_observatory_integration_bundle(
+    out_dir: &Path,
+    run_status: &adl::long_lived_agent::StatusRecord,
+    restart_status: &adl::long_lived_agent::StatusRecord,
+    stop_probe: &Value,
+    timeout_trace: &Value,
+    bulkhead_trace: &Value,
+    degraded_trace: &Value,
+    remote_timeout: &Value,
+    stopped: &adl::long_lived_agent::StatusRecord,
+) -> Result<Value> {
+    let artifact_root = repo_relative_ref(out_dir)?;
+    let observatory_dir = out_dir.join("runtime_v2/observatory");
+    let packet_path = observatory_dir.join("visibility_packet.json");
+    let packet = build_observatory_integration_packet(
+        &artifact_root,
+        run_status,
+        restart_status,
+        stop_probe,
+        timeout_trace,
+        bulkhead_trace,
+        degraded_trace,
+        remote_timeout,
+        stopped,
+    )?;
+    write_json(&packet_path, &packet)?;
+
+    let output =
+        write_observatory_outputs(&packet_path, &observatory_dir, ObservatoryFormat::Bundle)
+            .context("write integrated observatory bundle")?;
+
+    Ok(json!({
+        "packet_id": packet["packet_id"],
+        "classification": packet["review"]["demo_classification"],
+        "runtime_artifact_root": artifact_root,
+        "visibility_packet_ref": relative_ref(out_dir, output.packet_path.as_deref().unwrap_or(&packet_path))?,
+        "operator_report_ref": relative_ref(out_dir, output.report_path.as_deref().context("missing observatory report path")?)?,
+        "unity_contract_ref": relative_ref(out_dir, output.unity_contract_path.as_deref().context("missing Unity contract path")?)?,
+        "console_reference_ref": relative_ref(out_dir, output.console_reference_path.as_deref().context("missing observatory console reference path")?)?,
+        "manifest_ref": relative_ref(out_dir, output.manifest_path.as_deref().context("missing observatory manifest path")?)?
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_observatory_integration_packet(
+    artifact_root: &str,
+    run_status: &adl::long_lived_agent::StatusRecord,
+    restart_status: &adl::long_lived_agent::StatusRecord,
+    stop_probe: &Value,
+    timeout_trace: &Value,
+    bulkhead_trace: &Value,
+    degraded_trace: &Value,
+    remote_timeout: &Value,
+    stopped: &adl::long_lived_agent::StatusRecord,
+) -> Result<Value> {
+    let long_lived_status_ref = format!("{artifact_root}/long_lived_agent/state/status.json");
+    let ledger_ref = format!("{artifact_root}/long_lived_agent/state/cycle_ledger.jsonl");
+    let inspection_ref = format!("{artifact_root}/inspection/latest.json");
+    let stop_probe_ref = format!("{artifact_root}/long_lived_agent_stop_probe/stop_probe.json");
+    let timeout_ref = format!("{artifact_root}/resilience/timeout_execution.json");
+    let bulkhead_ref = format!("{artifact_root}/resilience/bulkhead_execution.json");
+    let degraded_ref = format!("{artifact_root}/resilience/degraded_fallback_execution.json");
+    let remote_ref = format!("{artifact_root}/remote_exec/timeout_probe.json");
+    let obsmem_ref = format!("{artifact_root}/obsmem/transition_memory_request.json");
+    let report_ref = format!("{artifact_root}/runtime_v2/observatory/operator_report.md");
+    let packet_ref = format!("{artifact_root}/runtime_v2/observatory/visibility_packet.json");
+    let contract_ref =
+        format!("{artifact_root}/runtime_v2/observatory/unity_observatory_contract.json");
+
+    let packet = json!({
+        "schema": "adl.csm_visibility_packet.v1",
+        "packet_id": "v0916-runtime-soak-observatory-packet-0001",
+        "generated_at": Utc::now().to_rfc3339(),
+        "source": {
+            "mode": "captured_artifacts",
+            "evidence_level": "bounded_local_runtime_capture",
+            "fixture": false,
+            "runtime_artifact_root": artifact_root,
+            "claim_boundary": "This packet is a bounded local capture produced by the v0.91.6 integrated runtime soak. It is derived from runtime-owned artifacts, suitable for Unity Observatory consumption, and explicitly does not claim full product completion, live telemetry streaming, or v0.92 coherence.",
+            "source_refs": [
+                long_lived_status_ref,
+                ledger_ref,
+                inspection_ref,
+                stop_probe_ref,
+                timeout_ref,
+                bulkhead_ref,
+                degraded_ref,
+                remote_ref,
+                obsmem_ref
+            ]
+        },
+        "manifold": {
+            "manifold_id": "v0916-runtime-soak-01",
+            "display_name": "Runtime / Ops Soak #1",
+            "state": format!("{:?}_after_reviewable_capture", stopped.state),
+            "lifecycle": "bounded_local_runtime_capture",
+            "current_tick": restart_status.completed_cycle_count,
+            "uptime": format!("{} bounded cadence cycles captured across restart-proof execution", restart_status.completed_cycle_count),
+            "policy_profile": "v0916_integrated_runtime_soak",
+            "snapshot_status": {
+                "state": "not_applicable",
+                "latest_snapshot_id": "none",
+                "rehydration_report_ref": obsmem_ref,
+                "note": "This soak exports observatory evidence from runtime-owned artifacts; it does not claim live snapshot streaming."
+            },
+            "health": {
+                "summary": format!(
+                    "Long-lived-agent cadence, stop-between-cycles control, resilience classifications, remote timeout semantics, and ObsMem handoff all emitted one bounded Unity-consumable review surface with final runtime state '{}'.",
+                    format!("{:?}", stopped.state)
+                ),
+                "level": "nominal",
+                "attention_items": [
+                    "Unity contract and operator report are generated from the same soak-owned packet.",
+                    "Artifact capture is bounded and local; no always-on or remote streaming claim is made.",
+                    "Direct runtime mutation remains out of scope for the Unity consumer surface."
+                ]
+            },
+            "evidence_refs": [
+                long_lived_status_ref,
+                stop_probe_ref,
+                timeout_ref,
+                remote_ref,
+                packet_ref
+            ]
+        },
+        "kernel": {
+            "scheduler_state": format!("cadence_run_settled_{:?}", stopped.state),
+            "trace_state": "reviewable_artifact_capture",
+            "invariant_state": "proof_gates_passed",
+            "resource_state": "bounded_local_execution",
+            "service_states": [
+                { "service_id": "long_lived_agent", "state": format!("{:?}", run_status.state) },
+                { "service_id": "resilience_timeout_lane", "state": timeout_trace["trace"]["final_status"] },
+                { "service_id": "resilience_bulkhead_lane", "state": bulkhead_trace["trace"]["final_status"] },
+                { "service_id": "remote_exec_timeout_lane", "state": remote_timeout["stable_failure_kind"] }
+            ],
+            "active_guardrails": [
+                "duplicate activation remains lease-blocked",
+                "stop requests settle between cadence cycles",
+                "remote timeouts remain classifiable and retry-aware",
+                "Unity handoff remains read-only and packet-driven"
+            ],
+            "pulse": {
+                "status": "bounded_review_tick_complete",
+                "completed_through_event_sequence": restart_status.completed_cycle_count,
+                "evidence_refs": [ledger_ref, inspection_ref]
+            }
+        },
+        "citizens": [
+            {
+                "citizen_id": "runtime-lane-alpha",
+                "display_name": "Runtime lane alpha",
+                "role": "worker",
+                "lifecycle_state": "paused",
+                "continuity_status": format!("restart_proved_then_{:?}", stopped.state),
+                "current_episode": "episode-runtime-cadence",
+                "resource_balance": {
+                    "compute_units": 6,
+                    "scarcity_note": "Completed bounded cadence execution and emitted durable status, ledger, and inspection artifacts."
+                },
+                "recent_decisions": [{
+                    "decision_id": "runtime-lane-alpha-stop-window",
+                    "decision": "allow",
+                    "summary": "Let one cycle complete, then honor stop during the cadence sleep window.",
+                    "evidence_ref": stop_probe_ref
+                }],
+                "capability_envelope": {
+                    "can_execute_episodes": true,
+                    "allowed": ["bounded_cadence_cycle", "status_and_inspection_export"],
+                    "forbidden": ["cross_session_mutation", "silent_overlap_activation", "unguarded_live_export"]
+                },
+                "alerts": [],
+                "evidence_refs": [long_lived_status_ref, ledger_ref, inspection_ref]
+            },
+            {
+                "citizen_id": "runtime-lane-beta",
+                "display_name": "Resilience review lane",
+                "role": "service",
+                "lifecycle_state": "active",
+                "continuity_status": "classification_proofs_captured",
+                "current_episode": "episode-resilience-classification",
+                "resource_balance": {
+                    "compute_units": 4,
+                    "scarcity_note": "Focused timeout, bulkhead saturation, and degraded fallback probes completed under bounded local policy execution."
+                },
+                "recent_decisions": [{
+                    "decision_id": "runtime-lane-beta-timeout-refusal",
+                    "decision": "refuse",
+                    "summary": "A hanging local endpoint was classified as a stable timeout with retryability captured explicitly.",
+                    "evidence_ref": remote_ref
+                }],
+                "capability_envelope": {
+                    "can_execute_episodes": true,
+                    "allowed": ["timeout_probe", "bulkhead_probe", "degraded_fallback_probe"],
+                    "forbidden": ["network_escape", "non_reviewable_failure", "silent_retry_loop"]
+                },
+                "alerts": [],
+                "evidence_refs": [timeout_ref, bulkhead_ref, degraded_ref, remote_ref]
+            },
+            {
+                "citizen_id": "runtime-lane-gamma",
+                "display_name": "Observatory export lane",
+                "role": "reviewer",
+                "lifecycle_state": "awake",
+                "continuity_status": "unity_contract_export_ready",
+                "current_episode": "episode-unity-handoff",
+                "resource_balance": {
+                    "compute_units": 2,
+                    "scarcity_note": "Exports a Unity-facing contract and operator report from the same bounded packet without direct runtime mutation."
+                },
+                "recent_decisions": [{
+                    "decision_id": "runtime-lane-gamma-unity-export",
+                    "decision": "allow",
+                    "summary": "Packet, report, console reference, and Unity contract are retained under one reviewable artifact root.",
+                    "evidence_ref": packet_ref
+                }],
+                "capability_envelope": {
+                    "can_execute_episodes": false,
+                    "allowed": ["read_only_report_export", "unity_contract_generation"],
+                    "forbidden": ["runtime_mutation", "identity_rebinding", "live_telemetry_claims"]
+                },
+                "alerts": [],
+                "evidence_refs": [packet_ref, report_ref, contract_ref]
+            }
+        ],
+        "episodes": [
+            {
+                "episode_id": "episode-runtime-cadence",
+                "title": "Bounded cadence run and restart continuity",
+                "state": "completed",
+                "citizen_ids": ["runtime-lane-alpha"],
+                "started_at": Utc::now().to_rfc3339(),
+                "last_event": "stop_honored_during_sleep_window",
+                "proof_surface": stop_probe_ref,
+                "blocked_reason": "not blocked; cadence run, restart proof, and stop-window control all emitted durable evidence"
+            },
+            {
+                "episode_id": "episode-resilience-classification",
+                "title": "Timeout, bulkhead, degraded fallback, and remote timeout classification",
+                "state": "completed",
+                "citizen_ids": ["runtime-lane-beta"],
+                "started_at": Utc::now().to_rfc3339(),
+                "last_event": "remote_timeout_classified",
+                "proof_surface": remote_ref,
+                "blocked_reason": "not blocked; focused resilience probes completed under bounded local execution"
+            },
+            {
+                "episode_id": "episode-unity-handoff",
+                "title": "Unity Observatory packet and contract export",
+                "state": "completed",
+                "citizen_ids": ["runtime-lane-alpha", "runtime-lane-gamma"],
+                "started_at": Utc::now().to_rfc3339(),
+                "last_event": "unity_contract_written",
+                "proof_surface": packet_ref,
+                "blocked_reason": "not blocked; Unity-facing contract is generated from the same packet and review path"
+            }
+        ],
+        "freedom_gate": {
+            "recent_docket": [
+                {
+                    "decision_id": "fg-runtime-stop-window",
+                    "actor": "runtime-lane-alpha",
+                    "action": "honor_stop_between_cycles",
+                    "decision": "allow",
+                    "rationale": "Stop requests are allowed only after a bounded cycle completes and the cadence window is safe.",
+                    "evidence_ref": stop_probe_ref
+                },
+                {
+                    "decision_id": "fg-resilience-bulkhead",
+                    "actor": "runtime-lane-beta",
+                    "action": "attempt_parallel_provider_work_under_saturation",
+                    "decision": "defer",
+                    "rationale": "Bulkhead saturation remains visible and reviewable instead of being hidden behind automatic queue growth.",
+                    "evidence_ref": bulkhead_ref
+                },
+                {
+                    "decision_id": "fg-remote-timeout-classification",
+                    "actor": "runtime-lane-beta",
+                    "action": "treat_hanging_local_endpoint_as_success",
+                    "decision": "refuse",
+                    "rationale": "Remote timeout failures must remain classifiable and retry-aware rather than being treated as success.",
+                    "evidence_ref": remote_ref
+                }
+            ],
+            "allow_count": 1,
+            "defer_count": 1,
+            "refuse_count": 1,
+            "open_questions": [],
+            "rejected_actions": ["treat_hanging_local_endpoint_as_success"]
+        },
+        "invariants": [
+            {
+                "invariant_id": "runtime_stop_only_between_cycles",
+                "name": "Stop requests settle between cadence cycles",
+                "state": "healthy",
+                "severity": "high",
+                "last_checked": stop_probe["persisted_state"],
+                "evidence_ref": stop_probe_ref
+            },
+            {
+                "invariant_id": "resilience_timeout_is_reviewable",
+                "name": "Timeout and degraded fallback traces remain reviewer-readable",
+                "state": "healthy",
+                "severity": "high",
+                "last_checked": timeout_trace["trace"]["final_status"],
+                "evidence_ref": timeout_ref
+            },
+            {
+                "invariant_id": "unity_surface_is_read_only",
+                "name": "Unity consumer surface remains packet-driven and read only",
+                "state": "healthy",
+                "severity": "critical",
+                "last_checked": "unity_contract_written",
+                "evidence_ref": report_ref
+            }
+        ],
+        "resources": {
+            "compute_units": { "total": 12, "allocated": 10, "available": 2 },
+            "memory_pressure": "bounded_local_probe",
+            "queue_depth": 0,
+            "fairness_notes": [
+                "The soak favors durable proof emission over high-throughput execution.",
+                "Unity consumes the contract after export rather than participating in the runtime run itself."
+            ],
+            "scarcity_events": [{
+                "event_id": "bulkhead_saturation_reviewed",
+                "summary": "Bulkhead saturation is surfaced explicitly as a bounded review event.",
+                "evidence_level": "bounded_local_runtime_capture"
+            }]
+        },
+        "trace": {
+            "trace_tail": [
+                {
+                    "event_sequence": 1,
+                    "actor": "runtime.long_lived_agent",
+                    "event_type": "cycle_restart_proved",
+                    "summary": format!("Restart path settled with completed_cycle_count={}.", restart_status.completed_cycle_count),
+                    "evidence_ref": long_lived_status_ref
+                },
+                {
+                    "event_sequence": 2,
+                    "actor": "runtime.stop_probe",
+                    "event_type": "stop_window_honored",
+                    "summary": format!("Stop probe persisted runtime state '{}'.", stop_probe["persisted_state"].as_str().unwrap_or("unknown")),
+                    "evidence_ref": stop_probe_ref
+                },
+                {
+                    "event_sequence": 3,
+                    "actor": "runtime.resilience",
+                    "event_type": "bulkhead_and_timeout_classified",
+                    "summary": format!(
+                        "Timeout={}, bulkhead={}, degraded={}.",
+                        timeout_trace["trace"]["final_status"].as_str().unwrap_or("unknown"),
+                        bulkhead_trace["trace"]["final_status"].as_str().unwrap_or("unknown"),
+                        degraded_trace["trace"]["final_status"].as_str().unwrap_or("unknown")
+                    ),
+                    "evidence_ref": timeout_ref
+                },
+                {
+                    "event_sequence": 4,
+                    "actor": "runtime.remote_exec",
+                    "event_type": "remote_timeout_captured",
+                    "summary": format!(
+                        "Remote timeout classified as '{}' with retryability '{}'.",
+                        remote_timeout["stable_failure_kind"].as_str().unwrap_or("unknown"),
+                        remote_timeout["retryability"].as_str().unwrap_or("unknown")
+                    ),
+                    "evidence_ref": remote_ref
+                },
+                {
+                    "event_sequence": 5,
+                    "actor": "runtime.observatory",
+                    "event_type": "unity_contract_emitted",
+                    "summary": "Packet, operator report, console reference, and Unity contract were emitted from the same capture.",
+                    "evidence_ref": packet_ref
+                }
+            ],
+            "causal_gaps": [],
+            "latest_operator_event": {
+                "event_sequence": 5,
+                "event_ref": packet_ref
+            },
+            "latest_citizen_event": {
+                "event_sequence": 2,
+                "event_ref": stop_probe_ref
+            },
+            "latest_kernel_event": {
+                "event_sequence": 4,
+                "event_ref": remote_ref
+            }
+        },
+        "operator_actions": {
+            "available_actions": [
+                { "action": "inspect_runtime_soak_packet", "mode": "read_only", "status": "available_from_bounded_capture" },
+                { "action": "open_unity_operator_report", "mode": "read_only", "status": "available_from_same_packet_bundle" },
+                { "action": "stage_unity_contract", "mode": "read_only", "status": "available_for_local_unity_consumption" }
+            ],
+            "disabled_actions": [
+                {
+                    "action": "promote_to_live_streaming",
+                    "reason": "The Soak #1 observatory handoff is a bounded retained capture, not a live streaming bridge.",
+                    "future_issue": 4555
+                },
+                {
+                    "action": "mutate_runtime_from_unity_surface",
+                    "reason": "The Unity Observatory consumer remains fail-closed and packet-driven in v0.91.6.",
+                    "future_issue": 4555
+                }
+            ],
+            "required_confirmations": [
+                "All Unity-facing controls remain proposal-only presentation surfaces.",
+                "Runtime truth is the retained artifact bundle, not the transient editor state."
+            ],
+            "safety_notes": [
+                "No private paths, credentials, or unbounded logs are required by the Unity contract.",
+                "This packet is truthful only for the bounded Soak #1 capture that produced it."
+            ]
+        },
+        "review": {
+            "primary_artifacts": [
+                packet_ref,
+                report_ref,
+                contract_ref,
+                long_lived_status_ref,
+                stop_probe_ref,
+                remote_ref,
+                obsmem_ref
+            ],
+            "missing_artifacts": [],
+            "demo_classification": "captured_artifacts",
+            "caveats": [
+                "This is a bounded local capture and not a live telemetry stream.",
+                "Unity consumes a deterministic contract produced after the soak run; it is not co-executing the runtime.",
+                "Inhabitant identity, profile, and v0.92 rebinding semantics remain out of scope."
+            ],
+            "next_consumers": [
+                { "issue": 2189, "consumer": "static Observatory console compatibility" },
+                { "issue": 2190, "consumer": "operator report generator compatibility" },
+                { "issue": 2191, "consumer": "CLI bundle compatibility" },
+                { "issue": 2192, "consumer": "operator command packet design" },
+                { "issue": 2258, "consumer": "WP-14 integrated first CSM run demo" },
+                { "issue": 4543, "consumer": "Runtime/Ops Soak #1 sprint closeout evidence" },
+                { "issue": 4548, "consumer": "Unity local-runtime consumption proof surfaces" }
+            ]
+        },
+        "observatory_ui": {
+            "default_room": "world",
+            "default_lens": "operator",
+            "default_memory_dot": "runtime_overview",
+            "proposal_mode_statement": "Every active-looking control is a governed request proposal only. No direct runtime mutation is performed from this surface.",
+            "rooms": [
+                {
+                    "room_id": "world",
+                    "label": "World / Reality",
+                    "question": "What runtime evidence exists right now, and what actually completed?",
+                    "note": "Default integrated soak evidence view."
+                },
+                {
+                    "room_id": "governance",
+                    "label": "Operator / Governance",
+                    "question": "What decision boundaries, disabled paths, and proof links remain explicit?",
+                    "note": "Freedom Gate docket and guarded follow-on paths live here."
+                },
+                {
+                    "room_id": "cognition",
+                    "label": "Cognition / Internal State",
+                    "question": "What bounded internal-state-adjacent signals are safe to project?",
+                    "note": "Only review-safe signals are exposed."
+                }
+            ],
+            "lenses": [
+                {
+                    "lens_id": "public",
+                    "label": "Public lens",
+                    "summary": "Investor-safe summary with bounded claims."
+                },
+                {
+                    "lens_id": "operator",
+                    "label": "Operator lens",
+                    "summary": "Operational state, disabled reasons, and review links."
+                },
+                {
+                    "lens_id": "reviewer",
+                    "label": "Reviewer lens",
+                    "summary": "Packet refs, report refs, and caveats."
+                }
+            ],
+            "memory_dots": [
+                {
+                    "dot_id": "runtime_overview",
+                    "label": "Runtime overview",
+                    "room": "world",
+                    "lens": "operator",
+                    "selected_target": "runtime-lane-alpha",
+                    "note": "Open the soak with runtime cadence state in focus."
+                },
+                {
+                    "dot_id": "resilience_watch",
+                    "label": "Resilience watch",
+                    "room": "governance",
+                    "lens": "reviewer",
+                    "selected_target": "runtime-lane-beta",
+                    "note": "Follow timeout and bulkhead evidence."
+                },
+                {
+                    "dot_id": "investor_view",
+                    "label": "Corporate Investor",
+                    "room": "world",
+                    "lens": "public",
+                    "selected_target": "runtime-lane-gamma",
+                    "note": "Presentation mode without changing evidence."
+                }
+            ],
+            "corporate_investor_fallback": {
+                "label": "Corporate Investor UI",
+                "keyboard_shortcut": "i",
+                "claim_boundary": "Presentation mode only; evidence, authority, and trace boundaries do not change."
+            },
+            "proposal_cases": [
+                {
+                    "proposal_id": "proposal-open-runtime-report",
+                    "title": "Open runtime operator report",
+                    "target_kind": "service_actor",
+                    "target_id": "runtime-lane-gamma",
+                    "room": "world",
+                    "lens": "operator",
+                    "disposition": "available",
+                    "summary": "Open the soak-owned operator report produced from the same packet.",
+                    "authority_checks": ["validate_projection_class", "append_trace_anchor"],
+                    "disabled_reason": null,
+                    "trace_anchor": packet_ref,
+                    "review_export": report_ref
+                },
+                {
+                    "proposal_id": "proposal-review-timeout-floor",
+                    "title": "Review remote timeout floor",
+                    "target_kind": "service_actor",
+                    "target_id": "runtime-lane-beta",
+                    "room": "governance",
+                    "lens": "reviewer",
+                    "disposition": "challenge",
+                    "summary": "Inspect retryability and stable-failure classification without widening into live network work.",
+                    "authority_checks": ["validate_service_actor_scope", "emit_review_anchor"],
+                    "disabled_reason": "Live transport closure remains future work after this bounded milestone proof.",
+                    "trace_anchor": remote_ref,
+                    "review_export": report_ref
+                },
+                {
+                    "proposal_id": "proposal-stage-unity-contract",
+                    "title": "Stage Unity contract",
+                    "target_kind": "service_actor",
+                    "target_id": "runtime-lane-gamma",
+                    "room": "world",
+                    "lens": "public",
+                    "disposition": "available",
+                    "summary": "Prepare the Unity-facing contract and screenshots for review without mutating runtime state.",
+                    "authority_checks": ["validate_operator_identity", "redact_private_state_by_lens"],
+                    "disabled_reason": null,
+                    "trace_anchor": packet_ref,
+                    "review_export": report_ref
+                }
+            ]
+        }
+    });
+    adl::csm_observatory::validate_visibility_packet(&packet)?;
+    Ok(packet)
+}
+
 fn build_evidence_index(out_dir: &Path) -> Result<Value> {
     let mut refs = Vec::new();
     collect_relative_files(out_dir, out_dir, &mut refs)?;
@@ -692,6 +1278,25 @@ fn collect_relative_files(root: &Path, current: &Path, out: &mut Vec<String>) ->
     Ok(())
 }
 
+fn repo_root() -> Result<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .context("derive repository root from manifest dir")
+}
+
+fn repo_relative_ref(path: &Path) -> Result<String> {
+    let root = repo_root()?;
+    relative_ref(&root, path)
+}
+
+fn relative_ref(root: &Path, path: &Path) -> Result<String> {
+    let rel = path
+        .strip_prefix(root)
+        .with_context(|| format!("{} is not under {}", path.display(), root.display()))?;
+    Ok(rel.to_string_lossy().replace('\\', "/"))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_proof_packet(
     initial_status: &adl::long_lived_agent::StatusRecord,
@@ -704,6 +1309,7 @@ fn build_proof_packet(
     bulkhead_trace: &Value,
     degraded_trace: &Value,
     remote_timeout: &Value,
+    observatory_bundle: &Value,
     evidence_index: &Value,
 ) -> Value {
     json!({
@@ -716,12 +1322,13 @@ fn build_proof_packet(
             "The deterministic scheduler economics fixture still resolves into a reviewable scheduler plan artifact that can be cited by the soak packet.",
             "Remote execution timeout classification is live against a hanging local endpoint and records stable failure kind plus retryability.",
             "ObsMem transition memory can still build a structured write request from a tracked handoff packet.",
-            "The long-lived-agent leased-state contract blocks overlap when an injected lease artifact is present."
+            "The long-lived-agent leased-state contract blocks overlap when an injected lease artifact is present.",
+            "The soak emits one runtime-owned Observatory packet, operator report, and Unity-facing contract from the same bounded artifact capture."
         ],
         "what_this_does_not_prove": [
             "full v0.92 activation readiness",
             "external-agent trust or transport closure",
-            "full Observatory or Unity UI completion",
+            "full Observatory or Unity UI product completion",
             "always-on autonomy",
             "end-to-end ACIP runtime execution beyond prerequisite consumption"
         ],
@@ -740,7 +1347,9 @@ fn build_proof_packet(
             "timeout_final_status": timeout_trace["trace"]["final_status"],
             "bulkhead_final_status": bulkhead_trace["trace"]["final_status"],
             "degraded_fallback_final_status": degraded_trace["trace"]["final_status"],
-            "degraded_output": degraded_trace["trace"]["output_degraded"]
+            "degraded_output": degraded_trace["trace"]["output_degraded"],
+            "observatory_classification": observatory_bundle["classification"],
+            "unity_contract_ref": observatory_bundle["unity_contract_ref"]
         },
         "reviewer_path": [
             "README.md",
@@ -756,8 +1365,12 @@ fn build_proof_packet(
             "remote_exec/timeout_probe.json",
             "obsmem/transition_memory_request.json",
             "completion_classification.json",
+            "runtime_v2/observatory/visibility_packet.json",
+            "runtime_v2/observatory/operator_report.md",
+            "runtime_v2/observatory/unity_observatory_contract.json",
             "audit/artifact_safety_scan.json"
         ],
+        "observatory_integration": observatory_bundle,
         "evidence_index_ref": "integrated_runtime_soak_evidence_index.json",
         "evidence_index": evidence_index,
         "disclaimer": DISCLAIMER,
@@ -843,12 +1456,12 @@ fn write_file(path: &Path, contents: &str) -> Result<()> {
 
 fn readme() -> String {
     format!(
-        "# V0.91.6 Integrated Runtime Soak\n\n{DISCLAIMER}\n\n## What This Proves\n\nThis run proves a bounded integrated runtime slice for `#4543`: one long-lived-agent run/restart/inspection continuity path, one companion live stop-between-cycles probe, timeout classification, bulkhead/backpressure saturation, degraded fallback, one deterministic scheduler decision artifact, remote-exec timeout handling, one tracked ObsMem handoff path, and one explicit injected-lease contract probe all converge under one reviewer-readable artifact root.\n\n## Reviewer Path\n\n1. Inspect `integrated_runtime_soak_proof.json`.\n2. Inspect `completion_classification.json` for integrated-proven versus blocked surfaces.\n3. Inspect `long_lived_agent/state/status.json` and `long_lived_agent/state/cycle_ledger.jsonl`.\n4. Inspect `inspection/latest.json`.\n5. Inspect `long_lived_agent_stop_probe/stop_probe.json`.\n6. Inspect `resilience/timeout_execution.json`, `resilience/bulkhead_execution.json`, and `resilience/degraded_fallback_execution.json`.\n7. Inspect `scheduler/scheduler_plan.json`.\n8. Inspect `remote_exec/timeout_probe.json`.\n9. Inspect `obsmem/transition_memory_request.json`.\n10. Inspect `audit/artifact_safety_scan.json`.\n"
+        "# V0.91.6 Integrated Runtime Soak\n\n{DISCLAIMER}\n\n## What This Proves\n\nThis run proves a bounded integrated runtime slice for `#4543`: one long-lived-agent run/restart/inspection continuity path, one companion live stop-between-cycles probe, timeout classification, bulkhead/backpressure saturation, degraded fallback, one deterministic scheduler decision artifact, remote-exec timeout handling, one tracked ObsMem handoff path, one explicit injected-lease contract probe, and one retained Unity Observatory handoff bundle all converge under one reviewer-readable artifact root.\n\n## Reviewer Path\n\n1. Inspect `integrated_runtime_soak_proof.json`.\n2. Inspect `completion_classification.json` for integrated-proven versus blocked surfaces.\n3. Inspect `long_lived_agent/state/status.json` and `long_lived_agent/state/cycle_ledger.jsonl`.\n4. Inspect `inspection/latest.json`.\n5. Inspect `long_lived_agent_stop_probe/stop_probe.json`.\n6. Inspect `resilience/timeout_execution.json`, `resilience/bulkhead_execution.json`, and `resilience/degraded_fallback_execution.json`.\n7. Inspect `scheduler/scheduler_plan.json`.\n8. Inspect `remote_exec/timeout_probe.json`.\n9. Inspect `obsmem/transition_memory_request.json`.\n10. Inspect `runtime_v2/observatory/visibility_packet.json`, `runtime_v2/observatory/operator_report.md`, and `runtime_v2/observatory/unity_observatory_contract.json`.\n11. Inspect `audit/artifact_safety_scan.json`.\n"
     )
 }
 
 fn reviewer_walkthrough() -> String {
-    "# Reviewer Walkthrough\n\nRun the soak with `cargo run --manifest-path adl/Cargo.toml --bin run_v0916_integrated_runtime_soak -- --out docs/milestones/v0.91.6/review/runtime/v0916_integrated_runtime_soak_4543`.\n\nThe review question is whether the runtime now leaves one honest, durable packet showing restart, a live stop between cycles, timeout, saturation/backpressure, degraded fallback, scheduler advisory evidence, remote-exec timeout semantics, and memory handoff under one bounded local proof surface without overclaiming ACIP, Unity/Observatory, or v0.92 readiness.\n".to_string()
+    "# Reviewer Walkthrough\n\nRun the soak with `cargo run --manifest-path adl/Cargo.toml --bin run_v0916_integrated_runtime_soak -- --out docs/milestones/v0.91.6/review/runtime/v0916_integrated_runtime_soak_4543`.\n\nThe review question is whether the runtime now leaves one honest, durable packet showing restart, a live stop between cycles, timeout, saturation/backpressure, degraded fallback, scheduler advisory evidence, remote-exec timeout semantics, memory handoff, and a Unity Observatory handoff contract under one bounded local proof surface without overclaiming ACIP, Observatory product readiness, Unity UI completion, or v0.92 readiness.\n".to_string()
 }
 
 #[cfg(test)]
@@ -862,7 +1475,10 @@ mod tests {
             std::process::id(),
             Utc::now().timestamp_nanos_opt().unwrap_or_default()
         );
-        std::env::temp_dir().join(unique)
+        repo_root()
+            .expect("repo root")
+            .join(".adl/tmp")
+            .join(unique)
     }
 
     #[test]
@@ -887,6 +1503,16 @@ mod tests {
             proof["status_summary"]["remote_timeout_failure_kind"],
             Value::String("timeout".to_string())
         );
+        assert_eq!(
+            proof["observatory_integration"]["classification"],
+            Value::String("captured_artifacts".to_string())
+        );
+        assert!(
+            out_dir
+                .join("runtime_v2/observatory/unity_observatory_contract.json")
+                .exists(),
+            "expected Unity contract bundle artifact"
+        );
 
         let evidence_index_path = out_dir.join("integrated_runtime_soak_evidence_index.json");
         let evidence_index: Value = serde_json::from_str(
@@ -904,7 +1530,9 @@ mod tests {
             "expected long-lived-agent status artifact in evidence index"
         );
         assert!(
-            artifact_refs.iter().any(|entry| entry == "scheduler/scheduler_plan.json"),
+            artifact_refs
+                .iter()
+                .any(|entry| entry == "scheduler/scheduler_plan.json"),
             "expected scheduler plan artifact in evidence index"
         );
 
@@ -972,7 +1600,7 @@ mod tests {
         let readme_text = readme();
         assert!(readme_text.contains("What This Proves"));
         let walkthrough = reviewer_walkthrough();
-        assert!(walkthrough.contains("bounded local proof surface"));
+        assert!(walkthrough.contains("Unity Observatory handoff contract"));
 
         let timeout = run_timeout_policy_probe();
         assert_eq!(

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4340,6 +4340,33 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_v0916_unity_observatory_contract.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
+                "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture" => {
+                    let unity65_smoke =
+                        repo_root.join("adl/tools/test_v0916_unity_observatory_unity65_smoke.sh");
+                    run_finish_validation_status("bash", &["-n", path_str(&unity65_smoke)?])?;
+                    let baseline =
+                        repo_root.join("adl/tools/test_v0916_unity_observatory_baseline.sh");
+                    run_finish_validation_status("bash", &[path_str(&baseline)?])?;
+                    let contract =
+                        repo_root.join("adl/tools/test_v0916_unity_observatory_contract.sh");
+                    run_finish_validation_status("bash", &[path_str(&contract)?])?;
+                    let soak_integration = repo_root
+                        .join("adl/tools/test_v0916_unity_observatory_soak_integration.sh");
+                    run_finish_validation_status("bash", &[path_str(&soak_integration)?])?;
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--test",
+                            "cli_smoke",
+                            "csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
                 "bash adl/tools/test_slow_proof_lane_contract.sh" => {
                     let script = repo_root.join("adl/tools/test_slow_proof_lane_contract.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;

--- a/adl/src/cli/scheduler_cmd.rs
+++ b/adl/src/cli/scheduler_cmd.rs
@@ -50,8 +50,12 @@ fn real_scheduler_plan(args: &[String]) -> Result<()> {
     let input = input.ok_or_else(|| anyhow!("scheduler plan requires --input <bundle.json>"))?;
     let raw = fs::read_to_string(&input)
         .with_context(|| format!("failed to read scheduler input {}", input.display()))?;
-    let bundle = parse_economics_bundle_json(&raw)
-        .with_context(|| format!("failed to parse scheduler economics bundle {}", input.display()))?;
+    let bundle = parse_economics_bundle_json(&raw).with_context(|| {
+        format!(
+            "failed to parse scheduler economics bundle {}",
+            input.display()
+        )
+    })?;
     let plan = schedule_economics_bundle(&bundle)
         .context("failed to build scheduler plan from economics bundle")?;
     let rendered = if compact {

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -205,7 +205,9 @@ fn runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch() {
 
     let usage = runtime_usage();
     assert!(usage.contains("adl-runtime run <adl.yaml>"));
-    assert!(usage.contains("adl-runtime scheduler plan --input <bundle.json> [--out <path>] [--json]"));
+    assert!(
+        usage.contains("adl-runtime scheduler plan --input <bundle.json> [--out <path>] [--json]")
+    );
     assert!(usage.contains("adl <adl.yaml> remains available as a compatibility shortcut"));
     assert!(usage.contains("C-SDLC issue work belongs to adl/tools/pr.sh run <issue>"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4261,6 +4261,91 @@ fn finish_helper_paths_run_manager_backed_owner_and_pr_fast_validation() {
 }
 
 #[test]
+fn finish_helper_paths_run_unity_observatory_soak_lane_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-unity-observatory-soak-lane-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_v0916_unity_observatory_unity65_smoke.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' unity65-smoke:$1 >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_v0916_unity_observatory_baseline.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' baseline >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_v0916_unity_observatory_contract.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' contract >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_v0916_unity_observatory_soak_integration.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' soak >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+            "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture".to_string(),
+        ],
+    };
+    run_finish_validation_rust(&repo, &plan).expect("unity observatory soak lane validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--test cli_smoke"));
+    assert!(cargo_calls
+        .contains("csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource"));
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(
+        !focused_calls.contains("unity65-smoke"),
+        "bash -n should syntax-check the Unity 6.5 smoke script without executing it"
+    );
+    assert!(focused_calls.contains("baseline"));
+    assert!(focused_calls.contains("contract"));
+    assert!(focused_calls.contains("soak"));
+}
+
+#[test]
 fn finish_helper_rejects_manager_backed_pr_fast_changed_files_substitution() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-manager-rejects-substituted-changed-files");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3504,12 +3504,27 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
         .commands
         .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
 
-    let unrelated_err =
+    let unrelated_plan =
         select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths)
-            .expect_err("unrelated issue should not get the issue-local Cargo.lock allowance");
-    assert!(unrelated_err
-        .to_string()
-        .contains("selector left changed paths without validation-lane coverage"));
+            .expect("unrelated issue should fall back to the generic larger-binary plan");
+    assert_eq!(
+        unrelated_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
+    assert!(unrelated_plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string()));
+    assert!(unrelated_plan
+        .commands
+        .contains(&"bash adl/tools/test_check_coverage_impact.sh".to_string()));
+    assert!(unrelated_plan
+        .commands
+        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
+    assert!(unrelated_plan
+        .commands
+        .iter()
+        .any(|command| command
+            .starts_with("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")));
 }
 
 #[test]

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -455,6 +455,7 @@ PY
 unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
 M	adl/tools/test_v0916_unity_observatory_contract.sh
+M	adl/tools/test_v0916_unity_observatory_soak_integration.sh
 M	adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
 M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json
 M	demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
@@ -476,6 +477,7 @@ assert lane["owner"] == "review"
 assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in lane["command"]
 assert "test_v0916_unity_observatory_baseline.sh" in lane["command"]
 assert "test_v0916_unity_observatory_contract.sh" in lane["command"]
+assert "test_v0916_unity_observatory_soak_integration.sh" in lane["command"]
 assert "csm_observatory_cli_writes_unity_contract_bundle" in lane["command"]
 PY
 

--- a/adl/tools/test_v0916_unity_observatory_soak_integration.sh
+++ b/adl/tools/test_v0916_unity_observatory_soak_integration.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROJECT_PATH="${ROOT_DIR}/demos/v0.91.6/unity-observatory"
+DEFAULT_EDITOR="/Applications/Unity/Hub/Editor/6000.5.1f1/Unity.app/Contents/MacOS/Unity"
+UNITY_EDITOR_BIN="${UNITY_6_5_EDITOR_BIN:-${UNITY_EDITOR_BIN:-$DEFAULT_EDITOR}}"
+LOG_DIR="${ROOT_DIR}/.adl/tmp/unity-observatory-4555"
+LOG_PATH="${LOG_DIR}/unity-soak-integration.log"
+TIMEOUT_SECS="${UNITY_6_5_SMOKE_TIMEOUT_SECS:-90}"
+TMP_BASE="/tmp"
+RUNTIME_ROOT="$(mktemp -d "${TMP_BASE}/adl-uo-4555.XXXXXX")"
+SOAK_TMP_BASE="${ROOT_DIR}/.adl/tmp"
+SOAK_OUT_DIR="$(mktemp -d "${SOAK_TMP_BASE}/v0916-soak-4555.XXXXXX")"
+STAGE_ROOT="${RUNTIME_ROOT}/project-stage"
+STAGED_PROJECT_PATH="${STAGE_ROOT}/unity-observatory"
+HOME_ROOT="${RUNTIME_ROOT}/home"
+TMP_ROOT="${RUNTIME_ROOT}/tmp"
+STAGED_CONTRACT_PATH="${STAGED_PROJECT_PATH}/Assets/Resources/observatory_contract.json"
+SOAK_CONTRACT_PATH="${SOAK_OUT_DIR}/runtime_v2/observatory/unity_observatory_contract.json"
+
+mkdir -p "${LOG_DIR}"
+mkdir -p "${SOAK_TMP_BASE}"
+rm -f "${LOG_PATH}"
+mkdir -p \
+  "${HOME_ROOT}/Library/Application Support" \
+  "${HOME_ROOT}/Library/Application Support/Unity" \
+  "${HOME_ROOT}/Library/Application Support/Unity/Asset Store-5.x" \
+  "${HOME_ROOT}/Library/Caches" \
+  "${HOME_ROOT}/Library/Logs" \
+  "${HOME_ROOT}/Library/Preferences" \
+  "${HOME_ROOT}/Library/Unity" \
+  "${TMP_ROOT}"
+
+if [[ ! -x "${UNITY_EDITOR_BIN}" ]]; then
+  echo "missing Unity 6.5 editor binary: ${UNITY_EDITOR_BIN}" >&2
+  exit 2
+fi
+
+if [[ ! -d "${PROJECT_PATH}" ]]; then
+  echo "missing Unity Observatory project: ${PROJECT_PATH}" >&2
+  exit 2
+fi
+
+mkdir -p "${STAGE_ROOT}"
+rsync -a \
+  --exclude 'Library/' \
+  --exclude 'Logs/' \
+  --exclude 'Temp/' \
+  --exclude 'UserSettings/' \
+  "${PROJECT_PATH}/" \
+  "${STAGED_PROJECT_PATH}/"
+
+cargo run --manifest-path "${ROOT_DIR}/adl/Cargo.toml" \
+  --bin run_v0916_integrated_runtime_soak -- \
+  --out "${SOAK_OUT_DIR}" >/dev/null
+
+if [[ ! -f "${SOAK_CONTRACT_PATH}" ]]; then
+  echo "missing soak-generated Unity Observatory contract: ${SOAK_CONTRACT_PATH}" >&2
+  exit 2
+fi
+
+cp "${SOAK_CONTRACT_PATH}" "${STAGED_CONTRACT_PATH}"
+
+EXPECTED_TITLE="$(jq -r '.manifold.display_name' "${SOAK_CONTRACT_PATH}")"
+EXPECTED_PACKET_REF="$(jq -r '.source_packet_ref' "${SOAK_CONTRACT_PATH}")"
+EXPECTED_ARTIFACT_ROOT="$(jq -r '.runtime_artifact_root' "${SOAK_CONTRACT_PATH}")"
+EXPECTED_REPORT_REF="$(jq -r '.review.operator_report_ref' "${SOAK_CONTRACT_PATH}")"
+EXPECTED_EVIDENCE_LEVEL="$(jq -r '.evidence_level' "${SOAK_CONTRACT_PATH}")"
+
+chmod -R u+rwX "${RUNTIME_ROOT}"
+
+report_known_batch_blocker() {
+  local readonly_msg="attempt to write a readonly database"
+  local headless_msg="com.unity.editor.headless"
+
+  if [[ -f "${LOG_PATH}" ]] && grep -Fq "${readonly_msg}" "${LOG_PATH}"; then
+    echo "Unity soak integration proof blocked: readonly-database failure against the staged project copy." >&2
+    echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+    exit 3
+  fi
+
+  if [[ -f "${LOG_PATH}" ]] && grep -Fq "${headless_msg}" "${LOG_PATH}"; then
+    echo "Unity soak integration proof blocked: headless entitlement unavailable for the current Unity seat." >&2
+    echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+    exit 4
+  fi
+}
+
+cleanup_child() {
+  if [[ -n "${unity_pid:-}" ]] && kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -INT "${unity_pid}" 2>/dev/null || true
+    sleep 1
+  fi
+  if [[ -n "${unity_pid:-}" ]] && kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -TERM "${unity_pid}" 2>/dev/null || true
+    sleep 1
+  fi
+  if [[ -n "${unity_pid:-}" ]] && kill -0 "${unity_pid}" 2>/dev/null; then
+    kill -KILL "${unity_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${RUNTIME_ROOT}" || true
+}
+
+trap cleanup_child EXIT
+
+ADL_UNITY_EXPECTED_TITLE="${EXPECTED_TITLE}" \
+ADL_UNITY_EXPECTED_PACKET_REF="${EXPECTED_PACKET_REF}" \
+ADL_UNITY_EXPECTED_ARTIFACT_ROOT="${EXPECTED_ARTIFACT_ROOT}" \
+ADL_UNITY_EXPECTED_REPORT_REF="${EXPECTED_REPORT_REF}" \
+ADL_UNITY_EXPECTED_EVIDENCE_LEVEL="${EXPECTED_EVIDENCE_LEVEL}" \
+HOME="${HOME_ROOT}" \
+TMPDIR="${TMP_ROOT}" \
+XDG_CACHE_HOME="${HOME_ROOT}/Library/Caches" \
+XDG_CONFIG_HOME="${HOME_ROOT}/Library/Application Support" \
+"${UNITY_EDITOR_BIN}" \
+  -projectPath "${STAGED_PROJECT_PATH}" \
+  -batchmode \
+  -executeMethod ADL.Demos.UnityObservatory.Editor.UnityObservatoryBatchValidator.ValidateScene \
+  -quit \
+  -logFile "${LOG_PATH}" &
+unity_pid="$!"
+
+deadline=$((SECONDS + TIMEOUT_SECS))
+while kill -0 "${unity_pid}" 2>/dev/null; do
+  if (( SECONDS >= deadline )); then
+    cleanup_child
+    wait "${unity_pid}" 2>/dev/null || true
+    report_known_batch_blocker
+    echo "Unity soak integration proof timed out after ${TIMEOUT_SECS}s." >&2
+    echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+    exit 124
+  fi
+  sleep 1
+done
+
+set +e
+wait "${unity_pid}"
+unity_status="$?"
+set -e
+trap - EXIT
+
+if [[ "${unity_status}" -ne 0 ]]; then
+  report_known_batch_blocker
+  echo "Unity soak integration proof failed with exit ${unity_status}." >&2
+  echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+  exit "${unity_status}"
+fi
+
+report_known_batch_blocker
+
+if ! grep -Fq "Unity Observatory compatibility verification passed." "${LOG_PATH}"; then
+  echo "Unity soak integration proof failed: validator success marker missing from log." >&2
+  echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+  exit 5
+fi
+
+for expected in \
+  "title=${EXPECTED_TITLE}" \
+  "packetRef=${EXPECTED_PACKET_REF}" \
+  "artifactRoot=${EXPECTED_ARTIFACT_ROOT}" \
+  "reportRef=${EXPECTED_REPORT_REF}"; do
+  if ! grep -Fq "${expected}" "${LOG_PATH}"; then
+    echo "Unity soak integration proof failed: expected log marker '${expected}' missing." >&2
+    echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log" >&2
+    exit 6
+  fi
+done
+
+rm -rf "${RUNTIME_ROOT}" || true
+
+echo "Unity soak integration proof passed."
+echo "log: .adl/tmp/unity-observatory-4555/unity-soak-integration.log"
+echo "artifacts: ${SOAK_OUT_DIR}"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -68,6 +68,7 @@ unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
 M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json
 M	demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
+M	adl/tools/test_v0916_unity_observatory_soak_integration.sh
 M	adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
 EOF
 bash "$SCRIPT" --changed-files "$unity_observatory" --json >"$TMP/unity-observatory.json"
@@ -89,6 +90,7 @@ assert surface["resource_class"] == "small"
 assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in profile["run"][0]["command"]
 assert "test_v0916_unity_observatory_baseline.sh" in profile["run"][0]["command"]
 assert "test_v0916_unity_observatory_contract.sh" in profile["run"][0]["command"]
+assert "test_v0916_unity_observatory_soak_integration.sh" in profile["run"][0]["command"]
 assert "csm_observatory_cli_writes_unity_contract_bundle" in profile["run"][0]["command"]
 assert profile["diagnostics"] == []
 assert profile["escalation"]["required"] is False

--- a/demos/v0.91.6/unity-observatory/Assets/Resources/ObservatoryShellRuntime.uss
+++ b/demos/v0.91.6/unity-observatory/Assets/Resources/ObservatoryShellRuntime.uss
@@ -1,39 +1,154 @@
 .observatory-screen {
   flex-grow: 1;
-  padding: 18px;
-  background-color: rgb(5, 8, 18);
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  background-color: rgb(6, 10, 22);
   color: rgb(232, 238, 255);
 }
 
 .observatory-shell {
   flex-grow: 1;
   flex-direction: column;
-  background-color: rgb(11, 15, 28);
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-color: rgba(118, 160, 255, 0.22);
+  border-right-color: rgba(118, 160, 255, 0.22);
+  border-top-color: rgba(118, 160, 255, 0.22);
+  border-bottom-color: rgba(118, 160, 255, 0.22);
+  background-color: rgba(10, 16, 34, 0.96);
 }
 
 .header {
-  padding-bottom: 16px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 24px;
+  padding-bottom: 18px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(118, 160, 255, 0.18);
+}
+
+#eyebrow {
+  color: rgb(119, 168, 255);
+  font-size: 11px;
+  -unity-font-style: bold;
+  margin-bottom: 6px;
 }
 
 #title {
-  color: rgb(245, 248, 255);
-  font-size: 24px;
+  color: rgb(247, 249, 255);
+  font-size: 30px;
+  margin-bottom: 4px;
 }
 
 #subtitle {
+  color: rgb(178, 194, 236);
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+#headline-summary {
+  color: rgb(214, 223, 247);
+  font-size: 15px;
+  margin-bottom: 18px;
+}
+
+.metric-rail {
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-left: -5px;
+  margin-right: -5px;
+}
+
+.metric-tile {
+  min-width: 150px;
+  flex-grow: 1;
+  margin-left: 5px;
+  margin-right: 5px;
+  margin-bottom: 10px;
+  padding-left: 14px;
+  padding-right: 14px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-color: rgba(118, 160, 255, 0.16);
+  border-right-color: rgba(118, 160, 255, 0.16);
+  border-top-color: rgba(118, 160, 255, 0.16);
+  border-bottom-color: rgba(118, 160, 255, 0.16);
+  background-color: rgba(18, 27, 51, 0.9);
+}
+
+.metric-label {
+  color: rgb(141, 161, 214);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+
+.metric-value {
+  color: rgb(247, 249, 255);
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+
+.metric-note {
   color: rgb(171, 186, 224);
-  font-size: 13px;
+  font-size: 11px;
 }
 
 .body {
   flex-grow: 1;
   flex-direction: row;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 22px;
+  padding-bottom: 16px;
 }
 
 .navigation {
-  width: 180px;
-  padding-right: 12px;
-  color: rgb(171, 186, 224);
+  width: 220px;
+  min-width: 220px;
+  margin-right: 18px;
+  padding-left: 14px;
+  padding-right: 14px;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+  background-color: rgba(14, 20, 39, 0.88);
+}
+
+#nav-title {
+  color: rgb(240, 245, 255);
+  margin-bottom: 12px;
+}
+
+#nav-section {
+  color: rgb(112, 164, 255);
+  margin-top: 8px;
+  margin-bottom: 6px;
+}
+
+.room,
+.lens {
+  color: rgb(194, 205, 233);
+  margin-left: 4px;
+  margin-bottom: 4px;
 }
 
 .content {
@@ -42,13 +157,154 @@
 }
 
 .card {
-  padding: 14px;
-  margin-bottom: 14px;
-  background-color: rgb(18, 24, 42);
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  margin-bottom: 12px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-color: rgba(121, 163, 255, 0.13);
+  border-right-color: rgba(121, 163, 255, 0.13);
+  border-top-color: rgba(121, 163, 255, 0.13);
+  border-bottom-color: rgba(121, 163, 255, 0.13);
+  background-color: rgba(18, 25, 46, 0.94);
   color: rgb(232, 238, 255);
 }
 
+.section-title {
+  color: rgb(244, 247, 255);
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.stat-row {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(255, 255, 255, 0.04);
+}
+
+.stat-label {
+  color: rgb(151, 171, 221);
+  font-size: 12px;
+}
+
+.stat-value {
+  color: rgb(232, 238, 255);
+  font-size: 12px;
+  max-width: 66%;
+  -unity-text-align: middle-right;
+}
+
+.status-pill,
+.observability-pill,
+.readiness-pill,
+.inhabitant-pill,
+.boundary-pill,
+.contract-pill,
+.investor-pill,
+.attention-pill {
+  align-self: flex-start;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+  border-top-left-radius: 999px;
+  border-top-right-radius: 999px;
+  border-bottom-left-radius: 999px;
+  border-bottom-right-radius: 999px;
+  background-color: rgba(101, 145, 244, 0.18);
+  color: rgb(209, 225, 255);
+  font-size: 11px;
+}
+
+.status-pill {
+  background-color: rgba(72, 196, 140, 0.18);
+  color: rgb(177, 244, 207);
+}
+
+.observability-pill,
+.contract-pill {
+  background-color: rgba(79, 164, 255, 0.18);
+}
+
+.readiness-pill {
+  background-color: rgba(208, 159, 54, 0.2);
+  color: rgb(251, 223, 163);
+}
+
+.inhabitant-pill {
+  background-color: rgba(142, 109, 255, 0.2);
+  color: rgb(225, 212, 255);
+}
+
+.boundary-pill,
+.attention-pill {
+  background-color: rgba(255, 120, 120, 0.16);
+  color: rgb(255, 207, 207);
+}
+
+.investor-pill {
+  background-color: rgba(113, 196, 255, 0.17);
+}
+
+.attention-row {
+  flex-direction: row;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.attention-text {
+  flex-grow: 1;
+  color: rgb(222, 229, 247);
+  margin-left: 8px;
+}
+
+#world-question,
+#readiness-check,
+#inhabitant-label {
+  color: rgb(240, 245, 255);
+}
+
+#world-note,
+#world-lens-summary,
+#status-snapshot-note,
+#observability-boundary,
+#observability-private-state,
+#readiness-boundary,
+#readiness-note,
+#inhabitant-capability,
+#inhabitant-alert-summary,
+#inhabitant-identity-boundary,
+#boundary-body,
+#boundary-caveat,
+#packet-note,
+#proposal-mode,
+#observability-findings-disposition {
+  color: rgb(207, 217, 241);
+}
+
 .footer {
-  padding-top: 16px;
-  color: rgb(171, 186, 224);
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 14px;
+  padding-bottom: 18px;
+  border-top-width: 1px;
+  border-top-color: rgba(118, 160, 255, 0.14);
+}
+
+#footer-line {
+  color: rgb(164, 180, 221);
+  font-size: 13px;
 }

--- a/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryShellController.cs
+++ b/demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryShellController.cs
@@ -469,10 +469,29 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement header = new();
             header.AddToClassList("header");
-            header.style.paddingBottom = 16f;
-            header.Add(CreateLabel(title, "title", 26, FontStyle.Bold));
+            header.Add(CreateLabel("Milestone proof demo", "eyebrow", 12, FontStyle.Bold));
+            header.Add(CreateLabel(title, "title", 30, FontStyle.Bold));
             header.Add(CreateLabel(subtitle, "subtitle", 14));
+            header.Add(CreateLabel(healthSummary, "headline-summary", 15));
+            header.Add(BuildMetricRail());
             return header;
+        }
+
+        private VisualElement BuildMetricRail()
+        {
+            VisualElement rail = new();
+            rail.AddToClassList("metric-rail");
+            rail.Add(CreateMetricTile("Citizens", citizenCount.ToString(), "Metric"));
+            rail.Add(CreateMetricTile("Episodes", episodeCount.ToString(), "Completed"));
+            rail.Add(CreateMetricTile("Current tick", currentTick.ToString(), kernelPulseStatus));
+            rail.Add(
+                CreateMetricTile(
+                    "Freedom Gate",
+                    $"{allowCount}/{deferCount}/{refuseCount}",
+                    "allow/defer/refuse"
+                )
+            );
+            return rail;
         }
 
         private VisualElement BuildBody()
@@ -505,17 +524,16 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement nav = new();
             nav.AddToClassList("navigation");
-            nav.style.width = 220f;
-            nav.style.paddingRight = 12f;
-            nav.Add(CreateLabel("Rooms", null, 16, FontStyle.Bold));
+            nav.Add(CreateLabel("Observatory map", "nav-title", 16, FontStyle.Bold));
+            nav.Add(CreateLabel("Rooms", "nav-section", 12, FontStyle.Bold));
             foreach (string label in roomLabels)
             {
-                nav.Add(CreateLabel(DefaultIfBlank(label, "Unnamed room")));
+                nav.Add(CreateNavItem(DefaultIfBlank(label, "Unnamed room"), "room"));
             }
-            nav.Add(CreateLabel("Lenses", null, 16, FontStyle.Bold));
+            nav.Add(CreateLabel("Lenses", "nav-section", 12, FontStyle.Bold));
             foreach (string label in lensLabels)
             {
-                nav.Add(CreateLabel(DefaultIfBlank(label, "Unnamed lens")));
+                nav.Add(CreateNavItem(DefaultIfBlank(label, "Unnamed lens"), "lens"));
             }
             return nav;
         }
@@ -523,12 +541,19 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildSummaryCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Observed summary", "summary-title", 18, FontStyle.Bold));
-            card.Add(CreateLabel($"Citizens: {citizenCount}", "citizen-count"));
-            card.Add(CreateLabel($"Episodes: {episodeCount}", "episode-count"));
-            card.Add(CreateLabel($"Default room: {defaultRoomLabel}", "default-room"));
-            card.Add(CreateLabel($"Default lens: {defaultLensLabel}", "default-lens"));
-            card.Add(CreateLabel($"Current tick: {currentTick}", "current-tick"));
+            card.Add(CreateSectionTitle("Observed summary"));
+            card.Add(CreateStatRow("Citizens", citizenCount.ToString(), "citizen-count"));
+            card.Add(CreateStatRow("Episodes", episodeCount.ToString(), "episode-count"));
+            card.Add(CreateStatRow("Default room", defaultRoomLabel, "default-room"));
+            card.Add(CreateStatRow("Default lens", defaultLensLabel, "default-lens"));
+            card.Add(CreateStatRow("Current tick", currentTick.ToString(), "current-tick"));
+            card.Add(
+                CreateStatRow(
+                    "Freedom Gate counts:",
+                    $"{allowCount} allow / {deferCount} defer / {refuseCount} refuse",
+                    "freedom-gate-counts"
+                )
+            );
             card.Add(CreateLabel(proposalModeStatement, "proposal-mode"));
             return card;
         }
@@ -536,27 +561,33 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildWorldCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Inhabited world", "world-title", 18, FontStyle.Bold));
-            card.Add(CreateLabel(worldQuestion, "world-question"));
+            card.Add(CreateSectionTitle("Inhabited world"));
+            card.Add(CreateLabel(worldQuestion, "world-question", 16, FontStyle.Bold));
             card.Add(CreateLabel(worldNote, "world-note"));
-            card.Add(CreateLabel($"Default lens: {defaultLensLabel}", "world-lens"));
+            card.Add(CreateStatRow("Default lens", defaultLensLabel, "world-lens"));
             card.Add(CreateLabel(lensSummary, "world-lens-summary"));
-            card.Add(CreateLabel($"{corporateInvestorLabel}: {corporateInvestorBoundary}", "world-investor-boundary"));
+            card.Add(CreatePill(corporateInvestorLabel, "investor-pill"));
+            card.Add(CreateLabel(corporateInvestorBoundary, "world-investor-boundary"));
             return card;
         }
 
         private VisualElement BuildStatusCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Runtime status", "status-title", 18, FontStyle.Bold));
+            card.Add(CreateSectionTitle("Runtime status"));
+            card.Add(CreatePill(kernelPulseStatus, "status-pill"));
             card.Add(CreateLabel(healthSummary, "status-health"));
-            card.Add(CreateLabel($"Kernel pulse: {kernelPulseStatus}", "status-pulse"));
-            card.Add(CreateLabel($"Resources: {resourceState}", "status-resources"));
-            card.Add(CreateLabel($"Snapshot: {snapshotState}", "status-snapshot"));
+            card.Add(CreateStatRow("Resources", resourceState, "status-resources"));
+            card.Add(CreateStatRow("Snapshot", snapshotState, "status-snapshot"));
             card.Add(CreateLabel(snapshotNote, "status-snapshot-note"));
             foreach (string item in attentionItems)
             {
-                card.Add(CreateLabel($"Attention: {DefaultIfBlank(item, "Review bounded state.")}", "status-attention"));
+                card.Add(
+                    CreateAttentionRow(
+                        DefaultIfBlank(item, "Review bounded state."),
+                        "status-attention"
+                    )
+                );
             }
             return card;
         }
@@ -564,20 +595,20 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildObservabilityCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Observability and security", "observability-title", 18, FontStyle.Bold));
+            card.Add(CreateSectionTitle("Observability and security", "observability-title"));
             if (!hasObservabilityContract)
             {
                 card.Add(CreateLabel("Observability/security consumption proof is not bound in this contract.", "observability-unbound"));
                 return card;
             }
-            card.Add(CreateLabel($"Consumption status: {observabilityStatus}", "observability-status"));
+            card.Add(CreatePill(observabilityStatus, "observability-pill"));
             card.Add(CreateLabel(observabilityClaimBoundary, "observability-boundary"));
             card.Add(CreateLabel(privateStatePosture, "observability-private-state"));
-            card.Add(CreateLabel($"OTel boundary: {otelBoundaryRef}", "observability-otel-ref"));
-            card.Add(CreateLabel($"Event stream example: {eventStreamExampleRef}", "observability-stream-ref"));
-            card.Add(CreateLabel($"Logging validation: {loggingValidationRef}", "observability-logging-ref"));
-            card.Add(CreateLabel($"Security review: {observabilitySecurityReviewRef}", "observability-security-ref"));
-            card.Add(CreateLabel($"Proof packet: {observabilityProofPacketRef}", "observability-proof-ref"));
+            card.Add(CreateStatRow("OTel boundary", otelBoundaryRef, "observability-otel-ref"));
+            card.Add(CreateStatRow("Event stream", eventStreamExampleRef, "observability-stream-ref"));
+            card.Add(CreateStatRow("Logging validation", loggingValidationRef, "observability-logging-ref"));
+            card.Add(CreateStatRow("Security review", observabilitySecurityReviewRef, "observability-security-ref"));
+            card.Add(CreateStatRow("Proof packet", observabilityProofPacketRef, "observability-proof-ref"));
             card.Add(CreateLabel(findingsDisposition, "observability-findings-disposition"));
             return card;
         }
@@ -585,9 +616,9 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildInhabitantReadinessCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Inhabitant readiness", "readiness-title", 18, FontStyle.Bold));
+            card.Add(CreateSectionTitle("Inhabitant readiness"));
             card.Add(CreateLabel(identityBoundary, "readiness-boundary"));
-            card.Add(CreateLabel($"Security floor: {securityFloorRef}", "readiness-security-floor"));
+            card.Add(CreateStatRow("Security floor", securityFloorRef, "readiness-security-floor"));
             foreach (ReadinessCheck check in readinessChecks)
             {
                 if (check == null)
@@ -595,7 +626,8 @@ namespace ADL.Demos.UnityObservatory
                     continue;
                 }
 
-                card.Add(CreateLabel($"{DefaultIfBlank(check.state, "unknown")}: {DefaultIfBlank(check.label, "Readiness check")}", "readiness-check"));
+                card.Add(CreatePill(DefaultIfBlank(check.state, "unknown"), "readiness-pill"));
+                card.Add(CreateLabel(DefaultIfBlank(check.label, "Readiness check"), "readiness-check", 15, FontStyle.Bold));
                 card.Add(CreateLabel(DefaultIfBlank(check.note, "No readiness note supplied."), "readiness-note"));
             }
             return card;
@@ -604,7 +636,7 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildInhabitantsCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Citizen explorer", "inhabitants-title", 18, FontStyle.Bold));
+            card.Add(CreateSectionTitle("Citizen explorer"));
             foreach (InhabitantProjection inhabitant in inhabitants)
             {
                 if (inhabitant == null)
@@ -612,8 +644,8 @@ namespace ADL.Demos.UnityObservatory
                     continue;
                 }
 
+                card.Add(CreatePill(DefaultIfBlank(inhabitant.activity_posture, "bounded"), "inhabitant-pill"));
                 card.Add(CreateLabel(DefaultIfBlank(inhabitant.projection_label, "Inhabitant lane"), "inhabitant-label", 15, FontStyle.Bold));
-                card.Add(CreateLabel(DefaultIfBlank(inhabitant.activity_posture, "bounded"), "inhabitant-state"));
                 card.Add(CreateLabel(DefaultIfBlank(inhabitant.capability_summary, "No capability summary supplied."), "inhabitant-capability"));
                 card.Add(CreateLabel(DefaultIfBlank(inhabitant.alert_summary, "No alert summary supplied."), "inhabitant-alert-summary"));
                 card.Add(CreateLabel($"{DefaultIfBlank(inhabitant.identity_visibility, "identity_bounded")}: {DefaultIfBlank(inhabitant.identity_note, "Identity details remain bounded.")}", "inhabitant-identity-boundary"));
@@ -624,9 +656,9 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildBoundaryCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Governed boundary", "boundary-title", 18, FontStyle.Bold));
+            card.Add(CreateSectionTitle("Governed boundary"));
             card.Add(CreateLabel(claimBoundary, "boundary-body"));
-            card.Add(CreateLabel($"Freedom Gate counts: allow {allowCount}, defer {deferCount}, refuse {refuseCount}.", "boundary-followon"));
+            card.Add(CreatePill($"allow {allowCount} / defer {deferCount} / refuse {refuseCount}", "boundary-pill"));
             card.Add(CreateLabel(caveat, "boundary-caveat"));
             return card;
         }
@@ -634,11 +666,12 @@ namespace ADL.Demos.UnityObservatory
         private VisualElement BuildPacketCard()
         {
             VisualElement card = CreateCard();
-            card.Add(CreateLabel("Packet contract", "packet-title", 18, FontStyle.Bold));
-            card.Add(CreateLabel(packetSchema, "packet-schema"));
-            card.Add(CreateLabel(packetRef, "packet-ref"));
-            card.Add(CreateLabel(runtimeArtifactRoot, "artifact-root"));
-            card.Add(CreateLabel(operatorReportRef, "report-ref"));
+            card.Add(CreateSectionTitle("Packet contract"));
+            card.Add(CreatePill(evidenceLevel.Replace("_", " "), "contract-pill"));
+            card.Add(CreateStatRow("Schema", packetSchema, "packet-schema"));
+            card.Add(CreateStatRow("Packet ref", packetRef, "packet-ref"));
+            card.Add(CreateStatRow("Artifact root", runtimeArtifactRoot, "artifact-root"));
+            card.Add(CreateStatRow("Report ref", operatorReportRef, "report-ref"));
             card.Add(CreateLabel($"This shell is reading a deterministic Unity-facing contract derived from {evidenceLevel} Observatory evidence.", "packet-note"));
             return card;
         }
@@ -647,8 +680,7 @@ namespace ADL.Demos.UnityObservatory
         {
             VisualElement footer = new();
             footer.AddToClassList("footer");
-            footer.style.paddingTop = 16f;
-            footer.Add(CreateLabel("Deterministic Unity Observatory logging, OTel, and security consumption projection for WP-09 O-04.", null, 13));
+            footer.Add(CreateLabel("Deterministic Unity Observatory logging, OTel, and security consumption projection for WP-09 O-04.", "footer-line", 13));
             return footer;
         }
 
@@ -665,17 +697,65 @@ namespace ADL.Demos.UnityObservatory
             return card;
         }
 
+        private static Label CreateSectionTitle(string text, string name = null)
+        {
+            return CreateLabel(text, name, 18, FontStyle.Bold, "section-title");
+        }
+
+        private static Label CreatePill(string text, string className)
+        {
+            return CreateLabel(text, null, 11, FontStyle.Bold, className);
+        }
+
+        private static Label CreateNavItem(string text, string className)
+        {
+            return CreateLabel(text, null, 13, FontStyle.Normal, className);
+        }
+
+        private static VisualElement CreateMetricTile(string label, string value, string note)
+        {
+            VisualElement tile = new();
+            tile.AddToClassList("metric-tile");
+            tile.Add(CreateLabel(label, null, 11, FontStyle.Bold, "metric-label"));
+            tile.Add(CreateLabel(value, null, 22, FontStyle.Bold, "metric-value"));
+            tile.Add(CreateLabel(note, null, 11, FontStyle.Normal, "metric-note"));
+            return tile;
+        }
+
+        private static VisualElement CreateStatRow(string label, string value, string valueName)
+        {
+            VisualElement row = new();
+            row.AddToClassList("stat-row");
+            row.Add(CreateLabel(label, null, 12, FontStyle.Bold, "stat-label"));
+            row.Add(CreateLabel(value, valueName, 12, FontStyle.Normal, "stat-value"));
+            return row;
+        }
+
+        private static VisualElement CreateAttentionRow(string text, string labelName)
+        {
+            VisualElement row = new();
+            row.AddToClassList("attention-row");
+            row.Add(CreateLabel("Attention", null, 11, FontStyle.Bold, "attention-pill"));
+            row.Add(CreateLabel(text, labelName, 12, FontStyle.Normal, "attention-text"));
+            return row;
+        }
+
         private static Label CreateLabel(
             string text,
             string name = null,
             int fontSize = 13,
-            FontStyle fontStyle = FontStyle.Normal
+            FontStyle fontStyle = FontStyle.Normal,
+            string className = null
         )
         {
             Label label = new(text);
             if (!string.IsNullOrWhiteSpace(name))
             {
                 label.name = name;
+            }
+            if (!string.IsNullOrWhiteSpace(className))
+            {
+                label.AddToClassList(className);
             }
 
             Font runtimeFont = ResolveRuntimeFont();


### PR DESCRIPTION
Closes #4555

## Summary
Integrated the Unity Observatory into the retained Soak #1 runtime path by
teaching the soak runner to emit a bounded Unity-consumable observatory bundle,
refreshing the Unity shell so it preserves the validator-facing contract while
using the richer Unity 6.5 presentation layer, and adding one focused end-to-end
proof script that drives the runtime producer and Unity consumer together.

The final bounded proof shows three things together:

1. The Soak #1 runtime path now writes a retained observatory packet, operator
   report, console reference, manifest, and Unity contract under the soak
   artifact root.
2. The Unity Observatory consumer can import that contract and validate the
   scene in batch mode without falling back to canned-only packet assumptions.
3. The integration remains explicitly bounded to local retained artifacts and
   does not claim live streaming telemetry, product-complete observatory
   readiness, or direct runtime mutation from Unity.

The bounded pre-PR review initially found two narrow issues: the proof script
deleted the generated observatory bundle after success, and the soak runner's
reviewer path omitted the new observatory artifacts. Both were fixed in the
issue worktree, and the final re-review returned no actionable findings.

## Artifacts
- Runtime-owned observatory export surfaces generated during proof:
  - `repo-local ignored Soak #1 artifact root / runtime_v2/observatory/visibility_packet.json`
  - `repo-local ignored Soak #1 artifact root / runtime_v2/observatory/operator_report.md`
  - `repo-local ignored Soak #1 artifact root / runtime_v2/observatory/unity_observatory_contract.json`
- Unity proof log:
  - `repo-local ignored Unity proof log for issue #4555`
- Tracked implementation and proof-path updates:
  - `adl/src/bin/run_v0916_integrated_runtime_soak.rs`
  - `adl/tools/test_v0916_unity_observatory_soak_integration.sh`
  - `demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryShellController.cs`
  - `demos/v0.91.6/unity-observatory/Assets/Resources/ObservatoryShellRuntime.uss`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified the touched Rust sources are normalized to repository formatting conventions before proof capture.
  - `cargo test --manifest-path adl/Cargo.toml --bin run_v0916_integrated_runtime_soak -- --nocapture`
    Verified the soak runner emits the observatory bundle and preserves the targeted test expectations.
  - `bash adl/tools/test_v0916_unity_observatory_soak_integration.sh`
    Verified the Unity Observatory consumes the generated runtime contract through the retained local proof path.
  - `git diff --check`
    Verified the final patch is whitespace-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4555__v0-91-6-observatory-runtime-integrate-unity-observatory-into-the-soak-1-runtime-path/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4555__v0-91-6-observatory-runtime-integrate-unity-observatory-into-the-soak-1-runtime-path/sor.md
- Idempotency-Key: v0-91-6-observatory-runtime-integrate-unity-observatory-into-the-soak-1-runtime-path-adl-v0-91-6-tasks-issue-4555-v0-91-6-observatory-runtime-integrate-unity-observatory-into-the-soak-1-runtime-path-sip-md-adl-v0-91-6-tasks-issue-4555-v0-91-6-observatory-runtime-integrate-unity-observatory-into-the-soak-1-runtime-path-sor-md