### PR TITLE
[v0.91.7][tools][closeout] Stop closeout from dirtying unrelated tracked card paths before worktree prune

### DIFF
--- a/adl/src/cli/pr_cmd/lifecycle/cleanup.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/cleanup.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub(crate) fn sync_completed_output_surfaces(
     repo_root: &Path,
@@ -131,6 +132,9 @@ pub(crate) fn scrub_noncanonical_issue_bundle_residue(
                     && name.starts_with(&body_prefix)
                     && path != canonical_body
                 {
+                    if path_has_tracked_entries(worktree_root, &path)? {
+                        continue;
+                    }
                     fs::remove_file(&path).with_context(|| {
                         format!(
                             "closeout: failed to scrub noncanonical local issue prompt residue '{}'",
@@ -151,6 +155,10 @@ pub(crate) fn scrub_noncanonical_issue_bundle_residue(
                     && name.starts_with(&task_prefix)
                     && path != canonical_bundle
                 {
+                    if path_has_tracked_entries(worktree_root, &path)? {
+                        scrub_untracked_entries(worktree_root, &path)?;
+                        continue;
+                    }
                     fs::remove_dir_all(&path).with_context(|| {
                         format!(
                             "closeout: failed to scrub noncanonical local task-bundle residue '{}'",
@@ -162,6 +170,53 @@ pub(crate) fn scrub_noncanonical_issue_bundle_residue(
         }
     }
 
+    Ok(())
+}
+
+fn path_has_tracked_entries(repo_root: &Path, path: &Path) -> Result<bool> {
+    let Ok(relative) = path.strip_prefix(repo_root) else {
+        return Ok(false);
+    };
+    let output = Command::new("git")
+        .args([
+            "-C",
+            path_str(repo_root)?,
+            "ls-files",
+            "--",
+            path_str(relative)?,
+        ])
+        .output()
+        .context("closeout: failed to inspect tracked noncanonical issue residue")?;
+    if !output.status.success() {
+        bail!(
+            "closeout: failed to inspect tracked noncanonical issue residue '{}'",
+            path.display()
+        );
+    }
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn scrub_untracked_entries(repo_root: &Path, path: &Path) -> Result<()> {
+    let Ok(relative) = path.strip_prefix(repo_root) else {
+        return Ok(());
+    };
+    let status = Command::new("git")
+        .args([
+            "-C",
+            path_str(repo_root)?,
+            "clean",
+            "-fd",
+            "--",
+            path_str(relative)?,
+        ])
+        .status()
+        .context("closeout: failed to scrub untracked noncanonical issue residue")?;
+    if !status.success() {
+        bail!(
+            "closeout: failed to scrub untracked noncanonical issue residue '{}'",
+            path.display()
+        );
+    }
     Ok(())
 }
 

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -2,6 +2,7 @@ use super::super::{path_str, IssueRef};
 use super::*;
 use crate::cli::pr_cmd::lifecycle::cleanup::{
     record_worktree_prune_result, replace_worktree_only_paths_remaining,
+    scrub_noncanonical_issue_bundle_residue,
 };
 use crate::cli::pr_cmd::{card_output_path, resolve_cards_root};
 use crate::cli::pr_cmd_cards::{ensure_pre_run_bootstrap_cards, ensure_task_bundle_stp};
@@ -361,6 +362,64 @@ fn matching_task_bundle_dirs_returns_sorted_prefix_matches() {
         .collect::<Vec<_>>();
 
     assert_eq!(names, vec!["issue-1410__a-slug", "issue-1410__z-slug"]);
+}
+
+#[test]
+fn scrub_noncanonical_issue_bundle_residue_preserves_tracked_card_paths() {
+    let _guard = env_lock();
+    let temp = temp_dir("adl-pr-lifecycle-scrub-tracked");
+    let repo = temp.join("repo");
+    let origin = temp.join("origin.git");
+    init_repo_with_origin(&repo, &origin);
+    let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+
+    let canonical_bundle = issue_ref.task_bundle_dir_path(&repo);
+    let legacy_bundle = repo
+        .join(".adl")
+        .join("v0.87")
+        .join("tasks")
+        .join("issue-1410__legacy-slug");
+    let legacy_vpp = legacy_bundle.join("vpp.md");
+    let legacy_scratch = legacy_bundle.join("scratch.tmp");
+    fs::create_dir_all(&canonical_bundle).expect("canonical bundle dir");
+    fs::create_dir_all(&legacy_bundle).expect("legacy bundle dir");
+    fs::write(canonical_bundle.join("vpp.md"), "# Canonical VPP\n").expect("canonical vpp");
+    fs::write(&legacy_vpp, "# Legacy tracked VPP\n").expect("legacy vpp");
+    assert!(Command::new("git")
+        .args(["add", ".adl"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add card bundles")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "track legacy vpp"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit legacy vpp")
+        .success());
+    fs::write(&legacy_scratch, "untracked closeout residue\n").expect("legacy scratch");
+
+    scrub_noncanonical_issue_bundle_residue(&repo, &issue_ref).expect("scrub residue");
+
+    assert!(
+        legacy_vpp.is_file(),
+        "tracked legacy VPP must not be deleted during closeout scrub"
+    );
+    assert!(
+        !legacy_scratch.exists(),
+        "untracked residue inside a tracked legacy bundle should still be scrubbed"
+    );
+    let status = Command::new("git")
+        .args(["status", "--short", "--", ".adl"])
+        .current_dir(&repo)
+        .output()
+        .expect("git status");
+    assert!(status.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&status.stdout).trim(),
+        "",
+        "tracked card paths must remain clean after scrub"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #4795

## Summary
Implemented a closeout scrub safety fix so noncanonical issue-card residue cleanup cannot delete or dirty tracked card paths before worktree prune. The fix preserves tracked noncanonical card files, still removes untracked residue inside mixed legacy bundles, and adds a focused regression test for the tracked-VPP plus untracked-scratch case.

## Artifacts
- `adl/src/cli/pr_cmd/lifecycle/cleanup.rs`
- `adl/src/cli/pr_cmd/lifecycle/tests.rs`
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4795__v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl scrub_noncanonical_issue_bundle_residue_preserves_tracked_card_paths -- --nocapture`
    Verified the closeout scrub regression for tracked legacy cards plus untracked residue.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace/diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4795__v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4795__v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune/sor.md
- Idempotency-Key: v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune-adl-src-cli-pr-cmd-lifecycle-cleanup-rs-adl-src-cli-pr-cmd-lifecycle-tests-rs-adl-v0-91-7-tasks-issue-4795-v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune-sip-md-adl-v0-91-7-tasks-issue-4795-v0-91-7-tools-closeout-stop-closeout-from-dirtying-unrelated-tracked-card-paths-before-worktree-prune-sor-md