### PR TITLE
[v0.91.6][tools][watcher] Make watcher packets mandatory for release-tail wait states

### DIFF
--- a/docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md
+++ b/docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md
@@ -28,7 +28,37 @@ The milestone closeout tail is one ordered sprint, not a loose collection of ind
 
 ## Watcher policy
 
+- Before a release-tail issue enters a long CI wait, run the cheapest
+  applicable local guardrail first and record it in the issue SOR or sprint
+  packet. Examples include `git diff --check`, docs/path hygiene for docs-only
+  changes, and `cargo fmt --all -- --check` for Rust changes. A release-tail
+  PR should not spend a long CI window discovering a deterministic formatting
+  or whitespace failure that the focused local preflight could have caught.
 - Every closeout-tail issue must have a watcher path whenever work is waiting on CI, review, mergeability, upstream truth, or dependent issue completion.
+- Every closeout-tail wait state must retain one of these evidence records in
+  the issue SOR, SRP, closeout artifact, or sprint execution packet before the
+  issue can truthfully advance:
+  - a repo-native `pr.sh watch <issue-or-pr> --json` packet;
+  - a summary that names the retained watcher packet path and disposition; or
+  - an explicit not-applicable reason for issues that never entered a wait
+    state.
+- Required watcher routing must use the packet's top-level
+  `classification`, `tail_owner`, and `next_skill` fields as the authority.
+  Nested fields such as `linked_pr.validation.disposition` are supporting
+  check evidence, not the lifecycle routing key.
+- Current watcher classifications route as follows:
+  - `pr_open` or `checks_running`: keep the issue in watcher-owned
+    `pr_waiting` state with `next_skill: issue-watcher`;
+  - `checks_failed`, review/action blockers, or merge-conflict blockers: route
+    to `pr-janitor` and preserve the watcher packet as janitor input;
+  - `checks_green_but_draft`: route to `pr-janitor` because the draft-state
+    transition is an actionable PR-tail task;
+  - `checks_green`: preserve the `next_skill: human_review` handoff and the
+    merge-authority boundary before claiming completion;
+  - `merged_pending_closeout` or `closeout_needed`: route to `pr-closeout`;
+  - `closed`: record the no-PR or already-settled rationale before advancing;
+  - `ready_for_run` or `blocked`: treat as pre-publication readiness truth and
+    route to the packet's declared `next_skill`.
 - Watchers are janitor and status-routing helpers, not silent implementers.
 - A watcher should check its target at most every 30 seconds while the issue is actively blocked and should stop once the target is healthy, merged, or rerouted to a human decision.
 - Watchers should record the blocker class explicitly: review wait, checks failing, merge conflict, upstream dependency wait, or operator decision required.
@@ -43,6 +73,10 @@ The milestone closeout tail is one ordered sprint, not a loose collection of ind
 ## Closeout expectations per issue
 
 - Each closeout-tail issue must stop at truthful PR publication and bounded subagent review; do not self-merge or silently self-close unless the operator explicitly requested that authority.
+- If the issue had any wait state, closeout must reference the retained watcher
+  packet or the explicit not-applicable reason. A closeout that says the issue
+  is complete while omitting watcher evidence for a known wait state is not
+  release-tail clean.
 - After merge or intentional closure, run normal issue closeout so `SIP`, `STP`, `SPP`, `SRP`, `SOR`, and GitHub truth agree.
 - The sprint umbrella should remain open until the ordered closeout-tail issue wave is actually complete.
 

--- a/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
+++ b/docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md
@@ -33,6 +33,9 @@ ledger.
 - [ ] Bridge ledger refreshed from first-tranche outcomes, consuming the
   retained-evidence matrix for closed bridge umbrellas and the closeout-tail
   sprint surface for open ordered release-tail work.
+- [ ] Every release-tail issue that entered a wait state records a retained
+  watcher packet, watcher-packet summary, or explicit not-applicable reason
+  before it is counted as cleanly advanced or complete.
 - [ ] Every touched product/runtime surface is classified with the operational
   completion gate before release truth calls it complete.
 - [ ] The operational completion gate is the required truth boundary for

--- a/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4585_LIVE_WATCHER_PACKET_PR_4589.json
+++ b/docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4585_LIVE_WATCHER_PACKET_PR_4589.json
@@ -1,0 +1,63 @@
+{
+  "schema": "adl.pr.watch.v1",
+  "issue": 4584,
+  "issue_state": "OPEN",
+  "authoritative_classifier": "adl",
+  "advisory_agent_mode": "local_agent_advisory_only",
+  "classification": "checks_failed",
+  "tail_owner": "pr-janitor",
+  "shepherd_state": "janitor_owned_checks_failed",
+  "next_skill": "pr-janitor",
+  "continuation": "action_required",
+  "reason": "linked_pr_checks_failed",
+  "local_readiness": {
+    "status": "failed",
+    "pr_run_readiness": "unknown",
+    "reason": "missing canonical source issue prompt: <repo>/.adl/v0.91.6/bodies/issue-4584-v0-91-6-tools-templates-infer-vpp-card-when-importing-older-sor-cards.md"
+  },
+  "linked_pr": {
+    "number": 4589,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/4589",
+    "head_ref_name": "codex/4584-infer-vpp-card-when-importing-older-sor-cards",
+    "base_ref_name": "main",
+    "is_draft": true,
+    "state": "OPEN",
+    "validation": {
+      "pr_number": 4589,
+      "commit_sha": "ecdd8bb61fd419d8ef828cd39dd17858f0069ce8",
+      "pr_state": "OPEN",
+      "is_draft": true,
+      "disposition": "failed",
+      "projection_status": "checks_failed",
+      "checks": [
+        {
+          "name": "adl-ci",
+          "status": "COMPLETED",
+          "conclusion": "FAILURE",
+          "job_run_id": "28273036502"
+        },
+        {
+          "name": "adl-slow-proof",
+          "status": "COMPLETED",
+          "conclusion": "SKIPPED",
+          "job_run_id": "28273036502"
+        },
+        {
+          "name": "adl-coverage",
+          "status": "COMPLETED",
+          "conclusion": "SUCCESS",
+          "job_run_id": "28273036502"
+        }
+      ],
+      "failed_checks": [
+        {
+          "name": "adl-ci",
+          "status": "COMPLETED",
+          "conclusion": "FAILURE",
+          "job_run_id": "28273036502"
+        }
+      ],
+      "pending_checks": []
+    }
+  }
+}

