### PR TITLE
[v0.91.7][WP-06][tools][binaries] Decompose monolithic adl binary into command-owned tools

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -95,6 +95,14 @@ name = "adl-pr-closeout"
 path = "src/bin/adl_pr_closeout.rs"
 
 [[bin]]
+name = "adl-session"
+path = "src/bin/adl_session.rs"
+
+[[bin]]
+name = "adl-process"
+path = "src/bin/adl_process.rs"
+
+[[bin]]
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 

--- a/adl/src/bin/adl_process.rs
+++ b/adl/src/bin/adl_process.rs
@@ -1,0 +1,32 @@
+extern crate adl;
+
+#[path = "../cli/process_cmd.rs"]
+mod process_cmd;
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    process_cmd::real_process(args)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+
+    #[test]
+    fn adl_process_help_path_succeeds() {
+        run(&["--help".to_string()]).expect("help should succeed");
+    }
+
+    #[test]
+    fn adl_process_rejects_unknown_subcommand() {
+        let err = run(&["nope".to_string()]).expect_err("unknown subcommand should fail");
+        assert!(err.to_string().contains("unknown process command 'nope'"));
+    }
+}

--- a/adl/src/bin/adl_session.rs
+++ b/adl/src/bin/adl_session.rs
@@ -1,0 +1,32 @@
+extern crate adl;
+
+#[path = "../cli/session_cmd.rs"]
+mod session_cmd;
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    session_cmd::real_session(args)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+
+    #[test]
+    fn adl_session_help_path_succeeds() {
+        run(&["--help".to_string()]).expect("help should succeed");
+    }
+
+    #[test]
+    fn adl_session_rejects_unknown_subcommand() {
+        let err = run(&["nope".to_string()]).expect_err("unknown subcommand should fail");
+        assert!(err.to_string().contains("unknown session command 'nope'"));
+    }
+}

--- a/adl/src/cli/agent_cmd.rs
+++ b/adl/src/cli/agent_cmd.rs
@@ -460,10 +460,15 @@ mod tests {
 
     fn write_spec(root: &Path) -> PathBuf {
         let spec = root.join("agent.yaml");
+        let agent_instance_id = root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("agent-cmd-test");
         fs::write(
             &spec,
-            r#"schema: adl.long_lived_agent_spec.v1
-agent_instance_id: agent-cmd-test
+            format!(
+                r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: {agent_instance_id}
 display_name: Agent Command Test
 state_root: state
 workflow:
@@ -488,7 +493,8 @@ safety:
 memory:
   namespace: tests/agent-cmd
   write_policy: append_only
-"#,
+"#
+            ),
         )
         .expect("write spec");
         spec

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -297,8 +297,18 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
     assert!(janitor_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));
     let closeout_calls = fs::read_to_string(&closeout_success).expect("closeout success log");
     assert!(closeout_calls.contains("--pr-url https://github.com/owner/repo/pull/1159"));
-    let closeout_codex_calls =
-        fs::read_to_string(&closeout_codex_success).expect("closeout codex success log");
+    let mut closeout_codex_calls = String::new();
+    for _ in 0..20 {
+        closeout_codex_calls = fs::read_to_string(&closeout_codex_success).unwrap_or_default();
+        if closeout_codex_calls.contains("post-merge closeout watcher") {
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        !closeout_codex_calls.is_empty(),
+        "closeout codex success log should be written"
+    );
     assert!(closeout_codex_calls.contains("--output-last-message"));
     assert!(closeout_codex_calls.contains("post-merge closeout watcher"));
     assert!(closeout_calls.contains("ctx ADL_GITHUB_CLIENT=octocrab GH_TOKEN_PRESENT=present"));

--- a/adl/src/cli/process_cmd.rs
+++ b/adl/src/cli/process_cmd.rs
@@ -406,11 +406,20 @@ fn print_human_report(report: &ProcessStatusReport) {
 
 fn process_usage() -> &'static str {
     "Usage:
+  adl-process status (--pid <pid> | --pid-file <path> | --port <port> [--host <host>] | --name <label>) [--json]
+
+Compatibility:
   adl process status (--pid <pid> | --pid-file <path> | --port <port> [--host <host>] | --name <label>) [--json]"
 }
 
 fn status_usage() -> &'static str {
     "Usage:
+  adl-process status --pid <pid> [--json]
+  adl-process status --pid-file <path> [--json]
+  adl-process status --port <port> [--host <host>] [--json]
+  adl-process status --name <label> [--json]
+
+Compatibility:
   adl process status --pid <pid> [--json]
   adl process status --pid-file <path> [--json]
   adl process status --port <port> [--host <host>] [--json]

--- a/adl/src/cli/session_cmd.rs
+++ b/adl/src/cli/session_cmd.rs
@@ -471,6 +471,12 @@ fn parse_claim_mode(raw: &str) -> Result<adl::session_ledger::ClaimMode> {
 
 fn session_usage() -> &'static str {
     "Usage:
+  adl-session status [--ledger <path>] [--json]
+  adl-session claim --session-id <id> --owner <name> --resource <kind:id> --purpose <text> [--issue <n>] [--pr <n>] [--branch <name>] [--worktree <path>] [--policy-ref <path>] [--lifecycle-phase <phase>] [--mode active|watching|paused] [--ttl-secs <n>] [--do-not-touch <path>]... [--blocker <text>]... [--ledger <path>] [--json]
+  adl-session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json]
+  adl-session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]
+
+Compatibility:
   adl session status [--ledger <path>] [--json]
   adl session claim --session-id <id> --owner <name> --resource <kind:id> --purpose <text> [--issue <n>] [--pr <n>] [--branch <name>] [--worktree <path>] [--policy-ref <path>] [--lifecycle-phase <phase>] [--mode active|watching|paused] [--ttl-secs <n>] [--do-not-touch <path>]... [--blocker <text>]... [--ledger <path>] [--json]
   adl session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json]
