### PR TITLE
[v0.91.7][tools][ci] Remove fake required-toolchain fixtures

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -165,7 +165,9 @@
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**",
         "adl/tools/run_ci_step_with_log.sh",
-        "adl/tools/test_run_ci_step_with_log.sh"
+        "adl/tools/test_run_ci_step_with_log.sh",
+        "adl/tools/setup_required_coverage_toolchain.sh",
+        "adl/tools/test_setup_required_coverage_toolchain.sh"
       ],
       "path_hints": [
         "adl/config/validation_lane_selector.v0.91.6.json",
@@ -183,7 +185,9 @@
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**",
         "adl/tools/run_ci_step_with_log.sh",
-        "adl/tools/test_run_ci_step_with_log.sh"
+        "adl/tools/test_run_ci_step_with_log.sh",
+        "adl/tools/setup_required_coverage_toolchain.sh",
+        "adl/tools/test_setup_required_coverage_toolchain.sh"
       ],
       "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
       "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",

--- a/adl/tools/run_ci_step_with_log.sh
+++ b/adl/tools/run_ci_step_with_log.sh
@@ -85,10 +85,22 @@ printf 'started_at=%s\n' "$started_at" | tee -a "$combined_log"
 printf 'command_argc=%s\n' "${#COMMAND[@]}" | tee -a "$combined_log"
 printf 'command_redaction=metadata_only\n' | tee -a "$combined_log"
 
+stdout_fifo="$log_dir/stdout.fifo"
+stderr_fifo="$log_dir/stderr.fifo"
+mkfifo "$stdout_fifo" "$stderr_fifo"
+tee "$stdout_log" <"$stdout_fifo" &
+stdout_tee_pid=$!
+tee "$stderr_log" <"$stderr_fifo" >&2 &
+stderr_tee_pid=$!
+
 set +e
-"${COMMAND[@]}" > >(tee "$stdout_log") 2> >(tee "$stderr_log" >&2)
+"${COMMAND[@]}" >"$stdout_fifo" 2>"$stderr_fifo"
 status=$?
 set -e
+
+wait "$stdout_tee_pid" || true
+wait "$stderr_tee_pid" || true
+rm -f "$stdout_fifo" "$stderr_fifo"
 
 finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 finished_epoch="$(date +%s)"

--- a/adl/tools/test_setup_required_coverage_toolchain.sh
+++ b/adl/tools/test_setup_required_coverage_toolchain.sh
@@ -6,69 +6,37 @@ SCRIPT="$ROOT_DIR/adl/tools/setup_required_coverage_toolchain.sh"
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
-mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
 
