### PR TITLE
[v0.91.7][chronosense][memory] Implement temporal query index for ObsMem and Memory Palace

### DIFF
--- a/adl/src/chronosense/retrieval.rs
+++ b/adl/src/chronosense/retrieval.rs
@@ -42,7 +42,11 @@ impl TemporalQueryRetrievalContract {
                 "adl::chronosense::TemporalQueryRetrievalContract".to_string(),
                 "adl::chronosense::TemporalQueryPrimitiveSet".to_string(),
                 "adl::execute::state::runtime_control::MemoryQueryState".to_string(),
+                "adl::obsmem_contract::MemoryTemporalAnchor".to_string(),
+                "adl::obsmem_contract::MemoryTemporalQuery".to_string(),
                 "adl::obsmem_contract::MemoryQuery".to_string(),
+                "adl::obsmem_adapter::ObsMemAdapter::query_temporal".to_string(),
+                "adl::obsmem_store::FileObsMemClient temporal filtering".to_string(),
                 "adl::obsmem_retrieval_policy::RetrievalPolicyV1".to_string(),
                 "adl identity retrieval".to_string(),
             ],
@@ -102,10 +106,12 @@ impl TemporalQueryRetrievalContract {
                     "lookup by time anchor".to_string(),
                     "lookup by interval".to_string(),
                     "ordering by monotonic sequence".to_string(),
+                    "ordering by effective temporal anchor then event sequence".to_string(),
                     "filtering by continuity-relevant boundaries".to_string(),
                     "neighbor retrieval around focal event".to_string(),
                 ],
                 deterministic_ordering: vec![
+                    "effective_epoch_ms_then_event_sequence_then_id_ascending".to_string(),
                     "workflow_id_then_run_id_ascending".to_string(),
                     "score_desc_id_asc".to_string(),
                     "evidence_adjusted_desc_id_asc".to_string(),
@@ -114,6 +120,11 @@ impl TemporalQueryRetrievalContract {
             },
             proof_fixture_hooks: vec![
                 "obsmem_retrieval_policy::apply_policy_filters_and_orders_deterministically"
+                    .to_string(),
+                "obsmem_store::file_store_temporal_query_filters_and_orders_deterministically"
+                    .to_string(),
+                "obsmem_store::file_store_temporal_query_supports_staleness".to_string(),
+                "obsmem_adapter::adapter_query_temporal_uses_file_store_temporal_index"
                     .to_string(),
                 "obsmem_validation_tests::retrieval_determinism_returns_identical_result_set_and_order"
                     .to_string(),
@@ -125,7 +136,7 @@ impl TemporalQueryRetrievalContract {
                     .to_string(),
             proof_hook_output_path: ".adl/state/temporal_query_retrieval_v1.json".to_string(),
             scope_boundary:
-                "temporal query/retrieval semantics only; full temporal indexing, causality, and distributed temporal truth remain downstream work"
+                "ObsMem / Memory Palace temporal anchors and local temporal index filtering are implemented here; causality, neighbor expansion, and distributed temporal truth remain downstream work"
                     .to_string(),
         }
     }

--- a/adl/src/chronosense/tests.rs
+++ b/adl/src/chronosense/tests.rs
@@ -383,6 +383,15 @@ fn temporal_query_retrieval_contract_matches_runtime_and_retrieval_surfaces() {
         .owned_runtime_surfaces
         .contains(&"adl::obsmem_contract::MemoryQuery".to_string()));
     assert!(contract
+        .owned_runtime_surfaces
+        .contains(&"adl::obsmem_contract::MemoryTemporalAnchor".to_string()));
+    assert!(contract
+        .owned_runtime_surfaces
+        .contains(&"adl::obsmem_contract::MemoryTemporalQuery".to_string()));
+    assert!(contract
+        .owned_runtime_surfaces
+        .contains(&"adl::obsmem_adapter::ObsMemAdapter::query_temporal".to_string()));
+    assert!(contract
         .query_primitives
         .staleness_queries
         .contains(&"stale beyond decision horizon".to_string()));
@@ -393,7 +402,10 @@ fn temporal_query_retrieval_contract_matches_runtime_and_retrieval_surfaces() {
     assert!(contract
         .retrieval_semantics
         .deterministic_ordering
-        .contains(&"score_desc_id_asc".to_string()));
+        .contains(&"effective_epoch_ms_then_event_sequence_then_id_ascending".to_string()));
+    assert!(contract.proof_fixture_hooks.contains(
+        &"obsmem_adapter::adapter_query_temporal_uses_file_store_temporal_index".to_string()
+    ));
     assert!(contract
         .proof_hook_output_path
         .contains("temporal_query_retrieval_v1.json"));

--- a/adl/src/obsmem_adapter.rs
+++ b/adl/src/obsmem_adapter.rs
@@ -5,8 +5,9 @@ use crate::obsmem_indexing::index_run_from_artifacts;
 use crate::obsmem_transition_memory::build_write_request_from_transition_handoff;
 
 use crate::obsmem_contract::{
-    MemoryCitation, MemoryQuery, MemoryQueryResult, MemoryWriteAck, MemoryWriteRequest,
-    ObsMemClient, ObsMemContractError, ObsMemContractErrorCode, OBSMEM_CONTRACT_VERSION,
+    MemoryCitation, MemoryQuery, MemoryQueryResult, MemoryTemporalQuery, MemoryWriteAck,
+    MemoryWriteRequest, ObsMemClient, ObsMemContractError, ObsMemContractErrorCode,
+    OBSMEM_CONTRACT_VERSION,
 };
 use crate::obsmem_retrieval_policy::{
     apply_policy_to_results, RetrievalPolicyV1, RetrievalRequest,
@@ -65,6 +66,7 @@ impl<C: ObsMemClient> ObsMemAdapter<C> {
             workflow_id: workflow_id.map(str::to_string),
             failure_code: failure_code.map(str::to_string),
             tags: tags.to_vec(),
+            temporal: None,
             limit,
         };
         q.normalize();
@@ -80,6 +82,29 @@ impl<C: ObsMemClient> ObsMemAdapter<C> {
         let query = request.to_query(policy)?;
         let result = self.client.query(&query)?;
         apply_policy_to_results(policy, request, result)
+    }
+
+    /// Execute deterministic temporal retrieval over ObsMem / Memory Palace
+    /// records using Chronosense-compatible anchors.
+    pub fn query_temporal(
+        &self,
+        workflow_id: Option<&str>,
+        failure_code: Option<&str>,
+        tags: &[String],
+        temporal: MemoryTemporalQuery,
+        limit: usize,
+    ) -> Result<MemoryQueryResult, ObsMemContractError> {
+        let mut q = MemoryQuery {
+            contract_version: OBSMEM_CONTRACT_VERSION,
+            workflow_id: workflow_id.map(str::to_string),
+            failure_code: failure_code.map(str::to_string),
+            tags: tags.to_vec(),
+            temporal: Some(temporal),
+            limit,
+        };
+        q.normalize();
+        q.validate()?;
+        self.client.query(&q)
     }
 }
 
@@ -134,6 +159,7 @@ pub fn build_write_request_from_run_artifacts(
         tags,
         citations,
         trace_event_refs,
+        temporal_anchor: None,
         review_findings: Vec::new(),
         residual_risks: Vec::new(),
         follow_on_refs: Vec::new(),
@@ -175,7 +201,10 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::obsmem_contract::MemoryRecord;
+    use crate::obsmem_contract::{
+        MemoryRecord, MemoryTemporalAnchor, MemoryTraceRef, OBSMEM_CONTRACT_VERSION,
+    };
+    use crate::obsmem_store::FileObsMemClient;
 
     #[derive(Clone, Default)]
     struct ObsMemInMemory {
@@ -216,6 +245,10 @@ mod tests {
                             .as_ref()
                             .is_none_or(|fc| e.failure_code.as_ref() == Some(fc))
                         && query.tags.iter().all(|t| e.tags.binary_search(t).is_ok())
+                        && query
+                            .temporal
+                            .as_ref()
+                            .is_none_or(|temporal| temporal_matches(temporal, e))
                 })
                 .map(|e| MemoryRecord {
                     id: format!("{}::{}", e.run_id, e.workflow_id),
@@ -226,6 +259,7 @@ mod tests {
                     score: "1.0".to_string(),
                     citations: e.citations.clone(),
                     trace_event_refs: e.trace_event_refs.clone(),
+                    temporal_anchor: e.temporal_anchor.clone(),
                     review_findings: e.review_findings.clone(),
                     residual_risks: e.residual_risks.clone(),
                     follow_on_refs: e.follow_on_refs.clone(),
@@ -235,6 +269,33 @@ mod tests {
             hits.truncate(query.limit);
             Ok(MemoryQueryResult { hits })
         }
+    }
+
+    fn temporal_matches(temporal: &MemoryTemporalQuery, entry: &MemoryWriteRequest) -> bool {
+        let Some(anchor) = &entry.temporal_anchor else {
+            return false;
+        };
+        let effective = anchor.effective_epoch_ms();
+        temporal
+            .after_epoch_ms
+            .is_none_or(|after| effective >= after)
+            && temporal
+                .before_epoch_ms
+                .is_none_or(|before| effective <= before)
+            && temporal
+                .interval_start_epoch_ms
+                .is_none_or(|start| effective >= start)
+            && temporal
+                .interval_end_epoch_ms
+                .is_none_or(|end| effective <= end)
+            && temporal
+                .continuity_id
+                .as_ref()
+                .is_none_or(|id| anchor.continuity_id.as_ref() == Some(id))
+            && match (temporal.stale_at_epoch_ms, temporal.stale_after_ms) {
+                (Some(at), Some(after)) => at.saturating_sub(effective) >= after,
+                _ => true,
+            }
     }
 
     fn write_fixture_run(root: &Path, run_id: &str) {
@@ -271,6 +332,49 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    fn temporal_write_request(
+        run_id: &str,
+        effective_epoch_ms: u128,
+        event_sequence: usize,
+        continuity_id: &str,
+    ) -> MemoryWriteRequest {
+        let mut request = MemoryWriteRequest {
+            contract_version: OBSMEM_CONTRACT_VERSION,
+            run_id: run_id.to_string(),
+            workflow_id: "wf-memory-palace".to_string(),
+            trace_bundle_rel_path: "trace_bundle_v2/manifest.json".to_string(),
+            activation_log_rel_path: format!("runs/{run_id}/logs/activation_log.json"),
+            failure_code: Some("temporal_lookup".to_string()),
+            summary: format!("temporal memory {run_id}"),
+            tags: vec![
+                "status:known".to_string(),
+                "workflow:wf-memory-palace".to_string(),
+            ],
+            citations: vec![MemoryCitation {
+                path: format!("runs/{run_id}/run_summary.json"),
+                hash: "det64:0000000000000042".to_string(),
+            }],
+            trace_event_refs: vec![MemoryTraceRef {
+                event_sequence,
+                event_kind: "memory_observed".to_string(),
+                step_id: Some("memory-palace".to_string()),
+                delegation_id: None,
+            }],
+            temporal_anchor: Some(MemoryTemporalAnchor {
+                t_created_epoch_ms: effective_epoch_ms,
+                t_observed_epoch_ms: Some(effective_epoch_ms),
+                t_effective_epoch_ms: Some(effective_epoch_ms),
+                continuity_id: Some(continuity_id.to_string()),
+                event_sequence: Some(event_sequence),
+            }),
+            review_findings: Vec::new(),
+            residual_risks: Vec::new(),
+            follow_on_refs: Vec::new(),
+        };
+        request.normalize();
+        request
     }
 
     #[test]
@@ -451,6 +555,64 @@ mod tests {
             .expect("query with evidence-adjusted policy");
         let ids: Vec<&str> = result.hits.iter().map(|h| h.run_id.as_str()).collect();
         assert_eq!(ids, vec!["r-success", "r-failed"]);
+    }
+
+    #[test]
+    fn adapter_query_temporal_uses_file_store_temporal_index() {
+        let tmp = unique_temp_dir("temporal-adapter");
+        let store_path = tmp.join("_shared/obsmem_store.v1.json");
+        let writer = FileObsMemClient::new(&store_path);
+        for (run_id, effective_epoch_ms, event_sequence, continuity_id) in [
+            ("run-late", 3_000_u128, 3_usize, "chain-a"),
+            ("run-early", 1_000_u128, 1_usize, "chain-a"),
+            ("run-mid", 2_000_u128, 2_usize, "chain-a"),
+            ("run-other", 1_500_u128, 4_usize, "chain-b"),
+        ] {
+            writer
+                .write_entry(&temporal_write_request(
+                    run_id,
+                    effective_epoch_ms,
+                    event_sequence,
+                    continuity_id,
+                ))
+                .expect("write temporal entry");
+        }
+
+        let adapter = ObsMemAdapter::new(FileObsMemClient::new(&store_path));
+        let temporal = MemoryTemporalQuery {
+            interval_start_epoch_ms: Some(1_500),
+            interval_end_epoch_ms: Some(3_000),
+            continuity_id: Some("chain-a".to_string()),
+            ..Default::default()
+        };
+        let first = adapter
+            .query_temporal(
+                Some("wf-memory-palace"),
+                Some("temporal_lookup"),
+                &["status:known".to_string()],
+                temporal.clone(),
+                10,
+            )
+            .expect("first temporal adapter query");
+        let second = adapter
+            .query_temporal(
+                Some("wf-memory-palace"),
+                Some("temporal_lookup"),
+                &["status:known".to_string()],
+                temporal,
+                10,
+            )
+            .expect("second temporal adapter query");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .hits
+                .iter()
+                .map(|hit| hit.run_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run-mid", "run-late"]
+        );
     }
 
     #[test]

--- a/adl/src/obsmem_contract/mod.rs
+++ b/adl/src/obsmem_contract/mod.rs
@@ -10,6 +10,6 @@ pub use client::ObsMemClient;
 pub use error::{ObsMemContractError, ObsMemContractErrorCode};
 pub use models::{
     MemoryCitation, MemoryFollowOnRef, MemoryQuery, MemoryQueryResult, MemoryRecord,
-    MemoryReviewFinding, MemoryTraceRef, MemoryWriteAck, MemoryWriteRequest,
-    OBSMEM_CONTRACT_VERSION,
+    MemoryReviewFinding, MemoryTemporalAnchor, MemoryTemporalQuery, MemoryTraceRef, MemoryWriteAck,
+    MemoryWriteRequest, OBSMEM_CONTRACT_VERSION,
 };

--- a/adl/src/obsmem_contract/models.rs
+++ b/adl/src/obsmem_contract/models.rs
@@ -46,6 +46,54 @@ pub struct MemoryTraceRef {
     pub delegation_id: Option<String>,
 }
 
+/// Optional Chronosense-compatible temporal anchor for memory records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryTemporalAnchor {
+    pub t_created_epoch_ms: u128,
+    pub t_observed_epoch_ms: Option<u128>,
+    pub t_effective_epoch_ms: Option<u128>,
+    pub continuity_id: Option<String>,
+    pub event_sequence: Option<usize>,
+}
+
+impl MemoryTemporalAnchor {
+    pub fn effective_epoch_ms(&self) -> u128 {
+        self.t_effective_epoch_ms
+            .or(self.t_observed_epoch_ms)
+            .unwrap_or(self.t_created_epoch_ms)
+    }
+
+    pub fn validate(&self) -> Result<(), ObsMemContractError> {
+        if let Some(observed) = self.t_observed_epoch_ms {
+            if observed < self.t_created_epoch_ms {
+                return Err(ObsMemContractError::new(
+                    ObsMemContractErrorCode::InvalidRequest,
+                    "memory temporal anchor observed time must not precede created time",
+                ));
+            }
+        }
+        if let Some(effective) = self.t_effective_epoch_ms {
+            if effective < self.t_created_epoch_ms {
+                return Err(ObsMemContractError::new(
+                    ObsMemContractErrorCode::InvalidRequest,
+                    "memory temporal anchor effective time must not precede created time",
+                ));
+            }
+        }
+        if self
+            .continuity_id
+            .as_ref()
+            .is_some_and(|id| id.trim().is_empty())
+        {
+            return Err(ObsMemContractError::new(
+                ObsMemContractErrorCode::InvalidRequest,
+                "memory temporal anchor continuity_id must be non-empty when present",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Contract payload used to write a normalized run summary into ObsMem.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryWriteRequest {
@@ -59,6 +107,8 @@ pub struct MemoryWriteRequest {
     pub tags: Vec<String>,
     pub citations: Vec<MemoryCitation>,
     pub trace_event_refs: Vec<MemoryTraceRef>,
+    #[serde(default)]
+    pub temporal_anchor: Option<MemoryTemporalAnchor>,
     #[serde(default)]
     pub review_findings: Vec<MemoryReviewFinding>,
     #[serde(default)]
@@ -160,6 +210,9 @@ impl MemoryWriteRequest {
                 ));
             }
         }
+        if let Some(anchor) = &self.temporal_anchor {
+            anchor.validate()?;
+        }
         for finding in &self.review_findings {
             if finding.id.trim().is_empty()
                 || finding.severity.trim().is_empty()
@@ -193,12 +246,13 @@ impl MemoryWriteRequest {
         }
 
         let text = format!(
-            "{}\n{}\n{:?}\n{:?}\n{:?}\n{:?}\n{:?}\n{:?}",
+            "{}\n{}\n{:?}\n{:?}\n{:?}\n{:?}\n{:?}\n{:?}\n{:?}",
             self.summary,
             self.trace_bundle_rel_path,
             self.tags,
             self.citations,
             self.trace_event_refs,
+            self.temporal_anchor,
             self.review_findings,
             self.residual_risks,
             self.follow_on_refs
@@ -228,7 +282,52 @@ pub struct MemoryQuery {
     pub workflow_id: Option<String>,
     pub failure_code: Option<String>,
     pub tags: Vec<String>,
+    #[serde(default)]
+    pub temporal: Option<MemoryTemporalQuery>,
     pub limit: usize,
+}
+
+/// Temporal retrieval filters for ObsMem / Memory Palace query paths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MemoryTemporalQuery {
+    pub after_epoch_ms: Option<u128>,
+    pub before_epoch_ms: Option<u128>,
+    pub interval_start_epoch_ms: Option<u128>,
+    pub interval_end_epoch_ms: Option<u128>,
+    pub stale_at_epoch_ms: Option<u128>,
+    pub stale_after_ms: Option<u128>,
+    pub continuity_id: Option<String>,
+}
+
+impl MemoryTemporalQuery {
+    pub fn validate(&self) -> Result<(), ObsMemContractError> {
+        if let (Some(start), Some(end)) = (self.interval_start_epoch_ms, self.interval_end_epoch_ms)
+        {
+            if start > end {
+                return Err(ObsMemContractError::new(
+                    ObsMemContractErrorCode::InvalidQuery,
+                    "temporal interval start must be <= interval end",
+                ));
+            }
+        }
+        if self.stale_at_epoch_ms.is_some() != self.stale_after_ms.is_some() {
+            return Err(ObsMemContractError::new(
+                ObsMemContractErrorCode::InvalidQuery,
+                "staleness queries require both stale_at_epoch_ms and stale_after_ms",
+            ));
+        }
+        if self
+            .continuity_id
+            .as_ref()
+            .is_some_and(|id| id.trim().is_empty())
+        {
+            return Err(ObsMemContractError::new(
+                ObsMemContractErrorCode::InvalidQuery,
+                "temporal continuity_id must be non-empty when present",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl MemoryQuery {
@@ -261,6 +360,9 @@ impl MemoryQuery {
                 "query limit must be <= 1000",
             ));
         }
+        if let Some(temporal) = &self.temporal {
+            temporal.validate()?;
+        }
         Ok(())
     }
 }
@@ -276,6 +378,8 @@ pub struct MemoryRecord {
     pub score: String,
     pub citations: Vec<MemoryCitation>,
     pub trace_event_refs: Vec<MemoryTraceRef>,
+    #[serde(default)]
+    pub temporal_anchor: Option<MemoryTemporalAnchor>,
     #[serde(default)]
     pub review_findings: Vec<MemoryReviewFinding>,
     #[serde(default)]

--- a/adl/src/obsmem_contract/tests.rs
+++ b/adl/src/obsmem_contract/tests.rs
@@ -66,6 +66,7 @@ impl ObsMemClient for ObsMemInMemory {
                 score: "1.0".to_string(),
                 citations: entry.citations.clone(),
                 trace_event_refs: entry.trace_event_refs.clone(),
+                temporal_anchor: entry.temporal_anchor.clone(),
                 review_findings: entry.review_findings.clone(),
                 residual_risks: entry.residual_risks.clone(),
                 follow_on_refs: entry.follow_on_refs.clone(),
@@ -104,6 +105,7 @@ fn sample_request() -> MemoryWriteRequest {
             step_id: Some("s1".to_string()),
             delegation_id: None,
         }],
+        temporal_anchor: None,
         review_findings: vec![MemoryReviewFinding {
             id: "finding-001".to_string(),
             severity: "P2".to_string(),
@@ -347,6 +349,7 @@ fn models_query_validation_rejects_invalid_bounds_and_version() {
         workflow_id: None,
         failure_code: None,
         tags: vec![],
+        temporal: None,
         limit: 1,
     };
     let err = query.validate().expect_err("version mismatch should fail");
@@ -363,12 +366,50 @@ fn models_query_validation_rejects_invalid_bounds_and_version() {
 }
 
 #[test]
+fn models_query_validation_rejects_invalid_temporal_filters() {
+    let mut query = MemoryQuery {
+        contract_version: OBSMEM_CONTRACT_VERSION,
+        workflow_id: None,
+        failure_code: None,
+        tags: vec![],
+        temporal: Some(crate::obsmem_contract::MemoryTemporalQuery {
+            interval_start_epoch_ms: Some(2_000),
+            interval_end_epoch_ms: Some(1_000),
+            ..Default::default()
+        }),
+        limit: 1,
+    };
+    let err = query.validate().expect_err("inverted interval should fail");
+    assert_eq!(err.code.as_str(), "OBSMEM_INVALID_QUERY");
+
+    query.temporal = Some(crate::obsmem_contract::MemoryTemporalQuery {
+        stale_at_epoch_ms: Some(10_000),
+        stale_after_ms: None,
+        ..Default::default()
+    });
+    let err = query
+        .validate()
+        .expect_err("partial staleness filter should fail");
+    assert_eq!(err.code.as_str(), "OBSMEM_INVALID_QUERY");
+
+    query.temporal = Some(crate::obsmem_contract::MemoryTemporalQuery {
+        continuity_id: Some(" ".to_string()),
+        ..Default::default()
+    });
+    let err = query
+        .validate()
+        .expect_err("blank continuity id should fail");
+    assert_eq!(err.code.as_str(), "OBSMEM_INVALID_QUERY");
+}
+
+#[test]
 fn models_query_normalization_is_deterministic() {
     let mut query = MemoryQuery {
         contract_version: OBSMEM_CONTRACT_VERSION,
         workflow_id: Some("wf-a".to_string()),
         failure_code: None,
         tags: vec!["z".to_string(), "a".to_string(), "a".to_string()],
+        temporal: None,
         limit: 5,
     };
 
@@ -384,6 +425,7 @@ fn models_query_validation_accepts_valid_query() {
         workflow_id: Some("wf-a".to_string()),
         failure_code: Some("TOOL_FAILURE".to_string()),
         tags: vec!["tool".to_string()],
+        temporal: None,
         limit: 2,
     };
 
@@ -420,6 +462,7 @@ fn models_in_memory_client_round_trip_is_deterministic() {
         workflow_id: Some("wf-a".to_string()),
         failure_code: Some("TOOL_FAILURE".to_string()),
         tags: vec!["tool".to_string(), "failure".to_string()],
+        temporal: None,
         limit: 5,
     };
 
@@ -451,6 +494,7 @@ fn models_in_memory_client_filters_and_truncates_results() {
         workflow_id: Some("wf-a".to_string()),
         failure_code: Some("TOOL_FAILURE".to_string()),
         tags: vec!["tool".to_string()],
+        temporal: None,
         limit: 5,
     };
     let failure_hits = client.query(&by_failure).expect("failure query");
@@ -464,6 +508,7 @@ fn models_in_memory_client_filters_and_truncates_results() {
         workflow_id: None,
         failure_code: None,
         tags: vec!["tool".to_string()],
+        temporal: None,
         limit: 1,
     };
     let limited_hits = client.query(&tag_filtered).expect("tag query");

--- a/adl/src/obsmem_retrieval_policy.rs
+++ b/adl/src/obsmem_retrieval_policy.rs
@@ -138,6 +138,7 @@ impl RetrievalRequest {
             workflow_id: request.workflow_id,
             failure_code,
             tags: merged_tags,
+            temporal: None,
             limit,
         };
         q.normalize();
@@ -446,6 +447,7 @@ mod tests {
                 step_id: Some("s1".to_string()),
                 delegation_id: None,
             }],
+            temporal_anchor: None,
             review_findings: Vec::new(),
             residual_risks: Vec::new(),
             follow_on_refs: Vec::new(),

--- a/adl/src/obsmem_store.rs
+++ b/adl/src/obsmem_store.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::obsmem_contract::{
-    MemoryQuery, MemoryQueryResult, MemoryRecord, MemoryWriteAck, MemoryWriteRequest, ObsMemClient,
-    ObsMemContractError, ObsMemContractErrorCode,
+    MemoryQuery, MemoryQueryResult, MemoryRecord, MemoryTemporalQuery, MemoryWriteAck,
+    MemoryWriteRequest, ObsMemClient, ObsMemContractError, ObsMemContractErrorCode,
 };
 
 pub const OBSMEM_STORE_SCHEMA_NAME: &str = "obsmem_store.v1";
@@ -148,45 +148,128 @@ impl ObsMemClient for FileObsMemClient {
         normalized_query.validate()?;
 
         let store = self.load_store()?;
-        let mut hits: Vec<MemoryRecord> = store
-            .entries
-            .iter()
-            .filter(|entry| {
-                normalized_query
-                    .workflow_id
-                    .as_ref()
-                    .is_none_or(|wid| &entry.workflow_id == wid)
-                    && normalized_query
-                        .failure_code
-                        .as_ref()
-                        .is_none_or(|fc| entry.failure_code.as_ref() == Some(fc))
-                    && normalized_query
-                        .tags
-                        .iter()
-                        .all(|tag| entry.tags.binary_search(tag).is_ok())
-            })
-            .map(|entry| MemoryRecord {
-                id: format!("{}::{}", entry.run_id, entry.workflow_id),
-                run_id: entry.run_id.clone(),
-                workflow_id: entry.workflow_id.clone(),
-                tags: entry.tags.clone(),
-                payload: entry.summary.clone(),
-                score: "1.00".to_string(),
-                citations: entry.citations.clone(),
-                trace_event_refs: entry.trace_event_refs.clone(),
-                review_findings: entry.review_findings.clone(),
-                residual_risks: entry.residual_risks.clone(),
-                follow_on_refs: entry.follow_on_refs.clone(),
-            })
-            .collect();
-        hits.sort_by(|a, b| {
-            a.id.cmp(&b.id)
-                .then_with(|| a.run_id.cmp(&b.run_id))
-                .then_with(|| a.workflow_id.cmp(&b.workflow_id))
-                .then_with(|| a.payload.cmp(&b.payload))
-        });
+        let mut hits: Vec<MemoryRecord> = if let Some(temporal) = &normalized_query.temporal {
+            temporal_index_for(&store.entries)
+                .into_iter()
+                .filter(|indexed| {
+                    base_query_matches(&normalized_query, indexed.entry)
+                        && temporal_query_matches(temporal, indexed.entry)
+                })
+                .map(|indexed| memory_record_from_entry(indexed.entry))
+                .collect()
+        } else {
+            store
+                .entries
+                .iter()
+                .filter(|entry| base_query_matches(&normalized_query, entry))
+                .map(memory_record_from_entry)
+                .collect()
+        };
+        if normalized_query.temporal.is_none() {
+            hits.sort_by(|a, b| {
+                a.id.cmp(&b.id)
+                    .then_with(|| a.run_id.cmp(&b.run_id))
+                    .then_with(|| a.workflow_id.cmp(&b.workflow_id))
+                    .then_with(|| a.payload.cmp(&b.payload))
+            });
+        }
         hits.truncate(normalized_query.limit);
         Ok(MemoryQueryResult { hits })
+    }
+}
+
+struct TemporalIndexedEntry<'a> {
+    effective_epoch_ms: u128,
+    event_sequence: usize,
+    id: String,
+    entry: &'a MemoryWriteRequest,
+}
+
+fn temporal_index_for(entries: &[MemoryWriteRequest]) -> Vec<TemporalIndexedEntry<'_>> {
+    let mut indexed: Vec<TemporalIndexedEntry<'_>> = entries
+        .iter()
+        .filter_map(|entry| {
+            let anchor = entry.temporal_anchor.as_ref()?;
+            Some(TemporalIndexedEntry {
+                effective_epoch_ms: anchor.effective_epoch_ms(),
+                event_sequence: anchor.event_sequence.unwrap_or(usize::MAX),
+                id: format!("{}::{}", entry.run_id, entry.workflow_id),
+                entry,
+            })
+        })
+        .collect();
+    indexed.sort_by(|a, b| {
+        a.effective_epoch_ms
+            .cmp(&b.effective_epoch_ms)
+            .then_with(|| a.event_sequence.cmp(&b.event_sequence))
+            .then_with(|| a.id.cmp(&b.id))
+            .then_with(|| a.entry.run_id.cmp(&b.entry.run_id))
+            .then_with(|| a.entry.workflow_id.cmp(&b.entry.workflow_id))
+            .then_with(|| a.entry.summary.cmp(&b.entry.summary))
+    });
+    indexed
+}
+
+fn base_query_matches(query: &MemoryQuery, entry: &MemoryWriteRequest) -> bool {
+    query
+        .workflow_id
+        .as_ref()
+        .is_none_or(|wid| &entry.workflow_id == wid)
+        && query
+            .failure_code
+            .as_ref()
+            .is_none_or(|fc| entry.failure_code.as_ref() == Some(fc))
+        && query
+            .tags
+            .iter()
+            .all(|tag| entry.tags.binary_search(tag).is_ok())
+}
+
+fn temporal_query_matches(temporal: &MemoryTemporalQuery, entry: &MemoryWriteRequest) -> bool {
+    let Some(anchor) = &entry.temporal_anchor else {
+        return false;
+    };
+    let effective = anchor.effective_epoch_ms();
+    temporal
+        .after_epoch_ms
+        .is_none_or(|after| effective >= after)
+        && temporal
+            .before_epoch_ms
+            .is_none_or(|before| effective <= before)
+        && temporal
+            .interval_start_epoch_ms
+            .is_none_or(|start| effective >= start)
+        && temporal
+            .interval_end_epoch_ms
+            .is_none_or(|end| effective <= end)
+        && temporal
+            .continuity_id
+            .as_ref()
+            .is_none_or(|id| anchor.continuity_id.as_ref() == Some(id))
+        && temporal_staleness_matches(temporal, effective)
+}
+
+fn temporal_staleness_matches(temporal: &MemoryTemporalQuery, effective: u128) -> bool {
+    match (temporal.stale_at_epoch_ms, temporal.stale_after_ms) {
+        (Some(at), Some(after)) => at.saturating_sub(effective) >= after,
+        _ => true,
+    }
+}
+
+fn memory_record_from_entry(entry: &MemoryWriteRequest) -> MemoryRecord {
+    MemoryRecord {
+        id: format!("{}::{}", entry.run_id, entry.workflow_id),
+        run_id: entry.run_id.clone(),
+        workflow_id: entry.workflow_id.clone(),
+        tags: entry.tags.clone(),
+        payload: entry.summary.clone(),
+        score: "1.00".to_string(),
+        citations: entry.citations.clone(),
+        trace_event_refs: entry.trace_event_refs.clone(),
+        temporal_anchor: entry.temporal_anchor.clone(),
+        review_findings: entry.review_findings.clone(),
+        residual_risks: entry.residual_risks.clone(),
+        follow_on_refs: entry.follow_on_refs.clone(),
     }
 }
 
@@ -232,6 +315,7 @@ mod tests {
                 step_id: Some("s1".to_string()),
                 delegation_id: None,
             }],
+            temporal_anchor: None,
             review_findings: Vec::new(),
             residual_risks: Vec::new(),
             follow_on_refs: Vec::new(),
@@ -263,6 +347,7 @@ mod tests {
                     "status:failed".to_string(),
                     "workflow:wf-shared".to_string(),
                 ],
+                temporal: None,
                 limit: 10,
             })
             .expect("query");
@@ -325,6 +410,7 @@ mod tests {
                     "workflow:wf-shared".to_string(),
                     "topic:memory".to_string(),
                 ],
+                temporal: None,
                 limit: 1,
             })
             .expect("query");
@@ -332,6 +418,147 @@ mod tests {
         assert_eq!(result.hits.len(), 1);
         assert_eq!(result.hits[0].run_id, "run-a");
         assert_eq!(result.hits[0].payload, "alpha");
+    }
+
+    #[test]
+    fn file_store_temporal_query_filters_and_orders_deterministically() {
+        let root = unique_temp_dir("temporal-query");
+        let store_path = root.join("_shared/obsmem_store.v1.json");
+        let client = FileObsMemClient::new(&store_path);
+
+        for (run_id, t, seq, continuity) in [
+            ("run-late", 3000_u128, 3_usize, "chain-a"),
+            ("run-early", 1000_u128, 1_usize, "chain-a"),
+            ("run-mid", 2000_u128, 2_usize, "chain-a"),
+            ("run-other", 1500_u128, 4_usize, "chain-b"),
+        ] {
+            let mut req = request(run_id, run_id);
+            req.temporal_anchor = Some(crate::obsmem_contract::MemoryTemporalAnchor {
+                t_created_epoch_ms: t,
+                t_observed_epoch_ms: Some(t),
+                t_effective_epoch_ms: Some(t),
+                continuity_id: Some(continuity.to_string()),
+                event_sequence: Some(seq),
+            });
+            req.normalize();
+            client.write_entry(&req).expect("write temporal entry");
+        }
+
+        let query = MemoryQuery {
+            contract_version: OBSMEM_CONTRACT_VERSION,
+            workflow_id: Some("wf-shared".to_string()),
+            failure_code: Some("tool_failure".to_string()),
+            tags: vec!["status:failed".to_string()],
+            temporal: Some(crate::obsmem_contract::MemoryTemporalQuery {
+                after_epoch_ms: Some(1000),
+                before_epoch_ms: Some(3000),
+                interval_start_epoch_ms: Some(1500),
+                interval_end_epoch_ms: Some(3000),
+                stale_at_epoch_ms: None,
+                stale_after_ms: None,
+                continuity_id: Some("chain-a".to_string()),
+            }),
+            limit: 10,
+        };
+
+        let first = client.query(&query).expect("first temporal query");
+        let second = client.query(&query).expect("second temporal query");
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .hits
+                .iter()
+                .map(|hit| hit.run_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run-mid", "run-late"]
+        );
+    }
+
+    #[test]
+    fn file_store_plain_query_preserves_existing_order_with_temporal_anchors() {
+        let root = unique_temp_dir("plain-query-temporal-anchors");
+        let store_path = root.join("_shared/obsmem_store.v1.json");
+        let client = FileObsMemClient::new(&store_path);
+
+        for (run_id, t) in [("run-b", 1_000_u128), ("run-a", 3_000_u128)] {
+            let mut req = request(run_id, run_id);
+            req.temporal_anchor = Some(crate::obsmem_contract::MemoryTemporalAnchor {
+                t_created_epoch_ms: t,
+                t_observed_epoch_ms: Some(t),
+                t_effective_epoch_ms: Some(t),
+                continuity_id: Some("chain-a".to_string()),
+                event_sequence: Some(1),
+            });
+            req.normalize();
+            client.write_entry(&req).expect("write anchored entry");
+        }
+
+        let result = client
+            .query(&MemoryQuery {
+                contract_version: OBSMEM_CONTRACT_VERSION,
+                workflow_id: Some("wf-shared".to_string()),
+                failure_code: Some("tool_failure".to_string()),
+                tags: vec!["status:failed".to_string()],
+                temporal: None,
+                limit: 10,
+            })
+            .expect("plain query");
+
+        assert_eq!(
+            result
+                .hits
+                .iter()
+                .map(|hit| hit.run_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run-a", "run-b"]
+        );
+    }
+
+    #[test]
+    fn file_store_temporal_query_supports_staleness() {
+        let root = unique_temp_dir("temporal-stale");
+        let store_path = root.join("_shared/obsmem_store.v1.json");
+        let client = FileObsMemClient::new(&store_path);
+
+        let mut old = request("run-old", "old");
+        old.temporal_anchor = Some(crate::obsmem_contract::MemoryTemporalAnchor {
+            t_created_epoch_ms: 1_000,
+            t_observed_epoch_ms: Some(1_000),
+            t_effective_epoch_ms: Some(1_000),
+            continuity_id: Some("chain-a".to_string()),
+            event_sequence: Some(1),
+        });
+        old.normalize();
+        client.write_entry(&old).expect("write old");
+
+        let mut fresh = request("run-fresh", "fresh");
+        fresh.temporal_anchor = Some(crate::obsmem_contract::MemoryTemporalAnchor {
+            t_created_epoch_ms: 9_500,
+            t_observed_epoch_ms: Some(9_500),
+            t_effective_epoch_ms: Some(9_500),
+            continuity_id: Some("chain-a".to_string()),
+            event_sequence: Some(2),
+        });
+        fresh.normalize();
+        client.write_entry(&fresh).expect("write fresh");
+
+        let result = client
+            .query(&MemoryQuery {
+                contract_version: OBSMEM_CONTRACT_VERSION,
+                workflow_id: Some("wf-shared".to_string()),
+                failure_code: Some("tool_failure".to_string()),
+                tags: vec!["status:failed".to_string()],
+                temporal: Some(crate::obsmem_contract::MemoryTemporalQuery {
+                    stale_at_epoch_ms: Some(10_000),
+                    stale_after_ms: Some(5_000),
+                    ..Default::default()
+                }),
+                limit: 10,
+            })
+            .expect("staleness query");
+
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].run_id, "run-old");
     }
 
     #[test]
@@ -348,6 +575,7 @@ mod tests {
                 workflow_id: None,
                 failure_code: None,
                 tags: Vec::new(),
+                temporal: None,
                 limit: 10,
             })
             .expect_err("malformed store should fail");
@@ -376,6 +604,7 @@ mod tests {
                 workflow_id: None,
                 failure_code: None,
                 tags: Vec::new(),
+                temporal: None,
                 limit: 10,
             })
             .expect_err("schema mismatch should fail");
@@ -415,6 +644,7 @@ mod tests {
                     "status:failed".to_string(),
                     "workflow:wf-shared".to_string(),
                 ],
+                temporal: None,
                 limit: 10,
             })
             .expect("query");

--- a/adl/src/obsmem_transition_memory.rs
+++ b/adl/src/obsmem_transition_memory.rs
@@ -204,6 +204,7 @@ pub fn build_write_request_from_transition_handoff(
             step_id: Some("csdlc_transition_memory".to_string()),
             delegation_id: None,
         }],
