### PR TITLE
[v0.91.7][WP-07][runtime] Add supervised daemon mode for integrated runtime

### DIFF
--- a/adl/src/cli/agent_cmd.rs
+++ b/adl/src/cli/agent_cmd.rs
@@ -2,18 +2,19 @@ use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
 use crate::cli::observability::ProgressHeartbeat;
-use ::adl::long_lived_agent::{self, InspectOptions, RunOptions, TickOptions};
+use ::adl::long_lived_agent::{self, DaemonOptions, InspectOptions, RunOptions, TickOptions};
 
 pub(crate) fn real_agent(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "agent requires a subcommand: tick | run | status | inspect | stop"
+            "agent requires a subcommand: tick | run | daemon | status | inspect | stop"
         ));
     };
 
     match subcommand {
         "tick" => real_tick(&args[1..]),
         "run" => real_run(&args[1..]),
+        "daemon" => real_daemon(&args[1..]),
         "status" => real_status(&args[1..]),
         "inspect" => real_inspect(&args[1..]),
         "stop" => real_stop(&args[1..]),
@@ -22,7 +23,7 @@ pub(crate) fn real_agent(args: &[String]) -> Result<()> {
             Ok(())
         }
         other => Err(anyhow!(
-            "unknown agent subcommand '{other}' (expected tick, run, status, inspect, stop)"
+            "unknown agent subcommand '{other}' (expected tick, run, daemon, status, inspect, stop)"
         )),
     }
 }
@@ -161,6 +162,97 @@ fn real_run(args: &[String]) -> Result<()> {
     }
 }
 
+fn real_daemon(args: &[String]) -> Result<()> {
+    let mut parsed = AgentArgs::default();
+    let mut max_restarts: u64 = 10;
+    let mut checkpoint_interval_secs: u64 = 3;
+    let mut interval_secs: Option<u64> = None;
+    let mut no_sleep = false;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--spec" => {
+                parsed.spec = Some(PathBuf::from(required_value(args, i, "--spec")?));
+                i += 1;
+            }
+            "--max-restarts" => {
+                max_restarts = parse_u64(required_value(args, i, "--max-restarts")?)?;
+                i += 1;
+            }
+            "--checkpoint-interval-secs" => {
+                checkpoint_interval_secs =
+                    parse_u64(required_value(args, i, "--checkpoint-interval-secs")?)?;
+                i += 1;
+            }
+            "--interval-secs" => {
+                interval_secs = Some(parse_positive_u64(
+                    required_value(args, i, "--interval-secs")?,
+                    "--interval-secs",
+                )?);
+                i += 1;
+            }
+            "--no-sleep" => no_sleep = true,
+            "--recover-stale-lease" => parsed.recover_stale_lease = true,
+            "--json" => parsed.json_output = true,
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for agent daemon: {other}")),
+        }
+        i += 1;
+    }
+    let spec_path = parsed.spec()?;
+    let max_restarts_label = max_restarts.to_string();
+    let checkpoint_interval_label = checkpoint_interval_secs.to_string();
+    let interval_secs_label = interval_secs
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "spec_default".to_string());
+    let no_sleep_label = if no_sleep { "true" } else { "false" }.to_string();
+    let heartbeat = ProgressHeartbeat::start(
+        "agent",
+        "agent_daemon",
+        &[
+            ("process_class", "long_lived_daemon"),
+            ("spec", &spec_path.display().to_string()),
+            ("max_restarts", &max_restarts_label),
+            ("checkpoint_interval_secs", &checkpoint_interval_label),
+            ("interval_secs", &interval_secs_label),
+            ("no_sleep", &no_sleep_label),
+        ],
+    );
+    let status = long_lived_agent::daemon(
+        &spec_path,
+        DaemonOptions {
+            max_restarts,
+            checkpoint_interval_secs,
+            interval_secs,
+            no_sleep,
+            recover_stale_lease: parsed.recover_stale_lease,
+        },
+    );
+    match status {
+        Ok(status) => {
+            heartbeat.completed(&[
+                ("daemon_state", status.state.as_str()),
+                ("restart_count", &status.restart_count.to_string()),
+            ]);
+            print_daemon_status(&status, parsed.json_output)
+        }
+        Err(err) => {
+            heartbeat.failed(&[
+                ("reason_code", "agent_daemon_failed"),
+                (
+                    "next_action_hint",
+                    "inspect_daemon_status_and_continuity_checkpoint",
+                ),
+            ]);
+            Err(err)
+        }
+    }
+}
+
 fn real_status(args: &[String]) -> Result<()> {
     let mut parsed = AgentArgs::default();
     let mut i = 0usize;
@@ -289,6 +381,40 @@ fn required_value<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'
 fn parse_u64(raw: &str) -> Result<u64> {
     raw.parse::<u64>()
         .map_err(|_| anyhow!("expected unsigned integer, got '{raw}'"))
+}
+
+fn parse_positive_u64(raw: &str, flag: &str) -> Result<u64> {
+    let value = parse_u64(raw)?;
+    if value == 0 {
+        return Err(anyhow!("{flag} must be greater than zero"));
+    }
+    Ok(value)
+}
+
+fn print_daemon_status(
+    status: &long_lived_agent::DaemonStatusRecord,
+    json_output: bool,
+) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(status)?);
+        return Ok(());
+    }
+    println!("agent: {}", status.agent_instance_id);
+    println!("daemon state: {}", status.state);
+    println!("supervisor pid: {}", status.supervisor_pid);
+    println!("restart count: {}", status.restart_count);
+    println!("max restarts: {}", status.max_restarts);
+    println!(
+        "checkpoint interval secs: {}",
+        status.checkpoint_interval_secs
+    );
+    println!("last event: {}", status.last_event);
+    println!(
+        "last child exit: {}",
+        status.last_child_exit.as_deref().unwrap_or("none")
+    );
+    println!("trace id: {}", status.trace_id);
+    Ok(())
 }
 
 fn print_status(status: &long_lived_agent::StatusRecord, json_output: bool) -> Result<()> {
@@ -547,6 +673,7 @@ memory:
         assert!(real_agent(&args(&["help"])).is_ok());
         assert!(real_agent(&args(&["tick", "--help"])).is_ok());
         assert!(real_agent(&args(&["run", "--help"])).is_ok());
+        assert!(real_agent(&args(&["daemon", "--help"])).is_ok());
         assert!(real_agent(&args(&["status", "--help"])).is_ok());
         assert!(real_agent(&args(&["inspect", "--help"])).is_ok());
         assert!(real_agent(&args(&["stop", "--help"])).is_ok());
@@ -583,6 +710,28 @@ memory:
             "expected unsigned integer",
         );
         assert_err_contains(real_agent(&args(&["run", "--bogus"])), "unknown arg");
