### PR TITLE
[v0.91.7][tools] Include PR inventory in owner binary build lane

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -301,6 +301,7 @@
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
+        "adl/tools/test_owner_validation_lane.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "path_hints": [
@@ -317,6 +318,7 @@
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
+        "adl/tools/test_owner_validation_lane.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "command": "bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan",

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -86,7 +86,7 @@ build_owner_bins() {
       --bin adl-pr-create --bin adl-pr-init --bin adl-pr-repair-issue-body \
       --bin adl-pr-run --bin adl-pr-doctor --bin adl-pr-ready \
       --bin adl-pr-preflight --bin adl-pr-finish --bin adl-pr-validation \
-      --bin adl-pr-closing-linkage \
+      --bin adl-pr-inventory --bin adl-pr-closing-linkage \
       --bin adl-issue \
       --bin adl-pr-closeout \
       --bin adl-prompt-template --bin adl-validate-structured-prompt

--- a/adl/tools/test_owner_validation_lane.sh
+++ b/adl/tools/test_owner_validation_lane.sh
@@ -7,13 +7,14 @@ RUNNER="$ROOT_DIR/adl/tools/run_owner_validation_lane.sh"
 plan_output="$(bash "$RUNNER" all --build --print-plan)"
 for expected in \
   "cargo build owner binaries" \
+  "--bin adl-pr-inventory" \
   "C-SDLC wrapper migration contract" \
   "C-SDLC run ambiguity policy" \
   "C-SDLC control-plane observability contract" \
   "runtime compatibility boundary" \
   "review compatibility boundary" \
   "PASS run_owner_validation_lane surface=all"; do
-  grep -Fq "$expected" <<<"$plan_output" || {
+  grep -Fq -- "$expected" <<<"$plan_output" || {
     echo "missing expected lane plan entry: $expected" >&2
     echo "$plan_output" >&2
     exit 1


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4622 remains open.

## Summary
Implemented a repo-native PR inventory path for release-tail review. The new
`pr-inventory` subcommand is available through `bash adl/tools/pr.sh
pr-inventory`, delegates to the dedicated Rust owner binary
`adl-pr-inventory`, emits machine-readable JSON on stdout, and keeps
human-oriented `adl_event` observability on stderr.

## Artifacts
- `adl/src/bin/adl_pr_inventory.rs`
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/github/transport.rs`
- `adl/src/cli/pr_cmd/github/tests/watch.rs`
- `adl/src/cli/pr_cmd_args.rs`
- `adl/src/cli/pr_cmd/lifecycle/tests.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `adl/src/cli/tests/pr_cmd_inline/support.rs`
- `adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs`
- `adl/tools/pr.sh`
- `adl/tools/pr_delegate.sh`
- `adl/tools/pr_usage.sh`
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/tools/test_ci_path_policy.sh`
- `adl/tools/test_validation_manager.sh`
- `adl/Cargo.toml`
- `docs/tooling/PR_INVENTORY_COMMAND.md`
- `docs/milestones/v0.91.7/README.md`
- `docs/milestones/v0.91.7/SPRINT_PLAN_v0.91.7.md`
- `docs/milestones/v0.91.7/WP_ISSUE_WAVE_v0.91.7.yaml`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified formatting.
  - `cargo check --manifest-path adl/Cargo.toml --bin adl-pr-inventory`
    Verified compileability of the new dedicated binary.
  - `cargo build --manifest-path adl/Cargo.toml --bin adl-pr-inventory`
    Built the owner binary so `pr.sh` could run without Cargo fallback.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-inventory adl_pr_inventory_forwards_args_to_dispatch -- --nocapture`
    Verified focused wrapper dispatch behavior.
  - `cargo test --manifest-path adl/Cargo.toml pr_inventory_summary_uses_effective_validation_report_counts -- --nocapture`
    Verified populated-row check-summary math.
  - `cargo test --manifest-path adl/Cargo.toml pr_validation_ignores_stale_duplicate_check_runs -- --nocapture`
    Verified effective-check handling for duplicate/rerun check rollups.
  - `bash adl/tools/pr.sh pr-inventory --help`
    Verified the command help path.
  - `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token bash adl/tools/pr.sh pr-inventory --json`
    Verified live JSON output through the repo-native command.
  - `git diff --check`
    Verified whitespace hygiene.
  - `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.7/WP_ISSUE_WAVE_v0.91.7.yaml"); puts "yaml ok"'`
    Verified YAML parseability.
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`
    Verified the validation selector configuration remains valid JSON.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified lane selector contracts after the selector change.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager contracts after the selector change, including the PR-inventory finish-path regression.
  - `bash adl/tools/validation_manager.sh --changed-files <changed-files> --json`
    Verified the current changed-file set is PR-publication sufficient and not escalated.
  - `bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh`
    Verified the complete current selected validation lane.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    Verified the current PR control-plane family lane passed with 8,400 selected test instances.
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified owner-binary freshness ignores test-only Rust source drift while still treating `Cargo.toml` drift as requiring fallback.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_dispatch_rejects_missing_and_unknown_subcommands -- --nocapture`
    Verified the PR dispatcher usage/error contract includes the new `pr-inventory` subcommand.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_profile_classifies_version_metadata_paths_without_issue_special_case -- --nocapture`
    Verified manifest-only Cargo path classification is covered by validation-manager routing.
  - `cargo test --manifest-path adl/Cargo.toml closeout_recovers_malformed_root_srp_from_bound_worktree_bundle -- --nocapture`
    Verified the lifecycle closeout fixture repair.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.6/tasks/issue-4622__v0-91-6-tools-github-add-repo-native-pr-inventory-for-release-tail-review/sip.md
- Output card: .adl/v0.91.6/tasks/issue-4622__v0-91-6-tools-github-add-repo-native-pr-inventory-for-release-tail-review/sor.md
- Idempotency-Key: v0-91-7-tools-include-pr-inventory-in-owner-binary-build-lane-adl-tools-run-owner-validation-lane-sh-adl-tools-test-owner-validation-lane-sh-adl-config-validation-lane-selector-v0-91-6-json-adl-v0-91-6-tasks-issue-4622-v0-91-6-tools-github-add-repo-native-pr-inventory-for-release-tail-review-sip-md-adl-v0-91-6-tasks-issue-4622-v0-91-6-tools-github-add-repo-native-pr-inventory-for-release-tail-review-sor-md