### PR TITLE
[v0.91.7][tools][skills] Resolve sprint-conductor installed/tracked parity drift

### DIFF
--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -146,6 +146,13 @@ missing sprint-management issue first.
    declaration, and activity-log declaration into one readiness result.
    Review and activity-log paths are declaration surfaces here; they do not
    need to exist on disk yet to satisfy readiness.
+   Installed skill parity means the installed `sprint-conductor` bundle must
+   match the tracked bundle after generated cache artifacts such as
+   `__pycache__`, `.pyc`, `.pyo`, and `.DS_Store` are filtered out. Real
+   installed-only helper scripts are drift and should be tracked or repaired,
+   not silently accepted as local-only behavior. The repo-native repair path is
+   `bash adl/tools/install_adl_operational_skills.sh`, which refreshes the
+   installed skill bundles from tracked repo sources.
 5. If the readiness sweep reports `needs_repair`, fix the flagged issue-local
    or sprint-local defects before starting child execution.
 6. Run sprint-wide structured prompt review before issue execution begins when

--- a/adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py
@@ -6,12 +6,23 @@ import json
 from pathlib import Path
 
 
+def is_generated_artifact(rel: str) -> bool:
+    parts = rel.split('/')
+    if '__pycache__' in parts:
+        return True
+    if rel.endswith(('.pyc', '.pyo')):
+        return True
+    if rel.endswith('.DS_Store'):
+        return True
+    return False
+
+
 def collect_files(root: Path) -> set[str]:
     files: set[str] = set()
     for path in root.rglob('*'):
         if path.is_file():
             rel = path.relative_to(root).as_posix()
-            if rel.endswith('.DS_Store'):
+            if is_generated_artifact(rel):
                 continue
             files.add(rel)
     return files
@@ -34,6 +45,7 @@ def main() -> int:
     left_only: list[str] = []
     right_only: list[str] = []
     diff_files: list[str] = []
+    ignored_generated_files: list[str] = []
     status = 'matched'
 
     if not tracked.is_dir():
@@ -44,6 +56,12 @@ def main() -> int:
         notes.append(f'installed skill dir missing: {installed}')
 
     if status != 'blocked':
+        ignored_generated_files = sorted(
+            rel
+            for root in (tracked, installed)
+            for rel in (path.relative_to(root).as_posix() for path in root.rglob('*') if path.is_file())
+            if is_generated_artifact(rel)
+        )
         tracked_files = collect_files(tracked)
         installed_files = collect_files(installed)
         left_only = sorted(tracked_files - installed_files)
@@ -53,9 +71,12 @@ def main() -> int:
                 diff_files.append(rel)
         if left_only or right_only or diff_files:
             status = 'drift_detected'
-            notes.append('installed sprint-conductor differs from tracked bundle')
+            notes.append('installed sprint-conductor differs from tracked bundle after generated-file filtering')
+            notes.append('repair by running: bash adl/tools/install_adl_operational_skills.sh')
         else:
-            notes.append('installed sprint-conductor matches tracked bundle')
+            notes.append('installed sprint-conductor matches tracked bundle after generated-file filtering')
+        if ignored_generated_files:
+            notes.append('ignored generated parity artifacts such as __pycache__, .pyc, .pyo, and .DS_Store')
 
     result = {
         'status': status,
@@ -64,6 +85,9 @@ def main() -> int:
         'left_only': left_only,
         'right_only': right_only,
         'diff_files': diff_files,
+        'ignored_generated_files': ignored_generated_files,
+        'parity_policy': 'installed bundle must match tracked bundle except generated cache artifacts',
+        'repair_command': 'bash adl/tools/install_adl_operational_skills.sh',
         'notes': notes,
     }
 

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1174,14 +1174,44 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_installed_
   --installed-skill-dir "${installed_skill_dir}" \
   --state "${state_path}" >/dev/null
 
