### PR TITLE
[v0.91.7][tools][conductor] Remove gh dependency from conductor tracker inference

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -115,6 +115,27 @@
       "reason": "prompt_template_or_editor_surface_requires_template_contract_checks"
     },
     {
+      "id": "workflow_conductor_contracts",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "csdlc",
+      "proof_role": "workflow_conductor_contract",
+      "requirement_ids": [
+        "workflow_conductor_contracts"
+      ],
+      "path_selectors": [
+        "adl/tools/skills/workflow-conductor/**",
+        "adl/tools/test_workflow_conductor_skill_contracts.sh"
+      ],
+      "path_hints": [
+        "adl/tools/skills/workflow-conductor/**",
+        "adl/tools/test_workflow_conductor_skill_contracts.sh"
+      ],
+      "command": "bash adl/tools/test_workflow_conductor_skill_contracts.sh",
+      "run_command": "bash adl/tools/test_workflow_conductor_skill_contracts.sh",
+      "reason": "workflow_conductor_surface_requires_conductor_contract_checks"
+    },
+    {
       "id": "pvf_contracts",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -115,6 +115,29 @@ def run_command_with_timeout(args, cwd: Path, timeout_secs=None):
         }
 
 
+def parse_json_from_mixed_output(raw: str):
+    lines = raw.splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            payload = "\n".join(lines[index:])
+            decoder = json.JSONDecoder()
+            value, _ = decoder.raw_decode(payload.lstrip())
+            return value
+    raise ValueError("command output did not contain JSON")
+
+
+def adl_binary(repo_root: Path):
+    candidates = [
+        repo_root / "adl" / "target" / "debug" / "adl",
+        repo_root.parent / "agent-design-language" / "adl" / "target" / "debug" / "adl",
+    ]
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return str(candidate)
+    return "adl"
+
+
 def read_text(path: Path):
     if not path or not path.exists():
         return ""
@@ -211,12 +234,7 @@ def find_source_prompt_for_issue(repo_root: Path, issue_number: int):
 
 
 def parse_doctor_output(raw: str):
-    lines = raw.splitlines()
-    for index, line in enumerate(lines):
-        if line.lstrip().startswith("{"):
-            payload = "\n".join(lines[index:])
-            return json.loads(payload)
-    raise ValueError("doctor output did not contain JSON")
+    return parse_json_from_mixed_output(raw)
 
 
 def frontmatter_value(text: str, key: str):
@@ -272,17 +290,22 @@ def classify_doctor_state(doctor):
     return "none"
 
 
-def gh_child_issue_wave_state(repo_root: Path, parent_issue_number: int):
+def repo_native_issue_list(repo_root: Path):
     result = run_command(
-        ["gh", "issue", "list", "--state", "all", "--limit", "200", "--json", "number,state,body,title"],
+        ["bash", "adl/tools/pr.sh", "issue", "list", "--state", "all", "--limit", "200", "--json"],
         repo_root,
     )
     if result.returncode != 0 or not result.stdout.strip():
-        return None
+        return []
     try:
-        issues = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return None
+        issues = parse_json_from_mixed_output(result.stdout)
+    except (ValueError, json.JSONDecodeError):
+        return []
+    return issues if isinstance(issues, list) else []
+
+
+def child_issue_wave_state(repo_root: Path, parent_issue_number: int):
+    issues = repo_native_issue_list(repo_root)
     children = []
     needle = f"child of #{parent_issue_number}"
     for issue in issues:
@@ -291,22 +314,13 @@ def gh_child_issue_wave_state(repo_root: Path, parent_issue_number: int):
             children.append(issue)
     if not children:
         return None
-    if all(issue.get("state") == "CLOSED" for issue in children):
+    if all(str(issue.get("state", "")).lower() == "closed" for issue in children):
         return "satisfied_by_child_issue_wave"
     return "active_child_issue_wave"
 
 
