### PR TITLE
[v0.91.7][WP-04][metrics] Implement SOR time-token-resource accounting

### DIFF
--- a/adl/src/cli/tooling_cmd/srp_sor_update.rs
+++ b/adl/src/cli/tooling_cmd/srp_sor_update.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 use serde_yaml::{Mapping, Value};
 
 use super::markdown::{markdown_block_field, split_front_matter};
@@ -67,17 +68,26 @@ struct ReleaseTailFacts {
 
 #[derive(Debug, Default, Deserialize)]
 struct MetricsFacts {
+    estimated_elapsed_seconds: Option<String>,
     actual_elapsed_seconds: Option<String>,
+    estimated_total_tokens: Option<String>,
     actual_total_tokens: Option<String>,
+    estimated_validation_seconds: Option<String>,
     actual_validation_seconds: Option<String>,
     goal_metrics_data_source: Option<String>,
     goal_metrics_source_ref: Option<String>,
     data_source_confidence: Option<String>,
+    estimate_error_percent: Option<String>,
+    variance_analysis_required: Option<String>,
+    variance_analysis_completed: Option<String>,
+    variance_category: Option<String>,
+    variance_note: Option<String>,
 }
 
 #[derive(Debug, Default)]
 struct Args {
     facts: Option<PathBuf>,
+    goal_metrics_summary: Option<PathBuf>,
     srp: Option<PathBuf>,
     sor: Option<PathBuf>,
     out_srp: Option<PathBuf>,
@@ -94,10 +104,10 @@ pub(super) fn real_srp_sor_update(args: &[String]) -> Result<()> {
     }
 
     let args = parse_args(args)?;
-    let facts_path = args
-        .facts
-        .as_deref()
-        .ok_or_else(|| anyhow!("missing required --facts <facts.yaml>"))?;
+    ensure!(
+        args.facts.is_some() || args.goal_metrics_summary.is_some(),
+        "missing required --facts <facts.yaml> or --goal-metrics-summary <summary.json>"
+    );
     let srp_path = args
         .srp
         .as_deref()
@@ -109,10 +119,19 @@ pub(super) fn real_srp_sor_update(args: &[String]) -> Result<()> {
     let out_srp = args.out_srp.as_deref().unwrap_or(srp_path);
     let out_sor = args.out_sor.as_deref().unwrap_or(sor_path);
 
-    let facts_text = fs::read_to_string(facts_path)
-        .with_context(|| format!("read facts file {}", facts_path.display()))?;
-    let facts: FactPacket = serde_yaml::from_str(&facts_text)
-        .with_context(|| format!("parse facts file {}", facts_path.display()))?;
+    let mut facts = if let Some(facts_path) = args.facts.as_deref() {
+        let facts_text = fs::read_to_string(facts_path)
+            .with_context(|| format!("read facts file {}", facts_path.display()))?;
+        serde_yaml::from_str(&facts_text)
+            .with_context(|| format!("parse facts file {}", facts_path.display()))?
+    } else {
+        FactPacket::default()
+    };
+    if let Some(summary_path) = args.goal_metrics_summary.as_deref() {
+        facts
+            .merge_goal_metrics_summary(summary_path)
+            .with_context(|| format!("project goal metrics summary {}", summary_path.display()))?;
+    }
     ensure!(
         facts.has_actionable_facts(),
         "facts file contains no SRP/SOR updates"
@@ -150,6 +169,10 @@ fn parse_args(raw: &[String]) -> Result<Args> {
     while idx < raw.len() {
         match raw[idx].as_str() {
             "--facts" => args.facts = Some(next_path(raw, &mut idx, "--facts")?),
+            "--goal-metrics-summary" => {
+                args.goal_metrics_summary =
+                    Some(next_path(raw, &mut idx, "--goal-metrics-summary")?)
+            }
             "--srp" => args.srp = Some(next_path(raw, &mut idx, "--srp")?),
             "--sor" => args.sor = Some(next_path(raw, &mut idx, "--sor")?),
             "--out-srp" => args.out_srp = Some(next_path(raw, &mut idx, "--out-srp")?),
@@ -162,7 +185,7 @@ fn parse_args(raw: &[String]) -> Result<Args> {
 }
 
 fn srp_sor_update_usage() -> &'static str {
-    "adl tooling srp-sor-update --facts <facts.yaml> --srp <srp.md> --sor <sor.md> [--out-srp <srp.md>] [--out-sor <sor.md>]"
+    "adl tooling srp-sor-update (--facts <facts.yaml> | --goal-metrics-summary <summary.json>) --srp <srp.md> --sor <sor.md> [--out-srp <srp.md>] [--out-sor <sor.md>]"
 }
 
 fn next_path(raw: &[String], idx: &mut usize, flag: &str) -> Result<PathBuf> {
@@ -190,12 +213,20 @@ impl FactPacket {
             || self.release_tail.pr_state.is_some()
             || self.release_tail.closeout_state.is_some()
             || !self.release_tail.residual_risks.is_empty()
+            || self.metrics.estimated_elapsed_seconds.is_some()
             || self.metrics.actual_elapsed_seconds.is_some()
+            || self.metrics.estimated_total_tokens.is_some()
             || self.metrics.actual_total_tokens.is_some()
+            || self.metrics.estimated_validation_seconds.is_some()
             || self.metrics.actual_validation_seconds.is_some()
             || self.metrics.goal_metrics_data_source.is_some()
             || self.metrics.goal_metrics_source_ref.is_some()
             || self.metrics.data_source_confidence.is_some()
+            || self.metrics.estimate_error_percent.is_some()
+            || self.metrics.variance_analysis_required.is_some()
+            || self.metrics.variance_analysis_completed.is_some()
+            || self.metrics.variance_category.is_some()
+            || self.metrics.variance_note.is_some()
     }
 
     fn validate_consistency(&self) -> Result<()> {
@@ -272,6 +303,39 @@ impl FactPacket {
             }
         }
 
+        Ok(())
+    }
+
+    fn merge_goal_metrics_summary(&mut self, summary_path: &Path) -> Result<()> {
+        let text = fs::read_to_string(summary_path)
+            .with_context(|| format!("read goal metrics summary {}", summary_path.display()))?;
+        let summary: JsonValue = serde_json::from_str(&text)
+            .with_context(|| format!("parse goal metrics summary {}", summary_path.display()))?;
+
+        let status = json_string(&summary, "status").unwrap_or_else(|| "not_recorded".to_string());
+        ensure!(
+            status == "recorded",
+            "goal metrics summary must have status recorded before it can update SOR metrics"
+        );
+
+        let elapsed =
+            json_metric_or_availability(&summary, "elapsed_seconds", "elapsed_availability");
+        let validation =
+            json_metric_or_availability(&summary, "validation_seconds", "validation_availability");
+        let token_usage = summary.get("token_usage").unwrap_or(&JsonValue::Null);
+        let total_tokens =
+            json_metric_or_availability(token_usage, "total_tokens", "total_availability");
+        let data_source =
+            json_string(&summary, "data_source").unwrap_or_else(|| "unknown".to_string());
+        let confidence =
+            json_string(&summary, "metrics_confidence").unwrap_or_else(|| "unknown".to_string());
+
+        self.metrics.actual_elapsed_seconds = Some(elapsed);
+        self.metrics.actual_total_tokens = Some(total_tokens);
+        self.metrics.actual_validation_seconds = Some(validation);
+        self.metrics.goal_metrics_data_source = Some(data_source);
+        self.metrics.goal_metrics_source_ref = Some(summary_path.to_string_lossy().to_string());
+        self.metrics.data_source_confidence = Some(confidence);
         Ok(())
     }
 }
@@ -395,13 +459,28 @@ fn assert_requested_facts_landed(srp_text: &str, sor_text: &str, facts: &FactPac
     for (block, label, value) in [
         (
             "Issue Metrics Truth",
+            "Estimated elapsed seconds",
+            facts.metrics.estimated_elapsed_seconds.as_deref(),
+        ),
+        (
+            "Issue Metrics Truth",
             "Actual elapsed seconds",
             facts.metrics.actual_elapsed_seconds.as_deref(),
         ),
         (
             "Issue Metrics Truth",
+            "Estimated total tokens",
+            facts.metrics.estimated_total_tokens.as_deref(),
+        ),
+        (
+            "Issue Metrics Truth",
             "Actual total tokens",
             facts.metrics.actual_total_tokens.as_deref(),
+        ),
+        (
+            "Issue Metrics Truth",
+            "Estimated validation seconds",
+            facts.metrics.estimated_validation_seconds.as_deref(),
         ),
         (
             "Issue Metrics Truth",
@@ -422,6 +501,31 @@ fn assert_requested_facts_landed(srp_text: &str, sor_text: &str, facts: &FactPac
             "Issue Metrics Truth",
             "Data-source confidence",
             facts.metrics.data_source_confidence.as_deref(),
+        ),
+        (
+            "Issue Metrics Truth",
+            "Estimate error percent",
+            facts.metrics.estimate_error_percent.as_deref(),
+        ),
+        (
+            "Variance Analysis",
+            "Variance analysis required",
+            facts.metrics.variance_analysis_required.as_deref(),
+        ),
+        (
+            "Variance Analysis",
+            "Variance analysis completed",
+            facts.metrics.variance_analysis_completed.as_deref(),
+        ),
+        (
+            "Variance Analysis",
+            "Variance category",
+            facts.metrics.variance_category.as_deref(),
+        ),
+        (
+            "Variance Analysis",
+            "Variance note",
+            facts.metrics.variance_note.as_deref(),
         ),
         (
             "Main Repo Integration (REQUIRED)",
@@ -530,12 +634,24 @@ fn replace_metric_fields(text: &str, metrics: &MetricsFacts) -> String {
     let mut out = text.to_string();
     for (label, value) in [
         (
+            "Estimated elapsed seconds",
+            metrics.estimated_elapsed_seconds.as_deref(),
+        ),
+        (
             "Actual elapsed seconds",
             metrics.actual_elapsed_seconds.as_deref(),
         ),
         (
+            "Estimated total tokens",
+            metrics.estimated_total_tokens.as_deref(),
+        ),
+        (
             "Actual total tokens",
             metrics.actual_total_tokens.as_deref(),
+        ),
+        (
+            "Estimated validation seconds",
+            metrics.estimated_validation_seconds.as_deref(),
         ),
         (
             "Actual validation seconds",
@@ -553,12 +669,40 @@ fn replace_metric_fields(text: &str, metrics: &MetricsFacts) -> String {
             "Data-source confidence",
             metrics.data_source_confidence.as_deref(),
         ),
+        (
+            "Estimate error percent",
+            metrics.estimate_error_percent.as_deref(),
+        ),
     ] {
         if let Some(value) = value {
             out = replace_dash_field(&out, label, &format!("`{value}`"));
         }
     }
+    out = replace_variance_fields(&out, metrics);
     out
+}
+
+fn replace_variance_fields(text: &str, metrics: &MetricsFacts) -> String {
+    replace_section_body(text, "Variance Analysis", |section_text| {
+        let mut out = section_text.to_string();
+        for (label, value) in [
+            (
+                "Variance analysis required",
+                metrics.variance_analysis_required.as_deref(),
+            ),
+            (
+                "Variance analysis completed",
+                metrics.variance_analysis_completed.as_deref(),
+            ),
+            ("Variance category", metrics.variance_category.as_deref()),
+            ("Variance note", metrics.variance_note.as_deref()),
+        ] {
+            if let Some(value) = value {
+                out = replace_dash_field(&out, label, &format!("`{value}`"));
+            }
+        }
+        out
+    })
 }
 
 fn replace_integration_fields(text: &str, integration: &IntegrationFacts) -> String {
@@ -916,6 +1060,28 @@ fn escape_backticks(value: &str) -> String {
 
 fn yaml_double_quoted(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn json_string(value: &JsonValue, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn json_metric_or_availability(
+    value: &JsonValue,
+    metric_key: &str,
+    availability_key: &str,
+) -> String {
+    if let Some(metric) = value.get(metric_key).and_then(JsonValue::as_i64) {
+        if metric >= 0 {
+            return metric.to_string();
+        }
+    }
+    json_string(value, availability_key).unwrap_or_else(|| "unknown".to_string())
 }
 
 fn normalize_status_token(value: &str) -> String {

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -71,6 +71,16 @@ fn validate_unknown_or_nonnegative_int(field: &str, actual: &str) -> Result<()> 
     Ok(())
 }
 
+fn validate_unknown_or_availability_or_nonnegative_int(field: &str, actual: &str) -> Result<()> {
+    if matches!(
+        actual,
+        "unknown" | "not_collected" | "not_available" | "not_applicable"
+    ) {
+        return Ok(());
+    }
+    validate_unknown_or_nonnegative_int(field, actual)
+}
+
 fn validate_optional_yaml_metric_field(fm: &serde_yaml::Mapping, field: &str) -> Result<()> {
     if let Some(value) = mapping_string(fm, field) {
         validate_unknown_or_positive_int(field, &value)?;
@@ -104,6 +114,11 @@ fn validate_optional_markdown_metric_field(section: &str, label: &str) -> Result
     if let Some(value) = markdown_metric_field(section, label) {
         if label == "Estimate error percent" {
             validate_unknown_or_nonnegative_int(&format!("Issue Metrics Truth.{label}"), &value)?;
+        } else if label.starts_with("Actual ") {
+            validate_unknown_or_availability_or_nonnegative_int(
+                &format!("Issue Metrics Truth.{label}"),
+                &value,
+            )?;
         } else {
             validate_unknown_or_positive_int(&format!("Issue Metrics Truth.{label}"), &value)?;
         }
@@ -112,7 +127,7 @@ fn validate_optional_markdown_metric_field(section: &str, label: &str) -> Result
 }
 
 fn metrics_pair_known(left: &str, right: &str) -> bool {
-    left != "unknown" && right != "unknown"
+    left.parse::<u64>().is_ok() && right.parse::<u64>().is_ok()
 }
 
 fn metrics_pair_exceeds_variance_threshold(left: &str, right: &str) -> Option<bool> {

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -269,6 +269,28 @@ fn structured_prompt_sor_issue_metrics_truth_rejects_zero_placeholders() {
 }
 
 #[test]
+fn structured_prompt_sor_actual_metrics_accept_availability_tokens() {
+    let sor = valid_sor_text()
+        .replace(
+            "- Actual elapsed seconds: `300`",
+            "- Actual elapsed seconds: `not_collected`",
+        )
+        .replace(
+            "- Actual validation seconds: `45`",
+            "- Actual validation seconds: `not_available`",
+        );
+    validate_sor_text(&sor, Some("completed"))
+        .expect("actual metrics should preserve availability tokens");
+
+    let zero_sor = valid_sor_text().replace(
+        "- Actual total tokens: `1200`",
+        "- Actual total tokens: `0`",
+    );
+    validate_sor_text(&zero_sor, Some("completed"))
+        .expect("actual metrics should accept machine-captured zero values");
+}
+
+#[test]
 fn structured_prompt_sor_issue_metrics_truth_allows_zero_percent_exact_match() {
     let sor = valid_sor_text()
         .replace(

--- a/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+++ b/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
@@ -347,6 +347,99 @@ release_tail:
 }
 
 #[test]
+fn srp_sor_update_projects_goal_metrics_summary_into_sor() {
+    let repo = TempRepo::new("srp-sor-update-goal-summary");
+    let summary = repo.write_rel(
+        "artifacts/goal_metrics/issue-4667-goal-metrics-summary.json",
+        r#"{
+  "status": "recorded",
+  "data_source": "codex_goal_tool",
+  "metrics_confidence": "high",
+  "elapsed_seconds": 1500,
+  "elapsed_availability": "known",
+  "validation_seconds": null,
+  "validation_availability": "not_collected",
+  "token_usage": {
+    "total_tokens": 320000,
+    "total_availability": "known"
+  }
+}
+"#,
+    );
+    let summary_arg = Path::new("..").join(
+        summary
+            .strip_prefix(repo_root_for_tests())
+            .expect("repo-relative summary"),
+    );
+    let srp = repo.write_rel("srp.md", &valid_srp_text(4667));
+    let sor = repo.write_rel("sor.md", &valid_sor_text());
+
+    real_srp_sor_update(&[
+        "--goal-metrics-summary".into(),
+        summary_arg.to_string_lossy().to_string(),
+        "--srp".into(),
+        srp.display().to_string(),
+        "--sor".into(),
+        sor.display().to_string(),
+    ])
+    .expect("summary-driven update should succeed");
+
+    let sor_text = fs::read_to_string(&sor).expect("read sor");
+    assert!(sor_text.contains("- Actual elapsed seconds: `1500`"));
+    assert!(sor_text.contains("- Actual total tokens: `320000`"));
+    assert!(sor_text.contains("- Actual validation seconds: `not_collected`"));
+    assert!(sor_text.contains("- Goal metrics data source: `codex_goal_tool`"));
+    assert!(sor_text.contains("- Data-source confidence: `high`"));
+    assert!(sor_text.contains("- Goal metrics source ref: `../.tmp/tooling_cmd_tests/"));
+    validate_sor_text(&sor_text, None).expect("sor validates");
+}
+
+#[test]
+fn srp_sor_update_preserves_known_zero_goal_metrics() {
+    let repo = TempRepo::new("srp-sor-update-zero-goal-summary");
+    let summary = repo.write_rel(
+        "artifacts/goal_metrics/issue-4667-goal-metrics-summary.json",
+        r#"{
+  "status": "recorded",
+  "data_source": "codex_goal_tool",
+  "metrics_confidence": "high",
+  "elapsed_seconds": 0,
+  "elapsed_availability": "known",
+  "validation_seconds": 0,
+  "validation_availability": "known",
+  "token_usage": {
+    "total_tokens": 0,
+    "total_availability": "known"
+  }
+}
+"#,
+    );
+    let summary_arg = Path::new("..").join(
+        summary
+            .strip_prefix(repo_root_for_tests())
+            .expect("repo-relative summary"),
+    );
+    let srp = repo.write_rel("srp.md", &valid_srp_text(4667));
+    let sor = repo.write_rel("sor.md", &valid_sor_text());
+
+    real_srp_sor_update(&[
+        "--goal-metrics-summary".into(),
+        summary_arg.to_string_lossy().to_string(),
+        "--srp".into(),
+        srp.display().to_string(),
+        "--sor".into(),
+        sor.display().to_string(),
+    ])
+    .expect("summary-driven update should preserve zero values");
+
+    let sor_text = fs::read_to_string(&sor).expect("read sor");
+    assert!(sor_text.contains("- Actual elapsed seconds: `0`"));
+    assert!(sor_text.contains("- Actual total tokens: `0`"));
+    assert!(sor_text.contains("- Actual validation seconds: `0`"));
+    validate_sor_text(&sor_text, None).expect("sor validates");
+}
+
+#[test]
 fn srp_sor_update_is_idempotent_when_facts_already_applied() {
     let repo = TempRepo::new("srp-sor-update-idempotent");
     let facts = repo.write_rel(

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -211,6 +211,20 @@ The helper validates that the discovered goal objective matches the target
 issue number and falls back to `unknown` instead of attaching a snapshot from a
 different issue or sprint thread.
 
+After the summary exists, project it into the issue-local SOR metrics section
+with the SRP/SOR updater rather than copying values by hand:
+
+```bash
+adl tooling srp-sor-update \
+  --goal-metrics-summary .adl/<version>/tasks/issue-<n>__<slug>/artifacts/goal_metrics/issue-<n>-goal-metrics-summary.json \
+  --srp .adl/<version>/tasks/issue-<n>__<slug>/srp.md \
+  --sor .adl/<version>/tasks/issue-<n>__<slug>/sor.md
+```
+
+The updater preserves `unknown`, `not_collected`, `not_available`, and
+`not_applicable` as explicit availability states. It must not translate missing
+metrics into `0`.
+
 ## 4.5) Prep-Scout Lane During Closeout Waits
 
 When the active issue is waiting on PR checks, review, janitor work, or


### PR DESCRIPTION
Closes #4667

## Summary
Implemented deterministic SOR time-token-resource accounting for forward issue execution. The `srp-sor-update` tooling can now consume a recorded issue goal metrics summary, project actual elapsed seconds, total tokens, validation availability, data source, source reference, confidence, and variance fields into SOR truth, and preserve machine-captured zero values without turning them into invalid availability tokens.

## Artifacts
- Updated tooling implementation at `adl/src/cli/tooling_cmd/srp_sor_update.rs`
- Updated SOR metric validator at `adl/src/cli/tooling_cmd/structured_prompt.rs`
- Focused regression tests at `adl/src/cli/tooling_cmd/tests/structured_prompt.rs`
- Focused summary projection and zero-metric regression tests at `adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs`
- Workflow documentation update at `docs/default_workflow.md`
- Local ignored SOR/SRP truth updated under `.adl/v0.91.7/tasks/issue-4667__v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting/`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - Verify Rust formatting for the touched tooling files.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_sor_actual_metrics -- --nocapture` - Verify SOR actual metrics accept availability tokens and machine-captured zero values without relaxing estimated metrics.
  - `cargo test --manifest-path adl/Cargo.toml srp_sor_update -- --nocapture` - Verify summary-driven SRP/SOR updates, zero-metric preservation, validation/integration fact updates, idempotence, and guarded failure cases.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc` - Verify the C-SDLC owner lane for wrapper delegation, prompt-template workflow, locked Cargo fallback, and control-plane observability.
  - `git diff --check` - Verify whitespace hygiene for the tracked diff.
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_sor_actual_metrics -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml srp_sor_update -- --nocapture`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4667__v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4667__v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting/sor.md
- Idempotency-Key: v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting-adl-v0-91-7-tasks-issue-4667-v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting-sip-md-adl-v0-91-7-tasks-issue-4667-v0-91-7-wp-04-metrics-implement-sor-time-token-resource-accounting-sor-md