### PR TITLE
[v0.91.7][tools] Fix pr finish focused-validation rejection for chained selector commands

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4328,6 +4328,15 @@ pub(super) fn run_finish_validation_rust(
                         repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
                     run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
                 }
+                "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py" => {
+                    let polis_status = repo_root.join("adl/tools/polis_status_for_ssm.sh");
+                    run_finish_validation_status("bash", &["-n", path_str(&polis_status)?])?;
+                    let polis_status_qts = repo_root.join("adl/tools/polis_status_for_ssm_qts.sh");
+                    run_finish_validation_status("bash", &["-n", path_str(&polis_status_qts)?])?;
+                    let validate_qts =
+                        repo_root.join("adl/tools/validate_polis_status_for_ssm_qts.py");
+                    run_finish_validation_status("python3", &[path_str(&validate_qts)?])?;
+                }
                 "bash adl/tools/test_validation_inventory.sh" => {
                     let script = repo_root.join("adl/tools/test_validation_inventory.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3504,9 +3504,14 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
         .commands
         .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
 
-    let unrelated_plan = select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths)
-        .expect("unrelated issue should now resolve through the general unified validation contract");
-    assert_eq!(unrelated_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    let unrelated_plan =
+        select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths).expect(
+            "unrelated issue should now resolve through the general unified validation contract",
+        );
+    assert_eq!(
+        unrelated_plan.mode,
+        FinishValidationMode::LargerBinaryFocused
+    );
     assert!(!unrelated_plan.commands.contains(
         &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation"
             .to_string()
@@ -4611,8 +4616,7 @@ fn finish_runner_executes_chained_local_polis_selector_command() {
             "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py".to_string(),
         ],
     };
-    run_finish_validation_rust(&repo, &plan)
-        .expect("chained local polis selector validation");
+    run_finish_validation_rust(&repo, &plan).expect("chained local polis selector validation");
 
     unsafe {
         env::set_var("PATH", old_path);

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3504,13 +3504,13 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
         .commands
         .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
 
-    let unrelated_plan =
-        select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths)
-            .expect("unrelated issue should fall back to the generic larger-binary plan");
-    assert_eq!(
-        unrelated_plan.mode,
-        FinishValidationMode::LargerBinaryFocused
-    );
+    let unrelated_plan = select_finish_validation_plan_for_finish(4305, &requested_paths, &changed_paths)
+        .expect("unrelated issue should now resolve through the general unified validation contract");
+    assert_eq!(unrelated_plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(!unrelated_plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation"
+            .to_string()
+    ));
     assert!(unrelated_plan
         .commands
         .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string()));
@@ -3520,6 +3520,10 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
     assert!(unrelated_plan
         .commands
         .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
+    assert!(unrelated_plan
+        .commands
+        .iter()
+        .any(|command| command.contains("test_run_nessus_remote_validation.sh")));
     assert!(unrelated_plan
         .commands
         .iter()
@@ -4550,6 +4554,124 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     assert!(focused_calls.contains("select-validation-lanes"));
     assert!(focused_calls.contains("validation-manager"));
     assert!(focused_calls.contains("nessus-remote-runner"));
+}
+
+#[test]
+fn finish_runner_executes_chained_local_polis_selector_command() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-chained-local-polis-selector-command");
+
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/polis_status_for_ssm.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' polis-status-ssm >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/polis_status_for_ssm_qts.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' polis-status-ssm-qts >> \"$FOCUSED_LOG\"\n",
+    );
+    fs::write(
+        repo.join("adl/tools/validate_polis_status_for_ssm_qts.py"),
+        "#!/usr/bin/env python3\nimport os\nfrom pathlib import Path\nPath(os.environ['FOCUSED_LOG']).write_text(Path(os.environ['FOCUSED_LOG']).read_text() + 'validate-polis-ssm-qts\\n' if Path(os.environ['FOCUSED_LOG']).exists() else 'validate-polis-ssm-qts\\n')\n",
+    )
+    .expect("write validate polis qts");
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    write_executable(
+        &bin_dir.join("cargo"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec![
+            "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py".to_string(),
+        ],
+    };
+    run_finish_validation_rust(&repo, &plan)
+        .expect("chained local polis selector validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    assert!(
+        !cargo_log.exists(),
+        "chained local polis selector command should not invoke cargo"
+    );
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert_eq!(focused_calls.trim(), "validate-polis-ssm-qts");
+}
+
+#[test]
+fn finish_runner_rejects_chained_local_polis_selector_command_when_shell_syntax_is_invalid() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-chained-local-polis-selector-command-invalid-shell");
+
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    fs::write(
+        repo.join("adl/tools/polis_status_for_ssm.sh"),
+        "#!/usr/bin/env bash\nif then\n",
+    )
+    .expect("write invalid polis ssm shell");
+    write_executable(
+        &repo.join("adl/tools/polis_status_for_ssm_qts.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    fs::write(
+        repo.join("adl/tools/validate_polis_status_for_ssm_qts.py"),
+        "#!/usr/bin/env python3\nprint('should-not-run')\n",
+    )
+    .expect("write validate polis qts");
+    init_git_repo(&repo);
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec![
+            "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py".to_string(),
+        ],
+    };
+    let err = run_finish_validation_rust(&repo, &plan)
+        .expect_err("invalid polis shell syntax should fail the chained selector command");
+    assert!(err.to_string().contains("bash failed with status"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4562

## Summary
Implemented Rust `pr finish` support for the chained local-polis focused validation
selector command, added focused regressions for both the success and fail-closed
paths, and normalized the adjacent locked-Cargo fallback test expectation so the
owner-binary finish lane reflects the current unified validation contract.

## Artifacts
- Local ignored output card updated at `.adl/v0.91.7/tasks/issue-4562__v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands/sor.md`
- Goal-metrics rollover artifacts at `.adl/v0.91.7/tasks/issue-4562__v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands/artifacts/goal_metrics/`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_executes_chained_local_polis_selector_command -- --test-threads=1`
    Verified the Rust finish delegate accepts and runs the chained local-polis selector command without invoking Cargo.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_rejects_chained_local_polis_selector_command_when_shell_syntax_is_invalid -- --test-threads=1`
    Verified the chained local-polis selector command fails closed when the shell syntax check is invalid.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_executes_combined_ci_policy_selector_command -- --test-threads=1`
    Verified the nearby combined CI policy selector path still succeeds after the delegate change.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_validation_profile_classifies_locked_cargo_fallback_slice -- --test-threads=1`
    Verified the locked-Cargo fallback regression reflects the current unified validation contract and no longer blocks finish publication on stale expectations.
  - `git diff --check`
    Verified whitespace and patch-format hygiene for the issue-local diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4562__v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4562__v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands/sor.md
- Idempotency-Key: v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands-adl-v0-91-7-tasks-issue-4562-v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands-sip-md-adl-v0-91-7-tasks-issue-4562-v0-91-7-tools-fix-pr-finish-focused-validation-rejection-for-chained-selector-commands-sor-md