### PR TITLE
[v0.91.7][tools][skills] Add VPP editor skill

### DIFF
--- a/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_OPERATIONAL_SKILL_INTEGRATION_4876.md
+++ b/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_OPERATIONAL_SKILL_INTEGRATION_4876.md
@@ -1,0 +1,30 @@
+# VPP Editor Operational Skill Integration (#4876)
+
+## Summary
+
+After adding the local `vpp-editor` skill, the surrounding local operational skill network was updated so VPP card drift routes to the new editor instead of falling through to manual card repair.
+
+## Updated Local Skill Surfaces
+
+- `workflow-conductor`: includes `vpp-editor` in the card-editor family and routes card-local VPP issues to it.
+- `sprint-conductor`: includes `vpp-editor` in sprint-level card-editor routing.
+- `pr-ready`: names `vpp-editor` as a bounded cleanup option for readiness blockers.
+- `pr-run`: composes with `vpp-editor` when validation-planning drift blocks execution binding.
+- `pr-finish`: composes with `vpp-editor` when validation-planning truth drift blocks finish.
+- `pr-closeout`: includes `vpp-editor` in the closeout card-editor family.
+
+## Contract Boundary
+
+The integration keeps the same boundary as the skill itself:
+
+- `VPP` remains validation-planning truth.
+- `SRP` remains review-result truth.
+- `SOR` remains execution, validation-result, integration, and closeout truth.
+- Operational skills may route to `vpp-editor`; they do not absorb VPP editing logic.
+
+## Non-Claims
+
+- This packet does not claim repository runtime code changed.
+- This packet does not claim all future VPP defects are automatically repaired.
+- This packet does not replace prompt-template/schema validation.
+- The authoritative operational skill files live in the local Codex skill root; this PR records the integration evidence.

--- a/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_SKILL_PROOF_4876.md
+++ b/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_SKILL_PROOF_4876.md
@@ -1,0 +1,53 @@
+# VPP Editor Skill Proof (#4876)
+
+## Summary
+
+Issue `#4876` adds a local Codex `vpp-editor` skill so ADL agents have a dedicated card-editor surface for Validation Planning Prompt cards.
+
+The skill lives in the operator skill root, not in this repository, so this proof packet records the reviewable contract and validation performed for the issue PR.
+
+## Local Skill Surface
+
+- Skill name: `vpp-editor`
+- Local path: operator Codex skill root, `skills/vpp-editor/SKILL.md`
+- UI metadata: `skills/vpp-editor/agents/openai.yaml`
+
+## Contract Covered
+
+The skill documents:
+
+- VPP as validation-planning truth, not validation-result truth.
+- Lifecycle placement: `SIP -> STP -> SPP -> VPP -> SRP -> SOR`.
+- PVF lane selection and validation profile repair.
+- Planned validation commands, selected lanes, parallel groups, and failure policy.
+- Explicit run/defer/block semantics so skipped or pending lanes cannot be mistaken for proof.
+- Required estimate and goal-budget fields for execution binding.
+- Prompt-template renderer guidance for `kind vpp` where supported.
+- Handoffs to `spp-editor`, `srp-editor`, and `sor-editor` when the defect is not actually VPP planning truth.
+
+## Validation
+
+Validated frontmatter with Ruby's built-in YAML parser:
+
+```sh
+ruby -e 'require "yaml"; ...'
+```
+
+Result: passed.
+
+The skill-creator `quick_validate.py` script was also attempted, but the local Python runtimes available in this session do not have `PyYAML` installed, so that specific helper could not run without modifying the tool environment. That is an environment/tooling limitation, not a skill frontmatter failure.
+
+## Non-Claims
+
+- This issue does not change ADL repository code.
+- This issue does not create or alter VPP prompt templates.
+- This issue does not claim PVF runtime behavior changes.
+- This issue does not claim any validation lane was executed beyond local skill-frontmatter validation.
+
+## Tracked Snapshot
+
+For reviewer convenience, this PR includes a snapshot copy of the local skill contract at:
+
+- `docs/milestones/v0.91.7/review/vpp_editor_skill/vpp-editor.SKILL.md`
+
+The authoritative runtime skill remains the local Codex skill root copy.

