### PR TITLE
[v0.91.7][tools][validation] Keep pr_cmd slow E2E tests out of the default fast lane

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -158,6 +158,19 @@ is_structural_family_barrel_surface() {
   family_token_for_path "$path" >/dev/null 2>&1
 }
 
+is_slow_pr_cmd_e2e_surface() {
+  local path="$1"
+  case "$path" in
+    adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs)
+      return 1
+      ;;
+    adl/src/cli/tests/pr_cmd_inline/*|adl/src/cli/tests/pr_cmd_inline/*/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 is_broad_rust_surface() {
   local path="$1"
   case "$path" in
@@ -290,7 +303,7 @@ filter_token_for_path() {
       printf 'pr_cmd::github'
       return 0
       ;;
-    adl/src/cli/pr_cmd/finish_support.rs|adl/src/cli/tests/pr_cmd_inline/finish/*)
+    adl/src/cli/pr_cmd/finish_support.rs|adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs)
       printf 'pr_cmd_finish'
       return 0
       ;;
@@ -327,8 +340,7 @@ filter_token_for_path() {
       return 0
       ;;
     adl/src/cli/tests/pr_cmd_inline/*/*|adl/src/cli/tests/pr_cmd_inline/*)
-      printf 'pr_cmd'
-      return 0
+      return 1
       ;;
     adl/src/cli/pr_cmd_cards.rs|adl/src/cli/pr_cmd_cards/*.rs)
       printf 'pr_cmd'
@@ -400,8 +412,7 @@ family_token_for_path() {
     adl/src/bin/adl_pr_*.rs|\
     adl/src/cli/pr_cmd.rs|\
     adl/src/cli/pr_cmd/*|\
-    adl/src/cli/pr_cmd_args.rs|\
-    adl/src/cli/tests/pr_cmd_inline/*)
+    adl/src/cli/pr_cmd_args.rs)
       printf 'pr_control_plane'
       return 0
       ;;
@@ -573,6 +584,14 @@ while IFS= read -r path; do
   if [ "$path" = "adl/src/runtime_v2/tests.rs" ] && [ "$saw_slow_proof_contract_surface" = true ]; then
     slow_proof_inventory_surface_count=$((slow_proof_inventory_surface_count + 1))
     continue
+  fi
+  if is_slow_pr_cmd_e2e_surface "$path"; then
+    mode="full"
+    reason="slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+    classification_locked=true
+    tokens=()
+    family_tokens=()
+    break
   fi
   if is_broad_rust_surface "$path"; then
     mode="full"

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -129,7 +129,7 @@ nested_cli_finish_mod="$TMP/nested_cli_finish_mod.txt"
 printf 'M\tadl/src/cli/tests/pr_cmd_inline/finish/mod.rs\n' >"$nested_cli_finish_mod"
 nested_cli_finish_mod_output="$(bash "$SCRIPT" --changed-files "$nested_cli_finish_mod" --print-plan)"
 assert_has "$nested_cli_finish_mod_output" "mode=full"
-assert_has "$nested_cli_finish_mod_output" "reason=broad_rust_surface_requires_full_nextest"
+assert_has "$nested_cli_finish_mod_output" "reason=slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
 
 non_structural_cli_mod="$TMP/non_structural_cli_mod.txt"
 printf 'M\tadl/src/cli/run_artifacts/mod.rs\n' >"$non_structural_cli_mod"
@@ -358,6 +358,26 @@ assert_has "$finish_only_output" "mode=focused"
 assert_has "$finish_only_output" "reason=bounded_rust_surface_runs_focused_nextest"
 assert_has "$finish_only_output" "filter_tokens=pr_cmd_finish"
 assert_has "$finish_only_output" "filter_expression=binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)"
+
+slow_pr_cmd_e2e_guardrail="$TMP/slow-pr-cmd-e2e-guardrail.txt"
+printf 'M\tadl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs\n' >"$slow_pr_cmd_e2e_guardrail"
+slow_pr_cmd_e2e_guardrail_output="$(bash "$SCRIPT" --changed-files "$slow_pr_cmd_e2e_guardrail" --print-plan)"
+assert_has "$slow_pr_cmd_e2e_guardrail_output" "mode=full"
+assert_has "$slow_pr_cmd_e2e_guardrail_output" "reason=slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+set +e
+slow_pr_cmd_e2e_run_output="$(bash "$SCRIPT" --changed-files "$slow_pr_cmd_e2e_guardrail" 2>&1)"
+slow_pr_cmd_e2e_run_status=$?
+set -e
+if [ "$slow_pr_cmd_e2e_run_status" -ne 3 ]; then
+  echo "expected slow pr_cmd E2E fast-lane refusal to exit 3, got $slow_pr_cmd_e2e_run_status" >&2
+  echo "$slow_pr_cmd_e2e_run_output" >&2
+  exit 1
+fi
+grep -Fq "Refusing full nextest lane in ordinary PR-fast validation: slow_pr_cmd_e2e_surface_requires_explicit_slow_lane" <<<"$slow_pr_cmd_e2e_run_output" || {
+  echo "expected slow pr_cmd E2E refusal message" >&2
+  echo "$slow_pr_cmd_e2e_run_output" >&2
+  exit 1
+}
 
 long_lived_agent_only="$TMP/long_lived_agent_only.txt"
 cat >"$long_lived_agent_only" <<'EOF'

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -302,15 +302,26 @@ import sys
 
 profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
-assert profile["selected_profile"] == "selected_4_lane_profile"
-assert profile["status"] == "ready_to_run"
-assert profile["pr_publication_sufficient"] is True
+assert profile["selected_profile"] == "escalated_4_lane_profile"
+assert profile["status"] == "escalation_required"
+assert profile["pr_publication_sufficient"] is False
 assert [item["lane_id"] for item in profile["run"]] == [
     "ci_path_policy_contracts",
     "csdlc_owner_lane",
     "docs_diff_check",
-    "rust_pr_fast",
 ]
+assert profile["escalation"]["required"] is True
+assert any(
+    reason["lane_id"] == "rust_pr_fast"
+    and reason["reason"] == "slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+    and "adl/src/cli/tests/pr_cmd_inline/basics.rs" in reason["matched_paths"]
+    for reason in profile["escalation"]["reasons"]
+)
+assert any(
+    diagnostic["code"] == "rust_pr_fast_requires_escalation"
+    and diagnostic["message"] == "rust_pr_fast requires escalation because slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+    for diagnostic in profile["diagnostics"]
+)
 PY
 
 pr_inventory_finish="$TMP/pr-inventory-finish.txt"
@@ -348,19 +359,26 @@ import sys
 
 profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
-assert profile["selected_profile"] == "selected_4_lane_profile"
-assert profile["status"] == "ready_to_run"
-assert profile["pr_publication_sufficient"] is True
-assert profile["escalation"]["required"] is False
-assert profile["diagnostics"] == []
+assert profile["selected_profile"] == "escalated_4_lane_profile"
+assert profile["status"] == "escalation_required"
+assert profile["pr_publication_sufficient"] is False
+assert profile["escalation"]["required"] is True
 assert {item["lane_id"] for item in profile["run"]} == {
     "ci_path_policy_contracts",
     "csdlc_owner_lane",
     "docs_diff_check",
-    "rust_pr_fast",
 }
-rust_lane = next(item for item in profile["run"] if item["lane_id"] == "rust_pr_fast")
-assert "adl/Cargo.toml" in rust_lane["matched_paths"]
+assert any(
+    reason["lane_id"] == "rust_pr_fast"
+    and reason["reason"] == "slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+    and "adl/src/cli/tests/pr_cmd_inline/repo_helpers/metadata.rs" in reason["matched_paths"]
+    for reason in profile["escalation"]["reasons"]
+)
+assert any(
+    diagnostic["code"] == "pr_fast_mode_full"
+    and diagnostic["manifest_rule"] == "manager_guardrails.pr_fast.blocked_modes"
+    for diagnostic in profile["diagnostics"]
+)
 PY
 
 sprint_conductor="$TMP/sprint-conductor.txt"


### PR DESCRIPTION
Closes #4835

## Summary
Implemented the #4835 PR-fast selector fix. The ordinary fast lane now treats broad `adl/src/cli/tests/pr_cmd_inline/` E2E surfaces as explicit slow/proving-lane work instead of assigning broad `pr_cmd` or `pr_cmd_finish` filters. Focused `finish_support.rs` plus `finish/arg_render.rs` validation remains available through the narrow `pr_cmd_finish` token.

## Artifacts
- Updated `adl/tools/run_pr_fast_test_lane.sh` with explicit slow `pr_cmd_inline` E2E surface classification.
- Updated `adl/tools/test_run_pr_fast_test_lane.sh` with regression coverage for slow `pr_cmd_inline` refusal and focused finish coverage preservation.
- Updated `adl/tools/test_validation_manager.sh` so validation-manager fixtures expect escalation for broad `pr_cmd_inline` E2E surfaces.
- Updated SRP/SOR issue truth for #4835.

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/run_pr_fast_test_lane.sh`
    Verified the modified shell selector parses.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified the ordinary PR-fast lane refuses slow `pr_cmd_inline` E2E surfaces by default, preserves focused `finish_support.rs` plus `finish/arg_render.rs` coverage, and keeps existing selector contracts intact.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager profiles escalate broad `pr_cmd_inline` E2E surfaces and keep focused/non-Rust lanes runnable.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified CI path policy remains aligned with the updated validation-manager and PR-fast selector contracts.
  - `git diff --check`
    Verified no whitespace/error-marker diff issues.
- Results:
  - PASS

Validation command/path rules:
- Repository-relative paths are used in recorded commands and artifact references.
- No absolute host paths are recorded in the final issue output record.
- Commands are listed with their issue-local effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4835__v0-91-7-tools-validation-keep-pr-cmd-slow-e2e-tests-out-of-the-default-fast-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4835__v0-91-7-tools-validation-keep-pr-cmd-slow-e2e-tests-out-of-the-default-fast-lane/sor.md
- Idempotency-Key: v0-91-7-tools-validation-keep-pr-cmd-slow-e2e-tests-out-of-the-default-fast-lane-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-tools-test-validation-manager-sh-adl-v0-91-7-tasks-issue-4835-v0-91-7-tools-validation-keep-pr-cmd-slow-e2e-tests-out-of-the-default-fast-lane-sip-md-adl-v0-91-7-tasks-issue-4835-v0-91-7-tools-validation-keep-pr-cmd-slow-e2e-tests-out-of-the-default-fast-lane-sor-md