### PR TITLE
[v0.91.7][tools][watcher] Implement Rust closeout watcher attach

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1877,52 +1877,141 @@ pub(super) fn attach_post_merge_closeout(
         return Ok(());
     }
 
-    let Some(command_path) = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD")
+    if let Some(command_path) = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD")
         .ok()
         .filter(|value| !value.trim().is_empty())
-    else {
-        observability::emit_event(
-            "adl",
-            "github_octocrab",
-            "skipped",
-            &[
-                ("operation", "post_merge_closeout.attach"),
-                ("reason", "rust_closeout_no_background_watcher"),
-            ],
-        );
+    {
+        let mut command = helper_command_with_github_context(&command_path);
+        let output = command
+            .arg("--repo-root")
+            .arg(repo_root)
+            .arg("--repo")
+            .arg(repo)
+            .arg("--issue")
+            .arg(issue.to_string())
+            .arg("--branch")
+            .arg(branch)
+            .arg("--pr-url")
+            .arg(pr_url)
+            .output()
+            .with_context(|| {
+                format!("finish: failed to spawn post-merge closeout command '{command_path}'")
+            })?;
+        if !output.status.success() {
+            let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&output.stderr));
+            let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
+            bail!(
+                "finish: post-merge closeout auto-attach failed for issue #{} and PR '{}': {}{}",
+                issue,
+                pr_url,
+                stderr.trim(),
+                if stdout.trim().is_empty() {
+                    String::new()
+                } else {
+                    format!(" (stdout: {})", stdout.trim())
+                }
+            );
+        }
         return Ok(());
-    };
-    let mut command = helper_command_with_github_context(&command_path);
-    let output = command
-        .arg("--repo-root")
-        .arg(repo_root)
-        .arg("--repo")
-        .arg(repo)
-        .arg("--issue")
-        .arg(issue.to_string())
-        .arg("--branch")
-        .arg(branch)
-        .arg("--pr-url")
-        .arg(pr_url)
-        .output()
-        .with_context(|| {
-            format!("finish: failed to spawn post-merge closeout command '{command_path}'")
-        })?;
-    if !output.status.success() {
-        let stderr = redact_for_diagnostics(&String::from_utf8_lossy(&output.stderr));
-        let stdout = redact_for_diagnostics(&String::from_utf8_lossy(&output.stdout));
-        bail!(
-            "finish: post-merge closeout auto-attach failed for issue #{} and PR '{}': {}{}",
+    }
+
+    let artifact_root = repo_root
+        .join(".adl")
+        .join("logs")
+        .join("post-merge-closeout")
+        .join(format!("issue-{issue}"));
+    fs::create_dir_all(&artifact_root).with_context(|| {
+        format!(
+            "finish: failed to create post-merge closeout artifact root '{}'",
+            artifact_root.display()
+        )
+    })?;
+    let input_file = artifact_root.join("input.yaml");
+    let prompt_file = artifact_root.join("prompt.md");
+    let run_log = artifact_root.join("codex.log");
+    let last_message_file = artifact_root.join("last_message.md");
+    let pid_file = artifact_root.join("pid");
+
+    fs::write(
+        &input_file,
+        format!(
+            "skill_input_schema: post_merge_closeout_watcher.v1\nmode: watch_pr_until_merged_then_closeout\nrepo_root: {}\nrepo: {}\ntarget:\n  issue_number: {}\n  pr_url: {}\n  branch: {}\npolicy:\n  monitor_merge_state: true\n  route_failed_checks_to_janitor: true\n  run_closeout_after_merge: true\n  merge_authority_human_only: true\n  issue_close_authority_human_only: true\n",
+            repo_root.display(),
+            repo,
             issue,
             pr_url,
-            stderr.trim(),
-            if stdout.trim().is_empty() {
-                String::new()
-            } else {
-                format!(" (stdout: {})", stdout.trim())
-            }
-        );
-    }
+            branch,
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "finish: failed to write post-merge closeout input '{}'",
+            input_file.display()
+        )
+    })?;
+    let prompt = format!(
+        "Use $issue-watcher and $pr-closeout for this post-merge closeout watcher.\n\nValidated input:\n\n```yaml\n{input}\n```\n\nRun bounded watcher passes for the PR until it is merged or blocked. If the PR is already merged, run truthful closeout for issue #{issue}. If checks fail, the PR conflicts, or review action is needed, route to $pr-janitor and stop. Preserve durable evidence in the issue records and do not claim closeout until the issue is actually settled.\n",
+        input = fs::read_to_string(&input_file).unwrap_or_default(),
+    );
+    fs::write(&prompt_file, &prompt).with_context(|| {
+        format!(
+            "finish: failed to write post-merge closeout prompt '{}'",
+            prompt_file.display()
+        )
+    })?;
+
+    let run_log_file = fs::File::create(&run_log).with_context(|| {
+        format!(
+            "finish: failed to create post-merge closeout log '{}'",
+            run_log.display()
+        )
+    })?;
+    let run_log_err = run_log_file.try_clone().with_context(|| {
+        format!(
+            "finish: failed to clone post-merge closeout log '{}'",
+            run_log.display()
+        )
+    })?;
+    let codex_command = std::env::var("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "codex".to_string());
+    let mut command = helper_command_without_secret_context(&codex_command);
+    let child = command
+        .arg("exec")
+        .arg("--full-auto")
+        .arg("--sandbox")
+        .arg("workspace-write")
+        .arg("--cd")
+        .arg(repo_root)
+        .arg("--skip-git-repo-check")
+        .arg("--add-dir")
+        .arg(repo_root)
+        .arg("--output-last-message")
+        .arg(&last_message_file)
+        .arg(&prompt)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(run_log_file))
+        .stderr(std::process::Stdio::from(run_log_err))
+        .spawn()
+        .with_context(|| {
+            format!("finish: failed to launch post-merge closeout watcher '{codex_command}'")
+        })?;
+    fs::write(&pid_file, format!("{}\n", child.id())).with_context(|| {
+        format!(
+            "finish: failed to record post-merge closeout watcher pid '{}'",
+            pid_file.display()
+        )
+    })?;
+    observability::emit_event(
+        "adl",
+        "github_octocrab",
+        "attached",
+        &[
+            ("operation", "post_merge_closeout.attach"),
+            ("artifact_root", &artifact_root.display().to_string()),
+        ],
+    );
     Ok(())
 }
 
