### PR TITLE
[v0.91.7][tools][finish] Publish registered multi-command validation lanes

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3231,6 +3231,9 @@ fn registered_validation_atom_supported(command: &str) -> bool {
                 | "adl/tools/test_select_validation_lanes.sh"
                 | "adl/tools/test_validation_manager.sh"
                 | "adl/tools/test_run_nessus_remote_validation.sh"
+                | "adl/tools/test_rust_validation_warm_cache.sh"
+                | "adl/tools/test_run_authoritative_coverage_lane.sh"
+                | "adl/tools/test_run_pr_fast_test_lane.sh"
                 | "adl/tools/test_check_coverage_impact.sh"
                 | "adl/tools/test_demo_v0904_csm_observatory_governed_prototype.sh"
                 | "adl/tools/test_v0916_unity_observatory_baseline.sh"
@@ -3246,21 +3249,37 @@ fn registered_validation_atom_supported(command: &str) -> bool {
             "adl/tools/polis_status_for_ssm.sh"
                 | "adl/tools/polis_status_for_ssm_qts.sh"
                 | "adl/tools/test_v0916_unity_observatory_unity65_smoke.sh"
+                | "tools/aws_remote_validation/scripts/remote_validation_runner.sh"
+                | "tools/aws_remote_validation/scripts/ssh_debug_control.sh"
         ),
         ["bash", "adl/tools/run_owner_validation_lane.sh", lane] => {
             matches!(*lane, "csdlc" | "runtime" | "review")
+        }
+        ["python3", "-m", "py_compile", scripts @ ..] => {
+            !scripts.is_empty()
+                && scripts
+                    .iter()
+                    .all(|script| script.starts_with("adl/tools/") && script.ends_with(".py"))
         }
         ["python3", script] => matches!(
             *script,
             "adl/tools/validate_polis_status_for_ssm_qts.py"
                 | "adl/tools/validate_polis_status_for_ssm_windows.py"
+                | "adl/tools/test_warm_rust_dependency_cache.py"
         ),
         ["python3", script, ..] => matches!(
             *script,
             "adl/tools/validate_polis_status_for_ssm_qts.py"
                 | "adl/tools/validate_polis_status_for_ssm_windows.py"
+                | "adl/tools/test_warm_rust_dependency_cache.py"
         ),
         ["cargo", "test", "--manifest-path", "adl/Cargo.toml", "--test", "cli_smoke", "csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource", "--", "--nocapture"] => {
+            true
+        }
+        ["cargo", "check", "--manifest-path", "tools/aws_remote_validation/Cargo.toml", "--bin", "adl-aws-remote-validation"] => {
+            true
+        }
+        ["cargo", "test", "--manifest-path", "tools/aws_remote_validation/Cargo.toml", "--bin", "adl-aws-remote-validation", "--", "--nocapture"] => {
             true
         }
         _ => false,
@@ -3316,6 +3335,14 @@ fn execute_registered_validation_atom(repo_root: &Path, command: &str) -> Result
             let refs = owned.iter().map(String::as_str).collect::<Vec<_>>();
             run_finish_validation_status("bash", &refs)
         }
+        ["python3", "-m", "py_compile", scripts @ ..] => {
+            let mut owned = vec!["-m".to_string(), "py_compile".to_string()];
+            for script in scripts {
+                owned.push(finish_registered_validation_arg(repo_root, script)?);
+            }
+            let refs = owned.iter().map(String::as_str).collect::<Vec<_>>();
+            run_finish_validation_status("python3", &refs)
+        }
         ["python3", script] => {
             let script = repo_root.join(script);
             run_finish_validation_status("python3", &[path_str(&script)?])
@@ -3329,11 +3356,11 @@ fn execute_registered_validation_atom(repo_root: &Path, command: &str) -> Result
             let refs = owned.iter().map(String::as_str).collect::<Vec<_>>();
             run_finish_validation_status("python3", &refs)
         }
-        ["cargo", "test", manifest_flag, manifest_path, args @ ..]
+        ["cargo", subcommand @ ("check" | "test"), manifest_flag, manifest_path, args @ ..]
             if *manifest_flag == "--manifest-path" =>
         {
             let mut owned = vec![
-                "test".to_string(),
+                (*subcommand).to_string(),
                 (*manifest_flag).to_string(),
                 finish_registered_validation_arg(repo_root, manifest_path)?,
             ];

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -5289,6 +5289,81 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
 }
 
 #[test]
