### PR TITLE
[v0.91.7][tools][github] Add repo-native label ensure command

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -85,7 +85,7 @@ use self::git_support::{
 use self::github::{
     ensure_issue_metadata_parity, ensure_repo_labels_exist, format_open_pr_wave, gh_issue_comment,
     gh_issue_create, gh_issue_edit_body, gh_issue_edit_title, gh_issue_set_labels, gh_issue_title,
-    issue_version, unresolved_milestone_pr_wave, IssueRecord,
+    gh_repo_ensure_labels, issue_version, unresolved_milestone_pr_wave, IssueRecord,
 };
 
 const DEFAULT_VERSION: &str = "v0.86";
@@ -795,6 +795,31 @@ fn real_pr_issue(args: &[String]) -> Result<()> {
                 })?;
             }
         }
+        IssueArgs::LabelEnsure(parsed) => {
+            let repo = parsed.repo.unwrap_or(default_repo(&repo_root)?);
+            let labels = parsed.labels.iter().cloned().collect::<BTreeSet<_>>();
+            let (existing, created) = gh_repo_ensure_labels(
+                &repo,
+                &labels,
+                &parsed.color,
+                parsed.description.as_deref(),
+            )?;
+            let report = IssueLabelEnsureResult {
+                status: "ensured",
+                repo: repo.clone(),
+                existing,
+                created,
+            };
+            if parsed.json {
+                print_json(&report)?;
+            } else {
+                println!(
+                    "ensured labels for {repo}: existing={} created={}",
+                    report.existing.join(","),
+                    report.created.join(",")
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -806,6 +831,14 @@ struct IssueMutationResult {
     url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct IssueLabelEnsureResult {
+    status: &'static str,
+    repo: String,
+    existing: Vec<String>,
+    created: Vec<String>,
 }
 
 struct IssueLifecycleSnapshot {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -2311,10 +2311,81 @@ pub(super) fn ensure_repo_labels_exist(
     if missing.is_empty() {
         return Ok(());
     }
+    let remediation = label_ensure_command(repo, &missing);
     bail!(
-        "{operation}: repo is missing required GitHub labels: {}. Create them through the approved ADL GitHub label path before retrying so issue metadata does not mutate partially.",
-        missing.join(", ")
+        "{operation}: repo is missing required GitHub labels: {}. Run `{remediation}` before retrying so issue metadata does not mutate partially.",
+        missing.join(", "),
     );
+}
+
+fn label_ensure_command(repo: &str, labels: &[String]) -> String {
+    let mut parts = vec![
+        "adl/tools/pr.sh".to_string(),
+        "issue".to_string(),
+        "label".to_string(),
+        "ensure".to_string(),
+        "-R".to_string(),
+        shell_quote(repo),
+    ];
+    for label in labels {
+        parts.push("--label".to_string());
+        parts.push(shell_quote(label));
+    }
+    parts.join(" ")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+pub(super) fn gh_repo_ensure_labels(
+    repo: &str,
+    labels: &BTreeSet<String>,
+    color: &str,
+    description: Option<&str>,
+) -> Result<(Vec<String>, Vec<String>)> {
+    if labels.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let available = gh_repo_label_names(repo)?;
+    let existing = labels.intersection(&available).cloned().collect::<Vec<_>>();
+    let missing = labels.difference(&available).cloned().collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok((existing, Vec::new()));
+    }
+
+    #[derive(Serialize)]
+    struct LabelCreatePayload<'a> {
+        name: &'a str,
+        color: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<&'a str>,
+    }
+
+    let repo_parts = parse_repo(repo)?;
+    with_octocrab("issue.label.ensure", |runtime, octo| {
+        let owner = repo_parts.owner.clone();
+        let name = repo_parts.name.clone();
+        let route = format!("/repos/{owner}/{name}/labels");
+        for label in &missing {
+            let payload = LabelCreatePayload {
+                name: label,
+                color,
+                description,
+            };
+            let _: serde_json::Value = block_on_octocrab(runtime, "issue.label.ensure", || async {
+                octo.post(route.as_str(), Some(&payload)).await
+            })
+            .with_context(|| format!("failed to create GitHub label '{label}' in repo {repo}"))?;
+        }
+        Ok((existing, missing))
+    })
 }
 
 pub(super) fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -245,6 +245,15 @@ pub(crate) struct IssueCloseArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueLabelEnsureArgs {
+    pub(crate) labels: Vec<String>,
+    pub(crate) repo: Option<String>,
+    pub(crate) color: String,
+    pub(crate) description: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IssueArgs {
     List(IssueListArgs),
     Search(IssueSearchArgs),
@@ -253,6 +262,7 @@ pub(crate) enum IssueArgs {
     Comment(IssueCommentArgs),
     Edit(IssueEditArgs),
     Close(IssueCloseArgs),
+    LabelEnsure(IssueLabelEnsureArgs),
 }
 
 pub(crate) fn parse_init_args(args: &[String]) -> Result<InitArgs> {
@@ -883,7 +893,9 @@ pub(crate) fn parse_closeout_args(args: &[String]) -> Result<CloseoutArgs> {
 
 pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
     let Some(subcommand) = args.first().map(|value| value.as_str()) else {
-        bail!("issue: missing subcommand (list | search | view | create | comment | edit | close)");
+        bail!(
+            "issue: missing subcommand (list | search | view | create | comment | edit | close | label)"
+        );
     };
 
     match subcommand {
@@ -894,6 +906,7 @@ pub(crate) fn parse_issue_args(args: &[String]) -> Result<IssueArgs> {
         "comment" => parse_issue_comment_args(&args[1..]).map(IssueArgs::Comment),
         "edit" => parse_issue_edit_args(&args[1..]).map(IssueArgs::Edit),
         "close" => parse_issue_close_args(&args[1..]).map(IssueArgs::Close),
+        "label" | "labels" => parse_issue_label_args(&args[1..]),
         other => bail!("issue: unknown subcommand: {other}"),
     }
 }
@@ -1227,6 +1240,81 @@ fn parse_issue_close_args(args: &[String]) -> Result<IssueCloseArgs> {
             other => bail!("issue close: unknown arg: {other}"),
         }
         i += 1;
+    }
+    Ok(parsed)
+}
+
+fn parse_issue_label_args(args: &[String]) -> Result<IssueArgs> {
+    let Some(subcommand) = args.first().map(|value| value.as_str()) else {
+        bail!("issue label: missing subcommand (ensure)");
+    };
+    match subcommand {
+        "ensure" => parse_issue_label_ensure_args(&args[1..]).map(IssueArgs::LabelEnsure),
+        other => bail!("issue label: unknown subcommand: {other}"),
+    }
+}
+
+fn parse_issue_label_ensure_args(args: &[String]) -> Result<IssueLabelEnsureArgs> {
+    let mut parsed = IssueLabelEnsureArgs {
+        labels: Vec::new(),
+        repo: None,
+        color: "ededed".to_string(),
+        description: None,
+        json: false,
+    };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--label" => {
+                parsed
+                    .labels
+                    .push(require_value(args, i, "issue label ensure", "--label")?);
+                i += 1;
+            }
+            "--labels" => {
+                parsed.labels.extend(split_labels(&require_value(
+                    args,
+                    i,
+                    "issue label ensure",
+                    "--labels",
+                )?));
+                i += 1;
+            }
+            "--color" => {
+                parsed.color = require_value(args, i, "issue label ensure", "--color")?
+                    .trim_start_matches('#')
+                    .to_string();
+                i += 1;
+            }
+            "--description" => {
+                parsed.description = Some(require_value(
+                    args,
+                    i,
+                    "issue label ensure",
+                    "--description",
+                )?);
+                i += 1;
+            }
+            "-R" | "--repo" => {
+                parsed.repo = Some(require_value(
+                    args,
+                    i,
+                    "issue label ensure",
+                    args[i].as_str(),
+                )?);
+                i += 1;
+            }
+            "--json" => parsed.json = true,
+            other => bail!("issue label ensure: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    parsed.labels = split_labels(&parsed.labels.join(","));
+    if parsed.labels.is_empty() {
+        bail!("issue label ensure: --label or --labels is required");
+    }
+    if parsed.color.len() != 6 || !parsed.color.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("issue label ensure: --color must be a 6-digit hex color");
     }
     Ok(parsed)
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -79,6 +79,9 @@ fn spawn_issue_octocrab_test_server(
                     "]"
                 )
                 .to_string(),
+                ("POST", "/repos/owner/repo/labels") => {
+                    "{\"name\":\"version:v0.91.7\",\"color\":\"ededed\"}".to_string()
+                }
                 ("POST", "/repos/owner/repo/issues/77/comments") => {
                     "{\"html_url\":\"https://github.com/owner/repo/issues/77#issuecomment-1\"}"
                         .to_string()
@@ -101,6 +104,51 @@ fn spawn_issue_octocrab_test_server(
                         .expect("content-type header"),
                 );
             request.respond(response).expect("respond");
+        }
+        seen
+    });
+    (format!("http://{bind_addr}"), handle)
+}
+
+fn spawn_missing_label_guard_server() -> (String, std::thread::JoinHandle<Vec<String>>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    let bind_addr = format!("127.0.0.1:{port}");
+    let server = tiny_http::Server::http(&bind_addr).expect("bind missing label guard server");
+    let handle = std::thread::spawn(move || {
+        let mut seen = Vec::new();
+        let Some(mut request) = server
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("missing label guard receive")
+        else {
+            return seen;
+        };
+        let method = request.method().as_str().to_string();
+        let url = request.url().to_string();
+        let mut body = String::new();
+        let _ = std::io::Read::read_to_string(&mut request.as_reader(), &mut body);
+        seen.push(format!("{method} {url} {body}"));
+        assert!(
+            method == "GET" && url.starts_with("/repos/owner/repo/labels?"),
+            "expected only repo-label lookup before fail-closed mutation guard, got {method} {url}"
+        );
+        let response = tiny_http::Response::from_string("[{\"name\":\"area:tools\"}]")
+            .with_status_code(200)
+            .with_header(
+                tiny_http::Header::from_bytes("Content-Type", "application/json")
+                    .expect("content-type header"),
+            );
+        request.respond(response).expect("respond");
+        if let Some(extra) = server
+            .recv_timeout(std::time::Duration::from_millis(250))
+            .expect("missing label extra receive")
+        {
+            panic!(
+                "missing label guard expected no mutation request, got {} {}",
+                extra.method(),
+                extra.url()
+            );
         }
         seen
     });
@@ -917,6 +965,36 @@ fn parse_issue_args_accepts_list_search_and_view_modes() {
     }
 
     let parsed = parse_issue_args(&[
+        "label".to_string(),
+        "ensure".to_string(),
+        "--label".to_string(),
+        "area:tools".to_string(),
+        "--labels".to_string(),
+        "version:v0.91.7,area:quality".to_string(),
+        "--color".to_string(),
+        "#ededed".to_string(),
+        "--description".to_string(),
+        "ADL managed label".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("parse issue label ensure");
+    match parsed {
+        IssueArgs::LabelEnsure(parsed) => {
+            assert_eq!(
+                parsed.labels,
+                vec!["area:tools", "version:v0.91.7", "area:quality"]
+            );
+            assert_eq!(parsed.color, "ededed");
+            assert_eq!(parsed.description.as_deref(), Some("ADL managed label"));
+            assert_eq!(parsed.repo.as_deref(), Some("owner/repo"));
+            assert!(parsed.json);
+        }
+        other => panic!("expected label ensure args, got {other:?}"),
+    }
+
+    let parsed = parse_issue_args(&[
         "comment".to_string(),
         "77".to_string(),
         "--body".to_string(),
@@ -1103,7 +1181,7 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     std::fs::write(&body_path, "Created body\n").expect("write body");
     let comment_path = repo.join("comment.md");
     std::fs::write(&comment_path, "Comment body\n").expect("write comment");
-    let (base_uri, server) = spawn_issue_octocrab_test_server(9);
+    let (base_uri, server) = spawn_issue_octocrab_test_server(11);
     unsafe {
         std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
         std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
@@ -1150,6 +1228,15 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     ])
     .expect("issue edit");
     real_pr_issue(&[
+        "label".to_string(),
+        "ensure".to_string(),
+        "--labels".to_string(),
+        "area:tools,version:v0.91.7".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+    ])
+    .expect("issue label ensure");
+    real_pr_issue(&[
         "close".to_string(),
         "77".to_string(),
         "--reason".to_string(),
@@ -1159,7 +1246,7 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
 
     std::env::set_current_dir(prev_dir).expect("restore cwd");
     let seen = server.join().expect("server join");
-    assert_eq!(seen.len(), 9);
+    assert_eq!(seen.len(), 11);
     assert!(seen[0].starts_with("GET /repos/owner/repo/issues?"));
     assert!(seen[1].contains("/search/issues?"));
     assert!(seen[2].starts_with("GET /repos/owner/repo/issues/77"));
@@ -1171,9 +1258,57 @@ fn real_pr_issue_covers_list_search_view_and_mutation_against_mock_github() {
     assert!(seen[6].starts_with("GET /repos/owner/repo/labels?"));
     assert!(seen[7].starts_with("PATCH /repos/owner/repo/issues/77 "));
     assert!(seen[7].contains("area:tools"));
-    assert!(seen[8].starts_with("PATCH /repos/owner/repo/issues/77 "));
-    assert!(seen[8].contains("\"state\":\"closed\""));
-    assert!(seen[8].contains("\"state_reason\":\"not_planned\""));
+    assert!(seen[8].starts_with("GET /repos/owner/repo/labels?"));
+    assert!(seen[9].starts_with("POST /repos/owner/repo/labels "));
+    assert!(seen[9].contains("version:v0.91.7"));
+    assert!(seen[10].starts_with("PATCH /repos/owner/repo/issues/77 "));
+    assert!(seen[10].contains("\"state\":\"closed\""));
+    assert!(seen[10].contains("\"state_reason\":\"not_planned\""));
+}
+
+#[test]
+fn real_pr_issue_create_fails_closed_before_mutation_when_label_is_missing() {
+    let _guard = env_lock();
+    let _transport_env = force_gh_cli_transport_env();
+    let repo = unique_temp_dir("adl-pr-issue-missing-label");
+    init_git_repo(&repo);
+    let (base_uri, server) = spawn_missing_label_guard_server();
+    let previous_dir = env::current_dir().expect("cwd");
+    let old_client = env::var_os("ADL_GITHUB_CLIENT");
+    let old_token = env::var_os("GITHUB_TOKEN");
+    let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
+    unsafe {
+        env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        env::set_var("GITHUB_TOKEN", "test-token");
+        env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+    }
+    env::set_current_dir(&repo).expect("enter repo");
+
+    let err = real_pr_issue(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.91.7][tools] Missing label guard".to_string(),
+        "--body".to_string(),
+        "Body".to_string(),
+        "--label".to_string(),
+        "good first issue".to_string(),
+        "-R".to_string(),
+        "owner/repo".to_string(),
+    ])
+    .expect_err("missing label should fail before issue mutation");
+
+    env::set_current_dir(previous_dir).expect("restore cwd");
+    restore_env_var("ADL_GITHUB_CLIENT", old_client);
+    restore_env_var("GITHUB_TOKEN", old_token);
+    restore_env_var("ADL_GITHUB_OCTOCRAB_BASE_URI", old_base_uri);
+
+    let message = err.to_string();
+    assert!(message.contains("issue create: repo is missing required GitHub labels"));
+    assert!(message.contains("adl/tools/pr.sh issue label ensure"));
+    assert!(message.contains("--label 'good first issue'"));
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1);
+    assert!(seen[0].starts_with("GET /repos/owner/repo/labels?"));
 }
 
 #[test]

--- a/adl/tools/pr_usage.sh
+++ b/adl/tools/pr_usage.sh
@@ -299,6 +299,7 @@ Usage:
   adl/tools/pr.sh issue comment <issue-number-or-url> [--body "<markdown>" | --body-file <path>] [-R owner/repo] [--json]
   adl/tools/pr.sh issue edit <issue-number-or-url> [--title "<title>"] [--body "<markdown>" | --body-file <path>] [--label <label>]... [--labels <csv>] [-R owner/repo] [--json]
   adl/tools/pr.sh issue close <issue-number-or-url> [--reason completed|not_planned] [-R owner/repo] [--json]
+  adl/tools/pr.sh issue label ensure [--label <label>]... [--labels <csv>] [-R owner/repo] [--color <hex>] [--description "<text>"] [--json]
 
 Behavior:
 - delegates to the Rust-owned issue inspection and mutation surface


### PR DESCRIPTION
Closes #4721

## Summary
Implemented the repo-native GitHub label ensure command. The issue worktree now contains a bounded Rust command surface for `adl/tools/pr.sh issue label ensure`, backed by the existing Octocrab GitHub transport and focused parser/mock-GitHub tests. PR publication and closeout are not complete yet.

## Artifacts
- Local ignored output card at `.adl/v0.91.7/tasks/issue-4721__v0-91-7-tools-github-add-repo-native-label-ensure-command/sor.md`
- Tracked implementation artifacts in the issue branch:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr_usage.sh`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/warm_rust_dependency_cache.py --source-target <primary-adl-target> --dest-target adl/target --manifest-path adl/Cargo.toml --json`
    Warmed dependency artifacts; this is acceleration evidence only, not functional proof.
  - `git diff --check`
    Verified changed files have no whitespace errors.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl parse_issue_args_accepts_list_search_and_view_modes -- --nocapture`
    Verified parser coverage including the new label ensure mode.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_issue_covers_list_search_view_and_mutation_against_mock_github -- --nocapture`
    Verified list/search/view/create/comment/edit/label-ensure/close through the mock Octocrab transport.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_issue_create_fails_closed_before_mutation_when_label_is_missing -- --nocapture`
    Verified missing labels stop `issue create` before mutation and provide a usable repo-native remediation command.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4721__v0-91-7-tools-github-add-repo-native-label-ensure-command/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4721__v0-91-7-tools-github-add-repo-native-label-ensure-command/sor.md
- Idempotency-Key: v0-91-7-tools-github-add-repo-native-label-ensure-command-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-usage-sh-adl-v0-91-7-tasks-issue-4721-v0-91-7-tools-github-add-repo-native-label-ensure-command-sip-md-adl-v0-91-7-tasks-issue-4721-v0-91-7-tools-github-add-repo-native-label-ensure-command-sor-md