@@ -1945,6 +2034,28 @@ fn helper_command_with_github_context(command_path: &str) -> Command {
             command.env(key, value);
         } else {
             command.env_remove(key);
+        }
+    }
+    command
+}
+
+fn helper_command_without_secret_context(command_path: &str) -> Command {
+    let mut command = Command::new(command_path);
+    for key in GITHUB_CONTEXT_ENVS {
+        match *key {
+            "ADL_GITHUB_CLIENT"
+            | "ADL_GITHUB_DISABLE_GH_FALLBACK"
+            | "ADL_GITHUB_OCTOCRAB_BASE_URI"
+            | "ADL_GITHUB_OCTOCRAB_MAX_ATTEMPTS" => {
+                if let Some(value) = std::env::var_os(key) {
+                    command.env(key, value);
+                } else {
+                    command.env_remove(key);
+                }
+            }
+            _ => {
+                command.env_remove(key);
+            }
         }
     }
     command

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -125,6 +125,7 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
 
     let janitor_success = temp.join("janitor-success.log");
     let closeout_success = temp.join("closeout-success.log");
+    let closeout_codex_success = temp.join("closeout-codex-success.log");
 
     write_executable(
         &tools_dir.join("attach_pr_janitor.sh"),
@@ -142,6 +143,13 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
             closeout_success.display()
         ),
     );