--- a/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_SKILL_PROOF_4876.md
+++ b/docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_SKILL_PROOF_4876.md
@@ -51,3 +51,9 @@ For reviewer convenience, this PR includes a snapshot copy of the local skill co
 - `docs/milestones/v0.91.7/review/vpp_editor_skill/vpp-editor.SKILL.md`
 
 The authoritative runtime skill remains the local Codex skill root copy.
+
+## Operational Skill Routing Update
+
+The surrounding local operational skills were updated after the first PR publication so VPP card defects route to `vpp-editor` consistently. See:
+
+- `docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_OPERATIONAL_SKILL_INTEGRATION_4876.md`

--- a/docs/milestones/v0.91.7/review/vpp_editor_skill/vpp-editor.SKILL.md
+++ b/docs/milestones/v0.91.7/review/vpp_editor_skill/vpp-editor.SKILL.md
@@ -1,0 +1,111 @@
+---
+name: vpp-editor
+description: Normalize and correct an ADL VPP validation-planning card so it preserves PVF lane selection, validation profile, run/defer boundaries, fail-closed semantics, estimate and goal-budget fields, and source-reference truth. Use when a `vpp.md` has stale lane assignments, missing validation budgets, generic bootstrap text, invalid deferred-lane claims, or readiness-blocking validation-planning drift.
+---
+
+# VPP Editor
+
+This skill owns bounded editing of `vpp.md` validation-planning cards.
+
+Its job is to:
+- normalize VPP structure and validation-planning truth
+- preserve the lifecycle `SIP -> STP -> SPP -> VPP -> SRP -> SOR`
+- keep VPP as pre-validation planning, not validation execution evidence
+- make PVF lane selection, proof scope, resource class, and run/defer decisions explicit
+- keep skipped, blocked, deferred, failed, and pending lanes impossible to confuse with passed validation
+- repair estimate fields that block execution binding: validation seconds, validation token budget, issue goal references, and rollup hooks
+- stop before running validation, claiming validation results, finishing the PR, or editing unrelated cards
+
+This is a helper skill, not a lifecycle orchestrator.
+
+## Prompt-Template Tooling Boundary
+
+When creating a new VPP or fully re-rendering one, prefer the active prompt-template values renderer and structure/schema validators before using Markdown as lifecycle state:
+
+```sh
+adl-csdlc tooling prompt-template validate-values --kind vpp --values <path>
+adl-csdlc tooling prompt-template edit-values --kind vpp --values <path> --set <field=value> --out <path>
+adl-csdlc tooling prompt-template render --kind vpp --values <path> --out <path>
+adl-csdlc tooling prompt-template validate-structure --kind vpp --input <path>
+```
+
+Use the repo-native owner binary when available. Rebuild tooling only when the issue explicitly permits tooling rebuilds or no repo binary exists.
+
+Use this skill for VPP truth repairs: PVF lane assignment, validation profile, selected lanes, validation commands, failure policy, run/defer rationale, parallel groups, estimates, token budgets, and source references. Do not use it to bypass locked template prose or schema validation. When a supported declared values field is the only change needed, prefer `edit-values` before rendering instead of patching rendered Markdown.
+
+## Required Inputs
+
+At minimum, gather:
+- repository root
+- `vpp_path`
+- one explicit editing mode
+
+Useful additional inputs:
+- issue number
+- source issue prompt
+- `stp.md`, `sip.md`, and `spp.md`
+- changed file list or planned touched surfaces
+- intended PVF lane or validation profile
+- required release-gate status
+- elapsed-time and token-budget estimate policy
+- validation commands that are planned, deferred, blocked, or out of scope
+
+## Quick Start
+
+1. Read the VPP and the issue/STP/SPP context supplied by the caller.
+2. Classify the planned validation surface: docs, prompt-template, tooling, Rust source, runtime, demo, release, or ambiguous.
+3. Confirm the planned PVF lane and validation profile are specific enough to execute.
+4. Normalize selected lanes, validation commands, parallel groups, failure policy, and defer/block rationale.
+5. Fill explicit validation seconds and token budgets when execution binding requires them; use truthful conservative estimates, not `0`.
+6. Remove placeholders, stale bootstrap claims, and validation-result claims.
+7. Emit a structured edit result and stop.
+
+## Allowed Edits
+
+This skill may:
+- normalize `artifact_type` to `structured_validation_planning_prompt`
+- set `card_status` to `draft`, `ready`, `approved`, `blocked`, or `superseded` according to observed validation-planning truth
+- repair `initial_pvf_lane`, `planned_pvf_lane`, `lane_registry_path`, `validation_family`, `validation_runtime_class`, `validation_resource_profile`, `validation_size_split`, and `expected_proof_cost`
+- make selected validation lanes explicit and scoped to the issue surface
+- separate small, large, slow, remote, release, coverage, and deferred lanes when the profile requires it
+- record planned validation commands without claiming they ran
+- explain deferred or blocked lanes with fail-closed language
+- fill `planned_validation_seconds`, `planned_validation_tokens`, `issue_goal_ref`, `sprint_goal_ref`, and `goal_metrics_rollup_ref`
+- align VPP source refs with the issue, STP, SIP, and SPP
+- return VPP to `draft` or `blocked` when lane selection is ambiguous or missing required budgets
+- remove stale claims that PR publication, path policy, or skipped CI equals validation proof
+
+This skill must not:
+- run broad validation unless the user explicitly asks
+- claim validation passed, failed, or was skipped after execution
+- edit `SRP` or `SOR` instead of handing off
+- weaken a release gate or convert required proof into a policy skip
+- hide a failed, pending, deferred, blocked, or unknown lane inside aggregate proof
+- use `unknown` for required estimates when the current execution gate requires explicit budgets
+- widen issue scope or alter the implementation plan in `SPP`
+
+## Handoff
+
+Typical callers are:
+- `workflow-conductor` when card-local VPP drift blocks execution binding
+- `pr-ready` or `pr-run` when validation-planning readiness is blocked
+- `pr-finish` when the VPP contradicts the validation record or release-gate disposition
+- `spp-editor` when the implementation plan itself is wrong
+- `sor-editor` after validation has actually run and outcome truth must be recorded
+
+Hand off instead of editing when:
+- source issue scope is unclear: use `stp-editor` or operator review
+- execution plan changed materially: use `spp-editor`
+- review findings need disposition: use `srp-editor`
+- actual validation results need recording: use `sor-editor`
+
+## Output
+
+Return a concise structured result including:
+- target VPP path
+- validation-planning state normalized
+- PVF lane and validation profile corrected
+- estimates or token budgets filled
+- deferred or blocked lanes made explicit
+- unresolved blockers
+- recommended next handoff


