### PR TITLE
[v0.91.7][WP-06][remote] Consume Nessus remote validation lane

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -177,6 +177,7 @@
         "adl/tools/run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh",
         "adl/tools/run_nessus_remote_validation.sh",
+        "adl/tools/run_validation_manager_nessus_lane.sh",
         "adl/tools/select_validation_lanes.py",
         "adl/tools/test_run_pr_fast_test_lane.sh",
         "adl/tools/test_select_validation_lanes.sh",
@@ -184,6 +185,7 @@
         "adl/tools/validation_manager.sh",
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_run_nessus_remote_validation.sh",
+        "adl/tools/test_run_validation_manager_nessus_lane.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**",
         "adl/tools/run_ci_step_with_log.sh",
@@ -199,6 +201,7 @@
         "adl/tools/run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh",
         "adl/tools/run_nessus_remote_validation.sh",
+        "adl/tools/run_validation_manager_nessus_lane.sh",
         "adl/tools/select_validation_lanes.py",
         "adl/tools/test_run_pr_fast_test_lane.sh",
         "adl/tools/test_select_validation_lanes.sh",
@@ -206,6 +209,7 @@
         "adl/tools/validation_manager.sh",
         "adl/tools/test_ci_path_policy.sh",
         "adl/tools/test_run_nessus_remote_validation.sh",
+        "adl/tools/test_run_validation_manager_nessus_lane.sh",
         "adl/tools/test_validation_manager.sh",
         ".github/workflows/**",
         "adl/tools/run_ci_step_with_log.sh",
@@ -214,8 +218,8 @@
         "adl/tools/setup_required_coverage_toolchain.sh",
         "adl/tools/test_setup_required_coverage_toolchain.sh"
       ],
