### PR TITLE
[v0.91.7][WP-06][tests] Reduce long-test fanout

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -28,7 +28,8 @@ This script selects the ordinary PR-fast non-coverage Rust test lane.
 It prefers:
   1. focused nextest filters for small, precisely-mapped changes
   2. bounded family filters for broader-but-still-bounded changes
-  3. the full nextest sweep only for broad or ambiguous changes
+  3. fail-closed refusal for broad or ambiguous changes, unless
+     ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 is set by an explicit manual/release lane
 USAGE
 }
 
@@ -699,6 +700,14 @@ if [ "$PRINT_PLAN" = true ]; then
   exit 0
 fi
 
+if [ "$mode" = "full" ] && [ "${ADL_PR_FAST_ALLOW_FULL_NEXTEST:-0}" != "1" ]; then
+  {
+    echo "Refusing full nextest lane in ordinary PR-fast validation: $reason"
+    echo "Set ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 only from an explicit manual/release lane that records why full fanout is intended."
+  } >&2
+  exit 3
+fi
+
 cd "$ROOT_DIR/adl"
 ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_TEST_WARM_SOURCE_TARGET:-}" \
 ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
@@ -713,6 +722,6 @@ elif [ "$mode" = "contract_only" ]; then
 elif [ "$mode" = "skip" ]; then
   echo "Skipping ordinary nextest lane: no Rust test surface was detected for this PR-fast lane."
 else
-  echo "Running full nextest lane: $reason"
+  echo "Running full nextest lane by explicit opt-in: $reason"
   cargo nextest run --status-level all --final-status-level slow
 fi

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -245,7 +245,9 @@ Truthful interpretation:
 - The non-coverage `test` step now runs through
   `adl/tools/run_pr_fast_test_lane.sh`. For bounded PRs, that runner may use a
   focused `cargo nextest` expression. For broad or ambiguous PRs, it fails
-  closed to the full ordinary nextest sweep.
+  closed before cache warmup or cargo execution. Full nextest fanout is allowed
+  only when an explicit manual or release lane sets
+  `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1` and records why full fanout is intended.
 - When the validation manager emits `validation_split.fast_lane`, use it as the
   machine-readable explanation for why the PR-fast lane is sufficient or not
   sufficient for publication. Keep `validation_profile.status`,

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -396,4 +396,72 @@ too_many_families_output="$(bash "$SCRIPT" --changed-files "$too_many_families" 
 assert_has "$too_many_families_output" "mode=full"
 assert_has "$too_many_families_output" "reason=unmapped_rust_surface_requires_full_nextest"
 
+refusal_warm_output="$TMP/refusal-warm-cache.json"
+set +e
+too_many_families_run_output="$(
+  ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT="$refusal_warm_output" \
+    ADL_PR_FAST_TEST_WARM_SOURCE_TARGET="$TMP/missing-source-target" \
+    bash "$SCRIPT" --changed-files "$too_many_families" 2>&1
+)"
+too_many_families_run_status=$?
+set -e
+if [ "$too_many_families_run_status" -ne 3 ]; then
+  echo "expected ordinary PR-fast full-fanout refusal to exit 3, got $too_many_families_run_status" >&2
+  echo "$too_many_families_run_output" >&2
+  exit 1
+fi
+grep -Fq "Refusing full nextest lane in ordinary PR-fast validation: unmapped_rust_surface_requires_full_nextest" <<<"$too_many_families_run_output" || {
+  echo "expected full-fanout refusal message" >&2
+  echo "$too_many_families_run_output" >&2
+  exit 1
+}
+grep -Fq "ADL_PR_FAST_ALLOW_FULL_NEXTEST=1" <<<"$too_many_families_run_output" || {
+  echo "expected explicit opt-in guidance" >&2
+  echo "$too_many_families_run_output" >&2
+  exit 1
+}
+if [ -e "$refusal_warm_output" ]; then
+  echo "expected full-fanout refusal before warm-cache side effects" >&2
+  cat "$refusal_warm_output" >&2
+  exit 1
+fi
+
+fakebin="$TMP/fakebin"
+mkdir -p "$fakebin"
+cat >"$fakebin/cargo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${ADL_FAKE_CARGO_ARGS:?}"
+if [ "$1" = "nextest" ] && [ "$2" = "run" ]; then
+  exit 0
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 99
+EOF
+chmod +x "$fakebin/cargo"
+opt_in_cargo_args="$TMP/opt-in-cargo-args.txt"
+opt_in_warm_output="$TMP/opt-in-warm-cache.json"
+opt_in_output="$(
+  PATH="$fakebin:$PATH" \
+    ADL_FAKE_CARGO_ARGS="$opt_in_cargo_args" \
+    ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 \
+    ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT="$opt_in_warm_output" \
+    ADL_PR_FAST_TEST_WARM_SOURCE_TARGET="$TMP/missing-source-target" \
+    bash "$SCRIPT" --changed-files "$too_many_families" 2>&1
+)"
+grep -Fq "Running full nextest lane by explicit opt-in: unmapped_rust_surface_requires_full_nextest" <<<"$opt_in_output" || {
+  echo "expected explicit opt-in full nextest message" >&2
+  echo "$opt_in_output" >&2
+  exit 1
+}
+grep -Fqx -- "nextest run --status-level all --final-status-level slow" "$opt_in_cargo_args" || {
+  echo "expected opt-in path to invoke cargo nextest run with full-lane args" >&2
+  cat "$opt_in_cargo_args" >&2
+  exit 1
+}
+grep -Fq '"status":"skipped"' "$opt_in_warm_output" || {
+  echo "expected opt-in path to run warm-cache wrapper before cargo" >&2
+  cat "$opt_in_warm_output" >&2
+  exit 1
+}
+
 echo "PASS test_run_pr_fast_test_lane"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -392,9 +392,11 @@ For broad non-coverage Rust lanes, prefer `cargo nextest run` over raw
 `cargo test` when the lane is executing the whole runnable test graph rather
 than a narrow filtered proof. The tracked CI workflow now routes ordinary PR
 test execution through `adl/tools/run_pr_fast_test_lane.sh`, which may use a
