### PR TITLE
[v0.91.7][tools][pr] Fix worktree owner-binary discovery for finish and validation

### DIFF
--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -77,7 +77,33 @@ rust_pr_delegate_primary_root() {
 }
 
 rust_pr_worktree_inputs_are_newer_than_bin() {
-  local root="$1" candidate="$2"
+  local root="$1" candidate="$2" primary_root="${3:-}"
+  if [[ -n "$primary_root" && "$primary_root" != "$root" ]] &&
+      git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1 &&
+      git -C "$primary_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    local primary_head
+    primary_head="$(git -C "$primary_root" rev-parse HEAD 2>/dev/null || true)"
+    if [[ -n "$primary_head" ]]; then
+      if ! git -C "$root" diff --quiet "$primary_head" -- \
+          adl/Cargo.toml \
+          adl/Cargo.lock \
+          adl/build.rs \
+          adl/src; then
+        return 0
+      fi
+      if git -C "$root" ls-files --others --exclude-standard -- \
+          adl/Cargo.toml \
+          adl/Cargo.lock \
+          adl/build.rs \
+          adl/src |
+          grep -Ev '(^adl/src/cli/tests/|/tests\.rs$|/tests/)' |
+          grep -q .; then
+        return 0
+      fi
+      return 1
+    fi
+  fi
+
   [[ -f "$root/adl/Cargo.toml" && "$root/adl/Cargo.toml" -nt "$candidate" ]] && return 0
   [[ -f "$root/adl/Cargo.lock" && "$root/adl/Cargo.lock" -nt "$candidate" ]] && return 0
   [[ -f "$root/adl/build.rs" && "$root/adl/build.rs" -nt "$candidate" ]] && return 0
@@ -109,7 +135,7 @@ rust_pr_delegate_primary_cached_bin() {
   candidate="$primary_root/adl/target/debug/adl"
   [[ -x "$candidate" ]] || return 1
   rust_pr_delegate_bin_is_fresh "$primary_root" "$candidate" || return 1
-  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate"; then
+  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate" "$primary_root"; then
     return 1
   fi
   printf '%s\n' "$candidate"
@@ -206,7 +232,7 @@ rust_pr_subcommand_primary_cached_bin() {
   candidate="$primary_root/adl/target/debug/$binary_name"
   [[ -x "$candidate" ]] || return 1
   rust_pr_delegate_bin_is_fresh "$primary_root" "$candidate" || return 1
-  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate"; then
+  if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate" "$primary_root"; then
     return 1
   fi
   printf '%s\n' "$candidate"

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -32,6 +32,20 @@ printf '%s\n' "$*" >"${TMP_ADL_ARGS}"
 EOF_ADL
 chmod +x "$repo/adl/target/debug/adl-pr-doctor"
 
+cat >"$repo/adl/target/debug/adl-pr-finish" <<'EOF_ADL_FINISH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'finish:%s\n' "$*" >"${TMP_ADL_ARGS}"
+EOF_ADL_FINISH
+chmod +x "$repo/adl/target/debug/adl-pr-finish"
+
+cat >"$repo/adl/target/debug/adl-pr-validation" <<'EOF_ADL_VALIDATION'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'validation:%s\n' "$*" >"${TMP_ADL_ARGS}"
+EOF_ADL_VALIDATION
+chmod +x "$repo/adl/target/debug/adl-pr-validation"
+
 cat >"$mockbin/cargo" <<'EOF_CARGO'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -52,7 +66,7 @@ chmod +x "$mockbin/cargo"
 )
 
 sleep 1
-touch "$repo/adl/target/debug/adl-pr-doctor"
+touch "$repo/adl/target/debug/adl-pr-doctor" "$repo/adl/target/debug/adl-pr-finish" "$repo/adl/target/debug/adl-pr-validation"
 
 TMP_ADL_ARGS="$tmpdir/adl_args.txt"
 TMP_CARGO_ARGS="$tmpdir/cargo_args.txt"
@@ -103,7 +117,7 @@ args="$(cat "$TMP_ADL_ARGS")"
 }
 
 sleep 1
-touch "$worktree/adl/Cargo.toml"
+printf '\n# worktree-only manifest drift\n' >>"$worktree/adl/Cargo.toml"
 : >"$TMP_ADL_ARGS"
 : >"$TMP_CARGO_ARGS"
 
@@ -115,17 +129,88 @@ touch "$worktree/adl/Cargo.toml"
 )
 
 [[ ! -s "$TMP_ADL_ARGS" ]] || {
-  echo "assertion failed: stale worktree Cargo.toml should block reuse of the primary checkout direct binary" >&2
+  echo "assertion failed: content-drifted worktree Cargo.toml should block reuse of the primary checkout direct binary" >&2
   cat "$TMP_ADL_ARGS" >&2
   exit 1
 }
 grep -F -- "--bin adl-pr-doctor -- 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full" "$TMP_CARGO_ARGS" >/dev/null || {
-  echo "assertion failed: stale worktree Cargo.toml should force cargo fallback" >&2
+  echo "assertion failed: content-drifted worktree Cargo.toml should force cargo fallback" >&2
   cat "$TMP_CARGO_ARGS" >&2
   exit 1
 }
 
 echo "pr.sh worktree prefers primary checkout built binary: ok"
