### PR TITLE
[v0.91.7][WP-07][runtime-v2] Reconcile Runtime v2 prototype with current runtime substrate

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -3231,6 +3231,7 @@ fn registered_validation_atom_supported(command: &str) -> bool {
                 | "adl/tools/test_select_validation_lanes.sh"
                 | "adl/tools/test_validation_manager.sh"
                 | "adl/tools/test_run_nessus_remote_validation.sh"
+                | "adl/tools/test_run_validation_manager_nessus_lane.sh"
                 | "adl/tools/test_rust_validation_warm_cache.sh"
                 | "adl/tools/test_run_authoritative_coverage_lane.sh"
                 | "adl/tools/test_run_pr_fast_test_lane.sh"
@@ -5322,6 +5323,24 @@ pub(super) fn run_finish_validation_rust(
                     let nessus_remote_runner =
                         repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
                     run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
+                }
+                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh" => {
+                    let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");
+                    run_finish_validation_status("bash", &[path_str(&ci_path_policy)?])?;
+                    let ci_runtime_contracts = repo_root.join("adl/tools/test_ci_runtime_contracts.sh");
+                    run_finish_validation_status("bash", &[path_str(&ci_runtime_contracts)?])?;
+                    let select_validation_lanes =
+                        repo_root.join("adl/tools/test_select_validation_lanes.sh");
+                    run_finish_validation_status("bash", &[path_str(&select_validation_lanes)?])?;
+                    let validation_manager =
+                        repo_root.join("adl/tools/test_validation_manager.sh");
+                    run_finish_validation_status("bash", &[path_str(&validation_manager)?])?;
+                    let nessus_remote_runner =
+                        repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
+                    run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
+                    let validation_manager_nessus =
+                        repo_root.join("adl/tools/test_run_validation_manager_nessus_lane.sh");
+                    run_finish_validation_status("bash", &[path_str(&validation_manager_nessus)?])?;
                 }
                 "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py" => {
                     let polis_status = repo_root.join("adl/tools/polis_status_for_ssm.sh");

--- a/adl/src/cli/runtime_v2_cmd/commands.rs
+++ b/adl/src/cli/runtime_v2_cmd/commands.rs
@@ -1,16 +1,21 @@
 use anyhow::{anyhow, Context, Result};
-use serde_json::to_string_pretty;
+use chrono::Utc;
+use serde::Serialize;
+use serde_json::{json, to_string_pretty};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::helpers::{resolve_relative_output_path, write_runtime_v2_governed_trace_demo};
 use crate::cli::usage;
-use ::adl::runtime_v2::{
-    runtime_v2_cognitive_being_flagship_demo_contract, runtime_v2_contract_market_demo_contract,
-    runtime_v2_csm_integrated_run_contract, runtime_v2_feature_proof_coverage_contract,
-    runtime_v2_foundation_demo_contract, runtime_v2_governed_tools_flagship_demo_contract,
-    runtime_v2_observatory_flagship_contract, runtime_v2_operator_control_report_contract,
-    runtime_v2_security_boundary_proof_contract,
+use ::adl::{
+    long_lived_agent::{self, RunOptions},
+    runtime_v2::{
+        runtime_v2_cognitive_being_flagship_demo_contract,
+        runtime_v2_contract_market_demo_contract, runtime_v2_csm_integrated_run_contract,
+        runtime_v2_feature_proof_coverage_contract, runtime_v2_foundation_demo_contract,
+        runtime_v2_governed_tools_flagship_demo_contract, runtime_v2_observatory_flagship_contract,
+        runtime_v2_operator_control_report_contract, runtime_v2_security_boundary_proof_contract,
+    },
 };
 
 pub(crate) fn real_runtime_v2_operator_controls(repo_root: &Path, args: &[String]) -> Result<()> {
@@ -183,6 +188,11 @@ pub(crate) fn real_runtime_v2_integrated_csm_run_demo(
                 out_path = Some(PathBuf::from(value));
                 i += 1;
             }
+            "--prototype-only" => {
+                return Err(anyhow!(
+                    "runtime-v2 integrated-csm-run-demo no longer supports prototype-only execution; use --out to produce the reconciled Runtime v2 plus current-runtime proof bundle"
+                ));
+            }
             "--help" | "-h" => {
                 println!("{}", usage::usage());
                 return Ok(());
@@ -210,6 +220,7 @@ pub(crate) fn real_runtime_v2_integrated_csm_run_demo(
     })?;
     artifacts.write_to_root(&resolved)?;
     write_runtime_v2_governed_trace_demo(&resolved)?;
+    write_current_runtime_reconciliation(&resolved)?;
     println!(
         "RUNTIME_V2_INTEGRATED_CSM_RUN_DEMO_ROOT={}",
         resolved.display()
@@ -219,6 +230,108 @@ pub(crate) fn real_runtime_v2_integrated_csm_run_demo(
     println!();
     println!("{}", artifacts.observatory_console_markdown()?);
     Ok(())
+}
+
+fn write_current_runtime_reconciliation(root: &Path) -> Result<()> {
+    let current_root = root.join("current_runtime/long_lived_agent");
+    fs::create_dir_all(&current_root)
+        .with_context(|| format!("create current runtime root {}", current_root.display()))?;
+    let spec_path = current_root.join("agent.yaml");
+    fs::write(
+        &spec_path,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: runtime-v2-reconciled-current-runtime
+display_name: Runtime v2 Reconciled Current Runtime
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: runtime_v2_reconciliation_current_runtime
+  run_args:
+    provider_id: local_ollama
+    model: gemma4:latest
+heartbeat:
+  interval_secs: 1
+  max_cycles: 1
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+  max_consecutive_failures: 2
+memory:
+  namespace: runtime-v2/reconciliation/current-runtime
+  write_policy: append_only
+"#,
+    )
+    .with_context(|| format!("write current runtime spec {}", spec_path.display()))?;
+
+    let initial_status = long_lived_agent::status(&spec_path)?;
+    let run_status = long_lived_agent::run(
+        &spec_path,
+        RunOptions {
+            max_cycles: 1,
+            interval_secs: Some(0),
+            no_sleep: true,
+            recover_stale_lease: false,
+        },
+    )?;
+    let stopped = long_lived_agent::stop(
+        &spec_path,
+        "bounded Runtime v2 reconciliation proof stop after current-runtime run",
+    )?;
+    let final_status = long_lived_agent::status(&spec_path)?;
+
+    write_json(&current_root.join("initial_status.json"), &initial_status)?;
+    write_json(&current_root.join("run_status.json"), &run_status)?;
+    write_json(&current_root.join("stop_status.json"), &stopped)?;
+    write_json(&current_root.join("final_status.json"), &final_status)?;
+
+    write_json(
+        &root.join("runtime_v2/reconciliation/reconciliation_packet.json"),
+        &json!({
+            "schema_version": "runtime_v2.current_runtime_reconciliation.v1",
+            "generated_at": Utc::now(),
+            "classification": "integrated_proof",
+            "runtime_v2_prototype": {
+                "status": "integrated_as_artifact_producer",
+                "proof_packet_ref": "runtime_v2/csm_run/integrated_first_run_proof_packet.json",
+                "transcript_ref": "runtime_v2/csm_run/integrated_first_run_transcript.jsonl",
+                "governed_trace_ref": "artifacts/runtime-v2-governed-demo-run/logs/activation_log.json"
+            },
+            "current_runtime_substrate": {
+                "status": "executed",
+                "agent_spec_ref": "current_runtime/long_lived_agent/agent.yaml",
+                "initial_status_ref": "current_runtime/long_lived_agent/initial_status.json",
+                "run_status_ref": "current_runtime/long_lived_agent/run_status.json",
+                "stop_status_ref": "current_runtime/long_lived_agent/stop_status.json",
+                "final_status_ref": "current_runtime/long_lived_agent/final_status.json",
+                "completed_cycle_count": final_status.completed_cycle_count,
+                "final_state": format!("{:?}", final_status.state)
+            },
+            "canonical_path_decision": "Runtime v2 integrated-csm-run-demo remains a bounded artifact producer only when it also emits this current-runtime reconciliation proof. WP-07 Soak #2 should consume the current runtime substrate path for start/run/stop truth.",
+            "fail_closed_negative_case": "The deprecated --prototype-only invocation is rejected by the command instead of silently producing a parallel Runtime v2-only proof.",
+            "non_claims": [
+                "does not execute full Soak #2",
+                "does not claim v0.92 runtime readiness",
+                "does not claim AWS, Observatory, provider, memory, or AEE completion beyond the referenced artifacts"
+            ]
+        }),
+    )?;
+    Ok(())
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create output directory {}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)
+        .with_context(|| format!("serialize json artifact {}", path.display()))?;
+    fs::write(path, bytes).with_context(|| format!("write json artifact {}", path.display()))
 }
 
 pub(crate) fn real_runtime_v2_observatory_flagship_demo(

--- a/adl/src/cli/runtime_v2_cmd/tests.rs
+++ b/adl/src/cli/runtime_v2_cmd/tests.rs
@@ -342,6 +342,15 @@ fn trace_runtime_v2_integrated_csm_run_demo_writes_proof_bundle() {
     assert!(out_dir
         .join("artifacts/runtime-v2-governed-demo-run/governed/result.redacted.json")
         .is_file());
+    assert!(out_dir
+        .join("runtime_v2/reconciliation/reconciliation_packet.json")
+        .is_file());
+    assert!(out_dir
+        .join("current_runtime/long_lived_agent/run_status.json")
+        .is_file());
+    assert!(out_dir
+        .join("current_runtime/long_lived_agent/final_status.json")
+        .is_file());
     let json: serde_json::Value =
         serde_json::from_slice(&fs::read(&proof_path).expect("proof packet should exist"))
             .expect("valid json");
@@ -364,6 +373,24 @@ fn trace_runtime_v2_integrated_csm_run_demo_writes_proof_bundle() {
     assert!(observatory_console.contains("D10 Integrated CSM Run Observatory"));
     assert!(observatory_console.contains("CSM Observatory Operator Report"));
     assert!(observatory_console.contains("runtime_v2/observatory/visibility_packet.json"));
+    let reconciliation_json: serde_json::Value = serde_json::from_slice(
+        &fs::read(out_dir.join("runtime_v2/reconciliation/reconciliation_packet.json"))
+            .expect("reconciliation packet should exist"),
+    )
+    .expect("valid reconciliation json");
+    assert_eq!(
+        reconciliation_json["schema_version"],
+        "runtime_v2.current_runtime_reconciliation.v1"
+    );
+    assert_eq!(reconciliation_json["classification"], "integrated_proof");
+    assert_eq!(
+        reconciliation_json["current_runtime_substrate"]["status"],
+        "executed"
+    );
+    assert_eq!(
+        reconciliation_json["runtime_v2_prototype"]["status"],
+        "integrated_as_artifact_producer"
+    );
 
     fs::remove_dir_all(repo).ok();
 }
@@ -411,6 +438,18 @@ fn trace_runtime_v2_integrated_csm_run_demo_validates_stdout_help_and_output_pat
     assert!(err
         .to_string()
         .contains("runtime-v2 integrated-csm-run-demo requires --out <dir>"));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "integrated-csm-run-demo".to_string(),
+            "--prototype-only".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("prototype-only path should fail closed");
+    assert!(err
+        .to_string()
+        .contains("no longer supports prototype-only execution"));
 
     fs::remove_dir_all(repo).ok();
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3920,7 +3920,7 @@ fn finish_validation_profile_classifies_locked_cargo_fallback_slice() {
     ));
     assert!(unrelated_plan
         .commands
-        .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string()));
+        .contains(&"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh".to_string()));
     assert!(unrelated_plan
         .commands
         .contains(&"bash adl/tools/test_check_coverage_impact.sh".to_string()));
@@ -4211,7 +4211,9 @@ fn finish_validation_profile_escalates_workflow_metrics_backfill_publication_sli
             "docs/milestones/v0.91.6/review/V0916_WORKFLOW_METRIC_BACKFILL_4441.json".to_string(),
         ],
     )
