### PR TITLE
[v0.91.7][tools][finish] Break draft PR ready-promotion deadlock when adl-ci is gated by pr_draft

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -585,6 +585,7 @@ mod pr_inventory_tests {
             status: status.to_string(),
             conclusion: conclusion.to_string(),
             job_run_id: job_run_id.to_string(),
+            wait_reason: "check_state".to_string(),
         }
     }
 

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -869,16 +869,32 @@ pub(super) fn validate_ready_only_finish_pr_state(
             }
         );
     }
-    match report.projection_status.as_str() {
-        "checks_green_but_draft" | "ready_to_merge_or_review" => Ok(()),
-        other => bail!(
+    if ready_only_finish_pr_state_is_promotable(report) {
+        Ok(())
+    } else {
+        let other = report.projection_status.as_str();
+        bail!(
             "finish --ready: existing PR #{} is not green enough for lightweight ready promotion (projection_status={}, disposition={}, pending={}, failed={})",
             report.pr_number,
             other,
             report.disposition,
             report.pending_checks.len(),
             report.failed_checks.len()
-        ),
+        )
+    }
+}
+
+pub(crate) fn ready_only_finish_pr_state_is_promotable(report: &PrValidationReport) -> bool {
+    match report.projection_status.as_str() {
+        "checks_green_but_draft" | "ready_to_merge_or_review" => true,
+        "checks_pending" if report.is_draft && report.failed_checks.is_empty() => {
+            !report.pending_checks.is_empty()
+                && report
+                    .pending_checks
+                    .iter()
+                    .all(|check| check.wait_reason == "pr_draft")
+        }
+        _ => false,
     }
 }
 
