### PR TITLE
[v0.91.7][tools][sessions] Emit repo-local session-claim remediation commands

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1708,6 +1708,7 @@ fn suggested_session_claim_command(
 ) -> String {
     let session_id = adl::session_ledger::current_codex_session_id()
         .unwrap_or_else(|| "<session-id>".to_string());
+    let adl_bin = repo_root.join("adl/target/debug/adl");
     let worktree_ref = if worktree_path.is_absolute() {
         worktree_path
             .strip_prefix(repo_root)
@@ -1718,9 +1719,28 @@ fn suggested_session_claim_command(
         worktree_path.display().to_string()
     };
     format!(
-        "adl session claim --session-id {} --owner codex --resource csdlc_issue:{} --purpose \"issue-mode execution ownership\" --issue {} --branch {} --worktree {} --policy-ref AGENTS.md --lifecycle-phase pr_run --mode active --json",
-        session_id, issue_number, issue_number, branch, worktree_ref
+        "{} session claim --session-id {} --owner codex --resource {} --purpose {} --issue {} --branch {} --worktree {} --policy-ref {} --lifecycle-phase {} --mode {} --json",
+        shell_quote_arg(&adl_bin.display().to_string()),
+        shell_quote_arg(&session_id),
+        shell_quote_arg(&format!("csdlc_issue:{issue_number}")),
+        shell_quote_arg("issue-mode execution ownership"),
+        issue_number,
+        shell_quote_arg(branch),
+        shell_quote_arg(&worktree_ref),
+        shell_quote_arg("AGENTS.md"),
+        shell_quote_arg("pr_run"),
+        shell_quote_arg("active"),
     )
+}
+
+fn shell_quote_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn format_session_claims_for_error(claims: &[adl::session_ledger::TargetClaimMatch]) -> String {

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -1198,8 +1198,33 @@ fn real_pr_start_requires_an_active_self_claim_before_binding_worktree() {
 
     let err_text = err.to_string();
     assert!(err_text.contains("missing active self-claim"));
-    assert!(err_text.contains("adl session claim"));
+    let expected_adl_bin = repo.join("adl/target/debug/adl");
+    assert!(
+        err_text.contains(&format!("{} session claim", expected_adl_bin.display())),
+        "expected repo-local adl binary in error text:\n{err_text}"
+    );
+    assert!(
+        !err_text.contains("\n  adl session claim --"),
+        "error text should not suggest a bare adl command:\n{err_text}"
+    );
     assert!(!issue_ref.default_worktree_path(&repo, None).exists());
+}
+
+#[test]
+fn suggested_session_claim_command_quotes_shell_unsafe_paths() {
+    let repo_root = std::path::Path::new("/tmp/adl repo with spaces");
+    let worktree = repo_root.join(".worktrees/adl wp 1157");
+    let command = suggested_session_claim_command(
+        repo_root,
+        1157,
+        "codex/1157-branch with spaces",
+        &worktree,
+    );
+
+    assert!(command.contains("'/tmp/adl repo with spaces/adl/target/debug/adl' session claim"));
+    assert!(command.contains("--branch 'codex/1157-branch with spaces'"));
+    assert!(command.contains("--worktree '.worktrees/adl wp 1157'"));
+    assert!(!command.starts_with("adl session claim"));
 }
 
 #[test]

--- a/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
+++ b/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
@@ -57,7 +57,7 @@ chmod +x "$mockbin/cargo"
 run_from_repo() {
   (
     cd "$repo"
-    PATH="$mockbin:$PATH" "$@"
+    PATH="$mockbin:/usr/bin:/bin:/usr/sbin:/sbin" "$@"
   )
 }
 

--- a/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
+++ b/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
@@ -58,7 +58,7 @@ chmod +x "$mockbin/cargo"
 TMP_CARGO_ARGS="$tmpdir/cargo_args.txt"
 TMP_LOCKFILE="$repo/adl/Cargo.lock"
 export TMP_CARGO_ARGS TMP_LOCKFILE
-export PATH="$mockbin:$PATH"
+export PATH="$mockbin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 set +e
 run_output="$(

--- a/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
+++ b/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
@@ -132,6 +132,12 @@ adl session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json
 adl session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]
 ```
 
+When `adl` is not installed globally, run the same subcommands through the
+repo-local binary, for example `./adl/target/debug/adl session claim ...` from
+the primary checkout. Workflow diagnostics should prefer that repo-local form
+so a fresh session does not need shell-profile setup before it can repair a
+session claim.
+
 Default local ledger path:
 
 ```text


### PR DESCRIPTION
Closes #4711

## Summary
Implemented a bounded session-ledger diagnostic fix so `pr run` session-claim remediation no longer depends on a globally installed `adl` binary. The remediation command now points at the repo-local `adl/target/debug/adl` executable, shell-quotes unsafe arguments, and the policy docs explain the repo-local invocation path.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-4711__v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands/sor.md`
- Tracked implementation artifact: `adl/src/cli/pr_cmd.rs`
- Tracked regression-test artifact: `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- Tracked owner-lane harness artifact: `adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
- Tracked owner-lane harness artifact: `adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`
- Tracked policy artifact: `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - Verified Rust formatting for the touched tooling code and tests.
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh` - Verified cargo-fallback liveness fixture behavior, including missing-owner-binary fail-closed behavior under a sanitized fixture `PATH`.
  - `bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh` - Verified locked cargo-fallback stale-lockfile refusal under a sanitized fixture `PATH`.
  - `cargo test --manifest-path adl/Cargo.toml session_claim_command --bin adl -- --nocapture` - Verified the session-claim command builder quotes shell-unsafe repo, branch, and worktree paths while avoiding a bare `adl session claim` command.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_requires_an_active_self_claim_before_binding_worktree --bin adl -- --nocapture` - Verified the real missing self-claim diagnostic emits a repo-local `adl/target/debug/adl` remediation command and does not suggest the old bare command.
  - `git diff --check` - Verified whitespace hygiene for the tracked diff.
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`: PASS
  - `bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml session_claim_command --bin adl -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_requires_an_active_self_claim_before_binding_worktree --bin adl -- --nocapture`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4711__v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4711__v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands/sor.md
- Idempotency-Key: v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-tools-test-pr-delegate-cargo-fallback-liveness-sh-adl-tools-test-pr-run-locked-cargo-fallback-refuses-cleanly-sh-docs-tooling-session-coordination-and-root-checkout-policy-md-adl-v0-91-7-tasks-issue-4711-v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands-sip-md-adl-v0-91-7-tasks-issue-4711-v0-91-7-tools-sessions-emit-repo-local-session-claim-remediation-commands-sor-md