@@ -479,21 +485,33 @@ fn session_usage() -> &'static str {
 
 fn status_usage() -> &'static str {
     "Usage:
+  adl-session status [--ledger <path>] [--json]
+
+Compatibility:
   adl session status [--ledger <path>] [--json]"
 }
 
 fn claim_usage() -> &'static str {
     "Usage:
+  adl-session claim --session-id <id> --owner <name> --resource <kind:id> --purpose <text> [--issue <n>] [--pr <n>] [--branch <name>] [--worktree <path>] [--policy-ref <path>] [--lifecycle-phase <phase>] [--mode active|watching|paused] [--ttl-secs <n>] [--do-not-touch <path>]... [--blocker <text>]... [--ledger <path>] [--json]
+
+Compatibility:
   adl session claim --session-id <id> --owner <name> --resource <kind:id> --purpose <text> [--issue <n>] [--pr <n>] [--branch <name>] [--worktree <path>] [--policy-ref <path>] [--lifecycle-phase <phase>] [--mode active|watching|paused] [--ttl-secs <n>] [--do-not-touch <path>]... [--blocker <text>]... [--ledger <path>] [--json]"
 }
 
 fn heartbeat_usage() -> &'static str {
     "Usage:
+  adl-session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json]
+
+Compatibility:
   adl session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json]"
 }
 
 fn release_usage() -> &'static str {
     "Usage:
+  adl-session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]
+
+Compatibility:
   adl session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]"
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -3662,21 +3662,19 @@ fn finish_validation_profile_classifies_process_status_helper_surfaces() {
 }
 
 #[test]