@@ -5309,7 +5325,7 @@ pub(super) fn run_finish_validation_rust(
                     let script = repo_root.join("adl/tools/test_validation_manager.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
-                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh" => {
+                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh" => {
                     let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");
                     run_finish_validation_status("bash", &[path_str(&ci_path_policy)?])?;
                     let ci_runtime_contracts = repo_root.join("adl/tools/test_ci_runtime_contracts.sh");
@@ -5323,6 +5339,12 @@ pub(super) fn run_finish_validation_rust(
                     let nessus_remote_runner =
                         repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
                     run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
+                    let validation_manager_nessus_lane =
+                        repo_root.join("adl/tools/test_run_validation_manager_nessus_lane.sh");
+                    run_finish_validation_status(
+                        "bash",
+                        &[path_str(&validation_manager_nessus_lane)?],
+                    )?;
                 }
                 "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh" => {
                     let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -5346,24 +5346,6 @@ pub(super) fn run_finish_validation_rust(
                         &[path_str(&validation_manager_nessus_lane)?],
                     )?;
                 }
-                "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh" => {
-                    let ci_path_policy = repo_root.join("adl/tools/test_ci_path_policy.sh");
-                    run_finish_validation_status("bash", &[path_str(&ci_path_policy)?])?;
-                    let ci_runtime_contracts = repo_root.join("adl/tools/test_ci_runtime_contracts.sh");
-                    run_finish_validation_status("bash", &[path_str(&ci_runtime_contracts)?])?;
-                    let select_validation_lanes =
-                        repo_root.join("adl/tools/test_select_validation_lanes.sh");
-                    run_finish_validation_status("bash", &[path_str(&select_validation_lanes)?])?;
-                    let validation_manager =
-                        repo_root.join("adl/tools/test_validation_manager.sh");
-                    run_finish_validation_status("bash", &[path_str(&validation_manager)?])?;
-                    let nessus_remote_runner =
-                        repo_root.join("adl/tools/test_run_nessus_remote_validation.sh");
-                    run_finish_validation_status("bash", &[path_str(&nessus_remote_runner)?])?;
-                    let validation_manager_nessus =
-                        repo_root.join("adl/tools/test_run_validation_manager_nessus_lane.sh");
-                    run_finish_validation_status("bash", &[path_str(&validation_manager_nessus)?])?;
-                }
                 "bash -n adl/tools/polis_status_for_ssm.sh && bash -n adl/tools/polis_status_for_ssm_qts.sh && python3 adl/tools/validate_polis_status_for_ssm_qts.py" => {
                     let polis_status = repo_root.join("adl/tools/polis_status_for_ssm.sh");
                     run_finish_validation_status("bash", &["-n", path_str(&polis_status)?])?;

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -152,6 +152,12 @@ pub(super) struct PrValidationCheckReport {
     pub(super) status: String,
     pub(super) conclusion: String,
     pub(super) job_run_id: String,
+    #[serde(default = "default_pr_validation_check_wait_reason")]
+    pub(super) wait_reason: String,
+}
+
+fn default_pr_validation_check_wait_reason() -> String {
+    "check_state".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -232,6 +232,10 @@ fn pr_validation_report_exposes_projection_status_for_pr_lifecycle_states() {
     );
     assert_eq!(pending_draft.disposition, "pending");
     assert_eq!(pending_draft.projection_status, "checks_pending");
+    assert_eq!(pending_draft.checks.len(), 1);
+    assert_eq!(pending_draft.checks[0].wait_reason, "pr_draft");
+    assert_eq!(pending_draft.pending_checks.len(), 1);
+    assert_eq!(pending_draft.pending_checks[0].wait_reason, "pr_draft");
 }
 
 #[test]

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -306,6 +306,7 @@ fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
             status: "COMPLETED".to_string(),
             conclusion: "FAILURE".to_string(),
             job_run_id: "1".to_string(),
+            wait_reason: "check_state".to_string(),
         }]
     } else {
         vec![]
@@ -316,6 +317,7 @@ fn validation_report(disposition: &str, is_draft: bool) -> PrValidationReport {
             status: "IN_PROGRESS".to_string(),
             conclusion: "PENDING".to_string(),
             job_run_id: "2".to_string(),
+            wait_reason: "check_state".to_string(),
         }]
     } else {
         vec![]

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -1317,10 +1317,18 @@ pub(super) fn pr_validation_report_from_snapshot_with_disposition(
     disposition: PrValidationDisposition,
 ) -> PrValidationReport {
     let effective_checks = effective_pr_validation_checks(&snapshot.checks);
+    let pending_wait_reason =
+        if snapshot.is_draft && disposition == PrValidationDisposition::Pending {
+            "pr_draft"
+        } else {
+            "check_state"
+        };
     let checks = snapshot
         .checks
         .iter()
-        .map(pr_validation_check_report)
+        .map(|check| {
+            pr_validation_check_report_with_pending_wait_reason(check, pending_wait_reason)
+        })
         .collect::<Vec<_>>();
     let failed_checks = effective_checks
         .iter()
@@ -1333,7 +1341,7 @@ pub(super) fn pr_validation_report_from_snapshot_with_disposition(
     let pending_checks = effective_checks
         .iter()
         .filter(|check| validation_check_is_pending(&check.status, &check.conclusion))
-        .map(|check| pr_validation_check_report(check))
+        .map(|check| pr_validation_check_report_with_wait_reason(check, pending_wait_reason))
         .collect::<Vec<_>>();
     PrValidationReport {
         pr_number: snapshot.pr_number,
@@ -1358,9 +1366,17 @@ pub(super) fn pr_validation_effective_report_from_snapshot_with_disposition(
     disposition: PrValidationDisposition,
 ) -> PrValidationReport {
     let effective_checks = effective_pr_validation_checks(&snapshot.checks);
+    let pending_wait_reason =
+        if snapshot.is_draft && disposition == PrValidationDisposition::Pending {
+            "pr_draft"
+        } else {
+            "check_state"
+        };
     let checks = effective_checks
         .iter()
-        .map(|check| pr_validation_check_report(check))
+        .map(|check| {
+            pr_validation_check_report_with_pending_wait_reason(check, pending_wait_reason)
+        })
         .collect::<Vec<_>>();
     let failed_checks = effective_checks
         .iter()
@@ -1373,7 +1389,7 @@ pub(super) fn pr_validation_effective_report_from_snapshot_with_disposition(
     let pending_checks = effective_checks
         .iter()
         .filter(|check| validation_check_is_pending(&check.status, &check.conclusion))
-        .map(|check| pr_validation_check_report(check))
+        .map(|check| pr_validation_check_report_with_wait_reason(check, pending_wait_reason))
         .collect::<Vec<_>>();
     PrValidationReport {
         pr_number: snapshot.pr_number,
@@ -1394,11 +1410,31 @@ pub(super) fn pr_validation_effective_report_from_snapshot_with_disposition(
 }
 
 fn pr_validation_check_report(check: &PrValidationCheckSnapshot) -> PrValidationCheckReport {
+    pr_validation_check_report_with_wait_reason(check, "check_state")
+}
+
+fn pr_validation_check_report_with_pending_wait_reason(
+    check: &PrValidationCheckSnapshot,
+    pending_wait_reason: &str,
+) -> PrValidationCheckReport {
+    let wait_reason = if validation_check_is_pending(&check.status, &check.conclusion) {
+        pending_wait_reason
+    } else {
+        "check_state"
+    };
+    pr_validation_check_report_with_wait_reason(check, wait_reason)
+}
+
+fn pr_validation_check_report_with_wait_reason(
+    check: &PrValidationCheckSnapshot,
+    wait_reason: &str,
+) -> PrValidationCheckReport {
     PrValidationCheckReport {
         name: check.name.clone(),
         status: check.status.clone(),
         conclusion: check.conclusion.clone(),
         job_run_id: check.job_run_id.clone(),
+        wait_reason: wait_reason.to_string(),
     }
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -9,12 +9,12 @@ use crate::cli::pr_cmd::finish_support::{
     load_finish_validation_profile, load_finish_validation_profile_for_execution,
     non_closing_lifecycle_line, normalize_docs_only_sor_text, normalize_sor_emitted_facts_fixture,
     open_pr_url_nonblocking, open_pr_url_nonblocking_with_timeout, push_finish_branch_with_git,
-    real_pr_finish, reject_local_issue_bundle_paths_in_finish_paths,
-    render_default_finish_validation, resolve_finish_issue_scope_and_slug,
-    restage_finish_output_truth_paths, run_finish_validation_status,
-    select_finish_validation_plan_for_finish, validate_ready_only_finish_pr_state,
-    validate_release_gate_disposition, FinishValidationMode, FinishValidationPlan,
-    FinishValidationProfile, FinishValidationProfileEscalation,
+    ready_only_finish_pr_state_is_promotable, real_pr_finish,
+    reject_local_issue_bundle_paths_in_finish_paths, render_default_finish_validation,
+    resolve_finish_issue_scope_and_slug, restage_finish_output_truth_paths,
+    run_finish_validation_status, select_finish_validation_plan_for_finish,
+    validate_ready_only_finish_pr_state, validate_release_gate_disposition, FinishValidationMode,
+    FinishValidationPlan, FinishValidationProfile, FinishValidationProfileEscalation,
     FinishValidationProfileEscalationReason, FinishValidationProfileRunItem,
     FinishValidationProfileSurfaceItem, FinishValidationSplit, FinishValidationSplitFailClosed,
     FinishValidationSplitFanoutPolicy, FinishValidationSplitFastLane,
@@ -46,6 +46,7 @@ fn ready_only_validation_report(projection_status: &str) -> PrValidationReport {
                 status: "IN_PROGRESS".to_string(),
                 conclusion: "UNKNOWN".to_string(),
                 job_run_id: "8801".to_string(),
+                wait_reason: "check_state".to_string(),
             }],
         ),
         "checks_failed" => (
@@ -56,6 +57,7 @@ fn ready_only_validation_report(projection_status: &str) -> PrValidationReport {
                 status: "COMPLETED".to_string(),
                 conclusion: "FAILURE".to_string(),
                 job_run_id: "8802".to_string(),
+                wait_reason: "check_state".to_string(),
             }],
             Vec::new(),
         ),
@@ -72,6 +74,19 @@ fn ready_only_validation_report(projection_status: &str) -> PrValidationReport {
         failed_checks,
         pending_checks,
     }
+}
+
+fn ready_only_draft_gated_pending_validation_report() -> PrValidationReport {
+    let mut report = ready_only_validation_report("checks_pending");
+    report.is_draft = true;
+    report.pending_checks = vec![PrValidationCheckReport {
+        name: "adl-ci".to_string(),
+        status: "IN_PROGRESS".to_string(),
+        conclusion: "UNKNOWN".to_string(),
+        job_run_id: "8803".to_string(),
+        wait_reason: "pr_draft".to_string(),
+    }];
+    report
 }
 
 fn ready_only_head_sha() -> &'static str {
@@ -114,6 +129,22 @@ fn ready_only_finish_accepts_green_draft_and_ready_pr_state() {
         false,
     )
     .expect("already-ready green PR should stay idempotent");
+}
+
+#[test]
+fn ready_only_finish_accepts_only_draft_gated_pending_checks_for_draft_pr() {
+    let report = ready_only_draft_gated_pending_validation_report();
+    assert!(ready_only_finish_pr_state_is_promotable(&report));
+    validate_ready_only_finish_pr_state(
+        &report,
+        "main",
+        "main",
+        ready_only_head_sha(),
+        &[4706],
+        4706,
+        false,
+    )
+    .expect("draft-gated pending checks should allow ready promotion");
 }
 
 #[test]
@@ -5044,7 +5075,7 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
     fs::create_dir_all(repo.join("adl/config")).expect("adl config dir");
     fs::write(
         repo.join("adl/config/validation_lane_selector.v0.91.6.json"),
-        r#"{"schema_version":"adl.validation_lane_selector.v1","lanes":[{"id":"validation_manager_surface","run_command":"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh"}]}"#,
+        r#"{"schema_version":"adl.validation_lane_selector.v1","lanes":[{"id":"validation_manager_surface","run_command":"bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh"}]}"#,
     )
     .expect("validation manifest");
     let profile = FinishValidationProfile {
@@ -5054,7 +5085,7 @@ fn finish_validation_profile_accepts_ready_profile_with_registered_nessus_remote
         validation_split: None,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "validation_manager_surface".to_string(),
-            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh".to_string(),
             reason: "fixture".to_string(),
             matched_paths: vec!["adl/tools/test_run_nessus_remote_validation.sh".to_string()],
             vpp_record: None,
@@ -5105,7 +5136,7 @@ residual_ci_proof_required_before_merge: required
         validation_split: None,
         run: vec![FinishValidationProfileRunItem {
             lane_id: "ci_path_policy_contracts".to_string(),
-            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh".to_string(),
+            command: "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh".to_string(),
             reason: "release gate policy contracts".to_string(),
             matched_paths: vec![".github/workflows/ci.yaml".to_string()],
             vpp_record: None,


### PR DESCRIPTION
Closes #4853

## Summary
Implemented the draft-PR ready-promotion fix for #4853. PR validation check reports now carry a `wait_reason`, the validation transport marks draft-gated pending checks as `pr_draft`, and `finish --ready` can promote a draft PR only when every pending check is explicitly draft-gated and there are no failed checks. Genuine pending, failed, stale-head, and missing-linkage states remain fail-closed.

During publication preflight, the focused finish-profile test exposed a stale validation-manager command sequence for the locked Cargo fallback slice. That support surface was aligned with the current validation-manager Nessus lane script so the ready-promotion fix can publish through the current finish validation profile without hiding an unrelated stale test fixture.

## Artifacts
- Updated `adl/src/cli/pr_cmd/github.rs` with `PrValidationCheckReport.wait_reason` and serde default compatibility.
- Updated `adl/src/cli/pr_cmd/github/transport.rs` to preserve `pr_draft` wait reason for draft-gated pending checks.
- Updated `adl/src/cli/pr_cmd/finish_support.rs` to allow ready promotion only for green states or draft-gated pending checks with no failures.
- Updated focused tests in `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs` and `adl/src/cli/pr_cmd/github/tests/validation.rs`.
- Updated helper fixture construction in `adl/src/cli/pr_cmd.rs` and `adl/src/cli/pr_cmd/github/tests/watch.rs`.
- Updated the finish validation support for the locked Cargo fallback slice so the current validation-manager Nessus lane command is recognized by `pr finish`.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting after the code change.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl ready_only_finish -- --nocapture`
    Verified the ready-promotion predicate and fail-closed behavior.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl pr_validation_report_exposes_projection_status_for_pr_lifecycle_states -- --nocapture`
    Verified validation-report preservation of `wait_reason=pr_draft`.
  - `git diff --check`
    Verified whitespace hygiene.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_classifies_locked_cargo_fallback_slice -- --nocapture`
    Verified the stale validation-profile fixture was aligned with the current validation-manager command sequence.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_runner_executes_combined_ci_policy_selector_command -- --nocapture`
    Verified the combined CI policy selector test fixture matches the current registered command sequence.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4853__v0-91-7-tools-finish-break-draft-pr-ready-promotion-deadlock-when-adl-ci-is-gated-by-pr-draft/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4853__v0-91-7-tools-finish-break-draft-pr-ready-promotion-deadlock-when-adl-ci-is-gated-by-pr-draft/sor.md
- Idempotency-Key: v0-91-7-tools-finish-break-draft-pr-ready-promotion-deadlock-when-adl-ci-is-gated-by-pr-draft-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-validation-rs-adl-src-cli-pr-cmd-github-tests-watch-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4853-v0-91-7-tools-finish-break-draft-pr-ready-promotion-deadlock-when-adl-ci-is-gated-by-pr-draft-sip-md-adl-v0-91-7-tasks-issue-4853-v0-91-7-tools-finish-break-draft-pr-ready-promotion-deadlock-when-adl-ci-is-gated-by-pr-draft-sor-md