+        temporal_anchor: None,
         review_findings: review_synthesis
             .findings
             .into_iter()

--- a/adl/src/runtime_v2/memory_identity_architecture.rs
+++ b/adl/src/runtime_v2/memory_identity_architecture.rs
@@ -539,6 +539,7 @@ fn memory_write_example(
                 hash: "observatory-projection-hash-0001".to_string(),
             },
         ],
+        temporal_anchor: None,
         review_findings: Vec::new(),
         residual_risks: Vec::new(),
         follow_on_refs: Vec::new(),
@@ -571,6 +572,7 @@ fn memory_query_example() -> MemoryQuery {
             "memory-identity".to_string(),
             "continuity".to_string(),
         ],
+        temporal: None,
         limit: 5,
     };
     query.normalize();

--- a/adl/tests/fixtures/runtime_v2/memory_identity/memory_identity_architecture.json
+++ b/adl/tests/fixtures/runtime_v2/memory_identity/memory_identity_architecture.json
@@ -113,6 +113,7 @@
         "delegation_id": null
       }
     ],
+    "temporal_anchor": null,
     "review_findings": [],
     "residual_risks": [],
     "follow_on_refs": []
@@ -126,6 +127,7 @@
       "memory-identity",
       "reviewable-evidence"
     ],
+    "temporal": null,
     "limit": 5
   },
   "fixture_matrix": [

--- a/adl/tests/obsmem_validation_tests.rs
+++ b/adl/tests/obsmem_validation_tests.rs
@@ -102,6 +102,7 @@ fn make_record(id: &str, score: &str, tags: &[&str], workflow_id: &str) -> Memor
             step_id: Some("s1".to_string()),
             delegation_id: None,
         }],
