### PR TITLE
[v0.91.7][provider] Add provider output-token budgets

### DIFF
--- a/adl/src/agent_comms/dispatch/coding.inc
+++ b/adl/src/agent_comms/dispatch/coding.inc
@@ -71,6 +71,7 @@ pub fn build_acip_coding_provider_boundary_adapter_v1(
         request_id: Some(contract.invocation.invocation_id.clone()),
         attempt_policy: attempt_policy_for_provider_lane(&contract.provider_lane),
         input_text: Some(message.content.clone()),
+        max_output_tokens: None,
         inference_parameter_fingerprint: Some(inference_parameter_fingerprint),
         tool_surface: Some("acip_coding_request".to_string()),
         governance_surface: Some(ACIP_CODING_PROVIDER_ADAPTER_SCHEMA_VERSION.to_string()),

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -392,6 +392,10 @@ fn validate_adapter_request(request: &ProviderInvocationRequestV1) -> Result<()>
     Ok(())
 }
 
+fn output_token_budget_or_default(request: &ProviderInvocationRequestV1, default: u64) -> u64 {
+    request.max_output_tokens.unwrap_or(default)
+}
+
 fn ensure_request_identity(request: &mut ProviderInvocationRequestV1) {
     let expected_runtime = match request.route.runtime_surface {
         RuntimeSurfaceV1::HostedApi => "hosted_api",
@@ -462,10 +466,7 @@ fn execute_hosted_openai(
     let response = client(policy)?
         .post(url)
         .bearer_auth(key)
-        .json(&json!({
-            "model": request.route.provider_model_id,
-            "input": request.input_text.as_deref().unwrap_or_default(),
-        }))
+        .json(&openai_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -474,6 +475,19 @@ fn execute_hosted_openai(
         |_| None,
         RuntimeSurfaceV1::HostedApi,
     )
+}
+
+fn openai_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    let mut body = json!({
+        "model": request.route.provider_model_id,
+        "input": request.input_text.as_deref().unwrap_or_default(),
+    });
+    if let Some(max_output_tokens) = request.max_output_tokens {
+        body.as_object_mut()
+            .expect("openai request body is object")
+            .insert("max_output_tokens".to_string(), json!(max_output_tokens));
+    }
+    body
 }
 
 fn execute_hosted_anthropic(
@@ -491,14 +505,7 @@ fn execute_hosted_anthropic(
         .post(url)
         .header("x-api-key", key)
         .header("anthropic-version", "2023-06-01")
-        .json(&json!({
-            "model": request.route.provider_model_id,
-            "max_tokens": 256,
-            "messages": [{
-                "role": "user",
-                "content": request.input_text.as_deref().unwrap_or_default(),
-            }],
-        }))
+        .json(&anthropic_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -507,6 +514,17 @@ fn execute_hosted_anthropic(
         |_| None,
         RuntimeSurfaceV1::HostedApi,
     )
+}
+
+fn anthropic_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    json!({
+        "model": request.route.provider_model_id,
+        "max_tokens": output_token_budget_or_default(request, 256),
+        "messages": [{
+            "role": "user",
+            "content": request.input_text.as_deref().unwrap_or_default(),
+        }],
+    })
 }
 
 fn execute_hosted_deepseek(
@@ -523,15 +541,7 @@ fn execute_hosted_deepseek(
     let response = client(policy)?
         .post(url)
         .bearer_auth(key)
-        .json(&json!({
-            "model": request.route.provider_model_id,
-            "messages": [{
-                "role": "user",
-                "content": request.input_text.as_deref().unwrap_or_default(),
-            }],
-            "max_tokens": 256,
-            "stream": false,
-        }))
+        .json(&deepseek_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -540,6 +550,18 @@ fn execute_hosted_deepseek(
         |_| None,
         RuntimeSurfaceV1::HostedApi,
     )
+}
+
+fn deepseek_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    json!({
+        "model": request.route.provider_model_id,
+        "messages": [{
+            "role": "user",
+            "content": request.input_text.as_deref().unwrap_or_default(),
+        }],
+        "max_tokens": output_token_budget_or_default(request, 256),
+        "stream": false,
+    })
 }
 
 fn execute_hosted_openrouter(
@@ -559,15 +581,7 @@ fn execute_hosted_openrouter(
     let response = client(policy)?
         .post(url)
         .bearer_auth(key)
-        .json(&json!({
-            "model": request.route.provider_model_id,
-            "messages": [{
-                "role": "user",
-                "content": request.input_text.as_deref().unwrap_or_default(),
-            }],
-            "max_tokens": DEFAULT_OPENROUTER_MAX_TOKENS,
-            "stream": false,
-        }))
+        .json(&openrouter_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -576,6 +590,18 @@ fn execute_hosted_openrouter(
         extract_chat_completion_model_id,
         RuntimeSurfaceV1::HostedApi,
     )
+}
+
+fn openrouter_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    json!({
+        "model": request.route.provider_model_id,
+        "messages": [{
+            "role": "user",
+            "content": request.input_text.as_deref().unwrap_or_default(),
+        }],
+        "max_tokens": output_token_budget_or_default(request, DEFAULT_OPENROUTER_MAX_TOKENS),
+        "stream": false,
+    })
 }
 
 fn execute_hosted_gemini(
@@ -597,12 +623,7 @@ fn execute_hosted_gemini(
     let response = client(policy)?
         .post(url)
         .header("x-goog-api-key", key)
-        .json(&json!({
-            "contents": [{
-                "role": "user",
-                "parts": [{"text": request.input_text.as_deref().unwrap_or_default()}],
-            }],
-        }))
+        .json(&gemini_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -613,6 +634,24 @@ fn execute_hosted_gemini(
     )
 }
 
+fn gemini_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    let mut body = json!({
+        "contents": [{
+            "role": "user",
+            "parts": [{"text": request.input_text.as_deref().unwrap_or_default()}],
+        }],
+    });
+    if let Some(max_output_tokens) = request.max_output_tokens {
+        body.as_object_mut()
+            .expect("gemini request body is object")
+            .insert(
+                "generationConfig".to_string(),
+                json!({"maxOutputTokens": max_output_tokens}),
+            );
+    }
+    body
+}
+
 fn execute_ollama_http(
     request: &mut ProviderInvocationRequestV1,
     policy: &ProviderAttemptPolicyV1,
@@ -620,12 +659,7 @@ fn execute_ollama_http(
     refresh_ollama_identity(request, policy);
     let response = client(policy)?
         .post(ollama_generate_url(request.route.endpoint_ref.as_deref()))
-        .json(&json!({
-            "model": request.route.provider_model_id,
-            "prompt": request.input_text.as_deref().unwrap_or_default(),
-            "stream": false,
-            "think": false,
-        }))
+        .json(&ollama_request_body(request))
         .send()
         .map_err(map_reqwest_error)?;
     decode_text_response(
@@ -638,6 +672,24 @@ fn execute_ollama_http(
         |_| None,
         RuntimeSurfaceV1::OllamaHttp,
     )
+}
+
+fn ollama_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    let mut body = json!({
+        "model": request.route.provider_model_id,
+        "prompt": request.input_text.as_deref().unwrap_or_default(),
+        "stream": false,
+        "think": false,
+    });
+    if let Some(max_output_tokens) = request.max_output_tokens {
+        body.as_object_mut()
+            .expect("ollama request body is object")
+            .insert(
+                "options".to_string(),
+                json!({"num_predict": max_output_tokens}),
+            );
+    }
+    body
 }
 
 fn decode_text_response(
@@ -1137,6 +1189,7 @@ mod tests {
                 retry_backoff_ms: Some(1),
             },
             input_text: Some("secret prompt should not enter logs".to_string()),
+            max_output_tokens: None,
             inference_parameter_fingerprint: None,
             tool_surface: None,
             governance_surface: None,
@@ -1184,6 +1237,59 @@ mod tests {
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-test:generateContent"
         );
         assert!(!url.contains("key="));
+    }
+
+    #[test]
+    fn optional_output_token_budget_maps_to_provider_native_fields() {
+        let mut req = request(
+            RuntimeSurfaceV1::HostedApi,
+            "http://127.0.0.1:1".to_string(),
+        );
+        req.max_output_tokens = Some(1_024);
+
+        assert_eq!(openai_request_body(&req)["max_output_tokens"], json!(1_024));
+        assert_eq!(anthropic_request_body(&req)["max_tokens"], json!(1_024));
+        assert_eq!(deepseek_request_body(&req)["max_tokens"], json!(1_024));
+        assert_eq!(openrouter_request_body(&req)["max_tokens"], json!(1_024));
+        assert_eq!(
+            gemini_request_body(&req)
+                .pointer("/generationConfig/maxOutputTokens")
+                .cloned(),
+            Some(json!(1_024))
+        );
+
+        let mut ollama_req = request(
+            RuntimeSurfaceV1::OllamaHttp,
+            "http://127.0.0.1:11434".to_string(),
+        );
+        ollama_req.max_output_tokens = Some(1_024);
+        assert_eq!(
+            ollama_request_body(&ollama_req).pointer("/options/num_predict"),
+            Some(&json!(1_024))
+        );
+    }
+
+    #[test]
+    fn omitted_output_token_budget_preserves_adapter_defaults() {
+        let req = request(
+            RuntimeSurfaceV1::HostedApi,
+            "http://127.0.0.1:1".to_string(),
+        );
+
+        assert!(openai_request_body(&req).get("max_output_tokens").is_none());
+        assert_eq!(anthropic_request_body(&req)["max_tokens"], json!(256));
+        assert_eq!(deepseek_request_body(&req)["max_tokens"], json!(256));
+        assert_eq!(
+            openrouter_request_body(&req)["max_tokens"],
+            json!(DEFAULT_OPENROUTER_MAX_TOKENS)
+        );
+        assert!(gemini_request_body(&req).get("generationConfig").is_none());
+
+        let ollama_req = request(
+            RuntimeSurfaceV1::OllamaHttp,
+            "http://127.0.0.1:11434".to_string(),
+        );
+        assert!(ollama_request_body(&ollama_req).get("options").is_none());
     }
 
     #[test]

--- a/adl/src/provider_communication.rs
+++ b/adl/src/provider_communication.rs
@@ -74,6 +74,8 @@ pub struct ProviderInvocationRequestV1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inference_parameter_fingerprint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_surface: Option<String>,
@@ -631,6 +633,9 @@ pub fn validate_provider_request(request: &ProviderInvocationRequestV1) -> Resul
         return Err(anyhow!(
             "attempt_policy.timeout_ms must be greater than zero"
         ));
+    }
+    if request.max_output_tokens == Some(0) {
+        return Err(anyhow!("max_output_tokens must be greater than zero"));
     }
     Ok(())
 }
@@ -1206,6 +1211,7 @@ mod tests {
                 retry_backoff_ms: Some(100),
             },
             input_text: Some("test prompt".to_string()),
+            max_output_tokens: None,
             inference_parameter_fingerprint: None,
             tool_surface: None,
             governance_surface: None,
@@ -1214,6 +1220,9 @@ mod tests {
         };
         validate_provider_request(&request).unwrap();
         request.attempt_policy.max_attempts = 0;
+        assert!(validate_provider_request(&request).is_err());
+        request.attempt_policy.max_attempts = 1;
+        request.max_output_tokens = Some(0);
         assert!(validate_provider_request(&request).is_err());
     }
 
@@ -1241,6 +1250,7 @@ mod tests {
                 retry_backoff_ms: None,
             },
             input_text: None,
+            max_output_tokens: None,
             inference_parameter_fingerprint: Some("sha256:test".to_string()),
             tool_surface: None,
             governance_surface: Some("codefriend.synthesis_required.v1".to_string()),

--- a/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
+++ b/docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md
@@ -35,7 +35,18 @@ Provider failures are normalized into the result file. The process exits non-zer
 
 ## Request Shape
 
-The request is `ProviderInvocationRequestV1`. The adapter requires `input_text` for execution while preserving existing `model_ref` / `provider_model_id` compatibility.
+The request is `ProviderInvocationRequestV1`. The adapter requires `input_text` for execution while preserving existing `model_ref` / `provider_model_id` compatibility. Callers may set optional `max_output_tokens` when a lane needs a larger response budget; the value must be greater than zero.
+
+When present, `max_output_tokens` maps to each provider's native request field:
+
+- OpenAI Responses API: `max_output_tokens`
+- Anthropic Messages API: `max_tokens`
+- DeepSeek chat completions: `max_tokens`
+- OpenRouter chat completions: `max_tokens`
+- Gemini `generateContent`: `generationConfig.maxOutputTokens`
+- Ollama `/api/generate`: `options.num_predict`
+
+When omitted, the adapter preserves its existing defaults: OpenAI, Gemini, and Ollama omit the provider-native cap; Anthropic and DeepSeek use `256`; OpenRouter uses the adapter's OpenRouter default.
 
 Hosted providers use `runtime_surface: "hosted_api"` and dispatch by `route.provider`:
 


### PR DESCRIPTION
Closes #4819

## Summary
Implemented a portable optional `max_output_tokens` field on `ProviderInvocationRequestV1`, validated that zero is rejected, and mapped the field to provider-native request payloads for OpenAI, Anthropic, DeepSeek, OpenRouter, Gemini, and Ollama. Existing adapter defaults are preserved when the field is omitted.

## Artifacts
- Tracked code artifacts:
  - `adl/src/provider_communication.rs`
  - `adl/src/provider_adapter.rs`
  - `adl/src/agent_comms/dispatch/coding.inc`
- Tracked documentation artifact: `docs/milestones/v0.91.4/review/provider_communication_substrate/PROVIDER_ADAPTER_RUNBOOK.md`
- Local ignored output card: `.adl/v0.91.7/tasks/issue-4819__v0-91-7-provider-adapter-output-token-budgets/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml output_token_budget -- --nocapture` - Verify optional max_output_tokens maps to provider-native fields and omitted budgets preserve defaults.
  - `cargo test --manifest-path adl/Cargo.toml request_validation_rejects_empty_and_zero_policy_fields -- --nocapture` - Verify request validation rejects zero-valued max_output_tokens.
  - `cargo test --manifest-path adl/Cargo.toml provider_adapter::tests -- --nocapture` - Run the full provider adapter unit-test slice after changing hosted and Ollama request bodies.
  - `cargo test --manifest-path adl/Cargo.toml schema_tests -- --nocapture` - Check schema-oriented test surface after extending ProviderInvocationRequestV1.
  - `git diff --check` - Verify the code and runbook diffs have no whitespace errors.
- Results:
  - `cargo test --manifest-path adl/Cargo.toml output_token_budget -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml request_validation_rejects_empty_and_zero_policy_fields -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml provider_adapter::tests -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml schema_tests -- --nocapture`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4819__v0-91-7-provider-adapter-output-token-budgets/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4819__v0-91-7-provider-adapter-output-token-budgets/sor.md
- Idempotency-Key: v0-91-7-provider-add-provider-output-token-budgets-adl-src-provider-communication-rs-adl-src-provider-adapter-rs-adl-src-agent-comms-dispatch-coding-inc-docs-milestones-v0-91-4-review-provider-communication-substrate-provider-adapter-runbook-md-adl-v0-91-7-tasks-issue-4819-v0-91-7-provider-adapter-output-token-budgets-sip-md-adl-v0-91-7-tasks-issue-4819-v0-91-7-provider-adapter-output-token-budgets-sor-md