### PR TITLE
[v0.91.7][tools][pr] Repair PR help and owner-binary discovery regressions

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -216,6 +216,12 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     };
 
     match subcommand {
+        "--help" | "-h" | "help" => {
+            println!(
+                "Usage:\n  adl pr <subcommand> [args]\n\nSubcommands:\n  create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | pr-inventory | watch | shepherd | closing-linkage | issue | projection-map | closeout\n\nUse `adl tools/pr.sh <subcommand> --help` or the matching owner binary help for subcommand-specific options."
+            );
+            Ok(())
+        }
         "create" => real_pr_create(&args[1..]),
         "init" => real_pr_init(&args[1..]),
         "repair-issue-body" => real_pr_repair_issue_body(&args[1..]),

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -2740,6 +2740,10 @@ fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
         "pr requires a subcommand: create | init | repair-issue-body | start | run | doctor | ready | preflight | finish | validation | pr-inventory | watch | shepherd | closing-linkage | issue | projection-map | closeout"
     ));
 
+    real_pr(&["--help".to_string()]).expect("top-level pr help should succeed");
+    real_pr(&["-h".to_string()]).expect("short top-level pr help should succeed");
+    real_pr(&["help".to_string()]).expect("help alias should succeed");
+
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown pr subcommand: bogus"));
 }

