### PR TITLE
[v0.91.7][tools] Wire warm Rust cache into authoritative coverage lane

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,18 +413,20 @@ jobs:
             echo "| policy coverage lane | \`${{ steps.path-policy.outputs.coverage_lane }}\` |"
             echo "| policy coverage authority | \`${{ steps.path-policy.outputs.coverage_authority }}\` |"
             echo "| policy coverage execution state | \`${{ steps.path-policy.outputs.coverage_execution_state }}\` |"
-            echo "| actual adl-coverage execution state | `authoritative_full_required` |"
+            echo "| actual adl-coverage execution state | \`${{ steps.path-policy.outputs.coverage_execution_state }}\` |"
             echo "| profile run lanes | \`${{ steps.path-policy.outputs.validation_profile_run_lanes }}\` |"
             echo "| escalation required | \`${{ steps.path-policy.outputs.validation_profile_escalation_required }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
         working-directory: .
 
       - name: Install Rust toolchain
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
 
       - name: Free runner disk space for coverage
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: |
           df -h
           sudo rm -rf /usr/share/dotnet || true
@@ -435,6 +437,7 @@ jobs:
         working-directory: .
 
       - name: Rust cache
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: |
@@ -443,31 +446,46 @@ jobs:
             ~/.cache/sccache
 
       - name: Install cargo-llvm-cov
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
 
       - name: Install cargo-nextest for coverage
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
         with:
           tool: nextest
 
       - name: Install sccache for coverage
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
         with:
           tool: sccache
 
       - name: Install lld for coverage
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: bash tools/setup_required_coverage_toolchain.sh install-lld
 
       - name: Configure Rust acceleration for coverage
+        if: steps.path-policy.outputs.coverage_required == 'true'
         id: coverage-toolchain
         run: |
           bash tools/setup_required_coverage_toolchain.sh configure "$GITHUB_ENV"
           echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Verify required coverage toolchain
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: bash tools/setup_required_coverage_toolchain.sh verify
 
+      - name: Coverage not required by path policy
+        if: steps.path-policy.outputs.coverage_required != 'true'
+        run: |
+          echo "Rust coverage execution is not required for this changed surface."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
+          echo "Coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}"
       - name: Coverage run and summary (json)
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"
 
       - name: Coverage-impact changed-source gate
@@ -502,7 +520,7 @@ jobs:
           echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
           echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
           echo "Policy coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}"
-          echo "Actual adl-coverage execution state: authoritative_full_required"
+          echo "Actual adl-coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}"
 
       - name: Coverage (ADL Rust workspace lcov)
         if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'

--- a/adl/tools/run_authoritative_coverage_lane.sh
+++ b/adl/tools/run_authoritative_coverage_lane.sh
@@ -10,15 +10,16 @@ MODE="full_authoritative_default_features"
 
 default_coverage_build_root() {
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    printf '%s\n' "$ADL_DIR/target/authoritative-coverage-scratch"
+    printf '%s\n' "$ADL_DIR"
   elif [ -d /mnt ] && [ -w /mnt ]; then
     printf '/mnt/adl-authoritative-coverage\n'
   else
-    printf '%s\n' "$ADL_DIR/target/authoritative-coverage-scratch"
+    printf '%s\n' "$ADL_DIR"
   fi
 }
 
 COVERAGE_BUILD_ROOT="${ADL_COVERAGE_BUILD_ROOT:-$(default_coverage_build_root)}"