+    write_executable(
+        &tools_dir.join("fake_post_merge_codex.sh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            closeout_codex_success.display()
+        ),
+    );
     let failing = temp.join("failing-helper.sh");
     write_executable(
             &failing,
@@ -152,6 +160,7 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     let old_janitor_cmd = std::env::var("ADL_PR_JANITOR_CMD").ok();
     let old_closeout_disable = std::env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let old_closeout_cmd = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_codex_cmd = std::env::var("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD").ok();
     let old_github_client = std::env::var("ADL_GITHUB_CLIENT").ok();
     let old_gh_token = std::env::var("GH_TOKEN").ok();
 
@@ -245,6 +254,10 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
 
     unsafe {
         std::env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", "   ");
+        std::env::set_var(
+            "ADL_POST_MERGE_CLOSEOUT_CODEX_CMD",
+            tools_dir.join("fake_post_merge_codex.sh"),
+        );
     }
     attach_post_merge_closeout(
         &repo,
@@ -276,6 +289,7 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     restore_env("ADL_PR_JANITOR_CMD", old_janitor_cmd);
     restore_env("ADL_POST_MERGE_CLOSEOUT_DISABLE", old_closeout_disable);
     restore_env("ADL_POST_MERGE_CLOSEOUT_CMD", old_closeout_cmd);
+    restore_env("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD", old_closeout_codex_cmd);
 
     let janitor_calls = fs::read_to_string(&janitor_success).expect("janitor success log");
     assert!(janitor_calls.contains("--expected-pr-state draft"));
@@ -283,6 +297,10 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     assert!(janitor_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));
     let closeout_calls = fs::read_to_string(&closeout_success).expect("closeout success log");
     assert!(closeout_calls.contains("--pr-url https://github.com/owner/repo/pull/1159"));
+    let closeout_codex_calls =
+        fs::read_to_string(&closeout_codex_success).expect("closeout codex success log");
+    assert!(closeout_codex_calls.contains("--output-last-message"));
+    assert!(closeout_codex_calls.contains("post-merge closeout watcher"));
     assert!(closeout_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));
 
     restore_env("ADL_GITHUB_CLIENT", old_github_client);

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/closeout.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/closeout.rs
@@ -143,26 +143,34 @@ fn attach_post_merge_closeout_invokes_helper_successfully() {
 }
 
 #[test]
