### PR TITLE
[v0.91.7][tools][github] Fix rustls CryptoProvider init for repo-native owner binaries

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rustls 0.23.36",
  "schemars",
  "serde",
  "serde_json",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -181,6 +181,7 @@ octocrab = { version = "0.53", default-features = false, features = [
   "rustls",
   "rustls-ring",
 ] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Shared async runtime floor for long-lived cadence, ACIP runtime work, and
 # later bounded recurring verification on the existing ADL runtime.
 tokio = { version = "1", features = ["fs", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }

--- a/adl/src/cli/pr_cmd/github_client.rs
+++ b/adl/src/cli/pr_cmd/github_client.rs
@@ -2,6 +2,7 @@
 // Shared GitHub client contract and octocrab transport bridge for C-SDLC issue
 // and PR workflow operations.
 
+use once_cell::sync::OnceCell;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::marker::PhantomData;
@@ -186,6 +187,7 @@ impl AdlGithubClient {
                 missing_token_message(),
             )
         })?;
+        ensure_rustls_crypto_provider()?;
         let builder = octocrab::Octocrab::builder().personal_token(token.to_string());
         #[cfg(test)]
         let builder = if let Ok(base_uri) = std::env::var(ADL_GITHUB_OCTOCRAB_BASE_URI_ENV) {
@@ -205,6 +207,32 @@ impl AdlGithubClient {
             )
         })
     }
+}
+
+fn ensure_rustls_crypto_provider() -> Result<(), AdlGithubClientError> {
+    static RUSTLS_PROVIDER: OnceCell<()> = OnceCell::new();
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+    RUSTLS_PROVIDER
+        .get_or_try_init(|| {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            let install_result = rustls::crypto::ring::default_provider().install_default();
+            if let Err(existing_provider) = install_result {
+                if rustls::crypto::CryptoProvider::get_default().is_none() {
+                    return Err(format!(
+                        "failed to install rustls ring CryptoProvider before octocrab client construction; existing process provider state remained unresolved: {existing_provider:?}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    })
+        .map(|_| ())
+        .map_err(|message| AdlGithubClientError::new(
+            AdlGithubClientErrorKind::Transport,
+            message,
+        ))
 }
 
 fn token_value(github_token: Option<&str>, gh_token: Option<&str>) -> Option<ResolvedGithubToken> {
@@ -695,6 +723,36 @@ mod tests {
         assert_eq!(GithubClientMode::Gh.as_str(), "gh");
         assert_eq!(GithubClientBackend::Octocrab.as_str(), "octocrab");
         assert_eq!(GithubClientBackend::GhFallback.as_str(), "gh");
+    }
+
+    #[test]
+    fn octocrab_build_installs_rustls_provider_once_before_client_construction() {
+        let _guard = env_lock();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let _runtime_guard = runtime.enter();
+        unsafe {
+            std::env::set_var(ADL_GITHUB_OCTOCRAB_BASE_URI_ENV, "https://api.github.test");
+        }
+        let client = AdlGithubClient::from_values(Some("octocrab"), Some("github"), None)
+            .expect("octocrab client config");
+
+        client
+            .octocrab()
+            .expect("first octocrab build should succeed");
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "octocrab path should leave a process-default rustls provider installed"
+        );
+        client
+            .octocrab()
+            .expect("second octocrab build should also succeed");
+
+        unsafe {
+            std::env::remove_var(ADL_GITHUB_OCTOCRAB_BASE_URI_ENV);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4751 remains open until merge and closeout.

## Summary

Stabilizes the repo-native GitHub transport by installing or observing a process-default rustls CryptoProvider before Octocrab client construction. This keeps `adl-issue`, `adl-pr-*`, and `pr.sh` owner-binary paths from panicking before GitHub issue/PR operations run.

## Changed Files

- `adl/src/cli/pr_cmd/github_client.rs`
- `adl/Cargo.toml`
- `adl/Cargo.lock`

## Validation

- `cargo fmt --manifest-path adl/Cargo.toml --all`
- `cargo test --manifest-path adl/Cargo.toml octocrab_build_installs_rustls_provider_once_before_client_construction -- --nocapture`
- `ADL_GITHUB_TOKEN_FILE=$HOME/keys/github.token cargo run --manifest-path adl/Cargo.toml --bin adl-issue -- view 4751 --json`
- `git diff --check origin/main...HEAD`

## Non-goals

- Does not redesign closeout watcher behavior.
- Does not change CI/toolchain policy.
- Does not restore raw `gh` as workflow authority.

