### PR TITLE
[v0.91.7][tools][rust-cache] Make warm-cache setup universal across Rust validation runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,9 @@ For a normal tracked issue:
 8. call `create_goal` for the bound tracked issue session before implementation
    starts
 9. make the bounded change in the issue worktree, never on `main`
-10. before Rust validation in a fresh or cold issue worktree, consider warming
-   dependency artifacts with `adl/tools/warm_rust_dependency_cache.py`; see
+10. before Rust validation in a fresh or cold issue worktree, warm dependency
+   artifacts through the shared wrapper when a trusted same-host source target
+   is available: `bash adl/tools/rust_validation_warm_cache.sh`; see
    `docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md`
 11. run the smallest meaningful validation for the touched surface
 12. run a pre-PR subagent review and fix findings
@@ -215,10 +216,10 @@ For a normal tracked issue:
 - For owner-binary surfaces, prefer the focused lane runner when it matches the
   change: `bash adl/tools/run_owner_validation_lane.sh csdlc|runtime|review|all`.
 - Before Rust-heavy validation in a fresh issue worktree or on an EC2/remote
-  builder, use the dependency-cache warmup helper only when a trusted warm
+  builder, use the dependency-cache warmup wrapper only when a trusted warm
   target from the same host, same filesystem, same checkout family, and same
   toolchain is available:
-  `python3 adl/tools/warm_rust_dependency_cache.py --source-target <warm-target> --dest-target <issue-worktree>/adl/target --manifest-path <issue-worktree>/adl/Cargo.toml`.
+  `ADL_RUST_WARM_CACHE_SOURCE_TARGET=<warm-target> ADL_RUST_WARM_CACHE_DEST_TARGET=<issue-worktree>/adl/target ADL_RUST_WARM_CACHE_MANIFEST_PATH=<issue-worktree>/adl/Cargo.toml bash adl/tools/rust_validation_warm_cache.sh`.
   Treat this as build acceleration only, not validation proof, and never replace
   the required validation lane with cache-warmup evidence.
 - Keep review records and output cards truthful about what was and was not run.

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -534,15 +534,27 @@
       ],
       "path_selectors": [
         "adl/tools/warm_rust_dependency_cache.py",
-        "adl/tools/test_warm_rust_dependency_cache.py"
+        "adl/tools/test_warm_rust_dependency_cache.py",
+        "adl/tools/rust_validation_warm_cache.sh",
+        "adl/tools/test_rust_validation_warm_cache.sh",
+        "adl/tools/run_authoritative_coverage_lane.sh",
+        "adl/tools/run_owner_validation_lane.sh",
+        "adl/tools/run_pr_fast_coverage_lane.sh",
+        "adl/tools/run_pr_fast_test_lane.sh"
       ],
       "path_hints": [
         "adl/tools/warm_rust_dependency_cache.py",
-        "adl/tools/test_warm_rust_dependency_cache.py"
+        "adl/tools/test_warm_rust_dependency_cache.py",
+        "adl/tools/rust_validation_warm_cache.sh",
+        "adl/tools/test_rust_validation_warm_cache.sh",
+        "adl/tools/run_authoritative_coverage_lane.sh",
+        "adl/tools/run_owner_validation_lane.sh",
+        "adl/tools/run_pr_fast_coverage_lane.sh",
+        "adl/tools/run_pr_fast_test_lane.sh"
       ],
