### PR TITLE
[v0.91.7][tools][ci] Install coverage tools before path-policy contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,16 @@ jobs:
         with:
           tool: sccache
 
+      - name: Install cargo-llvm-cov for CI contract checks
+        if: steps.path-policy.outputs.ci_contracts_required == 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
+
+      - name: Install cargo-nextest for CI contract checks
+        if: steps.path-policy.outputs.ci_contracts_required == 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: nextest
+
       - name: Install lld
         if: steps.path-policy.outputs.rust_required == 'true'
         run: |
@@ -153,12 +163,6 @@ jobs:
         if: steps.path-policy.outputs.ci_contracts_required == 'true'
         run: bash adl/tools/test_pvf_ci_release_policy.sh
         working-directory: .
-
-      - name: Install cargo-nextest for CI contract checks
-        if: steps.path-policy.outputs.ci_contracts_required == 'true'
-        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
-        with:
-          tool: nextest
 
       - name: tracked proof-validation lane contract
         if: steps.path-policy.outputs.ci_contracts_required == 'true'

--- a/adl/tools/setup_required_coverage_toolchain.sh
+++ b/adl/tools/setup_required_coverage_toolchain.sh
@@ -60,7 +60,13 @@ configure() {
     echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld"
     echo "RUST_LINK_ACCEL=lld"
   } >> "$github_env"
-  sccache --start-server
+  if ! sccache --start-server 2>/tmp/adl-sccache-start.err; then
+    if ! sccache --show-stats >/dev/null 2>&1; then
+      cat /tmp/adl-sccache-start.err >&2
+      exit 1
+    fi
+  fi
+  rm -f /tmp/adl-sccache-start.err
   sccache --zero-stats
 }
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -34,6 +34,20 @@ assert_file_not_has() {
   fi
 }
 
+assert_file_order() {
+  local file="$1"
+  local first="$2"
+  local second="$3"
+  local first_line
+  local second_line
+  first_line="$(grep -Fn -- "$first" "$file" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(grep -Fn -- "$second" "$file" | head -n 1 | cut -d: -f1 || true)"
+  if [ -z "$first_line" ] || [ -z "$second_line" ] || [ "$first_line" -ge "$second_line" ]; then
+    echo "expected $file to contain '$first' before '$second'" >&2
+    exit 1
+  fi
+}
+
 assert_current_coverage_workflow_contract() {
   local workflow="$ROOT_DIR/.github/workflows/ci.yaml"
   assert_file_has "$workflow" 'Determine PR fast coverage filters'
@@ -47,6 +61,8 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh install-lld'
   assert_file_has "$workflow" 'bash tools/setup_required_coverage_toolchain.sh configure "$GITHUB_ENV"'
   assert_file_has "$workflow" 'run: bash tools/setup_required_coverage_toolchain.sh verify'
+  assert_file_order "$workflow" 'Install cargo-llvm-cov for CI contract checks' 'path-policy PR-fast coverage contract'
+  assert_file_order "$workflow" 'Install cargo-nextest for CI contract checks' 'path-policy PR-fast coverage contract'
   assert_file_has "$workflow" 'Coverage not required by path policy'
   assert_file_has "$workflow" "if: steps.path-policy.outputs.coverage_required != 'true'"
   assert_file_has "$workflow" 'run: bash tools/run_ci_step_with_log.sh --name "coverage-run-summary-json" --log-root ci-step-logs -- bash tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" --event-name "${{ github.event_name }}"'


### PR DESCRIPTION
Closes #4790

## Summary

Fixes the shared `adl-ci` sequencing bug exposed by PR #4764: the path-policy contract ran before `cargo-llvm-cov` and `cargo-nextest` were installed, so feature PRs could fail CI despite not touching CI.

## Changes

- Installs `cargo-llvm-cov` and `cargo-nextest` before `path-policy PR-fast coverage contract` in `adl-ci`.
- Removes the later duplicate `cargo-nextest` install from the same job.
- Adds an order assertion to `test_ci_path_policy.sh` so this does not regress.

## Validation

- `bash adl/tools/test_ci_path_policy.sh`
- `bash adl/tools/test_setup_required_coverage_toolchain.sh`
- `bash adl/tools/test_ci_runtime_contracts.sh`
- `git diff --check`

## Non-goals

- Does not change rustls/Octocrab behavior from #4764.
- Does not skip coverage or fake tools.
- Does not rewrite the workflow beyond required installation ordering.
