### PR TITLE
[v0.91.7][docs][aws] Require business AWS account for ADL AWS work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,17 @@ These rules are mandatory for ADL issue work.
      or `DEEPSEEK_API_KEY`. For provider-specific names such as Gemini/Google,
      follow the active provider setup docs instead of assuming aliases, and
      prefer those docs when preparing reusable local environment files.
+   - AWS work for ADL must default to the Agent Logic business AWS account, not
+     the operator's personal/default AWS account. Use the approved business
+     profile `agent-logic-admin` for AWS billing checks, runtime experiments,
+     SSM, CodeBuild, SNS, EC2/Spot, storage, and other ADL-related AWS work.
+     Before relying on AWS account state, verify that the profile resolves to
+     the approved Agent Logic business account rather than recording a static
+     account identifier in repo policy.
+     Personal/default profiles such as `default` or legacy user profiles may be
+     used only when the operator explicitly authorizes a bounded task against a
+     personal account. Do not print, copy, commit, or expose AWS credentials or
+     credential-file contents.
 2. Edit cards only with editor skills.
    - Use `sip-editor`, `stp-editor`, `spp-editor`, `srp-editor`, `sor-editor`,
      or other issue-card editor skills when card surfaces need normalization.


### PR DESCRIPTION
Closes #4700

## Summary
Updated the root `AGENTS.md` operating contract so ADL AWS work defaults to the approved Agent Logic business AWS profile, with personal/default AWS profiles requiring explicit bounded operator authorization.

## Artifacts
- Updated root `AGENTS.md`
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-4700__require-business-aws-account-for-adl-work/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified the docs-only patch has no whitespace errors.
  - Bounded subagent review of `AGENTS.md` diff
    Verified the policy change did not expose credentials, did not overreach beyond AWS account defaulting, and surfaced a fixed P2 policy-drift issue.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4700__require-business-aws-account-for-adl-work/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4700__require-business-aws-account-for-adl-work/sor.md
- Idempotency-Key: v0-91-7-docs-aws-require-business-aws-account-for-adl-aws-work-agents-md-adl-v0-91-7-tasks-issue-4700-require-business-aws-account-for-adl-work-sip-md-adl-v0-91-7-tasks-issue-4700-require-business-aws-account-for-adl-work-sor-md