### PR TITLE
Fix Unity observatory proof tooling (Closes #4789)

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -285,6 +285,7 @@
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
         "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
+        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh",
         "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
         "demos/v0.91.6/unity-observatory/README.md",
@@ -299,6 +300,7 @@
         "adl/tools/test_v0916_unity_observatory_baseline.sh",
         "adl/tools/test_v0916_unity_observatory_contract.sh",
         "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
+        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh",
         "adl/tools/test_v0916_unity_observatory_soak_integration.sh",
         "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh",
         "demos/v0.91.6/unity-observatory/README.md",
@@ -309,8 +311,8 @@
         "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOCAL_RUNTIME_CONSUMPTION_4548.md",
         "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md"
       ],
-      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
-      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
+      "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
       "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
     },
     {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3191,6 +3191,7 @@ fn registered_validation_atom_supported(command: &str) -> bool {
                 | "adl/tools/test_v0916_unity_observatory_baseline.sh"
                 | "adl/tools/test_v0916_unity_observatory_contract.sh"
                 | "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh"
+                | "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh"
                 | "adl/tools/test_v0916_unity_observatory_soak_integration.sh"
                 | "adl/tools/test_sprint_conductor_helpers.sh"
                 | "adl/tools/test_install_adl_operational_skills.sh"
@@ -3602,6 +3603,8 @@ fn finish_path_is_small_binary_focused(path: &str) -> bool {
             | "adl/tools/test_sprint_conductor_helpers.sh"
             | "adl/tools/test_v0916_unity_observatory_baseline.sh"
             | "adl/tools/test_v0916_unity_observatory_contract.sh"
+            | "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh"
+            | "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh"
     ) || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
 }
 
@@ -5269,7 +5272,13 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_v0916_unity_observatory_contract.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
-                "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture" => {
+                "bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh" => {
+                    let script = repo_root.join(
+                        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh",
+                    );
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
+                "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture" => {
                     let unity65_smoke =
                         repo_root.join("adl/tools/test_v0916_unity_observatory_unity65_smoke.sh");
                     run_finish_validation_status("bash", &["-n", path_str(&unity65_smoke)?])?;
@@ -5279,6 +5288,13 @@ pub(super) fn run_finish_validation_rust(
                     let contract =
                         repo_root.join("adl/tools/test_v0916_unity_observatory_contract.sh");
                     run_finish_validation_status("bash", &[path_str(&contract)?])?;
+                    let local_runtime_consumption_unit = repo_root.join(
+                        "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh",
+                    );
+                    run_finish_validation_status(
+                        "bash",
+                        &[path_str(&local_runtime_consumption_unit)?],
+                    )?;
                     let local_runtime_consumption = repo_root
                         .join("adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh");
                     run_finish_validation_status(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4668,6 +4668,10 @@ fn finish_helper_paths_run_unity_observatory_soak_lane_validation() {
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' contract >> \"$FOCUSED_LOG\"\n",
     );
     write_executable(
+        &repo.join("adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' local-runtime-unit >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
         &repo.join("adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' local-runtime >> \"$FOCUSED_LOG\"\n",
     );
@@ -4700,7 +4704,7 @@ fn finish_helper_paths_run_unity_observatory_soak_lane_validation() {
         commands: vec![
             "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
             "git diff --check".to_string(),
-            "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture".to_string(),
+            "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture".to_string(),
         ],
     };
     run_finish_validation_rust(&repo, &plan).expect("unity observatory soak lane validation");
@@ -4726,6 +4730,7 @@ fn finish_helper_paths_run_unity_observatory_soak_lane_validation() {
     );
     assert!(focused_calls.contains("baseline"));
     assert!(focused_calls.contains("contract"));
+    assert!(focused_calls.contains("local-runtime-unit"));
     assert!(focused_calls.contains("local-runtime"));
     assert!(focused_calls.contains("soak"));
 }

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -527,6 +527,7 @@ assert lane["owner"] == "review"
 assert "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh" in lane["command"]
 assert "test_v0916_unity_observatory_baseline.sh" in lane["command"]
 assert "test_v0916_unity_observatory_contract.sh" in lane["command"]
+assert "test_v0916_unity_observatory_local_runtime_consumption_unit.sh" in lane["command"]
 assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
 assert "test_v0916_unity_observatory_soak_integration.sh" in lane["command"]
 assert "csm_observatory_cli_writes_unity_contract_bundle" in lane["command"]
@@ -557,11 +558,13 @@ assert lane["matched_paths"] == [
     "docs/milestones/v0.91.6/review/observatory/UNITY_OBSERVATORY_LOGGING_OTEL_SECURITY_CONSUMPTION_4034.md",
 ]
 assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
+assert "test_v0916_unity_observatory_local_runtime_consumption_unit.sh" in lane["command"]
 PY
 
 unity_observatory_runtime_script="$TMP/unity-observatory-runtime-script.txt"
 cat >"$unity_observatory_runtime_script" <<'EOF'
 M	adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
+M	adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh
 EOF
 bash "$SCRIPT" --changed-files "$unity_observatory_runtime_script" --json >"$TMP/unity-observatory-runtime-script.json"
 python3 - <<'PY' "$TMP/unity-observatory-runtime-script.json"
@@ -576,8 +579,10 @@ assert set(profile["lanes"].keys()) == {"unity_observatory_contract_surface"}
 lane = profile["lanes"]["unity_observatory_contract_surface"]
 assert lane["matched_paths"] == [
     "adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh",
+    "adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh",
 ]
 assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["command"]
+assert "test_v0916_unity_observatory_local_runtime_consumption_unit.sh" in lane["command"]
 PY
 
 echo "PASS test_select_validation_lanes"

--- a/adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
+++ b/adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PROJECT_PATH="${ROOT_DIR}/demos/v0.91.6/unity-observatory"
+PROJECT_PATH="${ADL_UNITY_OBSERVATORY_PROJECT_PATH:-${ROOT_DIR}/demos/v0.91.6/unity-observatory}"
 DEFAULT_EDITOR="/Applications/Unity/Hub/Editor/6000.5.1f1/Unity.app/Contents/MacOS/Unity"
 UNITY_EDITOR_BIN="${UNITY_6_5_EDITOR_BIN:-${UNITY_EDITOR_BIN:-$DEFAULT_EDITOR}}"
 LOG_DIR="${ROOT_DIR}/.adl/tmp/unity-observatory-4548"
@@ -16,6 +16,9 @@ TMP_ROOT="${RUNTIME_ROOT}/tmp"
 GEN_OUT_DIR="${RUNTIME_ROOT}/generated-contract"
 RUNTIME_PACKET="${ROOT_DIR}/adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
 STAGED_CONTRACT_PATH="${STAGED_PROJECT_PATH}/Assets/Resources/observatory_contract.json"
+ADL_BIN="${ADL_UNITY_OBSERVATORY_ADL_BIN:-${ADL_PR_RUST_BIN:-${ROOT_DIR}/adl/target/debug/adl}}"
+PREPARE_ONLY="${ADL_UNITY_OBSERVATORY_PREPARE_ONLY:-0}"
+ALLOW_TEST_ADL_BIN="${ADL_UNITY_OBSERVATORY_ALLOW_TEST_ADL_BIN:-0}"
 
 mkdir -p "${LOG_DIR}"
 rm -f "${LOG_PATH}"
@@ -45,6 +48,62 @@ if [[ ! -f "${RUNTIME_PACKET}" ]]; then
   exit 2
 fi
 
+if [[ ! -x "${ADL_BIN}" ]]; then
+  echo "missing repo ADL binary for Unity Observatory contract generation: ${ADL_BIN}" >&2
+  echo "set ADL_PR_RUST_BIN or ADL_UNITY_OBSERVATORY_ADL_BIN to an existing repo-owned binary" >&2
+  exit 2
+fi
+
+resolve_path() {
+  python3 - <<'PY' "$1"
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve())
+PY
+}
+
+is_repo_adl_binary() {
+  local candidate_real="$1"
+  local worktree
+
+  case "${candidate_real}" in
+    */adl/target/debug/adl) ;;
+    *) return 1 ;;
+  esac
+
+  while IFS= read -r worktree; do
+    [[ -n "${worktree}" ]] || continue
+    case "${candidate_real}" in
+      "${worktree}/adl/target/debug/adl") return 0 ;;
+    esac
+  done < <(git -C "${ROOT_DIR}" worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }')
+
+  return 1
+}
+
+ADL_BIN_REAL="$(resolve_path "${ADL_BIN}")"
+if ! is_repo_adl_binary "${ADL_BIN_REAL}"; then
+  if [[ "${PREPARE_ONLY}" == "1" && "${ALLOW_TEST_ADL_BIN}" == "1" ]]; then
+    :
+  else
+    echo "Unity Observatory contract generation requires a repo-owned ADL binary: ${ADL_BIN}" >&2
+    echo "expected a checked-out worktree path ending in adl/target/debug/adl" >&2
+    exit 2
+  fi
+fi
+
+make_tree_writable() {
+  local target="$1"
+  if [[ ! -e "${target}" ]]; then
+    return 0
+  fi
+  if command -v chflags >/dev/null 2>&1; then
+    chflags -R nouchg,noschg "${target}" 2>/dev/null || true
+  fi
+  chmod -R u+rwX "${target}"
+}
+
 mkdir -p "${STAGE_ROOT}"
 rsync -a \
   --exclude 'Library/' \
@@ -54,13 +113,16 @@ rsync -a \
   "${PROJECT_PATH}/" \
   "${STAGED_PROJECT_PATH}/"
 
-cargo run --manifest-path "${ROOT_DIR}/adl/Cargo.toml" --bin adl -- \
+make_tree_writable "${RUNTIME_ROOT}"
+
+"${ADL_BIN}" \
   csm observatory \
   --packet "${RUNTIME_PACKET}" \
   --format bundle \
   --out "${GEN_OUT_DIR}" >/dev/null
 
 cp "${GEN_OUT_DIR}/unity_observatory_contract.json" "${STAGED_CONTRACT_PATH}"
+make_tree_writable "${RUNTIME_ROOT}"
 
 EXPECTED_TITLE="Prototype CSM 01"
 EXPECTED_PACKET_REF="adl/tests/fixtures/runtime_v2/observatory/visibility_packet.json"
@@ -68,7 +130,20 @@ EXPECTED_ARTIFACT_ROOT="runtime_v2"
 EXPECTED_REPORT_REF="runtime_v2/observatory/operator_report.md"
 EXPECTED_EVIDENCE_LEVEL="artifact_backed_fixture"
 
-chmod -R u+rwX "${RUNTIME_ROOT}"
+if [[ "${PREPARE_ONLY}" == "1" ]]; then
+  if [[ ! -w "${STAGED_PROJECT_PATH}" ]]; then
+    echo "Unity local-runtime prepare proof failed: staged project is not writable." >&2
+    exit 7
+  fi
+  if [[ ! -w "${STAGED_CONTRACT_PATH}" ]]; then
+    echo "Unity local-runtime prepare proof failed: staged contract is not writable." >&2
+    exit 7
+  fi
+  rm -rf "${RUNTIME_ROOT}" || true
+  echo "Unity local-runtime prepare proof passed."
+  echo "repo_adl_binary=${ADL_BIN}"
+  exit 0
+fi
 
 ADL_UNITY_EXPECTED_TITLE="${EXPECTED_TITLE}" \
 ADL_UNITY_EXPECTED_PACKET_REF="${EXPECTED_PACKET_REF}" \

--- a/adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh
+++ b/adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT_DIR}/adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/adl-unity-local-runtime-unit.XXXXXX")"
+
+cleanup() {
+  chmod -R u+rwX "${TMP_ROOT}" 2>/dev/null || true
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+fixture_project="${TMP_ROOT}/unity-observatory"
+mkdir -p "${fixture_project}/Assets/Resources" "${fixture_project}/ProjectSettings"
+printf '{"fixture":true}\n' >"${fixture_project}/Assets/Resources/observatory_contract.json"
+printf 'm_EditorVersion: 6000.5.1f1\n' >"${fixture_project}/ProjectSettings/ProjectVersion.txt"
+chmod -R a-w "${fixture_project}"
+
+fake_bin_dir="${TMP_ROOT}/bin"
+mkdir -p "${fake_bin_dir}"
+fake_adl="${fake_bin_dir}/adl"
+fake_cargo="${fake_bin_dir}/cargo"
+fake_log="${TMP_ROOT}/fake-adl-invocation.log"
+
+cat >"${fake_adl}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${ADL_FAKE_LOG}"
+out_dir=""
+while (($#)); do
+  case "$1" in
+    --out)
+      shift
+      out_dir="$1"
+      ;;
+  esac
+  shift || true
+done
+if [[ -z "${out_dir}" ]]; then
+  echo "fake adl missing --out" >&2
+  exit 64
+fi
+mkdir -p "${out_dir}"
+printf '{"title":"Prototype CSM 01"}\n' >"${out_dir}/unity_observatory_contract.json"
+SH
+chmod +x "${fake_adl}"
+
+cat >"${fake_cargo}" <<'SH'
+#!/usr/bin/env bash
+echo "cargo must not be invoked by Unity local-runtime preparation" >&2
+exit 99
+SH
+chmod +x "${fake_cargo}"
+
+set +e
+reject_output="$(
+  ADL_UNITY_OBSERVATORY_PROJECT_PATH="${fixture_project}" \
+  ADL_PR_RUST_BIN="${fake_adl}" \
+  ADL_FAKE_LOG="${fake_log}" \
+  ADL_UNITY_OBSERVATORY_PREPARE_ONLY=1 \
+  PATH="${fake_bin_dir}:${PATH}" \
+  bash "${SCRIPT}" 2>&1
+)"
+reject_status="$?"
+set -e
+
+if [[ "${reject_status}" -eq 0 ]]; then
+  echo "prepare-only proof accepted an arbitrary external ADL binary" >&2
+  printf '%s\n' "${reject_output}" >&2
+  exit 1
+fi
+
+if [[ "${reject_output}" != *"requires a repo-owned ADL binary"* ]]; then
+  echo "arbitrary-binary rejection did not explain the repo-owned binary requirement" >&2
+  printf '%s\n' "${reject_output}" >&2
+  exit 1
+fi
+
+output="$(
+  ADL_UNITY_OBSERVATORY_PROJECT_PATH="${fixture_project}" \
+  ADL_PR_RUST_BIN="${fake_adl}" \
+  ADL_FAKE_LOG="${fake_log}" \
+  ADL_UNITY_OBSERVATORY_PREPARE_ONLY=1 \
+  ADL_UNITY_OBSERVATORY_ALLOW_TEST_ADL_BIN=1 \
+  PATH="${fake_bin_dir}:${PATH}" \
+  bash "${SCRIPT}"
+)"
+
+if [[ "${output}" != *"Unity local-runtime prepare proof passed."* ]]; then
+  echo "prepare-only proof did not pass" >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+if [[ "${output}" != *"repo_adl_binary=${fake_adl}"* ]]; then
+  echo "prepare-only proof did not report the configured repo ADL binary" >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+if ! grep -Fq "csm observatory" "${fake_log}"; then
+  echo "fake repo ADL binary was not invoked for contract generation" >&2
+  exit 1
+fi
+
+echo "PASS test_v0916_unity_observatory_local_runtime_consumption_unit"


### PR DESCRIPTION
Closes #4789

## Summary
#4789 was bound in `.worktrees/adl-wp-4789` and the immediate #4652 finish
blocker was repaired in the Unity local-runtime consumption script. The script
now uses the configured repo-owned ADL binary (`ADL_UNITY_OBSERVATORY_ADL_BIN`
or `ADL_PR_RUST_BIN`) instead of `cargo run`, normalizes the staged Unity
project tree to user-writable permissions after copy and contract generation,
and exposes a prepare-only proof mode for focused validation without launching a
second Unity editor.

The validation lane manifest and finish support were updated so the new focused
unit proof is treated as part of the Unity observatory validation surface and is
actually executed by the lane command. A gpt-5.4 review initially blocked on two
issues; both were fixed, and a focused gpt-5.4 re-review returned PASS. Full
live Unity batchmode proof was intentionally not run while avoiding extra Unity
processes; the repaired lane is ready for the next `pr.sh finish`/Unity proof
attempt.

## Artifacts
- Updated Unity local-runtime consumption validation script: `adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh`
- New focused unit proof script: `adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh`
- Updated validation lane manifest: `adl/config/validation_lane_selector.v0.91.6.json`
- Updated selector regression: `adl/tools/test_select_validation_lanes.sh`
- Updated finish support for the new Unity proof script: `adl/src/cli/pr_cmd/finish_support.rs`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh`
    Proved owner-binary selection and writable staged-project preparation using a read-only fixture project and fake cargo failure guard.
  - `ADL_PR_RUST_BIN=repo-root/adl/target/debug/adl ADL_UNITY_OBSERVATORY_PREPARE_ONLY=1 bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh`
    Proved real-project contract generation uses the repo-owned binary and can complete prepare-only staging without Unity launch.
  - `bash -n adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash -n adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json >/dev/null`
    Verified shell syntax and JSON manifest syntax.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified validation lane path selection, including the new unit script path.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager contract after lane-manifest changes.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified path-policy contract after lane-manifest changes.
  - `gpt-5.4 bounded re-review`
    Verified both initial review blockers were fixed: the unit script is executed by validation selection/finish support, and arbitrary external ADL binaries are rejected outside explicit prepare-only test mode.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting only; no binary build was run.
  - `git diff --check`
    Verified whitespace hygiene.
  - `gpt-5.4 bounded re-review`
    Confirmed review disposition PASS after fixes to the initial blocking findings.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4789__v0-91-7-unity-tools-fix-unity-mcp-project-binding-and-screenshot-proof-reliability/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4789__v0-91-7-unity-tools-fix-unity-mcp-project-binding-and-screenshot-proof-reliability/sor.md
- Idempotency-Key: fix-unity-observatory-proof-tooling-closes-4789-adl-config-validation-lane-selector-v0-91-6-json-adl-src-cli-pr-cmd-finish-support-rs-adl-tools-test-select-validation-lanes-sh-adl-tools-test-v0916-unity-observatory-local-runtime-consumption-sh-adl-tools-test-v0916-unity-observatory-local-runtime-consumption-unit-sh-adl-v0-91-7-tasks-issue-4789-v0-91-7-unity-tools-fix-unity-mcp-project-binding-and-screenshot-proof-reliability-sip-md-adl-v0-91-7-tasks-issue-4789-v0-91-7-unity-tools-fix-unity-mcp-project-binding-and-screenshot-proof-reliability-sor-md