### PR TITLE
[v0.91.7][chronosense][trace] Integrate temporal anchors into runtime events

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -14,6 +14,7 @@ pub const INSTINCT_MODEL_SCHEMA: &str = "instinct_model.v1";
 pub const INSTINCT_RUNTIME_SURFACE_SCHEMA: &str = "instinct_runtime_surface.v1";
 pub const CHRONOSENSE_RUNTIME_SERVICE_SCHEMA: &str = "chronosense_runtime_service.v1";
 pub const CHRONOSENSE_CLOCK_STACK_SCHEMA: &str = "chronosense_clock_stack.v1";
+pub const CHRONOSENSE_EVENT_ANCHOR_SCHEMA: &str = "chronosense_event_anchor.v1";
 
 mod causality;
 mod commitments;

--- a/adl/src/cli/run_artifacts/runtime/trace_envelope.rs
+++ b/adl/src/cli/run_artifacts/runtime/trace_envelope.rs
@@ -1,12 +1,14 @@
 use super::super::*;
 use ::adl::chronosense::{
     ChronosenseClockStack, ChronosenseRuntimeService, ChronosenseRuntimeServiceConfig,
+    CHRONOSENSE_EVENT_ANCHOR_SCHEMA,
 };
 use ::adl::trace_schema_v1::{
     validate_trace_event_envelope_v1, ContractValidationResultV1, TraceActorTypeV1, TraceActorV1,
     TraceChronosenseClockStackV1, TraceContractValidationV1, TraceDecisionContextV1, TraceErrorV1,
     TraceEventEnvelopeV1, TraceEventTypeV1, TraceEventV1, TraceGovernanceEvidenceV1,
-    TraceRedactionDecisionV1, TraceScopeLevelV1, TraceScopeV1, TraceVisibilityViewsV1,
+    TraceRedactionDecisionV1, TraceScopeLevelV1, TraceScopeV1, TraceTemporalAnchorV1,
+    TraceVisibilityViewsV1,
 };
 use serde_json::json;
 
