### PR TITLE
[v0.91.7][tools][pr] Add lightweight PR-ready promotion path for green unchanged PRs

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -18,9 +18,10 @@ use super::git_support::{
 };
 use super::github::{
     attach_issue_watcher, attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
-    ensure_or_repair_pr_closing_linkage, pr_create_finish, pr_edit_finish_existing,
-    pr_merge_finish, pr_ready_finish_allow_failure, pr_ready_finish_merge_allow_failure,
-    pr_view_base_ref_finish_existing, wait_for_pr_validation_finish, IssueWatcherAttachRequest,
+    ensure_or_repair_pr_closing_linkage, pr_closing_issue_numbers_finish_existing,
+    pr_create_finish, pr_edit_finish_existing, pr_merge_finish, pr_ready_finish_allow_failure,
+    pr_ready_finish_merge_allow_failure, pr_validation_report, pr_view_base_ref_finish_existing,
+    wait_for_pr_validation_finish, IssueWatcherAttachRequest, PrValidationReport,
 };
 use super::lifecycle;
 use super::DEFAULT_VERSION;
@@ -112,7 +113,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         .context("finish: failed to fetch origin/main before stale-base guard")?;
     let ahead = commits_ahead_of_origin_main(&repo_root)?;
     ensure_finish_branch_not_behind_origin_main(&repo_root)?;
-    if staged_diff_is_empty(&repo_root)? {
+    let staged_diff_empty = staged_diff_is_empty(&repo_root)?;
+    if staged_diff_empty {
         if !has_uncommitted && ahead == 0 {
             bail!("No changes detected and branch has no commits ahead of origin/main. Nothing to PR.");
         }
@@ -120,6 +122,47 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         bail!(
             "finish: staged .gitignore or adl/.gitignore changes detected. Revert them or re-run with --allow-gitignore. Canonical .adl issue bundles are local-only and must not be staged."
         );
+    }
+
+    if finish_ready_only_path_is_allowed(
+        parsed.ready,
+        parsed.merge_mode,
+        has_uncommitted,
+        staged_diff_empty,
+    ) {
+        if let Some(existing) = current_pr_url(&repo, &branch)? {
+            let pr_base = resolve_finish_pr_base(&repo_root, &branch)?;
+            ensure_existing_pr_base_matches(&repo, &existing, &pr_base)?;
+            let local_head = current_head_sha(&repo_root)?;
+            ensure_ready_only_finish_pr_is_green_and_linked(
+                &repo,
+                &existing,
+                parsed.issue,
+                &pr_base,
+                &local_head,
+                parsed.no_close,
+            )?;
+            let _ = pr_ready_finish_allow_failure(&repo, &existing)?;
+            attach_pr_janitor(&repo_root, &repo, parsed.issue, &branch, &existing, "ready")?;
+            attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &existing)?;
+            if let Err(err) = attach_issue_watcher(IssueWatcherAttachRequest {
+                repo_root: &repo_root,
+                repo: &repo,
+                issue: parsed.issue,
+                branch: &branch,
+                pr_url: &existing,
+                expected_pr_state: "ready",
+                classification: "checks_running",
+                tail_owner: "issue-watcher",
+                shepherd_state: "watcher_owned_checks_running",
+            }) {
+                eprintln!(
+                    "warning: issue watcher auto-attach failed after lightweight PR ready promotion; PR remains ready and other tail attachments succeeded. Resolve watcher setup separately: {err}"
+                );
+            }
+            println!("{existing}");
+            return Ok(());
+        }
     }
 
     let changed_paths = finish_changed_paths(&repo_root, has_uncommitted)?;
@@ -748,6 +791,102 @@ pub(super) fn finish_changed_paths(repo_root: &Path, has_uncommitted: bool) -> R
         .filter(|line| !line.is_empty())
         .map(ToString::to_string)
         .collect())
