### PR TITLE
[v0.91.7][tools] Add ADL-owned CI step log capture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -486,7 +486,16 @@ jobs:
           echo "Coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}"
       - name: Coverage run and summary (json)
         if: steps.path-policy.outputs.coverage_required == 'true'
-        run: bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"
+        run: bash tools/run_ci_step_with_log.sh --name "coverage-run-summary-json" --log-root ci-step-logs -- bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"
+
+      - name: Upload ADL-owned coverage step logs
+        if: always() && steps.path-policy.outputs.coverage_required == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: adl-coverage-step-logs
+          path: adl/ci-step-logs/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Coverage-impact changed-source gate
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true'
@@ -559,11 +568,12 @@ jobs:
       - name: Coverage policy annotation
         if: steps.path-policy.outputs.coverage_required != 'true'
         run: |
-          echo "Path policy did not require coverage for these changed paths, but adl-coverage is always-on and has already run authoritative coverage."
+          echo "Path policy did not require Rust coverage for these changed paths."
+          echo "The authoritative coverage command did not run in this job because coverage_required != true."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
           echo "Coverage lane requested by policy: ${{ steps.path-policy.outputs.coverage_lane }}"
           echo "Coverage authority requested by policy: ${{ steps.path-policy.outputs.coverage_authority }}"
-          echo "Actual adl-coverage execution state: authoritative_full_required"
+          echo "Actual adl-coverage execution state: skipped_by_path_policy"
         working-directory: .
 
       - name: Upload coverage to Codecov

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -163,7 +163,9 @@
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_run_nessus_remote_validation.sh",
         "adl/tools/test_validation_manager.sh",
-        ".github/workflows/**"
+        ".github/workflows/**",
+        "adl/tools/run_ci_step_with_log.sh",
+        "adl/tools/test_run_ci_step_with_log.sh"
       ],
       "path_hints": [
         "adl/config/validation_lane_selector.v0.91.6.json",
@@ -179,7 +181,9 @@
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_run_nessus_remote_validation.sh",
         "adl/tools/test_validation_manager.sh",
-        ".github/workflows/**"
+        ".github/workflows/**",
+        "adl/tools/run_ci_step_with_log.sh",
+        "adl/tools/test_run_ci_step_with_log.sh"
       ],
       "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
       "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",