-      "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
-      "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh",
+      "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh",
+      "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh",
       "reason": "ci_policy_surface_requires_path_policy_contract_checks"
     },
     {

--- a/adl/tools/run_validation_manager_nessus_lane.sh
+++ b/adl/tools/run_validation_manager_nessus_lane.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANAGER="$ROOT/adl/tools/validation_manager.sh"
+
+CHANGED_FILES=""
+BASE="origin/main"
+HEAD="HEAD"
+INCLUDE_WORKING_TREE=false
+REMOTE_COMMAND=""
+REMOTE_ARTIFACT_DIR=""
+REMOTE_GIT_REF=""
+REPORT_OUT=""
+RUN=false
+JSON=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/run_validation_manager_nessus_lane.sh [--changed-files <path> | --include-working-tree] [options]
+
+Options:
+  --changed-files <path>       Changed-file list used by the validation manager.
+  --base <ref>                 Base ref when --changed-files is not supplied.
+  --head <ref>                 Head ref when --changed-files is not supplied.
+  --include-working-tree       Select lanes from the current working tree.
+  --remote-command <command>   Explicit command for Nessus. Defaults to the single selected local lane command.
+  --remote-artifact-dir <dir>  Local directory for fetched Nessus summary and log bundle.
+  --remote-git-ref <ref>       Git ref checked out by the Nessus runner.
+  --report-out <path>          Write validation-manager JSON report.
+  --run                        Execute the selected Nessus lane.
+  --json                       Print JSON instead of text.
+  -h, --help                   Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --changed-files)
+      CHANGED_FILES="${2:-}"
+      shift 2
+      ;;
+    --base)
+      BASE="${2:-}"
+      shift 2
+      ;;
+    --head)
+      HEAD="${2:-}"
+      shift 2
+      ;;
+    --include-working-tree)
+      INCLUDE_WORKING_TREE=true
+      shift
+      ;;
+    --remote-command)
+      REMOTE_COMMAND="${2:-}"
+      shift 2
+      ;;
+    --remote-artifact-dir)
+      REMOTE_ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --remote-git-ref)
+      REMOTE_GIT_REF="${2:-}"
+      shift 2
+      ;;
+    --report-out)
+      REPORT_OUT="${2:-}"
+      shift 2
+      ;;
+    --run)
+      RUN=true
+      shift
+      ;;
+    --json)
+      JSON=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "run_validation_manager_nessus_lane: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "$CHANGED_FILES" && "$INCLUDE_WORKING_TREE" == true ]]; then
+  echo "run_validation_manager_nessus_lane: use either --changed-files or --include-working-tree, not both" >&2
+  exit 2
+fi
+
+selector_args=()
+if [[ -n "$CHANGED_FILES" ]]; then
+  selector_args+=(--changed-files "$CHANGED_FILES")
+elif [[ "$INCLUDE_WORKING_TREE" == true ]]; then
+  selector_args+=(--include-working-tree)
+else
+  selector_args+=(--base "$BASE" --head "$HEAD")
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/adl-validation-manager-nessus.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if [[ -n "$REMOTE_GIT_REF" ]]; then
+  export ADL_NESSUS_REMOTE_GIT_REF="$REMOTE_GIT_REF"
+fi
+
+if [[ -z "$REMOTE_COMMAND" ]]; then
+  profile_path="$tmpdir/profile.json"
+  "$MANAGER" "${selector_args[@]}" --json >"$profile_path"
+  REMOTE_COMMAND="$(python3 - "$profile_path" <<'PY'
+import json
+import sys
+
+profile = json.load(open(sys.argv[1], encoding="utf-8"))
+run = profile.get("run", [])
+if len(run) != 1:
+    raise SystemExit(
+        f"run_validation_manager_nessus_lane: expected exactly one selected local lane, observed {len(run)}"
+    )
+command = run[0].get("command", "")
+if not command:
+    raise SystemExit("run_validation_manager_nessus_lane: selected local lane has no command")
+print(command)
+PY
+)"
+  if [[ -n "$CHANGED_FILES" ]]; then
+    REMOTE_COMMAND="$(python3 - "$REMOTE_COMMAND" "$CHANGED_FILES" <<'PY'
+import base64
+import shlex
+import sys
+from pathlib import Path
+
+command = sys.argv[1]
+changed_files = Path(sys.argv[2]).resolve()
+remote_path = ".adl/tmp/validation-manager-nessus-changed-files.txt"
+
+local_tokens = [str(changed_files), shlex.quote(str(changed_files))]
+remote_token = shlex.quote(remote_path)
+rewritten = None
+for token in local_tokens:
+    if token in command:
+        rewritten = command.replace(token, remote_token)
+        break
+if rewritten is None:
+    raise SystemExit(
+        "run_validation_manager_nessus_lane: selected command did not include the changed-files path"
+    )
+
+payload = base64.b64encode(changed_files.read_bytes()).decode("ascii")
+print(
+    "mkdir -p .adl/tmp && "
+    f"printf %s {shlex.quote(payload)} | base64 -d > {remote_token} && "
+    f"{rewritten}"
+)
+PY
+)"
+  fi
+fi
+
+manager_args=("${selector_args[@]}" --remote-runner nessus --remote-command "$REMOTE_COMMAND")
+if [[ -n "$REMOTE_ARTIFACT_DIR" ]]; then
+  manager_args+=(--remote-artifact-dir "$REMOTE_ARTIFACT_DIR")
+fi
+if [[ -n "$REPORT_OUT" ]]; then
+  manager_args+=(--report-out "$REPORT_OUT")
+fi
+if [[ "$RUN" == true ]]; then
+  manager_args+=(--run)
+fi
+if [[ "$JSON" == true ]]; then
+  manager_args+=(--json)
+fi
+
+exec "$MANAGER" "${manager_args[@]}"

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -129,6 +129,28 @@ families remain visible as deferred or release-owned work. For release evidence
 or a fail-closed manager result, the same slow-family entries become routing
 obligations instead of background notes.
 
+When the selected profile contains exactly one deterministic local lane and the
+operator wants to offload it to Nessus, consume the validation-manager result
+through:
+
+```bash
+bash adl/tools/run_validation_manager_nessus_lane.sh \
+  --changed-files <changed-files> \
+  --remote-artifact-dir <artifact-dir> \
+  --remote-git-ref <branch-or-ref> \
+  --report-out <report.json> \
+  --run \
+  --json
+```
+
+Do not hand-promote docs-only, tiny, escalated, multi-lane, or missing-command
+profiles to Nessus. The validation manager's `--remote-runner nessus` eligibility
+gates remain authoritative, and the resulting report must preserve the consumed
+`local_run` evidence under the `nessus_remote_validation` lane.
+For live SSH proof, pass a pushed issue branch or explicit commit ref with
+`--remote-git-ref`; `--changed-files` manifests are recreated inside the remote
+checkout before the consumed lane runs.
+
 Skills should classify the changed surface first:
 
 - `docs-only`