+}
+
+pub(super) fn finish_ready_only_path_is_allowed(
+    ready: bool,
+    merge_mode: bool,
+    has_uncommitted: bool,
+    staged_diff_empty: bool,
+) -> bool {
+    ready && !merge_mode && !has_uncommitted && staged_diff_empty
+}
+
+fn ensure_ready_only_finish_pr_is_green_and_linked(
+    repo: &str,
+    pr_ref: &str,
+    issue: u32,
+    expected_base: &str,
+    expected_head: &str,
+    no_close: bool,
+) -> Result<()> {
+    let report = pr_validation_report(repo, pr_ref)?;
+    let base_ref = pr_view_base_ref_finish_existing(repo, pr_ref)?;
+    let closing_issues = if no_close {
+        Vec::new()
+    } else {
+        pr_closing_issue_numbers_finish_existing(repo, pr_ref)?
+    };
+    validate_ready_only_finish_pr_state(
+        &report,
+        &base_ref,
+        expected_base,
+        expected_head,
+        &closing_issues,
+        issue,
+        no_close,
+    )
+}
+
+pub(super) fn validate_ready_only_finish_pr_state(
+    report: &PrValidationReport,
+    actual_base: &str,
+    expected_base: &str,
+    expected_head: &str,
+    closing_issues: &[u32],
+    issue: u32,
+    no_close: bool,
+) -> Result<()> {
+    if !actual_base.trim().eq(expected_base.trim()) {
+        bail!(
+            "finish --ready: existing PR base '{}' does not match expected base '{}'",
+            actual_base,
+            expected_base
+        );
+    }
+    if !report.commit_sha.trim().eq(expected_head.trim()) {
+        bail!(
+            "finish --ready: existing PR #{} head '{}' does not match local HEAD '{}'; push the branch and wait for current checks before ready promotion",
+            report.pr_number,
+            report.commit_sha,
+            expected_head
+        );
+    }
+    if !no_close && !closing_issues.contains(&issue) {
+        bail!(
+            "finish --ready: existing PR #{} does not close issue #{}; linked closing issues: {}",
+            report.pr_number,
+            issue,
+            if closing_issues.is_empty() {
+                "none".to_string()
+            } else {
+                closing_issues
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            }
+        );
+    }
+    match report.projection_status.as_str() {
+        "checks_green_but_draft" | "ready_to_merge_or_review" => Ok(()),
+        other => bail!(
+            "finish --ready: existing PR #{} is not green enough for lightweight ready promotion (projection_status={}, disposition={}, pending={}, failed={})",
+            report.pr_number,
+            other,
+            report.disposition,
+            report.pending_checks.len(),
+            report.failed_checks.len()
+        ),
+    }
+}
+
+fn current_head_sha(repo_root: &Path) -> Result<String> {
+    Ok(
+        run_capture("git", &["-C", path_str(repo_root)?, "rev-parse", "HEAD"])?
+            .trim()
+            .to_string(),
+    )
 }
 
 pub(super) fn finish_declared_paths_for_validation(paths: &str) -> Vec<String> {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -793,6 +793,13 @@ pub(super) fn pr_view_base_ref_finish_existing(repo: &str, pr_ref: &str) -> Resu
     pr_base_ref_octocrab(repo, pr_ref)
 }
 