--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -38,6 +38,14 @@ rust_pr_delegate_available() {
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
   fi
+  cached_bin="$(rust_pr_issue_stale_cached_bin "${1:-}" || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
+  cached_bin="$(rust_pr_issue_stale_primary_cached_bin "${1:-}" || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
   cached_bin="$(rust_pr_delegate_path_bin || true)"
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
@@ -221,6 +229,15 @@ rust_pr_subcommand_cached_bin() {
   printf '%s\n' "$candidate"
 }
 
+rust_pr_issue_stale_cached_bin() {
+  [[ "${1:-}" == "issue" ]] || return 1
+  local root candidate
+  root="$(rust_pr_delegate_root)"
+  candidate="$root/adl/target/debug/adl-issue"
+  [[ -x "$candidate" ]] || return 1
+  printf '%s\n' "$candidate"
+}
+
 rust_pr_subcommand_primary_cached_bin() {
   local subcommand="$1"
   local root primary_root binary_name candidate
@@ -235,6 +252,17 @@ rust_pr_subcommand_primary_cached_bin() {
   if rust_pr_worktree_inputs_are_newer_than_bin "$root" "$candidate" "$primary_root"; then
     return 1
   fi
+  printf '%s\n' "$candidate"
+}
+
+rust_pr_issue_stale_primary_cached_bin() {
+  [[ "${1:-}" == "issue" ]] || return 1
+  local root primary_root candidate
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$primary_root" != "$root" ]] || return 1
+  candidate="$primary_root/adl/target/debug/adl-issue"
+  [[ -x "$candidate" ]] || return 1
   printf '%s\n' "$candidate"
 }
 
@@ -551,6 +579,16 @@ delegate_pr_command_to_rust() {
   direct_bin="$(rust_pr_subcommand_path_bin "$subcommand" || true)"
   if [[ -n "$direct_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin"
+    exec "$direct_bin" "$@"
+  fi
+  direct_bin="$(rust_pr_issue_stale_cached_bin "$subcommand" || true)"
+  if [[ -n "$direct_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "freshness" "stale_allowed_issue_last_resort"
+    exec "$direct_bin" "$@"
+  fi
+  direct_bin="$(rust_pr_issue_stale_primary_cached_bin "$subcommand" || true)"
+  if [[ -n "$direct_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "freshness" "stale_allowed_issue_last_resort"
     exec "$direct_bin" "$@"
   fi
   if rust_pr_subcommand_requires_dedicated_owner_binary "$subcommand"; then

--- a/adl/tools/test_pr_delegate_prefers_path_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_path_binary.sh
@@ -71,3 +71,74 @@ grep -Fqx 'path-doctor:4590 --slug path-bin --no-fetch-issue --version v0.91.6 -
 }
 
 echo "pr.sh prefers PATH owner binary: ok"
+
+repo_bin_log="$tmpdir/repo-bin-issue.log"
+path_issue_log="$tmpdir/path-issue.log"
+mkdir -p "$repo/adl/target/debug"
+cat >"$repo/adl/target/debug/adl-issue" <<'EOF_ISSUE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'repo-issue:%s\n' "$*" >"${ADL_TEST_REPO_ISSUE_LOG}"
+EOF_ISSUE
+chmod +x "$repo/adl/target/debug/adl-issue"
+cat >"$pathbin/adl-issue" <<'EOF_PATH_ISSUE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'path-issue:%s\n' "$*" >"${ADL_TEST_PATH_ISSUE_LOG}"
+EOF_PATH_ISSUE
+chmod +x "$pathbin/adl-issue"
+sleep 1
+touch "$repo/adl/Cargo.toml"
+: >"$cargo_args"
+
+(
+  cd "$repo"
+  PATH="$pathbin:$mockbin:$PATH" \
+    ADL_TEST_REPO_ISSUE_LOG="$repo_bin_log" \
+    ADL_TEST_PATH_ISSUE_LOG="$path_issue_log" \
+    ADL_TEST_CARGO_ARGS="$cargo_args" \
+    "$BASH_BIN" adl/tools/pr.sh issue search "owner binary" --json >/dev/null
+)
+grep -Fqx 'path-issue:search owner binary --json' "$path_issue_log" || {
+  echo "assertion failed: fresh PATH adl-issue should win over stale repo-local adl-issue" >&2
+  cat "$path_issue_log" >&2
+  exit 1
+}
+[[ ! -s "$repo_bin_log" ]] || {
+  echo "assertion failed: stale repo-local adl-issue should not beat PATH adl-issue" >&2
+  cat "$repo_bin_log" >&2
+  exit 1
+}
+[[ ! -s "$cargo_args" ]] || {
+  echo "assertion failed: cargo should not run when PATH adl-issue exists" >&2
+  cat "$cargo_args" >&2
+  exit 1
+}
+
+echo "pr.sh prefers PATH adl-issue before stale repo-local owner binary: ok"
+
+rm -f "$pathbin/adl-issue"
+: >"$repo_bin_log"
+: >"$path_issue_log"
+: >"$cargo_args"
+
+(
+  cd "$repo"
+  PATH="$pathbin:$mockbin:$PATH" \
+    ADL_TEST_REPO_ISSUE_LOG="$repo_bin_log" \
+    ADL_TEST_PATH_ISSUE_LOG="$path_issue_log" \
+    ADL_TEST_CARGO_ARGS="$cargo_args" \
+    "$BASH_BIN" adl/tools/pr.sh issue search "owner binary" --json >/dev/null
+)
+grep -Fqx 'repo-issue:search owner binary --json' "$repo_bin_log" || {
+  echo "assertion failed: repo-local adl-issue owner binary should be last-resort issue fallback" >&2
+  cat "$repo_bin_log" >&2
+  exit 1
+}
+[[ ! -s "$cargo_args" ]] || {
+  echo "assertion failed: cargo should not run when repo-local adl-issue exists" >&2
+  cat "$cargo_args" >&2
+  exit 1
+}
+
+echo "pr.sh prefers repo-local adl-issue owner binary: ok"


### PR DESCRIPTION
Closes #4804

## Summary
Implemented the #4804 repo-native PR/control-plane regression repair. `adl pr --help`, `adl pr -h`, and `adl pr help` now return PR help instead of failing as unknown subcommands. `pr.sh issue ...` now finds a stale repo-local or primary `adl-issue` owner binary only as an issue-specific last-resort path after fresh repo/primary/PATH owner-binary checks, avoiding broad freshness relaxation for other delegated PR subcommands.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-4804__v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr_delegate.sh`
  - `adl/tools/test_pr_delegate_prefers_path_binary.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_prefers_path_binary.sh`
    Verified owner-binary discovery behavior for `pr.sh` delegated shell paths.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_dispatch_rejects_missing_and_unknown_subcommands -- --nocapture`
    Verified Rust PR help dispatch behavior.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4804__v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4804__v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions/sor.md
- Idempotency-Key: v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-delegate-sh-adl-tools-test-pr-delegate-prefers-path-binary-sh-adl-v0-91-7-tasks-issue-4804-v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions-sip-md-adl-v0-91-7-tasks-issue-4804-v0-91-7-tools-pr-repair-pr-help-and-owner-binary-discovery-regressions-sor-md