--- a/adl/tools/test_run_validation_manager_nessus_lane.sh
+++ b/adl/tools/test_run_validation_manager_nessus_lane.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/run_validation_manager_nessus_lane.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "expected file to exist: $path" >&2
+    exit 1
+  fi
+}
+
+origin_src="$TMP/origin-src"
+origin_bare="$TMP/origin.git"
+mkdir -p "$origin_src"
+git -C "$origin_src" init -q
+git -C "$origin_src" branch -M main
+mkdir -p "$origin_src/adl/tools"
+cat >"$origin_src/adl/tools/run_pr_fast_test_lane.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture
+EOF
+chmod +x "$origin_src/adl/tools/run_pr_fast_test_lane.sh"
+git -C "$origin_src" add adl/tools/run_pr_fast_test_lane.sh
+git -C "$origin_src" -c user.name=Codex -c user.email=codex@example.com commit -q -m "fixture"
+git clone -q --bare "$origin_src" "$origin_bare"
+
+fake_bin="$TMP/fake-bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "rustc 1.96.0 (fixture)"
+else
+  echo "rustc fixture"
+fi
+EOF
+cat >"$fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "cargo 1.96.0 (fixture)"
+else
+  echo "cargo fixture remote lane command ok"
+fi
+EOF
+cat >"$fake_bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --version)
+    echo "sccache 0.16.0"
+    ;;
+  --zero-stats)
+    exit 0
+    ;;
+  --show-stats)
+    cat <<'STATS'
+Compile requests                      7
+Compile requests executed             3
+Cache hits                            4
+Cache misses                          3
+STATS
+    ;;
+  *)
+    echo "unexpected sccache invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+cat >"$fake_bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "apt-get update fixture ok"
+EOF
+chmod +x "$fake_bin/"*
+
+sources="$TMP/sources.list"
+kubernetes="$TMP/kubernetes.list"
+cat >"$sources" <<'EOF'
+deb https://apt.releases.hashicorp.com focal main
+EOF
+cat >"$kubernetes" <<'EOF'
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+changed="$TMP/changed-files.txt"
+printf 'M\tadl/src/provider_communication.rs\n' >"$changed"
+
+ADL_NESSUS_REMOTE_EXECUTOR=local \
+ADL_NESSUS_REMOTE_ROOT="$TMP/remote-root" \
+ADL_NESSUS_REMOTE_REPO_URL="$origin_bare" \
+ADL_NESSUS_REMOTE_GIT_REF=origin/main \
+ADL_NESSUS_APT_SOURCES_LIST="$sources" \
+ADL_NESSUS_APT_KUBERNETES_LIST="$kubernetes" \
+PATH="$fake_bin:$PATH" \
+bash "$SCRIPT" \
+  --changed-files "$changed" \
+  --remote-artifact-dir "$TMP/artifacts" \
+  --remote-git-ref origin/main \
+  --run \
+  --json \
+  --report-out "$TMP/report.json" >"$TMP/out.json"
+
+assert_file "$TMP/report.json"
+assert_file "$TMP/artifacts/summary.json"
+python3 - "$TMP/report.json" "$TMP/artifacts/summary.json" "$changed" <<'PY'
+import json
+import sys
+
+profile = json.load(open(sys.argv[1], encoding="utf-8"))
+summary = json.load(open(sys.argv[2], encoding="utf-8"))
+assert profile["run_status"] == "passed"
+assert profile["remote_runner"]["requested"] == "nessus"
+assert profile["remote_runner"]["decision"] == "selected"
+assert profile["run"][0]["lane_id"] == "nessus_remote_validation"
+assert profile["run"][0]["local_run"], "remote lane should retain consumed local lane evidence"
+assert "run_pr_fast_test_lane.sh" in summary["command"]
+assert ".adl/tmp/validation-manager-nessus-changed-files.txt" in summary["command"]
+assert sys.argv[3] not in summary["command"], "remote command must not keep local temp changed-files path"
+assert summary["git_ref"] == "origin/main"
+assert summary["runner"] == "nessus"
+assert summary["status"] == "passed"
+PY
+
+docs_only="$TMP/docs-only.txt"
+printf 'M\tdocs/README.md\n' >"$docs_only"
+if bash "$SCRIPT" \
+  --changed-files "$docs_only" \
+  --remote-command "printf no-remote-docs" \
+  --run >"$TMP/docs.out" 2>"$TMP/docs.err"; then
+  echo "expected docs-only Nessus lane request to fail closed" >&2
+  exit 1
+fi
+grep -F "requested remote runner is not eligible" "$TMP/docs.err" >/dev/null
+
+echo "PASS test_run_validation_manager_nessus_lane"

