### PR TITLE
[v0.91.7][tools][validation] Align scheduler finish profile with validation manager

### DIFF
--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4200,6 +4200,32 @@ fn finish_validation_profile_fails_closed_for_mixed_surface_with_unmapped_gap() 
 }
 
 #[test]
+fn finish_validation_profile_accepts_scheduler_provider_policy_slice() {
+    let plan = select_finish_validation_plan_for_finish(
+        4849,
+        ".",
+        &[
+            "adl/src/provider/profiles.rs".to_string(),
+            "adl/src/scheduler.rs".to_string(),
+            "adl/tests/fixtures/scheduler/cheapest_validated_outcome_inputs_v1.json".to_string(),
+            "docs/milestones/v0.91.7/review/provider/CHEAPEST_VALIDATED_OUTCOME_POLICY_4674.md".to_string(),
+            "docs/milestones/v0.91.7/review/provider/artifacts/cheapest_validated_outcome_plan_4674.json".to_string(),
+        ],
+    )
+    .expect("scheduler/provider policy slice should be finish-runnable");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.iter().any(|command| {
+        command.contains("bash adl/tools/run_pr_fast_test_lane.sh")
+            && command.contains("--changed-files")
+    }));
+    assert!(!plan.commands.iter().any(|command| {
+        command.contains("cargo nextest run")
+            || command.contains("cargo test --manifest-path adl/Cargo.toml --bin adl ")
+    }));
+}
+
+#[test]
 fn finish_validation_profile_escalates_workflow_metrics_backfill_slice() {
     let err = select_finish_validation_plan_for_finish(
         4441,

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -251,6 +251,10 @@ filter_token_for_path() {
       basename "$path" .rs
       return 0
       ;;
+    adl/src/scheduler.rs|adl/src/provider/profiles.rs)
+      printf 'scheduler_economics'
+      return 0
+      ;;
     adl/src/cli/mod.rs)
       if [ "$saw_scheduler_related_surface" = true ]; then
         printf 'scheduler_cli'
@@ -487,6 +491,7 @@ TOKEN_MAP = {
     "cli_smoke_basics": 'binary_id(adl::cli_smoke) and test(/^basics::/)',
     "process_status": 'binary_id(adl::cli_smoke) and test(/^process_status::/)',
     "scheduler_cli": 'test(/^cli::scheduler_cmd::tests::/) or test(/^cli::tests::runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch$/) or test(/^cli::tests::open_usage::usage_mentions_v0_4_and_legacy_examples$/)',
+    "scheduler_economics": 'test(/^scheduler::tests::/) or test(/^provider::tests::provider_mod_/) or binary_id(adl::provider_tests) and test(/^profiles::/)',
     "demo_adl_gws_context_mirror": 'binary_id(adl::bin/demo-adl-gws-context-mirror) and test(/^tests::/)',
     "demo_adl_gws_native_drive_sync": 'binary_id(adl::bin/demo-adl-gws-native-drive-sync) and test(/^tests::/)',
     "run_v0916_integrated_runtime_soak": 'binary_id(adl::bin/run_v0916_integrated_runtime_soak) and test(/^tests::/)',

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -592,4 +592,33 @@ assert "test_v0916_unity_observatory_local_runtime_consumption.sh" in lane["comm
 assert "test_v0916_unity_observatory_local_runtime_consumption_unit.sh" in lane["command"]
 PY
 
+scheduler_provider_policy="$TMP/scheduler-provider-policy.txt"
+cat >"$scheduler_provider_policy" <<'EOF'
+M	adl/src/provider/profiles.rs
+M	adl/src/scheduler.rs
+M	adl/tests/fixtures/scheduler/cheapest_validated_outcome_inputs_v1.json
+M	docs/milestones/v0.91.7/review/provider/CHEAPEST_VALIDATED_OUTCOME_POLICY_4674.md
+M	docs/milestones/v0.91.7/review/provider/artifacts/cheapest_validated_outcome_plan_4674.json
+EOF
+bash "$SCRIPT" --changed-files "$scheduler_provider_policy" --json >"$TMP/scheduler-provider-policy.json"
+python3 - <<'PY' "$TMP/scheduler-provider-policy.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert "rust_pr_fast" in profile["lanes"]
+lane = profile["lanes"]["rust_pr_fast"]
+assert lane["status"] == "selected"
+assert lane["mode"] == "focused"
+assert lane["filter_tokens"] == "scheduler_economics"
+assert "scheduler::tests::" in lane["filter_expression"]
+assert "provider::tests::provider_mod_" in lane["filter_expression"]
+assert "binary_id(adl::provider_tests) and test(/^profiles::/)" in lane["filter_expression"]
+assert "adl/src/provider/profiles.rs" in lane["matched_paths"]
+assert "adl/src/scheduler.rs" in lane["matched_paths"]
+PY
+
 echo "PASS test_select_validation_lanes"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -750,4 +750,37 @@ if bash "$SCRIPT" \
 fi
 assert_has "$TMP/remote-docs-run.err" "requested remote runner is not eligible"
 
+scheduler_provider_policy="$TMP/scheduler-provider-policy.txt"
+cat >"$scheduler_provider_policy" <<'EOF'
+M	adl/src/provider/profiles.rs
+M	adl/src/scheduler.rs
+M	adl/tests/fixtures/scheduler/cheapest_validated_outcome_inputs_v1.json
+M	docs/milestones/v0.91.7/review/provider/CHEAPEST_VALIDATED_OUTCOME_POLICY_4674.md
+M	docs/milestones/v0.91.7/review/provider/artifacts/cheapest_validated_outcome_plan_4674.json
+EOF
+bash "$SCRIPT" --changed-files "$scheduler_provider_policy" --json >"$TMP/scheduler-provider-policy.json"
+python3 - <<'PY' "$TMP/scheduler-provider-policy.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert profile["selected_profile"] == "selected_2_lane_profile"
+assert profile["pr_publication_sufficient"] is True
+assert profile["escalation"]["required"] is False
+assert profile["validation_split"]["fast_lane"]["selected_lanes"] == ["docs_diff_check", "rust_pr_fast"]
+assert profile["validation_split"]["fast_lane"]["runnable"] is True
+assert profile["validation_split"]["fail_closed"]["required"] is False
+assert [item["lane_id"] for item in profile["run"]] == ["docs_diff_check", "rust_pr_fast"]
+assert "run_pr_fast_test_lane.sh" in profile["run"][1]["command"]
+surfaces = {surface["id"]: surface for surface in profile["behavior_surfaces"]}
+surface = surfaces["rust_focused_behavior"]
+assert surface["id"] == "rust_focused_behavior"
+assert "scheduler_economics" in surface["requirement_ids"]
+assert "adl/src/provider/profiles.rs" in surface["matched_paths"]
+assert "adl/src/scheduler.rs" in surface["matched_paths"]
+assert profile["diagnostics"] == []
+PY
+
 echo "PASS test_validation_manager"


### PR DESCRIPTION
Non-closing lifecycle PR: issue #4854 remains open.

## Summary
Aligned the scheduler/provider focused validation slice so validation-manager and `pr finish` treat bounded scheduler/provider-policy changes as a publishable focused profile instead of escalating to broad nextest. Local implementation and focused proof are complete; PR publication and post-merge closeout are still pending.

## Artifacts
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/test_select_validation_lanes.sh`
- `adl/tools/test_validation_manager.sh`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `.adl/v0.91.7/tasks/issue-4854__v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector contract coverage, including the scheduler/provider-policy path set.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager contract coverage, including the scheduler/provider-policy path set.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_accepts_scheduler_provider_policy_slice -- --nocapture`
    Verified finish-plan alignment for scheduler/provider-policy slices.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <issue-4854-paths> --print-plan --json`
    Verified focused `scheduler_economics` lane selection for the path set.
- Results:
  - PASS

Validation command/path rules:
- Repository-relative paths are used in recorded commands and artifact references.
- Broad nextest, broad cargo test, remote Nessus lanes, full coverage, and release gates were not run and are not claimed.
- `absolute_path_leakage_detected: false`.

## Notes
Closes #4854

## Summary

- Adds focused scheduler/provider validation token `scheduler_economics`.
- Aligns validation-manager and PR finish behavior for bounded scheduler/provider policy slices.
- Proves the exact scheduler/provider path set selects focused validation without broad nextest fallback.

## Validation

- `bash adl/tools/test_select_validation_lanes.sh`
- `bash adl/tools/test_validation_manager.sh`
- `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_accepts_scheduler_provider_policy_slice -- --nocapture`
- `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <issue-4854-paths> --print-plan --json`
- `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <issue-4854-paths>`

## Review

Pre-PR subagent review found SOR truth issues only; SRP/SOR were tightened to focused validation truth before publication.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4854__v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4854__v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager/sor.md
- Idempotency-Key: v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-select-validation-lanes-sh-adl-tools-test-validation-manager-sh-adl-v0-91-7-tasks-issue-4854-v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager-sip-md-adl-v0-91-7-tasks-issue-4854-v0-91-7-tools-validation-align-scheduler-finish-profile-with-validation-manager-sor-md