### PR TITLE
[v0.91.6][tools][closeout] Sync root SRP and SOR truth before pruning merged issue worktrees

### DIFF
--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -41,7 +41,7 @@ fn reconcile_closed_completed_issue_bundle_with_recovery_sources(
 
     for relative in ["stp.md", "sip.md", "spp.md", "srp.md", "sor.md"] {
         let canonical_path = bundle_dir.join(relative);
-        if ensure_nonempty_file_path(&canonical_path)? {
+        if !canonical_bundle_path_needs_recovery(&canonical_path, relative)? {
             continue;
         }
         for duplicate in &duplicates {
@@ -49,7 +49,7 @@ fn reconcile_closed_completed_issue_bundle_with_recovery_sources(
                 continue;
             }
             let candidate = duplicate.join(relative);
-            if ensure_nonempty_file_path(&candidate)? {
+            if recovery_candidate_is_usable(&candidate, relative)? {
                 fs::copy(&candidate, &canonical_path).with_context(|| {
                     format!(
                         "doctor: failed to restore canonical bundle file '{}' from duplicate '{}'",
@@ -330,6 +330,16 @@ pub(crate) fn ensure_closed_completed_issue_bundle_truth(
         }
     }
 
+    let srp_path = issue_ref.task_bundle_review_policy_path(repo_root);
+    if !ensure_nonempty_file_path(&srp_path)? {
+        mismatches.push("missing canonical srp.md".to_string());
+    } else if !srp_has_final_review_results_text(&fs::read_to_string(&srp_path)?)? {
+        mismatches.push(
+            "SRP review_results must record final findings_status/recommended_outcome truth for closed issues"
+                .to_string(),
+        );
+    }
+
     if !mismatches.is_empty() {
         bail!(
             "canonical closed-issue sor truth drift at {}: {}",
@@ -338,6 +348,90 @@ pub(crate) fn ensure_closed_completed_issue_bundle_truth(
         );
     }
     Ok(())
+}
+
+fn canonical_bundle_path_needs_recovery(path: &Path, relative: &str) -> Result<bool> {
+    if !ensure_nonempty_file_path(path)? {
+        return Ok(true);
+    }
+    match relative {
+        "srp.md" => Ok(!srp_has_final_review_results_text(&fs::read_to_string(path)?)?),
+        "sor.md" => Ok(!sor_has_terminal_closeout_truth_text(&fs::read_to_string(path)?)),
+        _ => Ok(false),
+    }
+}
+
+fn recovery_candidate_is_usable(path: &Path, relative: &str) -> Result<bool> {
+    if !ensure_nonempty_file_path(path)? {
+        return Ok(false);
+    }
+    match relative {
+        "srp.md" => srp_has_final_review_results_text(&fs::read_to_string(path)?),
+        "sor.md" => Ok(sor_has_terminal_closeout_truth_text(&fs::read_to_string(path)?)),
+        _ => Ok(true),
+    }
+}
+
+fn srp_has_final_review_results_text(text: &str) -> Result<bool> {
+    let Some(front_matter) = markdown_front_matter_local(text) else {
+        return Ok(false);
+    };
+    let yaml: serde_yaml::Value = match serde_yaml::from_str(front_matter) {
+        Ok(value) => value,
+        Err(_) => return Ok(false),
+    };
+    let Some(mapping) = yaml.as_mapping() else {
+        return Ok(false);
+    };
+    let Some(review_results) = mapping
+        .get(serde_yaml::Value::String("review_results".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+    else {
+        return Ok(false);
+    };
+    let findings_status = yaml_mapping_string_local(review_results, "findings_status");
+    let recommended_outcome = yaml_mapping_string_local(review_results, "recommended_outcome");
+    Ok(matches!(
+        findings_status.as_deref(),
+        Some("no_findings" | "findings_present")
+    ) && matches!(
+        recommended_outcome.as_deref(),
+        Some("pass" | "block" | "needs_followup")
+    ))
+}
+
+fn markdown_front_matter_local(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("---\n")?;
+    let end = rest.find("\n---")?;
+    Some(&rest[..end])
+}
+
+fn yaml_mapping_string_local(mapping: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(serde_yaml::Value::String(key.to_string()))
+        .and_then(serde_yaml::Value::as_str)
+        .map(|value| value.trim().trim_matches('"').trim_matches('\'').to_ascii_lowercase())
+}
+
+fn sor_has_terminal_closeout_truth_text(text: &str) -> bool {
+    let status = line_value_after_prefix(text, "Status:").unwrap_or_default();
+    let integration_state =
+        line_value_after_prefix(text, "- Integration state:").unwrap_or_default();
+    let result = line_value_after_prefix(text, "- Result:").unwrap_or_default();
+    let worktree_only =
+        line_value_after_prefix(text, "- Worktree-only paths remaining:").unwrap_or_default();
+    let worktree_prune_result =
+        line_value_after_prefix(text, "- Worktree prune result:").unwrap_or_default();
+    let terminal_worktree_truth = worktree_only == "none"
+        || (worktree_only.starts_with("issue worktree retained: ")
+            && worktree_prune_result.starts_with("retained_with_reason: "));
+    ["merged", "closed_no_pr"].contains(&integration_state.as_str())
+        && matches!(
+            (status.as_str(), result.as_str()),
+            ("DONE", "PASS") | ("FAILED", "FAIL")
+        )
+        && terminal_worktree_truth
+        && text.contains("## Validation")
 }
 
 fn check_required_field(

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -355,8 +355,12 @@ fn canonical_bundle_path_needs_recovery(path: &Path, relative: &str) -> Result<b
         return Ok(true);
     }
     match relative {
-        "srp.md" => Ok(!srp_has_final_review_results_text(&fs::read_to_string(path)?)?),
-        "sor.md" => Ok(!sor_has_terminal_closeout_truth_text(&fs::read_to_string(path)?)),
+        "srp.md" => Ok(!srp_has_final_review_results_text(&fs::read_to_string(
+            path,
+        )?)?),
+        "sor.md" => Ok(!sor_has_terminal_closeout_truth_text(&fs::read_to_string(
+            path,
+        )?)),
         _ => Ok(false),
     }
 }
@@ -367,7 +371,9 @@ fn recovery_candidate_is_usable(path: &Path, relative: &str) -> Result<bool> {
     }
     match relative {
         "srp.md" => srp_has_final_review_results_text(&fs::read_to_string(path)?),
-        "sor.md" => Ok(sor_has_terminal_closeout_truth_text(&fs::read_to_string(path)?)),
+        "sor.md" => Ok(sor_has_terminal_closeout_truth_text(&fs::read_to_string(
+            path,
+        )?)),
         _ => Ok(true),
     }
 }
@@ -410,7 +416,13 @@ fn yaml_mapping_string_local(mapping: &serde_yaml::Mapping, key: &str) -> Option
     mapping
         .get(serde_yaml::Value::String(key.to_string()))
         .and_then(serde_yaml::Value::as_str)
-        .map(|value| value.trim().trim_matches('"').trim_matches('\'').to_ascii_lowercase())
+        .map(|value| {
+            value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_ascii_lowercase()
+        })
 }
 
 fn sor_has_terminal_closeout_truth_text(text: &str) -> bool {

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -565,8 +565,11 @@ fn ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle() {
             "# ADL Input Card\n\nBranch: codex/1410-canonical-slug\n\n## Goal\n\nPreserve the closed/completed issue prompt and local card truth after closeout.\n",
         )
         .expect("write normalized sip");
-    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write normalized srp");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write normalized srp");
     let output = canonical_dir.join("sor.md");
     fs::write(
             &output,
@@ -594,8 +597,11 @@ fn ensure_closed_completed_issue_bundle_truth_accepts_retrospective_no_branch_cl
             "# ADL Input Card\n\nBranch: retrospective-no-branch\n\n## Goal\n\nPreserve the closed/completed issue prompt and local card truth after closeout.\n",
         )
         .expect("write normalized sip");
-    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write normalized srp");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write normalized srp");
     let output = canonical_dir.join("sor.md");
     fs::write(
             &output,
@@ -889,8 +895,11 @@ fn closeout_closed_completed_issue_bundle_records_prune_result_on_canonical_outp
     fs::create_dir_all(&canonical_dir).expect("canonical dir");
     fs::write(canonical_dir.join("stp.md"), stp_text).expect("write stp");
     fs::write(canonical_dir.join("sip.md"), sip_text).expect("write sip");
-    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write srp");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write srp");
     let output = canonical_dir.join("sor.md");
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write sor");
 
@@ -949,8 +958,11 @@ fn closeout_recovers_missing_primary_cards_from_bound_worktree_bundle() {
     ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
     ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
     let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
-    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write completed srp");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write completed srp");
     let output = issue_ref.task_bundle_output_path(&repo);
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
 
@@ -1026,7 +1038,12 @@ fn closeout_recovers_stale_root_srp_and_sor_from_bound_worktree_bundle() {
     copy_prompt_templates(&repo);
     fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
     assert!(Command::new("git")
-        .args(["-C", path_str(&repo).expect("repo path"), "add", ".gitignore"])
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "add",
+            ".gitignore"
+        ])
         .status()
         .expect("git add gitignore")
         .success());
@@ -1084,25 +1101,19 @@ fn closeout_recovers_stale_root_srp_and_sor_from_bound_worktree_bundle() {
         .success());
     let worktree_bundle = issue_ref.task_bundle_dir_path(&worktree);
     fs::create_dir_all(&worktree_bundle).expect("worktree bundle");
-    fs::copy(
-        canonical_dir.join("stp.md"),
-        worktree_bundle.join("stp.md"),
+    fs::copy(canonical_dir.join("stp.md"), worktree_bundle.join("stp.md")).expect("copy stp");
+    fs::copy(canonical_dir.join("sip.md"), worktree_bundle.join("sip.md")).expect("copy sip");
+    fs::copy(canonical_dir.join("spp.md"), worktree_bundle.join("spp.md")).expect("copy spp");
+    fs::write(
+        worktree_bundle.join("srp.md"),
+        issue_ref_completed_srp_content(),
     )
-    .expect("copy stp");
-    fs::copy(
-        canonical_dir.join("sip.md"),
-        worktree_bundle.join("sip.md"),
+    .expect("write final worktree srp");
+    fs::write(
+        worktree_bundle.join("sor.md"),
+        issue_ref_sync_completed_output_content(),
     )
-    .expect("copy sip");
-    fs::copy(
-        canonical_dir.join("spp.md"),
-        worktree_bundle.join("spp.md"),
-    )
-    .expect("copy spp");
-    fs::write(worktree_bundle.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write final worktree srp");
-    fs::write(worktree_bundle.join("sor.md"), issue_ref_sync_completed_output_content())
-        .expect("write final worktree sor");
+    .expect("write final worktree sor");
 
     closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
         .expect("closeout should recover stale root review/output truth from worktree");
@@ -1130,7 +1141,12 @@ fn closeout_recovers_malformed_root_srp_from_bound_worktree_bundle() {
     copy_prompt_templates(&repo);
     fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
     assert!(Command::new("git")
-        .args(["-C", path_str(&repo).expect("repo path"), "add", ".gitignore"])
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "add",
+            ".gitignore"
+        ])
         .status()
         .expect("git add gitignore")
         .success());
@@ -1188,10 +1204,16 @@ fn closeout_recovers_malformed_root_srp_from_bound_worktree_bundle() {
         fs::copy(canonical_dir.join(relative), worktree_bundle.join(relative))
             .expect("copy card to worktree");
     }
-    fs::write(worktree_bundle.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write final worktree srp");
-    fs::write(worktree_bundle.join("sor.md"), issue_ref_sync_completed_output_content())
-        .expect("write final worktree sor");
+    fs::write(
+        worktree_bundle.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write final worktree srp");
+    fs::write(
+        worktree_bundle.join("sor.md"),
+        issue_ref_sync_completed_output_content(),
+    )
+    .expect("write final worktree sor");
 
     closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
         .expect("closeout should recover malformed root srp from worktree");
@@ -1250,8 +1272,11 @@ fn closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete() {
     ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
     ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
     let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
-    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
-        .expect("write completed srp");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write completed srp");
     let output = issue_ref.task_bundle_output_path(&repo);
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
 

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -492,6 +492,11 @@ fn ensure_closed_completed_issue_bundle_truth_rejects_stale_fields() {
             "Status: IN_PROGRESS\n- Integration state: pr_open\n- Verification scope: worktree\n- Worktree-only paths remaining: adl/src/foo.rs\n",
         )
         .expect("write stale output");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        "---\nschema_version: \"0.1\"\nartifact_type: \"structured_review_prompt\"\nname: \"fixture-review\"\nissue: 1410\ntask_id: \"issue-1410\"\nversion: v0.87\ntitle: \"Fixture\"\nbranch: \"codex/1410-canonical-slug\"\nstatus: \"draft\"\nreview_results:\n  findings_status: \"not_run\"\n  recommended_outcome: \"not_run\"\n---\n\n# Structured Review Prompt\n\n## Review Summary\n\nPre-review scaffold.\n\n## Scope Basis\n\n- fixture\n\n## In-Scope Surfaces\n\n- tracked changes\n\n## Evidence Rules\n\n- repo only\n\n## Validation Inputs\n\n- issue local\n\n## Allowed Dispositions\n\n- PASS\n- BLOCK\n\n## Reviewer Constraints\n\n- keep scope narrow\n\n## Refusal Policy\n\n- refuse unsupported claims\n\n## Follow-up Routing\n\n- route back to issue\n\n## Non-Claims\n\n- not final review\n\n## Notes\n\nPre-review scaffold.\n",
+    )
+    .expect("write stale srp");
 
     let err = ensure_closed_completed_issue_bundle_truth(&temp, &issue_ref, &output)
         .expect_err("stale truth should fail");
@@ -507,6 +512,9 @@ fn ensure_closed_completed_issue_bundle_truth_rejects_stale_fields() {
     assert!(rendered.contains("STP status expected '\"complete\"' but found '\"draft\"'"));
     assert!(rendered.contains("SIP Branch expected 'codex/1410-canonical-slug'"));
     assert!(rendered.contains("SIP still contains pre-run lifecycle wording"));
+    assert!(rendered.contains(
+        "SRP review_results must record final findings_status/recommended_outcome truth for closed issues"
+    ));
 }
 
 #[test]
@@ -557,6 +565,8 @@ fn ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle() {
             "# ADL Input Card\n\nBranch: codex/1410-canonical-slug\n\n## Goal\n\nPreserve the closed/completed issue prompt and local card truth after closeout.\n",
         )
         .expect("write normalized sip");
+    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write normalized srp");
     let output = canonical_dir.join("sor.md");
     fs::write(
             &output,
@@ -584,6 +594,8 @@ fn ensure_closed_completed_issue_bundle_truth_accepts_retrospective_no_branch_cl
             "# ADL Input Card\n\nBranch: retrospective-no-branch\n\n## Goal\n\nPreserve the closed/completed issue prompt and local card truth after closeout.\n",
         )
         .expect("write normalized sip");
+    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write normalized srp");
     let output = canonical_dir.join("sor.md");
     fs::write(
             &output,
@@ -618,6 +630,8 @@ fn ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle_with_dup
                 "# ADL Input Card\n\nBranch: codex/1410-canonical-slug\n\n## Goal\n\nPreserve the closed/completed issue prompt and local card truth after closeout.\n",
             )
             .expect("write normalized sip");
+        fs::write(dir.join("srp.md"), issue_ref_completed_srp_content())
+            .expect("write normalized srp");
     }
     let output = canonical_dir.join("sor.md");
     fs::write(
@@ -875,6 +889,8 @@ fn closeout_closed_completed_issue_bundle_records_prune_result_on_canonical_outp
     fs::create_dir_all(&canonical_dir).expect("canonical dir");
     fs::write(canonical_dir.join("stp.md"), stp_text).expect("write stp");
     fs::write(canonical_dir.join("sip.md"), sip_text).expect("write sip");
+    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write srp");
     let output = canonical_dir.join("sor.md");
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write sor");
 
@@ -933,6 +949,8 @@ fn closeout_recovers_missing_primary_cards_from_bound_worktree_bundle() {
     ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
     ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
     let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write completed srp");
     let output = issue_ref.task_bundle_output_path(&repo);
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
 
@@ -998,6 +1016,196 @@ fn closeout_recovers_missing_primary_cards_from_bound_worktree_bundle() {
 }
 
 #[test]
+fn closeout_recovers_stale_root_srp_and_sor_from_bound_worktree_bundle() {
+    let _guard = env_lock();
+    let _manifest_guard = set_tooling_manifest_root_to_workspace();
+    let temp = temp_dir("adl-pr-lifecycle-closeout-recovers-stale-root-review-output");
+    let repo = temp.join("repo");
+    let origin = temp.join("origin.git");
+    init_repo_with_origin(&repo, &origin);
+    copy_prompt_templates(&repo);
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
+    assert!(Command::new("git")
+        .args(["-C", path_str(&repo).expect("repo path"), "add", ".gitignore"])
+        .status()
+        .expect("git add gitignore")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "commit",
+            "-q",
+            "-m",
+            "ignore local adl state",
+        ])
+        .status()
+        .expect("git commit gitignore")
+        .success());
+
+    let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+    let title = "PR Command Sync Coverage";
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source parent");
+    fs::write(
+        &source_path,
+        "## Summary\n\nCloseout stale-root recovery fixture.\n\n## Goal\n\nRecover stale root SRP and SOR truth from the bound worktree before prune.\n\n## Required Outcome\n\n- closeout replaces stale root review/output truth with the final worktree truth\n\n## Deliverables\n\n- focused lifecycle regression test\n\n## Acceptance Criteria\n\n- canonical SRP and SOR are refreshed from the worktree\n- clean worktree is pruned\n\n## Repo Inputs\n\n- `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- no broader closeout redesign\n\n## Issue-Graph Notes\n\n- regression fixture\n\n## Notes\n\n- local `.adl` state is ignored\n\n## Tooling Notes\n\n- focused lifecycle test\n",
+    )
+    .expect("write source");
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    fs::write(
+        &output,
+        "Status: NOT_STARTED\n- Integration state: worktree_only\n- Verification scope: worktree\n- Worktree-only paths remaining: issue bundle still local\n",
+    )
+    .expect("write stale root sor");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        "---\nschema_version: \"0.1\"\nartifact_type: \"structured_review_prompt\"\nname: \"fixture-review\"\nissue: 1410\ntask_id: \"issue-1410\"\nversion: v0.87\ntitle: \"Fixture\"\nbranch: \"codex/1410-canonical-slug\"\nstatus: \"draft\"\nreview_results:\n  findings_status: \"not_run\"\n  recommended_outcome: \"not_run\"\n---\n\n# Structured Review Prompt\n\n## Review Summary\n\nStale root review scaffold.\n\n## Scope Basis\n\n- fixture\n\n## In-Scope Surfaces\n\n- tracked changes\n\n## Evidence Rules\n\n- repo only\n\n## Validation Inputs\n\n- issue local\n\n## Allowed Dispositions\n\n- PASS\n- BLOCK\n\n## Reviewer Constraints\n\n- keep scope narrow\n\n## Refusal Policy\n\n- refuse unsupported claims\n\n## Follow-up Routing\n\n- route back to issue\n\n## Non-Claims\n\n- stale scaffold\n\n## Notes\n\nStale root review scaffold.\n",
+    )
+    .expect("write stale root srp");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "worktree",
+            "add",
+            path_str(&worktree).expect("worktree path"),
+            "-b",
+            "codex/1410-canonical-slug",
+            "main",
+        ])
+        .status()
+        .expect("git worktree add")
+        .success());
+    let worktree_bundle = issue_ref.task_bundle_dir_path(&worktree);
+    fs::create_dir_all(&worktree_bundle).expect("worktree bundle");
+    fs::copy(
+        canonical_dir.join("stp.md"),
+        worktree_bundle.join("stp.md"),
+    )
+    .expect("copy stp");
+    fs::copy(
+        canonical_dir.join("sip.md"),
+        worktree_bundle.join("sip.md"),
+    )
+    .expect("copy sip");
+    fs::copy(
+        canonical_dir.join("spp.md"),
+        worktree_bundle.join("spp.md"),
+    )
+    .expect("copy spp");
+    fs::write(worktree_bundle.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write final worktree srp");
+    fs::write(worktree_bundle.join("sor.md"), issue_ref_sync_completed_output_content())
+        .expect("write final worktree sor");
+
+    closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
+        .expect("closeout should recover stale root review/output truth from worktree");
+
+    let root_srp_text =
+        fs::read_to_string(canonical_dir.join("srp.md")).expect("read recovered root srp");
+    assert!(root_srp_text.contains("findings_status: \"no_findings\""));
+    assert!(root_srp_text.contains("recommended_outcome: \"pass\""));
+    let root_sor_text = fs::read_to_string(&output).expect("read recovered root sor");
+    assert!(root_sor_text.contains("Status: DONE"));
+    assert!(root_sor_text.contains("- Integration state: merged"));
+    assert!(!worktree.exists(), "worktree should be pruned");
+    ensure_closed_completed_issue_bundle_truth(&repo, &issue_ref, &output)
+        .expect("canonical truth remains valid after stale-root recovery");
+}
+
+#[test]
+fn closeout_recovers_malformed_root_srp_from_bound_worktree_bundle() {
+    let _guard = env_lock();
+    let _manifest_guard = set_tooling_manifest_root_to_workspace();
+    let temp = temp_dir("adl-pr-lifecycle-closeout-recovers-malformed-root-srp");
+    let repo = temp.join("repo");
+    let origin = temp.join("origin.git");
+    init_repo_with_origin(&repo, &origin);
+    copy_prompt_templates(&repo);
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
+    assert!(Command::new("git")
+        .args(["-C", path_str(&repo).expect("repo path"), "add", ".gitignore"])
+        .status()
+        .expect("git add gitignore")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "commit",
+            "-q",
+            "-m",
+            "ignore local adl state",
+        ])
+        .status()
+        .expect("git commit gitignore")
+        .success());
+
+    let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+    let title = "PR Command Sync Coverage";
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    fs::create_dir_all(source_path.parent().expect("source parent")).expect("source parent");
+    fs::write(
+        &source_path,
+        "## Summary\n\nCloseout malformed-root recovery fixture.\n\n## Goal\n\nRecover malformed root SRP truth from the bound worktree before prune.\n\n## Required Outcome\n\n- closeout treats malformed root SRP as recoverable drift and restores final worktree truth\n\n## Deliverables\n\n- focused lifecycle regression test\n\n## Acceptance Criteria\n\n- malformed canonical SRP does not abort closeout recovery\n- canonical SRP is refreshed from the worktree\n- clean worktree is pruned\n\n## Repo Inputs\n\n- `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- no broader closeout redesign\n\n## Issue-Graph Notes\n\n- regression fixture\n\n## Notes\n\n- local `.adl` state is ignored\n\n## Tooling Notes\n\n- focused lifecycle test\n",
+    )
+    .expect("write source");
+    ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
+    ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        "---\nreview_results: [this is not valid yaml\n",
+    )
+    .expect("write malformed root srp");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "-C",
+            path_str(&repo).expect("repo path"),
+            "worktree",
+            "add",
+            path_str(&worktree).expect("worktree path"),
+            "-b",
+            "codex/1410-canonical-slug",
+            "main",
+        ])
+        .status()
+        .expect("git worktree add")
+        .success());
+    let worktree_bundle = issue_ref.task_bundle_dir_path(&worktree);
+    fs::create_dir_all(&worktree_bundle).expect("worktree bundle");
+    for relative in ["stp.md", "sip.md", "spp.md"] {
+        fs::copy(canonical_dir.join(relative), worktree_bundle.join(relative))
+            .expect("copy card to worktree");
+    }
+    fs::write(worktree_bundle.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write final worktree srp");
+    fs::write(worktree_bundle.join("sor.md"), issue_ref_sync_completed_output_content())
+        .expect("write final worktree sor");
+
+    closeout_closed_completed_issue_bundle(&repo, &repo, &issue_ref, &output)
+        .expect("closeout should recover malformed root srp from worktree");
+
+    let root_srp_text =
+        fs::read_to_string(canonical_dir.join("srp.md")).expect("read recovered root srp");
+    assert!(root_srp_text.contains("findings_status: \"no_findings\""));
+    assert!(root_srp_text.contains("recommended_outcome: \"pass\""));
+    assert!(!worktree.exists(), "worktree should be pruned");
+    ensure_closed_completed_issue_bundle_truth(&repo, &issue_ref, &output)
+        .expect("canonical truth remains valid after malformed-root recovery");
+}
+
+#[test]
 fn closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete() {
     let _guard = env_lock();
     let _manifest_guard = set_tooling_manifest_root_to_workspace();
@@ -1041,6 +1249,9 @@ fn closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete() {
     .expect("write source");
     ensure_task_bundle_stp(&repo, &issue_ref, &source_path).expect("stp");
     ensure_pre_run_bootstrap_cards(&repo, &issue_ref, title, &source_path).expect("cards");
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::write(canonical_dir.join("srp.md"), issue_ref_completed_srp_content())
+        .expect("write completed srp");
     let output = issue_ref.task_bundle_output_path(&repo);
     fs::write(&output, issue_ref_sync_completed_output_content()).expect("write completed sor");
 
@@ -1296,6 +1507,75 @@ fn issue_ref_sync_completed_output_content() -> String {
         "",
         "## Follow-ups / Deferred work",
         "- None.",
+        "",
+    ]
+    .join("\n")
+}
+
+fn issue_ref_completed_srp_content() -> String {
+    [
+        "---",
+        "schema_version: \"0.1\"",
+        "artifact_type: \"structured_review_prompt\"",
+        "name: \"fixture-review\"",
+        "issue: 1410",
+        "task_id: \"issue-1410\"",
+        "version: v0.87",
+        "title: \"PR Command Sync Coverage\"",
+        "branch: \"codex/1410-canonical-slug\"",
+        "status: \"approved\"",
+        "review_results:",
+        "  findings_status: \"no_findings\"",
+        "  recommended_outcome: \"pass\"",
+        "---",
+        "",
+        "# Structured Review Prompt",
+        "",
+        "## Review Summary",
+        "",
+        "Completed pre-PR review recorded.",
+        "",
+        "## Scope Basis",
+        "",
+        "- fixture",
+        "",
+        "## In-Scope Surfaces",
+        "",
+        "- tracked changes",
+        "",
+        "## Evidence Rules",
+        "",
+        "- repo only",
+        "",
+        "## Validation Inputs",
+        "",
+        "- issue local",
+        "",
+        "## Allowed Dispositions",
+        "",
+        "- PASS",
+        "- BLOCK",
+        "- NEEDS_FOLLOWUP",
+        "",
+        "## Reviewer Constraints",
+        "",
+        "- keep scope narrow",
+        "",
+        "## Refusal Policy",
+        "",
+        "- refuse unsupported claims",
+        "",
+        "## Follow-up Routing",
+        "",
+        "- route back to issue",
+        "",
+        "## Non-Claims",
+        "",
+        "- no non-claims beyond the fixture boundary",
+        "",
+        "## Notes",
+        "",
+        "Final review truth is recorded for closeout recovery.",
         "",
     ]
     .join("\n")

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
@@ -113,6 +113,13 @@ fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
         &issue_ref.issue_prompt_path(&repo),
         &repo,
     );
+    write_completed_srp_fixture(
+        &issue_ref.task_bundle_review_policy_path(&repo),
+        &issue_ref,
+        "[v0.87.1][tools] Make closeout automatic after merge/closure",
+        "codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+        &repo,
+    );
     let sor_path = issue_ref.task_bundle_output_path(&repo);
     write_completed_sor_fixture(
         &sor_path,
@@ -270,6 +277,13 @@ fn real_pr_closeout_reconciles_closed_no_pr_issue_bundle() {
         "[v0.87.1][tools] Closeout no-pr truth",
         "codex/1597-v0-87-1-tools-closeout-no-pr-truth",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_srp_fixture(
+        &issue_ref.task_bundle_review_policy_path(&repo),
+        &issue_ref,
+        "[v0.87.1][tools] Closeout no-pr truth",
+        "retrospective-no-branch",
         &repo,
     );
     let sor_path = issue_ref.task_bundle_output_path(&repo);
@@ -458,4 +472,140 @@ fn real_pr_closeout_refuses_issue_that_is_not_completed() {
 
     let err = closeout.expect_err("closeout should refuse unfinished issue");
     assert!(err.to_string().contains("refusing automatic closeout"));
+}
+
+fn write_completed_srp_fixture(
+    path: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    repo_root: &Path,
+) {
+    let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
+    let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
+    let sor_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_output_path(repo_root));
+    let content = format!(
+        r#"---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "{slug}-review-prompt"
+issue: {issue}
+task_id: "{task_id}"
+version: v0.87.1
+title: "{title}"
+branch: "{branch}"
+status: "approved"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/example/repo/issues/{issue}"
+  - kind: "stp"
+    ref: "{stp_rel}"
+  - kind: "sip"
+    ref: "{sip_rel}"
+  - kind: "sor"
+    ref: "{sor_rel}"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - "{stp_rel}"
+  - "{sip_rel}"
+in_scope_surfaces:
+  - "tracked changes for this issue branch"
+evidence_policy:
+  - "Use repository evidence and issue-local validation only."
+validation_inputs:
+  - "Issue-local proofs recorded in the SOR."
+allowed_dispositions:
+  - "PASS"
+  - "BLOCK"
+  - "NEEDS_FOLLOWUP"
+reviewer_constraints:
+  - "Do not widen issue scope."
+refusal_policy:
+  - "Refuse claims that are unsupported by repository evidence."
+follow_up_routing:
+  - "Route actionable findings back to the issue branch."
+non_claims:
+  - "This prompt does not guarantee review quality by itself."
+policy_refs:
+  - "{stp_rel}"
+review_results:
+  findings_status: "no_findings"
+  recommended_outcome: "pass"
+notes: "fixture review completed"
+---
+
+# Structured Review Prompt
+
+## Review Summary
+
+fixture review completed
+
+## Scope Basis
+
+- {stp_rel}
+- {sip_rel}
+
+## In-Scope Surfaces
+
+- tracked changes for this issue branch
+
+## Evidence Rules
+
+- Use repository evidence and issue-local validation only.
+
+## Validation Inputs
+
+- Issue-local proofs recorded in the SOR.
+
+## Allowed Dispositions
+
+- PASS
+- BLOCK
+- NEEDS_FOLLOWUP
+
+## Reviewer Constraints
+
+- Do not widen issue scope.
+
+## Refusal Policy
+
+- Refuse claims that are unsupported by repository evidence.
+
+## Follow-up Routing
+
+- Route actionable findings back to the issue branch.
+
+## Non-Claims
+
+- This prompt does not guarantee review quality by itself.
+
+## Review Results
+
+### Findings
+
+- No findings.
+
+### Dispositions
+
+- None.
+
+### Recommended Outcome
+
+- PASS
+
+## Notes
+
+fixture review completed
+"#,
+        slug = issue_ref.slug(),
+        issue = issue_ref.issue_number(),
+        task_id = issue_ref.task_issue_id(),
+        title = title,
+        branch = branch,
+        stp_rel = stp_rel,
+        sip_rel = sip_rel,
+        sor_rel = sor_rel,
+    );
+    fs::write(path, content).expect("write completed srp");
 }


### PR DESCRIPTION
Closes #4575

## Summary
Updated closed-issue closeout reconciliation so canonical root `srp.md` and `sor.md` are recovered from the bound issue worktree when the root copies are missing, stale, or malformed before the merged issue worktree is pruned.

The closeout truth checker now requires final SRP review results in addition to canonical STP, SIP, and SOR truth, which prevents stale pre-review root cards from surviving closeout while still allowing malformed recovery sources to be skipped safely.

## Artifacts
- Local ignored output-card at `.adl/v0.91.6/tasks/issue-4575__v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`
  - `adl/src/cli/pr_cmd/lifecycle/tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ensure_closed_completed_issue_bundle_truth_rejects_stale_fields -- --nocapture`
    Verified closed-issue truth checking rejects stale pre-review SRP and non-terminal closeout truth.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_recovers_missing_primary_cards_from_bound_worktree_bundle -- --nocapture`
    Verified closeout still restores missing canonical cards from the bound worktree under the stricter SRP truth requirement.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_recovers_stale_root_srp_and_sor_from_bound_worktree_bundle -- --nocapture`
    Verified stale root SRP and SOR truth are replaced from the bound worktree before prune.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_recovers_malformed_root_srp_from_bound_worktree_bundle -- --nocapture`
    Verified malformed canonical SRP content is treated as recoverable drift instead of aborting closeout.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete -- --nocapture`
    Verified dirty stale worktrees are still retained safely when canonical closeout truth is already complete.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle -- --nocapture`
    Verified normalized closed-issue bundle truth passes with final SRP review results present.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ensure_closed_completed_issue_bundle_truth_accepts_retrospective_no_branch_closed_no_pr -- --nocapture`
    Verified the retrospective `closed_no_pr` terminal path still passes under the stricter SRP contract.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle_with_duplicate -- --nocapture`
    Verified normalized canonical truth still passes when duplicate bundle residue exists.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_closed_completed_issue_bundle_records_prune_result_on_canonical_output -- --nocapture`
    Verified canonical closeout still records the prune result on the recovered output card.
  - `git diff --check`
    Verified the tracked patch is whitespace-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4575__v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4575__v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees/sor.md
- Idempotency-Key: v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees-adl-src-cli-pr-cmd-lifecycle-reconciliation-rs-adl-src-cli-pr-cmd-lifecycle-tests-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-closeout-rs-adl-v0-91-6-tasks-issue-4575-v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees-sip-md-adl-v0-91-6-tasks-issue-4575-v0-91-6-tools-closeout-sync-root-srp-and-sor-truth-before-pruning-merged-issue-worktrees-sor-md