+        temporal_anchor: None,
         review_findings: Vec::new(),
         residual_risks: Vec::new(),
         follow_on_refs: Vec::new(),

--- a/adl/tests/schema_tests.rs
+++ b/adl/tests/schema_tests.rs
@@ -156,11 +156,13 @@ fn committed_schema_matches_generated_language_surface() {
         .and_then(|value| value.as_object())
         .expect("generated schema should expose top-level properties");
 
-    let committed_keys: Vec<&str> = committed_properties.keys().map(String::as_str).collect();
-    let generated_keys: Vec<&str> = generated_properties.keys().map(String::as_str).collect();
+    let mut committed_keys: Vec<&str> = committed_properties.keys().map(String::as_str).collect();
+    committed_keys.sort_unstable();
+    let mut generated_keys: Vec<&str> = generated_properties.keys().map(String::as_str).collect();
+    generated_keys.sort_unstable();
     assert_eq!(
         committed_keys, generated_keys,
-        "committed and generated schema top-level key order drifted"
+        "committed and generated schema top-level keys drifted"
     );
 
     for key in &generated_keys {


### PR DESCRIPTION
Closes #4768

## Summary
Implemented Chronosense-compatible temporal anchors and temporal query filters for ObsMem / Memory Palace retrieval. Memory records can now carry created/observed/effective timestamps, continuity ids, and event sequence anchors; temporal queries support before/after, interval, staleness, and continuity filters; the file-backed ObsMem client builds a deterministic local temporal index for temporal queries while preserving existing non-temporal ordering.

## Artifacts
- Updated ObsMem memory contract models in `adl/src/obsmem_contract/models.rs`
- Updated contract exports and tests in `adl/src/obsmem_contract/mod.rs` and `adl/src/obsmem_contract/tests.rs`
- Updated file-backed ObsMem temporal query/index behavior in `adl/src/obsmem_store.rs`
- Updated adapter temporal query surface and file-backed integration proof in `adl/src/obsmem_adapter.rs`
- Updated runtime-v2 memory identity golden fixture for the new optional ObsMem temporal fields
- Updated integration-test compatibility fixture in `adl/tests/obsmem_validation_tests.rs`
- Repaired `adl/tests/schema_tests.rs` so schema drift proof compares top-level key sets and per-key values without depending on JSON object iteration order
- Updated retrieval-policy and runtime memory examples for the extended query/record shape
- Updated Chronosense retrieval contract and contract test in `adl/src/chronosense/retrieval.rs` and `adl/src/chronosense/tests.rs`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target REPO_ROOT/adl/target --dest-target REPO_ROOT/.worktrees/adl-wp-4768/adl/target --manifest-path REPO_ROOT/.worktrees/adl-wp-4768/adl/Cargo.toml`
    Warmed Rust dependencies for focused validation.
  - `cargo test --manifest-path adl/Cargo.toml --lib obsmem -- --nocapture`
    Verified 67 focused ObsMem tests, including temporal query validation, temporal index filtering/order, adapter file-store integration, and non-temporal ordering preservation.
  - `cargo test --manifest-path adl/Cargo.toml --lib chronosense::tests::temporal_query_retrieval_contract_matches_runtime_and_retrieval_surfaces -- --nocapture`
    Verified the Chronosense retrieval contract is aligned with implemented runtime/retrieval surfaces.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files TMPDIR/adl-4768-changed-files.txt`: FAIL, unrelated finish-profile publication test `finish_validation_profile_accepts_workflow_metrics_backfill_publication_slice`; #4768 temporal ObsMem/Chronosense tests passed before the failure
  - `cargo test --manifest-path adl/Cargo.toml --lib runtime_v2::tests::memory_identity_architecture::runtime_v2_memory_identity_architecture_matches_golden_fixture -- --nocapture`: PASS, 1 test
  - `cargo test --manifest-path adl/Cargo.toml --test schema_tests committed_schema_matches_generated_language_surface -- --nocapture`: PASS, 1 test
- Results:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target REPO_ROOT/adl/target --dest-target REPO_ROOT/.worktrees/adl-wp-4768/adl/target --manifest-path REPO_ROOT/.worktrees/adl-wp-4768/adl/Cargo.toml`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --lib obsmem -- --nocapture`: PASS, 67 tests
  - `cargo test --manifest-path adl/Cargo.toml --lib chronosense::tests::temporal_query_retrieval_contract_matches_runtime_and_retrieval_surfaces -- --nocapture`: PASS, 1 test
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `git diff --check`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4768__v0-91-7-chronosense-memory-implement-temporal-query-index-for-obsmem-and-memory-palace/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4768__v0-91-7-chronosense-memory-implement-temporal-query-index-for-obsmem-and-memory-palace/sor.md
- Idempotency-Key: v0-91-7-chronosense-memory-implement-temporal-query-index-for-obsmem-and-memory-palace-adl-src-chronosense-retrieval-rs-adl-src-chronosense-tests-rs-adl-src-obsmem-adapter-rs-adl-src-obsmem-contract-mod-rs-adl-src-obsmem-contract-models-rs-adl-src-obsmem-contract-tests-rs-adl-src-obsmem-retrieval-policy-rs-adl-src-obsmem-store-rs-adl-src-obsmem-transition-memory-rs-adl-src-runtime-v2-memory-identity-architecture-rs-adl-tests-fixtures-runtime-v2-memory-identity-memory-identity-architecture-json-adl-tests-obsmem-validation-tests-rs-adl-tests-schema-tests-rs-adl-v0-91-7-tasks-issue-4768-v0-91-7-chronosense-memory-implement-temporal-query-index-for-obsmem-and-memory-palace-sip-md-adl-v0-91-7-tasks-issue-4768-v0-91-7-chronosense-memory-implement-temporal-query-index-for-obsmem-and-memory-palace-sor-md