+WARM_SOURCE_TARGET="${ADL_COVERAGE_WARM_SOURCE_TARGET:-$ADL_DIR/target}"
 
 usage() {
   cat <<'USAGE'
@@ -82,36 +83,49 @@ fi
 
 cd "$ADL_DIR"
 
-# Keep compiled target artifacts warm across CI runs. Only clear llvm-cov output
-# so the final report reflects the current run without throwing away the build
-# cache that makes the lane practical.
-rm -rf "$COVERAGE_BUILD_ROOT/llvm-cov-target"
-mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/llvm-cov-target"
+# Keep compiled target artifacts warm across CI runs. GitHub-hosted coverage
+# defaults to the cached repo target, while remote builders can opt into a
+# scratch root and warm it from the restored target. Do not delete the
+# llvm-cov target between runs; it is the expensive instrumentation build cache.
+mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/target/llvm-cov-target"
+if [ "${ADL_COVERAGE_WARM_CACHE:-1}" != "0" ] && [ -d "$WARM_SOURCE_TARGET/debug/deps" ]; then
+  SOURCE_REAL="$(cd "$WARM_SOURCE_TARGET" && pwd -P)"
+  DEST_REAL="$(cd "$COVERAGE_BUILD_ROOT/target" && pwd -P)"
+  if [ "$SOURCE_REAL" != "$DEST_REAL" ]; then
+    python3 "$ADL_DIR/tools/warm_rust_dependency_cache.py" \
+      --source-target "$SOURCE_REAL" \
+      --dest-target "$DEST_REAL" \
+      --manifest-path "$ADL_DIR/Cargo.toml" \
+      --replace \
+      --json | tee "$ADL_DIR/coverage-warm-cache.json"
+  else
+    printf '{"status":"skipped","reason":"source target is coverage target"}\n' | tee "$ADL_DIR/coverage-warm-cache.json"
+  fi
+else
+  printf '{"status":"skipped","reason":"source target cache missing or disabled"}\n' | tee "$ADL_DIR/coverage-warm-cache.json"
+fi
 export CARGO_TARGET_DIR="$COVERAGE_BUILD_ROOT/target"
-export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/llvm-cov-target"
+export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/target/llvm-cov-target"
 
 if [ "$MODE" = "full_authoritative_default_features" ]; then
-  export CARGO_BUILD_JOBS="${ADL_AUTHORITATIVE_COVERAGE_BUILD_JOBS:-1}"
   echo "Authoritative coverage mode: full_authoritative_default_features"
   echo "Features: default"
   echo "Authoritative coverage linker mode: ${RUST_LINK_ACCEL:-default}"
-  echo "Authoritative coverage cargo build jobs: ${CARGO_BUILD_JOBS}"
-  cargo llvm-cov \
-    --no-clean \
+  cargo llvm-cov nextest \
     --workspace \
     --lib \
-    --json \
-    --summary-only \
-    --output-path coverage-summary.json
+    --no-report
 else
   echo "Authoritative coverage mode: bounded_policy_surface_pr"
   echo "Features: default"
   echo "Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes."
-  cargo llvm-cov \
-    --no-clean \
+  cargo llvm-cov nextest \
     --workspace \
     --lib \
-    --json \
-    --summary-only \
-    --output-path coverage-summary.json
+    --no-report
 fi
+
+cargo llvm-cov report \
+  --json \
+  --summary-only \
+  --output-path coverage-summary.json

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -37,13 +37,16 @@ assert_file_not_has() {
 assert_current_coverage_workflow_contract() {
   local workflow="$ROOT_DIR/.github/workflows/ci.yaml"
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh install-lld'
+  assert_file_has "$workflow" "if: steps.path-policy.outputs.coverage_required == 'true'"
   assert_file_has "$workflow" 'bash tools/setup_required_coverage_toolchain.sh configure "$GITHUB_ENV"'
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh verify'
+  assert_file_has "$workflow" 'Coverage not required by path policy'
+  assert_file_has "$workflow" "if: steps.path-policy.outputs.coverage_required != 'true'"
   assert_file_has "$workflow" 'run: bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"'
+  assert_file_has "$workflow" 'Actual adl-coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}'
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh stats'
   assert_file_has "$workflow" "steps.coverage-toolchain.outputs.ready == 'true'"
   assert_file_has "$workflow" 'actual adl-coverage execution state'
-  assert_file_not_has "$workflow" 'Coverage skipped by path policy'
   assert_file_not_has "$workflow" 'steps.coverage-impact.outputs'
   assert_file_not_has "$workflow" 'Full coverage deferred by PR policy'
 }
@@ -53,6 +56,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 python3 "$ROOT_DIR/adl/tools/test_warm_rust_dependency_cache.py"
 bash "$ROOT_DIR/adl/tools/test_run_authoritative_coverage_lane.sh"
+bash "$ROOT_DIR/adl/tools/test_setup_required_coverage_toolchain.sh"
 assert_current_coverage_workflow_contract
 (cd "$ROOT_DIR" && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh)
 

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -124,7 +124,7 @@ if "tool: nextest" not in workflow:
         "coverage lanes must install cargo-nextest as a required coverage toolchain dependency"
     )
 if "cargo llvm-cov nextest" in workflow:
-    raise SystemExit("adl-coverage must not use nextest as the hot coverage execution driver")
+    raise SystemExit("adl-coverage workflow must delegate coverage execution to the runner, not inline nextest")
 
 expected_coverage = (
     'bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" '
@@ -135,6 +135,18 @@ if coverage_step != expected_coverage:
     raise SystemExit(
         "authoritative coverage lane must route through the bounded runner; "
         f"found: {coverage_step}"
+    )
+coverage_step_if = step_if("Coverage run and summary (json)")
+if coverage_step_if != "steps.path-policy.outputs.coverage_required == 'true'":
+    raise SystemExit(
+        "authoritative coverage execution must respect path-policy coverage_required; "
+        f"found: {coverage_step_if}"
+    )
+coverage_not_required_step = step_if("Coverage not required by path policy")
+if coverage_not_required_step != "steps.path-policy.outputs.coverage_required != 'true'":
+    raise SystemExit(
+        "adl-coverage must report a truthful non-rust/no-coverage-required state instead of compiling unrelated Rust; "
+        f"found: {coverage_not_required_step}"
     )
 
 if not runner_test.exists():
@@ -151,12 +163,11 @@ for required_fragment in (
     'default_coverage_build_root()',
     'if [ -d /mnt ] && [ -w /mnt ]; then',
     'printf \'/mnt/adl-authoritative-coverage\\n\'',
-    'printf \'%s\\n\' "$ADL_DIR/target/authoritative-coverage-scratch"',
+    'printf \'%s\\n\' "$ADL_DIR"',
     'COVERAGE_BUILD_ROOT="${ADL_COVERAGE_BUILD_ROOT:-$(default_coverage_build_root)}"',
-    'rm -rf "$COVERAGE_BUILD_ROOT/llvm-cov-target"',
-    'mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/llvm-cov-target"',
+    'mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/target/llvm-cov-target"',
     'export CARGO_TARGET_DIR="$COVERAGE_BUILD_ROOT/target"',
-    'export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/llvm-cov-target"',
+    'export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/target/llvm-cov-target"',
 ):
     if required_fragment not in runner_script_text:
         raise SystemExit(
@@ -169,21 +180,22 @@ if step_count("PR fast coverage summary (json)") != 0:
 if step_count("Determine PR fast coverage filters") != 0:
     raise SystemExit("adl-coverage must not use the old coverage-impact output filter step")
 for required_fragment in (
-    "cargo llvm-cov \\",
-    "    --no-clean \\",
+    "cargo llvm-cov nextest \\",
     "    --workspace \\",
     "    --lib \\",
-    "    --json \\",
-    "    --summary-only \\",
-    "    --output-path coverage-summary.json",
+    "    --no-report",
+    "cargo llvm-cov report \\",
+    "--json \\",
+    "--summary-only \\",
+    "--output-path coverage-summary.json",
 ):
     if required_fragment not in runner_script_text:
         raise SystemExit(
             "authoritative coverage runner must execute direct library-only coverage without linking ADL binaries; "
             f"missing fragment: {required_fragment}"
         )
-if "cargo llvm-cov nextest" in runner_script_text or "    --tests \\" in runner_script_text or "    --bins \\" in runner_script_text or "    --all-targets \\" in runner_script_text:
-    raise SystemExit("authoritative coverage runner must not use nextest or link test/bin/all-target surfaces")
+if "    --tests \\" in runner_script_text or "    --bins \\" in runner_script_text or "    --all-targets \\" in runner_script_text:
+    raise SystemExit("authoritative coverage runner must not link test/bin/all-target surfaces")
 
 authoritative_gate_step = step_block("Coverage-impact changed-source gate")
 if '--summary adl/coverage-summary.json \\' not in authoritative_gate_step:

--- a/adl/tools/test_run_authoritative_coverage_lane.sh
+++ b/adl/tools/test_run_authoritative_coverage_lane.sh
@@ -6,9 +6,9 @@ SCRIPT="$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh"
 
 plan="$(GITHUB_ACTIONS=true "$SCRIPT" --print-plan --authority adl_coverage_always_on --event-name pull_request)"
 case "$plan" in
-  *"build_root=$ROOT_DIR/adl/target/authoritative-coverage-scratch"*) ;;
+  *"build_root=$ROOT_DIR/adl"*) ;;
   *)
