### PR TITLE
[v0.91.7][tools][worktree] Prevent issue edits from dirtying root main

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -75,10 +75,10 @@ use self::git_support::commits_ahead_of_origin_main;
 #[cfg(test)]
 use self::git_support::has_uncommitted_changes;
 #[cfg(test)]
-use self::git_support::{branch_checked_out_worktree_path, infer_repo_from_remote};
+use self::git_support::infer_repo_from_remote;
 use self::git_support::{
-    current_branch, default_repo, ensure_git_metadata_writable, ensure_local_branch_exists,
-    ensure_worktree_for_branch, fetch_origin_main_with_fallback,
+    branch_checked_out_worktree_path, current_branch, default_repo, ensure_git_metadata_writable,
+    ensure_local_branch_exists, ensure_worktree_for_branch, fetch_origin_main_with_fallback,
     has_uncommitted_or_untracked_changes, issue_create_repo, path_str, primary_checkout_root,
     repo_root, run_capture, run_status, tracked_changes_status,
 };
@@ -1197,8 +1197,27 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
     validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &body)?;
 
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
+    let primary_root = primary_checkout_root()?;
+    let local_repair_root = repair_issue_body_local_root(&repo_root, &primary_root, &issue_ref)?;
+    if !same_checkout_root(&local_repair_root, &repo_root)? {
+        if let Some((local_version, local_slug)) =
+            resolve_local_issue_identity(&local_repair_root, parsed.issue)?
+        {
+            if local_version != version || local_slug != slug {
+                bail!(
+                    "repair-issue-body: local identity drift in bound worktree for issue #{}; current worktree identity is {}:{} and requested identity is {}:{}. Keep the canonical identity or migrate the local prompt/task bundle manually before rerunning.",
+                    parsed.issue,
+                    local_version,
+                    local_slug,
+                    version,
+                    slug
+                );
+            }
+        }
+        ensure_no_duplicate_issue_identities(&local_repair_root, &issue_ref)?;
+    }
     ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
-    let source_path = issue_ref.issue_prompt_path(&repo_root);
+    let source_path = issue_ref.issue_prompt_path(&local_repair_root);
     if source_path.is_file() && !parsed.force {
         let current = fs::read_to_string(&source_path)
             .with_context(|| format!("failed to read {}", source_path.display()))?;
@@ -1240,27 +1259,27 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
         gh_issue_edit_body(&repo, parsed.issue, &body)?;
     }
     let source_path = write_source_issue_prompt(
-        &repo_root,
+        &local_repair_root,
         &issue_ref,
         &title,
         &normalized_labels,
         &issue_url,
         &body,
     )?;
-    validate_bootstrap_stp(&repo_root, &source_path)?;
+    validate_bootstrap_stp(&local_repair_root, &source_path)?;
     validate_authored_prompt_surface(
         "repair-issue-body",
         &source_path,
         PromptSurfaceKind::IssuePrompt,
     )?;
 
-    let bundle_dir = issue_ref.task_bundle_dir_path(&repo_root);
+    let bundle_dir = issue_ref.task_bundle_dir_path(&local_repair_root);
     if bundle_dir.is_dir() {
         fs::remove_dir_all(&bundle_dir)
             .with_context(|| format!("failed to remove stale bundle {}", bundle_dir.display()))?;
     }
     let (stp_path, bundle_input, bundle_output, bundle_dir) =
-        bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
+        bootstrap_root_task_bundle(&local_repair_root, &issue_ref, &title, &source_path)?;
 
     println!("• Repaired issue metadata/source prompt:");
     println!("  ISSUE     #{}", parsed.issue);