-cat > "$tmp_dir/bin/sudo" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-if [ "${1:-}" = "find" ]; then
-  exit 0
-fi
-if [ "${1:-}" = "apt-get" ]; then
-  shift
-  case "${1:-}" in
-    update)
-      exit 0
-      ;;
-    install)
-      cat > "$FAKE_BIN/ld.lld" <<'LLD'
-#!/usr/bin/env bash
-echo "LLD 17.0.0 fake installed"
-LLD
-      chmod +x "$FAKE_BIN/ld.lld"
-      exit 0
-      ;;
-  esac
-fi
-exec "$@"
-SH
-cat > "$tmp_dir/bin/sccache" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --version) echo "sccache 0.8.0 fake" ;;
-  --start-server|--zero-stats|--show-stats) exit 0 ;;
-  *) exit 2 ;;
-esac
-SH
-cat > "$tmp_dir/bin/rustc" <<'SH'
-#!/usr/bin/env bash
-echo "rustc fake"
-SH
-cat > "$tmp_dir/bin/cargo" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --version) echo "cargo fake" ;;
-  llvm-cov) echo "cargo-llvm-cov fake" ;;
-  nextest) echo "cargo-nextest fake" ;;
-  *) exit 2 ;;
-esac
-SH
-chmod +x "$tmp_dir/bin"/*
-
-env_file="$tmp_dir/github-env"
-FAKE_BIN="$tmp_dir/bin" PATH="$tmp_dir/bin:$PATH" HOME="$tmp_dir/home" "$SCRIPT" install-lld >/dev/null
-test -x "$tmp_dir/bin/ld.lld"
-PATH="$tmp_dir/bin:$PATH" HOME="$tmp_dir/home" "$SCRIPT" configure "$env_file" >/dev/null
-PATH="$tmp_dir/bin:$PATH" HOME="$tmp_dir/home" "$SCRIPT" verify >/dev/null
-PATH="$tmp_dir/bin:$PATH" HOME="$tmp_dir/home" RUST_LINK_ACCEL=lld "$SCRIPT" stats >/dev/null
-
-grep -Fx 'RUSTC_WRAPPER=sccache' "$env_file" >/dev/null
-grep -Fx 'RUSTFLAGS=-C link-arg=-fuse-ld=lld' "$env_file" >/dev/null
-grep -Fx 'RUST_LINK_ACCEL=lld' "$env_file" >/dev/null
-
-if PATH="/usr/bin:/bin" HOME="$tmp_dir/home" "$SCRIPT" verify >/dev/null 2>&1; then
-  echo "expected verify to fail without required fake tools" >&2
+if "$SCRIPT" >/dev/null 2>&1; then
+  echo "expected setup script with no subcommand to fail" >&2
   exit 1
+fi
+
+if "$SCRIPT" configure >/dev/null 2>"$tmp_dir/configure.err"; then
+  echo "expected configure without GITHUB_ENV path to fail" >&2
+  exit 1
+fi
+grep -F "configure requires a GITHUB_ENV path" "$tmp_dir/configure.err" >/dev/null
+
+if command -v rustc >/dev/null 2>&1 \
+  && command -v cargo >/dev/null 2>&1 \
+  && command -v sccache >/dev/null 2>&1 \
+  && command -v ld.lld >/dev/null 2>&1 \
+  && cargo llvm-cov --version >/dev/null 2>&1 \
+  && cargo nextest --version >/dev/null 2>&1; then
+  env_file="$tmp_dir/github-env"
+  "$SCRIPT" verify >/dev/null
+  "$SCRIPT" configure "$env_file" >/dev/null
+  RUST_LINK_ACCEL=lld "$SCRIPT" stats >/dev/null
+  grep -Fx 'RUSTC_WRAPPER=sccache' "$env_file" >/dev/null
+  grep -Fx 'RUSTFLAGS=-C link-arg=-fuse-ld=lld' "$env_file" >/dev/null
+  grep -Fx 'RUST_LINK_ACCEL=lld' "$env_file" >/dev/null
+else
+  if "$SCRIPT" verify >/dev/null 2>"$tmp_dir/verify.err"; then
+    echo "expected verify to fail when one or more real required tools are unavailable" >&2
+    exit 1
+  fi
+  grep -F "required command is unavailable" "$tmp_dir/verify.err" >/dev/null
 fi
 
 echo "PASS test_setup_required_coverage_toolchain"


### PR DESCRIPTION
Closes #4777

## Summary
Bound issue #4777 to repair the `adl-ci` required-toolchain path after fake required-toolchain fixtures blocked PR #4776. The current implementation removes fake binary fixtures from `adl/tools/test_setup_required_coverage_toolchain.sh` maps the required-toolchain setup/test scripts into the existing CI path-policy validation lane, and makes `run_ci_step_with_log.sh` portable by replacing `/dev/fd` process substitution with `mkfifo` plus `tee`, preserving live output streaming. The workflow itself is intentionally left on the older stable v0.91.2/v0.91.3 shape: Rust/sccache/lld are installed by the runner when Rust is required, and coverage-specific tools remain owned by the coverage lane.

## Artifacts
- Updated `adl/tools/test_setup_required_coverage_toolchain.sh` to remove fake `sudo`, fake `cargo`, fake `rustc`, fake `sccache`, and fake `ld.lld` fixtures while preserving real-tool success coverage for `verify`, `configure`, env exports, and `stats` when those real tools are present.
- Updated `adl/config/validation_lane_selector.v0.91.6.json` so required-toolchain setup/test scripts map to the existing `ci_path_policy_contracts` lane instead of escalating as unmapped surfaces.
- Updated `adl/tools/run_ci_step_with_log.sh` to capture stdout/stderr through portable FIFOs and `tee`, preserving live output streaming, retained logs, and local finish compatibility without `/dev/fd` process substitution.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type spp --phase final --input .adl/v0.91.7/tasks/issue-4777__repair-adl-ci-required-toolchain-without-fake-fixtures/spp.md`
    Verified the SPP contract after replacing `unknown` design-time estimates.
  - `bash adl/tools/validate_structured_prompt.sh --type vpp --phase final --input .adl/v0.91.7/tasks/issue-4777__repair-adl-ci-required-toolchain-without-fake-fixtures/vpp.md`
    Verified the VPP contract after recording the focused CI-toolchain validation lane.
  - `bash adl/tools/test_setup_required_coverage_toolchain.sh`
    Verified the required-toolchain script contract without fake binary fixtures.
  - `bash adl/tools/test_run_ci_step_with_log.sh`
    Verified stdout/stderr capture, failure exit-code preservation, metadata generation, and secret redaction after removing process substitution.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified the broader CI path-policy contract locally after the logging helper portability fix.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - SPP validation: PASS
  - VPP validation: PASS
  - Required-toolchain focused test: PASS
  - Path-policy full local test: PASS after replacing `/dev/fd` process substitution in `run_ci_step_with_log.sh` with portable FIFO/tee streaming.
  - Diff check: PASS
  - GitHub `adl-ci`: pending after PR publication

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4777__repair-adl-ci-required-toolchain-without-fake-fixtures/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4777__repair-adl-ci-required-toolchain-without-fake-fixtures/sor.md
- Idempotency-Key: v0-91-7-tools-ci-remove-fake-required-toolchain-fixtures-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-test-setup-required-coverage-toolchain-sh-adl-tools-run-ci-step-with-log-sh-adl-v0-91-7-tasks-issue-4777-repair-adl-ci-required-toolchain-without-fake-fixtures-sip-md-adl-v0-91-7-tasks-issue-4777-repair-adl-ci-required-toolchain-without-fake-fixtures-sor-md