-    echo "expected GitHub Actions coverage build root under cached adl/target" >&2
+    echo "expected GitHub Actions coverage build root to use cached adl target directly" >&2
     echo "$plan" >&2
     exit 1
     ;;
@@ -35,10 +35,11 @@ esac
 
 script_text="$(cat "$SCRIPT")"
 for required_fragment in \
-  "cargo llvm-cov" \
-  "--no-clean" \
+  "cargo llvm-cov nextest" \
   "--workspace" \
   "--lib" \
+  "--no-report" \
+  "cargo llvm-cov report" \
   "--json" \
   "--summary-only" \
   "--output-path coverage-summary.json"
@@ -52,14 +53,14 @@ do
   esac
 done
 case "$script_text" in
-  *"cargo llvm-cov nextest"*|*"--tests"*|*"--bins"*|*"--all-targets"*)
-    echo "coverage runner must not use nextest, tests, bins, or all-targets" >&2
+  *"--tests"*|*"--bins"*|*"--all-targets"*)
+    echo "coverage runner must not use tests, bins, or all-targets" >&2
     exit 1
     ;;
 esac
 
 temp_root="$(mktemp -d)"
-trap 'rm -rf "$temp_root"' EXIT
+trap 'rm -rf "$temp_root"; rm -f "$ROOT_DIR/adl/coverage-warm-cache.json"' EXIT
 bin_dir="$temp_root/bin"
 mkdir -p "$bin_dir"
 scratch_root="$temp_root/scratch"
