### PR TITLE
[v0.91.7][tools][pr] Repair pr finish root owner-binary discovery

### DIFF
--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -46,6 +46,10 @@ rust_pr_delegate_available() {
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
   fi
+  cached_bin="$(rust_pr_subcommand_primary_cached_bin_stale_last_resort "${1:-}" || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
   cached_bin="$(rust_pr_delegate_path_bin || true)"
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
@@ -302,6 +306,20 @@ rust_pr_issue_stale_primary_cached_bin() {
   primary_root="$(rust_pr_delegate_primary_root)"
   [[ "$primary_root" != "$root" ]] || return 1
   candidate="$primary_root/adl/target/debug/adl-issue"
+  [[ -x "$candidate" ]] || return 1
+  printf '%s\n' "$candidate"
+}
+
+rust_pr_subcommand_primary_cached_bin_stale_last_resort() {
+  rust_pr_cargo_fallback_allowed && return 1
+  local subcommand="${1:-}"
+  local root primary_root binary_name candidate
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$primary_root" != "$root" ]] || return 1
+  binary_name="$(rust_pr_subcommand_binary_name "$subcommand" || true)"
+  [[ -n "$binary_name" ]] || return 1
+  candidate="$primary_root/adl/target/debug/$binary_name"
   [[ -x "$candidate" ]] || return 1
   printf '%s\n' "$candidate"
 }
@@ -629,6 +647,11 @@ delegate_pr_command_to_rust() {
   direct_bin="$(rust_pr_issue_stale_primary_cached_bin "$subcommand" || true)"
   if [[ -n "$direct_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "freshness" "stale_allowed_issue_last_resort"
+    exec "$direct_bin" "$@"
+  fi
+  direct_bin="$(rust_pr_subcommand_primary_cached_bin_stale_last_resort "$subcommand" || true)"
+  if [[ -n "$direct_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "freshness" "stale_allowed_primary_owner_last_resort"
     exec "$direct_bin" "$@"
   fi
   if rust_pr_subcommand_requires_dedicated_owner_binary "$subcommand"; then

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -212,6 +212,41 @@ args="$(cat "$TMP_ADL_ARGS")"
 
 echo "pr.sh worktree prefers primary checkout finish/validation owner binaries: ok"
 
+mkdir -p "$worktree/adl/src"
+printf 'pub fn finish_owner_last_resort_probe() {}\n' >"$worktree/adl/src/finish_owner_last_resort_probe.rs"
+sleep 1
+touch "$repo/adl/target/debug/adl-pr-finish"
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+finish_last_resort_log="$tmpdir/finish-last-resort.log"
+
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "worktree finish stale last resort" --output-card out.md >"$finish_last_resort_log" 2>&1
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == "finish:4413 --title worktree finish stale last resort --output-card out.md" ]] || {
+  echo "assertion failed: worktree finish should use primary adl-pr-finish as dedicated last resort when cargo fallback is disabled" >&2
+  echo "$args" >&2
+  cat "$finish_last_resort_log" >&2
+  exit 1
+}
+grep -F "freshness=stale_allowed_primary_owner_last_resort" "$finish_last_resort_log" >/dev/null || {
+  echo "assertion failed: stale primary owner-binary last resort should be observable" >&2
+  cat "$finish_last_resort_log" >&2
+  exit 1
+}
+[[ ! -s "$TMP_CARGO_ARGS" ]] || {
+  echo "assertion failed: cargo should not run when primary finish owner binary is used as disabled-fallback last resort" >&2
+  cat "$TMP_CARGO_ARGS" >&2
+  exit 1
+}
+rm -f "$worktree/adl/src/finish_owner_last_resort_probe.rs"
+
+echo "pr.sh worktree uses primary finish owner binary as explicit disabled-fallback last resort: ok"
+
 rm -f "$repo/adl/target/debug/adl-pr-doctor"
 cat >"$repo/adl/target/debug/adl" <<'EOF_ADL_GENERIC'
 #!/usr/bin/env bash


### PR DESCRIPTION
Closes #4836

## Summary
Implemented a disabled-cargo-fallback last-resort path for dedicated primary-checkout PR owner binaries. This fixes `pr.sh finish` from issue worktrees when the primary checkout `adl-pr-finish` exists but strict freshness checks reject it because the worktree is modifying Rust control-plane sources. The fallback is explicit in observability as `freshness=stale_allowed_primary_owner_last_resort` and does not enable cargo fallback.

## Artifacts
- Updated `adl/tools/pr_delegate.sh` with a dedicated primary owner-binary stale last-resort resolver that activates only when cargo fallback is disabled.
- Updated `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh` with a regression proving `pr.sh finish` can use primary `adl-pr-finish` from a worktree even when worktree Rust inputs are newer.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified primary-checkout owner-binary discovery from issue worktrees, including the new `finish` disabled-fallback last-resort case.
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
    Verified cargo fallback remains explicit, observable, timeout-bound, and disabled by default.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4836__v0-91-7-tools-pr-repair-pr-finish-root-owner-binary-discovery/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4836__v0-91-7-tools-pr-repair-pr-finish-root-owner-binary-discovery/sor.md
- Idempotency-Key: v0-91-7-tools-pr-repair-pr-finish-root-owner-binary-discovery-adl-tools-pr-delegate-sh-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-adl-v0-91-7-tasks-issue-4836-v0-91-7-tools-pr-repair-pr-finish-root-owner-binary-discovery-sip-md-adl-v0-91-7-tasks-issue-4836-v0-91-7-tools-pr-repair-pr-finish-root-owner-binary-discovery-sor-md