-      "command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py",
-      "run_command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py",
-      "reason": "rust_dependency_cache_warmup_helper_requires_python_contract_checks"
+      "command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py && bash adl/tools/test_rust_validation_warm_cache.sh && bash adl/tools/test_run_authoritative_coverage_lane.sh && bash adl/tools/test_run_pr_fast_test_lane.sh",
+      "run_command": "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py && bash adl/tools/test_rust_validation_warm_cache.sh && bash adl/tools/test_run_authoritative_coverage_lane.sh && bash adl/tools/test_run_pr_fast_test_lane.sh",
+      "reason": "rust_dependency_cache_warmup_surface_requires_python_shell_and_runner_contract_checks"
     },
     {
       "id": "docs_diff_check",

--- a/adl/tools/run_authoritative_coverage_lane.sh
+++ b/adl/tools/run_authoritative_coverage_lane.sh
@@ -19,7 +19,6 @@ default_coverage_build_root() {
 }
 
 COVERAGE_BUILD_ROOT="${ADL_COVERAGE_BUILD_ROOT:-$(default_coverage_build_root)}"
-WARM_SOURCE_TARGET="${ADL_COVERAGE_WARM_SOURCE_TARGET:-$ADL_DIR/target}"
 
 usage() {
   cat <<'USAGE'
@@ -88,24 +87,13 @@ cd "$ADL_DIR"
 # scratch root and warm it from the restored target. Do not delete the
 # llvm-cov target between runs; it is the expensive instrumentation build cache.
 mkdir -p "$COVERAGE_BUILD_ROOT/target" "$COVERAGE_BUILD_ROOT/target/llvm-cov-target"
-if [ "${ADL_COVERAGE_WARM_CACHE:-1}" != "0" ] && [ -d "$WARM_SOURCE_TARGET/debug/deps" ]; then
-  SOURCE_REAL="$(cd "$WARM_SOURCE_TARGET" && pwd -P)"
-  DEST_REAL="$(cd "$COVERAGE_BUILD_ROOT/target" && pwd -P)"
-  if [ "$SOURCE_REAL" != "$DEST_REAL" ]; then
-    python3 "$ADL_DIR/tools/warm_rust_dependency_cache.py" \
-      --source-target "$SOURCE_REAL" \
-      --dest-target "$DEST_REAL" \
-      --manifest-path "$ADL_DIR/Cargo.toml" \
-      --replace \
-      --json | tee "$ADL_DIR/coverage-warm-cache.json"
-  else
-    printf '{"status":"skipped","reason":"source target is coverage target"}\n' | tee "$ADL_DIR/coverage-warm-cache.json"
-  fi
-else
-  printf '{"status":"skipped","reason":"source target cache missing or disabled"}\n' | tee "$ADL_DIR/coverage-warm-cache.json"
-fi
 export CARGO_TARGET_DIR="$COVERAGE_BUILD_ROOT/target"
 export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/target/llvm-cov-target"
+ADL_RUST_WARM_CACHE="${ADL_COVERAGE_WARM_CACHE:-${ADL_RUST_WARM_CACHE:-1}}" \
+ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_COVERAGE_WARM_SOURCE_TARGET:-}" \
+ADL_RUST_WARM_CACHE_DEST_TARGET="$CARGO_TARGET_DIR" \
+ADL_RUST_WARM_CACHE_OUTPUT="$ADL_DIR/coverage-warm-cache.json" \
+  bash "$ADL_DIR/tools/rust_validation_warm_cache.sh"
 
 if [ "$MODE" = "full_authoritative_default_features" ]; then
   echo "Authoritative coverage mode: full_authoritative_default_features"

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -134,6 +134,13 @@ run_review_lane() {
     bash adl/tools/test_adl_review_compatibility.sh
 }
 
+if [[ "$PRINT_PLAN" != "1" ]]; then
+  ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_OWNER_VALIDATION_WARM_SOURCE_TARGET:-}" \
+  ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
+  ADL_RUST_WARM_CACHE_OUTPUT="${ADL_OWNER_VALIDATION_WARM_CACHE_OUTPUT:-$ROOT_DIR/adl/owner-validation-warm-cache.json}" \
+    bash "$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
+fi
+
 build_owner_bins
 
 case "$SURFACE" in

--- a/adl/tools/run_pr_fast_coverage_lane.sh
+++ b/adl/tools/run_pr_fast_coverage_lane.sh
@@ -42,6 +42,10 @@ COVERAGE_BUILD_ROOT="${ADL_PR_FAST_COVERAGE_BUILD_ROOT:-$ADL_DIR/target/pr-fast-
 mkdir -p "$COVERAGE_BUILD_ROOT" "$COVERAGE_BUILD_ROOT/llvm-cov-target"
 export CARGO_TARGET_DIR="$COVERAGE_BUILD_ROOT"
 export CARGO_LLVM_COV_TARGET_DIR="$COVERAGE_BUILD_ROOT/llvm-cov-target"
+ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_COVERAGE_WARM_SOURCE_TARGET:-}" \
+ADL_RUST_WARM_CACHE_DEST_TARGET="$CARGO_TARGET_DIR" \
+ADL_RUST_WARM_CACHE_OUTPUT="${ADL_PR_FAST_COVERAGE_WARM_CACHE_OUTPUT:-$ADL_DIR/pr-fast-coverage-warm-cache.json}" \
+  bash "$ADL_DIR/tools/rust_validation_warm_cache.sh"
 
 printf 'PR-fast coverage expression: %s\n' "$FILTER_EXPRESSION"
 printf 'PR-fast coverage target: %s\n' "$CARGO_TARGET_DIR"

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -700,6 +700,10 @@ if [ "$PRINT_PLAN" = true ]; then
 fi
 
 cd "$ROOT_DIR/adl"
+ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_TEST_WARM_SOURCE_TARGET:-}" \
+ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
+ADL_RUST_WARM_CACHE_OUTPUT="${ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT:-$ROOT_DIR/adl/pr-fast-test-warm-cache.json}" \
+  bash "$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
 
 if [ "$mode" = "focused" ] || [ "$mode" = "family" ]; then
   echo "Running $mode nextest lane: $filter_expression"

--- a/adl/tools/rust_validation_warm_cache.sh
+++ b/adl/tools/rust_validation_warm_cache.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ADL_DIR="$ROOT_DIR/adl"
+MANIFEST_PATH="${ADL_RUST_WARM_CACHE_MANIFEST_PATH:-$ADL_DIR/Cargo.toml}"
+DEST_TARGET="${ADL_RUST_WARM_CACHE_DEST_TARGET:-${CARGO_TARGET_DIR:-$ADL_DIR/target}}"
+OUTPUT_PATH="${ADL_RUST_WARM_CACHE_OUTPUT:-}"
+PROFILE="${ADL_RUST_WARM_CACHE_PROFILE:-debug}"
+ENABLED="${ADL_RUST_WARM_CACHE:-1}"
+REPLACE="${ADL_RUST_WARM_CACHE_REPLACE:-1}"
+
+default_source_target() {
+  case "$ROOT_DIR" in
+    */.worktrees/adl-wp-*)
+      local primary_root="${ROOT_DIR%%/.worktrees/adl-wp-*}"
+      if [ -d "$primary_root/adl/target" ]; then
+        printf '%s\n' "$primary_root/adl/target"
+        return
+      fi
+      ;;
+  esac
+  printf '%s\n' "$ADL_DIR/target"
+}
+
+SOURCE_TARGET="${ADL_RUST_WARM_CACHE_SOURCE_TARGET:-$(default_source_target)}"
+
+emit_json() {
+  local payload="$1"
+  if [ -n "$OUTPUT_PATH" ]; then
+    printf '%s\n' "$payload" | tee "$OUTPUT_PATH"
+  else
+    printf '%s\n' "$payload"
+  fi
+}
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+skip() {
+  local reason="$1"
+  emit_json "{\"status\":\"skipped\",\"reason\":$(json_escape "$reason"),\"source_target\":$(json_escape "$SOURCE_TARGET"),\"dest_target\":$(json_escape "$DEST_TARGET"),\"validation_proof\":false}"
+}
+
+if [ "$ENABLED" = "0" ]; then
+  skip "disabled"
+  exit 0
+fi
+
+if [ ! -f "$MANIFEST_PATH" ]; then
+  skip "manifest missing"
+  exit 0
+fi
+
+if [ ! -d "$SOURCE_TARGET/$PROFILE/deps" ]; then
+  skip "source target cache missing"
+  exit 0
+fi
+
+mkdir -p "$DEST_TARGET"
+SOURCE_REAL="$(cd "$SOURCE_TARGET" && pwd -P)"
+DEST_REAL="$(cd "$DEST_TARGET" && pwd -P)"
+
+if [ "$SOURCE_REAL" = "$DEST_REAL" ]; then
+  skip "source target is destination target"
+  exit 0
+fi
+
+args=(
+  python3 "$ADL_DIR/tools/warm_rust_dependency_cache.py"
+  --source-target "$SOURCE_REAL"
+  --dest-target "$DEST_REAL"
+  --manifest-path "$MANIFEST_PATH"
+  --profile "$PROFILE"
+  --json
+)
+if [ "$REPLACE" != "0" ]; then
+  args+=(--replace)
+fi
+
+"${args[@]}" | {
+  if [ -n "$OUTPUT_PATH" ]; then
+    tee "$OUTPUT_PATH"
+  else
+    cat
+  fi
+}