-focused `cargo nextest` expression for bounded changed surfaces and otherwise
-fails closed to the full ordinary nextest sweep. Keep `cargo llvm-cov` on its
-own coverage lanes, and preserve doc-test signal explicitly with
+focused `cargo nextest` expression for bounded changed surfaces. Broad or
+ambiguous PR-fast changes fail closed before cache warmup or cargo execution
+unless an explicit manual or release lane sets `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1`
+and records why full fanout is intended. Keep `cargo llvm-cov` on its own
+coverage lanes, and preserve doc-test signal explicitly with
 `cargo test --doc` where needed. Do not add `--all-features` back onto the
 ordinary PR lane when opt-in heavy features such as `slow-proof-tests` are
 being used to keep proof-materialization surfaces out of routine validation.


### PR DESCRIPTION
Closes #4698

## Summary
Reduced ordinary PR-fast long-test fanout by changing `adl/tools/run_pr_fast_test_lane.sh` so broad or ambiguous `mode=full` selections fail closed before Rust cache warmup or `cargo nextest` execution unless an explicit manual/release lane sets `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1`. Updated runner contract tests and active operator/skill guidance to preserve that policy.

## Artifacts
- Updated `adl/tools/run_pr_fast_test_lane.sh` to fail closed for full ordinary PR-fast nextest fanout unless `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1` is set.
- Updated `adl/tools/test_run_pr_fast_test_lane.sh` to prove default full-fanout refusal, pre-warm-cache refusal, and the explicit opt-in path through a stubbed `cargo`.
- Updated `docs/default_workflow.md` with the new ordinary PR-fast fail-closed policy.
- Updated `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md` so operational skills preserve the new opt-in boundary.
- Updated `.adl/v0.91.7/tasks/issue-4698__v0-91-7-wp-06-tests-reduce-long-test-fanout/srp.md` and this SOR with pre-PR review and execution truth.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified the runner contract for focused/family/full planning, fail-closed broad PR-fast refusal, no warm-cache side effect before refusal, and explicit full-fanout opt-in.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager profile contracts after the runner policy change.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified lane selector contracts and docs-diff hygiene.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified CI workflow contract checks for the PR-fast test lane.
  - `rg -n "fails closed to the full ordinary nextest sweep|full nextest sweep only|full ordinary nextest sweep" docs/default_workflow.md adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md adl/tools/run_pr_fast_test_lane.sh`
    Verified stale active-doc claims were removed; the command returned no matches.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS: `bash adl/tools/test_run_pr_fast_test_lane.sh`
  - PASS: `bash adl/tools/test_validation_manager.sh`
  - PASS: `bash adl/tools/test_select_validation_lanes.sh`
  - PASS: `bash adl/tools/test_ci_runtime_contracts.sh`
  - PASS: stale wording grep returned no matches
  - PASS: `git diff --check`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4698__v0-91-7-wp-06-tests-reduce-long-test-fanout/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4698__v0-91-7-wp-06-tests-reduce-long-test-fanout/sor.md
- Idempotency-Key: v0-91-7-wp-06-tests-reduce-long-test-fanout-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-docs-default-workflow-md-adl-tools-skills-docs-ci-runtime-policy-guide-md-adl-v0-91-7-tasks-issue-4698-v0-91-7-wp-06-tests-reduce-long-test-fanout-sip-md-adl-v0-91-7-tasks-issue-4698-v0-91-7-wp-06-tests-reduce-long-test-fanout-sor-md