### PR TITLE
[v0.91.7][tools][finish] Repair pr_cmd fast-lane validation-profile failures

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2902,6 +2902,7 @@ fn registered_validation_atom_supported(command: &str) -> bool {
                 | "adl/tools/test_run_pvf_validation_lane.sh"
                 | "adl/tools/test_pvf_ci_release_policy.sh"
                 | "adl/tools/test_ci_path_policy.sh"
+                | "adl/tools/test_ci_runtime_contracts.sh"
                 | "adl/tools/test_select_validation_lanes.sh"
                 | "adl/tools/test_validation_manager.sh"
                 | "adl/tools/test_run_nessus_remote_validation.sh"

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4953,9 +4953,11 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
-                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh" => {
+                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh" => {
                     let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");
                     run_finish_validation_status("bash", &[path_str(&ci_path_policy)?])?;
+                    let ci_runtime_contracts = repo_root.join("adl/tools/test_ci_runtime_contracts.sh");
+                    run_finish_validation_status("bash", &[path_str(&ci_runtime_contracts)?])?;
                     let select_validation_lanes =
                         repo_root.join("adl/tools/test_select_validation_lanes.sh");
                     run_finish_validation_status("bash", &[path_str(&select_validation_lanes)?])?;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3880,7 +3880,7 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
     ));
     assert!(unrelated_plan
         .commands
-        .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string()));
+        .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string()));
     assert!(unrelated_plan
         .commands
         .contains(&"bash adl/tools/test_check_coverage_impact.sh".to_string()));
@@ -5007,7 +5007,7 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
     fs::create_dir_all(repo.join("adl/config")).expect("adl config dir");
     fs::write(
         repo.join("adl/config/validation_lane_selector.v0.91.6.json"),
-        r#"{"schema_version":"adl.validation_lane_selector.v1","lanes":[{"id":"validation_manager_surface","run_command":"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh"}]}"#,
+        r#"{"schema_version":"adl.validation_lane_selector.v1","lanes":[{"id":"validation_manager_surface","run_command":"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh"}]}"#,
     )
     .expect("validation manifest");
     let profile = FinishValidationProfile {
@@ -5016,7 +5016,7 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
         pr_publication_sufficient: true,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "validation_manager_surface".to_string(),
-            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
             reason: "fixture".to_string(),
             matched_paths: vec!["adl/tools/test_run_nessus_remote_validation.sh".to_string()],
             vpp_record: None,
@@ -5092,7 +5092,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     let plan = FinishValidationPlan {
         mode: FinishValidationMode::SmallBinaryFocused,
         commands: vec![
-            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
         ],
     };
     run_finish_validation_rust(&repo, &plan).expect("combined ci-policy selector validation");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -5058,6 +5058,10 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' ci-path-policy >> \"$FOCUSED_LOG\"\n",
     );
     write_executable(
+        &repo.join("adl/tools/test_ci_runtime_contracts.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' ci-runtime-contracts >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
         &repo.join("adl/tools/test_select_validation_lanes.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' select-validation-lanes >> \"$FOCUSED_LOG\"\n",
     );
@@ -5112,6 +5116,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
 
     let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
     assert!(focused_calls.contains("ci-path-policy"));
+    assert!(focused_calls.contains("ci-runtime-contracts"));
     assert!(focused_calls.contains("select-validation-lanes"));
     assert!(focused_calls.contains("validation-manager"));
     assert!(focused_calls.contains("nessus-remote-runner"));


### PR DESCRIPTION
Closes #4796

## Summary
Implemented a focused finish-validator repair for `#4796` so the workflow-metrics backfill validation profile can publish its existing command atom truthfully. The change registers `adl/tools/test_ci_runtime_contracts.sh` as a supported finish validation atom in the repo-native finish validation support path.

This issue does not change CI YAML, coverage policy, runtime behavior, path policy, or release-gate semantics. It is a narrow unblocker for PR `#4797`, whose `adl-ci` failure is caused by the missing registered validation atom.

## Artifacts
- Code change: `adl/src/cli/pr_cmd/finish_support.rs`
- Local output card: `.adl/v0.91.7/tasks/issue-4796__v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures/sor.md`
- No workflow, coverage, or CI configuration files were changed.

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target ../agent-design-language/adl/target --dest-target adl/target --manifest-path adl/Cargo.toml --json`
    Verified warm-cache preparation completed before the focused Rust test.
  - `cargo test --manifest-path adl/Cargo.toml finish_validation_profile_accepts_workflow_metrics_backfill_publication_slice -- --nocapture`
    Verified the finish validation-profile regression that blocked `#4797` now passes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` because the warm-cache command necessarily recorded local source and destination target directories for reproducibility; these paths are local validation evidence only and are not part of tracked public proof.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4796__v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4796__v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures/sor.md
- Idempotency-Key: v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures-adl-src-cli-pr-cmd-finish-support-rs-adl-v0-91-7-tasks-issue-4796-v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures-sip-md-adl-v0-91-7-tasks-issue-4796-v0-91-7-tools-finish-repair-pr-cmd-fast-lane-validation-profile-failures-sor-md