--- a/adl/tools/test_rust_validation_warm_cache.sh
+++ b/adl/tools/test_rust_validation_warm_cache.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_json_field() {
+  local file="$1"
+  local expr="$2"
+  python3 - "$file" "$expr" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+if not eval(sys.argv[2], {"payload": payload}):
+    raise SystemExit(f"assertion failed: {sys.argv[2]} payload={payload}")
+PY
+}
+
+missing_out="$TMP/missing.json"
+ADL_RUST_WARM_CACHE_SOURCE_TARGET="$TMP/missing-target" \
+ADL_RUST_WARM_CACHE_DEST_TARGET="$TMP/dest-target" \
+ADL_RUST_WARM_CACHE_OUTPUT="$missing_out" \
+  bash "$HELPER" >/dev/null
+assert_json_field "$missing_out" 'payload["status"] == "skipped"'
+assert_json_field "$missing_out" 'payload["reason"] == "source target cache missing"'
+assert_json_field "$missing_out" 'payload["validation_proof"] is False'
+
+same_target="$TMP/same-target"
+mkdir -p "$same_target/debug/deps"
+same_out="$TMP/same.json"
+ADL_RUST_WARM_CACHE_SOURCE_TARGET="$same_target" \
+ADL_RUST_WARM_CACHE_DEST_TARGET="$same_target" \
+ADL_RUST_WARM_CACHE_OUTPUT="$same_out" \
+  bash "$HELPER" >/dev/null
+assert_json_field "$same_out" 'payload["status"] == "skipped"'
+assert_json_field "$same_out" 'payload["reason"] == "source target is destination target"'
+
+if ! grep -Fq '*/.worktrees/adl-wp-*)' "$HELPER"; then
+  echo "expected helper to detect ADL issue worktrees for primary-checkout warm source discovery" >&2
+  exit 1
+fi
+
+for runner in \
+  "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh" \
+  "$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh" \
+  "$ROOT_DIR/adl/tools/run_pr_fast_test_lane.sh" \
+  "$ROOT_DIR/adl/tools/run_owner_validation_lane.sh"
+do
+  if ! grep -Fq 'rust_validation_warm_cache.sh' "$runner"; then
+    echo "expected runner to invoke shared warm-cache helper: $runner" >&2
+    exit 1
+  fi
+done
+
+owner_plan="$(bash "$ROOT_DIR/adl/tools/run_owner_validation_lane.sh" csdlc --print-plan)"
+if grep -Fq '"status"' <<<"$owner_plan"; then
+  echo "owner validation --print-plan must not execute warm-cache helper" >&2
+  exit 1
+fi
+
+echo "PASS test_rust_validation_warm_cache"

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -90,6 +90,24 @@ assert_has "$TMP/aws-remote-validation-tool.out" "aggregate_status=selected"
 assert_has "$TMP/aws-remote-validation-tool.out" "aws_remote_validation_tooling status=selected"
 assert_not_has "$TMP/aws-remote-validation-tool.out" "unmapped_change_surface"
 
