### PR TITLE
[v0.91.7][WP-06] Split validation into fast lane and slow families

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1759,12 +1759,57 @@ pub(super) struct FinishValidationProfile {
     pub status: String,
     pub pr_publication_sufficient: bool,
     #[serde(default)]
+    pub validation_split: Option<FinishValidationSplit>,
+    #[serde(default)]
     pub run: Vec<FinishValidationProfileRunItem>,
     #[serde(default)]
     pub not_run: Vec<FinishValidationProfileSurfaceItem>,
     #[serde(default)]
     pub deferred: Vec<FinishValidationProfileSurfaceItem>,
     pub escalation: FinishValidationProfileEscalation,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FinishValidationSplit {
+    pub schema_version: String,
+    pub fast_lane: FinishValidationSplitFastLane,
+    #[serde(default)]
+    pub slow_families: Vec<FinishValidationSplitSlowFamily>,
+    pub fanout_policy: FinishValidationSplitFanoutPolicy,
+    pub fail_closed: FinishValidationSplitFailClosed,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FinishValidationSplitFastLane {
+    pub status: String,
+    #[serde(default)]
+    pub selected_lanes: Vec<String>,
+    pub runnable: bool,
+    pub pr_publication_sufficient: bool,
+    pub execution_model: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FinishValidationSplitSlowFamily {
+    pub id: String,
+    pub feature: String,
+    pub proof_role: String,
+    pub disposition: String,
+    pub owner: String,
+    pub command: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FinishValidationSplitFanoutPolicy {
+    pub mode: String,
+    pub missing_or_unmapped_proof: String,
+    pub release_gate_note: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FinishValidationSplitFailClosed {
+    pub required: bool,
+    pub reason_count: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5681,6 +5726,48 @@ pub(super) fn render_default_finish_validation(
             "- Selected validation profile: `{}` (`status={}`, `pr_publication_sufficient={}`)",
             profile.selected_profile, profile.status, profile.pr_publication_sufficient
         ));
+        if let Some(split) = &profile.validation_split {
+            lines.push(format!(
+                "- Validation split: `{}` fast_lane_status={} runnable={} publication_sufficient={} execution_model={}",
+                split.schema_version,
+                split.fast_lane.status,
+                split.fast_lane.runnable,
+                split.fast_lane.pr_publication_sufficient,
+                split.fast_lane.execution_model
+            ));
+            let selected_lanes = if split.fast_lane.selected_lanes.is_empty() {
+                "none".to_string()
+            } else {
+                split.fast_lane.selected_lanes.join(", ")
+            };
+            lines.push(format!("  - Fast lane selected lanes: {selected_lanes}"));
+            if split.slow_families.is_empty() {
+                lines.push("  - Slow-family fanout: none".to_string());
+            } else {
+                lines.push("  - Slow-family fanout:".to_string());
+                for family in &split.slow_families {
+                    lines.push(format!(
+                        "    - `{}` feature={} proof_role={} disposition={} owner={} command=`{}`",
+                        family.id,
+                        family.feature,
+                        family.proof_role,
+                        family.disposition,
+                        family.owner,
+                        family.command
+                    ));
+                }
+            }
+            lines.push(format!(
+                "  - Fanout policy: mode={} missing_or_unmapped_proof={} release_gate_note={}",
+                split.fanout_policy.mode,
+                split.fanout_policy.missing_or_unmapped_proof,
+                split.fanout_policy.release_gate_note
+            ));
+            lines.push(format!(
+                "  - Fail-closed: required={} reason_count={}",
+                split.fail_closed.required, split.fail_closed.reason_count
+            ));
+        }
         if profile.run.is_empty() {
             lines.push("- Profile-selected run lanes: none".to_string());
         } else {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -16,7 +16,9 @@ use crate::cli::pr_cmd::finish_support::{
     validate_release_gate_disposition, FinishValidationMode, FinishValidationPlan,
     FinishValidationProfile, FinishValidationProfileEscalation,
     FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
-    FinishValidationProfileSurfaceItem, FinishValidationVppRecord, SorFactEmissionContext,
+    FinishValidationProfileSurfaceItem, FinishValidationSplit, FinishValidationSplitFailClosed,
+    FinishValidationSplitFanoutPolicy, FinishValidationSplitFastLane,
+    FinishValidationSplitSlowFamily, FinishValidationVppRecord, SorFactEmissionContext,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 use crate::cli::pr_cmd::github::{PrValidationCheckReport, PrValidationReport};
@@ -1157,6 +1159,34 @@ fn render_default_finish_validation_includes_profile_truth_and_sanitizes_changed
         selected_profile: "selected_2_lane_profile".to_string(),
         status: "ready_to_run".to_string(),
         pr_publication_sufficient: true,
+        validation_split: Some(FinishValidationSplit {
+            schema_version: "adl.validation_split.v1".to_string(),
+            fast_lane: FinishValidationSplitFastLane {
+                status: "ready_to_run".to_string(),
+                selected_lanes: vec!["csdlc_owner_lane".to_string(), "rust_pr_fast".to_string()],
+                runnable: true,
+                pr_publication_sufficient: true,
+                execution_model: "local_fast_lane".to_string(),
+            },
+            slow_families: vec![FinishValidationSplitSlowFamily {
+                id: "runtime".to_string(),
+                feature: "slow-proof-runtime".to_string(),
+                proof_role: "slow_proof".to_string(),
+                disposition: "reserved_for_explicit_family_selection".to_string(),
+                owner: "slow_proof_family_runner".to_string(),
+                command: "bash adl/tools/run_slow_proof_family.sh --family runtime --run"
+                    .to_string(),
+            }],
+            fanout_policy: FinishValidationSplitFanoutPolicy {
+                mode: "explicit_family_selection".to_string(),
+                missing_or_unmapped_proof: "fail_closed".to_string(),
+                release_gate_note: "Fast-lane proof does not replace required slow-proof or release-gate evidence.".to_string(),
+            },
+            fail_closed: FinishValidationSplitFailClosed {
+                required: false,
+                reason_count: 0,
+            },
+        }),
         run: vec![
             FinishValidationProfileRunItem {
                 lane_id: "csdlc_owner_lane".to_string(),
@@ -1204,6 +1234,11 @@ fn render_default_finish_validation_includes_profile_truth_and_sanitizes_changed
     let rendered = render_default_finish_validation(&plan, Some(&profile));
 
     assert!(rendered.contains("Selected validation profile: `selected_2_lane_profile`"));
+    assert!(rendered.contains("Validation split: `adl.validation_split.v1`"));
+    assert!(rendered.contains("Fast lane selected lanes: csdlc_owner_lane, rust_pr_fast"));
+    assert!(rendered.contains("`runtime` feature=slow-proof-runtime proof_role=slow_proof disposition=reserved_for_explicit_family_selection owner=slow_proof_family_runner"));
+    assert!(rendered.contains("missing_or_unmapped_proof=fail_closed"));
+    assert!(rendered.contains("Fail-closed: required=false reason_count=0"));
     assert!(rendered.contains("Profile-selected run lanes:"));
     assert!(rendered
         .contains("`csdlc_owner_lane` via `bash adl/tools/run_owner_validation_lane.sh csdlc`"));
@@ -4985,6 +5020,7 @@ fn finish_validation_profile_fails_closed_when_ready_profile_command_is_not_publ
         selected_profile: "unsupported_profile".to_string(),
         status: "ready_to_run".to_string(),
         pr_publication_sufficient: true,
+        validation_split: None,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "unsupported_lane".to_string(),
             command: "bash adl/tools/not-a-real-registered-command.sh --dangerous".to_string(),
@@ -5026,6 +5062,7 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
         selected_profile: "validation_manager_surface".to_string(),
         status: "ready_to_run".to_string(),
         pr_publication_sufficient: true,
+        validation_split: None,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "validation_manager_surface".to_string(),
             command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
@@ -5076,6 +5113,7 @@ residual_ci_proof_required_before_merge: required
         selected_profile: "release_gate_required_2_lane_profile".to_string(),
         status: "escalation_required".to_string(),
         pr_publication_sufficient: false,
+        validation_split: None,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "ci_path_policy_contracts".to_string(),
             command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
@@ -5136,6 +5174,7 @@ residual_ci_proof_required_before_merge: required
         selected_profile: "release_gate_required_2_lane_profile".to_string(),
         status: "escalation_required".to_string(),
         pr_publication_sufficient: false,
+        validation_split: None,
         run: Vec::new(),
         not_run: Vec::new(),
         deferred: Vec::new(),

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -101,6 +101,34 @@ or assembling release evidence:
 The CI path-policy classifier does not mean every issue should run the full
 local Rust cycle before publication.
 
+ADL issue publication should prefer the repo-native validation profile emitted
+by:
+
+```bash
+python3 adl/tools/validation_manager.py --json --changed-files <changed-files>
+```
+
+That profile now includes a `validation_split` block when the manager can
+classify the changed surface. Skills and scripts that consume validation truth
+should preserve this block rather than flattening it into a generic pass/skip:
+
+- `fast_lane` records the ordinary PR validation lane that is selected for the
+  current changed surface, including whether it is runnable and sufficient for
+  PR publication.
+- `slow_families` records explicit slow-proof families that are fanned out or
+  deferred, with the family owner and command that would run the proof.
+- `fanout_policy.missing_or_unmapped_proof=fail_closed` means an unmapped
+  required proof is not an approved skip; it requires an explicit family
+  selection, a broader validation lane, or human/process routing.
+- `fail_closed.required=true` keeps the existing manager gates authoritative;
+  do not mark a PR-ready validation result from the fast lane alone when the
+  manager says fail-closed proof is required.
+
+For ordinary PRs, the fast lane can prove the changed surface while the slow
+families remain visible as deferred or release-owned work. For release evidence
+or a fail-closed manager result, the same slow-family entries become routing
+obligations instead of background notes.
+
 Skills should classify the changed surface first:
 
 - `docs-only`
@@ -218,6 +246,11 @@ Truthful interpretation:
   `adl/tools/run_pr_fast_test_lane.sh`. For bounded PRs, that runner may use a
   focused `cargo nextest` expression. For broad or ambiguous PRs, it fails
   closed to the full ordinary nextest sweep.
+- When the validation manager emits `validation_split.fast_lane`, use it as the
+  machine-readable explanation for why the PR-fast lane is sufficient or not
+  sufficient for publication. Keep `validation_profile.status`,
+  `pr_publication_sufficient`, and `escalation.required` as the authoritative
+  gates.
 - The ordinary PR lane must not re-enable heavyweight opt-in features such as
   `slow-proof-tests`; those stay reserved for dedicated heavy proof or
   authoritative coverage lanes.
@@ -250,6 +283,13 @@ cargo nextest run --features slow-proof-tests --partition count:1/4 --status-lev
 Use the matching `count:2/4`, `count:3/4`, and `count:4/4` partitions for the
 other shards. Individual tests should not contain shard-specific logic; they
 should only be classified as ordinary fast proof or explicit slow proof.
+
+When slow proof is intentionally deferred from a PR, record the family in
+`validation_split.slow_families` with disposition
+`reserved_for_explicit_family_selection` or a more specific owner-visible
+state. Do not collapse slow proof into a generic skipped check; the SOR and PR
+evidence should say which family owns the remaining proof and why ordinary
+PR-fast validation did not run it.
 
 ### Full-Evidence Runtime Event Or Policy-Surface PR
 

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -495,6 +495,19 @@ Validation should match the changed surface:
 - `janitor-focused`: failed PR checks or conflicts; reproduce the smallest
   failing check and validate the bounded repair
 
+When repo-native tooling provides a validation-manager profile, lifecycle and
+editor skills should carry its split truth forward:
+
+- record the selected `validation_split.fast_lane` in PR/SOR evidence when it
+  explains why ordinary PR validation is sufficient
+- record each `validation_split.slow_families` entry as executed, explicitly
+  deferred, or routed to its owning slow-proof/release surface
+- preserve fail-closed manager results; a fast lane is not publication proof
+  when `fail_closed.required=true`, `pr_publication_sufficient=false`, or
+  `escalation.required=true`
+- do not describe slow-family proof as merely skipped when the manager provides
+  a named family, command, and owner
+
 Default mapping:
 
 - `docs-only` -> `docs-bounded`

--- a/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
+++ b/adl/tools/test_pr_delegate_cargo_fallback_liveness.sh
@@ -11,6 +11,7 @@ BASH_BIN="$(command -v bash)"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+unset ADL_PR_RUST_BIN
 
 repo="$tmpdir/repo"
 mockbin="$tmpdir/mockbin"

--- a/adl/tools/test_pr_delegate_prefers_path_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_path_binary.sh
@@ -12,6 +12,8 @@ BASH_BIN="$(command -v bash)"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+unset ADL_PR_RUST_BIN
+
 repo="$tmpdir/repo"
 pathbin="$tmpdir/pathbin"
 mockbin="$tmpdir/mockbin"

--- a/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
+++ b/adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh
@@ -10,6 +10,7 @@ BASH_BIN="$(command -v bash)"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+unset ADL_PR_RUST_BIN
 
 repo="$tmpdir/repo"
 mockbin="$tmpdir/mockbin"

--- a/adl/tools/test_pr_small_binary_delegation.sh
+++ b/adl/tools/test_pr_small_binary_delegation.sh
@@ -12,6 +12,8 @@ BASH_BIN="$(command -v bash)"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+unset ADL_PR_RUST_BIN
+
 repo="$tmpdir/repo"
 mkdir -p "$repo/adl/tools" "$repo/adl" "$repo/bin"
 cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -41,6 +41,11 @@ assert profile["behavior_surfaces"][0]["resource_class"] == "tiny"
 assert profile["validation_dag"]["nodes"][0]["status"] == "runnable"
 assert profile["validation_dag"]["nodes"][0]["proof_role"] == "diff_hygiene"
 assert profile["estimated_cost"]["runtime_class"] == "tiny"
+assert profile["validation_split"]["schema_version"] == "adl.validation_split.v1"
+assert profile["validation_split"]["fast_lane"]["selected_lanes"] == ["docs_diff_check"]
+assert profile["validation_split"]["fast_lane"]["runnable"] is True
+assert profile["validation_split"]["fast_lane"]["pr_publication_sufficient"] is True
+assert profile["validation_split"]["fanout_policy"]["missing_or_unmapped_proof"] == "fail_closed"
 assert profile["validation_dag"]["compression_note"].startswith("profile validates behavior surfaces")
 assert profile["diagnostics"] == []
 PY
@@ -127,6 +132,16 @@ assert [family["id"] for family in profile["slow_proof_families"]] == [
     "observatory",
     "security",
 ]
+split = profile["validation_split"]
+assert split["fast_lane"]["selected_lanes"] == ["rust_pr_fast"]
+assert split["fast_lane"]["execution_model"] == "local_fast_lane"
+assert [family["id"] for family in split["slow_families"]] == [
+    "runtime",
+    "private_state",
+    "observatory",
+    "security",
+]
+assert split["slow_families"][0]["disposition"] == "reserved_for_explicit_family_selection"
 assert profile["slow_proof_families"][0]["feature"] == "slow-proof-runtime"
 surface = profile["behavior_surfaces"][0]
 assert surface["id"] == "rust_focused_behavior"
@@ -219,6 +234,8 @@ assert profile["schema_version"] == "adl.validation_profile.v1"
 assert profile["selected_profile"] == "validation_none"
 assert profile["status"] == "escalation_required"
 assert profile["pr_publication_sufficient"] is False
+assert profile["validation_split"]["fast_lane"]["runnable"] is False
+assert profile["validation_split"]["fail_closed"]["required"] is True
 assert profile["run"] == []
 assert profile["escalation"]["required"] is True
 reason = profile["escalation"]["reasons"][0]

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -206,6 +206,47 @@ def estimate_cost(selected: list[tuple[str, dict[str, Any]]], blocked: list[tupl
     }
 
 
+def validation_split_contract(
+    *,
+    status: str,
+    pr_publication_sufficient: bool,
+    selected: list[tuple[str, dict[str, Any]]],
+    slow_proof_families: list[dict[str, Any]],
+    escalation_required: bool,
+    escalation_reasons: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "adl.validation_split.v1",
+        "fast_lane": {
+            "status": status,
+            "selected_lanes": [lane_id for lane_id, _lane in selected],
+            "runnable": status in {"ready_to_run", "no_validation_needed"},
+            "pr_publication_sufficient": pr_publication_sufficient,
+            "execution_model": "local_fast_lane",
+        },
+        "slow_families": [
+            {
+                "id": family["id"],
+                "feature": family["feature"],
+                "proof_role": family.get("proof_role", "slow_proof"),
+                "disposition": "reserved_for_explicit_family_selection",
+                "owner": "slow_proof_family_runner",
+                "command": f"bash adl/tools/run_slow_proof_family.sh --family {family['id']} --run",
+            }
+            for family in slow_proof_families
+        ],
+        "fanout_policy": {
+            "mode": "explicit_family_selection",
+            "missing_or_unmapped_proof": "fail_closed",
+            "release_gate_note": "Fast-lane proof does not replace required slow-proof or release-gate evidence.",
+        },
+        "fail_closed": {
+            "required": escalation_required,
+            "reason_count": len(escalation_reasons),
+        },
+    }
+
+
 def manifest_rule_for(lane: dict[str, Any]) -> str:
     manifest_rule = lane.get("manifest_rule")
     if isinstance(manifest_rule, str) and manifest_rule:
@@ -553,6 +594,14 @@ def build_profile(plan: dict[str, Any], guardrails: dict[str, Any], manifest_pat
         and not escalation_required
         and status == "ready_to_run"
     )
+    validation_split = validation_split_contract(
+        status=status,
+        pr_publication_sufficient=pr_publication_sufficient,
+        selected=selected,
+        slow_proof_families=slow_proof_families,
+        escalation_required=escalation_required,
+        escalation_reasons=escalation_reasons,
+    )
 
     return {
         "schema_version": "adl.validation_profile.v1",
@@ -564,6 +613,7 @@ def build_profile(plan: dict[str, Any], guardrails: dict[str, Any], manifest_pat
         "run": run,
         "not_run": not_run,
         "deferred": [],
+        "validation_split": validation_split,
         "behavior_surfaces": behavior_surfaces,
         "validation_dag": {
             "nodes": dag_nodes,


### PR DESCRIPTION
Closes #4800

## Summary
Implemented explicit validation-split truth in the validation-manager profile and finish rendering path. The manager now emits an `adl.validation_split.v1` block that records the selected fast lane, reserved slow-proof family fanout commands, fanout policy, and fail-closed state. `pr finish` now deserializes this optional block and renders it into finish validation truth without changing existing runnable/escalation gates. The branch was initially stacked on #4676 because #4800 depends on #4676 and shares `adl/tools/test_validation_manager.sh`, then rebased onto `origin/main` after #4676 merged.

## Artifacts
- Updated `adl/tools/validation_manager.py` to emit `validation_split` with fast-lane, slow-family fanout, policy, and fail-closed truth.
- Updated `adl/src/cli/pr_cmd/finish_support.rs` to accept optional split truth and render it in finish validation records.
- Updated `adl/tools/test_validation_manager.sh` to assert fast-lane selection, slow-family fanout metadata, and fail-closed unmapped-path split truth.
- Updated `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` to cover finish rendering of validation split truth and maintain compatibility for older profile fixtures.
- Updated `adl/tools/test_pr_small_binary_delegation.sh`, `adl/tools/test_pr_delegate_prefers_path_binary.sh`, `adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`, and `adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh` to keep delegation fixtures hermetic when owner-lane validation is invoked from an environment that sets `ADL_PR_RUST_BIN`.
- Updated `.adl/v0.91.7/tasks/issue-4800__v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families/srp.md` with completed pre-PR review results.
- Updated `.adl/v0.91.7/tasks/issue-4800__v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families/sor.md` with execution and validation truth.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_manager.sh`
    Verified manager profile selection, split contract emission, slow-family metadata, fail-closed escalation, and remote-runner compatibility.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified CI path-policy and validation-manager integration contracts after the profile schema extension.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::render_default_finish_validation_includes_profile_truth_and_sanitizes_changed_files -- --exact --nocapture`
    Verified finish validation rendering of split truth and changed-file path sanitization.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::load_finish_validation_profile_reads_manager_json_from_repo_tooling -- --exact --nocapture`
    Verified optional split-field deserialization through the manager-backed finish path.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_validation_manager_slice_as_small_binary_focused -- --exact --nocapture`
    Verified finish validation profile classification remains focused for this slice.
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified the owner-lane fixture fix for `ADL_PR_RUST_BIN` environment hygiene.
  - `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_small_binary_delegation.sh`
    Verified the small-binary fixture passes with a poisoned inherited broad delegate.
  - `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_delegate_prefers_path_binary.sh`
    Verified the PATH-binary fixture passes with a poisoned inherited broad delegate.
  - `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
    Verified the cargo-fallback liveness fixture passes with a poisoned inherited broad delegate.
  - `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`
    Verified the locked-cargo fallback fixture passes with a poisoned inherited broad delegate.
  - `ADL_PR_RUST_BIN=adl/target/debug/adl bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the C-SDLC owner lane passes after the delegation fixture hermeticity fixes.
  - `git diff --check`
    Verified no whitespace errors exist in the tracked diff.
- Results:
  - PASS: `bash adl/tools/test_validation_manager.sh`
  - PASS: `bash adl/tools/test_ci_path_policy.sh`
  - PASS: `cargo fmt --manifest-path adl/Cargo.toml --all --check`
  - PASS: focused `cargo test` renderer check
  - PASS: focused `cargo test` manager JSON load check
  - PASS: focused `cargo test` validation-manager slice classification check
  - PASS: `bash adl/tools/test_pr_small_binary_delegation.sh`
  - PASS: `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_small_binary_delegation.sh`
  - PASS: `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_delegate_prefers_path_binary.sh`
  - PASS: `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
  - PASS: `env ADL_PR_RUST_BIN=/bin/false bash adl/tools/test_pr_run_locked_cargo_fallback_refuses_cleanly.sh`
  - PASS: `ADL_PR_RUST_BIN=adl/target/debug/adl bash adl/tools/run_owner_validation_lane.sh csdlc`
  - PASS: `git diff --check`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4800__v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4800__v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families/sor.md
- Idempotency-Key: v0-91-7-wp-06-split-validation-into-fast-lane-and-slow-families-adl-tools-validation-manager-py-adl-tools-test-validation-manager-sh-adl-tools-test-pr-small-binary-delegation-sh-adl-tools-test-pr-delegate-prefers-path-binary-sh-adl-tools-test-pr-delegate-cargo-fallback-liveness-sh-adl-tools-test-pr-run-locked-cargo-fallback-refuses-cleanly-sh-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4800-v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families-sip-md-adl-v0-91-7-tasks-issue-4800-v0-91-7-wp-06-validation-split-full-validation-into-fast-lane-plus-fanned-slow-families-sor-md