### PR TITLE
[v0.91.7][tools][rust-build] Add hardlinked Rust dependency cache warmup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,10 +195,13 @@ For a normal tracked issue:
 8. call `create_goal` for the bound tracked issue session before implementation
    starts
 9. make the bounded change in the issue worktree, never on `main`
-10. run the smallest meaningful validation for the touched surface
-11. run a pre-PR subagent review and fix findings
-12. verify PR base/stack topology, then publish through the normal PR workflow
-13. use `update_goal` for truthful terminal session state, then perform closeout
+10. before Rust validation in a fresh or cold issue worktree, consider warming
+   dependency artifacts with `adl/tools/warm_rust_dependency_cache.py`; see
+   `docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md`
+11. run the smallest meaningful validation for the touched surface
+12. run a pre-PR subagent review and fix findings
+13. verify PR base/stack topology, then publish through the normal PR workflow
+14. use `update_goal` for truthful terminal session state, then perform closeout
    after merge/closure
 
 ## Validation Expectations
@@ -211,6 +214,13 @@ For a normal tracked issue:
   safe for the touched surface.
 - For owner-binary surfaces, prefer the focused lane runner when it matches the
   change: `bash adl/tools/run_owner_validation_lane.sh csdlc|runtime|review|all`.
+- Before Rust-heavy validation in a fresh issue worktree or on an EC2/remote
+  builder, use the dependency-cache warmup helper only when a trusted warm
+  target from the same host, same filesystem, same checkout family, and same
+  toolchain is available:
+  `python3 adl/tools/warm_rust_dependency_cache.py --source-target <warm-target> --dest-target <issue-worktree>/adl/target --manifest-path <issue-worktree>/adl/Cargo.toml`.
+  Treat this as build acceleration only, not validation proof, and never replace
+  the required validation lane with cache-warmup evidence.
 - Keep review records and output cards truthful about what was and was not run.
 - Docs-only and policy-only PVF work should prefer focused docs/path/contract/
   guardrail proof unless tracked runtime behavior changed.

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -460,6 +460,27 @@
       "reason": "sprint_conductor_surface_requires_helper_contract_checks"
     },
     {
+      "id": "rust_dependency_cache_warmup_contracts",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "regression",
+      "requirement_ids": [
+        "rust_dependency_cache_warmup_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/warm_rust_dependency_cache.py",
+        "adl/tools/test_warm_rust_dependency_cache.py"
+      ],
+      "path_hints": [
+        "adl/tools/warm_rust_dependency_cache.py",
+        "adl/tools/test_warm_rust_dependency_cache.py"
+      ],
+      "command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py",
+      "run_command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py",
+      "reason": "rust_dependency_cache_warmup_helper_requires_python_contract_checks"
+    },
+    {
       "id": "docs_diff_check",
       "lane_class": "docs",
       "default_surface": "docs",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -831,8 +831,146 @@ manager_profile_is_release_gate_only_escalation() {
   [ "$validation_profile_escalation_lanes" = "release_gate_review" ]
 }
 
+is_warmup_guidance_patch() {
+  local path="$1"
+  local saw_warmup_marker=false
+  local line content
+  while IFS= read -r line; do
+    case "$line" in
+      diff\ --git*|index\ *|@@*|---*|+++*)
+        continue
+        ;;
+      +*|-*)
+        content="${line#?}"
+        case "$content" in
+          ""|\
+          *"warm_rust_dependency_cache.py"*|\
+          *"test_warm_rust_dependency_cache.py"*|\
+          *"HARDLINKED_RUST_DEPENDENCY_CACHE.md"*|\
+          *"dependency-cache warmup"*|\
+          *"Dependency-Cache Warmup"*|\
+          *"dependency-cache"*|\
+          *"warmup"*|\
+          *"dependency artifacts"*|\
+          *"fresh or cold"*|\
+          *"run the smallest meaningful validation"*|\
+          *"run a pre-PR subagent review"*|\
+          *"verify PR base/stack topology"*|\
+          *"use \`update_goal\`"*|\
+          *"For local issue worktrees and remote builders"*|\
+          *"ADL also provides"*|\
+          *"hardlinked dependency-cache"*|\
+          *"available:"*|\
+          *"trusted warm"*|\
+          *"source target"*|\
+          *"filesystem relationship"*|\
+          *"shared global"*|\
+          *"workspace outputs"*|\
+          *".fingerprint"*|\
+          *"build metadata"*|\
+          *"focused proof"*|\
+          *"does not prove"*|\
+          *"selected validation lane"*|\
+          *"is uncertain"*|\
+          *"do not skip"*|\
+          *"cache warmup succeeded"*|\
+          *"materially affects validation time"*|\
+          *"warm target"*|\
+          *"same host"*|\
+          *"same filesystem"*|\
+          *"same checkout family"*|\
+          *"same toolchain"*|\
+          *"same-host"*|\
+          *"same-filesystem"*|\
+          *"same-checkout-family"*|\
+          *"same-toolchain"*|\
+          *"CARGO_TARGET_DIR"*|\
+          *"build acceleration"*|\
+          *"validation proof"*|\
+          *"required validation lane"*|\
+          *"cache-warmup evidence"*|\
+          *"issue's selected validation"*|\
+          *"execution record"*|\
+          *"The reminder"*|\
+          *"skipped when no trusted"*|\
+          *"Rust-heavy validation"*|\
+          *"Rust validation"*|\
+          *"owner-lane validation"*|\
+          *"--source-target"*|\
+          *"--dest-target"*|\
+          *"--manifest-path"*|\
+          *"--dry-run"*|\
+          *"--json"*|\
+          *"<issue-worktree>/adl/target"*|\
+          *"<issue-worktree>/adl/Cargo.toml"*|\
+          *"docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md"*|\
+          *"run_owner_validation_lane.sh"*|\
+          *\`\`\`*)
+            case "$content" in
+              *"warm_rust_dependency_cache.py"*|\
+              *"test_warm_rust_dependency_cache.py"*|\
+              *"HARDLINKED_RUST_DEPENDENCY_CACHE.md"*|\
+              *"dependency-cache warmup"*|\
+              *"warmup"*)
+                saw_warmup_marker=true
+                ;;
+            esac
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done < <(git_pr_patch "$path")
+  [ "$saw_warmup_marker" = true ]
+}
+
+is_bounded_rust_dependency_cache_warmup_policy_change() {
+  local saw_warmup_surface=false
+  local saw_policy_surface=false
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in
+      adl/tools/warm_rust_dependency_cache.py|\
+      adl/tools/test_warm_rust_dependency_cache.py|\
+      docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md)
+        saw_warmup_surface=true
+        ;;
+      AGENTS.md|\
+      adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md|\
+      adl/tools/skills/pr-run/SKILL.md|\
+      adl/tools/skills/workflow-conductor/SKILL.md)
+        is_warmup_guidance_patch "$path" || return 1
+        saw_warmup_surface=true
+        ;;
+      adl/config/validation_lane_selector.v0.91.6.json|\
+      adl/tools/ci_path_policy.sh|\
+      adl/tools/test_ci_path_policy.sh)
+        saw_policy_surface=true
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done <<EOF
+$changed_files
+EOF
+  [ "$saw_warmup_surface" = true ] && [ "$saw_policy_surface" = true ]
+}
+
 apply_validation_manager_routing() {
   case "$validation_profile_status:$validation_profile_run_lanes:$validation_profile_escalation_required" in
+    ready_to_run:ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts:false)
+      if is_bounded_rust_dependency_cache_warmup_policy_change; then
+        reason="bounded_rust_dependency_cache_warmup_policy_change_runs_python_and_path_policy_checks"
+      else
+        ci_contracts_required=true
+        reason="${validation_profile_primary_reason:-ci_policy_surface_requires_path_policy_contract_checks}"
+      fi
+      return 0
+      ;;
     ready_to_run:*ci_path_policy_contracts*:false)
       ci_contracts_required=true
       reason="${validation_profile_primary_reason:-ci_policy_surface_requires_path_policy_contract_checks}"
@@ -845,6 +983,12 @@ apply_validation_manager_routing() {
     ready_to_run:sprint_conductor_contracts:false|\
     ready_to_run:docs_diff_check,sprint_conductor_contracts:false)
       reason="sprint_conductor_surface_requires_helper_contract_checks"
+      return 0
+      ;;
+    ready_to_run:rust_dependency_cache_warmup_contracts:false|\
+    ready_to_run:docs_diff_check,rust_dependency_cache_warmup_contracts:false|\
+    ready_to_run:rust_dependency_cache_warmup_contracts,docs_diff_check:false)
+      reason="rust_dependency_cache_warmup_helper_requires_python_contract_checks"
       return 0
       ;;
     ready_to_run:rust_pr_fast:false)

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -162,6 +162,30 @@ Skills should treat this as throughput infrastructure, not proof by itself:
 - missing `lld` after the install step is a CI failure because the workflow is
   explicitly claiming linker acceleration on the hosted runner path
 
+For local issue worktrees and remote builders, ADL also provides a bounded
+dependency-artifact warmup helper:
+
+```bash
+python3 adl/tools/warm_rust_dependency_cache.py \
+  --source-target <warm-target> \
+  --dest-target <issue-worktree>/adl/target \
+  --manifest-path <issue-worktree>/adl/Cargo.toml \
+  --json
+```
+
+Use it before Rust-heavy validation only when a trusted warm source target from
+the same host, same filesystem, same checkout family, and same toolchain is
+available. It hardlinks dependency artifacts under `target/<profile>/deps` and
+intentionally avoids workspace outputs, `.fingerprint`, and `build` metadata.
+Its focused proof is:
+
+```bash
+python3 adl/tools/test_warm_rust_dependency_cache.py
+```
+
+Skills must treat this as acceleration only. A successful warmup does not prove
+the issue and must not replace the selected validation lane.
+
 ### Docs-Only PR
 
 Observed:

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -236,6 +236,27 @@ Do not run an oversized validation suite unless the changed surface truly requir
 Use `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md` when selecting and
 recording the validation lane.
 
+#### Rust Dependency-Cache Warmup
+
+Before Rust-heavy validation in a fresh or cold issue worktree, consider using
+the hardlinked dependency-cache warmup helper when a trusted warm target from
+the same host, same filesystem, same checkout family, and same toolchain is
+available:
+
+```bash
+python3 adl/tools/warm_rust_dependency_cache.py \
+  --source-target <warm-target> \
+  --dest-target <issue-worktree>/adl/target \
+  --manifest-path <issue-worktree>/adl/Cargo.toml \
+  --json
+```
+
+Use `--dry-run --json` first when the source target or filesystem relationship
+is uncertain. Do not use a shared global `CARGO_TARGET_DIR`, do not treat
+warmup as validation proof, and do not skip the issue's selected validation
+lane because cache warmup succeeded. Record warmup as build acceleration in the
+execution record when it materially affects validation time.
+
 For docs, planning, and non-runtime tooling changes:
 - run focused docs, tooling, contract, path, and guardrail checks
 - record the lane as a docs-only or tooling-only path-policy validation surface

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -186,6 +186,12 @@ Important rule:
 - when routing to `pr-run` or resuming bound execution, include the issue-bound
   session-goal requirement in the handoff: create the goal after bind/readiness
   succeeds and before implementation starts
+- when routing to `pr-run` for Rust-heavy validation in a fresh or cold
+  worktree, include the dependency-cache warmup reminder in the handoff:
+  `python3 adl/tools/warm_rust_dependency_cache.py --source-target <warm-target> --dest-target <issue-worktree>/adl/target --manifest-path <issue-worktree>/adl/Cargo.toml`.
+  The reminder is an acceleration step, not validation proof, and should be
+  skipped when no trusted same-host, same-filesystem, same-checkout-family, and
+  same-toolchain warm target is available.
 
 ## Policy Model
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -18,6 +18,9 @@ assert_has() {
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
+python3 "$ROOT_DIR/adl/tools/test_warm_rust_dependency_cache.py"
+(cd "$ROOT_DIR" && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh)
+
 (
   cd "$tmp_dir"
   git init -q
@@ -314,6 +317,129 @@ EOF
   assert_has "$sprint_conductor_only_output" "validation_profile_status=ready_to_run"
   assert_has "$sprint_conductor_only_output" "validation_profile_escalation_required=false"
   assert_has "$sprint_conductor_only_output" "validation_profile_run_lanes=sprint_conductor_contracts"
+
+  git checkout -q -b rust-dependency-cache-warmup-helper "$base_sha"
+  mkdir -p adl/tools docs/tooling
+  printf 'print("warmup")\n' > adl/tools/warm_rust_dependency_cache.py
+  printf '# Hardlinked Rust dependency cache\n' > docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git add adl/tools/warm_rust_dependency_cache.py docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git commit -q -m rust-dependency-cache-warmup-helper
+  rust_dependency_cache_warmup_head="$(git rev-parse HEAD)"
+
+  rust_dependency_cache_warmup_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$rust_dependency_cache_warmup_head" --ref "refs/pull/1/merge")"
+  assert_has "$rust_dependency_cache_warmup_output" "rust_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "coverage_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "full_coverage_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "demo_smoke_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "v0913_proof_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "release_version_only=false"
+  assert_has "$rust_dependency_cache_warmup_output" "ci_contracts_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "fail_closed=false"
+  assert_has "$rust_dependency_cache_warmup_output" "coverage_lane=skip"
+  assert_has "$rust_dependency_cache_warmup_output" "coverage_authority=not_required"
+  assert_has "$rust_dependency_cache_warmup_output" "reason=rust_dependency_cache_warmup_helper_requires_python_contract_checks"
+  assert_has "$rust_dependency_cache_warmup_output" "validation_profile_status=ready_to_run"
+  assert_has "$rust_dependency_cache_warmup_output" "validation_profile_escalation_required=false"
+  assert_has "$rust_dependency_cache_warmup_output" "validation_profile_run_lanes=docs_diff_check,rust_dependency_cache_warmup_contracts"
+
+  git checkout -q -b rust-dependency-cache-warmup-policy-change "$base_sha"
+  mkdir -p adl/config adl/tools/skills/docs adl/tools/skills/pr-run adl/tools/skills/workflow-conductor docs/tooling
+  printf '{\"schema_version\":\"adl.validation_lane_selector.v1\",\"surface_defaults\":{},\"lanes\":[],\"special_surfaces\":{},\"manager_guardrails\":{\"docs_only_forbidden_lane_ids\":[\"rust_pr_fast\"],\"pr_fast\":{\"max_rust_surface_count\":4,\"max_filter_token_count\":4,\"max_family_token_count\":3,\"blocked_modes\":[\"full\",\"contract_only\"]}},\"release_gate_hints\":[],\"rust_path_hints\":[]}\n' > adl/config/validation_lane_selector.v0.91.6.json
+  printf '#!/usr/bin/env bash\nprintf policy\\n' > adl/tools/ci_path_policy.sh
+  printf '#!/usr/bin/env bash\nprintf policy-test\\n' > adl/tools/test_ci_path_policy.sh
+  printf 'print("warmup")\n' > adl/tools/warm_rust_dependency_cache.py
+  printf 'print("warmup test")\n' > adl/tools/test_warm_rust_dependency_cache.py
+  printf '# AGENTS warmup guidance\n' > AGENTS.md
+  printf '# CI warmup guidance\n' > adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+  printf '# pr-run warmup guidance\n' > adl/tools/skills/pr-run/SKILL.md
+  printf '# workflow-conductor warmup guidance\n' > adl/tools/skills/workflow-conductor/SKILL.md
+  printf '# Hardlinked Rust dependency cache\n' > docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git add AGENTS.md \
+    adl/config/validation_lane_selector.v0.91.6.json \
+    adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md \
+    adl/tools/skills/pr-run/SKILL.md \
+    adl/tools/skills/workflow-conductor/SKILL.md \
+    adl/tools/ci_path_policy.sh \
+    adl/tools/test_ci_path_policy.sh \
+    adl/tools/warm_rust_dependency_cache.py \
+    adl/tools/test_warm_rust_dependency_cache.py \
+    docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git commit -q -m rust-dependency-cache-warmup-policy-change
+  rust_dependency_cache_policy_head="$(git rev-parse HEAD)"
+
+  rust_dependency_cache_policy_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$rust_dependency_cache_policy_head" --ref "refs/pull/1/merge")"
+  assert_has "$rust_dependency_cache_policy_output" "rust_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "coverage_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "full_coverage_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "demo_smoke_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "v0913_proof_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "release_version_only=false"
+  assert_has "$rust_dependency_cache_policy_output" "ci_contracts_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "fail_closed=false"
+  assert_has "$rust_dependency_cache_policy_output" "coverage_lane=skip"
+  assert_has "$rust_dependency_cache_policy_output" "coverage_authority=not_required"
+  assert_has "$rust_dependency_cache_policy_output" "reason=bounded_rust_dependency_cache_warmup_policy_change_runs_python_and_path_policy_checks"
+  assert_has "$rust_dependency_cache_policy_output" "validation_profile_status=ready_to_run"
+  assert_has "$rust_dependency_cache_policy_output" "validation_profile_escalation_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts"
+
+  git checkout -q -b rust-dependency-cache-warmup-mixed-policy-change "$base_sha"
+  mkdir -p adl/config adl/tools docs/tooling
+  printf '{\"schema_version\":\"adl.validation_lane_selector.v1\",\"surface_defaults\":{},\"lanes\":[],\"special_surfaces\":{},\"manager_guardrails\":{\"docs_only_forbidden_lane_ids\":[\"rust_pr_fast\"],\"pr_fast\":{\"max_rust_surface_count\":4,\"max_filter_token_count\":4,\"max_family_token_count\":3,\"blocked_modes\":[\"full\",\"contract_only\"]}},\"release_gate_hints\":[],\"rust_path_hints\":[]}\n' > adl/config/validation_lane_selector.v0.91.6.json
+  printf '#!/usr/bin/env bash\nprintf policy\\n' > adl/tools/ci_path_policy.sh
+  printf '#!/usr/bin/env bash\nprintf policy-test\\n' > adl/tools/test_ci_path_policy.sh
+  printf 'print("selector mixed change")\n' > adl/tools/select_validation_lanes.py
+  printf 'print("warmup")\n' > adl/tools/warm_rust_dependency_cache.py
+  printf 'print("warmup test")\n' > adl/tools/test_warm_rust_dependency_cache.py
+  printf '# Hardlinked Rust dependency cache\n' > docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git add adl/config/validation_lane_selector.v0.91.6.json \
+    adl/tools/ci_path_policy.sh \
+    adl/tools/test_ci_path_policy.sh \
+    adl/tools/select_validation_lanes.py \
+    adl/tools/warm_rust_dependency_cache.py \
+    adl/tools/test_warm_rust_dependency_cache.py \
+    docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git commit -q -m rust-dependency-cache-warmup-mixed-policy-change
+  rust_dependency_cache_mixed_policy_head="$(git rev-parse HEAD)"
+
+  rust_dependency_cache_mixed_policy_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$rust_dependency_cache_mixed_policy_head" --ref "refs/pull/1/merge")"
+  assert_has "$rust_dependency_cache_mixed_policy_output" "ci_contracts_required=true"
+  assert_has "$rust_dependency_cache_mixed_policy_output" "reason=ci_policy_surface_requires_path_policy_contract_checks"
+  assert_has "$rust_dependency_cache_mixed_policy_output" "validation_profile_status=ready_to_run"
+  assert_has "$rust_dependency_cache_mixed_policy_output" "validation_profile_escalation_required=false"
+  assert_has "$rust_dependency_cache_mixed_policy_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts"
+
+  git checkout -q -b rust-dependency-cache-warmup-unrelated-guidance-change "$base_sha"
+  mkdir -p adl/config adl/tools/skills/docs adl/tools/skills/pr-run adl/tools/skills/workflow-conductor docs/tooling
+  printf '{\"schema_version\":\"adl.validation_lane_selector.v1\",\"surface_defaults\":{},\"lanes\":[],\"special_surfaces\":{},\"manager_guardrails\":{\"docs_only_forbidden_lane_ids\":[\"rust_pr_fast\"],\"pr_fast\":{\"max_rust_surface_count\":4,\"max_filter_token_count\":4,\"max_family_token_count\":3,\"blocked_modes\":[\"full\",\"contract_only\"]}},\"release_gate_hints\":[],\"rust_path_hints\":[]}\n' > adl/config/validation_lane_selector.v0.91.6.json
+  printf '#!/usr/bin/env bash\nprintf policy\\n' > adl/tools/ci_path_policy.sh
+  printf '#!/usr/bin/env bash\nprintf policy-test\\n' > adl/tools/test_ci_path_policy.sh
+  printf 'print("warmup")\n' > adl/tools/warm_rust_dependency_cache.py
+  printf 'print("warmup test")\n' > adl/tools/test_warm_rust_dependency_cache.py
+  printf '# unrelated AGENTS guidance\n' > AGENTS.md
+  printf '# unrelated CI guidance\n' > adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+  printf '# unrelated pr-run guidance\n' > adl/tools/skills/pr-run/SKILL.md
+  printf '# unrelated workflow guidance\n' > adl/tools/skills/workflow-conductor/SKILL.md
+  printf '# Hardlinked Rust dependency cache\n' > docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git add AGENTS.md \
+    adl/config/validation_lane_selector.v0.91.6.json \
+    adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md \
+    adl/tools/skills/pr-run/SKILL.md \
+    adl/tools/skills/workflow-conductor/SKILL.md \
+    adl/tools/ci_path_policy.sh \
+    adl/tools/test_ci_path_policy.sh \
+    adl/tools/warm_rust_dependency_cache.py \
+    adl/tools/test_warm_rust_dependency_cache.py \
+    docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+  git commit -q -m rust-dependency-cache-warmup-unrelated-guidance-change
+  rust_dependency_cache_unrelated_guidance_head="$(git rev-parse HEAD)"
+
+  rust_dependency_cache_unrelated_guidance_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$rust_dependency_cache_unrelated_guidance_head" --ref "refs/pull/1/merge")"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "ci_contracts_required=true"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "reason=ci_policy_surface_requires_path_policy_contract_checks"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_status=ready_to_run"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_escalation_required=false"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts"
 
   git checkout -q -b classifier-followup "$base_sha"
   mkdir -p adl/tools/skills/sprint-conductor/scripts adl/config adl/tools

--- a/adl/tools/test_warm_rust_dependency_cache.py
+++ b/adl/tools/test_warm_rust_dependency_cache.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Focused contract tests for warm_rust_dependency_cache.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "adl" / "tools" / "warm_rust_dependency_cache.py"
+
+
+def run_helper(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(HELPER), *args, "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"helper failed with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    adl = project / "adl"
+    member = adl / "crates" / "helper"
+    source_target = root / "source-target"
+    deps = source_target / "debug" / "deps"
+    build = source_target / "debug" / "build"
+    fingerprint = source_target / "debug" / ".fingerprint"
+
+    member.mkdir(parents=True)
+    deps.mkdir(parents=True)
+    build.mkdir(parents=True)
+    fingerprint.mkdir(parents=True)
+
+    (adl / "Cargo.toml").write_text(
+        "\n".join(
+            [
+                "[package]",
+                'name = "adl"',
+                'version = "0.1.0"',
+                'edition = "2021"',
+                "",
+                "[workspace]",
+                'members = ["crates/helper"]',
+                "",
+            ]
+        )
+    )
+    (member / "Cargo.toml").write_text(
+        "\n".join(
+            [
+                "[package]",
+                'name = "helper"',
+                'version = "0.1.0"',
+                'edition = "2021"',
+                "",
+            ]
+        )
+    )
+    (adl / "Cargo.lock").write_text(
+        "\n".join(
+            [
+                "version = 4",
+                "",
+                "[[package]]",
+                'name = "adl"',
+                'version = "0.1.0"',
+                "",
+                "[[package]]",
+                'name = "helper"',
+                'version = "0.1.0"',
+                "",
+                "[[package]]",
+                'name = "serde"',
+                'version = "1.0.0"',
+                "",
+                "[[package]]",
+                'name = "proc-macro2"',
+                'version = "1.0.0"',
+                "",
+            ]
+        )
+    )
+
+    for name, content in {
+        "libserde-abc.rlib": "serde rlib",
+        "serde-abc.d": "serde depinfo",
+        "libproc_macro2-def.rmeta": "proc macro metadata",
+        "libadl-aaa.rlib": "workspace root output",
+        "libhelper-bbb.rlib": "workspace member output",
+        "unmatched-file": "not a cargo dependency artifact",
+    }.items():
+        (deps / name).write_text(content)
+
+    (build / "libserde-build-output").write_text("must not link build output")
+    (fingerprint / "serde-fingerprint").write_text("must not link fingerprint")
+    return adl / "Cargo.toml", source_target, root / "dest-target"
+
+
+def assert_same_inode(a: Path, b: Path) -> None:
+    a_stat = a.stat()
+    b_stat = b.stat()
+    if (a_stat.st_dev, a_stat.st_ino) != (b_stat.st_dev, b_stat.st_ino):
+        raise AssertionError(f"expected hardlink inode match: {a} {b}")
+
+
+def test_links_only_external_dependency_deps() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        manifest, source_target, dest_target = write_fixture(Path(temp))
+        summary = run_helper(
+            "--source-target",
+            str(source_target),
+            "--dest-target",
+            str(dest_target),
+            "--manifest-path",
+            str(manifest),
+        )
+
+        if summary["status"] != "ok":
+            raise AssertionError(summary)
+        if summary["linked_files"] != 3:
+            raise AssertionError(f"expected 3 linked dependency files: {summary}")
+
+        for name in ["libserde-abc.rlib", "serde-abc.d", "libproc_macro2-def.rmeta"]:
+            assert_same_inode(source_target / "debug" / "deps" / name, dest_target / "debug" / "deps" / name)
+
+        for name in ["libadl-aaa.rlib", "libhelper-bbb.rlib", "unmatched-file"]:
+            if (dest_target / "debug" / "deps" / name).exists():
+                raise AssertionError(f"unexpected workspace or unmatched artifact linked: {name}")
+
+        if (dest_target / "debug" / "build").exists():
+            raise AssertionError("build directory must not be linked")
+        if (dest_target / "debug" / ".fingerprint").exists():
+            raise AssertionError(".fingerprint directory must not be linked")
+
+
+def test_replace_semantics_are_explicit() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        manifest, source_target, dest_target = write_fixture(Path(temp))
+        dest_deps = dest_target / "debug" / "deps"
+        dest_deps.mkdir(parents=True)
+        existing = dest_deps / "libserde-abc.rlib"
+        existing.write_text("old file")
+
+        no_replace = run_helper(
+            "--source-target",
+            str(source_target),
+            "--dest-target",
+            str(dest_target),
+            "--manifest-path",
+            str(manifest),
+        )
+        if no_replace["skipped_existing"] < 1:
+            raise AssertionError(no_replace)
+        if existing.read_text() != "old file":
+            raise AssertionError("existing destination changed without --replace")
+
+        replaced = run_helper(
+            "--source-target",
+            str(source_target),
+            "--dest-target",
+            str(dest_target),
+            "--manifest-path",
+            str(manifest),
+            "--replace",
+        )
+        if replaced["status"] != "ok":
+            raise AssertionError(replaced)
+        assert_same_inode(source_target / "debug" / "deps" / "libserde-abc.rlib", existing)
+
+
+def main() -> int:
+    test_links_only_external_dependency_deps()
+    test_replace_semantics_are_explicit()
+    print("PASS test_warm_rust_dependency_cache")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/warm_rust_dependency_cache.py
+++ b/adl/tools/warm_rust_dependency_cache.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Warm a Rust target directory by hardlinking dependency artifacts.
+
+This helper is intentionally conservative. It uses Cargo.lock to identify dependency package names, then links only
+artifacts that look like dependency outputs. Workspace package outputs are not
+selected intentionally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class Summary:
+    source_target: str
+    dest_target: str
+    manifest_path: str
+    profile: str
+    dry_run: bool
+    replace: bool
+    external_packages: int = 0
+    external_target_prefixes: int = 0
+    candidate_files: int = 0
+    linked_files: int = 0
+    skipped_existing: int = 0
+    skipped_unmatched: int = 0
+    errors: int = 0
+
+
+def normalize_target_name(name: str) -> str:
+    return name.replace("-", "_")
+
+
+def read_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def read_workspace_package_names(manifest_path: Path) -> set[str]:
+    manifest = read_toml(manifest_path)
+    names: set[str] = set()
+
+    package_name = manifest.get("package", {}).get("name")
+    if package_name:
+        names.add(package_name)
+
+    for member in manifest.get("workspace", {}).get("members", []):
+        if "*" in member:
+            # Keep wildcard handling conservative; the current ADL manifest does
+            # not need it, and guessing can accidentally exclude dependencies.
+            continue
+        member_manifest = (manifest_path.parent / member / "Cargo.toml").resolve()
+        if not member_manifest.exists():
+            continue
+        member_name = read_toml(member_manifest).get("package", {}).get("name")
+        if member_name:
+            names.add(member_name)
+
+    return names
+
+
+def read_lockfile_package_prefixes(manifest_path: Path) -> set[str]:
+    lockfile = manifest_path.parent / "Cargo.lock"
+    if not lockfile.exists():
+        lockfile = manifest_path.parent.parent / "Cargo.lock"
+    if not lockfile.exists():
+        raise RuntimeError(f"Cargo.lock not found near manifest: {manifest_path}")
+
+    workspace_names = read_workspace_package_names(manifest_path)
+    prefixes: set[str] = set()
+    for line in lockfile.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("name ="):
+            continue
+        _, value = stripped.split("=", 1)
+        package_name = value.strip().strip('"')
+        if package_name in workspace_names:
+            continue
+        prefixes.add(normalize_target_name(package_name))
+    return prefixes
+
+
+def load_external_target_prefixes(manifest_path: Path) -> set[str]:
+    # Cargo metadata can have registry side effects in constrained environments.
+    # Cargo.lock gives us a deterministic, local, conservative dependency-name
+    # set and keeps this warmup helper usable before any network/cache access.
+    return read_lockfile_package_prefixes(manifest_path)
+
+def artifact_matches(path: Path, prefixes: set[str]) -> bool:
+    name = path.name
+    stem = name.split(".", 1)[0]
+    stem = stem.removeprefix("lib")
+    for prefix in prefixes:
+        if stem == prefix or stem.startswith(prefix + "-"):
+            return True
+    return False
+
+
+def iter_dependency_artifacts(profile_dir: Path, prefixes: set[str], summary: Summary) -> Iterable[tuple[Path, Path]]:
+    deps_dir = profile_dir / "deps"
+    if not deps_dir.exists():
+        return
+    for source in deps_dir.iterdir():
+        if not source.is_file():
+            continue
+        if artifact_matches(source, prefixes):
+            yield source, Path("deps") / source.name
+        else:
+            summary.skipped_unmatched += 1
+
+def same_inode(a: Path, b: Path) -> bool:
+    try:
+        return a.stat().st_ino == b.stat().st_ino and a.stat().st_dev == b.stat().st_dev
+    except FileNotFoundError:
+        return False
+
+
+def hardlink_file(source: Path, dest: Path, summary: Summary) -> None:
+    summary.candidate_files += 1
+    if dest.exists() or dest.is_symlink():
+        if same_inode(source, dest):
+            summary.skipped_existing += 1
+            return
+        if not summary.replace:
+            summary.skipped_existing += 1
+            return
+        if summary.dry_run:
+            summary.linked_files += 1
+            return
+        dest.unlink()
+
+    if summary.dry_run:
+        summary.linked_files += 1
+        return
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(source, dest)
+        summary.linked_files += 1
+    except OSError as exc:
+        summary.errors += 1
+        print(f"error: failed to hardlink {source} -> {dest}: {exc}", file=sys.stderr)
+
+
+def warm_cache(args: argparse.Namespace) -> Summary:
+    manifest_path = Path(args.manifest_path).resolve()
+    source_target = Path(args.source_target).resolve()
+    dest_target = Path(args.dest_target).resolve()
+    source_profile = source_target / args.profile
+    dest_profile = dest_target / args.profile
+
+    if not manifest_path.exists():
+        raise RuntimeError(f"manifest path does not exist: {manifest_path}")
+    if not source_profile.exists():
+        raise RuntimeError(f"source profile directory does not exist: {source_profile}")
+
+    prefixes = load_external_target_prefixes(manifest_path)
+    summary = Summary(
+        source_target=str(source_target),
+        dest_target=str(dest_target),
+        manifest_path=str(manifest_path),
+        profile=args.profile,
+        dry_run=args.dry_run,
+        replace=args.replace,
+        external_packages=len(prefixes),
+        external_target_prefixes=len(prefixes),
+    )
+
+    for source, relative in iter_dependency_artifacts(source_profile, prefixes, summary):
+        hardlink_file(source, dest_profile / relative, summary)
+
+    return summary
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Warm a Rust target directory by hardlinking external dependency artifacts.")
+    parser.add_argument("--source-target", required=True, help="Existing warm Cargo target directory.")
+    parser.add_argument("--dest-target", required=True, help="Destination Cargo target directory to warm.")
+    parser.add_argument("--manifest-path", default="adl/Cargo.toml", help="Cargo manifest used for dependency classification.")
+    parser.add_argument("--profile", default="debug", help="Cargo profile directory under target, usually debug or release.")
+    parser.add_argument("--dry-run", action="store_true", help="Report what would be linked without modifying the destination.")
+    parser.add_argument("--replace", action="store_true", help="Replace existing destination files before linking.")
+    parser.add_argument("--json", action="store_true", help="Emit a JSON summary.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        summary = warm_cache(args)
+    except Exception as exc:  # noqa: BLE001 - CLI fail-closed with clear message.
+        if args.json:
+            print(json.dumps({"status": "error", "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    payload = asdict(summary)
+    payload["status"] = "ok" if summary.errors == 0 else "completed_with_errors"
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"status={payload['status']} candidate_files={summary.candidate_files} linked_files={summary.linked_files} skipped_existing={summary.skipped_existing} errors={summary.errors}")
+    return 0 if summary.errors == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+++ b/docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
@@ -1,0 +1,84 @@
+# Hardlinked Rust Dependency Cache Warmup
+
+ADL issue worktrees often pay avoidable Rust cold-build cost. In one EC2 warm-build comparison, warming build state cut build time by roughly 60%. This helper turns that lesson into a small, explicit local tool without introducing a shared global `CARGO_TARGET_DIR`.
+
+The design follows the dependency-artifact hardlinking pattern described in Howard John, [Sharing Rust Build Cache](https://blog.howardjohn.info/posts/shared-rust-build/): do not share one target directory, and do not copy mutable workspace outputs. Instead, reuse dependency artifacts by hardlinking them into a fresh target directory. ADL's first helper uses `Cargo.lock` rather than live registry metadata so dry-run and review paths stay local and predictable, and it starts with the safer `deps/` artifact surface only.
+
+## Tool
+
+```sh
+python3 adl/tools/warm_rust_dependency_cache.py \
+  --source-target /path/to/warm/target \
+  --dest-target /path/to/issue/worktree/adl/target \
+  --manifest-path /path/to/issue/worktree/adl/Cargo.toml \
+  --dry-run \
+  --json
+```
+
+Remove `--dry-run` only after inspecting the JSON summary.
+
+## Safety Contract
+
+- The tool uses `Cargo.lock` package names as a local, deterministic dependency classifier.
+- The current manifest package and explicit workspace-member packages are excluded from the eligible prefix set.
+- Only files under `target/<profile>/deps` are warmed by default; `.fingerprint` and `build` metadata are intentionally not hardlinked in this first version.
+- Dependency package artifacts are eligible for warmup when their filenames match lockfile-derived prefixes.
+- Workspace package outputs are not selected intentionally.
+- Existing destination files are skipped unless `--replace` is supplied.
+- Missing source target/profile directories fail closed.
+- The tool does not set or require a shared `CARGO_TARGET_DIR`.
+- The warmup is an optimization only; correctness still belongs to Cargo and the normal validation lane.
+
+## Recommended ADL Usage
+
+Use this helper before Rust-heavy validation in a fresh or cold issue worktree
+when a trusted warm source target already exists on the same host and
+filesystem. Typical places to use it:
+
+- after `pr run <issue>` binds a fresh issue worktree and before the first
+  focused Rust validation command
+- before owner-lane validation such as
+  `bash adl/tools/run_owner_validation_lane.sh csdlc|runtime|review|all`
+- on EC2 or remote builders after checkout/worktree setup and before the first
+  Rust validation pass
+
+For local issue worktrees, use a trusted warm source target from the same
+checkout family and toolchain:
+
+```sh
+python3 adl/tools/warm_rust_dependency_cache.py \
+  --source-target /Users/daniel/git/agent-design-language/adl/target \
+  --dest-target /Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/target \
+  --manifest-path /Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/Cargo.toml \
+  --json
+```
+
+For EC2 or remote builders, warm from the local persistent target cache on that host before running focused validation. Keep the source and destination on the same filesystem so hardlinks work.
+
+## Agent Workflow Integration
+
+Agents should not rely on memory for this optimization. The repo surfaces this
+helper through:
+
+- root `AGENTS.md`, under the normal issue execution and validation flow
+- `adl/tools/skills/pr-run/SKILL.md`, before bounded validation
+- `adl/tools/skills/workflow-conductor/SKILL.md`, when routing to `pr-run`
+- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`, under build acceleration
+- `adl/config/validation_lane_selector.v0.91.6.json`, which assigns the helper
+  and its contract test to `rust_dependency_cache_warmup_contracts`
+
+The helper has its own focused behavior test:
+
+```sh
+python3 adl/tools/test_warm_rust_dependency_cache.py
+```
+
+That test proves dependency artifacts are linked, workspace outputs are not
+linked, `.fingerprint` and `build` are not linked, and `--replace` is explicit.
+
+## Non-Claims
+
+This does not replace sccache, remote builders, PVF scheduling,
+validation-manager routing, or any required validation lane. It is a standalone
+worktree warmup primitive that agents and future tooling can call before Rust
+validation to reduce cold-build cost.