--- a/adl/tools/run_ci_step_with_log.sh
+++ b/adl/tools/run_ci_step_with_log.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/run_ci_step_with_log.sh --name <step-name> [--log-root <dir>] -- <command> [args...]
+
+Run one CI command while preserving ADL-owned stdout, stderr, combined log, and
+metadata files. The wrapped command exit code is preserved.
+USAGE
+}
+
+STEP_NAME=""
+LOG_ROOT="${ADL_CI_STEP_LOG_ROOT:-ci-step-logs}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      STEP_NAME="${2:-}"
+      shift 2
+      ;;
+    --log-root)
+      LOG_ROOT="${2:-}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$STEP_NAME" ]; then
+  echo "--name is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "command after -- is required" >&2
+  usage >&2
+  exit 2
+fi
+
+COMMAND=("$@")
+
+slug="$(
+  python3 - "$STEP_NAME" <<'PY'
+import re
+import sys
+
+value = sys.argv[1].strip().lower()
+value = re.sub(r"[^a-z0-9._-]+", "-", value)
+value = value.strip("-._")
+print(value or "ci-step")
+PY
+)"
+
+run_id="${GITHUB_RUN_ID:-local}"
+attempt="${GITHUB_RUN_ATTEMPT:-0}"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+log_dir="$LOG_ROOT/${slug}-${run_id}-${attempt}-${stamp}"
+mkdir -p "$log_dir"
+
+stdout_log="$log_dir/stdout.log"
+stderr_log="$log_dir/stderr.log"
+combined_log="$log_dir/combined.log"
+metadata_json="$log_dir/metadata.json"
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+started_epoch="$(date +%s)"
+
+printf 'ADL CI step log start: %s\n' "$STEP_NAME" | tee "$combined_log"
+printf 'started_at=%s\n' "$started_at" | tee -a "$combined_log"
+printf 'command_argc=%s\n' "${#COMMAND[@]}" | tee -a "$combined_log"
+printf 'command_redaction=metadata_only\n' | tee -a "$combined_log"
+
+set +e
+"${COMMAND[@]}" > >(tee "$stdout_log") 2> >(tee "$stderr_log" >&2)
+status=$?
+set -e
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+finished_epoch="$(date +%s)"
+elapsed_seconds=$((finished_epoch - started_epoch))
+
+if [ -s "$stdout_log" ]; then
+  sed 's/^/[stdout] /' "$stdout_log" >>"$combined_log"
+fi
+if [ -s "$stderr_log" ]; then
+  sed 's/^/[stderr] /' "$stderr_log" >>"$combined_log"
+fi
+printf 'finished_at=%s\n' "$finished_at" | tee -a "$combined_log"
+printf 'exit_code=%s\n' "$status" | tee -a "$combined_log"
+printf 'elapsed_seconds=%s\n' "$elapsed_seconds" | tee -a "$combined_log"
+
+python3 - "$metadata_json" "$STEP_NAME" "$started_at" "$finished_at" "$status" "$elapsed_seconds" "$stdout_log" "$stderr_log" "$combined_log" "${COMMAND[@]}" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+(
+    out_path,
+    step_name,
+    started_at,
+    finished_at,
+    exit_code,
+    elapsed_seconds,
+    stdout_log,
+    stderr_log,
+    combined_log,
+    *command,
+) = sys.argv[1:]
+
+root = Path.cwd()
+try:
+    repo_root = Path(os.popen("git rev-parse --show-toplevel 2>/dev/null").read().strip() or root)
+except Exception:
+    repo_root = root
+
+def rel(path: str) -> str:
+    p = Path(path)
+    if not p.is_absolute():
+        p = root / p
+    try:
+        return p.resolve().relative_to(repo_root.resolve()).as_posix()
+    except Exception:
+        return p.name
+
+def is_sensitive_token(value: str) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in ("token", "secret", "api_key", "apikey", "password"))
+
+def redact(value: str) -> str:
+    if is_sensitive_token(value):
+        return "<redacted>"
+    return value
+
+def redact_command(command: list[str]) -> list[str]:
+    redacted = []
+    redact_next = False
+    for part in command:
+        if redact_next:
+            redacted.append("<redacted>")
+            redact_next = False
+            continue
+        if is_sensitive_token(part):
+            redacted.append("<redacted>")
+            if "=" not in part:
+                redact_next = True
+            continue
+        redacted.append(part)
+    return redacted
+
+payload = {
+    "schema": "adl.ci.step_log.v1",
+    "step_name": step_name,
+    "started_at": started_at,
+    "finished_at": finished_at,
+    "exit_code": int(exit_code),
+    "elapsed_seconds": int(elapsed_seconds),
+    "command": redact_command(command),
+    "stdout_path": rel(stdout_log),
+    "stderr_path": rel(stderr_log),
+    "combined_path": rel(combined_log),
+}
+
+Path(out_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+
+exit "$status"

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -42,7 +42,10 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh verify'
   assert_file_has "$workflow" 'Coverage not required by path policy'
   assert_file_has "$workflow" "if: steps.path-policy.outputs.coverage_required != 'true'"
-  assert_file_has "$workflow" 'run: bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"'
+  assert_file_has "$workflow" 'run: bash tools/run_ci_step_with_log.sh --name "coverage-run-summary-json" --log-root ci-step-logs -- bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "${{ github.event_name }}"'
+  assert_file_has "$workflow" 'Upload ADL-owned coverage step logs'
+  assert_file_has "$workflow" "if: always() && steps.path-policy.outputs.coverage_required == 'true'"
+  assert_file_has "$workflow" 'name: adl-coverage-step-logs'
   assert_file_has "$workflow" 'Actual adl-coverage execution state: ${{ steps.path-policy.outputs.coverage_execution_state }}'
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh stats'
   assert_file_has "$workflow" "steps.coverage-toolchain.outputs.ready == 'true'"
@@ -56,6 +59,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 python3 "$ROOT_DIR/adl/tools/test_warm_rust_dependency_cache.py"
 bash "$ROOT_DIR/adl/tools/test_run_authoritative_coverage_lane.sh"
+bash "$ROOT_DIR/adl/tools/test_run_ci_step_with_log.sh"
 bash "$ROOT_DIR/adl/tools/test_setup_required_coverage_toolchain.sh"
 assert_current_coverage_workflow_contract
 (cd "$ROOT_DIR" && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh)

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -130,10 +130,14 @@ expected_coverage = (
     'bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" '
     '--event-name "${{ github.event_name }}"'
 )
+expected_wrapped_coverage = (
+    'bash tools/run_ci_step_with_log.sh --name "coverage-run-summary-json" --log-root ci-step-logs -- '
+    + expected_coverage
+)
 coverage_step = step_run("Coverage run and summary (json)")
-if coverage_step != expected_coverage:
+if coverage_step not in {expected_coverage, expected_wrapped_coverage}:
     raise SystemExit(
-        "authoritative coverage lane must route through the bounded runner; "
+        "authoritative coverage lane must route through the bounded runner, optionally via the ADL-owned step-log wrapper; "
         f"found: {coverage_step}"
     )
 coverage_step_if = step_if("Coverage run and summary (json)")

--- a/adl/tools/test_run_ci_step_with_log.sh
+++ b/adl/tools/test_run_ci_step_with_log.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/adl/tools/run_ci_step_with_log.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+success_root="$tmp_dir/success"
+bash "$SCRIPT" --name "Coverage run and summary (json)" --log-root "$success_root" -- \
+  bash -c 'echo success-out; echo success-err >&2'
+
+success_meta="$(find "$success_root" -name metadata.json -print -quit)"
+if [ ! -s "$success_meta" ]; then
+  echo "expected success metadata.json" >&2
+  exit 1
+fi
+python3 - "$success_meta" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["schema"] == "adl.ci.step_log.v1"
+assert data["step_name"] == "Coverage run and summary (json)"
+assert data["exit_code"] == 0
+assert data["stdout_path"].endswith("stdout.log")
+assert data["stderr_path"].endswith("stderr.log")
+assert data["combined_path"].endswith("combined.log")
+PY
+
+if ! grep -R "success-out" "$success_root" >/dev/null 2>&1; then
+  echo "expected stdout capture" >&2
+  exit 1
+fi
+if ! grep -R "success-err" "$success_root" >/dev/null 2>&1; then
+  echo "expected stderr capture" >&2
+  exit 1
+fi
+
+failure_root="$tmp_dir/failure"
+set +e
+bash "$SCRIPT" --name "failing step" --log-root "$failure_root" -- \
+  bash -c 'echo fail-out; echo fail-err >&2; exit 37'
+status=$?
+set -e
+if [ "$status" -ne 37 ]; then
+  echo "expected wrapped command exit code 37, got $status" >&2
+  exit 1
+fi
+
+failure_meta="$(find "$failure_root" -name metadata.json -print -quit)"
+if [ ! -s "$failure_meta" ]; then
+  echo "expected failure metadata.json" >&2
+  exit 1
+fi
+python3 - "$failure_meta" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["exit_code"] == 37
+PY
+
+if ! grep -R "fail-err" "$failure_root" >/dev/null 2>&1; then
+  echo "expected failing stderr capture" >&2
+  exit 1
+fi
+
+secret_root="$tmp_dir/secret"
+bash "$SCRIPT" --name "secret step" --log-root "$secret_root" -- \
+  bash -c 'echo no-secret-output' -- --token super-secret-value
+secret_meta="$(find "$secret_root" -name metadata.json -print -quit)"
+if grep -R "super-secret-value" "$secret_root" >/dev/null 2>&1; then
+  echo "secret-looking command argument leaked into retained logs" >&2
+  exit 1
+fi
+python3 - "$secret_meta" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+command = data["command"]
+assert "<redacted>" in command
+assert "super-secret-value" not in command
+PY
+
+if bash "$SCRIPT" --name missing-command --log-root "$tmp_dir/missing" >/dev/null 2>&1; then
+  echo "expected missing command invocation to fail" >&2
+  exit 1
+fi
+
+echo "PASS test_run_ci_step_with_log"

--- a/docs/tooling/ADL_OWNED_CI_STEP_LOGS.md
+++ b/docs/tooling/ADL_OWNED_CI_STEP_LOGS.md
@@ -1,0 +1,62 @@
+# ADL-Owned CI Step Logs
+
+ADL keeps GitHub Actions logs as useful operator context, but important CI
+steps should also produce small ADL-owned log artifacts. This gives reviewers a
+durable fallback when a step fails late, times out, or GitHub's native log view
+is hard to inspect.
+
+## Current Coverage
+
+The first covered critical step is the `adl-coverage` job's `Coverage run and
+summary (json)` step.
+
+The workflow runs it through:
+
+```bash
+bash tools/run_ci_step_with_log.sh --name "coverage-run-summary-json" --log-root ci-step-logs -- bash tools/run_authoritative_coverage_lane.sh --authority "adl_coverage_always_on" --event-name "$GITHUB_EVENT_NAME"
+```
+
+The wrapper preserves the wrapped command's exit code. It does not hide
+coverage failures, skip policy gates, or replace GitHub's normal job status.
+
+## Artifact Shape
+
+Each wrapped step writes a timestamped directory under `adl/ci-step-logs/`:
+
+- `stdout.log`
+- `stderr.log`
+- `combined.log`
+- `metadata.json`
+
+`metadata.json` uses schema `adl.ci.step_log.v1` and records:
+
+- step name
+- start and finish timestamps
+- elapsed seconds
+- exit code
+- redacted command tokens
+- repo-relative log paths when possible
+
+## GitHub Artifact Fallback
+
+The CI workflow uploads `adl/ci-step-logs/` with `if: always()` whenever the
+coverage lane is required. That means the log artifact should still be
+available when the wrapped coverage command fails.
+
+Download path:
+
+1. Open the failed workflow run.
+2. Open `Artifacts`.
+3. Download `adl-coverage-step-logs`.
+4. Inspect `metadata.json`, then `stderr.log`, `stdout.log`, or `combined.log`.
+
+## Boundaries
+
+- These artifacts are review and debugging evidence, not publication-ready
+  evidence.
+- Do not paste secrets into wrapped command arguments.
+- The wrapper performs basic command-token redaction for sensitive-looking
+  argument names, but CI steps should still avoid putting credentials on the
+  command line.
+- The wrapper is not a performance fix. It makes slow or failing CI steps
+  diagnosable and durable.


### PR DESCRIPTION
Closes #4724

## Summary

Adds ADL-owned retained log artifacts for the expensive `adl-coverage` coverage step.

This PR:
- adds `adl/tools/run_ci_step_with_log.sh`
- adds focused wrapper regression coverage
- wraps the `Coverage run and summary (json)` workflow step
- uploads `adl/ci-step-logs/` as `adl-coverage-step-logs` with `if: always()`
- maps the new wrapper files into `ci_path_policy_contracts`
- documents the retrieval and artifact boundary in `docs/tooling/ADL_OWNED_CI_STEP_LOGS.md`

## Validation

Passed locally:
- `bash adl/tools/test_run_ci_step_with_log.sh`
- `bash adl/tools/test_ci_path_policy.sh`
- `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.7/tasks/issue-4724__v0-91-7-tools-add-adl-owned-ci-step-log-capture-and-artifact-fallback/sor.md`
- `bash -n adl/tools/run_ci_step_with_log.sh adl/tools/test_run_ci_step_with_log.sh && git diff --check`

## Review Findings Resolved

- Avoids persisting command-line secret values into combined logs.
- Redacts sensitive-looking flags and following values in metadata.
- Corrects skipped-coverage annotation so it no longer claims coverage ran when path policy skipped it.

## Release-Gate Boundary

This changes `.github/workflows/ci.yaml`, so release-gate posture remains explicit. The focused local proof validates wrapper/path-policy behavior; this PR does not claim release proof. GitHub CI is the integration proof for artifact upload behavior.

## Tooling Fallback Note

`pr.sh finish` validated the SOR but the owner binary panicked in Rustls `CryptoProvider` initialization before PR publication. This PR was therefore published manually after the repo-native finish path staged the intended files.