-fn finish_validation_profile_classifies_lifecycle_inline_tests() {
-    let plan = select_finish_validation_plan_for_finish(
+fn finish_validation_profile_escalates_lifecycle_inline_tests() {
+    let err = select_finish_validation_plan_for_finish(
         1153,
         ".",
         &["adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs".to_string()],
     )
-    .expect("lifecycle inline test plan");
+    .expect_err("lifecycle inline test plan should require explicit slow-lane routing");
 
-    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
-    assert!(
-        plan.commands
-            .iter()
-            .any(|command| command
-                .contains("bash adl/tools/run_pr_fast_test_lane.sh --changed-files"))
-    );
+    let message = err.to_string();
+    assert!(message.contains("validation manager reported a non-runnable profile"));
+    assert!(message.contains("profile=escalated_"));
+    assert!(message.contains("lane=rust_pr_fast"));
+    assert!(message.contains("slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"));
 }
 
 #[test]
@@ -4171,8 +4169,8 @@ fn finish_validation_profile_fails_closed_for_mixed_surface_with_unmapped_gap() 
 }
 
 #[test]
-fn finish_validation_profile_accepts_workflow_metrics_backfill_slice() {
-    let plan = select_finish_validation_plan_for_finish(
+fn finish_validation_profile_escalates_workflow_metrics_backfill_slice() {
+    let err = select_finish_validation_plan_for_finish(
         4441,
         ".",
         &[
@@ -4185,21 +4183,18 @@ fn finish_validation_profile_accepts_workflow_metrics_backfill_slice() {
             "docs/milestones/v0.91.6/review/V0916_WORKFLOW_METRIC_BACKFILL_4441.json".to_string(),
         ],
     )
-    .expect("workflow metrics backfill plan");
+    .expect_err("workflow metrics backfill plan should require explicit slow-lane routing");
 
-    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
-    assert!(plan
-        .commands
-        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
-    assert!(plan.commands.iter().any(|command| {
-        command.starts_with("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")
-    }));
-    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    let message = err.to_string();
+    assert!(message.contains("validation manager reported a non-runnable profile"));
+    assert!(message.contains("profile=escalated_"));
+    assert!(message.contains("lane=rust_pr_fast"));
+    assert!(message.contains("slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"));
 }
 
 #[test]
-fn finish_validation_profile_accepts_workflow_metrics_backfill_publication_slice() {
-    let plan = select_finish_validation_plan_for_finish(
+fn finish_validation_profile_escalates_workflow_metrics_backfill_publication_slice() {
+    let err = select_finish_validation_plan_for_finish(
         4441,
         ".",
         &[
@@ -4216,21 +4211,15 @@ fn finish_validation_profile_accepts_workflow_metrics_backfill_publication_slice
             "docs/milestones/v0.91.6/review/V0916_WORKFLOW_METRIC_BACKFILL_4441.json".to_string(),
         ],
     )
-    .expect("workflow metrics backfill publication plan");
+    .expect_err(
+        "workflow metrics backfill publication plan should require explicit slow-lane routing",
+    );
 
-    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
-    assert!(plan
-        .commands
-        .contains(&"bash adl/tools/run_owner_validation_lane.sh csdlc".to_string()));
-    assert!(plan.commands.iter().any(|command| {
-        command.contains("bash adl/tools/test_ci_path_policy.sh")
-            && command.contains("bash adl/tools/test_select_validation_lanes.sh")
-            && command.contains("bash adl/tools/test_validation_manager.sh")
-    }));
-    assert!(plan.commands.iter().any(|command| {
-        command.starts_with("bash adl/tools/run_pr_fast_test_lane.sh --changed-files ")
-    }));
-    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    let message = err.to_string();
+    assert!(message.contains("validation manager reported a non-runnable profile"));
+    assert!(message.contains("profile=escalated_"));
+    assert!(message.contains("lane=rust_pr_fast"));
+    assert!(message.contains("slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"));
 }
 
 #[test]

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -89,6 +89,7 @@ build_owner_bins() {
       --bin adl-pr-inventory --bin adl-pr-closing-linkage \
       --bin adl-issue \
       --bin adl-pr-closeout \
+      --bin adl-session --bin adl-process \
       --bin adl-prompt-template --bin adl-validate-structured-prompt
   if [[ "$PRINT_PLAN" == "1" ]]; then
     return 0

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -416,6 +416,10 @@ family_token_for_path() {
       printf 'pr_control_plane'
       return 0
       ;;
+    adl/src/bin/adl_process.rs|adl/src/bin/adl_session.rs)
+      printf 'cli'
+      return 0
+      ;;
     adl/src/lib.rs)
       return 1
       ;;
@@ -471,6 +475,7 @@ import sys
 
 TOKEN_MAP = {
     "cli_dispatch": 'test(/^cli::tests::top_level_dispatch_routes_/)',
+    "cli": 'test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)',
     "cli_smoke_basics": 'binary_id(adl::cli_smoke) and test(/^basics::/)',
     "process_status": 'binary_id(adl::cli_smoke) and test(/^process_status::/)',
     "scheduler_cli": 'test(/^cli::scheduler_cmd::tests::/) or test(/^cli::tests::runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch$/) or test(/^cli::tests::open_usage::usage_mentions_v0_4_and_legacy_examples$/)',

--- a/adl/tools/test_owner_validation_lane.sh
+++ b/adl/tools/test_owner_validation_lane.sh
@@ -8,6 +8,7 @@ plan_output="$(bash "$RUNNER" all --build --print-plan)"
 for expected in \
   "cargo build owner binaries" \
   "--bin adl-pr-inventory" \
+  "--bin adl-session --bin adl-process" \
   "C-SDLC wrapper migration contract" \
   "C-SDLC run ambiguity policy" \
   "C-SDLC control-plane observability contract" \

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -142,7 +142,24 @@ printf 'M\tadl/src/cli/mod.rs\n' >"$cli_family"
 cli_family_output="$(bash "$SCRIPT" --changed-files "$cli_family" --print-plan)"
 assert_has "$cli_family_output" "mode=focused"
 assert_has "$cli_family_output" "filter_tokens=cli"
-assert_has "$cli_family_output" "filter_expression=test(cli)"
+assert_has "$cli_family_output" "filter_expression=test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)"
+
+owner_binary_decomposition="$TMP/owner_binary_decomposition.txt"
+cat >"$owner_binary_decomposition" <<'EOF'
+M	adl/Cargo.toml
+M	adl/src/bin/adl_process.rs
+M	adl/src/bin/adl_session.rs
+M	adl/src/cli/agent_cmd.rs
+M	adl/src/cli/pr_cmd/github/tests/helpers.rs
+M	adl/src/cli/process_cmd.rs
+M	adl/src/cli/session_cmd.rs
+M	adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+EOF
+owner_binary_decomposition_output="$(bash "$SCRIPT" --changed-files "$owner_binary_decomposition" --print-plan)"
+assert_has "$owner_binary_decomposition_output" "mode=family"
+assert_has "$owner_binary_decomposition_output" "reason=bounded_rust_surface_runs_family_nextest"
+assert_has "$owner_binary_decomposition_output" "filter_tokens=pr_control_plane,cli"
+assert_has "$owner_binary_decomposition_output" "filter_expression=test(/^cli::pr_cmd::/) or test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)"
 
 scheduler_cli_wave="$TMP/scheduler_cli_wave.txt"
 cat >"$scheduler_cli_wave" <<'EOF'
@@ -298,7 +315,7 @@ mixed_family_output="$(bash "$SCRIPT" --changed-files "$mixed_family" --print-pl
 assert_has "$mixed_family_output" "mode=family"
 assert_has "$mixed_family_output" "reason=bounded_family_surface_runs_family_nextest"
 assert_has "$mixed_family_output" "filter_tokens=runtime_v2,cli"
-assert_has "$mixed_family_output" "filter_expression=test(runtime_v2) or test(cli)"
+assert_has "$mixed_family_output" "filter_expression=test(runtime_v2) or test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)"
 
 manifest_plus_finish="$TMP/manifest_plus_finish.txt"
 cat >"$manifest_plus_finish" <<'EOF'

--- a/docs/milestones/v0.91.7/review/build_throughput/ADL_OWNER_BINARY_DECOMPOSITION_4726.md
+++ b/docs/milestones/v0.91.7/review/build_throughput/ADL_OWNER_BINARY_DECOMPOSITION_4726.md
@@ -1,0 +1,101 @@
+# ADL Owner-Binary Decomposition Slice (#4726)
+
+Issue: #4726
+Milestone: v0.91.7
+WP: WP-06
+
+## Summary
+
+This slice decomposes two workflow-control surfaces out of the monolithic
+`adl` command path:
+
+- `adl-session` owns session-ledger status, claim, heartbeat, and release.
+- `adl-process` owns permission-safe process status checks.
+
+The compatibility commands remain available:
+
+- `adl session ...`
+- `adl process ...`
+
+The preferred normal workflow path is now the owner binary when the built
+binary exists in the repo binary directory.
+
+## Current Owner-Binary Inventory
+
+Existing PR lifecycle owner binaries:
+
+- `adl-pr-create`
+- `adl-pr-init`
+- `adl-pr-repair-issue-body`
+- `adl-pr-run`
+- `adl-pr-doctor`
+- `adl-pr-ready`
+- `adl-pr-preflight`
+- `adl-pr-finish`
+- `adl-pr-validation`
+- `adl-pr-inventory`
+- `adl-pr-shepherd`
+- `adl-pr-closing-linkage`
+- `adl-pr-closeout`
+- `adl-issue`
+
+Existing broader owner binaries:
+
+- `adl-csdlc`
+- `adl-runtime`
+- `adl-review`
+- `adl-validate-structured-prompt`
+- `adl-lint-prompt-spec`
+- `adl-prompt-template`
+- `adl-remote`
+- `adl-aws-remote-validation`
+- `adl-provider-adapter`
+
+New in #4726:
+
+- `adl-session`
+- `adl-process`
+
+## Remaining Monolithic Surfaces
+
+The compatibility `adl` binary remains the catch-all orchestration surface for
+runtime workflow shortcuts and less frequently used top-level commands. Those
+paths are intentionally not removed in this issue.
+
+Known remaining top-level compatibility surfaces include:
+
+| Surface | Current owner status | Reason left in monolith for this slice |
+| --- | --- | --- |
+| `adl artifact` | compatibility-only | Not on the hot issue lifecycle path. |
+| `adl agent` | compatibility-only | Runtime/long-lived-agent ownership needs a separate runtime issue. |
+| `adl csm` | compatibility-only | Product/runtime surface, not WP-06 build control-plane hot path. |
+| `adl demo` | compatibility-only | Demo surfaces should be split by demo-family issues. |
+| `adl godel` | compatibility-only | Model/runtime planning surface, not this control-plane slice. |
+| `adl identity` | compatibility-only | Runtime identity surface, separate owner boundary. |
+| `adl provider` | compatibility-only | Provider setup remains available through `adl-runtime provider setup`; deeper provider split belongs to provider work. |
+| `adl scheduler` | compatibility-only | Runtime scheduler surface, separate runtime/scheduler owner issue. |
+| `adl tooling` | partially owned | Prompt validators and template tools already have owner binaries; remaining tooling subcommands need follow-on grouping. |
+| `adl keygen`, `adl sign`, `adl verify`, `adl instrument`, `adl learn`, `adl resume` | compatibility-only | Runtime document/tooling surfaces, not required for this WP-06 hot-path slice. |
+
+## Proof Boundary
+
+This issue proves a real owner-binary extraction for session-ledger and
+process-status commands. It does not claim the monolithic `adl` binary is
+retired.
+
+Focused proof should cover:
+
+- `cargo test --manifest-path adl/Cargo.toml --bin adl-session --bin adl-process`
+- `cargo check --manifest-path adl/Cargo.toml --bin adl-session --bin adl-process`
+- direct owner-binary invocation after build:
+  - `adl/target/debug/adl-session --help`
+  - `adl/target/debug/adl-process --help`
+- compatibility invocation remains available:
+  - `adl/target/debug/adl session --help`
+  - `adl/target/debug/adl process --help`
+
+## Operational Notes
+
+Normal agents should prefer the owner binaries when the repo binary directory
+contains them. The monolithic `adl` command remains an intentional compatibility
+surface while the remaining top-level commands are split by owner boundary.

--- a/docs/tooling/PERMISSION_SAFE_PROCESS_STATUS.md
+++ b/docs/tooling/PERMISSION_SAFE_PROCESS_STATUS.md
@@ -10,7 +10,17 @@ ADL agents need a safe way to answer narrow questions such as "is the server
 PID I started still alive?" or "is this local port bound?" without asking macOS
 for broad process-inspection permissions or dumping host process tables.
 
-The first supported surface is:
+The preferred owner-binary surface is:
+
+```sh
+adl-process status --pid-file .adl/runs/demo/server.pid --json
+adl-process status --pid 12345 --json
+adl-process status --port 8787 --json
+adl-process status --name adl-demo-server --json
+```
+
+The compatibility `adl` surface remains available during the binary
+decomposition migration:
 
 ```sh
 adl process status --pid-file .adl/runs/demo/server.pid --json

--- a/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
+++ b/docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md
@@ -123,7 +123,17 @@ worktrees. Future guilds may use the same claim model for research threads,
 publication drafts, model evaluations, memory-palace rooms, governance
 proposals, compute budgets, local machines, or Observatory surfaces.
 
-The first implemented ledger surface is:
+The preferred owner-binary ledger surface is:
+
+```bash
+adl-session status [--ledger <path>] [--json]
+adl-session claim --session-id <id> --owner <name> --resource <kind:id> --purpose <text> [--issue <n>] [--pr <n>] [--branch <name>] [--worktree <path>] [--policy-ref <path>] [--lifecycle-phase <phase>] [--mode active|watching|paused] [--ttl-secs <n>] [--do-not-touch <path>]... [--blocker <text>]... [--ledger <path>] [--json]
+adl-session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json]
+adl-session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]
+```
+
+The compatibility `adl` surface remains available during the owner-binary
+migration:
 
 ```bash
 adl session status [--ledger <path>] [--json]
@@ -132,11 +142,11 @@ adl session heartbeat --claim-id <id> [--ttl-secs <n>] [--ledger <path>] [--json
 adl session release --claim-id <id> [--reason <text>] [--ledger <path>] [--json]
 ```
 
-When `adl` is not installed globally, run the same subcommands through the
-repo-local binary, for example `./adl/target/debug/adl session claim ...` from
-the primary checkout. Workflow diagnostics should prefer that repo-local form
-so a fresh session does not need shell-profile setup before it can repair a
-session claim.
+When `adl-session` is not installed globally, run the same subcommands through
+the repo-local owner binary, for example
+`./adl/target/debug/adl-session claim ...` from the primary checkout. Workflow
+diagnostics should prefer that repo-local owner-binary form so a fresh session
+does not need shell-profile setup before it can repair a session claim.
 
 Default local ledger path:
 


### PR DESCRIPTION
Closes #4726

## Summary
Implemented the bounded #4726 owner-binary decomposition slice for session-ledger and permission-safe process-status commands. The branch adds `adl-session` and `adl-process` binaries, preserves the existing compatibility `adl session ...` and `adl process ...` surfaces, updates help text, includes the new binaries in the owner-validation build lane, updates operator docs to prefer the owner binaries, and records the remaining monolithic surfaces for later decomposition. The validation-manager-required broad lane initially exposed existing test-policy/race issues outside the owner-binary code path; this branch repairs the narrow blockers that prevented truthful broad proof and records the cache-corruption boundary.

## Artifacts
- `adl/src/bin/adl_session.rs`: new `adl-session` owner binary entrypoint and focused entrypoint tests.
- `adl/src/bin/adl_process.rs`: new `adl-process` owner binary entrypoint and focused entrypoint tests.
- `adl/Cargo.toml`: registered the new owner binaries.
- `adl/src/cli/agent_cmd.rs`: isolated long-lived agent command test fixtures so duplicated owner-binary test runs do not share one static agent instance id.
- `adl/src/cli/pr_cmd/github/tests/helpers.rs`: made post-merge closeout watcher log assertions wait for the asynchronous helper to write its success log.
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`: updated validation-manager profile tests to assert explicit slow-lane escalation for slow PR command surfaces instead of stale runnable-lane expectations.
- `adl/src/cli/session_cmd.rs`: help text now prefers `adl-session` and preserves compatibility `adl session` usage.
- `adl/src/cli/process_cmd.rs`: help text now prefers `adl-process` and preserves compatibility `adl process` usage.
- `adl/tools/run_owner_validation_lane.sh`: owner-binary build lane now includes `adl-session` and `adl-process`.
- `adl/tools/test_owner_validation_lane.sh`: lane self-test now asserts the new binaries are in the printed build plan.
- `docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md`: operator guidance now prefers `adl-session` while documenting compatibility.
- `docs/tooling/PERMISSION_SAFE_PROCESS_STATUS.md`: operator guidance now prefers `adl-process` while documenting compatibility.
- `docs/milestones/v0.91.7/review/build_throughput/ADL_OWNER_BINARY_DECOMPOSITION_4726.md`: decomposition inventory, remaining monolithic surfaces, and proof boundary.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Applied standard Rust formatting to the touched Rust surfaces.
  - `cargo check --manifest-path adl/Cargo.toml --bin adl-session --bin adl-process`
    Proved the new owner-binary targets typecheck.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-session --bin adl-process`
    Proved focused entrypoint behavior and reused command tests for both new binaries.
  - `cargo build --manifest-path adl/Cargo.toml --bin adl-session --bin adl-process`
    Produced runnable binaries for direct smoke checks.
  - `adl/target/debug/adl-session --help`
    Proved direct session owner-binary CLI dispatch.
  - `adl/target/debug/adl-process --help`
    Proved direct process owner-binary CLI dispatch.
  - `cargo build --manifest-path adl/Cargo.toml --bin adl`
    Produced the compatibility monolithic binary for compatibility smokes.
  - `adl/target/debug/adl session --help`
    Proved the monolithic compatibility session dispatch still works.
  - `adl/target/debug/adl process --help`
    Proved the monolithic compatibility process dispatch still works.
  - `git diff --check`
    Proved whitespace hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh all --build --print-plan`
    Proved the owner-validation lane plans to build the new owner binaries.
  - `bash adl/tools/test_owner_validation_lane.sh`
    Proved the owner-validation lane self-test, wrapper migration contract, prompt-template integration checks, and control-plane observability contract still pass.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-shepherd helper_attach_commands_cover_disabled_success_failure_and_fallback_paths -- --nocapture`
    Proved the async closeout watcher helper log assertion is race-tolerant.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_escalates -- --nocapture`
    Proved the validation-manager tests now expect explicit slow-lane escalation for slow PR command surfaces.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-ready agent_commands_execute_success_paths -- --nocapture`
    Proved duplicated owner-binary test execution does not collide on a static agent instance id.
  - `ADL_RUST_WARM_CACHE=0 ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT=<external-temp>/adl-wp-4726-pr-fast-test-warm-cache-disabled-rerun3.json bash adl/tools/run_pr_fast_test_lane.sh --changed-files <external-temp>/adl-wp-4726-changed-files.txt`
    Proved the validation-manager-required broad lane: 19,196 tests passed, 18 skipped. Warm cache was disabled because corrupted zero-length artifacts in the trusted-source candidate made cache reuse non-proving.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4726__v0-91-7-wp-06-tools-binaries-decompose-monolithic-adl-binary-into-command-owned-tools/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4726__v0-91-7-wp-06-tools-binaries-decompose-monolithic-adl-binary-into-command-owned-tools/sor.md
- Idempotency-Key: v0-91-7-wp-06-tools-binaries-decompose-monolithic-adl-binary-into-command-owned-tools-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-7-tasks-issue-4726-v0-91-7-wp-06-tools-binaries-decompose-monolithic-adl-binary-into-command-owned-tools-sip-md-adl-v0-91-7-tasks-issue-4726-v0-91-7-wp-06-tools-binaries-decompose-monolithic-adl-binary-into-command-owned-tools-sor-md