--- a/docs/milestones/v0.91.7/review/build_throughput/NESSUS_VALIDATION_MANAGER_LANE_4678.md
+++ b/docs/milestones/v0.91.7/review/build_throughput/NESSUS_VALIDATION_MANAGER_LANE_4678.md
@@ -1,0 +1,116 @@
+# Nessus Validation Manager Consumption Proof for `#4678`
+
+Status: `implemented_local_contract_proven`
+Issue: `#4678`
+Date: 2026-07-04
+
+## Scope
+
+This packet records the v0.91.7 WP-06 follow-up that consumes the existing
+Nessus remote validation lane through a first-class validation-manager wrapper.
+
+This issue proves:
+
+- a repo-local command can derive the single selected local lane from
+  `adl/tools/validation_manager.sh`
+- the derived command is routed back through the validation manager with
+  `--remote-runner nessus`
+- local `--changed-files` manifests are recreated inside the remote checkout
+  before the consumed lane runs
+- operators can pin the remote checkout with `--remote-git-ref`
+- the remote report preserves the consumed `local_run` evidence under the
+  `nessus_remote_validation` lane
+- in local-executor contract mode, the fetched Nessus summary and
+  validation-manager report both record a passed run
+- docs-only remote requests still fail closed through the manager eligibility
+  gates
+
+This issue does not prove:
+
+- a fresh live SSH run on `nessus.local` for this branch
+- that Nessus is the default lane for all ADL validation
+- that provider-credentialed or network-bound validation is safe to run on
+  Nessus
+- that GitHub CI has migrated to Nessus
+
+## Implemented Surfaces
+
+- `adl/tools/run_validation_manager_nessus_lane.sh`
+- `adl/tools/test_run_validation_manager_nessus_lane.sh`
+- `adl/config/validation_lane_selector.v0.91.6.json`
+- `docs/tooling/NESSUS_VALIDATION_MANAGER_LANE.md`
+- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
+
+## Prior Evidence Consumed
+
+The underlying remote runner and validation-manager remote selection were proven
+before this issue:
+
+- `docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md`
+- `docs/milestones/v0.91.6/review/build_throughput/REMOTE_BUILD_LANES_4587.md`
+
+Those packets establish the operational Nessus runner, retained summary/log
+artifact contract, and the v0.91.6 decision to use Nessus as the immediate
+Phase 1 remote validation lane.
+
+## Local Contract Proof
+
+Focused proving command:
+
+```bash
+bash adl/tools/test_run_validation_manager_nessus_lane.sh
+```
+
+Observed result:
+
+```text
+PASS test_run_validation_manager_nessus_lane
+```
+
+The test fixture runs `run_validation_manager_nessus_lane.sh` with:
+
+- `ADL_NESSUS_REMOTE_EXECUTOR=local`
+- a changed-file set that selects the focused Rust PR-fast lane
+- no explicit `--remote-command`, forcing the wrapper to consume the manager's
+  selected local command
+- `--remote-git-ref origin/main`, proving the wrapper forwards the remote ref
+  to the underlying runner
+- `--remote-artifact-dir` and `--report-out`, proving both artifact surfaces
+
+Assertions covered:
+
+- `profile["run_status"] == "passed"`
+- `profile["remote_runner"]["requested"] == "nessus"`
+- `profile["remote_runner"]["decision"] == "selected"`
+- `profile["run"][0]["lane_id"] == "nessus_remote_validation"`
+- `profile["run"][0]["local_run"]` is retained
+- fetched `summary.json` records `runner=nessus` and `status=passed`
+- fetched `summary.json` records `.adl/tmp/validation-manager-nessus-changed-files.txt`
+  instead of the caller's local temporary changed-files path
+- fetched `summary.json` records `git_ref=origin/main`
+- docs-only changed files fail closed with
+  `requested remote runner is not eligible`
+
+## Operator Command
+
+For an eligible single-lane changed surface:
+
+```bash
+bash adl/tools/run_validation_manager_nessus_lane.sh \
+  --changed-files <changed-files.txt> \
+  --remote-artifact-dir <artifact-dir> \
+  --remote-git-ref <branch-or-ref> \
+  --report-out <validation-manager-report.json> \
+  --run \
+  --json
+```
+
+The wrapper may also accept an explicit `--remote-command`, but that path still
+uses the validation-manager remote eligibility gates.
+
+## Residual Risk
+
+This issue intentionally uses local-executor contract proof plus prior live
+Nessus evidence. A fresh SSH run against `nessus.local` can be recorded by a
+later operator proof when the machine is available and a branch-specific remote
+checkout is desired.