-def gh_issue_index(repo_root: Path):
-    result = run_command(
-        ["gh", "issue", "list", "--state", "all", "--limit", "200", "--json", "number,state,body,title"],
-        repo_root,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return {}
-    try:
-        issues = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return {}
+def issue_index(repo_root: Path):
+    issues = repo_native_issue_list(repo_root)
     return {int(issue.get("number")): issue for issue in issues if issue.get("number") is not None}
 
 
@@ -326,7 +340,7 @@ def related_issue_reference_state(texts, issue_index):
     referenced = [issue for issue in referenced if issue]
     if not referenced:
         return "none"
-    if all(issue.get("state") == "CLOSED" for issue in referenced):
+    if all(str(issue.get("state", "")).lower() == "closed" for issue in referenced):
         return "satisfied_by_related_issue_refs"
     return "related_issue_ref_active"
 
@@ -365,7 +379,7 @@ def sibling_issue_artifact_state(repo_root: Path, texts, issue_number: int, vers
     sibling_needle = f"child of #{parent_issue}"
     for sibling_issue in issue_index.values():
         sibling_number = int(sibling_issue.get("number", 0) or 0)
-        if sibling_number == issue_number or sibling_issue.get("state") != "CLOSED":
+        if sibling_number == issue_number or str(sibling_issue.get("state", "")).lower() != "closed":
             continue
         sibling_body = sibling_issue.get("body") or ""
         if sibling_needle not in sibling_body.lower():
@@ -522,8 +536,8 @@ def issue_tracker_state(repo_root: Path, bundle: Path, source_prompt: Path, issu
     is_tracker_like = bool(wp_value and wp_value != "unassigned") or bool(title and "[WP-" in title)
     if not is_tracker_like:
         return "none"
-    gh_state = gh_child_issue_wave_state(repo_root, issue_number)
-    return gh_state or "none"
+    state = child_issue_wave_state(repo_root, issue_number)
+    return state or "none"
 
 
 def collect_route_issue(repo_root: Path, payload):
@@ -557,7 +571,7 @@ def collect_route_issue(repo_root: Path, payload):
         workflow["evidence_used"].append("missing_root_bundle")
         return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
-    issue_index = gh_issue_index(repo_root)
+    issues_by_number = issue_index(repo_root)
     tracker_state = issue_tracker_state(repo_root, bundle, source_prompt, issue_number)
     if tracker_state == "satisfied_by_child_issue_wave":
         workflow["blocker_class"] = "satisfied_by_child_issue_wave"
@@ -568,7 +582,7 @@ def collect_route_issue(repo_root: Path, payload):
 
     related_state = related_issue_reference_state(
         [read_text(source_prompt), read_text(bundle / "stp.md") if bundle else ""],
-        issue_index,
+        issues_by_number,
     )
     if workflow["blocker_class"] == "none" and related_state == "satisfied_by_related_issue_refs":
         workflow["blocker_class"] = "satisfied_by_related_issue_refs"
@@ -582,7 +596,7 @@ def collect_route_issue(repo_root: Path, payload):
         [read_text(source_prompt), read_text(bundle / "stp.md") if bundle else ""],
         issue_number,
         resolved_target.get("version"),
-        issue_index,
+        issues_by_number,
     )
     if workflow["blocker_class"] == "none" and sibling_artifact_state == "satisfied_by_sibling_issue_artifact":
         workflow["blocker_class"] = "satisfied_by_sibling_issue_artifact"
@@ -808,23 +822,44 @@ def summarize_checks(status_rollup):
     return "pass"
 
 
+def pr_from_validation_report(report):
+    checks = []
+    for check in report.get("checks", []):
+        checks.append(
+            {
+                "status": check.get("status"),
+                "conclusion": check.get("conclusion"),
+            }
+        )
+    pr_state = report.get("pr_state") or "OPEN"
+    return {
+        "state": "MERGED" if pr_state == "MERGED" else pr_state,
+        "isDraft": bool(report.get("is_draft")),
+        "reviewDecision": report.get("reviewDecision") or report.get("review_decision"),
+        "mergeStateStatus": report.get("mergeStateStatus") or report.get("merge_state_status") or "UNKNOWN",
+        "headRefName": report.get("head_ref_name"),
+        "statusCheckRollup": checks,
+    }
+
+
+def repo_native_pr_validation(repo_root: Path, pr_number: int):
+    result = run_command(
+        [adl_binary(repo_root), "pr", "validation", str(pr_number), "--json"],
+        repo_root,
+    )
+    if not result.stdout.strip():
+        fail(f"workflow-conductor: failed to inspect PR #{pr_number} with repo-native ADL validation")
+    try:
+        report = parse_json_from_mixed_output(result.stdout)
+    except (ValueError, json.JSONDecodeError) as exc:
+        fail(f"workflow-conductor: failed to parse repo-native PR #{pr_number} validation JSON: {exc}")
+    return report
+
+
 def collect_route_pr(repo_root: Path, payload):
     target = payload.get("target", {})
     pr_number = int(target["pr_number"])
-    result = run_command(
-        [
-            "gh",
-            "pr",
-            "view",
-            str(pr_number),
-            "--json",
-            "state,isDraft,reviewDecision,mergeStateStatus,headRefName,statusCheckRollup",
-        ],
-        repo_root,
-    )
-    if result.returncode != 0:
-        fail(f"workflow-conductor: failed to inspect PR #{pr_number}")
-    pr = json.loads(result.stdout)
+    pr = pr_from_validation_report(repo_native_pr_validation(repo_root, pr_number))
     resolved_target = dict(target)
     resolved_target.setdefault("branch", pr.get("headRefName"))
     identity = parse_branch_identity(pr.get("headRefName", ""))
@@ -846,7 +881,7 @@ def collect_route_pr(repo_root: Path, payload):
         "pr_state": "open_unknown",
         "blocker_class": "none",
         "subagent_assigned": bool(payload.get("observed_state", {}).get("subagent_assigned", False)),
-        "evidence_used": ["gh_pr"],
+        "evidence_used": ["repo_native_pr_validation"],
     }
     workflow["pr_state"], workflow["blocker_class"] = classify_pr_state(pr)
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -450,15 +450,15 @@ EOF
   assert_has "$rust_dependency_cache_policy_output" "demo_smoke_required=false"
   assert_has "$rust_dependency_cache_policy_output" "v0913_proof_required=false"
   assert_has "$rust_dependency_cache_policy_output" "release_version_only=false"
-  assert_has "$rust_dependency_cache_policy_output" "ci_contracts_required=false"
+  assert_has "$rust_dependency_cache_policy_output" "ci_contracts_required=true"
   assert_has "$rust_dependency_cache_policy_output" "validation_profile_contract_lanes_selected=true"
   assert_has "$rust_dependency_cache_policy_output" "fail_closed=false"
   assert_has "$rust_dependency_cache_policy_output" "coverage_lane=skip"
   assert_has "$rust_dependency_cache_policy_output" "coverage_authority=not_required"
-  assert_has "$rust_dependency_cache_policy_output" "reason=bounded_rust_dependency_cache_warmup_policy_change_runs_python_and_path_policy_checks"
+  assert_has "$rust_dependency_cache_policy_output" "reason=ci_policy_surface_requires_path_policy_contract_checks"
   assert_has "$rust_dependency_cache_policy_output" "validation_profile_status=ready_to_run"
   assert_has "$rust_dependency_cache_policy_output" "validation_profile_escalation_required=false"
-  assert_has "$rust_dependency_cache_policy_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts"
+  assert_has "$rust_dependency_cache_policy_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts,workflow_conductor_contracts"
 
   git checkout -q -b rust-dependency-cache-warmup-mixed-policy-change "$base_sha"
   mkdir -p adl/config adl/tools docs/tooling
@@ -516,7 +516,7 @@ EOF
   assert_has "$rust_dependency_cache_unrelated_guidance_output" "reason=ci_policy_surface_requires_path_policy_contract_checks"
   assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_status=ready_to_run"
   assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_escalation_required=false"
-  assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts"
+  assert_has "$rust_dependency_cache_unrelated_guidance_output" "validation_profile_run_lanes=ci_path_policy_contracts,docs_diff_check,rust_dependency_cache_warmup_contracts,workflow_conductor_contracts"
 
   git checkout -q -b classifier-followup "$base_sha"
   mkdir -p adl/tools/skills/sprint-conductor/scripts adl/config adl/tools

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -316,6 +316,20 @@ if [[ "$cmd" == "closeout" ]]; then
   echo "CLOSEOUT:${issue}" >>"${ADL_DISPATCH_LOG}"
   exit 0
 fi
+if [[ "$cmd" == "issue" && "${2:-}" == "list" ]]; then
+  cat <<'JSON'
+[
+  {"number":2011,"state":"closed","title":"child-a","body":"## Issue-Graph Notes\n- child of #2006"},
+  {"number":2012,"state":"closed","title":"child-b","body":"## Issue-Graph Notes\n- child of #2006"},
+  {"number":2013,"state":"closed","title":"covered-fix","body":"Resolved by prior child issue"},
+  {"number":2014,"state":"open","title":"active-follow-on","body":"Still in progress"},
+  {"number":2016,"state":"closed","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2020"},
+  {"number":2017,"state":"closed","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2021"},
+  {"number":2018,"state":"closed","title":"Unrelated closed sibling","body":"## Issue-Graph Notes\n- child of #2022"}
+]
+JSON
+  exit 0
+fi
 if [[ "$cmd" != "doctor" ]]; then
   exit 1
 fi
@@ -911,47 +925,49 @@ mkdir -p "${mock_bin}"
 cat >"${mock_bin}/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "$1" == "pr" && "$2" == "view" && "$3" == "3001" ]]; then
-  cat <<'JSON'
-{"state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","mergeStateStatus":"BLOCKED","headRefName":"codex/3001-pr-blocked","statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}
-JSON
-  exit 0
-fi
-if [[ "$1" == "issue" && "$2" == "list" ]]; then
-  cat <<'JSON'
-[
-  {"number":2011,"state":"CLOSED","title":"child-a","body":"## Issue-Graph Notes\n- child of #2006"},
-  {"number":2012,"state":"CLOSED","title":"child-b","body":"## Issue-Graph Notes\n- child of #2006"},
-  {"number":2013,"state":"CLOSED","title":"covered-fix","body":"Resolved by prior child issue"},
-  {"number":2014,"state":"OPEN","title":"active-follow-on","body":"Still in progress"},
-  {"number":2016,"state":"CLOSED","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2020"},
-  {"number":2017,"state":"CLOSED","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2021"},
-  {"number":2018,"state":"CLOSED","title":"Unrelated closed sibling","body":"## Issue-Graph Notes\n- child of #2022"}
-]
-JSON
-  exit 0
-fi
-if [[ "$1" == "pr" && "$2" == "view" && "$3" == "3004" ]]; then
-  cat <<'JSON'
-{"state":"OPEN","isDraft":false,"reviewDecision":null,"mergeStateStatus":"BLOCKED","headRefName":"codex/3004-pr-linkage-only","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}
-JSON
-  exit 0
-fi
-if [[ "$1" == "pr" && "$2" == "view" && "$3" == "3002" ]]; then
-  cat <<'JSON'
-{"state":"MERGED","isDraft":false,"reviewDecision":null,"mergeStateStatus":"UNKNOWN","headRefName":"codex/3002-pr-merged","statusCheckRollup":[]}
-JSON
-  exit 0
-fi
-if [[ "$1" == "pr" && "$2" == "view" && "$3" == "3003" ]]; then
-  cat <<'JSON'
-{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN","headRefName":"codex/3003-pr-clean","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}
-JSON
-  exit 0
-fi
-exit 1
+echo "unexpected gh invocation: $*" >&2
+exit 91
 EOF
 chmod +x "${mock_bin}/gh"
+
+cat >"${mock_bin}/adl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "validation" ]]; then
+  case "$3" in
+    3001)
+      cat <<'JSON'
+{"pr_number":3001,"pr_state":"OPEN","is_draft":false,"reviewDecision":"CHANGES_REQUESTED","mergeStateStatus":"BLOCKED","head_ref_name":"codex/3001-pr-blocked","checks":[{"status":"COMPLETED","conclusion":"FAILURE"}]}
+JSON
+      exit 0
+      ;;
+    3002)
+      cat <<'JSON'
+{"pr_number":3002,"pr_state":"MERGED","is_draft":false,"reviewDecision":null,"mergeStateStatus":"UNKNOWN","head_ref_name":"codex/3002-pr-merged","checks":[]}
+JSON
+      exit 0
+      ;;
+    3003)
+      cat <<'JSON'
+{"pr_number":3003,"pr_state":"OPEN","is_draft":false,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN","head_ref_name":"codex/3003-pr-clean","checks":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}
+JSON
+      exit 0
+      ;;
+    3004)
+      cat <<'JSON'
+{"pr_number":3004,"pr_state":"OPEN","is_draft":false,"reviewDecision":null,"mergeStateStatus":"BLOCKED","head_ref_name":"codex/3004-pr-linkage-only","checks":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}
+JSON
+      exit 0
+      ;;
+  esac
+fi
+echo "unexpected adl invocation: $*" >&2
+exit 92
+EOF
+chmod +x "${mock_bin}/adl"
+mkdir -p "${fixture_repo}/adl/target/debug"
+cp "${mock_bin}/adl" "${fixture_repo}/adl/target/debug/adl"
+chmod +x "${fixture_repo}/adl/target/debug/adl"
 
 mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-3001__pr-blocked" "${fixture_repo}/.adl/v0.88/tasks/issue-3002__pr-merged" "${fixture_repo}/.adl/v0.88/tasks/issue-3003__pr-clean"
 mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-3004__pr-linkage-only"


