### PR TITLE
[v0.91.7][tools] Fix process status loopback reachability

### DIFF
--- a/adl/src/cli/process_cmd.rs
+++ b/adl/src/cli/process_cmd.rs
@@ -1,13 +1,15 @@
 use std::fs;
 use std::io::Read;
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
 
 const SCHEMA: &str = "adl.process_status.v1";
 const MAX_PID_FILE_BYTES: u64 = 64;
+const PORT_CONNECT_TIMEOUT: Duration = Duration::from_millis(150);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Check {
@@ -291,6 +293,17 @@ fn pid_report(check: &'static str, pid: u32, live: Option<bool>) -> ProcessStatu
 }
 
 fn port_report(host: String, port: u16) -> ProcessStatusReport {
+    if port_accepts_tcp_connection(&host, port) {
+        return base_report(
+            "port",
+            "bound_port",
+            None,
+            Some(host),
+            Some(port),
+            "exact TCP connect probe reached a loopback service",
+        );
+    }
+
     match TcpListener::bind((host.as_str(), port)) {
         Ok(listener) => {
             drop(listener);
@@ -319,6 +332,15 @@ fn port_report(host: String, port: u16) -> ProcessStatusReport {
             Some(port),
             "local bind probe could not classify the port",
         ),
+    }
+}
+
+fn port_accepts_tcp_connection(host: &str, port: u16) -> bool {
+    match (host, port).to_socket_addrs() {
+        Ok(addrs) => addrs
+            .filter(|addr| addr.ip().is_loopback())
+            .any(|addr| TcpStream::connect_timeout(&addr, PORT_CONNECT_TIMEOUT).is_ok()),
+        Err(_) => false,
     }
 }
 
@@ -396,4 +418,56 @@ fn status_usage() -> &'static str {
 
 Notes:
   The helper classifies exact metadata targets only. It does not run ps, pgrep, lsof, or broad process scans."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::thread;
+
+    #[test]
+    fn port_report_classifies_reachable_loopback_service_as_bound() {
+        assert_reachable_loopback_service_reports_bound("127.0.0.1");
+    }
+
+    #[test]
+    fn port_report_classifies_reachable_localhost_service_as_bound() {
+        assert_reachable_loopback_service_reports_bound("localhost");
+    }
+
+    fn assert_reachable_loopback_service_reports_bound(host: &str) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind local test listener");
+        let port = listener.local_addr().expect("local listener addr").port();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept process-status probe");
+            let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+        });
+
+        let report = port_report(host.to_string(), port);
+
+        server.join().expect("test server should finish");
+        assert_eq!(report.status, "bound_port");
+        assert_eq!(
+            report.note,
+            "exact TCP connect probe reached a loopback service"
+        );
+        assert!(!report.broad_process_scan);
+        assert!(!report.uses_ps);
+    }
+
+    #[test]
+    fn port_report_preserves_unbound_status_for_free_loopback_port() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind local test listener");
+        let port = listener.local_addr().expect("local listener addr").port();
+        drop(listener);
+
+        let report = port_report("127.0.0.1".to_string(), port);
+
+        assert_eq!(report.status, "unbound_port");
+        assert_eq!(report.note, "local bind probe succeeded");
+        assert!(!report.broad_process_scan);
+        assert!(!report.uses_ps);
+    }
 }

--- a/adl/tests/cli_smoke/process_status.rs
+++ b/adl/tests/cli_smoke/process_status.rs
@@ -135,6 +135,27 @@ fn process_status_reports_reachable_localhost_port_as_bound() {
 }
 
 #[test]
+fn process_status_human_output_reports_port_status() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
+    let port = listener
+        .local_addr()
+        .expect("listener address")
+        .port()
+        .to_string();
+
+    let out = run_adl(&["process", "status", "--port", &port]);
+
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("bound_port 127.0.0.1:"));
+}
+
+#[test]
 fn process_status_rejects_non_loopback_port_hosts() {
     let out = run_status_failure(&["--port", "8787", "--host", "0.0.0.0", "--json"]);
 
@@ -246,4 +267,19 @@ fn process_status_help_documents_safe_surface() {
     assert!(stdout.contains("adl process status --pid <pid>"));
     assert!(stdout.contains("--pid-file <path>"));
     assert!(stdout.contains("does not run ps, pgrep, lsof"));
+}
+
+#[test]
+fn process_status_parent_help_and_unknown_subcommand_are_bounded() {
+    let help = run_adl(&["process", "--help"]);
+    assert!(help.status.success());
+    assert!(String::from_utf8_lossy(&help.stdout).contains("adl process status"));
+
+    let unknown = run_adl(&["process", "unknown"]);
+    assert!(!unknown.status.success());
+    assert!(
+        String::from_utf8_lossy(&unknown.stderr).contains("unknown process command"),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&unknown.stderr)
+    );
 }

--- a/adl/tests/cli_smoke/process_status.rs
+++ b/adl/tests/cli_smoke/process_status.rs
@@ -113,6 +113,28 @@ fn process_status_reports_bound_and_unbound_local_ports() {
 }
 
 #[test]
+fn process_status_reports_reachable_localhost_port_as_bound() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
+    let port = listener
+        .local_addr()
+        .expect("listener address")
+        .port()
+        .to_string();
+
+    let json = run_status_json(&["--port", &port, "--host", "localhost"]);
+
+    assert_eq!(json["check"], "port");
+    assert_eq!(json["status"], "bound_port");
+    assert_eq!(json["host"], "localhost");
+    assert_eq!(
+        json["note"],
+        "exact TCP connect probe reached a loopback service"
+    );
+    assert_eq!(json["broad_process_scan"], false);
+    assert_eq!(json["uses_ps"], false);
+}
+
+#[test]
 fn process_status_rejects_non_loopback_port_hosts() {
     let out = run_status_failure(&["--port", "8787", "--host", "0.0.0.0", "--json"]);
 


### PR DESCRIPTION
Closes #4740

## Summary

Fixes `adl process status --port ... --json` so a reachable loopback TCP service is not falsely reported as `unbound_port` merely because a local bind probe has limitations.

The helper now:
- first attempts an exact-target loopback TCP connect probe with a short timeout
- reports `bound_port` when that probe reaches a service, even if the service would later return an application-level error
- preserves the existing bind probe for truly free ports
- preserves the permission-safe contract: no broad `ps`, `pgrep`, or `lsof` scan

## Validation

Passed locally:

- `cargo test --manifest-path adl/Cargo.toml process_status -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml port_report_ -- --nocapture`
- `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
- `git diff --check`

## Review

Pre-PR subagent review completed. Reviewer found no correctness or regression findings. A validation gap for accepted host spellings was addressed before publication by adding direct `localhost` coverage. IPv6 `::1` is not asserted because local IPv6 loopback availability can be environment-dependent.

## Tooling note

`./adl/tools/pr.sh doctor 4740 --json` was attempted before publication but the current owner-binary path panicked in rustls `CryptoProvider` initialization before producing doctor output. That is outside this issue's process-status behavior and is already part of the GitHub tooling repair lane. This PR uses GitHub fallback publication so the process-status fix is not blocked behind that unrelated control-plane defect.