+rust_warm_cache_surface="$TMP/rust-warm-cache-surface.txt"
+cat >"$rust_warm_cache_surface" <<'EOF'
+M	AGENTS.md
+M	adl/config/validation_lane_selector.v0.91.6.json
+M	adl/tools/run_authoritative_coverage_lane.sh
+M	adl/tools/run_owner_validation_lane.sh
+M	adl/tools/run_pr_fast_coverage_lane.sh
+M	adl/tools/run_pr_fast_test_lane.sh
+A	adl/tools/rust_validation_warm_cache.sh
+A	adl/tools/test_rust_validation_warm_cache.sh
+M	docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+EOF
+bash "$SCRIPT" --changed-files "$rust_warm_cache_surface" >"$TMP/rust-warm-cache-surface.out"
+assert_has "$TMP/rust-warm-cache-surface.out" "aggregate_status=selected"
+assert_has "$TMP/rust-warm-cache-surface.out" "rust_dependency_cache_warmup_contracts status=selected"
+assert_has "$TMP/rust-warm-cache-surface.out" "ci_path_policy_contracts status=selected"
+assert_not_has "$TMP/rust-warm-cache-surface.out" "unmapped_change_surface"
+
 issue_4603_surface="$TMP/issue-4603-surface.txt"
 cat >"$issue_4603_surface" <<'EOF'
 M	adl/Cargo.lock

--- a/docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
+++ b/docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md
@@ -21,7 +21,7 @@ Remove `--dry-run` only after inspecting the JSON summary.
 
 - The tool uses `Cargo.lock` package names as a local, deterministic dependency classifier.
 - The current manifest package and explicit workspace-member packages are excluded from the eligible prefix set.
-- Only files under `target/<profile>/deps` are warmed by default; `.fingerprint` and `build` metadata are intentionally not hardlinked in this first version.
+- Files under `target/<profile>/deps` and dependency `.fingerprint` entries are eligible for warmup; `build` metadata is intentionally not hardlinked.
 - Cargo dep-info files (`*.d`) are intentionally skipped because they can encode paths from the source target.
 - Dependency package artifacts are eligible for warmup when their filenames match lockfile-derived prefixes.
 - Workspace package outputs are not selected intentionally.
@@ -32,9 +32,20 @@ Remove `--dry-run` only after inspecting the JSON summary.
 
 ## Recommended ADL Usage
 
-Use this helper before Rust-heavy validation in a fresh or cold issue worktree
-when a trusted warm source target already exists on the same host and
-filesystem. Typical places to use it:
+Use the shared shell wrapper before Rust-heavy validation in a fresh or cold
+issue worktree when a trusted warm source target already exists on the same
+host and filesystem:
+
+```sh
+bash adl/tools/rust_validation_warm_cache.sh
+```
+
+The wrapper computes deterministic defaults from the current checkout. In an
+ADL issue worktree under `.worktrees/adl-wp-*`, it automatically prefers the
+primary checkout's `adl/target` as the warm source when that target exists. It
+respects `CARGO_TARGET_DIR` for the destination target, emits one JSON status
+payload, and skips safely when no trusted source target is available. Typical
+places to use it:
 
 - after `pr run <issue>` binds a fresh issue worktree and before the first
   focused Rust validation command
@@ -47,14 +58,24 @@ For local issue worktrees, use a trusted warm source target from the same
 checkout family and toolchain:
 
 ```sh
-python3 adl/tools/warm_rust_dependency_cache.py \
-  --source-target /Users/daniel/git/agent-design-language/adl/target \
-  --dest-target /Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/target \
-  --manifest-path /Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/Cargo.toml \
-  --json
+ADL_RUST_WARM_CACHE_SOURCE_TARGET=/Users/daniel/git/agent-design-language/adl/target \
+ADL_RUST_WARM_CACHE_DEST_TARGET=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/target \
+ADL_RUST_WARM_CACHE_MANIFEST_PATH=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-XXXX/adl/Cargo.toml \
+  bash adl/tools/rust_validation_warm_cache.sh
 ```
 
 For EC2 or remote builders, warm from the local persistent target cache on that host before running focused validation. Keep the source and destination on the same filesystem so hardlinks work.
+
+The lower-level Python helper remains available for direct dry-run inspection:
+
+```sh
+python3 adl/tools/warm_rust_dependency_cache.py \
+  --source-target /path/to/warm/target \
+  --dest-target /path/to/issue/worktree/adl/target \
+  --manifest-path /path/to/issue/worktree/adl/Cargo.toml \
+  --dry-run \
+  --json
+```
 
 ## Agent Workflow Integration
 