--- a/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
+++ b/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
@@ -128,6 +128,42 @@ Acceptable durable evidence surfaces include:
 - PR closeout results
 - task-bundle records when those records are the canonical issue truth surface
 
+## Wait-State Evidence Rule
+
+Healthy waiting is active lifecycle work. It must leave durable evidence.
+
+When an issue or PR enters `pr_waiting`, `janitor_active`, or
+`merged_needs_closeout`, the owning workflow must retain one of:
+
+- a repo-native `pr.sh watch <issue-or-pr> --json` packet;
+- a task-bundle, SRP, SOR, or closeout summary that names the retained watcher
+  packet path and its disposition; or
+- an explicit not-applicable reason when the issue never entered a wait state.
+
+Watcher routing must use the packet's top-level `classification`,
+`tail_owner`, and `next_skill` fields as the authoritative lifecycle routing
+surface. Nested fields such as `linked_pr.validation.disposition` explain the
+check result and may support diagnosis, but they are not the routing key.
+
+Current watcher classifications route as follows:
+
+- `pr_open` or `checks_running` keeps the issue in watcher-owned wait state
+  with `next_skill: issue-watcher`.
+- `checks_failed`, requested changes, merge-conflict blockers, or other
+  actionable blockers route to `pr-janitor`.
+- `checks_green_but_draft` routes to `pr-janitor` because the draft-state
+  transition is an actionable PR-tail task.
+- `checks_green` preserves the `next_skill: human_review` handoff and the
+  merge-authority boundary before completion is claimed.
+- `merged_pending_closeout` or `closeout_needed` routes to `pr-closeout`.
+- `closed` requires explicit no-PR or already-settled closeout rationale.
+- `ready_for_run` or `blocked` is pre-publication readiness truth and should
+  route to the packet's declared `next_skill`.
+
+Issue closeout is not clean when a known wait state occurred but the final SOR,
+SRP, closeout artifact, or sprint execution packet has no watcher packet
+reference and no not-applicable reason.
+
 ## Shared Output Shape
 
 When a lifecycle or observation surface needs to record shepherd state, use


### PR DESCRIPTION
Closes #4585

## Summary
Implemented the #4585 watcher-policy adoption slice. The release-tail sprint
now requires retained watcher evidence for every known wait state, routes
watcher dispositions to `issue-watcher`, `pr-janitor`, or `pr-closeout`, and
blocks clean closeout claims when a known wait state lacks a watcher packet or
explicit not-applicable reason. The change also adds the corresponding release
checklist item and shared issue-lifecycle shepherd rule.

## Artifacts
- `docs/milestones/v0.91.6/CLOSEOUT_TAIL_SPRINT_v0.91.6.md`
- `docs/milestones/v0.91.6/RELEASE_PLAN_v0.91.6.md`
- `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
- `docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4585_LIVE_WATCHER_PACKET_PR_4589.json`
- Local ignored output-card record at `.adl/v0.91.6/tasks/issue-4585__make-watcher-packets-mandatory-for-release-tail-wait-states/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace safety for tracked changes.
  - `python3 -m json.tool docs/milestones/v0.91.6/review/sprint_execution_packets/ISSUE_4585_LIVE_WATCHER_PACKET_PR_4589.json`
    Verified retained watcher packet is valid JSON.
  - `python3 adl/tools/check_repo_quality_staleness.py --milestone v0.91.6`
    Checked milestone docs staleness; failed on an existing feature-index mismatch outside #4585 scope.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - `git diff --check`: PASS
  - watcher packet JSON parse: PASS
  - repo quality staleness: FAIL on existing feature-index mismatch unrelated to #4585 changes

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4585__make-watcher-packets-mandatory-for-release-tail-wait-states/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4585__make-watcher-packets-mandatory-for-release-tail-wait-states/sor.md
- Idempotency-Key: v0-91-6-tools-watcher-make-watcher-packets-mandatory-for-release-tail-wait-states-docs-milestones-v0-91-6-review-sprint-execution-packets-issue-4585-live-watcher-packet-pr-4589-json-adl-v0-91-6-tasks-issue-4585-make-watcher-packets-mandatory-for-release-tail-wait-states-sip-md-adl-v0-91-6-tasks-issue-4585-make-watcher-packets-mandatory-for-release-tail-wait-states-sor-md