-fn attach_post_merge_closeout_skips_when_command_override_is_blank() {
+fn attach_post_merge_closeout_uses_rust_owned_watcher_when_command_override_is_blank() {
     let _guard = env_lock();
-    let temp = unique_temp_dir("adl-pr-attach-closeout-blank-override");
+    let temp = unique_temp_dir("adl-pr-attach-closeout-default-watcher");
     let repo = temp.join("repo");
-    let tools_dir = repo.join("adl/tools");
-    let argv_log = temp.join("closeout-args.log");
-    fs::create_dir_all(&tools_dir).expect("tools dir");
+    let bin_dir = temp.join("bin");
+    let codex_log = temp.join("codex-args.log");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
     write_executable(
-        &tools_dir.join("attach_post_merge_closeout.sh"),
-        &format!(
-            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" > '{}'\n",
-            argv_log.display()
-        ),
+        &bin_dir.join("fake-codex"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'fake-codex-invoked\\n'\nprintf '%s\\n' \"$*\"\nprintf 'GITHUB_TOKEN=%s\\n' \"${GITHUB_TOKEN:-}\"\nprintf 'GH_TOKEN=%s\\n' \"${GH_TOKEN:-}\"\nprintf 'ADL_GITHUB_TOKEN_FILE=%s\\n' \"${ADL_GITHUB_TOKEN_FILE:-}\"\n",
     );
 
     let old_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let old_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_codex_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD").ok();
+    let old_github_token = env::var("GITHUB_TOKEN").ok();
+    let old_gh_token = env::var("GH_TOKEN").ok();
+    let old_token_file = env::var("ADL_GITHUB_TOKEN_FILE").ok();
     unsafe {
         env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
         env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", "   ");
+        env::set_var(
+            "ADL_POST_MERGE_CLOSEOUT_CODEX_CMD",
+            bin_dir.join("fake-codex"),
+        );
+        env::set_var("GITHUB_TOKEN", "ghp_default_closeout_secret");
+        env::set_var("GH_TOKEN", "github_pat_default_closeout_secret");
+        env::set_var("ADL_GITHUB_TOKEN_FILE", "/tmp/default-closeout-token-file");
     }
 
     attach_post_merge_closeout(
@@ -185,10 +193,55 @@ fn attach_post_merge_closeout_skips_when_command_override_is_blank() {
         } else {
             env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
         }
+        if let Some(value) = old_codex_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CODEX_CMD");
+        }
+        if let Some(value) = old_github_token {
+            env::set_var("GITHUB_TOKEN", value);
+        } else {
+            env::remove_var("GITHUB_TOKEN");
+        }
+        if let Some(value) = old_gh_token {
+            env::set_var("GH_TOKEN", value);
+        } else {
+            env::remove_var("GH_TOKEN");
+        }
+        if let Some(value) = old_token_file {
+            env::set_var("ADL_GITHUB_TOKEN_FILE", value);
+        } else {
+            env::remove_var("ADL_GITHUB_TOKEN_FILE");
+        }
     }
 
+    let artifact_root = repo
+        .join(".adl/logs/post-merge-closeout")
+        .join("issue-1153");
+    assert!(artifact_root.join("input.yaml").exists());
+    assert!(artifact_root.join("prompt.md").exists());
+    assert!(artifact_root.join("pid").exists());
+    let input = fs::read_to_string(artifact_root.join("input.yaml")).expect("input");
+    assert!(input.contains("watch_pr_until_merged_then_closeout"));
+    assert!(input.contains("pr_url: https://github.com/owner/repo/pull/1159"));
+    let prompt = fs::read_to_string(artifact_root.join("prompt.md")).expect("prompt");
+    assert!(prompt.contains("post-merge closeout watcher"));
+    assert!(prompt.contains("issue #1153"));
     assert!(
-        !argv_log.exists(),
-        "blank override must not invoke retired closeout helper"
+        !codex_log.exists(),
+        "fake codex stdout should be redirected to the durable watcher log"
     );
+    let durable_log = artifact_root.join("codex.log");
+    let mut codex_args = String::new();
+    for _ in 0..20 {
+        codex_args = fs::read_to_string(&durable_log).unwrap_or_default();
+        if codex_args.contains("fake-codex-invoked") {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(codex_args.contains("fake-codex-invoked"));
+    assert!(!codex_args.contains("ghp_default_closeout_secret"));
+    assert!(!codex_args.contains("github_pat_default_closeout_secret"));
+    assert!(!codex_args.contains("/tmp/default-closeout-token-file"));
 }

--- a/docs/milestones/v0.91.7/review/post_merge_closeout_watcher/POST_MERGE_CLOSEOUT_WATCHER_PROOF_4713.md
+++ b/docs/milestones/v0.91.7/review/post_merge_closeout_watcher/POST_MERGE_CLOSEOUT_WATCHER_PROOF_4713.md
@@ -1,0 +1,65 @@
+# Post-Merge Closeout Watcher Proof (#4713)
+
+## Summary
+
+`#4713` removes the Rust `pr finish` skip path that emitted `rust_closeout_no_background_watcher` when no post-merge closeout shell helper was configured.
+
+The default Rust path now creates a durable post-merge closeout watcher packet and launches the configured Codex closeout watcher command. The explicit compatibility hook `ADL_POST_MERGE_CLOSEOUT_CMD` remains supported for operators who intentionally provide a helper command.
+
+## Changed Surfaces
+
+- `adl/src/cli/pr_cmd/github.rs`
+  - keeps `ADL_POST_MERGE_CLOSEOUT_DISABLE=1` as the explicit opt-out
+  - keeps non-empty `ADL_POST_MERGE_CLOSEOUT_CMD` as a compatibility command override
+  - treats missing or blank `ADL_POST_MERGE_CLOSEOUT_CMD` as the Rust-owned default path
+  - writes watcher artifacts under `.adl/logs/post-merge-closeout/issue-<issue>/`
+  - launches `codex exec` by default, or `ADL_POST_MERGE_CLOSEOUT_CODEX_CMD` when set
+- `adl/src/cli/pr_cmd/github/tests/helpers.rs`
+  - proves disabled, helper, failure, and default fallback behavior
+- `adl/src/cli/tests/pr_cmd_inline/finish/publication/closeout.rs`
+  - proves the default watcher packet and durable log behavior
+- `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
+  - documents post-merge closeout watcher packets as retained wait-state evidence
+
+## Durable Artifact Shape
+
+The Rust default path writes:
+
+```text
+.adl/logs/post-merge-closeout/issue-<issue>/input.yaml
+.adl/logs/post-merge-closeout/issue-<issue>/prompt.md
+.adl/logs/post-merge-closeout/issue-<issue>/codex.log
+.adl/logs/post-merge-closeout/issue-<issue>/last_message.md
+.adl/logs/post-merge-closeout/issue-<issue>/pid
+```
+
+The input packet uses `post_merge_closeout_watcher.v1` and records issue, PR, branch, repo, and closeout policy.
+
+## Validation
+
+Passed locally in the issue worktree:
+
+```bash
+ADL_RUST_WARM_CACHE_SOURCE_TARGET=/Users/daniel/git/agent-design-language/adl/target \
+ADL_RUST_WARM_CACHE_DEST_TARGET=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-4713/adl/target \
+ADL_RUST_WARM_CACHE_MANIFEST_PATH=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-4713/adl/Cargo.toml \
+bash adl/tools/rust_validation_warm_cache.sh
+
+cargo test --manifest-path adl/Cargo.toml --bin adl attach_post_merge_closeout -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --bin adl helper_attach_commands_cover_disabled_success_failure_and_fallback_paths -- --nocapture
+cargo fmt --manifest-path adl/Cargo.toml --all --check
+git diff --check
+```
+
+## Non-Claims
+
+- This does not merge PRs automatically.
+- This does not close issues without the normal closeout path.
+- This does not make watcher output authoritative over human review or merge authority.
+- This does not remove the explicit helper-command compatibility hook.
+
+## Pre-PR Review Finding And Disposition
+
+A bounded subagent review found a P1 risk in the initial implementation: the default Codex watcher command inherited GitHub token environment variables and wrote raw child stdout/stderr to durable `codex.log`.
+
+Disposition: fixed before PR. The default Rust-owned watcher path now launches through a no-secret helper command that removes `GITHUB_TOKEN`, `GH_TOKEN`, `ADL_GITHUB_TOKEN_FILE`, `ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`, and `ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT` from the child environment. Focused tests set fake token values and prove they are not retained in the durable watcher log. Explicit non-empty `ADL_POST_MERGE_CLOSEOUT_CMD` compatibility overrides still receive the GitHub context because they are operator-provided helper commands and keep the previous failure redaction behavior.

--- a/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
+++ b/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
@@ -151,6 +151,8 @@ When an issue or PR enters `pr_waiting`, `janitor_active`, or
 `merged_needs_closeout`, the owning workflow must retain one of:
 
 - a repo-native `pr.sh watch <issue-or-pr> --json` packet;
+- a repo-native post-merge closeout watcher packet under
+  `.adl/logs/post-merge-closeout/issue-<number>/` created by `pr finish`;
 - a task-bundle, SRP, SOR, or closeout summary that names the retained watcher
   packet path and its disposition; or
 - an explicit not-applicable reason when the issue never entered a wait state.
@@ -212,6 +214,8 @@ Rules:
 - `workflow-conductor` owns routing into the next bounded skill.
 - `pr-run` owns bind and bounded implementation execution.
 - `pr-finish` owns publication handoff into PR-tail shepherding.
+- `pr-finish` also attaches the post-merge closeout watcher unless the
+  operator explicitly disables it with `ADL_POST_MERGE_CLOSEOUT_DISABLE=1`.
 - `issue-watcher` owns healthy wait-state observation.
 - `pr-janitor` owns bounded blocker remediation while a PR is in flight.
 - `pr-closeout` owns terminal local settlement.


### PR DESCRIPTION
Closes #4713

## Summary
Implemented the Rust-owned post-merge closeout watcher attach path for `pr finish`. Missing or blank `ADL_POST_MERGE_CLOSEOUT_CMD` no longer emits `rust_closeout_no_background_watcher`; it now writes a durable watcher packet under `.adl/logs/post-merge-closeout/issue-N/` and launches a configured Codex watcher command.

The explicit disable switch and explicit helper-command override remain supported. A pre-PR review found a P1 durable-log secret exposure risk in the first implementation; this was fixed before publication by removing token-bearing GitHub environment variables from the default watcher child process and adding regression coverage.

## Artifacts
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd/github/tests/helpers.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/publication/closeout.rs`
- `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
- `docs/milestones/v0.91.7/review/post_merge_closeout_watcher/POST_MERGE_CLOSEOUT_WATCHER_PROOF_4713.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl attach_post_merge_closeout -- --nocapture`
    Verified post-merge closeout attach behavior including no-secret default watcher logs.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl helper_attach_commands_cover_disabled_success_failure_and_fallback_paths -- --nocapture`
    Verified helper-level fallback and failure behavior.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting.
  - `git diff --check`
    Verified diff hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified owner C-SDLC lane during finish.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files changed files manifest`
    Verified fast lane during finish.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
# Post-Merge Closeout Watcher Proof (#4713)

## Summary

`#4713` removes the Rust `pr finish` skip path that emitted `rust_closeout_no_background_watcher` when no post-merge closeout shell helper was configured.

The default Rust path now creates a durable post-merge closeout watcher packet and launches the configured Codex closeout watcher command. The explicit compatibility hook `ADL_POST_MERGE_CLOSEOUT_CMD` remains supported for operators who intentionally provide a helper command.

## Changed Surfaces

- `adl/src/cli/pr_cmd/github.rs`
  - keeps `ADL_POST_MERGE_CLOSEOUT_DISABLE=1` as the explicit opt-out
  - keeps non-empty `ADL_POST_MERGE_CLOSEOUT_CMD` as a compatibility command override
  - treats missing or blank `ADL_POST_MERGE_CLOSEOUT_CMD` as the Rust-owned default path
  - writes watcher artifacts under `.adl/logs/post-merge-closeout/issue-<issue>/`
  - launches `codex exec` by default, or `ADL_POST_MERGE_CLOSEOUT_CODEX_CMD` when set
- `adl/src/cli/pr_cmd/github/tests/helpers.rs`
  - proves disabled, helper, failure, and default fallback behavior
- `adl/src/cli/tests/pr_cmd_inline/finish/publication/closeout.rs`
  - proves the default watcher packet and durable log behavior
- `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
  - documents post-merge closeout watcher packets as retained wait-state evidence

## Durable Artifact Shape

The Rust default path writes:

```text
.adl/logs/post-merge-closeout/issue-<issue>/input.yaml
.adl/logs/post-merge-closeout/issue-<issue>/prompt.md
.adl/logs/post-merge-closeout/issue-<issue>/codex.log
.adl/logs/post-merge-closeout/issue-<issue>/last_message.md
.adl/logs/post-merge-closeout/issue-<issue>/pid
```

The input packet uses `post_merge_closeout_watcher.v1` and records issue, PR, branch, repo, and closeout policy.

## Validation

Passed locally in the issue worktree:

```bash
ADL_RUST_WARM_CACHE_SOURCE_TARGET=/Users/daniel/git/agent-design-language/adl/target \
ADL_RUST_WARM_CACHE_DEST_TARGET=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-4713/adl/target \
ADL_RUST_WARM_CACHE_MANIFEST_PATH=/Users/daniel/git/agent-design-language/.worktrees/adl-wp-4713/adl/Cargo.toml \
bash adl/tools/rust_validation_warm_cache.sh

cargo test --manifest-path adl/Cargo.toml --bin adl attach_post_merge_closeout -- --nocapture
cargo test --manifest-path adl/Cargo.toml --bin adl helper_attach_commands_cover_disabled_success_failure_and_fallback_paths -- --nocapture
cargo fmt --manifest-path adl/Cargo.toml --all --check
git diff --check
```

## Non-Claims

- This does not merge PRs automatically.
- This does not close issues without the normal closeout path.
- This does not make watcher output authoritative over human review or merge authority.
- This does not remove the explicit helper-command compatibility hook.

## Pre-PR Review Finding And Disposition

A bounded subagent review found a P1 risk in the initial implementation: the default Codex watcher command inherited GitHub token environment variables and wrote raw child stdout/stderr to durable `codex.log`.

Disposition: fixed before PR. The default Rust-owned watcher path now launches through a no-secret helper command that removes `GITHUB_TOKEN`, `GH_TOKEN`, `ADL_GITHUB_TOKEN_FILE`, `ADL_GITHUB_TOKEN_KEYCHAIN_SERVICE`, and `ADL_GITHUB_TOKEN_KEYCHAIN_ACCOUNT` from the child environment. Focused tests set fake token values and prove they are not retained in the durable watcher log. Explicit non-empty `ADL_POST_MERGE_CLOSEOUT_CMD` compatibility overrides still receive the GitHub context because they are operator-provided helper commands and keep the previous failure redaction behavior.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4713__v0-91-7-tools-watcher-implement-rust-closeout-watcher-attach/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4713__v0-91-7-tools-watcher-implement-rust-closeout-watcher-attach/sor.md
- Idempotency-Key: v0-91-7-tools-watcher-implement-rust-closeout-watcher-attach-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-helpers-rs-adl-src-cli-tests-pr-cmd-inline-finish-publication-closeout-rs-docs-tooling-issue-lifecycle-shepherd-contract-md-docs-milestones-v0-91-7-review-post-merge-closeout-watcher-post-merge-closeout-watcher-proof-4713-md-adl-v0-91-7-tasks-issue-4713-v0-91-7-tools-watcher-implement-rust-closeout-watcher-attach-sip-md-adl-v0-91-7-tasks-issue-4713-v0-91-7-tools-watcher-implement-rust-closeout-watcher-attach-sor-md