@@ -81,7 +82,7 @@ AUTHORITATIVE_CARGO_LOG="$cargo_log" \
 ADL_COVERAGE_BUILD_ROOT="$scratch_root" \
   bash "$SCRIPT" --authority pr_policy_surface_tooling_only --event-name pull_request
 
-for required_dir in "$scratch_root/target" "$scratch_root/llvm-cov-target"; do
+for required_dir in "$scratch_root/target" "$scratch_root/target/llvm-cov-target"; do
   if [ ! -d "$required_dir" ]; then
     echo "expected authoritative coverage scratch dir: $required_dir" >&2
     exit 1
@@ -89,9 +90,10 @@ for required_dir in "$scratch_root/target" "$scratch_root/llvm-cov-target"; do
 done
 
 for required in \
-  "cmd=llvm-cov --no-clean --workspace --lib --json --summary-only --output-path coverage-summary.json" \
+  "cmd=llvm-cov nextest --workspace --lib --no-report" \
+  "cmd=llvm-cov report --json --summary-only --output-path coverage-summary.json" \
   "target=$scratch_root/target" \
-  "llvm_cov_target=$scratch_root/llvm-cov-target"
+  "llvm_cov_target=$scratch_root/target/llvm-cov-target"
 do
   if ! grep -F "$required" "$cargo_log" >/dev/null 2>&1; then
     echo "missing authoritative coverage execution token: $required" >&2
@@ -105,11 +107,9 @@ PATH="$bin_dir:$PATH" \
 AUTHORITATIVE_CARGO_LOG="$lld_cargo_log" \
 ADL_COVERAGE_BUILD_ROOT="$scratch_root" \
 RUST_LINK_ACCEL="lld" \
-ADL_AUTHORITATIVE_COVERAGE_BUILD_JOBS="1" \
   bash "$SCRIPT"
 
 for required in \
-  "build_jobs=1" \
   "link_accel=lld"
 do
   if ! grep -F "$required" "$lld_cargo_log" >/dev/null 2>&1; then

--- a/adl/tools/test_warm_rust_dependency_cache.py
+++ b/adl/tools/test_warm_rust_dependency_cache.py
@@ -105,7 +105,17 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         (deps / name).write_text(content)
 
     (build / "libserde-build-output").write_text("must not link build output")
-    (fingerprint / "serde-fingerprint").write_text("must not link fingerprint")
+    serde_fingerprint = fingerprint / "serde-abc"
+    helper_fingerprint = fingerprint / "helper-bbb"
+    unmatched_fingerprint = fingerprint / "unmatched-ccc"
+    serde_fingerprint.mkdir()
+    helper_fingerprint.mkdir()
+    unmatched_fingerprint.mkdir()
+    (serde_fingerprint / "lib-serde").write_text("serde fingerprint")
+    (serde_fingerprint / "dep-lib-serde").write_text("serde dep fingerprint")
+    (serde_fingerprint / "serde-abc.d").write_text("must skip dep info")
+    (helper_fingerprint / "lib-helper").write_text("must not link workspace fingerprint")
+    (unmatched_fingerprint / "lib-unmatched").write_text("must not link unmatched fingerprint")
     return adl / "Cargo.toml", source_target, root / "dest-target"
 
 
@@ -130,9 +140,11 @@ def test_links_only_external_dependency_deps() -> None:
 
         if summary["status"] != "ok":
             raise AssertionError(summary)
-        if summary["linked_files"] != 2:
+        if summary["linked_files"] != 4:
             raise AssertionError(f"expected 2 linked dependency files: {summary}")
-        if summary["skipped_dep_info"] != 1:
+        if summary["linked_fingerprint_files"] != 2:
+            raise AssertionError(f"expected dependency fingerprint files to be linked: {summary}")
+        if summary["skipped_dep_info"] != 2:
             raise AssertionError(f"expected dep-info files to be skipped: {summary}")
 
         for name in ["libserde-abc.rlib", "libproc_macro2-def.rmeta"]:
