### PR TITLE
[v0.91.7][tools] Implement workflow-conductor helper without gh fallback

### DIFF
--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -136,6 +136,20 @@ When conductor routing depends on doctor/readiness/PR state:
 - when a routing result depends on wait state, queue blocking, or PR inference,
   preserve the relevant log-policy caveat in the output or handoff notes
 
+## Repo-Native Tracker And PR Inference
+
+The conductor helper must not call the GitHub CLI directly for tracker or PR
+state inference. Its supported repo-native read surfaces are:
+- issue/tracker discovery through
+  `bash adl/tools/pr.sh issue list --state all --limit 200 --json`
+- PR state discovery through `adl pr validation <pr-number> --json`
+
+Those commands may emit human `adl_event` observability alongside structured
+payloads. The helper must parse the first JSON object or array from mixed
+output, record the repo-native surface in `workflow_state.evidence_used`, and
+fail closed when those surfaces are missing or malformed. Raw `gh` is not a
+supported fallback for this skill.
+
 ## Routing Model
 
 Preferred next-skill mapping:

--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -13,6 +13,8 @@ workflow_state:
   blocker_class: none | open_pr_wave_only | doctor_failed_or_inconclusive | review_changes_requested | merge_conflict | checks_failed | merge_blocked | healthy_pr_waiting | satisfied_by_child_issue_wave | satisfied_by_related_issue_refs | satisfied_by_sibling_issue_artifact | active_child_issue_wave | related_issue_ref_active | tracked_adl_residue | unsafe_root_checkout_execution | mismatched_publication_surface | rebind_to_issue_worktree_required | open_linkage_only
   evidence_used:
     - <doctor_json_or_path_or_state_surface>
+    - repo_native_issue_list:<state-scope>   # when tracker/umbrella inference reads `pr.sh issue list`
+    - repo_native_pr_validation:<pr-number> # when PR inference reads `adl pr validation`
 selected_skill:
   phase: init | ready | run | finish | janitor | closeout | editor | blocked
   skill_name: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | none

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -42,6 +42,11 @@ grep -Fq "rebind_to_issue_worktree_required" "${skills_root}/docs/OPERATIONAL_SK
 grep -Fq "card-local SPP issue -> \`spp-editor\`" "${skills_root}/workflow-conductor/SKILL.md"
 grep -Fq "card-local SRP issue -> \`srp-editor\`" "${skills_root}/workflow-conductor/SKILL.md"
 grep -Fq "srp-editor" "${skills_root}/workflow-conductor/references/output-contract.md"
+grep -Fq "bash adl/tools/pr.sh issue list --state all --limit 200 --json" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "adl pr validation <pr-number> --json" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "Raw \`gh\` is not a" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "repo_native_issue_list" "${skills_root}/workflow-conductor/references/output-contract.md"
+grep -Fq "repo_native_pr_validation" "${skills_root}/workflow-conductor/references/output-contract.md"
 
 cat >"${tmpdir}/bootstrap_missing.json" <<'EOF'
 {


### PR DESCRIPTION
Closes #4738

## Summary
Implemented the workflow-conductor no-raw-gh contract alignment for #4738. The code path had already moved to repo-native issue-list and PR-validation surfaces; this issue records and tests the skill contract so future conductor use does not fall back to raw gh for tracker or PR inference.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4738__v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback/sor.md`
- Tracked implementation artifacts: `adl/tools/skills/workflow-conductor/SKILL.md`, `adl/tools/skills/workflow-conductor/references/output-contract.md`, `adl/tools/test_workflow_conductor_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
    Verified the existing route helper remains Python-syntax valid.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified the workflow-conductor skill-contract fixture suite and new no-raw-gh contract assertions.
  - `git diff --check`
    Verified whitespace/patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4738__v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4738__v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback/sor.md
- Idempotency-Key: v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback-adl-tools-skills-workflow-conductor-skill-md-adl-tools-skills-workflow-conductor-references-output-contract-md-adl-tools-test-workflow-conductor-skill-contracts-sh-adl-v0-91-7-tasks-issue-4738-v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback-sip-md-adl-v0-91-7-tasks-issue-4738-v0-91-7-tools-implement-workflow-conductor-helper-without-gh-fallback-sor-md