### PR TITLE
[v0.91.6][tools][finish] Make finish ready-publication and Git push auth deterministic

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 use std::collections::BTreeSet;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
@@ -22,6 +24,11 @@ use super::github::{
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
+use crate::cli::github_token::{
+    resolve_github_token, ResolvedGithubToken, ADL_GITHUB_TOKEN_FILE_ENV,
+    ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV, ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV, GH_TOKEN_ENV,
+    GITHUB_TOKEN_ENV,
+};
 use crate::cli::observability::ProgressHeartbeat;
 use crate::cli::pr_cmd_args::parse_finish_args;
 use crate::cli::pr_cmd_cards::{
@@ -238,10 +245,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         )?;
     }
 
-    let _ = run_status_allow_failure(
-        "git",
-        &["-C", path_str(&repo_root)?, "push", "origin", &branch],
-    )?;
+    push_finish_branch(&repo_root, &branch)?;
 
     let pr_base = resolve_finish_pr_base(&repo_root, &branch)?;
 
@@ -449,6 +453,151 @@ pub(super) fn open_pr_url_nonblocking_with_timeout(
             ),
         },
     }
+}
+
+pub(super) fn push_finish_branch(repo_root: &Path, branch: &str) -> Result<()> {
+    let token = resolve_github_token()?;
+    push_finish_branch_with_git("git", repo_root, branch, token.as_ref())
+}
+
+pub(super) fn push_finish_branch_with_git(
+    git_program: &str,
+    repo_root: &Path,
+    branch: &str,
+    token: Option<&ResolvedGithubToken>,
+) -> Result<()> {
+    let auth_dir = if let Some(token) = token {
+        Some(write_finish_git_askpass_bundle(token)?)
+    } else {
+        None
+    };
+
+    let mut command = Command::new(git_program);
+    command
+        .args(["-C", path_str(repo_root)?, "push", "origin", branch])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env_remove(GITHUB_TOKEN_ENV)
+        .env_remove(GH_TOKEN_ENV)
+        .env_remove(ADL_GITHUB_TOKEN_FILE_ENV)
+        .env_remove(ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE_ENV)
+        .env_remove(ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT_ENV);
+
+    if let Some(auth_dir) = auth_dir.as_ref() {
+        command
+            .env("GIT_ASKPASS", &auth_dir.askpass_path)
+            .env("SSH_ASKPASS", &auth_dir.askpass_path)
+            .env("ADL_GIT_ASKPASS_TOKEN_FILE", &auth_dir.token_path);
+    }
+
+    let status = command.status();
+
+    let cleanup_result = auth_dir.map(FinishGitAuthDir::cleanup);
+
+    let status =
+        status.with_context(|| "finish: failed to spawn git push for publication branch")?;
+
+    if let Some(cleanup_result) = cleanup_result {
+        cleanup_result?;
+    }
+
+    if !status.success() {
+        bail!(
+            "finish: git push failed for publication branch '{}' with status {:?}; configure the shared GitHub token source or remote auth before rerunning finish",
+            branch,
+            status.code()
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct FinishGitAuthDir {
+    dir: PathBuf,
+    askpass_path: PathBuf,
+    token_path: PathBuf,
+}
+
+impl FinishGitAuthDir {
+    fn cleanup(self) -> Result<()> {
+        let dir = self.dir;
+        fs::remove_dir_all(&dir).with_context(|| {
+            format!(
+                "finish: failed to remove temporary git auth directory {}; remove it manually before rerunning finish",
+                dir.display()
+            )
+        })
+    }
+}
+
+fn write_finish_git_askpass_bundle(token: &ResolvedGithubToken) -> Result<FinishGitAuthDir> {
+    let dir = std::env::temp_dir().join(format!(
+        "adl-pr-finish-git-auth-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    fs::create_dir(&dir).with_context(|| {
+        format!(
+            "finish: failed to create temporary git auth directory {}",
+            dir.display()
+        )
+    })?;
+    #[cfg(unix)]
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).with_context(|| {
+        format!(
+            "finish: failed to restrict temporary git auth directory {}",
+            dir.display()
+        )
+    })?;
+
+    let token_path = dir.join("token");
+    fs::write(&token_path, token.value()).with_context(|| {
+        format!(
+            "finish: failed to write temporary git auth token file {}",
+            token_path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    fs::set_permissions(&token_path, fs::Permissions::from_mode(0o600)).with_context(|| {
+        format!(
+            "finish: failed to restrict temporary git auth token file {}",
+            token_path.display()
+        )
+    })?;
+
+    let askpass_path = dir.join("askpass.sh");
+    fs::write(
+        &askpass_path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  *Username*) printf '%s\n' 'x-access-token' ;;
+  *Password*) cat "${ADL_GIT_ASKPASS_TOKEN_FILE:?}" ;;
+  *) printf '%s\n' 'x-access-token' ;;
+esac
+"#,
+    )
+    .with_context(|| {
+        format!(
+            "finish: failed to write temporary git askpass helper {}",
+            askpass_path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    fs::set_permissions(&askpass_path, fs::Permissions::from_mode(0o700)).with_context(|| {
+        format!(
+            "finish: failed to make temporary git askpass helper executable {}",
+            askpass_path.display()
+        )
+    })?;
+
+    Ok(FinishGitAuthDir {
+        dir,
+        askpass_path,
+        token_path,
+    })
 }
 
 pub(super) fn ensure_finish_branch_not_behind_origin_main(repo_root: &Path) -> Result<()> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::github_token::{GithubTokenSource, ResolvedGithubToken};
 use crate::cli::pr_cmd::finish_support::{
     ensure_finish_branch_not_behind_origin_main, ensure_finish_task_bundle_surfaces,
     ensure_finish_validation_profile_is_runnable, ensure_no_staged_issue_bundle_mutations,
@@ -7,7 +8,7 @@ use crate::cli::pr_cmd::finish_support::{
     issue_bundle_issue_number_from_repo_relative, load_finish_validation_profile,
     load_finish_validation_profile_for_execution, non_closing_lifecycle_line,
     normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture, open_pr_url_nonblocking,
-    open_pr_url_nonblocking_with_timeout, real_pr_finish,
+    open_pr_url_nonblocking_with_timeout, push_finish_branch_with_git, real_pr_finish,
     reject_local_issue_bundle_paths_in_finish_paths, render_default_finish_validation,
     resolve_finish_issue_scope_and_slug, restage_finish_output_truth_paths,
     run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
@@ -142,6 +143,95 @@ fn local_pr_url_opener_timeout_is_non_blocking_warning() {
     assert!(result.warning.contains(
         "Open manually: https://github.com/danielbaustin/agent-design-language/pull/3830"
     ));
+}
+
+#[test]
+fn finish_push_uses_token_askpass_without_leaking_token_in_argv() {
+    let temp = unique_temp_dir("adl-pr-finish-token-aware-push");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    let log = temp.join("git-push.log");
+    let git = temp.join("git");
+    write_executable(
+        &git,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+log='{log}'
+printf 'argv:%s\n' "$*" >"$log"
+printf 'prompt:%s\n' "${{GIT_TERMINAL_PROMPT:-}}" >>"$log"
+printf 'askpass:%s\n' "${{GIT_ASKPASS:-}}" >>"$log"
+printf 'token_file:%s\n' "${{ADL_GIT_ASKPASS_TOKEN_FILE:-}}" >>"$log"
+printf 'github_token_env:%s\n' "${{GITHUB_TOKEN:-}}" >>"$log"
+printf 'gh_token_env:%s\n' "${{GH_TOKEN:-}}" >>"$log"
+printf 'token_file_env:%s\n' "${{ADL_GITHUB_TOKEN_FILE:-}}" >>"$log"
+if [[ -n "${{GIT_ASKPASS:-}}" ]]; then
+  printf 'user:%s\n' "$("$GIT_ASKPASS" 'Username for https://github.com')" >>"$log"
+  printf 'pass:%s\n' "$("$GIT_ASKPASS" 'Password for https://x-access-token@github.com')" >>"$log"
+fi
+"#,
+            log = path_str(&log).expect("log path")
+        ),
+    );
+    let token = ResolvedGithubToken::new("test-token-4598", GithubTokenSource::GithubToken)
+        .expect("fake token");
+
+    push_finish_branch_with_git(
+        path_str(&git).expect("git path"),
+        &repo,
+        "codex/4598-example",
+        Some(&token),
+    )
+    .expect("push succeeds");
+
+    let log_text = fs::read_to_string(&log).expect("read push log");
+    assert!(log_text.contains("argv:-C "));
+    assert!(log_text.contains(" push origin codex/4598-example"));
+    assert!(log_text.contains("prompt:0"));
+    assert!(log_text.contains("askpass:"));
+    assert!(log_text.contains("token_file:"));
+    assert!(log_text.contains("github_token_env:\n"));
+    assert!(log_text.contains("gh_token_env:\n"));
+    assert!(log_text.contains("token_file_env:\n"));
+    assert!(log_text.contains("user:x-access-token"));
+    assert!(log_text.contains("pass:test-token-4598"));
+    let token_file_line = log_text
+        .lines()
+        .find_map(|line| line.strip_prefix("token_file:"))
+        .expect("token file line");
+    assert!(
+        !Path::new(token_file_line).exists(),
+        "temporary git askpass token file must be removed after push"
+    );
+    let argv_line = log_text
+        .lines()
+        .find(|line| line.starts_with("argv:"))
+        .expect("argv line");
+    assert!(
+        !argv_line.contains("test-token-4598"),
+        "token must not be passed on the git command line"
+    );
+}
+
+fn copy_finish_bootstrap_support_files(repo: &Path) {
+    copy_bootstrap_support_files(repo);
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+    let tools_dir = repo.join("adl/tools");
+    fs::copy(
+        workspace_root.join("adl/tools/owner_binary_resolution.sh"),
+        tools_dir.join("owner_binary_resolution.sh"),
+    )
+    .expect("copy owner binary resolution helper");
+    #[cfg(unix)]
+    {
+        let helper = tools_dir.join("owner_binary_resolution.sh");
+        let mut perms = fs::metadata(&helper).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&helper, perms).expect("chmod owner binary helper");
+    }
 }
 
 #[test]
@@ -6211,7 +6301,7 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -6454,7 +6544,7 @@ fn real_pr_finish_restages_tracked_output_truth_written_during_validation() {
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -6836,7 +6926,7 @@ fn real_pr_finish_updates_existing_pr_marks_ready_and_keeps_non_closing_commit_t
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7089,7 +7179,7 @@ fn real_pr_finish_rejects_missing_output_card_before_publication() {
     let temp = unique_temp_dir("adl-pr-finish-missing-output");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7186,7 +7276,7 @@ fn real_pr_finish_rejects_empty_output_card_before_publication() {
     let temp = unique_temp_dir("adl-pr-finish-empty-output");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7285,7 +7375,7 @@ fn real_pr_finish_rejects_branch_name_mismatch() {
     let temp = unique_temp_dir("adl-pr-finish-branch-mismatch");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7388,7 +7478,7 @@ fn real_pr_finish_rejects_closed_issue_with_stale_canonical_truth() {
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7547,7 +7637,7 @@ fn real_pr_finish_opener_failure_is_nonblocking_when_no_open_is_false() {
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])
@@ -7715,7 +7805,7 @@ fn real_pr_finish_merge_mode_rejects_no_checks() {
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
-    copy_bootstrap_support_files(&repo);
+    copy_finish_bootstrap_support_files(&repo);
     init_git_repo(&repo);
     assert!(Command::new("git")
         .args(["config", "user.name", "Test User"])

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1921,6 +1921,29 @@ cmd_finish() {
     usage_finish
     return 0
   fi
+  local finish_arg previous_arg title_value_seen
+  previous_arg=""
+  title_value_seen=0
+  for finish_arg in "$@"; do
+    if [[ "$previous_arg" == "--title" ]]; then
+      if [[ -n "$finish_arg" && "$finish_arg" != --* ]]; then
+        title_value_seen=1
+      fi
+      break
+    fi
+    case "$finish_arg" in
+      --title=*)
+        if [[ -n "${finish_arg#--title=}" && "${finish_arg#--title=}" != --* ]]; then
+          title_value_seen=1
+        fi
+        break
+        ;;
+    esac
+    previous_arg="$finish_arg"
+  done
+  if [[ "$title_value_seen" != "1" ]]; then
+    die_with_usage "finish: --title is required" usage_finish
+  fi
   adl_obs_event "pr.sh" "finish" "started" "issue" "${1:-}"
   require_rust_pr_delegate finish
   delegate_pr_command_to_rust finish "$@"

--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -81,7 +81,7 @@ rust_pr_worktree_inputs_are_newer_than_bin() {
   [[ -f "$root/adl/Cargo.toml" && "$root/adl/Cargo.toml" -nt "$candidate" ]] && return 0
   [[ -f "$root/adl/Cargo.lock" && "$root/adl/Cargo.lock" -nt "$candidate" ]] && return 0
   [[ -f "$root/adl/build.rs" && "$root/adl/build.rs" -nt "$candidate" ]] && return 0
-  if [[ -d "$root/adl/src" ]] && find "$root/adl/src" -type f -newer "$candidate" -print -quit | grep -q .; then
+  if [[ -d "$root/adl/src" ]] && find "$root/adl/src" -type f -newer "$candidate" ! -path "$root/adl/src/cli/tests/*" -print -quit | grep -q .; then
     return 0
   fi
   return 1
@@ -122,7 +122,7 @@ rust_pr_delegate_bin_is_fresh() {
     return 1
   fi
   if [[ -d "$root/adl/src" ]]; then
-    if find "$root/adl/src" -type f -newer "$candidate" -print -quit | grep -q .; then
+    if find "$root/adl/src" -type f -newer "$candidate" ! -path "$root/adl/src/cli/tests/*" -print -quit | grep -q .; then
       return 1
     fi
   fi

--- a/adl/tools/test_pr_small_binary_delegation.sh
+++ b/adl/tools/test_pr_small_binary_delegation.sh
@@ -121,6 +121,48 @@ grep -Fqx 'run:3838 --slug demo --no-fetch-issue --version v0.91.5' "$run_log" |
 }
 
 finish_log="$tmpdir/finish.log"
+set +e
+missing_title_output="$(
+  cd "$repo"
+  ADL_TEST_LOG="$finish_log" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 2>&1
+)"
+missing_title_status=$?
+set -e
+if [[ "$missing_title_status" -eq 0 ]]; then
+  echo "assertion failed: finish without --title should fail before delegate" >&2
+  exit 1
+fi
+if [[ -e "$finish_log" ]]; then
+  echo "assertion failed: finish without --title should not invoke delegated Rust binary" >&2
+  exit 1
+fi
+if [[ "$missing_title_output" != *"finish: --title is required"* ]]; then
+  echo "assertion failed: finish without --title should report missing title" >&2
+  exit 1
+fi
+set +e
+flag_as_title_output="$(
+  cd "$repo"
+  ADL_TEST_LOG="$finish_log" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 --title --ready 2>&1
+)"
+flag_as_title_status=$?
+set -e
+if [[ "$flag_as_title_status" -eq 0 ]]; then
+  echo "assertion failed: finish with --title followed by a flag should fail before delegate" >&2
+  exit 1
+fi
+if [[ -e "$finish_log" ]]; then
+  echo "assertion failed: finish with --title followed by a flag should not invoke delegated Rust binary" >&2
+  exit 1
+fi
+if [[ "$flag_as_title_output" != *"finish: --title is required"* ]]; then
+  echo "assertion failed: finish with --title followed by a flag should report missing title" >&2
+  exit 1
+fi
 (
   cd "$repo"
   ADL_TEST_LOG="$finish_log" \


### PR DESCRIPTION
Closes #4598

## Summary
Implemented deterministic finish-publication hardening for #4598. The change makes `pr finish` fail fast for missing title arguments, makes finish-time `git push` token-aware and noninteractive, preserves credential hygiene for the push helper, and fixes owner-binary freshness checks so test-only source edits do not make production owner binaries appear stale.

## Artifacts
- Updated finish publication support in `adl/src/cli/pr_cmd/finish_support.rs`
- Updated finish-focused tests in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Updated shell finish preflight in `adl/tools/pr.sh`
- Updated owner-binary freshness policy in `adl/tools/pr_delegate.sh`
- Updated small-binary delegation proof in `adl/tools/test_pr_small_binary_delegation.sh`
- Updated issue-local SRP/SOR truth in `.adl/v0.91.6/tasks/issue-4598__v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic/`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - Verified Rust formatting for the touched finish and test surfaces.
  - `git diff --check` - Verified the patch has no whitespace errors.
  - `bash adl/tools/test_pr_small_binary_delegation.sh` - Verified pr.sh delegates to owner binaries and now fails finish calls without a real --title before delegation.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_push_uses_token_askpass_without_leaking_token_in_argv -- --exact --nocapture` - Verified finish git push uses askpass, scrubs inherited token env, avoids argv token leakage, and cleans the temporary token file.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files a temporary file containing the #4598 changed-file list` - Verified the focused pr_cmd_finish lane selected for the original finish change passed 162/162 tests.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc --build` - Built dedicated owner binaries and verified the C-SDLC owner lane after cargo fallback removal.
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `git diff --check`: PASS
  - `bash adl/tools/test_pr_small_binary_delegation.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_push_uses_token_askpass_without_leaking_token_in_argv -- --exact --nocapture`: PASS
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files a temporary file containing the #4598 changed-file list`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh csdlc --build`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4598__v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4598__v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic/sor.md
- Idempotency-Key: v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-pr-sh-adl-tools-pr-delegate-sh-adl-tools-test-pr-small-binary-delegation-sh-adl-v0-91-6-tasks-issue-4598-v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic-sip-md-adl-v0-91-6-tasks-issue-4598-v0-91-6-tools-finish-make-finish-ready-publication-and-git-push-auth-deterministic-sor-md