### PR DESCRIPTION
Closes #4876

## Summary
Added the local `vpp-editor` Codex skill and recorded a tracked proof packet plus skill-contract snapshot for review.

## Artifacts
- Local Codex skill: operator skill root `skills/vpp-editor/SKILL.md`
- Local Codex skill UI metadata: operator skill root `skills/vpp-editor/agents/openai.yaml`
- Tracked proof packet: `docs/milestones/v0.91.7/review/vpp_editor_skill/VPP_EDITOR_SKILL_PROOF_4876.md`
- Tracked skill snapshot: `docs/milestones/v0.91.7/review/vpp_editor_skill/vpp-editor.SKILL.md`

## Validation
- Validation commands and their purpose:
  - `ruby -e 'require "yaml"; ...'`
    Verified local skill frontmatter can be parsed and includes the expected skill name.
  - `git diff --check`
    Verified no whitespace errors in the tracked proof artifacts.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4876__v0-91-7-tools-skills-add-vpp-editor-skill/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4876__v0-91-7-tools-skills-add-vpp-editor-skill/sor.md
- Idempotency-Key: v0-91-7-tools-skills-add-vpp-editor-skill-docs-milestones-v0-91-7-review-vpp-editor-skill-adl-v0-91-7-tasks-issue-4876-v0-91-7-tools-skills-add-vpp-editor-skill-sip-md-adl-v0-91-7-tasks-issue-4876-v0-91-7-tools-skills-add-vpp-editor-skill-sor-md