--- a/docs/tooling/NESSUS_VALIDATION_MANAGER_LANE.md
+++ b/docs/tooling/NESSUS_VALIDATION_MANAGER_LANE.md
@@ -1,0 +1,83 @@
+# Nessus Validation Manager Lane
+
+`adl/tools/run_validation_manager_nessus_lane.sh` is the repo-native wrapper for
+consuming the validation-manager selected local lane on the Nessus remote
+runner.
+
+Use it when the changed surface is eligible for exactly one deterministic local
+validation lane and the operator wants to offload that lane to the existing
+`nessus.local` runner without hand-copying the selected command.
+
+## Command
+
+```bash
+bash adl/tools/run_validation_manager_nessus_lane.sh \
+  --changed-files <changed-files.txt> \
+  --remote-artifact-dir <artifact-dir> \
+  --remote-git-ref <branch-or-ref> \
+  --report-out <validation-manager-report.json> \
+  --run \
+  --json
+```
+
+The wrapper first asks `adl/tools/validation_manager.sh` for the selected local
+profile. If the profile contains exactly one runnable local command, the wrapper
+passes that command back through the validation manager with:
+
+```text
+--remote-runner nessus --remote-command '<selected local command>'
+```
+
+The validation manager remains authoritative for remote eligibility. Docs-only,
+tiny, none, escalated, nondeterministic, multi-lane, or missing-command profiles
+fail closed instead of being routed to Nessus.
+
+## Inputs
+
+- `--changed-files <path>` uses a precomputed changed-file list. When the
+  wrapper derives the remote command from this mode, it recreates that manifest
+  inside the remote checkout at
+  `.adl/tmp/validation-manager-nessus-changed-files.txt` before running the
+  consumed lane.
+- `--include-working-tree` lets the validation manager derive changes from the
+  current worktree.
+- `--base <ref> --head <ref>` lets the validation manager derive changes from
+  git refs when neither of the above is provided.
+- `--remote-command <command>` bypasses command derivation but still keeps the
+  validation-manager remote eligibility gates.
+- `--remote-artifact-dir <dir>` fetches the Nessus summary and bounded log
+  bundle into a local directory.
+- `--remote-git-ref <ref>` sets `ADL_NESSUS_REMOTE_GIT_REF` for the underlying
+  Nessus runner. Use the pushed issue branch or an explicit commit ref for
+  branch-specific live proof.
+- `--report-out <path>` writes the validation-manager JSON report.
+
+## Evidence Contract
+
+When `--run` is supplied, the report should preserve both layers:
+
+- `run[0].lane_id=nessus_remote_validation`
+- `run[0].local_run` containing the consumed local lane metadata
+- `remote_runner.requested=nessus`
+- `remote_runner.decision=selected`
+- `run_status=passed` only after the remote command exits successfully
+
+The fetched Nessus `summary.json` records the command handed to the remote
+runner, the resolved git ref, elapsed time, cache roots, and retained remote log
+paths. It does not expand nested shell scripts into every child command.
+
+For live SSH proof, publish the target branch/ref before running and pass it via
+`--remote-git-ref`; otherwise the underlying Nessus runner's default ref applies.
+
+## Non-Claims
+
+This wrapper does not make Nessus the default lane for every issue. It also does
+not copy provider, GitHub, AWS, or other operator credentials to Nessus. Remote
+provider or network-bound validation remains out of scope unless a tracked issue
+declares and proves that credential boundary explicitly.
+
+## Related Evidence
+
+- `docs/milestones/v0.91.6/review/build_throughput/NESSUS_REMOTE_VALIDATION_LANE_4553.md`
+- `docs/milestones/v0.91.6/review/build_throughput/REMOTE_BUILD_LANES_4587.md`
+- `docs/milestones/v0.91.7/review/build_throughput/NESSUS_VALIDATION_MANAGER_LANE_4678.md`

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -91,6 +91,9 @@ Important repo-local tooling surfaces include:
 - `adl tooling review-runtime-surface` — deterministic validator for the `v0.87.1` runtime review package
 - `bash adl/tools/demo_v0871_operator_surface.sh` — canonical `v0.87.1` operator-surface demo for runtime bring-up and proof-surface inspection
 - `bash adl/tools/demo_v0871_review_surface.sh` — canonical `v0.87.1` reviewer walkthrough package across operator and runtime-state proof roots