+
+cp "$repo/adl/Cargo.toml" "$worktree/adl/Cargo.toml"
+mkdir -p "$worktree/adl/src"
+printf 'pub fn untracked_worktree_input() {}\n' >"$worktree/adl/src/untracked_owner_input.rs"
+sleep 1
+touch "$repo/adl/target/debug/adl-pr-doctor"
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    ADL_PR_RUST_ALLOW_CARGO_FALLBACK=1 \
+    "$BASH_BIN" adl/tools/pr.sh doctor 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full >/dev/null
+)
+
+[[ ! -s "$TMP_ADL_ARGS" ]] || {
+  echo "assertion failed: untracked worktree Rust input should block reuse of the primary checkout direct binary" >&2
+  cat "$TMP_ADL_ARGS" >&2
+  exit 1
+}
+grep -F -- "--bin adl-pr-doctor -- 4413 --slug rust-start --no-fetch-issue --version v0.91.6 --mode full" "$TMP_CARGO_ARGS" >/dev/null || {
+  echo "assertion failed: untracked worktree Rust input should force cargo fallback" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+rm -f "$worktree/adl/src/untracked_owner_input.rs"
+
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "worktree finish" --output-card out.md >/dev/null
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == "finish:4413 --title worktree finish --output-card out.md" ]] || {
+  echo "assertion failed: worktree finish should delegate through the primary checkout adl-pr-finish binary without override" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ ! -s "$TMP_CARGO_ARGS" ]] || {
+  echo "assertion failed: cargo should not run when the primary checkout finish binary is fresh for the worktree" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh validation 4772 --json >/dev/null
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == "validation:4772 --json" ]] || {
+  echo "assertion failed: worktree validation should delegate through the primary checkout adl-pr-validation binary without override" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ ! -s "$TMP_CARGO_ARGS" ]] || {
+  echo "assertion failed: cargo should not run when the primary checkout validation binary is fresh for the worktree" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+
+echo "pr.sh worktree prefers primary checkout finish/validation owner binaries: ok"
 
 rm -f "$repo/adl/target/debug/adl-pr-doctor"
 cat >"$repo/adl/target/debug/adl" <<'EOF_ADL_GENERIC'


### PR DESCRIPTION
Closes #4723

## Summary
Implementation is in progress for issue `#4723`. The current patch fixes primary-checkout owner-binary discovery from bound issue worktrees and adds regression coverage for `finish` and `validation` without explicit binary overrides.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4723__fix-worktree-owner-binary-discovery-for-finish-and-validation/sor.md`
- Tracked implementation artifacts:
  - `adl/tools/pr_delegate.sh`
  - `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified primary-checkout owner-binary reuse from a bound worktree for doctor, finish, and validation, including no cargo invocation in the clean-worktree case.
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified small-binary delegation behavior was preserved.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4723__fix-worktree-owner-binary-discovery-for-finish-and-validation/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4723__fix-worktree-owner-binary-discovery-for-finish-and-validation/sor.md
- Idempotency-Key: v0-91-7-tools-pr-fix-worktree-owner-binary-discovery-for-finish-and-validation-adl-tools-pr-delegate-sh-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-adl-v0-91-7-tasks-issue-4723-fix-worktree-owner-binary-discovery-for-finish-and-validation-sip-md-adl-v0-91-7-tasks-issue-4723-fix-worktree-owner-binary-discovery-for-finish-and-validation-sor-md