### PR TITLE
[v0.91.7][chronosense] Integrate temporal causality with trace review

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -28,8 +28,9 @@ mod service;
 mod temporal_schema;
 
 pub use causality::{
-    CausalRelationContract, ExplanationFixture, ExplanationSurfaceContract,
-    TemporalCausalityExplanationContract,
+    build_temporal_causality_trace_review, CausalRelationContract, ExplanationFixture,
+    ExplanationSurfaceContract, TemporalCausalityExplanationContract,
+    TemporalCausalityTraceExplanation, TemporalCausalityTraceReviewArtifact,
 };
 pub use commitments::{
     CommitmentDeadlineContract, CommitmentLifecycleContract, CommitmentRecordRequirements,

--- a/adl/src/chronosense/causality.rs
+++ b/adl/src/chronosense/causality.rs
@@ -1,7 +1,11 @@
 //! Chronosense temporal causality contracts.
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 use super::TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA;
+use crate::trace_schema_v1::{
+    validate_trace_event_envelope_v1, TraceEventEnvelopeV1, TraceEventV1,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CausalRelationContract {
@@ -37,6 +41,31 @@ pub struct TemporalCausalityExplanationContract {
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
     pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TemporalCausalityTraceReviewArtifact {
+    pub schema_version: String,
+    pub source_trace_schema_version: String,
+    pub run_id: String,
+    pub explanations: Vec<TemporalCausalityTraceExplanation>,
+    pub sequence_only_count: usize,
+    pub causal_or_dependency_count: usize,
+    pub uncertainty_count: usize,
+    pub review_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TemporalCausalityTraceExplanation {
+    pub source_event_id: String,
+    pub target_event_id: String,
+    pub source_event_sequence: Option<u64>,
+    pub target_event_sequence: Option<u64>,
+    pub relation_type: String,
+    pub confidence: String,
+    pub temporal_delta_ms: Option<u64>,
+    pub evidence_refs: Vec<String>,
+    pub explanation_note: String,
 }
 
 impl TemporalCausalityExplanationContract {
@@ -125,5 +154,200 @@ impl TemporalCausalityExplanationContract {
                 "bounded causal-link and explanation semantics only; full causal inference, planning policy, and global explanation graphs remain downstream work"
                     .to_string(),
         }
+    }
+}
+
+pub fn build_temporal_causality_trace_review(
+    envelope: &TraceEventEnvelopeV1,
+) -> Result<TemporalCausalityTraceReviewArtifact> {
+    validate_trace_event_envelope_v1(envelope)?;
+    let contract = TemporalCausalityExplanationContract::v1();
+    let ordered_events = events_in_temporal_review_order(envelope);
+    if ordered_events.len() < 2 {
+        return Err(anyhow!(
+            "temporal causality review requires at least two trace events"
+        ));
+    }
+    if let Some(event) = ordered_events
+        .iter()
+        .find(|event| event.temporal_anchor.is_none())
+    {
+        return Err(anyhow!(
+            "temporal causality review requires temporal_anchor on event '{}'",
+            event.event_id
+        ));
+    }
+
+    let mut explanations = Vec::new();
+    for window in ordered_events.windows(2) {
+        let source = window[0];
+        let target = window[1];
+        explanations.push(explain_temporal_successor_relation(
+            source, target, &contract,
+        ));
+    }
+    for (target_index, target) in ordered_events.iter().enumerate() {
+        explanations.extend(explain_explicit_evidence_relations(
+            &ordered_events[..target_index],
+            target,
+            &contract,
+        ));
+    }
+
+    let sequence_only_count = explanations
+        .iter()
+        .filter(|explanation| explanation.relation_type == "temporal_succession")
+        .count();
+    let causal_or_dependency_count = explanations
+        .iter()
+        .filter(|explanation| {
+            matches!(
+                explanation.relation_type.as_str(),
+                "declared_dependency" | "causal_contribution"
+            )
+        })
+        .count();
+    let uncertainty_count = explanations
+        .iter()
+        .filter(|explanation| matches!(explanation.confidence.as_str(), "unknown" | "low"))
+        .count();
+
+    Ok(TemporalCausalityTraceReviewArtifact {
+        schema_version: TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA.to_string(),
+        source_trace_schema_version: envelope.schema_version.clone(),
+        run_id: ordered_events[0].run_id.clone(),
+        explanations,
+        sequence_only_count,
+        causal_or_dependency_count,
+        uncertainty_count,
+        review_notes: vec![
+            contract.causal_relations.sequence_boundary_rule,
+            "reviewers must inspect relation_type, confidence, and evidence_refs before treating sequence as causality".to_string(),
+        ],
+    })
+}
+
+fn events_in_temporal_review_order(envelope: &TraceEventEnvelopeV1) -> Vec<&TraceEventV1> {
+    let mut events = envelope.events.iter().collect::<Vec<_>>();
+    events.sort_by(|left, right| {
+        let left_key = left
+            .temporal_anchor
+            .as_ref()
+            .map(|anchor| (anchor.event_sequence, anchor.runtime_monotonic_elapsed_ms))
+            .unwrap_or((0, 0));
+        let right_key = right
+            .temporal_anchor
+            .as_ref()
+            .map(|anchor| (anchor.event_sequence, anchor.runtime_monotonic_elapsed_ms))
+            .unwrap_or((0, 0));
+        left_key
+            .cmp(&right_key)
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
+    events
+}
+
+fn explain_temporal_successor_relation(
+    source: &TraceEventV1,
+    target: &TraceEventV1,
+    contract: &TemporalCausalityExplanationContract,
+) -> TemporalCausalityTraceExplanation {
+    build_trace_explanation(
+        source,
+        target,
+        "temporal_succession",
+        "unknown",
+        Vec::new(),
+        contract.causal_relations.sequence_boundary_rule.clone(),
+    )
+}
+
+fn explain_explicit_evidence_relations(
+    prior_events: &[&TraceEventV1],
+    target: &TraceEventV1,
+    contract: &TemporalCausalityExplanationContract,
+) -> Vec<TemporalCausalityTraceExplanation> {
+    let mut explanations = Vec::new();
+    let target_evidence_refs = target
+        .governance
+        .as_ref()
+        .map(|governance| governance.evidence_refs.clone())
+        .unwrap_or_default();
+
+    for source in prior_events {
+        if target_evidence_refs
+            .iter()
+            .any(|evidence_ref| evidence_ref == &source.event_id)
+        {
+            explanations.push(build_trace_explanation(
+                source,
+                target,
+                "causal_contribution",
+                "medium",
+                target_evidence_refs.clone(),
+                format!(
+                    "target event cites source event as evidence; {}",
+                    contract.causal_relations.dependency_evidence_requirements[3]
+                ),
+            ));
+        }
+        if target
+            .parent_span_id
+            .as_ref()
+            .is_some_and(|parent_span_id| parent_span_id == &source.span_id)
+        {
+            explanations.push(build_trace_explanation(
+                source,
+                target,
+                "declared_dependency",
+                "medium",
+                vec![format!(
+                    "parent_span_id:{}->{}",
+                    source.span_id, target.span_id
+                )],
+                "target event declares the source span as its parent; this is dependency evidence, not global causal proof"
+                    .to_string(),
+            ));
+        }
+    }
+    explanations
+}
+
+fn build_trace_explanation(
+    source: &TraceEventV1,
+    target: &TraceEventV1,
+    relation_type: &str,
+    confidence: &str,
+    evidence_refs: Vec<String>,
+    explanation_note: String,
+) -> TemporalCausalityTraceExplanation {
+    let source_sequence = source
+        .temporal_anchor
+        .as_ref()
+        .map(|anchor| anchor.event_sequence);
+    let target_sequence = target
+        .temporal_anchor
+        .as_ref()
+        .map(|anchor| anchor.event_sequence);
+    let temporal_delta_ms = source
+        .temporal_anchor
+        .as_ref()
+        .zip(target.temporal_anchor.as_ref())
+        .map(|(source_anchor, target_anchor)| {
+            target_anchor
+                .runtime_monotonic_elapsed_ms
+                .saturating_sub(source_anchor.runtime_monotonic_elapsed_ms)
+        });
+
+    TemporalCausalityTraceExplanation {
+        source_event_id: source.event_id.clone(),
+        target_event_id: target.event_id.clone(),
+        source_event_sequence: source_sequence,
+        target_event_sequence: target_sequence,
+        relation_type: relation_type.to_string(),
+        confidence: confidence.to_string(),
+        temporal_delta_ms,
+        evidence_refs,
+        explanation_note,
     }
 }

--- a/adl/src/chronosense/tests.rs
+++ b/adl/src/chronosense/tests.rs
@@ -1,5 +1,10 @@
 //! Test helpers for chronosense fixtures.
 use super::*;
+use crate::trace_schema_v1::{
+    TraceActorTypeV1, TraceActorV1, TraceDecisionContextV1, TraceEventEnvelopeV1, TraceEventTypeV1,
+    TraceEventV1, TraceGovernanceEvidenceV1, TraceScopeLevelV1, TraceScopeV1,
+    TraceTemporalAnchorV1,
+};
 use chrono::{TimeZone, Utc};
 use std::{
     env, fs,
@@ -16,6 +21,103 @@ fn unique_temp_path(label: &str) -> PathBuf {
         "chronosense-{label}-{}-{nanos}",
         std::process::id()
     ))
+}
+
+fn trace_review_envelope(events: Vec<TraceEventV1>) -> TraceEventEnvelopeV1 {
+    TraceEventEnvelopeV1 {
+        schema_version: "trace.v2".to_string(),
+        chronosense_clock_stack: None,
+        events,
+    }
+}
+
+fn trace_review_event(
+    event_id: &str,
+    event_type: TraceEventTypeV1,
+    event_sequence: u64,
+    runtime_elapsed_ms: u64,
+    prior_event_delta_ms: u64,
+) -> TraceEventV1 {
+    let decision_context = if matches!(
+        event_type,
+        TraceEventTypeV1::Decision
+            | TraceEventTypeV1::Approval
+            | TraceEventTypeV1::Rejection
+            | TraceEventTypeV1::Revision
+    ) {
+        Some(TraceDecisionContextV1 {
+            context: format!("chronosense-review:{event_id}"),
+            outcome: format!("{event_type:?}"),
+            rationale: Some("fixture decision context for trace schema validation".to_string()),
+        })
+    } else {
+        None
+    };
+
+    TraceEventV1 {
+        event_id: event_id.to_string(),
+        timestamp: "2026-04-03T12:00:00Z".to_string(),
+        temporal_anchor: Some(TraceTemporalAnchorV1 {
+            schema_version: CHRONOSENSE_EVENT_ANCHOR_SCHEMA.to_string(),
+            utc_timestamp_rfc3339: "2026-04-03T12:00:00Z".to_string(),
+            local_timestamp_rfc3339: "2026-04-03T12:00:00Z".to_string(),
+            timezone: "UTC".to_string(),
+            utc_offset: "+00:00".to_string(),
+            runtime_lifetime_elapsed_ms: runtime_elapsed_ms,
+            runtime_monotonic_elapsed_ms: runtime_elapsed_ms,
+            event_sequence,
+            prior_event_delta_ms,
+            reference_frames: vec![
+                "utc_epoch_millis".to_string(),
+                "local_civil_time".to_string(),
+                "runtime_lifetime".to_string(),
+                "runtime_monotonic_elapsed".to_string(),
+                "event_sequence".to_string(),
+            ],
+        }),
+        event_type,
+        trace_id: "trace-chronosense-review".to_string(),
+        run_id: "run-chronosense-review".to_string(),
+        span_id: format!("span-{event_id}"),
+        parent_span_id: None,
+        actor: TraceActorV1 {
+            r#type: TraceActorTypeV1::Agent,
+            id: "agent.main".to_string(),
+        },
+        scope: TraceScopeV1 {
+            level: TraceScopeLevelV1::Run,
+            name: "chronosense-review".to_string(),
+        },
+        inputs_ref: None,
+        outputs_ref: None,
+        artifact_ref: None,
+        decision_context,
+        provider: None,
+        error: None,
+        contract_validation: None,
+        governance: None,
+        redaction: None,
+    }
+}
+
+fn trace_governance_with_evidence(evidence_ref: &str) -> TraceGovernanceEvidenceV1 {
+    TraceGovernanceEvidenceV1 {
+        proposal_id: Some("proposal-1".to_string()),
+        normalized_proposal_ref: None,
+        acc_contract_id: None,
+        policy_evidence_ref: None,
+        gate_candidate_id: None,
+        gate_boundary: None,
+        gate_reason_code: None,
+        action_id: None,
+        tool_name: None,
+        adapter_id: None,
+        replay_posture: Some("reviewable".to_string()),
+        result_ref: None,
+        redaction_summary: None,
+        evidence_refs: vec![evidence_ref.to_string()],
+        visibility_views: None,
+    }
 }
 
 #[test]
@@ -473,6 +575,170 @@ fn temporal_causality_explanation_contract_has_bounded_proof_hook_and_uncertaint
     assert!(contract
         .proof_hook_output_path
         .contains("temporal_causality_explanation_v1.json"));
+}
+
+#[test]
+fn temporal_causality_trace_review_preserves_sequence_uncertainty() {
+    let envelope = trace_review_envelope(vec![
+        trace_review_event("event-run-start", TraceEventTypeV1::RunStart, 1, 0, 0),
+        trace_review_event("event-a", TraceEventTypeV1::Decision, 2, 10, 10),
+        trace_review_event("event-b", TraceEventTypeV1::Revision, 3, 25, 15),
+        trace_review_event("event-run-end", TraceEventTypeV1::RunEnd, 4, 30, 5),
+    ]);
+
+    let artifact =
+        build_temporal_causality_trace_review(&envelope).expect("causality review artifact");
+
+    assert_eq!(
+        artifact.schema_version,
+        TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA
+    );
+    assert_eq!(artifact.sequence_only_count, 3);
+    assert_eq!(artifact.causal_or_dependency_count, 0);
+    assert_eq!(artifact.uncertainty_count, 3);
+    assert!(artifact
+        .review_notes
+        .contains(&"sequence alone is insufficient evidence for causality".to_string()));
+    assert!(artifact.explanations.iter().all(|explanation| {
+        explanation.relation_type == "temporal_succession"
+            && explanation.confidence == "unknown"
+            && explanation.evidence_refs.is_empty()
+    }));
+}
+
+#[test]
+fn temporal_causality_trace_review_uses_parent_span_and_evidence_refs() {
+    let mut event_a = trace_review_event("event-a", TraceEventTypeV1::Decision, 2, 10, 10);
+    event_a.span_id = "span-a".to_string();
+    let mut event_b = trace_review_event("event-b", TraceEventTypeV1::Revision, 3, 25, 15);
+    event_b.span_id = "span-b".to_string();
+    event_b.parent_span_id = Some("span-a".to_string());
+    let mut event_c = trace_review_event("event-c", TraceEventTypeV1::Approval, 4, 35, 10);
+    event_c.governance = Some(trace_governance_with_evidence("event-b"));
+    let envelope = trace_review_envelope(vec![
+        trace_review_event("event-run-start", TraceEventTypeV1::RunStart, 1, 0, 0),
+        event_a,
+        event_b,
+        event_c,
+        trace_review_event("event-run-end", TraceEventTypeV1::RunEnd, 5, 40, 5),
+    ]);
+
+    let artifact =
+        build_temporal_causality_trace_review(&envelope).expect("causality review artifact");
+
+    assert_eq!(artifact.causal_or_dependency_count, 2);
+    assert!(artifact.uncertainty_count >= 2);
+    let dependency = artifact
+        .explanations
+        .iter()
+        .find(|explanation| {
+            explanation.source_event_id == "event-a"
+                && explanation.target_event_id == "event-b"
+                && explanation.relation_type == "declared_dependency"
+        })
+        .expect("parent span dependency");
+    assert_eq!(dependency.relation_type, "declared_dependency");
+    assert_eq!(dependency.confidence, "medium");
+    assert_eq!(dependency.temporal_delta_ms, Some(15));
+    assert!(dependency
+        .evidence_refs
+        .contains(&"parent_span_id:span-a->span-b".to_string()));
+
+    let contribution = artifact
+        .explanations
+        .iter()
+        .find(|explanation| {
+            explanation.source_event_id == "event-b"
+                && explanation.target_event_id == "event-c"
+                && explanation.relation_type == "causal_contribution"
+        })
+        .expect("evidence ref contribution");
+    assert_eq!(contribution.relation_type, "causal_contribution");
+    assert_eq!(contribution.confidence, "medium");
+    assert_eq!(contribution.evidence_refs, vec!["event-b".to_string()]);
+    assert!(contribution
+        .explanation_note
+        .contains("record bounded confidence or uncertainty"));
+}
+
+#[test]
+fn temporal_causality_trace_review_requires_temporal_anchors() {
+    let mut run_start = trace_review_event("event-run-start", TraceEventTypeV1::RunStart, 1, 0, 0);
+    run_start.temporal_anchor = None;
+    let mut event_a = trace_review_event("event-a", TraceEventTypeV1::Decision, 2, 10, 10);
+    event_a.temporal_anchor = None;
+    let mut run_end = trace_review_event("event-run-end", TraceEventTypeV1::RunEnd, 3, 20, 10);
+    run_end.temporal_anchor = None;
+    let envelope = trace_review_envelope(vec![run_start, event_a, run_end]);
+
+    let err = build_temporal_causality_trace_review(&envelope)
+        .expect_err("unanchored temporal causality review must fail");
+
+    assert!(err
+        .to_string()
+        .contains("temporal causality review requires temporal_anchor"));
+}
+
+#[test]
+fn temporal_causality_trace_review_finds_non_adjacent_evidence_and_parent_span_links() {
+    let mut event_a = trace_review_event("event-a", TraceEventTypeV1::Decision, 2, 10, 10);
+    event_a.span_id = "span-a".to_string();
+    let event_b = trace_review_event("event-b", TraceEventTypeV1::StepStart, 3, 20, 10);
+    let event_c = trace_review_event("event-c", TraceEventTypeV1::StepEnd, 4, 30, 10);
+    let mut event_d = trace_review_event("event-d", TraceEventTypeV1::Revision, 5, 45, 15);
+    event_d.parent_span_id = Some("span-a".to_string());
+    event_d.governance = Some(trace_governance_with_evidence("event-b"));
+
+    let envelope = trace_review_envelope(vec![
+        trace_review_event("event-run-start", TraceEventTypeV1::RunStart, 1, 0, 0),
+        event_a,
+        event_b,
+        event_c,
+        event_d,
+        trace_review_event("event-run-end", TraceEventTypeV1::RunEnd, 6, 50, 5),
+    ]);
+
+    let artifact =
+        build_temporal_causality_trace_review(&envelope).expect("causality review artifact");
+
+    let dependency = artifact
+        .explanations
+        .iter()
+        .find(|explanation| {
+            explanation.source_event_id == "event-a" && explanation.target_event_id == "event-d"
+        })
+        .expect("non-adjacent parent span dependency");
+    assert_eq!(dependency.relation_type, "declared_dependency");
+    assert_eq!(dependency.confidence, "medium");
+    assert_eq!(dependency.temporal_delta_ms, Some(35));
+
+    let contribution = artifact
+        .explanations
+        .iter()
+        .find(|explanation| {
+            explanation.source_event_id == "event-b" && explanation.target_event_id == "event-d"
+        })
+        .expect("non-adjacent evidence ref contribution");
+    assert_eq!(contribution.relation_type, "causal_contribution");
+    assert_eq!(contribution.confidence, "medium");
+    assert_eq!(contribution.temporal_delta_ms, Some(25));
+    assert_eq!(contribution.evidence_refs, vec!["event-b".to_string()]);
+}
+
+#[test]
+fn temporal_causality_trace_review_rejects_single_event_trace() {
+    let envelope = trace_review_envelope(vec![trace_review_event(
+        "event-run-start",
+        TraceEventTypeV1::RunStart,
+        1,
+        0,
+        0,
+    )]);
+
+    let err = build_temporal_causality_trace_review(&envelope).expect_err("invalid trace");
+    assert!(err
+        .to_string()
+        .contains("trace schema v1 requires at least one RUN_END event"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4770

## Summary
Implemented the Chronosense temporal-causality trace review path for issue `#4770`. The change adds a review artifact builder that validates trace envelopes, requires explicit temporal anchors for causality review, separates temporal succession from causal/dependency evidence, and emits reviewable explanation records for bounded evidence references and parent-span dependencies.

The review findings from the first bounded subagent pass were repaired:
- unanchored traces no longer fabricate a temporal order for causality review
- non-adjacent evidence refs and parent-span dependencies are detected across prior events, not only adjacent pairs

## Artifacts
- `adl/src/chronosense/causality.rs`
- `adl/src/chronosense.rs`
- `adl/src/chronosense/tests.rs`
- `.adl/v0.91.7/tasks/issue-4770__v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review/srp.md`
- `.adl/v0.91.7/tasks/issue-4770__v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified Rust formatting for the touched crate.
  - `git diff --check`
    Verified whitespace hygiene for the current diff.
  - `cargo test --manifest-path adl/Cargo.toml chronosense --lib -- --nocapture`
    Verified the focused Chronosense runtime/review test surface.
- Results:
  - PASS; 36 Chronosense-related library tests passed, 0 failed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4770__v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4770__v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review/sor.md
- Idempotency-Key: v0-91-7-chronosense-integrate-temporal-causality-with-trace-review-adl-src-chronosense-causality-rs-adl-src-chronosense-rs-adl-src-chronosense-tests-rs-adl-v0-91-7-tasks-issue-4770-v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review-sip-md-adl-v0-91-7-tasks-issue-4770-v0-91-7-chronosense-causality-integrate-temporal-causality-and-explanation-with-trace-review-sor-md