+mkdir -p "${installed_skill_dir}/__pycache__" "${installed_skill_dir}/scripts/__pycache__"
+printf 'cache\n' > "${installed_skill_dir}/__pycache__/SKILL.cpython-312.pyc"
+printf 'cache\n' > "${installed_skill_dir}/scripts/__pycache__/helper.cpython-312.pyc"
+printf 'cache\n' > "${installed_skill_dir}/scripts/__pycache__/helper.pyo"
+printf 'cache\n' > "${installed_skill_dir}/.DS_Store"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py" \
+  --repo-root "${fake_repo}" \
+  --tracked-skill-dir "${tracked_skill_dir}" \
+  --installed-skill-dir "${installed_skill_dir}" \
+  --state "${state_path}" >/dev/null
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+parity = state["installed_skill_parity"]
+assert parity["status"] == "matched"
+assert parity["right_only"] == []
+assert parity["diff_files"] == []
+assert parity["ignored_generated_files"]
+assert parity["parity_policy"] == "installed bundle must match tracked bundle except generated cache artifacts"
+assert parity["repair_command"] == "bash adl/tools/install_adl_operational_skills.sh"
+assert any(path.endswith(".pyo") for path in parity["ignored_generated_files"])
+assert any(path.endswith(".DS_Store") for path in parity["ignored_generated_files"])
+PY
+
 printf 'beta\n' > "${installed_skill_dir}/SKILL.md"
+parity_failure_json="${tmpdir}/parity-failure.json"
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py" \
   --repo-root "${fake_repo}" \
   --tracked-skill-dir "${tracked_skill_dir}" \
-  --installed-skill-dir "${installed_skill_dir}" >/dev/null 2>&1; then
+  --installed-skill-dir "${installed_skill_dir}" \
+  --print-json >"${parity_failure_json}" 2>/dev/null; then
   echo "expected installed skill parity drift to fail" >&2
   exit 1
 fi
+grep -Fq "bash adl/tools/install_adl_operational_skills.sh" "${parity_failure_json}"
 
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sor.md" <<'EOF2'
 Status: IN_PROGRESS


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4877 remains open.

## Summary
Implemented the `#4877` sprint-conductor parity fix. The installed `sprint-conductor` bundle now compares against the tracked bundle after generated cache artifacts are filtered, while real installed-only helper scripts remain drift. The parity result now includes a repo-native repair command so operators know how to restore parity without manual skill-root surgery.

## Artifacts
- `adl/tools/skills/sprint-conductor/scripts/check_installed_skill_parity.py`
- `adl/tools/test_sprint_conductor_helpers.sh`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `.adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/srp.md`
- `.adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh && bash adl/tools/test_install_adl_operational_skills.sh`
    Verified the focused sprint-conductor helper contract and installed operational skill bundle behavior.
- Results:
  - PASS

Validation command/path rules:
- Recorded commands use repository-relative paths.
- No broad Rust validation was run because the touched surface is Python/shell/Markdown sprint-conductor tooling and the VPP selected the focused sprint-conductor contract lane.
- `absolute_path_leakage_detected: false`.

## Notes
Closes #4877\n\n## Summary\n\n- Filters generated skill-cache artifacts out of sprint-conductor installed/tracked parity checks.\n- Keeps real installed-only helper scripts as drift.\n- Emits and documents the repo-native repair command: bash adl/tools/install_adl_operational_skills.sh.\n- Adds focused regression proof for generated-file filtering and repair-command reporting.\n\n## Validation\n\n- bash adl/tools/test_sprint_conductor_helpers.sh && bash adl/tools/test_install_adl_operational_skills.sh\n- bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/srp.md\n- bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/sor.md\n\n## Review\n\nPre-PR subagent review found two issues; both were fixed and re-review reported no blocker.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4877__v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift/sor.md
- Idempotency-Key: v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sprint-conductor-scripts-check-installed-skill-parity-py-adl-tools-test-sprint-conductor-helpers-sh-adl-v0-91-7-tasks-issue-4877-v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift-sip-md-adl-v0-91-7-tasks-issue-4877-v0-91-7-tools-skills-resolve-sprint-conductor-installed-tracked-parity-drift-sor-md