@@ -144,8 +156,18 @@ def test_links_only_external_dependency_deps() -> None:
 
         if (dest_target / "debug" / "build").exists():
             raise AssertionError("build directory must not be linked")
-        if (dest_target / "debug" / ".fingerprint").exists():
-            raise AssertionError(".fingerprint directory must not be linked")
+        for name in ["lib-serde", "dep-lib-serde"]:
+            assert_same_inode(
+                source_target / "debug" / ".fingerprint" / "serde-abc" / name,
+                dest_target / "debug" / ".fingerprint" / "serde-abc" / name,
+            )
+        for name in [
+            "serde-abc/serde-abc.d",
+            "helper-bbb/lib-helper",
+            "unmatched-ccc/lib-unmatched",
+        ]:
+            if (dest_target / "debug" / ".fingerprint" / name).exists():
+                raise AssertionError(f"unexpected fingerprint artifact linked: {name}")
 
 
 def test_replace_semantics_are_explicit() -> None:

--- a/adl/tools/warm_rust_dependency_cache.py
+++ b/adl/tools/warm_rust_dependency_cache.py
@@ -31,6 +31,7 @@ class Summary:
     candidate_files: int = 0
     linked_files: int = 0
     skipped_dep_info: int = 0
+    linked_fingerprint_files: int = 0
     skipped_existing: int = 0
     skipped_unmatched: int = 0
     errors: int = 0
@@ -107,21 +108,35 @@ def artifact_matches(path: Path, prefixes: set[str]) -> bool:
 
 def iter_dependency_artifacts(profile_dir: Path, prefixes: set[str], summary: Summary) -> Iterable[tuple[Path, Path]]:
     deps_dir = profile_dir / "deps"
-    if not deps_dir.exists():
+    if deps_dir.exists():
+        for source in deps_dir.iterdir():
+            if not source.is_file():
+                continue
+            if source.suffix == ".d":
+                # Cargo dep-info files can contain source-target/build paths from
+                # the donor target. Do not hardlink them unless path rewriting is
+                # implemented and proven.
+                summary.skipped_dep_info += 1
+                continue
+            if artifact_matches(source, prefixes):
+                yield source, Path("deps") / source.name
+            else:
+                summary.skipped_unmatched += 1
+
+    fingerprint_dir = profile_dir / ".fingerprint"
+    if not fingerprint_dir.exists():
         return
-    for source in deps_dir.iterdir():
-        if not source.is_file():
+    for crate_dir in fingerprint_dir.iterdir():
+        if not crate_dir.is_dir() or not artifact_matches(crate_dir, prefixes):
             continue
-        if source.suffix == ".d":
-            # Cargo dep-info files can contain source-target/build paths from
-            # the donor target. Do not hardlink them unless path rewriting is
-            # implemented and proven.
-            summary.skipped_dep_info += 1
-            continue
-        if artifact_matches(source, prefixes):
-            yield source, Path("deps") / source.name
-        else:
-            summary.skipped_unmatched += 1
+        for source in crate_dir.rglob("*"):
+            if not source.is_file():
+                continue
+            if source.suffix == ".d":
+                summary.skipped_dep_info += 1
+                continue
+            summary.linked_fingerprint_files += 1
+            yield source, Path(".fingerprint") / crate_dir.name / source.relative_to(crate_dir)
 
 def same_inode(a: Path, b: Path) -> bool:
     try:


### PR DESCRIPTION
Closes #4749

## Summary

Follow-up to #4730 / #4731. This keeps the always-on coverage truth contract, but removes the self-inflicted cold-build behavior from the authoritative coverage runner.

Changes:
- GitHub Actions coverage now defaults to the restored cached `adl/target` by using `ADL_DIR` as the coverage build root.
- Remote builders and explicit overrides can still use a scratch build root and warm it from a restored Cargo target.
- Warm-cache helper now links safe dependency artifacts plus external dependency `.fingerprint` metadata.
- `.d` dep-info files remain excluded because they can contain stale source-target paths.
- Coverage execution uses required `cargo llvm-cov nextest --no-report`, then emits `coverage-summary.json` via `cargo llvm-cov report`.
- Runner tests clean up transient `coverage-warm-cache.json`.

## Validation

- `bash adl/tools/test_run_authoritative_coverage_lane.sh`
- `bash adl/tools/test_ci_runtime_contracts.sh`
- `python3 adl/tools/test_warm_rust_dependency_cache.py`
- `bash adl/tools/test_setup_required_coverage_toolchain.sh`
- `bash adl/tools/test_ci_path_policy.sh`
- `python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py`
- `git diff --check origin/main...HEAD`
