### PR TITLE
[v0.91.7][chronosense][closeout] Repair Chronosense closeout truth and continuity proof artifact

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -50,10 +50,11 @@ pub use instinct::{
 pub use long_running_proof::{
     build_long_running_context_continuity_proof, validate_long_running_context_continuity_proof,
     write_long_running_context_continuity_proof, ContinuityProofCheck,
-    LongRunningContextContinuityProof, LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_PATH,
-    LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_SCHEMA,
+    LongRunningContextContinuityProof, LongRunningContextContinuityTraceArtifact,
+    LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_PATH, LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_SCHEMA,
     LONG_RUNNING_CONTEXT_CONTINUITY_RUNTIME_STATE_PATH,
     LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_REF,
+    LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA,
 };
 pub use phi::{
     PhiComparisonFixture, PhiComparisonProfile, PhiIntegrationMetricsContract, PhiMetricDimension,

--- a/adl/src/chronosense/long_running_proof.rs
+++ b/adl/src/chronosense/long_running_proof.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     build_temporal_causality_trace_review, ChronosenseRuntimeService,
-    ChronosenseRuntimeServiceConfig, CHRONOSENSE_EVENT_ANCHOR_SCHEMA, COMMITMENT_DEADLINE_SCHEMA,
+    ChronosenseRuntimeServiceConfig, TemporalCausalityTraceReviewArtifact,
+    CHRONOSENSE_EVENT_ANCHOR_SCHEMA, COMMITMENT_DEADLINE_SCHEMA,
 };
 use crate::{
     obsmem_adapter::ObsMemAdapter,
@@ -34,6 +35,8 @@ use crate::{
 
 pub const LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_SCHEMA: &str =
     "chronosense.long_running_context_continuity_proof.v1";
+pub const LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA: &str =
+    "chronosense.long_running_context_continuity_trace_artifact.v1";
 pub const LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_PATH: &str =
     ".adl/state/chronosense/long_running_context_continuity_proof_v1.json";
 pub const LONG_RUNNING_CONTEXT_CONTINUITY_RUNTIME_STATE_PATH: &str =
@@ -78,9 +81,32 @@ pub struct ContinuityProofCheck {
     pub evidence: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LongRunningContextContinuityTraceArtifact {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub continuity_id: String,
+    pub trace: TraceEventEnvelopeV1,
+    pub temporal_causality_review: TemporalCausalityTraceReviewArtifact,
+    pub review_surface: String,
+    pub claim_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LongRunningContextContinuityBuild {
+    proof: LongRunningContextContinuityProof,
+    trace_artifact: LongRunningContextContinuityTraceArtifact,
+}
+
 pub fn build_long_running_context_continuity_proof(
     proof_root: impl AsRef<Path>,
 ) -> Result<LongRunningContextContinuityProof> {
+    Ok(build_long_running_context_continuity_output(proof_root)?.proof)
+}
+
+fn build_long_running_context_continuity_output(
+    proof_root: impl AsRef<Path>,
+) -> Result<LongRunningContextContinuityBuild> {
     let proof_root = proof_root.as_ref();
     let continuity_id = "chronosense-proof-chain-a";
     let started_epoch_ms = 1_800_000_000_000_u128;
@@ -205,20 +231,33 @@ pub fn build_long_running_context_continuity_proof(
                 .to_string(),
     };
     validate_long_running_context_continuity_proof(&proof)?;
-    Ok(proof)
+    let trace_artifact = LongRunningContextContinuityTraceArtifact {
+        schema_version: LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA.to_string(),
+        proof_id: proof.proof_id.clone(),
+        continuity_id: proof.continuity_id.clone(),
+        trace,
+        temporal_causality_review: causality_review,
+        review_surface: proof.review_surface.clone(),
+        claim_boundary: proof.claim_boundary.clone(),
+    };
+    validate_long_running_context_continuity_trace_artifact(&trace_artifact, &proof)?;
+    Ok(LongRunningContextContinuityBuild {
+        proof,
+        trace_artifact,
+    })
 }
 
 pub fn write_long_running_context_continuity_proof(
     proof_root: impl AsRef<Path>,
 ) -> Result<PathBuf> {
     let proof_root = proof_root.as_ref();
-    let proof = build_long_running_context_continuity_proof(proof_root)?;
+    let output = build_long_running_context_continuity_output(proof_root)?;
     let output_path = proof_root.join(LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_PATH);
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create proof directory '{}'", parent.display()))?;
     }
-    let bytes = serde_json::to_vec_pretty(&proof)?;
+    let bytes = serde_json::to_vec_pretty(&output.proof)?;
     std::fs::write(&output_path, bytes)
         .with_context(|| format!("write proof '{}'", output_path.display()))?;
     let artifact_path = proof_root.join(LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_REF);
@@ -226,10 +265,50 @@ pub fn write_long_running_context_continuity_proof(
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create trace artifact directory '{}'", parent.display()))?;
     }
-    let artifact_bytes = serde_json::to_vec_pretty(&proof)?;
+    let artifact_bytes = serde_json::to_vec_pretty(&output.trace_artifact)?;
     std::fs::write(&artifact_path, artifact_bytes)
         .with_context(|| format!("write trace artifact '{}'", artifact_path.display()))?;
     Ok(output_path)
+}
+
+pub fn validate_long_running_context_continuity_trace_artifact(
+    artifact: &LongRunningContextContinuityTraceArtifact,
+    proof: &LongRunningContextContinuityProof,
+) -> Result<()> {
+    if artifact.schema_version != LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA {
+        return Err(anyhow!(
+            "unsupported long-running context continuity trace artifact schema '{}'",
+            artifact.schema_version
+        ));
+    }
+    if artifact.proof_id != proof.proof_id || artifact.continuity_id != proof.continuity_id {
+        return Err(anyhow!(
+            "trace artifact identity does not match continuity proof"
+        ));
+    }
+    validate_trace_event_envelope_v1(&artifact.trace)?;
+    if artifact.trace.events.len() != proof.trace_event_count {
+        return Err(anyhow!("trace artifact event count does not match proof"));
+    }
+    if artifact.temporal_causality_review.run_id != proof.trace_run_id {
+        return Err(anyhow!(
+            "trace artifact causality review run id does not match proof"
+        ));
+    }
+    if artifact.temporal_causality_review.sequence_only_count
+        != proof.temporal_causality_sequence_only_count
+        || artifact
+            .temporal_causality_review
+            .causal_or_dependency_count
+            != proof.temporal_causality_or_dependency_count
+        || artifact.temporal_causality_review.uncertainty_count
+            != proof.temporal_causality_uncertainty_count
+    {
+        return Err(anyhow!(
+            "trace artifact causality review counts do not match proof"
+        ));
+    }
+    Ok(())
 }
 
 pub fn validate_long_running_context_continuity_proof(

--- a/adl/src/chronosense/tests.rs
+++ b/adl/src/chronosense/tests.rs
@@ -583,6 +583,35 @@ fn long_running_context_continuity_proof_writes_reviewable_artifact_without_host
     assert!(root
         .join(LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_REF)
         .is_file());
+    let trace_artifact_text =
+        fs::read_to_string(root.join(LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_REF))
+            .expect("trace artifact text");
+    assert!(trace_artifact_text.contains(LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA));
+    assert!(!trace_artifact_text.contains(LONG_RUNNING_CONTEXT_CONTINUITY_PROOF_SCHEMA));
+    assert!(!trace_artifact_text.contains(root.to_string_lossy().as_ref()));
+    let trace_artifact: LongRunningContextContinuityTraceArtifact =
+        serde_json::from_str(&trace_artifact_text).expect("trace artifact json");
+    assert_eq!(
+        trace_artifact.schema_version,
+        LONG_RUNNING_CONTEXT_CONTINUITY_TRACE_ARTIFACT_SCHEMA
+    );
+    assert_eq!(
+        trace_artifact.trace.events.len(),
+        trace_artifact
+            .temporal_causality_review
+            .explanations
+            .iter()
+            .map(|explanation| explanation.target_event_id.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+            + 1
+    );
+    assert!(
+        trace_artifact
+            .temporal_causality_review
+            .causal_or_dependency_count
+            >= 4
+    );
 
     fs::remove_dir_all(root).expect("cleanup proof root");
 }


### PR DESCRIPTION
Closes #4807

## Summary
Repaired the tracked Chronosense proof-artifact defect for issue `#4807`. The long-running continuity writer now emits a separate trace/review artifact at the trace artifact path instead of duplicating the summary proof object, and the focused Chronosense proof test asserts that artifact shape. Separately, outside the tracked PR artifact set, the local ignored Chronosense sprint records in the primary checkout were normalized so `#4765`, `#4766`, `#4767`, `#4769`, and `#4770` no longer claim stale `not_run`, `not_open`, `NOT_STARTED`, or `worktree_only` states after their issues/PRs closed.

## Artifacts
- `adl/src/chronosense/long_running_proof.rs`
- `adl/src/chronosense.rs`
- `adl/src/chronosense/tests.rs`
- Non-PR local reconciliation: ignored root lifecycle repairs for the cited Chronosense sprint SRP/SOR records under `.adl/v0.91.7/tasks/issue-4765__*`, `.adl/v0.91.7/tasks/issue-4766__*`, `.adl/v0.91.7/tasks/issue-4767__*`, `.adl/v0.91.7/tasks/issue-4769__*`, and `.adl/v0.91.7/tasks/issue-4770__*`

## Validation
- Validation commands and their purpose:
- `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    Verified Rust formatting for the touched Chronosense files.
  - `cargo test --manifest-path adl/Cargo.toml long_running_context_continuity_proof_writes_reviewable_artifact_without_host_path_leakage --lib -- --nocapture`
    Verified the trace artifact path now contains a trace/review packet and not a duplicate proof packet.
  - `cargo test --manifest-path adl/Cargo.toml chronosense --lib -- --nocapture`
    Verified all 46 focused Chronosense tests passed after the remediation.
  - `git diff --check`
    Verified patch whitespace hygiene.
  - Companion local reconciliation check in the primary checkout verified stale local Chronosense sprint card truth patterns were removed from the root ignored bundle; this is recorded as local lifecycle hygiene, not tracked PR proof.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4807__v0-91-7-chronosense-closeout-repair-chronosense-closeout-truth-and-continuity-proof-artifact/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4807__v0-91-7-chronosense-closeout-repair-chronosense-closeout-truth-and-continuity-proof-artifact/sor.md
- Idempotency-Key: v0-91-7-chronosense-closeout-repair-chronosense-closeout-truth-and-continuity-proof-artifact-adl-src-chronosense-rs-adl-src-chronosense-long-running-proof-rs-adl-src-chronosense-tests-rs-adl-v0-91-7-tasks-issue-4807-v0-91-7-chronosense-closeout-repair-chronosense-closeout-truth-and-continuity-proof-artifact-sip-md-adl-v0-91-7-tasks-issue-4807-v0-91-7-chronosense-closeout-repair-chronosense-closeout-truth-and-continuity-proof-artifact-sor-md