+- `bash adl/tools/run_validation_manager_nessus_lane.sh` — validation-manager
+  wrapper that consumes one eligible local lane and routes it to the Nessus
+  remote runner; see [Nessus Validation Manager Lane](NESSUS_VALIDATION_MANAGER_LANE.md)
 - `adl/tools/*.sh` wrappers remain available as compatibility entrypoints over the Rust-owned commands
 - `adl/tools/report_large_rust_modules.sh` — non-blocking Rust source-and-test module size report; by default it scans both `adl/src` and `adl/tests`, and current snapshots should live under `.adl/reports/manual/` instead of tracked repo docs
 - `adl/tools/sync_task_bundle_prompts.sh` — refresh canonical local task-bundle prompt layout from compatibility paths


### PR DESCRIPTION
Closes #4678

## Summary
Implemented a repo-native wrapper that consumes the validation manager's single
eligible local lane and routes it to the existing Nessus remote validation lane.
The wrapper now recreates local changed-file manifests inside the remote checkout
before running derived commands and supports explicit `--remote-git-ref` for
branch-specific live proof.

## Artifacts
- `adl/tools/run_validation_manager_nessus_lane.sh`
- `adl/tools/test_run_validation_manager_nessus_lane.sh`
- `adl/config/validation_lane_selector.v0.91.6.json`
- `docs/tooling/NESSUS_VALIDATION_MANAGER_LANE.md`
- `docs/tooling/README.md`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `docs/milestones/v0.91.7/review/build_throughput/NESSUS_VALIDATION_MANAGER_LANE_4678.md`
- `.adl/v0.91.7/tasks/issue-4678__v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane/srp.md`
- `.adl/v0.91.7/tasks/issue-4678__v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_validation_manager_nessus_lane.sh`
    Verified the new wrapper's remote command derivation and local-executor Nessus artifact contract.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager remote-runner gates and existing contract coverage.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector behavior after adding the new wrapper/test surfaces.
  - `bash adl/tools/test_run_nessus_remote_validation.sh`
    Verified the raw Nessus runner contract remained green.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified CI runtime contracts remained green.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified aggregate CI path-policy contract remained green with the new wrapper test included.
  - `git diff --check`
    Verified whitespace cleanliness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4678__v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4678__v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane/sor.md
- Idempotency-Key: v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane-adl-tools-run-validation-manager-nessus-lane-sh-adl-tools-test-run-validation-manager-nessus-lane-sh-adl-config-validation-lane-selector-v0-91-6-json-docs-tooling-nessus-validation-manager-lane-md-docs-tooling-readme-md-adl-tools-skills-docs-ci-runtime-policy-guide-md-docs-milestones-v0-91-7-review-build-throughput-nessus-validation-manager-lane-4678-md-adl-v0-91-7-tasks-issue-4678-v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane-sip-md-adl-v0-91-7-tasks-issue-4678-v0-91-7-wp-06-remote-consume-nessus-remote-validation-lane-sor-md