### PR TITLE
[v0.91.6][tools][validation] Map Unity observatory proof surfaces into validation lane selection

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -239,23 +239,33 @@
       "path_selectors": [
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
         "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
+        "demos/v0.91.6/unity-observatory/README.md",
+        "demos/v0.91.6/unity-observatory/PROOF_PACKET.md",
         "demos/v0.91.6/unity-observatory/Assets/**",
         "demos/v0.91.6/unity-observatory/Packages/**",
-        "demos/v0.91.6/unity-observatory/ProjectSettings/**"
+        "demos/v0.91.6/unity-observatory/ProjectSettings/**",
+        "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md",
+        "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md"
       ],
       "path_hints": [
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
+        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
         "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
+        "demos/v0.91.6/unity-observatory/README.md",
+        "demos/v0.91.6/unity-observatory/PROOF_PACKET.md",
         "demos/v0.91.6/unity-observatory/Assets/**",
         "demos/v0.91.6/unity-observatory/Packages/**",
-        "demos/v0.91.6/unity-observatory/ProjectSettings/**"
+        "demos/v0.91.6/unity-observatory/ProjectSettings/**",
+        "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md",
+        "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md"
       ],
-      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
-      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
       "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
     },
     {

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -454,11 +454,15 @@ PY
 
 unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
+M	adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
 M	adl/tools/test_v0916_unity_observatory_contract.sh
 M	adl/tools/test_v0916_unity_observatory_soak_integration.sh
 M	adl/tools/test_v0916_unity_observatory_unity65_smoke.sh
+M	demos/v0.91.6/unity-observatory/README.md
+M	demos/v0.91.6/unity-observatory/PROOF_PACKET.md
 M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json
 M	demos/v0.91.6/unity-observatory/Assets/Scripts/UnityObservatoryBootstrap.cs
+M	docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md
 EOF
 bash "$SCRIPT" --changed-files "$unity_observatory" --json >"$TMP/unity-observatory.json"
 python3 - <<'PY' "$TMP/unity-observatory.json"
@@ -477,8 +481,57 @@ assert lane["owner"] == "review"
 assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in lane["command"]
 assert "test_v0916_unity_observatory_baseline.sh" in lane["command"]
 assert "test_v0916_unity_observatory_contract.sh" in lane["command"]
+assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
 assert "test_v0916_unity_observatory_soak_integration.sh" in lane["command"]
 assert "csm_observatory_cli_writes_unity_contract_bundle" in lane["command"]
+PY
+
+unity_observatory_docs="$TMP/unity-observatory-docs.txt"
+cat >"$unity_observatory_docs" <<'EOF'
+M	demos/v0.91.6/unity-observatory/README.md
+M	demos/v0.91.6/unity-observatory/PROOF_PACKET.md
+M	docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md
+M	docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md
+EOF
+bash "$SCRIPT" --changed-files "$unity_observatory_docs" --json >"$TMP/unity-observatory-docs.json"
+python3 - <<'PY' "$TMP/unity-observatory-docs.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert set(profile["lanes"].keys()) == {"unity_observatory_contract_surface"}
+lane = profile["lanes"]["unity_observatory_contract_surface"]
+assert lane["matched_paths"] == [
+    "demos/v0.91.6/unity-observatory/README.md",
+    "demos/v0.91.6/unity-observatory/PROOF_PACKET.md",
+    "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md",
+    "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md",
+]
+assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
+PY
+
+unity_observatory_runtime_script="$TMP/unity-observatory-runtime-script.txt"
+cat >"$unity_observatory_runtime_script" <<'EOF'
+M	adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
+EOF
+bash "$SCRIPT" --changed-files "$unity_observatory_runtime_script" --json >"$TMP/unity-observatory-runtime-script.json"
+python3 - <<'PY' "$TMP/unity-observatory-runtime-script.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert set(profile["lanes"].keys()) == {"unity_observatory_contract_surface"}
+lane = profile["lanes"]["unity_observatory_contract_surface"]
+assert lane["matched_paths"] == [
+    "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
+]
+assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
 PY
 
 echo "PASS test_select_validation_lanes"


### PR DESCRIPTION
Closes #4572

## Summary
Mapped the Unity observatory local-runtime script, docs, proof packet, and observatory review surfaces into the `unity_observatory_contract_surface` validation lane, added isolated selector coverage for those surfaces, and reran focused validation plus bounded review so `pr.sh finish` can publish this proof-only issue without falling into `unmapped_change_surface`.

## Artifacts
- Updated validation-lane selector at `adl/config/validation_lane_selector.v0.91.6.json`
- Expanded selector coverage at `adl/tools/test_select_validation_lanes.sh`
- Updated review truth at `.adl/v0.91.6/tasks/issue-4572__v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection/srp.md`
- Updated execution truth at `.adl/v0.91.6/tasks/issue-4572__v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the issue diff is syntactically clean.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified the path-policy contract for the touched validation tooling surface.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector mappings, including the new isolated Unity observatory fixtures.
  - `python3 adl/tools/select_validation_lanes.py --manifest adl/config/validation_lane_selector.v0.91.6.json --changed-files <temp changed-files manifest> --json`
    Verified the issue's docs/proof/runtime changed-file surface selects `unity_observatory_contract_surface`.
  - `bash adl/tools/test_validation_manager.sh`
    Verified the validation manager executes the selected-lane contract successfully.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4572__v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4572__v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection/sor.md
- Idempotency-Key: v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-test-select-validation-lanes-sh-adl-v0-91-6-tasks-issue-4572-v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection-sip-md-adl-v0-91-6-tasks-issue-4572-v0-91-6-tools-validation-map-unity-observatory-proof-surfaces-into-validation-lane-selection-sor-md