### PR DESCRIPTION
Closes #4720

## Summary
Implemented a conservative Rust dependency-cache warmup helper for ADL issue worktrees. The helper uses `Cargo.lock` plus workspace-package exclusion to classify dependency artifact prefixes, hardlinks only `target/PROFILE/deps` files, emits JSON summaries, and fails closed for missing source targets. Added reviewer-facing documentation for local and EC2 warm-builder usage, including the observed roughly 60% EC2 warm-build speedup and the non-goal of shared `CARGO_TARGET_DIR`.

## Artifacts
- `adl/tools/warm_rust_dependency_cache.py`
- `docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md`
- `adl/config/validation_lane_selector.v0.91.6.json` selector update for the new helper/doc surface

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/warm_rust_dependency_cache.py`
    Verified Python syntax.
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target REPO_ROOT/adl/target --dest-target TMPDIR/adl-4720-target-warmup --manifest-path adl/Cargo.toml --dry-run --json`
    Verified dry-run JSON summary generation against a warm target without writing hardlinks.
  - `python3 adl/tools/warm_rust_dependency_cache.py --help >/dev/null`
    Verified CLI option parsing/help path.
  - `git diff --check`
    Verified diff hygiene.
  - `bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh`
    Verified validation-lane selector and validation-manager contract behavior after adding the new tool surface.
  - `pr finish` CI-path-policy lane
    Verified `test_ci_path_policy`, `test_select_validation_lanes`, `test_validation_manager`, and `test_run_nessus_remote_validation` before SOR normalization.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4720__hardlinked-rust-dependency-cache-warmup-for-worktrees/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4720__hardlinked-rust-dependency-cache-warmup-for-worktrees/sor.md
- Idempotency-Key: v0-91-7-tools-rust-build-add-hardlinked-rust-dependency-cache-warmup-adl-v0-91-7-tasks-issue-4720-hardlinked-rust-dependency-cache-warmup-for-worktrees-sip-md-adl-v0-91-7-tasks-issue-4720-hardlinked-rust-dependency-cache-warmup-for-worktrees-sor-md