### PR TITLE
[v0.91.7][WP-04][goals] Implement nested issue and sprint goal accounting

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -302,6 +302,7 @@
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
         "adl/tools/test_owner_validation_lane.sh",
+        "adl/tools/test_readiness_prep_metrics_non_terminal.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "path_hints": [
@@ -319,6 +320,7 @@
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
         "adl/tools/test_owner_validation_lane.sh",
+        "adl/tools/test_readiness_prep_metrics_non_terminal.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "command": "bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan",

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1629,23 +1629,120 @@ fn record_issue_goal_metrics_stage(
         issue_ref.scope(),
         issue_ref.issue_number()
     );
-    let args = [
-        path_str(&script_path)?,
-        "--issue-number",
-        issue_number.as_str(),
-        "--artifacts-dir",
-        path_str(&artifacts_dir)?,
-        "--capture-stage",
-        capture_stage,
-        "--issue-goal-ref",
-        issue_goal_ref.as_str(),
-        "--metrics-confidence",
-        "high",
-        "--fallback-data-source",
-        "derived_sprint_state",
+    let (sprint_goal_ref, goal_metrics_rollup_ref) =
+        read_issue_goal_metric_refs(repo_root, issue_ref)?;
+    let mut args = vec![
+        path_str(&script_path)?.to_string(),
+        "--issue-number".to_string(),
+        issue_number,
+        "--artifacts-dir".to_string(),
+        path_str(&artifacts_dir)?.to_string(),
+        "--capture-stage".to_string(),
+        capture_stage.to_string(),
+        "--issue-goal-ref".to_string(),
+        issue_goal_ref,
     ];
-    run_capture("python3", &args)?;
+    if let Some(value) = sprint_goal_ref {
+        args.push("--sprint-goal-ref".to_string());
+        args.push(value);
+    }
+    if let Some(value) = goal_metrics_rollup_ref {
+        args.push("--goal-metrics-rollup-ref".to_string());
+        args.push(value);
+    }
+    args.extend([
+        "--metrics-confidence".to_string(),
+        "high".to_string(),
+        "--fallback-data-source".to_string(),
+        "derived_sprint_state".to_string(),
+    ]);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_capture("python3", &arg_refs)?;
     Ok(())
+}
+
+fn read_issue_goal_metric_refs(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<(Option<String>, Option<String>)> {
+    let bundle_dir = issue_ref.task_bundle_dir_path(repo_root);
+    let mut sprint_goal_ref = None;
+    let mut goal_metrics_rollup_ref = None;
+    for card_name in ["spp.md", "vpp.md"] {
+        let card_path = bundle_dir.join(card_name);
+        let Some(frontmatter) = read_yaml_frontmatter(&card_path)? else {
+            continue;
+        };
+        let yaml: serde_yaml::Value = serde_yaml::from_str(&frontmatter).with_context(|| {
+            format!(
+                "failed to parse goal metric refs from '{}'",
+                card_path.display()
+            )
+        })?;
+        merge_goal_metric_ref(
+            &mut sprint_goal_ref,
+            yaml_string_field(&yaml, "sprint_goal_ref"),
+            "sprint_goal_ref",
+            &card_path,
+        )?;
+        merge_goal_metric_ref(
+            &mut goal_metrics_rollup_ref,
+            yaml_string_field(&yaml, "goal_metrics_rollup_ref"),
+            "goal_metrics_rollup_ref",
+            &card_path,
+        )?;
+    }
+    Ok((sprint_goal_ref, goal_metrics_rollup_ref))
+}
+
+fn merge_goal_metric_ref(
+    current: &mut Option<String>,
+    candidate: Option<String>,
+    field: &str,
+    card_path: &Path,
+) -> Result<()> {
+    let Some(candidate) = candidate.filter(|value| !value.eq_ignore_ascii_case("unknown")) else {
+        return Ok(());
+    };
+    if let Some(existing) = current.as_ref() {
+        if existing != &candidate {
+            bail!(
+                "conflicting {field} values in issue goal metric cards: existing '{existing}' but '{}' declares '{candidate}'",
+                card_path.display()
+            );
+        }
+        return Ok(());
+    }
+    *current = Some(candidate);
+    Ok(())
+}
+
+fn read_yaml_frontmatter(path: &Path) -> Result<Option<String>> {
+    let Ok(text) = fs::read_to_string(path) else {
+        return Ok(None);
+    };
+    let mut lines = text.lines();
+    if lines.next() != Some("---") {
+        return Ok(None);
+    }
+    let mut yaml = Vec::new();
+    for line in lines {
+        if line == "---" {
+            return Ok(Some(yaml.join("\n")));
+        }
+        yaml.push(line);
+    }
+    Ok(None)
+}
+
+fn yaml_string_field(value: &serde_yaml::Value, key: &str) -> Option<String> {
+    value
+        .as_mapping()?
+        .get(serde_yaml::Value::String(key.to_string()))?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn emit_start_session_ledger_notes(assessment: &adl::session_ledger::TargetClaimAssessment) {
@@ -1999,7 +2096,9 @@ fn bootstrap_ready_status_label(status: &str) -> &str {
 
 #[cfg(test)]
 mod bootstrap_output_tests {
-    use super::bootstrap_ready_status_label;
+    use super::{bootstrap_ready_status_label, read_issue_goal_metric_refs};
+    use ::adl::control_plane::IssueRef;
+    use std::fs;
 
     #[test]
     fn bootstrap_ready_status_explains_card_review_blockers() {
@@ -2008,6 +2107,92 @@ mod bootstrap_output_tests {
             "BLOCKED_PENDING_CARD_REVIEW"
         );
         assert_eq!(bootstrap_ready_status_label("PASS"), "PASS");
+    }
+
+    #[test]
+    fn issue_goal_metric_refs_are_read_from_task_bundle_cards() {
+        let repo =
+            std::env::temp_dir().join(format!("adl-goal-metric-refs-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&repo);
+        let issue_ref =
+            IssueRef::new(4666, "v0.91.7", "nested-goal-accounting").expect("issue ref");
+        let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+        fs::create_dir_all(&bundle_dir).expect("bundle dir");
+        fs::write(
+            bundle_dir.join("spp.md"),
+            "---\nsprint_goal_ref: \"issue-4631\"\ngoal_metrics_rollup_ref: \".adl/v0.91.7/tasks/issue-4666__nested-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json\"\n---\n",
+        )
+        .expect("write spp");
+
+        let (sprint_goal_ref, rollup_ref) =
+            read_issue_goal_metric_refs(&repo, &issue_ref).expect("read refs");
+        assert_eq!(sprint_goal_ref.as_deref(), Some("issue-4631"));
+        assert_eq!(
+            rollup_ref.as_deref(),
+            Some(".adl/v0.91.7/tasks/issue-4666__nested-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json")
+        );
+
+        let _ = fs::remove_dir_all(&repo);
+    }
+
+    #[test]
+    fn issue_goal_metric_refs_fall_back_from_spp_to_vpp_when_spp_is_unknown() {
+        let repo = std::env::temp_dir().join(format!(
+            "adl-goal-metric-refs-vpp-fallback-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&repo);
+        let issue_ref =
+            IssueRef::new(4666, "v0.91.7", "nested-goal-accounting").expect("issue ref");
+        let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+        fs::create_dir_all(&bundle_dir).expect("bundle dir");
+        fs::write(
+            bundle_dir.join("spp.md"),
+            "---\nsprint_goal_ref: unknown\ngoal_metrics_rollup_ref: unknown\n---\n",
+        )
+        .expect("write spp");
+        fs::write(
+            bundle_dir.join("vpp.md"),
+            "---\nsprint_goal_ref: \"issue-4631\"\ngoal_metrics_rollup_ref: \".adl/v0.91.7/tasks/issue-4666__nested-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json\"\n---\n",
+        )
+        .expect("write vpp");
+
+        let (sprint_goal_ref, rollup_ref) =
+            read_issue_goal_metric_refs(&repo, &issue_ref).expect("read refs");
+        assert_eq!(sprint_goal_ref.as_deref(), Some("issue-4631"));
+        assert_eq!(
+            rollup_ref.as_deref(),
+            Some(".adl/v0.91.7/tasks/issue-4666__nested-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json")
+        );
+
+        let _ = fs::remove_dir_all(&repo);
+    }
+
+    #[test]
+    fn issue_goal_metric_refs_reject_spp_vpp_drift() {
+        let repo =
+            std::env::temp_dir().join(format!("adl-goal-metric-refs-drift-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&repo);
+        let issue_ref =
+            IssueRef::new(4666, "v0.91.7", "nested-goal-accounting").expect("issue ref");
+        let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+        fs::create_dir_all(&bundle_dir).expect("bundle dir");
+        fs::write(
+            bundle_dir.join("spp.md"),
+            "---\nsprint_goal_ref: \"issue-4631\"\ngoal_metrics_rollup_ref: \".adl/v0.91.7/tasks/issue-4666__nested-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json\"\n---\n",
+        )
+        .expect("write spp");
+        fs::write(
+            bundle_dir.join("vpp.md"),
+            "---\nsprint_goal_ref: \"issue-9999\"\ngoal_metrics_rollup_ref: \".adl/v0.91.7/tasks/issue-9999__wrong/artifacts/goal_metrics/issue-9999-goal-metrics-summary.json\"\n---\n",
+        )
+        .expect("write vpp");
+
+        let err = read_issue_goal_metric_refs(&repo, &issue_ref)
+            .expect_err("conflicting refs should fail closed");
+        assert!(err.to_string().contains("conflicting sprint_goal_ref"));
+
+        let _ = fs::remove_dir_all(&repo);
     }
 }
 

--- a/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
+++ b/adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py
@@ -772,6 +772,10 @@ def build_issue_goal_metrics_record_from_codex_goal_snapshot(
 ) -> dict[str, Any]:
     snapshot = parse_codex_goal_tool_snapshot(goal_state_path)
     completion_state = completion_state_override or snapshot["completion_state"]
+    completed_at = snapshot.get("completed_at")
+    if completion_state_override is None and CAPTURE_SEGMENT_BY_STAGE[capture_stage] == "readiness_prep":
+        completion_state = "unknown"
+        completed_at = None
     thread_id = snapshot.get("thread_id")
     return build_issue_goal_metrics_record(
         sprint_issue_number=None,
@@ -786,7 +790,7 @@ def build_issue_goal_metrics_record_from_codex_goal_snapshot(
         goal_id=None,
         goal_id_state="not_available",
         started_at=snapshot.get("started_at"),
-        completed_at=snapshot.get("completed_at"),
+        completed_at=completed_at,
         elapsed_seconds_raw=snapshot.get("elapsed_seconds_raw"),
         active_work_seconds_raw=snapshot.get("active_work_seconds_raw"),
         validation_seconds_raw="unknown",

--- a/adl/tools/test_readiness_prep_metrics_non_terminal.sh
+++ b/adl/tools/test_readiness_prep_metrics_non_terminal.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+home_dir="${tmpdir}/home"
+session_root="${home_dir}/.codex/sessions/2026/07/02"
+artifacts_dir="${tmpdir}/artifacts"
+mkdir -p "${session_root}" "${artifacts_dir}"
+
+thread_id="thread-4666-completed"
+transcript_path="${session_root}/rollout-2026-07-02T00-00-00-${thread_id}.jsonl"
+cat >"${transcript_path}" <<'EOF_TRANSCRIPT'
+{"type":"response_item","payload":{"item":{"type":"function_call","name":"get_goal","call_id":"call_goal_4666"}}}
+{"type":"response_item","payload":{"item":{"type":"function_call_output","call_id":"call_goal_4666","output":"{\"goal\":{\"threadId\":\"thread-4666-completed\",\"objective\":\"Issue #4666 session\",\"status\":\"complete\",\"tokensUsed\":2500,\"timeUsedSeconds\":60,\"createdAt\":1783010000,\"updatedAt\":1783010060}}"}}}
+EOF_TRANSCRIPT
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4666 \
+  --artifacts-dir "${artifacts_dir}" \
+  --capture-stage card_repair \
+  --issue-goal-ref goal:v0.91.7:issue:4666 \
+  --sprint-goal-ref issue-4631 \
+  --thread-id "${thread_id}" \
+  --session-root "${home_dir}/.codex/sessions" \
+  --metrics-confidence high \
+  >/tmp/adl-readiness-prep-non-terminal.out
+
+python3 - "$artifacts_dir/issue-4666-goal-metrics-summary.json" <<'PY'
+import json
+import sys
+summary = json.loads(open(sys.argv[1], encoding="utf-8").read())
+assert summary["selected_stage"] == "card_repair", summary
+assert summary["selected_segment"] == "readiness_prep", summary
+assert summary["completion_state"] == "unknown", summary
+assert summary["goal_terminal_state"]["completion_allowed"] is False, summary
+assert summary["sprint_goal_ref"] == "issue-4631", summary
+PY
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4666 \
+  --artifacts-dir "${tmpdir}/bound-artifacts" \
+  --capture-stage issue_start \
+  --issue-goal-ref goal:v0.91.7:issue:4666 \
+  --sprint-goal-ref issue-4631 \
+  --thread-id "${thread_id}" \
+  --session-root "${home_dir}/.codex/sessions" \
+  --metrics-confidence high \
+  >"${tmpdir}/issue-start.out" 2>"${tmpdir}/issue-start.err"; then
+  echo "expected issue_start capture to reject terminal completion without PR truth" >&2
+  exit 1
+fi
+
+grep -q "issue goal cannot be recorded as completed" "${tmpdir}/issue-start.err"
+echo "PASS readiness prep metrics remain non-terminal"


### PR DESCRIPTION
Closes #4666

## Summary
Implemented nested issue/sprint goal accounting for the readiness-prep metrics path and fixed the issue binding blocker exposed by #4666. Readiness-prep stages now remain non-terminal even when a completed Codex goal transcript is present, while bound execution stages still fail closed if terminal issue completion is claimed too early. The PR command hook also consumes `sprint_goal_ref` and `goal_metrics_rollup_ref` from issue cards and rejects conflicting SPP/VPP truth.

## Artifacts
- Updated readiness-prep metrics behavior in `adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py`
- Updated PR command metrics hook in `adl/src/cli/pr_cmd.rs`
- Added focused regression proof at `adl/tools/test_readiness_prep_metrics_non_terminal.sh`
- Local issue metrics summary at `.adl/v0.91.7/tasks/issue-4666__v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting/artifacts/goal_metrics/issue-4666-goal-metrics-summary.json`

## Validation
- Validation commands and their purpose:
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json > .adl/validation_lane_selector_4666.normalized.json && bash adl/tools/test_select_validation_lanes.sh && rm .adl/validation_lane_selector_4666.normalized.json` - verified the validation selector manifest maps the new readiness-prep proof script
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - verified Rust formatting after the readiness-prep and nested-goal changes
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py && bash adl/tools/test_readiness_prep_metrics_non_terminal.sh` - verified Python syntax and the focused readiness-prep non-terminal regression proof
  - `cargo test --manifest-path adl/Cargo.toml issue_goal_metric_refs -- --nocapture` - verified nested metric refs are read, unknown SPP values can fall back to VPP, and SPP/VPP drift fails closed
  - `git diff --check` - verified whitespace hygiene for the issue diff
- Results:
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json > .adl/validation_lane_selector_4666.normalized.json && bash adl/tools/test_select_validation_lanes.sh && rm .adl/validation_lane_selector_4666.normalized.json`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/issue_goal_metrics.py adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py && bash adl/tools/test_readiness_prep_metrics_non_terminal.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml issue_goal_metric_refs -- --nocapture`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4666__v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4666__v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting/sor.md
- Idempotency-Key: v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting-adl-v0-91-7-tasks-issue-4666-v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting-sip-md-adl-v0-91-7-tasks-issue-4666-v0-91-7-wp-04-goals-implement-nested-issue-and-sprint-goal-accounting-sor-md