@@ -72,11 +93,12 @@ The helper has its own focused behavior test:
 
 ```sh
 python3 adl/tools/test_warm_rust_dependency_cache.py
+bash adl/tools/test_rust_validation_warm_cache.sh
 ```
 
-That test proves dependency artifacts are linked, Cargo dep-info files are not
-linked, workspace outputs are not linked, `.fingerprint` and `build` are not
-linked, and `--replace` is explicit.
+That test proves dependency artifacts and dependency fingerprint files are
+linked, Cargo dep-info files are not linked, workspace outputs are not linked,
+`build` outputs are not linked, and `--replace` is explicit.
 
 ## Non-Claims
 


### PR DESCRIPTION
Closes #4788

## Summary
Implemented a shared Rust validation warm-cache wrapper and wired it into the Rust-heavy validation runners used by ADL workflow paths. The change makes warm-cache setup available consistently from the authoritative coverage lane, PR fast coverage lane, PR fast test lane, and owner validation lane while preserving the rule that cache warmup is acceleration only, never validation proof.

## Artifacts
- `adl/tools/rust_validation_warm_cache.sh`
- `adl/tools/test_rust_validation_warm_cache.sh`
- Updated `adl/tools/run_authoritative_coverage_lane.sh`
- Updated `adl/tools/run_owner_validation_lane.sh`
- Updated `adl/tools/run_pr_fast_coverage_lane.sh`
- Updated `adl/tools/run_pr_fast_test_lane.sh`
- Updated `adl/config/validation_lane_selector.v0.91.6.json`
- Updated `adl/tools/test_select_validation_lanes.sh`
- Updated `AGENTS.md`
- Updated `docs/tooling/HARDLINKED_RUST_DEPENDENCY_CACHE.md`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/test_warm_rust_dependency_cache.py && bash adl/tools/test_rust_validation_warm_cache.sh`
    Verified the existing Python cache helper and the new shared wrapper contract, including safe skips, issue-worktree primary-target discovery, runner integration markers, and owner-lane print-plan side-effect prevention.
  - `bash adl/tools/test_run_authoritative_coverage_lane.sh && bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified the authoritative coverage and PR fast test runner contracts still pass with shared warm-cache integration.
  - `bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_ci_path_policy.sh`
    Verified CI runtime and path-policy contracts after runner integration changes.
  - `bash adl/tools/run_pr_fast_coverage_lane.sh --help && git diff --check`
    Verified the fast coverage command surface remains available and the diff has no whitespace errors.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the C-SDLC owner validation lane passes with warm-cache setup active in the issue worktree.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan > scratch/owner-plan-4788.txt && if rg -q '"status"' scratch/owner-plan-4788.txt; then echo 'unexpected warm-cache status in print-plan'; exit 1; fi`
    Verified owner-lane print-plan output does not execute or emit warm-cache status JSON.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified the changed warm-cache runner surface maps to selected proving lanes and does not produce `unmapped_change_surface`.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified the CI path-policy contract after selector and runner updates.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4788__v0-91-7-tools-rust-cache-make-warm-cache-setup-universal-across-rust-validation-runners/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4788__v0-91-7-tools-rust-cache-make-warm-cache-setup-universal-across-rust-validation-runners/sor.md
- Idempotency-Key: v0-91-7-tools-rust-cache-make-warm-cache-setup-universal-across-rust-validation-runners-agents-md-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-rust-validation-warm-cache-sh-adl-tools-test-rust-validation-warm-cache-sh-adl-tools-run-authoritative-coverage-lane-sh-adl-tools-run-owner-validation-lane-sh-adl-tools-run-pr-fast-coverage-lane-sh-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-select-validation-lanes-sh-docs-tooling-hardlinked-rust-dependency-cache-md-adl-v0-91-7-tasks-issue-4788-v0-91-7-tools-rust-cache-make-warm-cache-setup-universal-across-rust-validation-runners-sip-md-adl-v0-91-7-tasks-issue-4788-v0-91-7-tools-rust-cache-make-warm-cache-setup-universal-across-rust-validation-runners-sor-md