### PR TITLE
Add first-class pr finish release-gate disposition support

### DIFF
--- a/adl/src/bin/adl_pr_finish.rs
+++ b/adl/src/bin/adl_pr_finish.rs
@@ -8,7 +8,7 @@ mod pr_dispatch_support;
 
 const USAGE: &str = "adl-pr-finish - ADL direct PR lifecycle binary\n\n\
 Usage:\n\
-  adl-pr-finish <issue> --title \"<title>\" [-f <input_card.md>] [--output-card <output_card.md>] [--body \"<extra body>\"] [--paths \"<p1,p2,...>\"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]\n\
+  adl-pr-finish <issue> --title \"<title>\" [-f <input_card.md>] [--output-card <output_card.md>] [--body \"<extra body>\"] [--paths \"<p1,p2,...>\"] [--release-gate-disposition <repo-relative.yaml>] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]\n\
   adl-pr-finish --help\n\
   adl-pr-finish --version";
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2941,7 +2941,7 @@ fn yaml_key(name: &str) -> Value {
 
 fn yaml_string(mapping: &Mapping, key: &str) -> Option<String> {
     mapping
-        .get(&yaml_key(key))
+        .get(yaml_key(key))
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -2949,7 +2949,7 @@ fn yaml_string(mapping: &Mapping, key: &str) -> Option<String> {
 }
 
 fn yaml_number_or_string(mapping: &Mapping, key: &str) -> Option<String> {
-    let value = mapping.get(&yaml_key(key))?;
+    let value = mapping.get(yaml_key(key))?;
     if let Some(text) = value.as_str() {
         let text = text.trim();
         if !text.is_empty() {
@@ -2960,7 +2960,7 @@ fn yaml_number_or_string(mapping: &Mapping, key: &str) -> Option<String> {
 }
 
 fn yaml_string_array(mapping: &Mapping, key: &str) -> Option<Vec<String>> {
-    let values = mapping.get(&yaml_key(key))?.as_sequence()?;
+    let values = mapping.get(yaml_key(key))?.as_sequence()?;
     Some(
         values
             .iter()

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 use std::collections::BTreeSet;
@@ -182,10 +182,11 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
             commands: Vec::new(),
         }
     } else {
-        select_finish_validation_plan_for_finish(
+        select_finish_validation_plan_for_finish_with_release_gate_disposition(
             parsed.issue,
             &parsed.paths,
             &validation_changed_paths,
+            parsed.release_gate_disposition.as_deref(),
         )?
     };
     let finish_validation_profile = if parsed.no_checks {
@@ -2532,10 +2533,25 @@ fn validate_manager_backed_retained_changed_file(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub(super) fn select_finish_validation_plan_for_finish(
     issue_number: u32,
     requested_paths_csv: &str,
     changed_paths: &[String],
+) -> Result<FinishValidationPlan> {
+    select_finish_validation_plan_for_finish_with_release_gate_disposition(
+        issue_number,
+        requested_paths_csv,
+        changed_paths,
+        None,
+    )
+}
+
+pub(super) fn select_finish_validation_plan_for_finish_with_release_gate_disposition(
+    issue_number: u32,
+    requested_paths_csv: &str,
+    changed_paths: &[String],
+    release_gate_disposition: Option<&Path>,
 ) -> Result<FinishValidationPlan> {
     let requested_paths = requested_paths_csv
         .split(',')
@@ -2600,6 +2616,14 @@ pub(super) fn select_finish_validation_plan_for_finish(
                     )?;
                     return Ok(plan);
                 }
+                if let Some(plan) = release_gate_disposition_backed_finish_validation_plan(
+                    &repo_root,
+                    issue_number,
+                    finish_profile,
+                    release_gate_disposition,
+                )? {
+                    return Ok(plan);
+                }
             }
         }
         return Ok(FinishValidationPlan {
@@ -2621,6 +2645,14 @@ pub(super) fn select_finish_validation_plan_for_finish(
                 )?;
                 return Ok(plan);
             }
+            if let Some(plan) = release_gate_disposition_backed_finish_validation_plan(
+                &repo_root,
+                issue_number,
+                finish_profile,
+                release_gate_disposition,
+            )? {
+                return Ok(plan);
+            }
         }
     }
 
@@ -2640,6 +2672,14 @@ pub(super) fn select_finish_validation_plan_for_finish(
     let finish_profile = finish_profile_result?;
     if let Some(plan) = profile_backed_finish_validation_plan(issue_number, &finish_profile) {
         ensure_finish_validation_profile_is_runnable(&repo_root, &finish_profile, changed_paths)?;
+        return Ok(plan);
+    }
+    if let Some(plan) = release_gate_disposition_backed_finish_validation_plan(
+        &repo_root,
+        issue_number,
+        &finish_profile,
+        release_gate_disposition,
+    )? {
         return Ok(plan);
     }
     if !finish_validation_profile_allows_legacy_fallback(&finish_profile, changed_paths) {
@@ -2699,6 +2739,246 @@ fn profile_backed_finish_validation_plan(
     }
     let mode = profile_backed_finish_validation_mode(issue_number, profile);
     Some(FinishValidationPlan { mode, commands })
+}
+
+fn release_gate_disposition_backed_finish_validation_plan(
+    repo_root: &Path,
+    issue_number: u32,
+    profile: &FinishValidationProfile,
+    release_gate_disposition: Option<&Path>,
+) -> Result<Option<FinishValidationPlan>> {
+    if !finish_validation_profile_requires_release_gate_disposition(profile) {
+        if release_gate_disposition.is_some() {
+            bail!("finish: --release-gate-disposition was supplied, but validation manager did not report a release-gate escalation");
+        }
+        return Ok(None);
+    }
+
+    let Some(disposition_path) = release_gate_disposition else {
+        return Ok(None);
+    };
+    validate_release_gate_disposition(repo_root, issue_number, profile, disposition_path)?;
+
+    for item in &profile.run {
+        ensure_finish_validation_command_supported(repo_root, &item.command)?;
+    }
+
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+    ];
+    if finish_validation_profile_runs_rust_fast_lane(profile) {
+        push_finish_validation_command(
+            &mut commands,
+            "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+        );
+    }
+    for item in &profile.run {
+        push_finish_validation_command(&mut commands, &item.command);
+    }
+    let mode = profile_backed_finish_validation_mode(issue_number, profile);
+    Ok(Some(FinishValidationPlan { mode, commands }))
+}
+
+fn finish_validation_profile_requires_release_gate_disposition(
+    profile: &FinishValidationProfile,
+) -> bool {
+    profile.escalation.required
+        && profile.escalation.reasons.iter().all(|reason| {
+            reason.lane_id == "release_gate_review" && reason.status == "release_gate_required"
+        })
+        && !profile.escalation.reasons.is_empty()
+}
+
+pub(super) fn validate_release_gate_disposition(
+    repo_root: &Path,
+    issue_number: u32,
+    profile: &FinishValidationProfile,
+    disposition_path: &Path,
+) -> Result<()> {
+    if disposition_path.is_absolute() {
+        bail!("finish: --release-gate-disposition must be repo-relative");
+    }
+    let disposition_rel = disposition_path.to_string_lossy();
+    if disposition_rel.trim().is_empty() || disposition_rel.contains("..") {
+        bail!("finish: --release-gate-disposition must name a stable repo-relative file");
+    }
+    let disposition_abs = repo_root.join(disposition_path);
+    if !ensure_nonempty_file_path(&disposition_abs)? {
+        bail!(
+            "finish: release-gate disposition is missing or empty: {}",
+            disposition_path.display()
+        );
+    }
+    ensure_release_gate_disposition_is_in_index(repo_root, disposition_path)?;
+
+    let body = fs::read_to_string(&disposition_abs).with_context(|| {
+        format!(
+            "finish: failed to read release-gate disposition '{}'",
+            disposition_path.display()
+        )
+    })?;
+    reject_release_gate_disposition_path_leakage(&body)?;
+    let value: Value = serde_yaml::from_str(&body).with_context(|| {
+        format!(
+            "finish: release-gate disposition '{}' is not valid YAML/JSON",
+            disposition_path.display()
+        )
+    })?;
+    let mapping = value
+        .as_mapping()
+        .ok_or_else(|| anyhow!("finish: release-gate disposition must be a YAML/JSON mapping"))?;
+
+    let disposition_issue = yaml_number_or_string(mapping, "issue")
+        .ok_or_else(|| anyhow!("finish: release-gate disposition missing issue"))?;
+    if disposition_issue != issue_number.to_string() {
+        bail!(
+            "finish: release-gate disposition issue '{}' does not match finish issue #{}",
+            disposition_issue,
+            issue_number
+        );
+    }
+
+    let decision = yaml_string(mapping, "disposition")
+        .or_else(|| yaml_string(mapping, "decision"))
+        .ok_or_else(|| anyhow!("finish: release-gate disposition missing disposition/decision"))?;
+    let decision_lc = decision.trim().to_ascii_lowercase();
+    if decision_lc.is_empty()
+        || matches!(
+            decision_lc.as_str(),
+            "blocked" | "block" | "rejected" | "reject" | "failed" | "fail"
+        )
+    {
+        bail!("finish: release-gate disposition is not publishable: {decision}");
+    }
+
+    require_nonempty_yaml_string(
+        mapping,
+        &["reviewer_or_review_mode", "reviewer", "review_mode"],
+        "reviewer/review mode",
+    )?;
+    require_nonempty_yaml_string(
+        mapping,
+        &["focused_validation_run", "focused_validation", "validation"],
+        "focused validation run",
+    )?;
+    require_nonempty_yaml_string(
+        mapping,
+        &[
+            "residual_ci_proof_required_before_merge",
+            "residual_ci_proof",
+            "ci_proof",
+        ],
+        "residual CI proof",
+    )?;
+
+    let declared_surfaces = yaml_string_array(mapping, "changed_release_gate_surfaces")
+        .or_else(|| yaml_string_array(mapping, "release_gate_surfaces"))
+        .ok_or_else(|| {
+            anyhow!("finish: release-gate disposition missing changed_release_gate_surfaces")
+        })?;
+    if declared_surfaces.is_empty() {
+        bail!("finish: release-gate disposition declares no release-gate surfaces");
+    }
+    let missing = release_gate_matched_paths(profile)
+        .into_iter()
+        .filter(|path| !declared_surfaces.iter().any(|declared| declared == path))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!(
+            "finish: release-gate disposition does not cover required release-gate surface(s): {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn ensure_release_gate_disposition_is_in_index(repo_root: &Path, path: &Path) -> Result<()> {
+    let path = path_str(path)?;
+    let result = run_capture_allow_failure(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "ls-files",
+            "--error-unmatch",
+            path,
+        ],
+    )
+    .context("finish: failed to inspect release-gate disposition index state")?;
+    if result.is_some() {
+        return Ok(());
+    }
+    bail!("finish: release-gate disposition must be tracked or staged for publication: {path}");
+}
+
+fn release_gate_matched_paths(profile: &FinishValidationProfile) -> Vec<String> {
+    let mut paths = Vec::new();
+    for reason in &profile.escalation.reasons {
+        if reason.lane_id == "release_gate_review" && reason.status == "release_gate_required" {
+            for path in &reason.matched_paths {
+                if !paths.iter().any(|existing| existing == path) {
+                    paths.push(path.clone());
+                }
+            }
+        }
+    }
+    paths
+}
+
+fn reject_release_gate_disposition_path_leakage(body: &str) -> Result<()> {
+    for marker in ["/Users/", "/private/tmp", "/tmp/", "\\Users\\"] {
+        if body.contains(marker) {
+            bail!("finish: release-gate disposition contains machine-local path marker: {marker}");
+        }
+    }
+    Ok(())
+}
+
+fn yaml_key(name: &str) -> Value {
+    Value::String(name.to_string())
+}
+
+fn yaml_string(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(&yaml_key(key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn yaml_number_or_string(mapping: &Mapping, key: &str) -> Option<String> {
+    let value = mapping.get(&yaml_key(key))?;
+    if let Some(text) = value.as_str() {
+        let text = text.trim();
+        if !text.is_empty() {
+            return Some(text.to_string());
+        }
+    }
+    value.as_i64().map(|number| number.to_string())
+}
+
+fn yaml_string_array(mapping: &Mapping, key: &str) -> Option<Vec<String>> {
+    let values = mapping.get(&yaml_key(key))?.as_sequence()?;
+    Some(
+        values
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn require_nonempty_yaml_string(mapping: &Mapping, keys: &[&str], label: &str) -> Result<String> {
+    for key in keys {
+        if let Some(value) = yaml_string(mapping, key) {
+            return Ok(value);
+        }
+    }
+    bail!("finish: release-gate disposition missing {label}")
 }
 
 fn profile_backed_finish_validation_mode(

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -86,6 +86,7 @@ pub(crate) struct FinishArgs {
     pub(crate) title: String,
     pub(crate) extra_body: Option<String>,
     pub(crate) paths: String,
+    pub(crate) release_gate_disposition: Option<PathBuf>,
     pub(crate) no_checks: bool,
     pub(crate) no_close: bool,
     pub(crate) ready: bool,
@@ -608,6 +609,7 @@ pub(crate) fn parse_finish_args(args: &[String]) -> Result<FinishArgs> {
         title: String::new(),
         extra_body: None,
         paths: ".".to_string(),
+        release_gate_disposition: None,
         no_checks: false,
         no_close: false,
         ready: false,
@@ -632,6 +634,15 @@ pub(crate) fn parse_finish_args(args: &[String]) -> Result<FinishArgs> {
             }
             "--paths" => {
                 parsed.paths = require_value(args, i, "finish", "--paths")?;
+                i += 2;
+            }
+            "--release-gate-disposition" => {
+                parsed.release_gate_disposition = Some(PathBuf::from(require_value(
+                    args,
+                    i,
+                    "finish",
+                    "--release-gate-disposition",
+                )?));
                 i += 2;
             }
             "--no-checks" => {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -13,14 +13,15 @@ use crate::cli::pr_cmd::finish_support::{
     render_default_finish_validation, resolve_finish_issue_scope_and_slug,
     restage_finish_output_truth_paths, run_finish_validation_status,
     select_finish_validation_plan_for_finish, validate_ready_only_finish_pr_state,
-    FinishValidationMode, FinishValidationPlan, FinishValidationProfile,
-    FinishValidationProfileEscalation, FinishValidationProfileEscalationReason,
-    FinishValidationProfileRunItem, FinishValidationProfileSurfaceItem, FinishValidationVppRecord,
-    SorFactEmissionContext,
+    validate_release_gate_disposition, FinishValidationMode, FinishValidationPlan,
+    FinishValidationProfile, FinishValidationProfileEscalation,
+    FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
+    FinishValidationProfileSurfaceItem, FinishValidationVppRecord, SorFactEmissionContext,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 use crate::cli::pr_cmd::github::{PrValidationCheckReport, PrValidationReport};
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn finish_declared_paths_for_validation_splits_operator_surface() {
@@ -168,6 +169,8 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
         "Example".to_string(),
         "--paths".to_string(),
         "adl,docs".to_string(),
+        "--release-gate-disposition".to_string(),
+        "docs/review/release-gate.yaml".to_string(),
         "--no-checks".to_string(),
         "--ready".to_string(),
         "--allow-gitignore".to_string(),
@@ -177,6 +180,10 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
     assert_eq!(parsed.issue, 1153);
     assert_eq!(parsed.title, "Example");
     assert_eq!(parsed.paths, "adl,docs");
+    assert_eq!(
+        parsed.release_gate_disposition,
+        Some(PathBuf::from("docs/review/release-gate.yaml"))
+    );
     assert!(parsed.no_checks);
     assert!(parsed.ready);
     assert!(parsed.allow_gitignore);
@@ -5035,6 +5042,121 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
         &["adl/tools/test_run_nessus_remote_validation.sh".to_string()],
     )
     .expect("registered nessus remote validation command should be publishable");
+}
+
+#[test]
+fn release_gate_disposition_validates_tracked_publishable_surface() {
+    let repo = unique_temp_dir("adl-pr-finish-release-gate-disposition-valid");
+    fs::create_dir_all(repo.join("docs/review")).expect("review dir");
+    init_finish_helper_git_repo(&repo);
+    fs::write(
+        repo.join("docs/review/release-gate.yaml"),
+        r#"issue: 4787
+disposition: approved_with_residual_ci
+changed_release_gate_surfaces:
+  - .github/workflows/ci.yaml
+reviewer_or_review_mode: bounded release-gate review
+focused_validation_run: ci policy selector lane passed locally
+residual_ci_proof_required_before_merge: required
+"#,
+    )
+    .expect("release gate disposition");
+    assert!(Command::new("git")
+        .args(["add", "docs/review/release-gate.yaml"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    let profile = FinishValidationProfile {
+        selected_profile: "release_gate_required_2_lane_profile".to_string(),
+        status: "escalation_required".to_string(),
+        pr_publication_sufficient: false,
+        run: vec![FinishValidationProfileRunItem {
+            lane_id: "ci_path_policy_contracts".to_string(),
+            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            reason: "release gate policy contracts".to_string(),
+            matched_paths: vec![".github/workflows/ci.yaml".to_string()],
+            vpp_record: None,
+        }],
+        not_run: Vec::new(),
+        deferred: Vec::new(),
+        escalation: FinishValidationProfileEscalation {
+            required: true,
+            reasons: vec![FinishValidationProfileEscalationReason {
+                lane_id: "release_gate_review".to_string(),
+                status: "release_gate_required".to_string(),
+                reason: "changed_surface_requires_release_or_ci_policy_review".to_string(),
+                matched_paths: vec![".github/workflows/ci.yaml".to_string()],
+                manifest_rule: Some("special_surfaces.release_gate_review".to_string()),
+                remediation_hint: Some(
+                    "Record a release-gate disposition before publication.".to_string(),
+                ),
+            }],
+        },
+    };
+
+    validate_release_gate_disposition(
+        &repo,
+        4787,
+        &profile,
+        Path::new("docs/review/release-gate.yaml"),
+    )
+    .expect("valid release-gate disposition should pass");
+}
+
+#[test]
+fn release_gate_disposition_fails_closed_when_surface_is_missing() {
+    let repo = unique_temp_dir("adl-pr-finish-release-gate-disposition-missing-surface");
+    fs::create_dir_all(repo.join("docs/review")).expect("review dir");
+    init_finish_helper_git_repo(&repo);
+    fs::write(
+        repo.join("docs/review/release-gate.yaml"),
+        r#"issue: 4787
+disposition: approved
+changed_release_gate_surfaces:
+  - docs/not-the-release-gate.md
+reviewer_or_review_mode: bounded release-gate review
+focused_validation_run: ci policy selector lane passed locally
+residual_ci_proof_required_before_merge: required
+"#,
+    )
+    .expect("release gate disposition");
+    assert!(Command::new("git")
+        .args(["add", "docs/review/release-gate.yaml"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    let profile = FinishValidationProfile {
+        selected_profile: "release_gate_required_2_lane_profile".to_string(),
+        status: "escalation_required".to_string(),
+        pr_publication_sufficient: false,
+        run: Vec::new(),
+        not_run: Vec::new(),
+        deferred: Vec::new(),
+        escalation: FinishValidationProfileEscalation {
+            required: true,
+            reasons: vec![FinishValidationProfileEscalationReason {
+                lane_id: "release_gate_review".to_string(),
+                status: "release_gate_required".to_string(),
+                reason: "changed_surface_requires_release_or_ci_policy_review".to_string(),
+                matched_paths: vec![".github/workflows/ci.yaml".to_string()],
+                manifest_rule: None,
+                remediation_hint: None,
+            }],
+        },
+    };
+
+    let err = validate_release_gate_disposition(
+        &repo,
+        4787,
+        &profile,
+        Path::new("docs/review/release-gate.yaml"),
+    )
+    .expect_err("missing release-gate surface should fail closed");
+    assert!(err
+        .to_string()
+        .contains("does not cover required release-gate surface"));
 }
 
 #[test]

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/PR_FINISH_RELEASE_GATE_DISPOSITION_PROOF_4787.md
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/PR_FINISH_RELEASE_GATE_DISPOSITION_PROOF_4787.md
@@ -1,0 +1,32 @@
+# PR Finish Release-Gate Disposition Proof (#4787)
+
+## Summary
+
+`pr finish` now accepts a first-class `--release-gate-disposition <repo-relative-path>` argument for validation-manager profiles that require `release_gate_review` disposition before PR publication.
+
+## Contract
+
+A release-gate disposition is publishable only when it is:
+
+- repo-relative
+- tracked or staged for publication
+- valid YAML/JSON
+- tied to the same issue number as the finish command
+- explicitly covers every release-gate matched surface reported by the validation manager
+- includes a non-blocking disposition/decision
+- includes reviewer/review-mode, focused-validation, and residual-CI proof fields
+- free of machine-local absolute path markers
+
+Missing, malformed, blocked, rejected, or unrelated disposition files fail closed.
+
+## Validation
+
+Focused validation run locally:
+
+- `cargo test --manifest-path adl/Cargo.toml --bin adl parse_finish_args_requires_title_and_accepts_finish_flags -- --nocapture`
+- `cargo test --manifest-path adl/Cargo.toml --bin adl release_gate_disposition_ -- --nocapture`
+- `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish adl_pr_finish_ -- --nocapture`
+
+## Non-claims
+
+This issue does not make every validation-manager lane publishable. The broader registered multi-command publication surface remains routed through `#4815` where applicable.


### PR DESCRIPTION
Closes #4787

## Summary
Implemented first-class `pr finish --release-gate-disposition DISPOSITION_PATH` support so release-gate escalation can be resolved by an explicit tracked disposition artifact instead of implicit prose. The implementation validates disposition files fail-closed, wires the finish planner to consume the disposition, preserves the existing planner compatibility wrapper, updates the owner binary help surface, adds focused regression coverage, and records a bounded proof packet.

PR publication is not complete yet. A prior `pr finish` attempt passed the selected validation lanes but stopped because this SOR still contained bootstrap `NOT_STARTED` truth; this card repair records the actual execution state so finish can be rerun.

## Artifacts
- `adl/src/cli/pr_cmd_args.rs`
  Added the `--release-gate-disposition DISPOSITION_PATH` finish argument.
- `adl/src/cli/pr_cmd/finish_support.rs`
  Added disposition-aware release-gate validation and planner selection while preserving the existing planner wrapper.
- `adl/src/bin/adl_pr_finish.rs`
  Updated public finish usage/help text.
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  Added parser and disposition validation regression tests.
- `docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/PR_FINISH_RELEASE_GATE_DISPOSITION_PROOF_4787.md`
  Added proof packet for the bounded release-gate disposition surface.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl parse_finish_args_requires_title_and_accepts_finish_flags -- --nocapture`
    Verified finish argument parsing includes `--release-gate-disposition`.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl release_gate_disposition_ -- --nocapture`
    Verified tracked release-gate disposition success and missing-surface failure paths.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote_validation_command -- --nocapture`
    Verified existing profile command registration remained accepted.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_runner_executes_combined_ci_policy_selector_command -- --nocapture`
    Verified existing finish runner command execution coverage remained intact.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish adl_pr_finish_ -- --nocapture`
    Verified owner binary help/version paths after CLI help update.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace/diff hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the owner C-SDLC validation lane selected by `pr finish`.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files CHANGED_FILES`
    Verified the selected fast PR test lane; nextest ran 727 tests, all passed, with 18,411 tests skipped by the lane filter.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4787__v0-91-7-tools-pr-finish-add-first-class-release-gate-disposition-support/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4787__v0-91-7-tools-pr-finish-add-first-class-release-gate-disposition-support/sor.md
- Idempotency-Key: add-first-class-pr-finish-release-gate-disposition-support-adl-src-cli-pr-cmd-args-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-src-bin-adl-pr-finish-rs-docs-milestones-v0-91-7-review-pr-finish-release-gate-disposition-pr-finish-release-gate-disposition-proof-4787-md-adl-v0-91-7-tasks-issue-4787-v0-91-7-tools-pr-finish-add-first-class-release-gate-disposition-support-sip-md-adl-v0-91-7-tasks-issue-4787-v0-91-7-tools-pr-finish-add-first-class-release-gate-disposition-support-sor-md