@@ -1268,27 +1287,44 @@ fn real_pr_repair_issue_body(args: &[String]) -> Result<()> {
     println!("  SLUG      {slug}");
     println!(
         "  SOURCE    {}",
-        path_relative_to_repo(&repo_root, &source_path)
+        path_relative_to_repo(&local_repair_root, &source_path)
     );
     println!(
         "  STP       {}",
-        path_relative_to_repo(&repo_root, &stp_path)
+        path_relative_to_repo(&local_repair_root, &stp_path)
     );
     println!(
         "  SIP       {}",
-        path_relative_to_repo(&repo_root, &bundle_input)
+        path_relative_to_repo(&local_repair_root, &bundle_input)
     );
     println!(
         "  SOR       {}",
-        path_relative_to_repo(&repo_root, &bundle_output)
+        path_relative_to_repo(&local_repair_root, &bundle_output)
     );
     println!(
         "  BUNDLE    {}",
-        path_relative_to_repo(&repo_root, &bundle_dir)
+        path_relative_to_repo(&local_repair_root, &bundle_dir)
     );
     println!("  STATE     ISSUE_BODY_AND_BUNDLE_REPAIRED");
     println!("• Done.");
     Ok(())
+}
+
+fn repair_issue_body_local_root(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<PathBuf> {
+    if !same_checkout_root(repo_root, primary_root)? {
+        return Ok(repo_root.to_path_buf());
+    }
+    let expected_branch = issue_ref.branch_name("codex");
+    if let Some(path) = branch_checked_out_worktree_path(&expected_branch)? {
+        if !same_checkout_root(&path, primary_root)? {
+            return Ok(path);
+        }
+    }
+    Ok(primary_root.to_path_buf())
 }
 
 fn real_pr_create(args: &[String]) -> Result<()> {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -2387,6 +2387,256 @@ fn real_pr_repair_issue_body_updates_github_source_prompt_and_bundle() {
 }
 
 #[test]
+fn real_pr_repair_issue_body_from_primary_writes_bound_worktree_not_root() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-bound-worktree-not-root");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    assert!(std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config email")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["config", "user.name", "ADL Test"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config name")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["commit", "-qm", "seed"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+
+    let issue_ref = IssueRef::new(1302, "v0.91.5", "repair-body").expect("issue ref");
+    let branch = issue_ref.branch_name("codex");
+    assert!(std::process::Command::new("git")
+        .args(["branch", &branch])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    let worktree = repo.join(".worktrees/custom-repair-body-worktree");
+    assert!(std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-q",
+            path_str(&worktree).expect("worktree path"),
+            &branch
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &fixture,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> '{}'
+if [[ "$1 $2" == "label list" ]]; then
+  printf 'track:backlog\ntype:docs\narea:docs\nversion:v0.91.5\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" ]]; then
+  if printf '%s\n' "$*" | grep -q -- '--json title'; then
+    printf '[v0.91.5][tools] Repair body\n'
+    exit 0
+  fi
+  if printf '%s\n' "$*" | grep -q -- '--json labels'; then
+    printf 'track:backlog\ntype:docs\narea:docs\nversion:v0.91.5\n'
+    exit 0
+  fi
+fi
+if [[ "$1 $2" == "issue edit" ]]; then
+  exit 0
+fi
+exit 1
+"#,
+            gh_log.display()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    let body_path = repo.join("repair-body.md");
+    fs::write(&body_path, authored_repair_body()).expect("write body");
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir primary");
+
+    let result = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1302".to_string(),
+        "--slug".to_string(),
+        "repair-body".to_string(),
+        "--body-file".to_string(),
+        body_path.display().to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    result.expect("repair issue body");
+
+    assert!(
+        !issue_ref.issue_prompt_path(&repo).exists(),
+        "primary checkout should not receive repaired local issue prompt when bound worktree exists"
+    );
+    assert!(
+        !issue_ref.task_bundle_dir_path(&repo).exists(),
+        "primary checkout should not receive regenerated task bundle when bound worktree exists"
+    );
+    assert!(
+        issue_ref.issue_prompt_path(&worktree).is_file(),
+        "bound worktree should receive repaired local issue prompt"
+    );
+    assert!(
+        issue_ref.task_bundle_stp_path(&worktree).is_file(),
+        "bound worktree should receive regenerated task bundle"
+    );
+}
+
+#[test]
+fn real_pr_repair_issue_body_blocks_bound_worktree_identity_drift() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-repair-bound-worktree-identity-drift");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    assert!(std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config email")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["config", "user.name", "ADL Test"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config name")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["commit", "-qm", "seed"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+
+    let requested_ref = IssueRef::new(1302, "v0.91.5", "repair-body").expect("issue ref");
+    let branch = requested_ref.branch_name("codex");
+    assert!(std::process::Command::new("git")
+        .args(["branch", &branch])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    let worktree = repo.join(".worktrees/custom-repair-body-drift");
+    assert!(std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-q",
+            path_str(&worktree).expect("worktree path"),
+            &branch,
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+
+    let drift_ref = IssueRef::new(1302, "v0.91.5", "old-repair-body").expect("drift ref");
+    let drift_source = drift_ref.issue_prompt_path(&worktree);
+    fs::create_dir_all(drift_source.parent().expect("drift parent")).expect("drift dir");
+    fs::write(&drift_source, authored_repair_body()).expect("write drift source");
+
+    let fixture = repo.join(".adl/test-fixtures/gh");
+    fs::create_dir_all(fixture.parent().expect("fixture parent")).expect("fixture dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &fixture,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> '{}'
+if [[ "$1 $2" == "label list" ]]; then
+  printf 'track:backlog\ntype:docs\narea:docs\nversion:v0.91.5\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" ]]; then
+  if printf '%s\n' "$*" | grep -q -- '--json title'; then
+    printf '[v0.91.5][tools] Repair body\n'
+    exit 0
+  fi
+  if printf '%s\n' "$*" | grep -q -- '--json labels'; then
+    printf 'track:backlog\ntype:docs\narea:docs\nversion:v0.91.5\n'
+    exit 0
+  fi
+fi
+if [[ "$1 $2" == "issue edit" ]]; then
+  exit 0
+fi
+exit 1
+"#,
+            gh_log.display()
+        ),
+    );
+    let _fixture_guard = GithubCliFixtureGuard::set(&fixture);
+
+    let body_path = repo.join("repair-body.md");
+    fs::write(&body_path, authored_repair_body()).expect("write body");
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir primary");
+
+    let err = real_pr(&[
+        "repair-issue-body".to_string(),
+        "1302".to_string(),
+        "--slug".to_string(),
+        "repair-body".to_string(),
+        "--body-file".to_string(),
+        body_path.display().to_string(),
+        "--version".to_string(),
+        "v0.91.5".to_string(),
+    ])
+    .expect_err("bound worktree identity drift should fail closed");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    assert!(
+        err.to_string()
+            .contains("local identity drift in bound worktree")
+            || err
+                .to_string()
+                .contains("duplicate local issue identities detected for issue #1302"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !requested_ref.issue_prompt_path(&repo).exists(),
+        "primary checkout should not receive a prompt when bound-worktree identity drift blocks repair"
+    );
+    assert!(
+        !requested_ref.issue_prompt_path(&worktree).exists(),
+        "repair should not create a second issue prompt beside the drifted bound-worktree identity"
+    );
+}
+
+#[test]
 fn real_pr_repair_issue_body_repairs_title_and_labels_without_body_mutation() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-repair-issue-metadata");


### PR DESCRIPTION
Closes #4709

## Summary
Implemented bounded `repair-issue-body` root-safety fixes for #4709. The command now resolves the actual bound issue worktree from git worktree branch ownership when invoked from the primary checkout, writes repaired local prompt/task-bundle surfaces into that worktree instead of dirtying root main, and fails closed when the bound worktree already contains conflicting local identity for the same issue.

## Artifacts
- Updated `adl/src/cli/pr_cmd.rs` with bound-worktree routing and fail-closed identity checks for `repair-issue-body`.
- Updated `adl/src/cli/tests/pr_cmd_inline/basics.rs` with regression coverage for non-default bound worktree routing and bound-worktree identity drift.
- Preserved unrelated root scheduler residue separately under `.adl/recovery/root-dirty-state/` before restoring primary checkout clean; that recovery packet is not part of #4709 implementation scope.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for the touched Rust files.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_repair_issue_body -- --nocapture`
    Verified all focused repair-body tests, including the new bound-worktree root-safety regressions.
  - `git diff --check`
    Verified whitespace and patch hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Run by `pr finish`; verified C-SDLC owner contracts.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    Run by `pr finish`; verified the focused `cli::pr_cmd` nextest lane.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Closes #4709

Summary
- Routes repair-issue-body local prompt/task-bundle writes to the bound issue worktree when invoked from the primary checkout.
- Uses actual git worktree branch ownership instead of assuming default worktree paths.
- Fails closed when the bound worktree already contains conflicting local issue identity for the same issue.

Validation
- cargo fmt --manifest-path adl/Cargo.toml --all --check
- cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_repair_issue_body -- --nocapture
- git diff --check
- bash adl/tools/run_owner_validation_lane.sh csdlc
- bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>
- bounded subagent re-review: no findings

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4709__v0-91-7-tools-worktree-prevent-issue-edits-from-dirtying-root-main/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4709__v0-91-7-tools-worktree-prevent-issue-edits-from-dirtying-root-main/sor.md
- Idempotency-Key: v0-91-7-tools-worktree-prevent-issue-edits-from-dirtying-root-main-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-v0-91-7-tasks-issue-4709-v0-91-7-tools-worktree-prevent-issue-edits-from-dirtying-root-main-sip-md-adl-v0-91-7-tasks-issue-4709-v0-91-7-tools-worktree-prevent-issue-edits-from-dirtying-root-main-sor-md