@@ -32,9 +34,11 @@ pub(super) fn build_trace_v1_envelope(
     push_trace_v1_event(
         &mut events,
         &mut next_id,
+        &chronosense,
         TraceEventV1 {
             event_id: String::new(),
             timestamp: chronosense_trace_timestamp(&chronosense, start_ms),
+            temporal_anchor: None,
             event_type: TraceEventTypeV1::RunStart,
             trace_id: trace_id.clone(),
             run_id: resolved.run_id.clone(),
@@ -65,9 +69,11 @@ pub(super) fn build_trace_v1_envelope(
             trace::TraceEvent::LifecyclePhaseEntered { ts_ms, phase, .. } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::LifecyclePhase,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -104,9 +110,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::ExecutionBoundary,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -149,9 +157,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::Proposal,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -201,9 +211,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::ProposalNormalization,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -255,9 +267,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::CapabilityContract,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -307,9 +321,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::PolicyInjection,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -366,9 +382,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::VisibilityPolicy,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -427,9 +445,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::FreedomGateDecision,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -485,9 +505,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::ActionSelection,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -544,9 +566,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::ActionRejection,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -602,9 +626,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::ExecutionResult,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -659,9 +685,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::Refusal,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -717,9 +745,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::RedactionDecision,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -773,9 +803,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::StepStart,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -810,9 +842,11 @@ pub(super) fn build_trace_v1_envelope(
                 push_trace_v1_event(
                     &mut events,
                     &mut next_id,
+                    &chronosense,
                     TraceEventV1 {
                         event_id: String::new(),
                         timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                        temporal_anchor: None,
                         event_type: TraceEventTypeV1::StepEnd,
                         trace_id: trace_id.clone(),
                         run_id: resolved.run_id.clone(),
@@ -841,9 +875,11 @@ pub(super) fn build_trace_v1_envelope(
                     push_trace_v1_event(
                         &mut events,
                         &mut next_id,
+                        &chronosense,
                         TraceEventV1 {
                             event_id: String::new(),
                             timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                            temporal_anchor: None,
                             event_type: TraceEventTypeV1::Error,
                             trace_id: trace_id.clone(),
                             run_id: resolved.run_id.clone(),
@@ -894,9 +930,11 @@ pub(super) fn build_trace_v1_envelope(
                 push_trace_v1_event(
                     &mut events,
                     &mut next_id,
+                    &chronosense,
                     TraceEventV1 {
                         event_id: String::new(),
                         timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                        temporal_anchor: None,
                         event_type: TraceEventTypeV1::ContractValidation,
                         trace_id: trace_id.clone(),
                         run_id: resolved.run_id.clone(),
@@ -935,9 +973,11 @@ pub(super) fn build_trace_v1_envelope(
             trace::TraceEvent::DelegationApproved { ts_ms, step_id, .. } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::Approval,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -976,9 +1016,11 @@ pub(super) fn build_trace_v1_envelope(
             } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::Rejection,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -1010,9 +1052,11 @@ pub(super) fn build_trace_v1_envelope(
             trace::TraceEvent::RunFailed { ts_ms, message, .. } => push_trace_v1_event(
                 &mut events,
                 &mut next_id,
+                &chronosense,
                 TraceEventV1 {
                     event_id: String::new(),
                     timestamp: chronosense_trace_timestamp(&chronosense, *ts_ms),
+                    temporal_anchor: None,
                     event_type: TraceEventTypeV1::Error,
                     trace_id: trace_id.clone(),
                     run_id: resolved.run_id.clone(),
@@ -1055,9 +1099,11 @@ pub(super) fn build_trace_v1_envelope(
     push_trace_v1_event(
         &mut events,
         &mut next_id,
+        &chronosense,
         TraceEventV1 {
             event_id: String::new(),
             timestamp: chronosense_trace_timestamp(&chronosense, end_ms),
+            temporal_anchor: None,
             event_type: TraceEventTypeV1::RunEnd,
             trace_id,
             run_id: resolved.run_id.clone(),
@@ -1141,10 +1187,59 @@ fn trace_clock_stack_from_chronosense(
     })
 }
 
-fn push_trace_v1_event(events: &mut Vec<TraceEventV1>, next_id: &mut u64, mut event: TraceEventV1) {
+fn push_trace_v1_event(
+    events: &mut Vec<TraceEventV1>,
+    next_id: &mut u64,
+    chronosense: &Option<ChronosenseRuntimeService>,
+    mut event: TraceEventV1,
+) {
+    let event_sequence = *next_id;
     event.event_id = format!("trace-v1-{:04}", *next_id);
+    let previous_elapsed_ms = events
+        .last()
+        .and_then(|event| event.temporal_anchor.as_ref())
+        .map(|anchor| anchor.runtime_monotonic_elapsed_ms);
+    event.temporal_anchor = trace_temporal_anchor_from_chronosense(
+        chronosense,
+        &event.timestamp,
+        event_sequence,
+        previous_elapsed_ms,
+    );
     *next_id = next_id.saturating_add(1);
     events.push(event);
+}
+
+fn trace_temporal_anchor_from_chronosense(
+    service: &Option<ChronosenseRuntimeService>,
+    event_timestamp: &str,
+    event_sequence: u64,
+    previous_elapsed_ms: Option<u64>,
+) -> Option<TraceTemporalAnchorV1> {
+    let service = service.as_ref()?;
+    let epoch_ms = chrono::DateTime::parse_from_rfc3339(event_timestamp)
+        .ok()?
+        .timestamp_millis();
+    let epoch_ms = u128::try_from(epoch_ms).ok()?;
+    let stack = service.capture_epoch_millis(epoch_ms).ok()?;
+    let elapsed = u64::try_from(stack.monotonic_elapsed_ms).ok()?;
+    Some(TraceTemporalAnchorV1 {
+        schema_version: CHRONOSENSE_EVENT_ANCHOR_SCHEMA.to_string(),
+        utc_timestamp_rfc3339: stack.utc_timestamp_rfc3339,
+        local_timestamp_rfc3339: stack.local_timestamp_rfc3339,
+        timezone: stack.timezone,
+        utc_offset: stack.utc_offset,
+        runtime_lifetime_elapsed_ms: u64::try_from(stack.lifetime_elapsed_ms).ok()?,
+        runtime_monotonic_elapsed_ms: elapsed,
+        event_sequence,
+        prior_event_delta_ms: previous_elapsed_ms
+            .map(|previous| elapsed.saturating_sub(previous))
+            .unwrap_or(0),
+        reference_frames: {
+            let mut frames = stack.reference_frames;
+            frames.push("event_sequence".to_string());
+            frames
+        },
+    })
 }
 
 fn artifact_ref(run_id: &str, relative_path: &str) -> String {

--- a/adl/src/cli/tests/run_state/persistence.rs
+++ b/adl/src/cli/tests/run_state/persistence.rs
@@ -116,6 +116,41 @@ fn write_run_state_and_load_resume_round_trip() {
     assert!(clock_stack
         .reference_frames
         .contains(&"runtime_monotonic_elapsed".to_string()));
+    assert!(
+        trace_v1
+            .events
+            .iter()
+            .all(|event| event.temporal_anchor.is_some()),
+        "runtime trace events must carry chronosense temporal anchors"
+    );
+    let run_start_anchor = trace_v1
+        .events
+        .iter()
+        .find(|event| event.event_type == TraceEventTypeV1::RunStart)
+        .and_then(|event| event.temporal_anchor.as_ref())
+        .expect("run start anchor");
+    assert_eq!(
+        run_start_anchor.schema_version,
+        "chronosense_event_anchor.v1"
+    );
+    assert_eq!(run_start_anchor.runtime_lifetime_elapsed_ms, 0);
+    assert_eq!(run_start_anchor.prior_event_delta_ms, 0);
+    assert_eq!(run_start_anchor.event_sequence, 1);
+    assert!(run_start_anchor
+        .reference_frames
+        .contains(&"event_sequence".to_string()));
+    for (index, event) in trace_v1.events.iter().enumerate() {
+        let anchor = event.temporal_anchor.as_ref().expect("event anchor");
+        assert_eq!(anchor.utc_timestamp_rfc3339, event.timestamp);
+        assert_eq!(anchor.event_sequence, u64::try_from(index + 1).unwrap());
+    }
+    let run_end_anchor = trace_v1
+        .events
+        .iter()
+        .find(|event| event.event_type == TraceEventTypeV1::RunEnd)
+        .and_then(|event| event.temporal_anchor.as_ref())
+        .expect("run end anchor");
+    assert_eq!(run_end_anchor.runtime_lifetime_elapsed_ms, 50);
     let event_types: Vec<TraceEventTypeV1> = trace_v1
         .events
         .iter()

--- a/adl/src/remote_exec.rs
+++ b/adl/src/remote_exec.rs
@@ -340,6 +340,7 @@ mod tests {
         let event = TraceEventV1 {
             event_id: "event-1".to_string(),
             timestamp: "2026-06-20T00:00:00.000Z".to_string(),
+            temporal_anchor: None,
             event_type: TraceEventTypeV1::Error,
             trace_id: "trace-1".to_string(),
             run_id: "run-1".to_string(),

--- a/adl/src/trace_schema_v1.rs
+++ b/adl/src/trace_schema_v1.rs
@@ -3,7 +3,10 @@ use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::model_identity::{validate_model_identity_v1, ModelIdentityV1};
+use crate::{
+    chronosense::CHRONOSENSE_EVENT_ANCHOR_SCHEMA,
+    model_identity::{validate_model_identity_v1, ModelIdentityV1},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -155,6 +158,8 @@ pub struct TraceRedactionDecisionV1 {
 pub struct TraceEventV1 {
     pub event_id: String,
     pub timestamp: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temporal_anchor: Option<TraceTemporalAnchorV1>,
     pub event_type: TraceEventTypeV1,
     pub trace_id: String,
     pub run_id: String,
@@ -171,6 +176,20 @@ pub struct TraceEventV1 {
     pub contract_validation: Option<TraceContractValidationV1>,
     pub governance: Option<TraceGovernanceEvidenceV1>,
     pub redaction: Option<TraceRedactionDecisionV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+pub struct TraceTemporalAnchorV1 {
+    pub schema_version: String,
+    pub utc_timestamp_rfc3339: String,
+    pub local_timestamp_rfc3339: String,
+    pub timezone: String,
+    pub utc_offset: String,
+    pub runtime_lifetime_elapsed_ms: u64,
+    pub runtime_monotonic_elapsed_ms: u64,
+    pub event_sequence: u64,
+    pub prior_event_delta_ms: u64,
+    pub reference_frames: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -247,8 +266,15 @@ pub fn validate_trace_event_envelope_v1(envelope: &TraceEventEnvelopeV1) -> Resu
             "governed trace events require schema_version=trace.v2"
         ));
     }
+    let has_temporal_anchor = envelope
+        .events
+        .iter()
+        .any(|event| event.temporal_anchor.is_some());
     if let Some(clock_stack) = envelope.chronosense_clock_stack.as_ref() {
         validate_trace_chronosense_clock_stack_v1(clock_stack)?;
+        validate_trace_event_temporal_anchors_v1(&envelope.events, true)?;
+    } else if has_temporal_anchor {
+        validate_trace_event_temporal_anchors_v1(&envelope.events, false)?;
     }
     Ok(())
 }
@@ -293,6 +319,103 @@ fn validate_trace_chronosense_clock_stack_v1(
         {
             return Err(anyhow!(
                 "chronosense_clock_stack.reference_frames missing required frame '{required}'"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_trace_event_temporal_anchors_v1(
+    events: &[TraceEventV1],
+    require_all_events: bool,
+) -> Result<()> {
+    let mut previous_elapsed_ms: Option<u64> = None;
+    for (index, event) in events.iter().enumerate() {
+        let Some(anchor) = event.temporal_anchor.as_ref() else {
+            if require_all_events {
+                return Err(anyhow!(
+                    "trace event '{}' requires temporal_anchor when chronosense_clock_stack is present",
+                    event.event_id
+                ));
+            }
+            continue;
+        };
+        validate_trace_temporal_anchor_v1(&event.timestamp, anchor)?;
+        let expected_sequence = u64::try_from(index + 1).context("trace event index overflow")?;
+        if anchor.event_sequence != expected_sequence {
+            return Err(anyhow!(
+                "trace event '{}' temporal_anchor.event_sequence must be {}, found {}",
+                event.event_id,
+                expected_sequence,
+                anchor.event_sequence
+            ));
+        }
+        let expected_delta = previous_elapsed_ms
+            .map(|previous| anchor.runtime_monotonic_elapsed_ms.saturating_sub(previous))
+            .unwrap_or(0);
+        if anchor.prior_event_delta_ms != expected_delta {
+            return Err(anyhow!(
+                "trace event '{}' temporal_anchor.prior_event_delta_ms must be {}, found {}",
+                event.event_id,
+                expected_delta,
+                anchor.prior_event_delta_ms
+            ));
+        }
+        previous_elapsed_ms = Some(anchor.runtime_monotonic_elapsed_ms);
+    }
+    Ok(())
+}
+
+fn validate_trace_temporal_anchor_v1(
+    event_timestamp: &str,
+    anchor: &TraceTemporalAnchorV1,
+) -> Result<()> {
+    if anchor.schema_version != CHRONOSENSE_EVENT_ANCHOR_SCHEMA {
+        return Err(anyhow!(
+            "temporal_anchor schema_version must be {}, found '{}'",
+            CHRONOSENSE_EVENT_ANCHOR_SCHEMA,
+            anchor.schema_version
+        ));
+    }
+    require_non_empty(
+        "temporal_anchor.utc_timestamp_rfc3339",
+        &anchor.utc_timestamp_rfc3339,
+    )?;
+    require_non_empty(
+        "temporal_anchor.local_timestamp_rfc3339",
+        &anchor.local_timestamp_rfc3339,
+    )?;
+    require_non_empty("temporal_anchor.timezone", &anchor.timezone)?;
+    require_non_empty("temporal_anchor.utc_offset", &anchor.utc_offset)?;
+    if anchor.utc_timestamp_rfc3339 != event_timestamp {
+        return Err(anyhow!(
+            "temporal_anchor.utc_timestamp_rfc3339 must match event timestamp"
+        ));
+    }
+    if anchor.runtime_lifetime_elapsed_ms != anchor.runtime_monotonic_elapsed_ms {
+        return Err(anyhow!(
+            "temporal_anchor.runtime_lifetime_elapsed_ms must match runtime_monotonic_elapsed_ms"
+        ));
+    }
+    if anchor.reference_frames.is_empty() {
+        return Err(anyhow!(
+            "temporal_anchor.reference_frames must not be empty"
+        ));
+    }
+    for required in [
+        "utc_epoch_millis",
+        "local_civil_time",
+        "runtime_lifetime",
+        "runtime_monotonic_elapsed",
+        "event_sequence",
+    ] {
+        if !anchor
+            .reference_frames
+            .iter()
+            .any(|frame| frame == required)
+        {
+            return Err(anyhow!(
+                "temporal_anchor.reference_frames missing required frame '{required}'"
             ));
         }
     }
@@ -661,6 +784,7 @@ mod tests {
         TraceEventV1 {
             event_id: format!("event-{event_type:?}"),
             timestamp: "2026-04-03T12:00:00Z".to_string(),
+            temporal_anchor: None,
             event_type,
             trace_id: "trace-1".to_string(),
             run_id: "run-1".to_string(),
@@ -702,6 +826,46 @@ mod tests {
                 "runtime_monotonic_elapsed".to_string(),
             ],
         }
+    }
+
+    fn sample_temporal_anchor(
+        event_sequence: u64,
+        runtime_elapsed_ms: u64,
+        prior_event_delta_ms: u64,
+    ) -> TraceTemporalAnchorV1 {
+        TraceTemporalAnchorV1 {
+            schema_version: CHRONOSENSE_EVENT_ANCHOR_SCHEMA.to_string(),
+            utc_timestamp_rfc3339: "2026-04-03T12:00:00Z".to_string(),
+            local_timestamp_rfc3339: "2026-04-03T12:00:00Z".to_string(),
+            timezone: "UTC".to_string(),
+            utc_offset: "+00:00".to_string(),
+            runtime_lifetime_elapsed_ms: runtime_elapsed_ms,
+            runtime_monotonic_elapsed_ms: runtime_elapsed_ms,
+            event_sequence,
+            prior_event_delta_ms,
+            reference_frames: vec![
+                "utc_epoch_millis".to_string(),
+                "local_civil_time".to_string(),
+                "runtime_lifetime".to_string(),
+                "runtime_monotonic_elapsed".to_string(),
+                "event_sequence".to_string(),
+            ],
+        }
+    }
+
+    fn anchored_sample_event(
+        event_type: TraceEventTypeV1,
+        event_sequence: u64,
+        runtime_elapsed_ms: u64,
+        prior_event_delta_ms: u64,
+    ) -> TraceEventV1 {
+        let mut event = sample_event(event_type);
+        event.temporal_anchor = Some(sample_temporal_anchor(
+            event_sequence,
+            runtime_elapsed_ms,
+            prior_event_delta_ms,
+        ));
+        event
     }
 
     #[test]
@@ -761,12 +925,93 @@ mod tests {
             schema_version: "trace.v1".to_string(),
             chronosense_clock_stack: Some(sample_clock_stack()),
             events: vec![
-                sample_event(TraceEventTypeV1::RunStart),
-                sample_event(TraceEventTypeV1::RunEnd),
+                anchored_sample_event(TraceEventTypeV1::RunStart, 1, 0, 0),
+                anchored_sample_event(TraceEventTypeV1::RunEnd, 2, 1_000, 1_000),
             ],
         };
 
         validate_trace_event_envelope_v1(&envelope).expect("clock stack should validate");
+    }
+
+    #[test]
+    fn validate_trace_event_envelope_v1_rejects_clock_stack_without_event_anchor() {
+        let envelope = TraceEventEnvelopeV1 {
+            schema_version: "trace.v1".to_string(),
+            chronosense_clock_stack: Some(sample_clock_stack()),
+            events: vec![
+                anchored_sample_event(TraceEventTypeV1::RunStart, 1, 0, 0),
+                sample_event(TraceEventTypeV1::RunEnd),
+            ],
+        };
+
+        let err = validate_trace_event_envelope_v1(&envelope)
+            .expect_err("clock stack requires event anchors");
+        assert!(err.to_string().contains("requires temporal_anchor"));
+    }
+
+    #[test]
+    fn validate_trace_event_envelope_v1_rejects_mismatched_event_anchor_timestamp() {
+        let mut event = anchored_sample_event(TraceEventTypeV1::RunStart, 1, 0, 0);
+        event
+            .temporal_anchor
+            .as_mut()
+            .expect("anchor")
+            .utc_timestamp_rfc3339 = "2026-04-03T12:00:01Z".to_string();
+        let envelope = TraceEventEnvelopeV1 {
+            schema_version: "trace.v1".to_string(),
+            chronosense_clock_stack: Some(sample_clock_stack()),
+            events: vec![
+                event,
+                anchored_sample_event(TraceEventTypeV1::RunEnd, 2, 1_000, 1_000),
+            ],
+        };
+
+        let err = validate_trace_event_envelope_v1(&envelope)
+            .expect_err("anchor timestamp must match event timestamp");
+        assert!(err.to_string().contains("must match event timestamp"));
+    }
+
+    #[test]
+    fn validate_trace_event_envelope_v1_rejects_bad_anchor_without_clock_stack() {
+        let mut event = anchored_sample_event(TraceEventTypeV1::RunStart, 1, 0, 0);
+        event
+            .temporal_anchor
+            .as_mut()
+            .expect("anchor")
+            .utc_timestamp_rfc3339 = "2026-04-03T12:00:01Z".to_string();
+        let envelope = TraceEventEnvelopeV1 {
+            schema_version: "trace.v1".to_string(),
+            chronosense_clock_stack: None,
+            events: vec![event, sample_event(TraceEventTypeV1::RunEnd)],
+        };
+
+        let err = validate_trace_event_envelope_v1(&envelope)
+            .expect_err("malformed event anchor should fail even without clock stack");
+        assert!(err.to_string().contains("must match event timestamp"));
+    }
+
+    #[test]
+    fn validate_trace_event_envelope_v1_rejects_lifetime_and_monotonic_anchor_drift() {
+        let mut event = anchored_sample_event(TraceEventTypeV1::RunStart, 1, 0, 0);
+        event
+            .temporal_anchor
+            .as_mut()
+            .expect("anchor")
+            .runtime_lifetime_elapsed_ms = 10;
+        let envelope = TraceEventEnvelopeV1 {
+            schema_version: "trace.v1".to_string(),
+            chronosense_clock_stack: Some(sample_clock_stack()),
+            events: vec![
+                event,
+                anchored_sample_event(TraceEventTypeV1::RunEnd, 2, 1_000, 1_000),
+            ],
+        };
+
+        let err =
+            validate_trace_event_envelope_v1(&envelope).expect_err("lifetime drift must fail");
+        assert!(err
+            .to_string()
+            .contains("runtime_lifetime_elapsed_ms must match"));
     }
 
     #[test]
@@ -792,6 +1037,24 @@ mod tests {
                 {
                     "event_id": "run-start-1",
                     "timestamp": "2026-04-03T12:00:00Z",
+                    "temporal_anchor": {
+                        "schema_version": "chronosense_event_anchor.v1",
+                        "utc_timestamp_rfc3339": "2026-04-03T12:00:00Z",
+                        "local_timestamp_rfc3339": "2026-04-03T12:00:00Z",
+                        "timezone": "UTC",
+                        "utc_offset": "+00:00",
+                        "runtime_lifetime_elapsed_ms": 0,
+                        "runtime_monotonic_elapsed_ms": 0,
+                        "event_sequence": 1,
+                        "prior_event_delta_ms": 0,
+                        "reference_frames": [
+                            "utc_epoch_millis",
+                            "local_civil_time",
+                            "runtime_lifetime",
+                            "runtime_monotonic_elapsed",
+                            "event_sequence"
+                        ]
+                    },
                     "event_type": "RUN_START",
                     "trace_id": "trace-1",
                     "run_id": "run-1",
@@ -812,6 +1075,24 @@ mod tests {
                 {
                     "event_id": "run-end-1",
                     "timestamp": "2026-04-03T12:00:01Z",
+                    "temporal_anchor": {
+                        "schema_version": "chronosense_event_anchor.v1",
+                        "utc_timestamp_rfc3339": "2026-04-03T12:00:01Z",
+                        "local_timestamp_rfc3339": "2026-04-03T12:00:01Z",
+                        "timezone": "UTC",
+                        "utc_offset": "+00:00",
+                        "runtime_lifetime_elapsed_ms": 1000,
+                        "runtime_monotonic_elapsed_ms": 1000,
+                        "event_sequence": 2,
+                        "prior_event_delta_ms": 1000,
+                        "reference_frames": [
+                            "utc_epoch_millis",
+                            "local_civil_time",
+                            "runtime_lifetime",
+                            "runtime_monotonic_elapsed",
+                            "event_sequence"
+                        ]
+                    },
                     "event_type": "RUN_END",
                     "trace_id": "trace-1",
                     "run_id": "run-1",


### PR DESCRIPTION
Closes #4767

## Summary
Implemented Chronosense event-level temporal anchors in runtime trace events. Runtime trace envelopes now populate per-event anchors from the Chronosense runtime service, validate anchors when a clock stack is present, validate malformed anchors even during partial rollout without a top-level clock stack, and prove the integrated persisted `trace_v1.json` path carries anchors for every emitted event.

## Artifacts
- Updated trace schema and validator in `adl/src/trace_schema_v1.rs`
- Updated Chronosense schema constant in `adl/src/chronosense.rs`
- Updated runtime trace emission in `adl/src/cli/run_artifacts/runtime/trace_envelope.rs`
- Updated integrated run-state persistence proof in `adl/src/cli/tests/run_state/persistence.rs`
- Updated compatibility constructor in `adl/src/remote_exec.rs`
- Local ignored SRP/SOR lifecycle records updated under `.adl/v0.91.7/tasks/issue-4767__v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events/`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target REPO_ROOT/adl/target --dest-target REPO_ROOT/.worktrees/adl-wp-4767/adl/target --manifest-path REPO_ROOT/.worktrees/adl-wp-4767/adl/Cargo.toml` - warm the issue worktree Rust dependency cache before focused validation
  - `cargo test --manifest-path adl/Cargo.toml --lib trace_schema_v1::tests:: -- --nocapture` - prove trace schema validation accepts valid Chronosense anchors and rejects missing, malformed, timestamp-drifted, and lifetime/monotonic-drifted anchors
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files TMPDIR/adl-4767-changed-files.txt` - run focused PR-fast nextest lane for chronosense, run_state, remote_exec, and trace_schema_v1 surfaces
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - verify Rust formatting for touched files
  - `git diff --check` - verify whitespace hygiene
- Results:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target REPO_ROOT/adl/target --dest-target REPO_ROOT/.worktrees/adl-wp-4767/adl/target --manifest-path REPO_ROOT/.worktrees/adl-wp-4767/adl/Cargo.toml`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --lib trace_schema_v1::tests:: -- --nocapture`: PASS
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files TMPDIR/adl-4767-changed-files.txt`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4767__v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4767__v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events/sor.md
- Idempotency-Key: v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events-adl-src-chronosense-rs-adl-src-cli-run-artifacts-runtime-trace-envelope-rs-adl-src-cli-tests-run-state-persistence-rs-adl-src-remote-exec-rs-adl-src-trace-schema-v1-rs-adl-v0-91-7-tasks-issue-4767-v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events-sip-md-adl-v0-91-7-tasks-issue-4767-v0-91-7-chronosense-trace-integrate-temporal-anchors-into-runtime-events-sor-md