-    .expect_err("workflow metrics backfill publication plan should require explicit slow-lane routing");
+    .expect_err(
+        "workflow metrics backfill publication plan should require explicit slow-lane routing",
+    );
 
     let message = err.to_string();
     assert!(message.contains("validation manager reported a non-runnable profile"));
@@ -5226,6 +5228,10 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
         &repo.join("adl/tools/test_run_nessus_remote_validation.sh"),
         "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' nessus-remote-runner >> \"$FOCUSED_LOG\"\n",
     );
+    write_executable(
+        &repo.join("adl/tools/test_run_validation_manager_nessus_lane.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' validation-manager-nessus-lane >> \"$FOCUSED_LOG\"\n",
+    );
     init_git_repo(&repo);
 
     let bin_dir = temp.join("bin");
@@ -5249,7 +5255,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     let plan = FinishValidationPlan {
         mode: FinishValidationMode::SmallBinaryFocused,
         commands: vec![
-            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh".to_string(),
         ],
     };
     run_finish_validation_rust(&repo, &plan).expect("combined ci-policy selector validation");
@@ -5273,6 +5279,7 @@ fn finish_runner_executes_combined_ci_policy_selector_command() {
     assert!(focused_calls.contains("select-validation-lanes"));
     assert!(focused_calls.contains("validation-manager"));
     assert!(focused_calls.contains("nessus-remote-runner"));
+    assert!(focused_calls.contains("validation-manager-nessus-lane"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4211,9 +4211,7 @@ fn finish_validation_profile_escalates_workflow_metrics_backfill_publication_sli
             "docs/milestones/v0.91.6/review/V0916_WORKFLOW_METRIC_BACKFILL_4441.json".to_string(),
         ],
     )
-    .expect_err(
-        "workflow metrics backfill publication plan should require explicit slow-lane routing",
-    );
+    .expect_err("workflow metrics backfill publication plan should require explicit slow-lane routing");
 
     let message = err.to_string();
     assert!(message.contains("validation manager reported a non-runnable profile"));

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -283,6 +283,10 @@ filter_token_for_path() {
       printf 'tokio_bootstrap'
       return 0
       ;;
+    adl/src/cli/runtime_v2_cmd.rs|adl/src/cli/runtime_v2_cmd/*.rs)
+      printf 'runtime_v2_cmd'
+      return 0
+      ;;
     adl/src/csdlc_prompt_editor.rs|adl/src/csdlc_prompt_editor/*.rs)
       printf 'csdlc_prompt_editor'
       return 0
@@ -482,6 +486,7 @@ TOKEN_MAP = {
     "demo_adl_gws_context_mirror": 'binary_id(adl::bin/demo-adl-gws-context-mirror) and test(/^tests::/)',
     "demo_adl_gws_native_drive_sync": 'binary_id(adl::bin/demo-adl-gws-native-drive-sync) and test(/^tests::/)',
     "run_v0916_integrated_runtime_soak": 'binary_id(adl::bin/run_v0916_integrated_runtime_soak) and test(/^tests::/)',
+    "runtime_v2_cmd": 'test(/^cli::runtime_v2_cmd::/)',
     "tokio_bootstrap": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/)',
     "pr_cmd": 'binary_id(adl::bin/adl) and test(/^cli::pr_cmd::/)',
     "pr_control_plane": 'test(/^cli::pr_cmd::/)',

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -117,6 +117,18 @@ assert_has "$nested_private_state_sanctuary_output" "mode=focused"
 assert_has "$nested_private_state_sanctuary_output" "filter_tokens=private_state_sanctuary"
 assert_has "$nested_private_state_sanctuary_output" "filter_expression=test(private_state_sanctuary)"
 
+runtime_v2_cmd_with_finish="$TMP/runtime_v2_cmd_with_finish.txt"
+cat >"$runtime_v2_cmd_with_finish" <<'EOF'
+M	adl/src/cli/runtime_v2_cmd/commands.rs
+M	adl/src/cli/runtime_v2_cmd/tests.rs
+M	adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+EOF
+runtime_v2_cmd_with_finish_output="$(bash "$SCRIPT" --changed-files "$runtime_v2_cmd_with_finish" --print-plan)"
+assert_has "$runtime_v2_cmd_with_finish_output" "mode=focused"
+assert_has "$runtime_v2_cmd_with_finish_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$runtime_v2_cmd_with_finish_output" "filter_tokens=runtime_v2_cmd,pr_cmd_finish"
+assert_has "$runtime_v2_cmd_with_finish_output" "filter_expression=test(/^cli::runtime_v2_cmd::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)"
+
 nested_runtime_mod_family="$TMP/nested_runtime_mod_family.txt"
 printf 'M\tadl/src/runtime_v2/standing/mod.rs\n' >"$nested_runtime_mod_family"
 nested_runtime_mod_family_output="$(bash "$SCRIPT" --changed-files "$nested_runtime_mod_family" --print-plan)"


### PR DESCRIPTION
Closes #4842

## Summary
Issue #4842 implemented a bounded Runtime v2 reconciliation path in the runtime-v2 CLI. The integrated CSM run demo remains an artifact producer only when `--out` also emits a current-runtime long-lived-agent proof bundle, and the deprecated `--prototype-only` path now fails closed.

## Artifacts
- Updated runtime-v2 command implementation in `adl/src/cli/runtime_v2_cmd/commands.rs`
- Updated runtime-v2 command tests in `adl/src/cli/runtime_v2_cmd/tests.rs`
- Local ignored lifecycle truth updated at `.adl/v0.91.7/tasks/issue-4842__v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate/sor.md`
- Retained ignored proof bundle produced at `artifacts/v0917/issue-4842-runtime-v2-reconciliation`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/rust_validation_warm_cache.sh` - Warmed issue-worktree Rust dependency artifacts from the trusted same-host root target before validation; acceleration only, not proof.
  - `cargo fmt --all -- --check` - Verified Rust formatting after applying cargo fmt.
  - `cargo test --manifest-path adl/Cargo.toml cli::runtime_v2_cmd -- --nocapture` - Exercised the runtime-v2 CLI command surface, including the integrated-csm-run reconciliation bundle and fail-closed prototype-only path.
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 integrated-csm-run-demo --out artifacts/v0917/issue-4842-runtime-v2-reconciliation` - Produced the retained Runtime v2 plus current-runtime reconciliation proof bundle with a bounded long-lived-agent run/status/stop/status sequence.
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 integrated-csm-run-demo --prototype-only` - Verified the deprecated prototype-only invocation fails closed instead of emitting a parallel Runtime v2-only proof.
  - `git diff --check` - Verified the tracked diff has no whitespace errors.
- Results:
  - `bash adl/tools/rust_validation_warm_cache.sh`: PASS
  - `cargo fmt --all -- --check`: PASS
  - `cargo test --manifest-path adl/Cargo.toml cli::runtime_v2_cmd -- --nocapture`: PASS
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 integrated-csm-run-demo --out artifacts/v0917/issue-4842-runtime-v2-reconciliation`: PASS
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 integrated-csm-run-demo --prototype-only`: EXPECTED_FAIL_CLOSED
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4842__v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4842__v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4842-v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate-sip-md-adl-v0-91-7-tasks-issue-4842-v0-91-7-wp-07-runtime-v2-reconcile-runtime-v2-prototype-with-current-runtime-substrate-sor-md