+pub(super) fn pr_closing_issue_numbers_finish_existing(
+    repo: &str,
+    pr_ref: &str,
+) -> Result<Vec<u32>> {
+    pr_closing_issue_numbers_octocrab(repo, pr_ref)
+}
+
 pub(super) fn pr_edit_finish_existing(
     repo: &str,
     pr_ref: &str,

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -5,18 +5,21 @@ use crate::cli::pr_cmd::finish_support::{
     ensure_finish_validation_profile_is_runnable, ensure_no_staged_issue_bundle_mutations,
     extra_pr_body_looks_like_issue_template, extract_markdown_section,
     finish_declared_paths_for_validation, finish_inputs_fingerprint,
-    issue_bundle_issue_number_from_repo_relative, load_finish_validation_profile,
-    load_finish_validation_profile_for_execution, non_closing_lifecycle_line,
-    normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture, open_pr_url_nonblocking,
-    open_pr_url_nonblocking_with_timeout, push_finish_branch_with_git, real_pr_finish,
-    reject_local_issue_bundle_paths_in_finish_paths, render_default_finish_validation,
-    resolve_finish_issue_scope_and_slug, restage_finish_output_truth_paths,
-    run_finish_validation_status, select_finish_validation_plan_for_finish, FinishValidationMode,
-    FinishValidationPlan, FinishValidationProfile, FinishValidationProfileEscalation,
-    FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
-    FinishValidationProfileSurfaceItem, FinishValidationVppRecord, SorFactEmissionContext,
+    finish_ready_only_path_is_allowed, issue_bundle_issue_number_from_repo_relative,
+    load_finish_validation_profile, load_finish_validation_profile_for_execution,
+    non_closing_lifecycle_line, normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture,
+    open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, push_finish_branch_with_git,
+    real_pr_finish, reject_local_issue_bundle_paths_in_finish_paths,
+    render_default_finish_validation, resolve_finish_issue_scope_and_slug,
+    restage_finish_output_truth_paths, run_finish_validation_status,
+    select_finish_validation_plan_for_finish, validate_ready_only_finish_pr_state,
+    FinishValidationMode, FinishValidationPlan, FinishValidationProfile,
+    FinishValidationProfileEscalation, FinishValidationProfileEscalationReason,
+    FinishValidationProfileRunItem, FinishValidationProfileSurfaceItem, FinishValidationVppRecord,
+    SorFactEmissionContext,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
+use crate::cli::pr_cmd::github::{PrValidationCheckReport, PrValidationReport};
 use std::os::unix::fs::PermissionsExt;
 
 #[test]
@@ -25,6 +28,133 @@ fn finish_declared_paths_for_validation_splits_operator_surface() {
         finish_declared_paths_for_validation("docs, adl/src , ,README.md"),
         vec!["docs", "adl/src", "README.md"]
     );
+}
+
+fn ready_only_validation_report(projection_status: &str) -> PrValidationReport {
+    let (disposition, is_draft, failed_checks, pending_checks) = match projection_status {
+        "checks_green_but_draft" => ("success", true, Vec::new(), Vec::new()),
+        "ready_to_merge_or_review" => ("success", false, Vec::new(), Vec::new()),
+        "checks_pending" => (
+            "pending",
+            true,
+            Vec::new(),
+            vec![PrValidationCheckReport {
+                name: "adl-ci".to_string(),
+                status: "IN_PROGRESS".to_string(),
+                conclusion: "UNKNOWN".to_string(),
+                job_run_id: "8801".to_string(),
+            }],
+        ),
+        "checks_failed" => (
+            "failed",
+            false,
+            vec![PrValidationCheckReport {
+                name: "adl-coverage".to_string(),
+                status: "COMPLETED".to_string(),
+                conclusion: "FAILURE".to_string(),
+                job_run_id: "8802".to_string(),
+            }],
+            Vec::new(),
+        ),
+        other => (other, false, Vec::new(), Vec::new()),
+    };
+    PrValidationReport {
+        pr_number: 4705,
+        commit_sha: ready_only_head_sha().to_string(),
+        pr_state: "OPEN".to_string(),
+        is_draft,
+        disposition: disposition.to_string(),
+        projection_status: projection_status.to_string(),
+        checks: Vec::new(),
+        failed_checks,
+        pending_checks,
+    }
+}
+
+fn ready_only_head_sha() -> &'static str {
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+
+#[test]
+fn finish_ready_only_path_is_limited_to_clean_ready_non_merge_calls() {
+    assert!(finish_ready_only_path_is_allowed(true, false, false, true));
+    assert!(!finish_ready_only_path_is_allowed(
+        false, false, false, true
+    ));
+    assert!(!finish_ready_only_path_is_allowed(true, true, false, true));
+    assert!(!finish_ready_only_path_is_allowed(true, false, true, true));
+    assert!(!finish_ready_only_path_is_allowed(
+        true, false, false, false
+    ));
+}
+
+#[test]
+fn ready_only_finish_accepts_green_draft_and_ready_pr_state() {
+    validate_ready_only_finish_pr_state(
+        &ready_only_validation_report("checks_green_but_draft"),
+        "main",
+        "main",
+        ready_only_head_sha(),
+        &[4706],
+        4706,
+        false,
+    )
+    .expect("green draft PR should be promotable without local validation");
+
+    validate_ready_only_finish_pr_state(
+        &ready_only_validation_report("ready_to_merge_or_review"),
+        "main",
+        "main",
+        ready_only_head_sha(),
+        &[4706],
+        4706,
+        false,
+    )
+    .expect("already-ready green PR should stay idempotent");
+}
+
+#[test]
+fn ready_only_finish_fails_closed_for_pending_checks_or_missing_linkage() {
+    let pending = validate_ready_only_finish_pr_state(
+        &ready_only_validation_report("checks_pending"),
+        "main",
+        "main",
+        ready_only_head_sha(),
+        &[4706],
+        4706,
+        false,
+    )
+    .expect_err("pending checks cannot be promoted");
+    assert!(pending.to_string().contains("not green enough"));
+
+    let missing_linkage = validate_ready_only_finish_pr_state(
+        &ready_only_validation_report("checks_green_but_draft"),
+        "main",
+        "main",
+        ready_only_head_sha(),
+        &[],
+        4706,
+        false,
+    )
+    .expect_err("closing issue linkage is required");
+    assert!(missing_linkage
+        .to_string()
+        .contains("does not close issue #4706"));
+}
+
+#[test]
+fn ready_only_finish_fails_closed_when_remote_head_is_stale() {
+    let stale = validate_ready_only_finish_pr_state(
+        &ready_only_validation_report("checks_green_but_draft"),
+        "main",
+        "main",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        &[4706],
+        4706,
+        false,
+    )
+    .expect_err("remote PR head must match local HEAD");
+    assert!(stale.to_string().contains("does not match local HEAD"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -944,7 +944,7 @@ fn real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails() {
 }
 
 #[test]
-fn real_pr_finish_updates_existing_pr_and_marks_ready() {
+fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-edit");
     let origin = temp.join("origin.git");
@@ -1075,6 +1075,11 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
         .status()
         .expect("git commit")
         .success());
+    let head_sha = run_capture(
+        "git",
+        &["-C", path_str(&repo).unwrap(), "rev-parse", "HEAD"],
+    )
+    .expect("current head sha");
 
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -1088,10 +1093,88 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
             ),
         );
 
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind validation server");
+    let addr = listener.local_addr().expect("validation server addr");
+    let server = tiny_http::Server::from_listener(listener, None).expect("validation server");
+    let validation_handle = std::thread::spawn(move || {
+        for _ in 0..2 {
+            let Some(mut request) = server
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("validation server receive")
+            else {
+                return;
+            };
+            let mut body = String::new();
+            let _ = std::io::Read::read_to_string(&mut request.as_reader(), &mut body);
+            let response = if body.contains("statusCheckRollup") {
+                serde_json::json!({
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "number": 1160,
+                                "headRefOid": head_sha.trim(),
+                                "state": "OPEN",
+                                "isDraft": true,
+                                "statusCheckRollup": {
+                                    "contexts": {
+                                        "nodes": [
+                                            {
+                                                "__typename": "CheckRun",
+                                                "name": "adl-ci",
+                                                "status": "COMPLETED",
+                                                "conclusion": "SUCCESS",
+                                                "databaseId": 991,
+                                                "checkSuite": {
+                                                    "workflowRun": {
+                                                        "databaseId": 8801
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": false,
+                                            "endCursor": null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+            } else if body.contains("closingIssuesReferences") {
+                serde_json::json!({
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "closingIssuesReferences": {
+                                    "nodes": [
+                                        {
+                                            "number": 1153
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                })
+            } else {
+                panic!("unexpected validation server query: {body}");
+            }
+            .to_string();
+            let mut response = tiny_http::Response::from_string(response).with_status_code(200);
+            if let Ok(header) = tiny_http::Header::from_bytes("Content-Type", "application/json") {
+                response = response.with_header(header);
+            }
+            request.respond(response).expect("respond validation");
+        }
+    });
+
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", format!("http://{addr}"));
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -1114,14 +1197,18 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
+        if let Some(value) = old_base_uri {
+            env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", value);
+        } else {
+            env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        }
     }
+    validation_handle.join().expect("validation server join");
     result.expect("real_pr finish edit");
 
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
-    assert!(gh_calls.contains("pr edit"));
+    assert!(!gh_calls.contains("pr edit"));
     assert!(gh_calls.contains("danielbaustin/agent-design-language"));
     assert!(gh_calls.contains("https://github.com/danielbaustin/agent-design-language/pull/1160"));
-    assert!(gh_calls.contains("--title [v0.86][tools] Rust finish test edit"));
-    assert!(gh_calls.contains("--body-file"));
     assert!(gh_calls.contains("pr ready"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -1184,10 +1184,12 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
 
     let old_path = env::var("PATH").unwrap_or_default();
     let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    let old_github_token = env::var_os("GITHUB_TOKEN");
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", format!("http://{addr}"));
+        env::set_var("GITHUB_TOKEN", "test-token-for-mock-octocrab");
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -1214,6 +1216,11 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
             env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", value);
         } else {
             env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        }
+        if let Some(value) = old_github_token {
+            env::set_var("GITHUB_TOKEN", value);
+        } else {
+            env::remove_var("GITHUB_TOKEN");
         }
     }
     validation_handle.join().expect("validation server join");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -1097,15 +1097,13 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     let addr = listener.local_addr().expect("validation server addr");
     let server = tiny_http::Server::from_listener(listener, None).expect("validation server");
     let validation_handle = std::thread::spawn(move || {
-        for _ in 0..2 {
-            let Some(mut request) = server
-                .recv_timeout(std::time::Duration::from_secs(5))
-                .expect("validation server receive")
-            else {
-                return;
-            };
+        while let Some(mut request) = server
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("validation server receive")
+        {
             let mut body = String::new();
             let _ = std::io::Read::read_to_string(&mut request.as_reader(), &mut body);
+            let is_closing_issue_query = body.contains("closingIssuesReferences");
             let response = if body.contains("statusCheckRollup") {
                 serde_json::json!({
                     "data": {
@@ -1129,6 +1127,18 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
                                                         "databaseId": 8801
                                                     }
                                                 }
+                                            },
+                                            {
+                                                "__typename": "CheckRun",
+                                                "name": "adl-coverage",
+                                                "status": "COMPLETED",
+                                                "conclusion": "SUCCESS",
+                                                "databaseId": 992,
+                                                "checkSuite": {
+                                                    "workflowRun": {
+                                                        "databaseId": 8801
+                                                    }
+                                                }
                                             }
                                         ],
                                         "pageInfo": {
@@ -1141,7 +1151,7 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
                         }
                     }
                 })
-            } else if body.contains("closingIssuesReferences") {
+            } else if is_closing_issue_query {
                 serde_json::json!({
                     "data": {
                         "repository": {
@@ -1166,6 +1176,9 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
                 response = response.with_header(header);
             }
             request.respond(response).expect("respond validation");
+            if is_closing_issue_query {
+                break;
+            }
         }
     });
 


### PR DESCRIPTION
Closes #4706

## Summary
Pre-run output scaffold initialized during issue-wave opening. No implementation has started yet.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4706__v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs/sor.md`
- Tracked implementation artifacts: not_applicable until execution begins

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - verify Rust formatting for the touched ADL crate
  - `git diff --check` - verify whitespace hygiene for the changed patch
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::finish_ready_only_path_is_limited_to_clean_ready_non_merge_calls -- --exact` - prove the lightweight ready-only path is limited to clean ready non-merge calls
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_accepts_green_draft_and_ready_pr_state -- --exact` - prove green draft and ready PR states are accepted for lightweight ready promotion
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_fails_closed_for_pending_checks_or_missing_linkage -- --exact` - prove pending checks and missing closing linkage fail closed
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_fails_closed_when_remote_head_is_stale -- --exact` - prove stale remote PR heads fail closed before ready promotion
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh finish 4706 --title "[v0.91.7][tools][pr] Add lightweight PR-ready promotion path for green unchanged PRs" --output-card .adl/v0.91.7/tasks/issue-4706__v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs/sor.md --paths "adl/src/cli/pr_cmd/finish_support.rs,adl/src/cli/pr_cmd/github.rs,adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs" --no-open` - prove the repo finish validation lane for the touched pr finish control-plane surface
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `git diff --check`: PASS
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::finish_ready_only_path_is_limited_to_clean_ready_non_merge_calls -- --exact`: PASS
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_accepts_green_draft_and_ready_pr_state -- --exact`: PASS
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_fails_closed_for_pending_checks_or_missing_linkage -- --exact`: PASS
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render::ready_only_finish_fails_closed_when_remote_head_is_stale -- --exact`: PASS
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh finish 4706 --title "[v0.91.7][tools][pr] Add lightweight PR-ready promotion path for green unchanged PRs" --output-card .adl/v0.91.7/tasks/issue-4706__v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs/sor.md --paths "adl/src/cli/pr_cmd/finish_support.rs,adl/src/cli/pr_cmd/github.rs,adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs" --no-open`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4706__v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4706__v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs/sor.md
- Idempotency-Key: v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4706-v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs-sip-md-adl-v0-91-7-tasks-issue-4706-v0-91-7-tools-pr-add-lightweight-pr-ready-promotion-path-for-green-unchanged-prs-sor-md