### PR TITLE
[v0.91.7][WP-04][telemetry] Implement Codex session telemetry harvesting

### DIFF
--- a/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
+++ b/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from issue_goal_metrics import (
+    CAPTURE_STAGES,
     build_issue_goal_metrics_record,
     build_issue_goal_metrics_record_from_codex_goal_snapshot,
     build_unknown_issue_goal_metrics_record,
@@ -25,7 +26,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--issue-number", type=int, required=True)
     parser.add_argument("--artifacts-dir", required=True)
-    parser.add_argument("--capture-stage", required=True)
+    parser.add_argument("--capture-stage", required=True, choices=sorted(CAPTURE_STAGES))
     parser.add_argument("--issue-goal-ref")
     parser.add_argument("--sprint-goal-ref")
     parser.add_argument("--goal-metrics-rollup-ref")

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1973,6 +1973,25 @@ assert summary["active_work_availability"] == "unknown"
 assert summary["token_usage"]["total_availability"] == "unknown"
 PY
 
+codex_invalid_stage_artifacts_dir="${tmpdir}/issue-4444-invalid-stage-artifacts/goal_metrics"
+codex_invalid_stage_err="${tmpdir}/issue-4444-invalid-stage.err"
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py" \
+  --issue-number 4444 \
+  --artifacts-dir "${codex_invalid_stage_artifacts_dir}" \
+  --capture-stage issue_execution \
+  --issue-goal-ref "goal:v0.91.6:issue:4444" \
+  --metrics-confidence unknown \
+  --thread-id "thread-missing" \
+  --session-root "${tmpdir}/missing-codex-sessions" 2>"${codex_invalid_stage_err}"; then
+  echo "expected invalid capture stage to fail closed" >&2
+  exit 1
+fi
+grep -Fq "invalid choice: 'issue_execution'" "${codex_invalid_stage_err}"
+test ! -e "${codex_invalid_stage_artifacts_dir}/issue-4444-goal-metrics.jsonl"
+test ! -e "${codex_invalid_stage_artifacts_dir}/issue-4444-goal-metrics-summary.json"
+test ! -e "${codex_invalid_stage_artifacts_dir}/issue-4444-pr-publication-snapshot.json"
+test ! -d "${codex_invalid_stage_artifacts_dir}"
+
 python3 - "${repo_root}" <<'PY'
 import sys
 from pathlib import Path

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -210,6 +210,10 @@ and preserves metric fields as `unknown` rather than fabricating values.
 The helper validates that the discovered goal objective matches the target
 issue number and falls back to `unknown` instead of attaching a snapshot from a
 different issue or sprint thread.
+Accepted `--capture-stage` values are: `issue_init`, `doctor_readiness`,
+`card_repair`, `execution_ready`, `issue_start`, `pr_publication`,
+`review_handoff`, `merge_closeout`, and `sprint_closeout`. The helper fails
+closed before writing artifacts for any other stage name.
 
 ## 4.5) Prep-Scout Lane During Closeout Waits
 


### PR DESCRIPTION
Closes #4668

## Summary
Implemented a fail-closed capture-stage guard for the Codex session telemetry harvester used by sprint-conductor issue-goal metrics. The harvester now accepts only the shared `CAPTURE_STAGES` registry values, preventing accidental unregistered stage names from reaching artifact-writing code. Added focused shell regression coverage proving invalid stages fail before creating any telemetry artifacts, and updated workflow docs with the accepted capture-stage set and fail-closed behavior.

## Artifacts
- Updated telemetry harvester: `adl/tools/skills/sprint-conductor/scripts/record_issue_goal_stage_from_codex_session.py`
- Updated focused regression test: `adl/tools/test_sprint_conductor_helpers.sh`
- Updated workflow docs: `docs/default_workflow.md`
- Ignored local metrics artifacts under `.adl/v0.91.7/tasks/issue-4668__v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting/artifacts/goal_metrics/`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified focused sprint-conductor helper coverage, including Codex session goal metrics fallback behavior and the new invalid-stage fail-closed regression.
  - `git diff --check`
    Verified the issue diff has no whitespace errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4668__v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4668__v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting/sor.md
- Idempotency-Key: v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting-adl-v0-91-7-tasks-issue-4668-v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting-sip-md-adl-v0-91-7-tasks-issue-4668-v0-91-7-wp-04-telemetry-implement-codex-session-telemetry-harvesting-sor-md