+        assert_err_contains(real_agent(&args(&["daemon"])), "requires --spec");
+        assert_err_contains(
+            real_agent(&args(&[
+                "daemon",
+                "--spec",
+                "/tmp/example-agent.yaml",
+                "--checkpoint-interval-secs",
+                "0",
+            ])),
+            "greater than zero",
+        );
+        assert_err_contains(
+            real_agent(&args(&[
+                "daemon",
+                "--spec",
+                "/tmp/example-agent.yaml",
+                "--interval-secs",
+                "0",
+            ])),
+            "--interval-secs must be greater than zero",
+        );
+        assert_err_contains(real_agent(&args(&["daemon", "--bogus"])), "unknown arg");
         assert_err_contains(real_agent(&args(&["status", "--bogus"])), "unknown arg");
         assert_err_contains(real_agent(&args(&["inspect", "--bogus"])), "unknown arg");
         assert_err_contains(
@@ -626,6 +775,19 @@ memory:
 
         assert!(real_agent(&args(&["status", "--spec", spec])).is_ok());
         assert!(real_agent(&args(&["status", "--spec", spec, "--json"])).is_ok());
+        assert!(real_agent(&args(&[
+            "daemon",
+            "--spec",
+            spec,
+            "--max-restarts",
+            "1",
+            "--checkpoint-interval-secs",
+            "1",
+            "--no-sleep",
+            "--json",
+        ]))
+        .is_ok());
+        assert!(root.join("state/daemon_status.json").exists());
         assert!(real_agent(&args(&["inspect", "--spec", spec])).is_ok());
         assert!(real_agent(&args(&[
             "inspect",

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -4,6 +4,7 @@ pub fn usage() -> &'static str {
   adl resume <run_id> [--steer <steering.json>]
   adl agent tick --spec <agent-spec.yaml> [--recover-stale-lease] [--json]
   adl agent run --spec <agent-spec.yaml> --max-cycles <n> [--interval-secs <n>] [--no-sleep] [--recover-stale-lease] [--json]
+  adl agent daemon --spec <agent-spec.yaml> [--max-restarts <n>] [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--no-sleep] [--recover-stale-lease] [--json]
   adl agent status --spec <agent-spec.yaml> [--json]
   adl agent inspect --spec <agent-spec.yaml> [--cycle <cycle-id>] [--json]
   adl agent stop --spec <agent-spec.yaml> --reason <text> [--json]
@@ -93,6 +94,7 @@ Examples:
   adl resume hitl-pause-seq --steer artifacts/examples/steer.json
   adl agent tick --spec .adl/long_lived_agents/example-agent.yaml
   adl agent run --spec .adl/long_lived_agents/example-agent.yaml --max-cycles 3 --no-sleep
+  adl agent daemon --spec .adl/long_lived_agents/example-agent.yaml --checkpoint-interval-secs 3 --json
   adl agent status --spec .adl/long_lived_agents/example-agent.yaml --json
   adl agent inspect --spec .adl/long_lived_agents/example-agent.yaml --json
   adl agent stop --spec .adl/long_lived_agents/example-agent.yaml --reason \"operator pause\"

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -17,9 +17,12 @@ use schema::*;
 use storage::*;
 use types::LedgerCursor;
 pub use types::{
-    AgentSpec, AgentStatusState, HeartbeatSpec, InspectOptions, LeaseRecord, LoadedAgentSpec,
-    RunOptions, StatusError, StatusRecord, StopRecord, TickOptions, WorkflowSpec,
+    AgentSpec, AgentStatusState, DaemonOptions, DaemonStatusRecord, HeartbeatSpec, InspectOptions,
+    LeaseRecord, LoadedAgentSpec, RunOptions, StatusError, StatusRecord, StopRecord, TickOptions,
+    WorkflowSpec,
 };
+
+const DAEMON_DEFAULT_INTERVAL_SECS: u64 = 3;
 
 pub fn load_spec(spec_path: &Path) -> Result<LoadedAgentSpec> {
     let raw = fs::read_to_string(spec_path)
@@ -115,6 +118,277 @@ pub fn run(spec_path: &Path, options: RunOptions) -> Result<StatusRecord> {
         loaded,
         sleep_secs,
     ))
+}
+
+pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRecord> {
+    if options.checkpoint_interval_secs == 0 {
+        return Err(anyhow!(
+            "agent daemon requires --checkpoint-interval-secs greater than zero"
+        ));
+    }
+    if options.interval_secs == Some(0) {
+        return Err(anyhow!(
+            "agent daemon requires --interval-secs greater than zero"
+        ));
+    }
+    let loaded = load_spec(spec_path)?;
+    ensure_state_root(&loaded)?;
+    let mut restart_count = 0u64;
+    let mut last_child_exit = None;
+    let _ = write_daemon_status(
+        &loaded,
+        DaemonStatusInput {
+            state: "starting",
+            restart_count,
+            max_restarts: options.max_restarts,
+            checkpoint_interval_secs: options.checkpoint_interval_secs,
+            last_event: "daemon_started",
+            last_child_exit: None,
+            next_backoff_secs: 0,
+        },
+    )?;
+    let mut daemon_status: DaemonStatusRecord;
+    emit_daemon_event(
+        &loaded,
+        "daemon_started",
+        "started",
+        restart_count,
+        json!({
+            "checkpoint_interval_secs": options.checkpoint_interval_secs,
+            "max_restarts": options.max_restarts,
+            "unsupported_permanence_claims": unsupported_permanence_claims()
+        }),
+    )?;
+
+    loop {
+        if read_stop(&loaded)?.is_some() {
+            let status = status(spec_path)?;
+            persist_status(&loaded, &status, "daemon_stop_observed")?;
+            let daemon_status = write_daemon_status(
+                &loaded,
+                DaemonStatusInput {
+                    state: "stopped",
+                    restart_count,
+                    max_restarts: options.max_restarts,
+                    checkpoint_interval_secs: options.checkpoint_interval_secs,
+                    last_event: "stop_completed",
+                    last_child_exit: last_child_exit.clone(),
+                    next_backoff_secs: 0,
+                },
+            )?;
+            emit_daemon_event(
+                &loaded,
+                "stop_completed",
+                "completed",
+                restart_count,
+                json!({"recoverable_state": status.state}),
+            )?;
+            return Ok(daemon_status);
+        }
+
+        emit_daemon_event(
+            &loaded,
+            "child_spawn",
+            "started",
+            restart_count,
+            json!({"supervised_unit": "long_lived_agent_tick"}),
+        )?;
+        let _ = write_daemon_status(
+            &loaded,
+            DaemonStatusInput {
+                state: "running",
+                restart_count,
+                max_restarts: options.max_restarts,
+                checkpoint_interval_secs: options.checkpoint_interval_secs,
+                last_event: "child_spawn",
+                last_child_exit: last_child_exit.clone(),
+                next_backoff_secs: 0,
+            },
+        )?;
+
+        match tick(
+            spec_path,
+            TickOptions {
+                recover_stale_lease: options.recover_stale_lease,
+            },
+        ) {
+            Ok(status) => {
+                last_child_exit = Some("success".to_string());
+                emit_daemon_event(
+                    &loaded,
+                    "child_exit",
+                    "completed",
+                    restart_count,
+                    json!({
+                        "exit_class": "success",
+                        "recoverable_state": status.state,
+                        "checkpoint_ref": "continuity_checkpoint.json"
+                    }),
+                )?;
+                daemon_status = write_daemon_status(
+                    &loaded,
+                    DaemonStatusInput {
+                        state: "running",
+                        restart_count,
+                        max_restarts: options.max_restarts,
+                        checkpoint_interval_secs: options.checkpoint_interval_secs,
+                        last_event: "child_exit",
+                        last_child_exit: last_child_exit.clone(),
+                        next_backoff_secs: 0,
+                    },
+                )?;
+            }
+            Err(err) => {
+                last_child_exit = Some(format!("error:{err}"));
+                let mut status = read_status(&loaded)?.unwrap_or_else(|| {
+                    status_with_state(
+                        &loaded,
+                        AgentStatusState::Failed,
+                        None,
+                        None,
+                        None,
+                        false,
+                        None,
+                    )
+                });
+                status.state = AgentStatusState::Failed;
+                status.active_lease = read_lease(&loaded)?;
+                status.last_error = Some(StatusError {
+                    class: "daemon_child_failed".to_string(),
+                    message: err.to_string(),
+                });
+                status.updated_at = Utc::now();
+                persist_status(&loaded, &status, "daemon_child_failed_recoverable")?;
+                emit_daemon_event(
+                    &loaded,
+                    "child_exit",
+                    "failed",
+                    restart_count,
+                    json!({
+                        "exit_class": "error",
+                        "error": err.to_string(),
+                        "recoverable_state": status.state,
+                        "checkpoint_ref": "continuity_checkpoint.json"
+                    }),
+                )?;
+                if restart_count >= options.max_restarts {
+                    let _ = write_daemon_status(
+                        &loaded,
+                        DaemonStatusInput {
+                            state: "failed",
+                            restart_count,
+                            max_restarts: options.max_restarts,
+                            checkpoint_interval_secs: options.checkpoint_interval_secs,
+                            last_event: "restart_budget_exhausted",
+                            last_child_exit: last_child_exit.clone(),
+                            next_backoff_secs: 0,
+                        },
+                    )?;
+                    emit_daemon_event(
+                        &loaded,
+                        "restart_budget_exhausted",
+                        "failed",
+                        restart_count,
+                        json!({"recoverable_state": status.state}),
+                    )?;
+                    return Err(err.context("daemon restart budget exhausted"));
+                }
+                restart_count += 1;
+                let backoff_secs = restart_backoff_secs(restart_count);
+                daemon_status = write_daemon_status(
+                    &loaded,
+                    DaemonStatusInput {
+                        state: "restarting",
+                        restart_count,
+                        max_restarts: options.max_restarts,
+                        checkpoint_interval_secs: options.checkpoint_interval_secs,
+                        last_event: "restart_scheduled",
+                        last_child_exit: last_child_exit.clone(),
+                        next_backoff_secs: backoff_secs,
+                    },
+                )?;
+                emit_daemon_event(
+                    &loaded,
+                    "restart_scheduled",
+                    "scheduled",
+                    restart_count,
+                    json!({"backoff_secs": backoff_secs}),
+                )?;
+                let stop_observed = sleep_with_partial_checkpoints(
+                    &loaded,
+                    backoff_secs,
+                    options.checkpoint_interval_secs,
+                    restart_count,
+                    &mut daemon_status,
+                    options.max_restarts,
+                    last_child_exit.clone(),
+                    status.last_error.clone(),
+                    "restart_backoff",
+                    options.no_sleep,
+                )?;
+                if stop_observed {
+                    continue;
+                }
+                emit_daemon_event(
+                    &loaded,
+                    "restart_attempted",
+                    "started",
+                    restart_count,
+                    json!({"previous_exit": last_child_exit}),
+                )?;
+                continue;
+            }
+        }
+
+        let sleep_secs = daemon_interval_secs(&loaded, options.interval_secs)?;
+        let stop_observed = sleep_with_partial_checkpoints(
+            &loaded,
+            sleep_secs,
+            options.checkpoint_interval_secs,
+            restart_count,
+            &mut daemon_status,
+            options.max_restarts,
+            last_child_exit.clone(),
+            None,
+            "daemon_heartbeat",
+            options.no_sleep,
+        )?;
+        if stop_observed {
+            continue;
+        }
+        if options.no_sleep {
+            daemon_status = write_daemon_status(
+                &loaded,
+                DaemonStatusInput {
+                    state: "completed",
+                    restart_count,
+                    max_restarts: options.max_restarts,
+                    checkpoint_interval_secs: options.checkpoint_interval_secs,
+                    last_event: "daemon_completed",
+                    last_child_exit: last_child_exit.clone(),
+                    next_backoff_secs: 0,
+                },
+            )?;
+            emit_daemon_event(
+                &loaded,
+                "daemon_completed",
+                "completed",
+                restart_count,
+                json!({"reason": "no_sleep_test_boundary"}),
+            )?;
+            return Ok(daemon_status);
+        }
+    }
+}
+
+fn daemon_interval_secs(loaded: &LoadedAgentSpec, override_secs: Option<u64>) -> Result<u64> {
+    match override_secs.or(loaded.spec.heartbeat.interval_secs) {
+        Some(0) => Err(anyhow!(
+            "agent daemon requires heartbeat.interval_secs or --interval-secs greater than zero"
+        )),
+        Some(secs) => Ok(secs),
+        None => Ok(DAEMON_DEFAULT_INTERVAL_SECS),
+    }
 }
 
 async fn run_with_tokio_cadence(
@@ -1012,6 +1286,215 @@ fn persist_status(
 ) -> Result<()> {
     write_status(loaded, status)?;
     write_continuity_restore_artifacts(loaded, status, checkpoint_reason)
+}
+
+struct DaemonStatusInput<'a> {
+    state: &'a str,
+    restart_count: u64,
+    max_restarts: u64,
+    checkpoint_interval_secs: u64,
+    last_event: &'a str,
+    last_child_exit: Option<String>,
+    next_backoff_secs: u64,
+}
+
+fn write_daemon_status(
+    loaded: &LoadedAgentSpec,
+    input: DaemonStatusInput<'_>,
+) -> Result<DaemonStatusRecord> {
+    let now = Utc::now();
+    let status = DaemonStatusRecord {
+        schema: DAEMON_STATUS_SCHEMA.to_string(),
+        agent_instance_id: loaded.spec.agent_instance_id.clone(),
+        state: input.state.to_string(),
+        supervisor_pid: std::process::id(),
+        restart_count: input.restart_count,
+        max_restarts: input.max_restarts,
+        checkpoint_interval_secs: input.checkpoint_interval_secs,
+        last_event: input.last_event.to_string(),
+        last_child_exit: input.last_child_exit,
+        last_checkpoint_at: now,
+        next_backoff_secs: input.next_backoff_secs,
+        trace_id: daemon_trace_id(loaded),
+        span_id: daemon_span_id(input.last_event, input.restart_count),
+        parent_span_id: Some(daemon_parent_span_id(loaded)),
+        unsupported_permanence_claims: unsupported_permanence_claims(),
+        updated_at: now,
+    };
+    write_json_pretty(&daemon_status_path(loaded), &status)?;
+    Ok(status)
+}
+
+fn sleep_with_partial_checkpoints(
+    loaded: &LoadedAgentSpec,
+    total_sleep_secs: u64,
+    checkpoint_interval_secs: u64,
+    restart_count: u64,
+    daemon_status: &mut DaemonStatusRecord,
+    max_restarts: u64,
+    last_child_exit: Option<String>,
+    recoverable_error: Option<StatusError>,
+    event: &str,
+    no_sleep: bool,
+) -> Result<bool> {
+    let mut remaining = total_sleep_secs;
+    if remaining == 0 || no_sleep {
+        let mut current = status(&loaded.spec_path)?;
+        if let Some(error) = recoverable_error.clone() {
+            current.state = AgentStatusState::Failed;
+            current.last_error = Some(error);
+        }
+        persist_status(loaded, &current, "daemon_partial_checkpoint")?;
+        *daemon_status = write_daemon_status(
+            loaded,
+            DaemonStatusInput {
+                state: daemon_status.state.as_str(),
+                restart_count,
+                max_restarts,
+                checkpoint_interval_secs,
+                last_event: "checkpoint_write",
+                last_child_exit,
+                next_backoff_secs: 0,
+            },
+        )?;
+        emit_daemon_event(
+            loaded,
+            "checkpoint_write",
+            "completed",
+            restart_count,
+            json!({
+                "checkpoint_reason": "daemon_partial_checkpoint",
+                "checkpoint_ref": "continuity_checkpoint.json",
+                "status_ref": "status.json",
+                "trigger": event
+            }),
+        )?;
+        return Ok(false);
+    }
+
+    let mut stop_observed = false;
+    while remaining > 0 {
+        let slice = remaining.min(checkpoint_interval_secs);
+        std::thread::sleep(Duration::from_secs(slice));
+        remaining -= slice;
+        let mut current = status(&loaded.spec_path)?;
+        if let Some(error) = recoverable_error.clone() {
+            current.state = AgentStatusState::Failed;
+            current.last_error = Some(error);
+        }
+        persist_status(loaded, &current, "daemon_partial_checkpoint")?;
+        let next_backoff_secs = if event == "restart_backoff" {
+            remaining
+        } else {
+            0
+        };
+        *daemon_status = write_daemon_status(
+            loaded,
+            DaemonStatusInput {
+                state: daemon_status.state.as_str(),
+                restart_count,
+                max_restarts,
+                checkpoint_interval_secs,
+                last_event: "checkpoint_write",
+                last_child_exit: last_child_exit.clone(),
+                next_backoff_secs,
+            },
+        )?;
+        emit_daemon_event(
+            loaded,
+            "checkpoint_write",
+            "completed",
+            restart_count,
+            json!({
+                "checkpoint_reason": "daemon_partial_checkpoint",
+                "checkpoint_ref": "continuity_checkpoint.json",
+                "status_ref": "status.json",
+                "trigger": event,
+                "remaining_sleep_secs": remaining
+            }),
+        )?;
+        if read_stop(loaded)?.is_some() {
+            stop_observed = true;
+            emit_daemon_event(
+                loaded,
+                "graceful_shutdown_requested",
+                "observed",
+                restart_count,
+                json!({"stop_ref": "stop.json"}),
+            )?;
+            break;
+        }
+    }
+    Ok(stop_observed)
+}
+
+fn emit_daemon_event(
+    loaded: &LoadedAgentSpec,
+    event: &str,
+    result: &str,
+    restart_count: u64,
+    details: Value,
+) -> Result<()> {
+    let trace_id = daemon_trace_id(loaded);
+    let span_id = daemon_span_id(event, restart_count);
+    let parent_span_id = daemon_parent_span_id(loaded);
+    let event_details = json!({
+        "event": event,
+        "result": result,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "otel": {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "service_name": "adl-long-lived-agent-daemon",
+            "event_name": event
+        },
+        "details": details
+    });
+    append_operator_event(loaded, event, event_details)?;
+    let restart_count_s = restart_count.to_string();
+    crate::observability::emit_event(
+        "agent",
+        event,
+        result,
+        &[
+            ("process_class", "long_lived_daemon"),
+            ("agent_instance_id", loaded.spec.agent_instance_id.as_str()),
+            ("trace_id", trace_id.as_str()),
+            ("span_id", span_id.as_str()),
+            ("parent_span_id", parent_span_id.as_str()),
+            ("otel_service_name", "adl-long-lived-agent-daemon"),
+            ("restart_count", restart_count_s.as_str()),
+        ],
+    );
+    Ok(())
+}
+
+fn daemon_trace_id(loaded: &LoadedAgentSpec) -> String {
+    format!("agent.{}.daemon", loaded.spec.agent_instance_id)
+}
+
+fn daemon_parent_span_id(loaded: &LoadedAgentSpec) -> String {
+    format!("daemon:{}:supervisor", loaded.spec.agent_instance_id)
+}
+
+fn daemon_span_id(event: &str, restart_count: u64) -> String {
+    format!("daemon:{event}:{restart_count}")
+}
+
+fn restart_backoff_secs(restart_count: u64) -> u64 {
+    2u64.saturating_pow(restart_count.min(4) as u32).min(30)
+}
+
+fn unsupported_permanence_claims() -> Vec<String> {
+    vec![
+        "not_os_boot_persistent".to_string(),
+        "not_kill_9_resistant".to_string(),
+        "not_host_resource_exhaustion_resistant".to_string(),
+        "not_missing_binary_resistant".to_string(),
+    ]
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/adl/src/long_lived_agent/schema.rs
+++ b/adl/src/long_lived_agent/schema.rs
@@ -2,6 +2,7 @@
 pub(crate) const SPEC_SCHEMA: &str = "adl.long_lived_agent_spec.v1";
 pub(crate) const LEASE_SCHEMA: &str = "adl.long_lived_agent_lease.v1";
 pub(crate) const STATUS_SCHEMA: &str = "adl.long_lived_agent_status.v1";
+pub(crate) const DAEMON_STATUS_SCHEMA: &str = "adl.long_lived_agent_daemon_status.v1";
 pub(crate) const STOP_SCHEMA: &str = "adl.long_lived_agent_stop.v1";
 pub(crate) const CYCLE_MANIFEST_SCHEMA: &str = "adl.long_lived_agent_cycle_manifest.v1";
 pub(crate) const OBSERVATIONS_SCHEMA: &str = "adl.long_lived_agent_observations.v1";

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -46,6 +46,10 @@ pub(super) fn operator_events_path(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join("operator_events.jsonl")
 }
 
+pub(super) fn daemon_status_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("daemon_status.json")
+}
+
 pub(super) fn status_path(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join("status.json")
 }

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1050,6 +1050,196 @@ fn loom_duplicate_activation_allows_only_one_cycle_start() {
 }
 
 #[test]
+fn daemon_partial_checkpoint_preserves_recoverable_failure_reason() {
+    let root = temp_dir("daemon-partial-failure-reason");
+    let spec = write_spec_with_workflow_kind(&root, "unsupported_adapter");
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let error = StatusError {
+        class: "daemon_child_failed".to_string(),
+        message: "cycle failed before restart".to_string(),
+    };
+    let failed = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        Some(error.clone()),
+    );
+    persist_status(&loaded, &failed, "daemon_child_failed_recoverable").expect("persist failed");
+    let mut daemon_status = write_daemon_status(
+        &loaded,
+        DaemonStatusInput {
+            state: "restarting",
+            restart_count: 1,
+            max_restarts: 1,
+            checkpoint_interval_secs: 1,
+            last_event: "restart_scheduled",
+            last_child_exit: Some("error:cycle failed".to_string()),
+            next_backoff_secs: 0,
+        },
+    )
+    .expect("daemon status");
+
+    let stop_observed = sleep_with_partial_checkpoints(
+        &loaded,
+        0,
+        1,
+        1,
+        &mut daemon_status,
+        1,
+        Some("error:cycle failed".to_string()),
+        Some(error),
+        "restart_backoff",
+        true,
+    )
+    .expect("partial checkpoint");
+    assert!(!stop_observed);
+
+    let status = read_status(&loaded)
+        .expect("read status")
+        .expect("status exists");
+    assert_eq!(status.state, AgentStatusState::Failed);
+    assert_eq!(
+        status.last_error.as_ref().map(|error| error.class.as_str()),
+        Some("daemon_child_failed")
+    );
+    let checkpoint: serde_json::Value =
+        read_json_required(&continuity_checkpoint_path(&loaded)).expect("checkpoint");
+    assert_eq!(checkpoint["state"], "failed");
+}
+
+#[test]
+fn daemon_interval_defaults_positive_and_rejects_zero_cadence() {
+    let root = temp_dir("daemon-positive-cadence");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    assert_eq!(
+        daemon_interval_secs(&loaded, None).expect("spec interval"),
+        1
+    );
+    assert_eq!(
+        daemon_interval_secs(&loaded, Some(2)).expect("override interval"),
+        2
+    );
+    assert!(daemon_interval_secs(&loaded, Some(0))
+        .expect_err("zero override must fail")
+        .to_string()
+        .contains("greater than zero"));
+
+    let no_interval_spec = root.join("agent-no-interval.yaml");
+    let body = fs::read_to_string(&spec).expect("read spec");
+    fs::write(&no_interval_spec, body.replace("  interval_secs: 1\n", ""))
+        .expect("write no-interval spec");
+    let no_interval_loaded = load_spec(&no_interval_spec).expect("load no-interval spec");
+    assert_eq!(
+        daemon_interval_secs(&no_interval_loaded, None).expect("default interval"),
+        3
+    );
+
+    let zero_interval_spec = root.join("agent-zero-interval.yaml");
+    fs::write(
+        &zero_interval_spec,
+        fs::read_to_string(&spec)
+            .expect("read spec")
+            .replace("  interval_secs: 1\n", "  interval_secs: 0\n"),
+    )
+    .expect("write zero-interval spec");
+    let zero_interval_loaded = load_spec(&zero_interval_spec).expect("load zero-interval spec");
+    assert!(daemon_interval_secs(&zero_interval_loaded, None)
+        .expect_err("zero spec interval must fail")
+        .to_string()
+        .contains("greater than zero"));
+}
+
+#[test]
+fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
+    let root = temp_dir("daemon-heartbeat-no-backoff");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let mut daemon_status = write_daemon_status(
+        &loaded,
+        DaemonStatusInput {
+            state: "running",
+            restart_count: 0,
+            max_restarts: 1,
+            checkpoint_interval_secs: 1,
+            last_event: "daemon_started",
+            last_child_exit: None,
+            next_backoff_secs: 0,
+        },
+    )
+    .expect("daemon status");
+
+    let stop_observed = sleep_with_partial_checkpoints(
+        &loaded,
+        1,
+        1,
+        0,
+        &mut daemon_status,
+        1,
+        None,
+        None,
+        "daemon_heartbeat",
+        false,
+    )
+    .expect("partial checkpoint");
+
+    assert!(!stop_observed);
+    assert_eq!(daemon_status.next_backoff_secs, 0);
+}
+
+#[test]
+fn daemon_partial_checkpoint_reports_stop_observed_before_restart_attempt() {
+    let root = temp_dir("daemon-stop-during-backoff");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    write_stop_record(
+        &loaded,
+        "operator pause before restart",
+        "operator",
+        "operator_stop_requested",
+    )
+    .expect("write stop");
+    let mut daemon_status = write_daemon_status(
+        &loaded,
+        DaemonStatusInput {
+            state: "restarting",
+            restart_count: 1,
+            max_restarts: 1,
+            checkpoint_interval_secs: 1,
+            last_event: "restart_scheduled",
+            last_child_exit: Some("error:cycle failed".to_string()),
+            next_backoff_secs: 1,
+        },
+    )
+    .expect("daemon status");
+
+    let stop_observed = sleep_with_partial_checkpoints(
+        &loaded,
+        1,
+        1,
+        1,
+        &mut daemon_status,
+        1,
+        Some("error:cycle failed".to_string()),
+        None,
+        "restart_backoff",
+        false,
+    )
+    .expect("partial checkpoint");
+    assert!(stop_observed);
+
+    let events = fs::read_to_string(operator_events_path(&loaded)).expect("operator events");
+    assert!(events.contains("\"event\":\"graceful_shutdown_requested\""));
+    assert!(!events.contains("\"event\":\"restart_attempted\""));
+}
+
+#[test]
 fn loom_stop_request_wins_over_concurrent_activation_and_follow_up_status() {
     loom::model(|| {
         use loom::sync::{Arc, Mutex};

--- a/adl/src/long_lived_agent/types.rs
+++ b/adl/src/long_lived_agent/types.rs
@@ -95,6 +95,27 @@ pub struct StatusRecord {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Persistent daemon supervisor status for one long-lived agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonStatusRecord {
+    pub schema: String,
+    pub agent_instance_id: String,
+    pub state: String,
+    pub supervisor_pid: u32,
+    pub restart_count: u64,
+    pub max_restarts: u64,
+    pub checkpoint_interval_secs: u64,
+    pub last_event: String,
+    pub last_child_exit: Option<String>,
+    pub last_checkpoint_at: DateTime<Utc>,
+    pub next_backoff_secs: u64,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub unsupported_permanence_claims: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// Stop request artifact persisted by operator/API calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StopRecord {
@@ -126,6 +147,16 @@ pub struct TickOptions {
 #[derive(Debug, Clone, Copy)]
 pub struct RunOptions {
     pub max_cycles: u64,
+    pub interval_secs: Option<u64>,
+    pub no_sleep: bool,
+    pub recover_stale_lease: bool,
+}
+
+/// Supervisor options for daemon-style foreground runtime execution.
+#[derive(Debug, Clone, Copy)]
+pub struct DaemonOptions {
+    pub max_restarts: u64,
+    pub checkpoint_interval_secs: u64,
     pub interval_secs: Option<u64>,
     pub no_sleep: bool,
     pub recover_stale_lease: bool,

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -261,3 +261,183 @@ memory:
     .expect("parse continuity checkpoint");
     assert_eq!(checkpoint["latest_cycle_id"], "cycle-000003");
 }
+
+#[test]
+fn agent_daemon_writes_status_checkpoints_and_otel_observability() {
+    let root = unique_test_temp_dir("agent-daemon");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: daemon-agent
+display_name: Daemon Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: wp02_smoke_probe
+  run_args:
+    provider_id: local_ollama
+    model: gemma4:latest
+heartbeat:
+  interval_secs: 1
+  max_cycles: 3
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+  max_consecutive_failures: 2
+memory:
+  namespace: smoke/daemon-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+
+    let observability_log = root.join("observability.log");
+    let spec_str = spec.to_str().expect("utf8 path");
+    let log_str = observability_log.to_str().expect("utf8 log path");
+    let out = run_adl_with_env(
+        &[
+            "agent",
+            "daemon",
+            "--spec",
+            spec_str,
+            "--max-restarts",
+            "1",
+            "--checkpoint-interval-secs",
+            "1",
+            "--no-sleep",
+            "--json",
+        ],
+        &[
+            ("ADL_OBSERVABILITY_STDERR", "0"),
+            ("ADL_OBSERVABILITY_LOG", log_str),
+            ("ADL_OBSERVABILITY_HEARTBEAT_MS", "25"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "expected daemon success, stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("\"schema\": \"adl.long_lived_agent_daemon_status.v1\""),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"state\": \"completed\""),
+        "stdout:\n{stdout}"
+    );
+    assert!(root.join("state/daemon_status.json").exists());
+    assert!(root.join("state/continuity_checkpoint.json").exists());
+    assert!(root.join("state/continuity_replay_manifest.json").exists());
+
+    let daemon_status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("state/daemon_status.json")).expect("read daemon status"),
+    )
+    .expect("parse daemon status");
+    assert_eq!(
+        daemon_status["unsupported_permanence_claims"][0],
+        "not_os_boot_persistent"
+    );
+    assert_eq!(daemon_status["trace_id"], "agent.daemon-agent.daemon");
+
+    let operator_events =
+        fs::read_to_string(root.join("state/operator_events.jsonl")).expect("operator events");
+    assert!(operator_events.contains("\"event\":\"daemon_started\""));
+    assert!(operator_events.contains("\"event\":\"child_spawn\""));
+    assert!(operator_events.contains("\"event\":\"checkpoint_write\""));
+    assert!(operator_events.contains("\"trace_id\":\"agent.daemon-agent.daemon\""));
+    assert!(operator_events.contains("\"otel\""));
+
+    let observability = fs::read_to_string(&observability_log).expect("read observability log");
+    assert!(observability.contains("stage=agent_daemon"));
+    assert!(observability.contains("stage=daemon_started"));
+    assert!(observability.contains("stage=checkpoint_write"));
+    assert!(observability.contains("otel_service_name=adl-long-lived-agent-daemon"));
+    assert!(observability.contains("trace_id=agent.daemon-agent.daemon"));
+}
+
+#[test]
+fn agent_daemon_restart_budget_failure_leaves_recoverable_checkpoint() {
+    let root = unique_test_temp_dir("agent-daemon-failure");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: daemon-failure-agent
+display_name: Daemon Failure Agent
+state_root: state
+workflow:
+  kind: unsupported_adapter
+  name: failing_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 1
+  max_cycles: 3
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+  max_consecutive_failures: 5
+memory:
+  namespace: smoke/daemon-failure-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+
+    let spec_str = spec.to_str().expect("utf8 path");
+    let out = run_adl(&[
+        "agent",
+        "daemon",
+        "--spec",
+        spec_str,
+        "--max-restarts",
+        "1",
+        "--checkpoint-interval-secs",
+        "1",
+        "--no-sleep",
+        "--json",
+    ]);
+    assert!(
+        !out.status.success(),
+        "expected daemon failure, stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let daemon_status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("state/daemon_status.json")).expect("read daemon status"),
+    )
+    .expect("parse daemon status");
+    assert_eq!(daemon_status["state"], "failed");
+    assert_eq!(daemon_status["restart_count"], 1);
+    assert_eq!(daemon_status["last_event"], "restart_budget_exhausted");
+    assert!(root.join("state/continuity_checkpoint.json").exists());
+    assert!(root.join("state/continuity_replay_manifest.json").exists());
+
+    let status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("state/status.json")).expect("read status"),
+    )
+    .expect("parse status");
+    assert_eq!(status["state"], "failed");
+    assert_eq!(status["last_error"]["class"], "daemon_child_failed");
+
+    let operator_events =
+        fs::read_to_string(root.join("state/operator_events.jsonl")).expect("operator events");
+    assert!(operator_events.contains("\"event\":\"restart_scheduled\""));
+    assert!(operator_events.contains("\"event\":\"restart_attempted\""));
+    assert!(operator_events.contains("\"event\":\"restart_budget_exhausted\""));
+    assert!(operator_events.contains("\"checkpoint_ref\":\"continuity_checkpoint.json\""));
+}

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -335,7 +335,7 @@ filter_token_for_path() {
       printf 'chronosense'
       return 0
       ;;
-    adl/src/long_lived_agent.rs|adl/src/long_lived_agent/tests.rs)
+    adl/src/long_lived_agent.rs|adl/src/long_lived_agent/*.rs)
       printf 'long_lived_agent'
       return 0
       ;;
@@ -368,6 +368,10 @@ filter_token_for_path() {
       ;;
     docs/default_workflow.md|docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
       printf 'pr_cmd'
+      return 0
+      ;;
+    adl/tests/cli_smoke/agent.rs)
+      printf 'agent_cli_smoke'
       return 0
       ;;
     adl/tests/cli_smoke.rs|adl/tests/cli_smoke/*.rs)
@@ -485,6 +489,8 @@ TOKEN_MAP = {
     "cli_dispatch": 'test(/^cli::tests::top_level_dispatch_routes_/)',
     "cli": 'test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)',
     "cli_smoke_basics": 'binary_id(adl::cli_smoke) and test(/^basics::/)',
+    "agent_cli_smoke": 'binary_id(adl::cli_smoke) and test(/^agent::/)',
+    "agent_cmd": 'test(/^cli::agent_cmd::/)',
     "process_status": 'binary_id(adl::cli_smoke) and test(/^process_status::/)',
     "scheduler_cli": 'test(/^cli::scheduler_cmd::tests::/) or test(/^cli::tests::runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch$/) or test(/^cli::tests::open_usage::usage_mentions_v0_4_and_legacy_examples$/)',
     "demo_adl_gws_context_mirror": 'binary_id(adl::bin/demo-adl-gws-context-mirror) and test(/^tests::/)',

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -419,6 +419,23 @@ assert_has "$long_lived_agent_only_output" "reason=bounded_rust_surface_runs_foc
 assert_has "$long_lived_agent_only_output" "filter_tokens=long_lived_agent"
 assert_has "$long_lived_agent_only_output" "filter_expression=test(/^long_lived_agent::/)"
 
+long_lived_agent_daemon_wave="$TMP/long_lived_agent_daemon_wave.txt"
+cat >"$long_lived_agent_daemon_wave" <<'EOF'
+M	adl/src/cli/agent_cmd.rs
+M	adl/src/cli/usage.rs
+M	adl/src/long_lived_agent.rs
+M	adl/src/long_lived_agent/schema.rs
+M	adl/src/long_lived_agent/storage.rs
+M	adl/src/long_lived_agent/tests.rs
+M	adl/src/long_lived_agent/types.rs
+M	adl/tests/cli_smoke/agent.rs
+EOF
+long_lived_agent_daemon_wave_output="$(bash "$SCRIPT" --changed-files "$long_lived_agent_daemon_wave" --print-plan)"
+assert_has "$long_lived_agent_daemon_wave_output" "mode=focused"
+assert_has "$long_lived_agent_daemon_wave_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$long_lived_agent_daemon_wave_output" "filter_tokens=agent_cmd,cli_smoke_basics,long_lived_agent,agent_cli_smoke"
+assert_has "$long_lived_agent_daemon_wave_output" "filter_expression=test(/^cli::agent_cmd::/) or binary_id(adl::cli_smoke) and test(/^basics::/) or test(/^long_lived_agent::/) or binary_id(adl::cli_smoke) and test(/^agent::/)"
+
 chronosense_runtime_trace="$TMP/chronosense-runtime-trace.txt"
 cat >"$chronosense_runtime_trace" <<'EOF'
 M	adl/src/chronosense.rs

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -178,6 +178,47 @@ assert node["resource_class"] == "medium"
 assert profile["diagnostics"] == []
 PY
 
+daemon_wave="$TMP/daemon-wave.txt"
+cat >"$daemon_wave" <<'EOF'
+M	adl/src/cli/agent_cmd.rs
+M	adl/src/cli/usage.rs
+M	adl/src/long_lived_agent.rs
+M	adl/src/long_lived_agent/schema.rs
+M	adl/src/long_lived_agent/storage.rs
+M	adl/src/long_lived_agent/tests.rs
+M	adl/src/long_lived_agent/types.rs
+M	adl/tests/cli_smoke/agent.rs
+M	docs/milestones/v0.91.7/review/runtime/RUNTIME_DAEMON_SUPERVISION_4885.md
+EOF
+bash "$SCRIPT" --changed-files "$daemon_wave" --json >"$TMP/daemon-wave.json"
+python3 - <<'PY' "$TMP/daemon-wave.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert profile["escalation"]["required"] is False
+assert [item["lane_id"] for item in profile["run"]] == [
+    "docs_diff_check",
+    "rust_pr_fast",
+]
+rust = next(item for item in profile["run"] if item["lane_id"] == "rust_pr_fast")
+assert rust["reason"] == "bounded_rust_surface_runs_focused_nextest"
+assert rust["matched_paths"] == [
+    "adl/src/cli/agent_cmd.rs",
+    "adl/src/cli/usage.rs",
+    "adl/src/long_lived_agent.rs",
+    "adl/src/long_lived_agent/schema.rs",
+    "adl/src/long_lived_agent/storage.rs",
+    "adl/src/long_lived_agent/tests.rs",
+    "adl/src/long_lived_agent/types.rs",
+    "adl/tests/cli_smoke/agent.rs",
+]
+assert profile["diagnostics"] == []
+PY
+
 release_gate="$TMP/release-gate.txt"
 printf 'M\t.github/workflows/ci.yaml\n' >"$release_gate"
 bash "$SCRIPT" --changed-files "$release_gate" --json >"$TMP/release.json"

--- a/docs/milestones/v0.91.7/review/runtime/RUNTIME_DAEMON_SUPERVISION_4885.md
+++ b/docs/milestones/v0.91.7/review/runtime/RUNTIME_DAEMON_SUPERVISION_4885.md
@@ -1,0 +1,66 @@
+# Runtime Daemon Supervision Proof Note (#4885)
+
+Status: `implemented_local_proof`
+
+Issue `#4885` adds a foreground supervised daemon mode for the integrated long-lived runtime path:
+
+- Command: `adl agent daemon --spec <agent-spec.yaml>`.
+- Durable daemon state: `state/daemon_status.json`.
+- Recoverable agent state: existing `status.json`, `continuity_checkpoint.json`, `continuity_replay_manifest.json`, `cycle_ledger.jsonl`, and stop/lease records.
+- Restart policy: ordinary child tick failures are classified, checkpointed, and restarted until the bounded restart budget is exhausted.
+- Partial checkpoint cadence: `--checkpoint-interval-secs <n>` defaults to `3` and must be greater than zero.
+- Stop semantics: daemon observes the existing `stop.json` control plane and exits through a recoverable stopped state.
+- Observability: each daemon lifecycle event writes `operator_events.jsonl` and emits `adl_event` records with OTel-compatible `trace_id`, `span_id`, `parent_span_id`, and `otel_service_name` fields.
+
+Covered daemon lifecycle events:
+
+- `daemon_started`
+- `child_spawn`
+- `child_exit`
+- `checkpoint_write`
+- `restart_scheduled`
+- `restart_attempted`
+- `restart_budget_exhausted`
+- `graceful_shutdown_requested`
+- `stop_completed`
+- `daemon_completed`
+
+Truth boundary:
+
+- This is not OS service-manager persistence.
+- This does not claim survival across host reboot, operator `kill -9`, missing binaries, or host resource exhaustion.
+- Those unsupported permanence claims are retained in `daemon_status.json` as explicit non-claims.
+
+Focused validation:
+
+- `cargo check --manifest-path adl/Cargo.toml --lib --bin adl`
+- `cargo test --manifest-path adl/Cargo.toml daemon_partial_checkpoint --lib`
+- `cargo test --manifest-path adl/Cargo.toml daemon_ --lib`
+- `cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent_daemon`
+- `cargo test --manifest-path adl/Cargo.toml cli::agent_cmd::tests::agent_`
+- `cargo test --manifest-path adl/Cargo.toml cli::agent_cmd::tests::agent_argument_validation_reports_missing_values_and_unknown_args`
+- `cargo fmt --manifest-path adl/Cargo.toml --all --check`
+- `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/generated-vpp-changed-files.txt`
+- `bash adl/tools/test_run_pr_fast_test_lane.sh`
+- `bash adl/tools/test_validation_manager.sh`
+
+The smoke tests prove:
+
+- daemon happy path writes `daemon_status.json`, continuity checkpoint/replay artifacts, operator events, and OTel-compatible observability fields
+- daemon restart-budget failure leaves `status.json` in `failed` with `daemon_child_failed`
+- restart scheduling, restart attempt, budget exhaustion, and checkpoint references are retained as operator events
+- restart-backoff partial checkpoints preserve the child failure reason
+- stop observed during restart backoff suppresses false `restart_attempted` evidence
+- daemon cadence fails closed for explicit zero interval and defaults to 3 seconds when the spec omits heartbeat interval
+- heartbeat partial checkpoints do not report restart backoff state
+
+Escalated publication proof:
+
+- The PR-fast validation manager classified the changed Rust surface as requiring explicit full nextest proof.
+- Full nextest result: 19,383 tests passed, 18 skipped, 1 slow, and 1 leaky test reported.
+
+Validation-selector repair:
+
+- `adl/tools/run_pr_fast_test_lane.sh` now maps the daemon wave to focused `agent_cmd`, `cli_smoke_basics`, `long_lived_agent`, and `agent_cli_smoke` tokens.
+- `adl/tools/test_run_pr_fast_test_lane.sh` covers the focused daemon-wave plan.
+- `adl/tools/test_validation_manager.sh` covers manager-level publication sufficiency for this daemon wave plus the retained proof note.


### PR DESCRIPTION
Closes #4885

## Summary
Implemented `adl agent daemon` as a supervised foreground daemon mode for the existing long-lived agent runtime. The daemon writes durable daemon state, keeps agent status and continuity checkpoints recoverable, restarts ordinary child failures within a bounded budget, observes stop requests, and emits structured observability with OTel-compatible correlation fields.

## Artifacts
- `adl/src/cli/agent_cmd.rs`
- `adl/src/cli/usage.rs`
- `adl/src/long_lived_agent.rs`
- `adl/src/long_lived_agent/schema.rs`
- `adl/src/long_lived_agent/storage.rs`
- `adl/src/long_lived_agent/types.rs`
- `adl/tests/cli_smoke/agent.rs`
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/test_run_pr_fast_test_lane.sh`
- `adl/tools/test_validation_manager.sh`
- `docs/milestones/v0.91.7/review/runtime/RUNTIME_DAEMON_SUPERVISION_4885.md`

## Validation
- Validation commands and their purpose:
  - `cargo check --manifest-path adl/Cargo.toml --lib --bin adl`
    Verified compile correctness for the changed library and `adl` command.
  - `cargo test --manifest-path adl/Cargo.toml daemon_partial_checkpoint --lib`
    Verified review-finding regressions for recoverable failure reason and stop/restart observability truth.
  - `cargo test --manifest-path adl/Cargo.toml daemon_ --lib`
    Verified daemon cadence fail-closed behavior, heartbeat checkpoint backoff truth, and restart-backoff checkpoint regressions.
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent_daemon`
    Verified daemon command retained status/checkpoint/OTel evidence and restart-budget failure behavior.
  - `cargo test --manifest-path adl/Cargo.toml cli::agent_cmd::tests::agent_`
    Verified agent command dispatch, argument validation, success path, and heartbeat observability still pass.
  - `cargo test --manifest-path adl/Cargo.toml cli::agent_cmd::tests::agent_argument_validation_reports_missing_values_and_unknown_args`
    Verified daemon zero-interval CLI rejection.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified no whitespace errors.
  - `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/generated-vpp-changed-files.txt`
    Verified the escalated full nextest publication proof required for the changed Rust surface.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified daemon-wave selector coverage and the focused token expression.
  - `bash adl/tools/test_validation_manager.sh`
    Verified manager-level publication-sufficient classification for the daemon wave.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4885__v0-91-7-wp-07-runtime-add-supervised-daemon-mode-for-integrated-runtime/stp.md
- Output card: .adl/v0.91.7/tasks/issue-4885__v0-91-7-wp-07-runtime-add-supervised-daemon-mode-for-integrated-runtime/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-add-supervised-daemon-mode-for-integrated-runtime-adl-src-cli-agent-cmd-rs-adl-src-cli-usage-rs-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-schema-rs-adl-src-long-lived-agent-storage-rs-adl-src-long-lived-agent-tests-rs-adl-src-long-lived-agent-types-rs-adl-tests-cli-smoke-agent-rs-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-tools-test-validation-manager-sh-docs-milestones-v0-91-7-review-runtime-runtime-daemon-supervision-4885-md-adl-v0-91-7-tasks-issue-4885-v0-91-7-wp-07-runtime-add-supervised-daemon-mode-for-integrated-runtime-stp-md-adl-v0-91-7-tasks-issue-4885-v0-91-7-wp-07-runtime-add-supervised-daemon-mode-for-integrated-runtime-sor-md