### PR DESCRIPTION
Closes #4737

## Summary
Implemented the workflow-conductor helper tracker inference change so the route helper no longer shells out to `gh` for issue-list or PR-state inference. Issue wave state now uses repo-native `pr.sh issue list`, PR routing uses repo-native `adl pr validation --json`, and mixed observability-plus-JSON output is parsed safely without depending on a clean stdout stream. Added focused contract coverage that makes `gh` a failing sentinel and forces the production-style `adl/target/debug/adl` discovery path.

## Artifacts
- Updated `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
- Updated `adl/tools/test_workflow_conductor_skill_contracts.sh`
- Updated `adl/config/validation_lane_selector.v0.91.6.json`
- Updated `adl/tools/test_ci_path_policy.sh`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
    Verified Python syntax for the changed route helper.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified workflow-conductor routing contracts, no live `gh` calls in the covered helper paths, repo-native PR validation fixture behavior, and issue-list inference behavior.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified validation lane selector classification after adding `workflow_conductor_contracts`.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified path-policy and validation-manager contract behavior for the updated selector.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4737__v0-91-7-tools-conductor-remove-gh-dependency-from-conductor-helper-tracker-inference/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4737__v0-91-7-tools-conductor-remove-gh-dependency-from-conductor-helper-tracker-inference/sor.md
- Idempotency-Key: v0-91-7-tools-conductor-remove-gh-dependency-from-conductor-tracker-inference-adl-tools-skills-workflow-conductor-scripts-route-workflow-py-adl-tools-test-workflow-conductor-skill-contracts-sh-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-test-ci-path-policy-sh-adl-v0-91-7-tasks-issue-4737-v0-91-7-tools-conductor-remove-gh-dependency-from-conductor-helper-tracker-inference-sip-md-adl-v0-91-7-tasks-issue-4737-v0-91-7-tools-conductor-remove-gh-dependency-from-conductor-helper-tracker-inference-sor-md