+fn finish_runner_executes_registered_rust_warm_cache_contract_sequence() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-registered-rust-warm-cache-contracts");
+
+    let command = "python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py && python3 adl/tools/test_warm_rust_dependency_cache.py && bash adl/tools/test_rust_validation_warm_cache.sh && bash adl/tools/test_run_authoritative_coverage_lane.sh && bash adl/tools/test_run_pr_fast_test_lane.sh";
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/config")).expect("adl config dir");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/config/validation_lane_selector.v0.91.6.json"),
+        format!(
+            r#"{{"schema_version":"adl.validation_lane_selector.v1","lanes":[{{"id":"rust_dependency_cache_warmup_contracts","run_command":"{}"}}]}}"#,
+            command
+        ),
+    )
+    .expect("validation manifest");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    fs::write(
+        repo.join("adl/tools/warm_rust_dependency_cache.py"),
+        "#!/usr/bin/env python3\nVALUE = 1\n",
+    )
+    .expect("warm cache py");
+    fs::write(
+        repo.join("adl/tools/test_warm_rust_dependency_cache.py"),
+        "#!/usr/bin/env python3\nimport os\nfrom pathlib import Path\nPath(os.environ['FOCUSED_LOG']).write_text(Path(os.environ['FOCUSED_LOG']).read_text() + 'warm-cache-python\\n' if Path(os.environ['FOCUSED_LOG']).exists() else 'warm-cache-python\\n')\n",
+    )
+    .expect("warm cache test py");
+    write_executable(
+        &repo.join("adl/tools/test_rust_validation_warm_cache.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' rust-validation-warm-cache >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_run_authoritative_coverage_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' authoritative-coverage-lane >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_run_pr_fast_test_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' pr-fast-test-lane >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let focused_log = temp.join("focused.log");
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = FinishValidationPlan {
+        mode: FinishValidationMode::SmallBinaryFocused,
+        commands: vec![command.to_string()],
+    };
+    run_finish_validation_rust(&repo, &plan)
+        .expect("registered rust warm-cache contract sequence validation");
+
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("warm-cache-python"));
+    assert!(focused_calls.contains("rust-validation-warm-cache"));
+    assert!(focused_calls.contains("authoritative-coverage-lane"));
+    assert!(focused_calls.contains("pr-fast-test-lane"));
+}
+
+#[test]
 fn finish_runner_executes_chained_local_polis_selector_command() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-chained-local-polis-selector-command");


### PR DESCRIPTION
Closes #4815

## Summary
Implemented finish-side support for current registered multi-command validation lanes. The change keeps validation fail-closed, executes registered command sequences atom-by-atom through the manifest-backed path, and adds focused regression coverage for the rust dependency warm-cache contract sequence.

## Artifacts
- Updated `adl/src/cli/pr_cmd/finish_support.rs` to recognize and execute current registered validation-lane atoms for rust warm-cache and AWS remote-validation command sequences.
- Updated `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` with a manifest-backed regression proving registered multi-command warm-cache lanes execute through `run_finish_validation_rust`.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_executes_registered_rust_warm_cache_contract_sequence -- --nocapture`
    Verified the new manifest-backed registered multi-command warm-cache lane path executes py-compile, Python runner, and shell validation atoms.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish finish_runner_executes_combined_ci_policy_selector_command -- --nocapture`
    Verified the existing combined CI policy selector command still executes all command atoms.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for the touched source/test files.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4815__v0-91-7-tools-finish-publish-registered-multi-command-validation-lanes/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4815__v0-91-7-tools-finish-publish-registered-multi-command-validation-lanes/sor.md
- Idempotency-Key: v0-91-7-tools-finish-publish-registered-multi-command-validation-lanes-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4815-v0-91-7-tools-finish-publish-registered-multi-command-validation-lanes-sip-md-adl-v0-91-7-tasks-issue-4815-v0-91-7-tools-finish-publish-registered-multi-command-validation-lanes-sor-md