### PR TITLE
[v0.91.7][WP-06] Implement validation manager profile recording

### DIFF
--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -79,6 +79,7 @@ validation_profile_run_lanes=""
 validation_profile_primary_reason=""
 validation_profile_escalation_lanes=""
 validation_profile_error=""
+validation_profile_report=""
 validation_profile_contract_lanes_selected="$bool_false"
 large_file_lines="${COVERAGE_IMPACT_LARGE_FILE_LINES:-200}"
 large_file_delta="${COVERAGE_IMPACT_LARGE_FILE_DELTA:-80}"
@@ -825,12 +826,17 @@ load_validation_manager_profile() {
   printf '%s\n' "$changed_rows" >"$changed_file_list"
   if ! python3 - "$VALIDATION_MANAGER" "$changed_file_list" <<'PY' >"$tmp_dir/meta.txt" 2>"$tmp_dir/error.txt"
 import json
+import os
 import subprocess
 import sys
 
 manager, changed_files = sys.argv[1], sys.argv[2]
+cmd = ["python3", manager, "--changed-files", changed_files, "--json"]
+report_out = os.environ.get("ADL_VALIDATION_PROFILE_REPORT", "").strip()
+if report_out:
+    cmd.extend(["--report-out", report_out])
 result = subprocess.run(
-    ["python3", manager, "--changed-files", changed_files, "--json"],
+    cmd,
     text=True,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -860,6 +866,7 @@ print(
 print(f"run_lanes={run_lanes}")
 print(f"primary_reason={primary_reason}")
 print(f"escalation_lanes={escalation_lanes}")
+print(f"report_out={report_out}")
 PY
   then
     validation_profile_error="$(tr '\n' ' ' <"$tmp_dir/error.txt" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
@@ -876,6 +883,7 @@ PY
   validation_profile_run_lanes="$(awk -F= '$1=="run_lanes"{print substr($0, index($0, "=")+1)}' "$tmp_dir/meta.txt")"
   validation_profile_primary_reason="$(awk -F= '$1=="primary_reason"{print substr($0, index($0, "=")+1)}' "$tmp_dir/meta.txt")"
   validation_profile_escalation_lanes="$(awk -F= '$1=="escalation_lanes"{print substr($0, index($0, "=")+1)}' "$tmp_dir/meta.txt")"
+  validation_profile_report="$(awk -F= '$1=="report_out"{print substr($0, index($0, "=")+1)}' "$tmp_dir/meta.txt")"
   rm -rf "$tmp_dir"
 }
 
@@ -1295,6 +1303,7 @@ emit "validation_profile_run_lanes" "$validation_profile_run_lanes"
 emit "validation_profile_primary_reason" "$validation_profile_primary_reason"
 emit "validation_profile_escalation_lanes" "$validation_profile_escalation_lanes"
 emit "validation_profile_error" "$validation_profile_error"
+emit "validation_profile_report" "$validation_profile_report"
 
 printf '\nChanged path policy: %s\n' "$reason"
 printf '  rust_required=%s\n' "$rust_required"
@@ -1305,6 +1314,7 @@ printf '  v0913_proof_required=%s\n' "$v0913_proof_required"
 printf '  release_version_only=%s\n' "$release_version_only"
 printf '  ci_contracts_required=%s\n' "$ci_contracts_required"
 printf '  validation_profile_contract_lanes_selected=%s\n' "$validation_profile_contract_lanes_selected"
+printf '  validation_profile_report=%s\n' "$validation_profile_report"
 printf '  fail_closed=%s\n' "$fail_closed"
 printf '  coverage_lane=%s\n' "$coverage_lane"
 printf '  coverage_authority=%s\n' "$coverage_authority"

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -194,6 +194,20 @@ EOF
   assert_has "$docs_output" "validation_profile_run_lanes=docs_diff_check"
   assert_has "$docs_output" "validation_profile_primary_reason=docs_only_surface_requires_diff_hygiene"
 
+  docs_profile_report="$tmp_dir/docs-profile-report.json"
+  docs_report_output="$(ADL_VALIDATION_PROFILE_REPORT="$docs_profile_report" "$POLICY" --event-name pull_request --base "$base_sha" --head "$docs_head" --ref "refs/pull/1/merge")"
+  assert_has "$docs_report_output" "validation_profile_report=$docs_profile_report"
+  python3 - <<'PY' "$docs_profile_report"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "docs_diff_check_profile"
+assert profile["status"] == "ready_to_run"
+assert [item["lane_id"] for item in profile["run"]] == ["docs_diff_check"]
+PY
+
   git checkout -q -b release-version-only "$base_sha"
   python3 - <<'PY'
 from pathlib import Path

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -45,6 +45,20 @@ assert profile["validation_dag"]["compression_note"].startswith("profile validat
 assert profile["diagnostics"] == []
 PY
 
+docs_report="$TMP/docs-report.json"
+bash "$SCRIPT" --changed-files "$docs_only" --json --report-out "$docs_report" >"$TMP/docs-report-stdout.json"
+python3 - <<'PY' "$docs_report" "$TMP/docs-report-stdout.json"
+import json
+import sys
+
+recorded = json.load(open(sys.argv[1]))
+stdout_profile = json.load(open(sys.argv[2]))
+assert recorded["schema_version"] == "adl.validation_profile.v1"
+assert recorded["selected_profile"] == "docs_diff_check_profile"
+assert recorded["status"] == "ready_to_run"
+assert recorded == stdout_profile
+PY
+
 tooling="$TMP/tooling.txt"
 printf 'M\tadl/tools/ci_path_policy.sh\n' >"$tooling"
 bash "$SCRIPT" --changed-files "$tooling" --json >"$TMP/tooling.json"


### PR DESCRIPTION
Closes #4676

## Summary
Implemented the issue-local validation-manager integration by allowing CI path policy to ask `validation_manager.py` to retain the selected validation profile as a durable JSON report. The path policy now honors `ADL_VALIDATION_PROFILE_REPORT`, forwards it to the manager via argv-list subprocess invocation, emits the resulting `validation_profile_report` field in machine-readable and human summaries, and keeps existing fail-closed behavior. Focused tests now prove both direct manager `--report-out` behavior and the CI path-policy forwarding/recording path.

## Artifacts
- Updated `adl/tools/ci_path_policy.sh` to forward optional retained validation-profile report requests and emit `validation_profile_report`.
- Updated `adl/tools/test_validation_manager.sh` to prove `--report-out` records the exact emitted validation profile.
- Updated `adl/tools/test_ci_path_policy.sh` to prove CI path policy records the selected docs-only profile report through `ADL_VALIDATION_PROFILE_REPORT`.
- Updated `.adl/v0.91.7/tasks/issue-4676__v0-91-7-wp-06-validation-manager-implement-validation-manager/srp.md` with completed pre-PR review results.
- Updated `.adl/v0.91.7/tasks/issue-4676__v0-91-7-wp-06-validation-manager-implement-validation-manager/sor.md` with execution and validation truth.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager docs/tooling/rust/remotes/deletion/fail-closed contracts and proved `--report-out` writes the exact JSON profile emitted on stdout.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified path-policy contracts and proved `ADL_VALIDATION_PROFILE_REPORT` forwards retained validation-profile recording through the integrated path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused -- --exact --nocapture`
    Verified issue-relevant pr-finish validation-profile classification remains aligned with validation-manager/path-policy tooling changes.
  - `git diff --check`
    Verified no whitespace errors exist in the tracked diff.
- Results:
  - PASS: `bash adl/tools/test_validation_manager.sh`
  - PASS: `bash adl/tools/test_ci_path_policy.sh`
  - PASS: focused `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish ...`
  - PASS: `git diff --check`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4676__v0-91-7-wp-06-validation-manager-implement-validation-manager/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4676__v0-91-7-wp-06-validation-manager-implement-validation-manager/sor.md
- Idempotency-Key: v0-91-7-wp-06-implement-validation-manager-profile-recording-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-tools-test-validation-manager-sh-adl-v0-91-7-tasks-issue-4676-v0-91-7-wp-06-validation-manager-implement-validation-manager-sip-md-adl-v0-91-7-tasks-issue-4676-v0-91-7-wp-06-validation-manager-implement-validation-manager-sor-md