### PR TITLE
[v0.91.6][runtime] Fix blocked-live AWS heartbeat cursor semantics

### DIFF
--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -445,6 +445,13 @@ fn tick_live_mode_without_approval_stays_fail_closed_and_observable() {
         !mock_signal_artifact_path(&loaded).exists(),
         "live-blocked mode should not write mock heartbeat envelopes"
     );
+    assert!(
+        !loaded
+            .state_root
+            .join("aws_runtime_heartbeat_cursor.json")
+            .exists(),
+        "live-blocked mode should not allocate heartbeat cursor state"
+    );
 }
 
 #[test]

--- a/adl/src/runtime_aws_signal.rs
+++ b/adl/src/runtime_aws_signal.rs
@@ -341,74 +341,75 @@ pub(crate) fn publish_runtime_heartbeat_signal(
         };
     }
 
-    let heartbeat_seq = match reserve_heartbeat_seq(loaded) {
-        Ok(sequence) => sequence,
-        Err(_) => {
-            let failure_class = "aws_signal_cursor_write_failed";
+    match config.mode {
+        AwsSignalMode::Disabled => unreachable!("disabled mode returns before sequence allocation"),
+        AwsSignalMode::Mock => {
+            let heartbeat_seq = match reserve_heartbeat_seq(loaded) {
+                Ok(sequence) => sequence,
+                Err(_) => {
+                    let failure_class = "aws_signal_cursor_write_failed";
+                    emit_publish_failure(
+                        &config,
+                        loaded.spec.agent_instance_id.as_str(),
+                        cycle_id_for_status(status).as_str(),
+                        "not_allocated",
+                        runtime_signal_status(status),
+                        failure_class,
+                    );
+                    return PublishOutcome {
+                        disposition: PublishDisposition::Blocked,
+                        failure_class: Some(failure_class.to_string()),
+                    };
+                }
+            };
+
+            let envelope = build_runtime_heartbeat_envelope(loaded, status, &config, heartbeat_seq);
+            let heartbeat_seq_label = envelope.heartbeat_seq.to_string();
+            match append_mock_signal(loaded, &envelope) {
+                Ok(()) => {
+                    emit_event(
+                        "agent",
+                        "aws_runtime_heartbeat",
+                        "completed",
+                        &[
+                            ("mode", config.mode_label()),
+                            ("target_kind", config.target_kind.as_str()),
+                            ("runtime_id", envelope.runtime_id.as_str()),
+                            ("cycle_id", envelope.cycle_id.as_str()),
+                            ("heartbeat_seq", heartbeat_seq_label.as_str()),
+                            ("signal_status", envelope.status.as_str()),
+                        ],
+                    );
+                    PublishOutcome {
+                        disposition: PublishDisposition::PublishedMock,
+                        failure_class: None,
+                    }
+                }
+                Err(_) => {
+                    let failure_class = "aws_signal_mock_write_failed";
+                    emit_publish_failure(
+                        &config,
+                        envelope.runtime_id.as_str(),
+                        envelope.cycle_id.as_str(),
+                        heartbeat_seq_label.as_str(),
+                        envelope.status.as_str(),
+                        failure_class,
+                    );
+                    PublishOutcome {
+                        disposition: PublishDisposition::Blocked,
+                        failure_class: Some(failure_class.to_string()),
+                    }
+                }
+            }
+        }
+        AwsSignalMode::Live => {
+            let failure_class = config.live_block_reason();
             emit_publish_failure(
                 &config,
                 loaded.spec.agent_instance_id.as_str(),
                 cycle_id_for_status(status).as_str(),
                 "not_allocated",
                 runtime_signal_status(status),
-                failure_class,
-            );
-            return PublishOutcome {
-                disposition: PublishDisposition::Blocked,
-                failure_class: Some(failure_class.to_string()),
-            };
-        }
-    };
-
-    let envelope = build_runtime_heartbeat_envelope(loaded, status, &config, heartbeat_seq);
-    let heartbeat_seq_label = envelope.heartbeat_seq.to_string();
-
-    match config.mode {
-        AwsSignalMode::Disabled => unreachable!("disabled mode returns before sequence allocation"),
-        AwsSignalMode::Mock => match append_mock_signal(loaded, &envelope) {
-            Ok(()) => {
-                emit_event(
-                    "agent",
-                    "aws_runtime_heartbeat",
-                    "completed",
-                    &[
-                        ("mode", config.mode_label()),
-                        ("target_kind", config.target_kind.as_str()),
-                        ("runtime_id", envelope.runtime_id.as_str()),
-                        ("cycle_id", envelope.cycle_id.as_str()),
-                        ("heartbeat_seq", heartbeat_seq_label.as_str()),
-                        ("signal_status", envelope.status.as_str()),
-                    ],
-                );
-                PublishOutcome {
-                    disposition: PublishDisposition::PublishedMock,
-                    failure_class: None,
-                }
-            }
-            Err(_) => {
-                let failure_class = "aws_signal_mock_write_failed";
-                emit_publish_failure(
-                    &config,
-                    envelope.runtime_id.as_str(),
-                    envelope.cycle_id.as_str(),
-                    heartbeat_seq_label.as_str(),
-                    envelope.status.as_str(),
-                    failure_class,
-                );
-                PublishOutcome {
-                    disposition: PublishDisposition::Blocked,
-                    failure_class: Some(failure_class.to_string()),
-                }
-            }
-        },
-        AwsSignalMode::Live => {
-            let failure_class = config.live_block_reason();
-            emit_publish_failure(
-                &config,
-                envelope.runtime_id.as_str(),
-                envelope.cycle_id.as_str(),
-                heartbeat_seq_label.as_str(),
-                envelope.status.as_str(),
                 failure_class,
             );
             PublishOutcome {
@@ -1182,6 +1183,7 @@ mod tests {
                 unsupported.failure_class.as_deref(),
                 Some("aws_signal_unsupported_target")
             );
+            assert!(!heartbeat_cursor_path(&loaded).exists());
         }
 
         {
@@ -1196,7 +1198,55 @@ mod tests {
                 blocked.failure_class.as_deref(),
                 Some("aws_signal_live_not_approved")
             );
+            assert!(!heartbeat_cursor_path(&loaded).exists());
         }
+    }
+
+    #[test]
+    fn runtime_aws_signal_live_blocked_mode_preserves_existing_cursor_state() {
+        let root = temp_dir("live-blocked-cursor");
+        let loaded = sample_loaded(&root);
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "mock"),
+                ("ADL_AWS_REGION", "us-west-2"),
+            ]);
+            let outcome = publish_runtime_heartbeat_signal(
+                &loaded,
+                &sample_status(AgentStatusState::RunningCycle),
+            );
+            assert_eq!(outcome.disposition, PublishDisposition::PublishedMock);
+        }
+
+        let before: HeartbeatCursor = serde_json::from_str(
+            &fs::read_to_string(heartbeat_cursor_path(&loaded)).expect("cursor before"),
+        )
+        .expect("parse cursor before");
+        assert_eq!(before.next_heartbeat_seq, 2);
+
+        {
+            let _guard = MultiEnvGuard::set_all(&[
+                ("ADL_AWS_SIGNAL_MODE", "live"),
+                ("ADL_AWS_REGION", "us-west-2"),
+                ("ADL_AWS_HEARTBEAT_TARGET", "cloudwatch_logs"),
+                ("ADL_AWS_HEARTBEAT_LOG_GROUP", "private"),
+                ("ADL_AWS_HEARTBEAT_LOG_STREAM", "private"),
+            ]);
+            let blocked =
+                publish_runtime_heartbeat_signal(&loaded, &sample_status(AgentStatusState::Idle));
+            assert_eq!(blocked.disposition, PublishDisposition::Blocked);
+            assert_eq!(
+                blocked.failure_class.as_deref(),
+                Some("aws_signal_live_not_approved")
+            );
+        }
+
+        let after: HeartbeatCursor = serde_json::from_str(
+            &fs::read_to_string(heartbeat_cursor_path(&loaded)).expect("cursor after"),
+        )
+        .expect("parse cursor after");
+        assert_eq!(after.next_heartbeat_seq, 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #4612

## Summary
Execution context is bound and the bounded `#4612` runtime fix is now implemented in the issue worktree. Blocked live AWS heartbeat publication no longer allocates or advances local cursor state, mock-mode heartbeat sequencing remains intact, and focused runtime proofs cover both direct publisher behavior and the long-lived-agent fail-closed path.

## Artifacts
- Bound issue worktree at `.worktrees/adl-wp-4612`
- Runtime heartbeat cursor fix in `adl/src/runtime_aws_signal.rs`
- Focused runtime regression coverage in `adl/src/runtime_aws_signal.rs`
- Long-lived-agent fail-closed coverage update in `adl/src/long_lived_agent/tests.rs`
- Updated issue-local execution record at `.adl/v0.91.6/tasks/issue-4612__wp14a-runtime-heartbeat-cursor/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.6/tasks/issue-4612__wp14a-runtime-heartbeat-cursor/sor.md`
    Verified bootstrap SOR contract compliance for the local output scaffold.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token ./adl/tools/pr.sh doctor 4612 --version v0.91.6 --json`
    Verified structural readiness and identified the required pre-bind session-claim gate.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token ./adl/tools/pr.sh run 4612 --version v0.91.6`
    Verified execution-context bind completed and created the issue worktree without starting implementation.
  - `cargo test --manifest-path adl/Cargo.toml runtime_aws_signal_publish_handles_disabled_unsupported_and_live_blocked_modes -- --nocapture`
    Verified blocked and unsupported heartbeat publication paths do not create cursor state.
  - `cargo test --manifest-path adl/Cargo.toml runtime_aws_signal_live_blocked_mode_preserves_existing_cursor_state -- --nocapture`
    Verified blocked live mode preserves existing cursor state after prior mock publication.
  - `cargo test --manifest-path adl/Cargo.toml tick_live_mode_without_approval_stays_fail_closed_and_observable -- --nocapture`
    Verified the bound long-lived-agent heartbeat path remains fail-closed and cursor-free when live mode is unapproved.
  - `git diff --check`
    Verified diff hygiene for the bounded runtime issue changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4612__wp14a-runtime-heartbeat-cursor/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4612__wp14a-runtime-heartbeat-cursor/sor.md
- Idempotency-Key: v0-91-6-runtime-fix-blocked-live-aws-heartbeat-cursor-semantics-adl-src-runtime-aws-signal-rs-adl-src-long-lived-agent-tests-rs-adl-v0-91-6-tasks-issue-4612-wp14a-runtime-heartbeat-cursor-sip-md-adl-v0-91-6-tasks-issue-4612-wp14a-runtime-heartbeat-cursor-sor-md