### PR TITLE
[v0.91.7][WP-06][validation] Operationalize validation platform routing

### DIFF
--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -791,6 +791,131 @@ if bash "$SCRIPT" \
 fi
 assert_has "$TMP/remote-docs-run.err" "requested remote runner is not eligible"
 
+bash "$SCRIPT" \
+  --changed-files "$docs_only" \
+  --platform-routing \
+  --json >"$TMP/platform-docs.json"
+python3 - <<'PY' "$TMP/platform-docs.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+routing = profile["platform_routing"]
+assert routing["schema_version"] == "adl.validation_platform_routing.v1"
+assert routing["requested_platform"] == "auto"
+assert routing["decision"] == "selected"
+assert routing["selected_platform"] == "local"
+assert routing["no_launch"] is True
+candidates = {item["platform"]: item for item in routing["candidates"]}
+assert candidates["local"]["decision"] == "eligible"
+assert candidates["local"]["cache_posture"] == "local_target_or_repo_configured"
+assert candidates["aws_spot"]["decision"] == "rejected"
+assert "not cost-appropriate" in candidates["aws_spot"]["reason"]
+assert candidates["codebuild"]["decision"] == "rejected"
+assert "CodeBuild wrapper is not present" in candidates["codebuild"]["reason"]
+PY
+
+bash "$SCRIPT" \
+  --changed-files "$remote_profile_changed" \
+  --validation-platform nessus \
+  --json >"$TMP/platform-nessus.json"
+python3 - <<'PY' "$TMP/platform-nessus.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+routing = profile["platform_routing"]
+assert routing["requested_platform"] == "nessus"
+assert routing["decision"] == "selected"
+assert routing["selected_platform"] == "nessus"
+candidates = {item["platform"]: item for item in routing["candidates"]}
+assert candidates["nessus"]["decision"] == "eligible"
+assert "run_nessus_remote_validation.sh" in candidates["nessus"]["command"]
+assert candidates["nessus"]["cache_posture"] == "remote_target_sccache_warm"
+PY
+
+bash "$SCRIPT" \
+  --changed-files "$remote_profile_changed" \
+  --validation-platform aws_spot \
+  --json >"$TMP/platform-spot.json"
+python3 - <<'PY' "$TMP/platform-spot.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+routing = profile["platform_routing"]
+assert routing["requested_platform"] == "aws_spot"
+assert routing["decision"] == "selected"
+assert routing["selected_platform"] == "aws_spot"
+candidates = {item["platform"]: item for item in routing["candidates"]}
+spot = candidates["aws_spot"]
+assert spot["decision"] == "eligible"
+assert "run_aws_spot_remote_validation_lane.sh" in spot["command"]
+assert "--print-command" in spot["command"]
+assert "<branch-or-ref>" not in spot["command"]
+assert spot["cache_posture"] == "warm_ebs_cache:/mnt/adl-cache"
+assert any("retained EBS cache" in caveat for caveat in spot["caveats"])
+PY
+
+bash "$SCRIPT" \
+  --changed-files "$daemon_wave" \
+  --validation-platform codebuild \
+  --json >"$TMP/platform-codebuild.json"
+python3 - <<'PY' "$TMP/platform-codebuild.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+routing = profile["platform_routing"]
+assert routing["requested_platform"] == "codebuild"
+assert routing["decision"] == "rejected"
+assert routing["selected_platform"] is None
+candidates = {item["platform"]: item for item in routing["candidates"]}
+codebuild = candidates["codebuild"]
+assert codebuild["decision"] == "rejected"
+assert "CodeBuild wrapper is not present" in codebuild["reason"]
+assert codebuild["cache_posture"] == "stable_local_target_cache_plus_s3_sccache_when_wrapper_available"
+assert "dependency_issue=#4838" in codebuild["caveats"]
+PY
+
+if bash "$SCRIPT" \
+  --changed-files "$daemon_wave" \
+  --validation-platform codebuild \
+  --run >"$TMP/platform-codebuild-run.out" 2>"$TMP/platform-codebuild-run.err"; then
+  echo "expected rejected CodeBuild platform request to fail closed under --run" >&2
+  exit 1
+fi
+assert_has "$TMP/platform-codebuild-run.err" "requested validation platform is not eligible"
+
+if bash "$SCRIPT" \
+  --changed-files "$remote_profile_changed" \
+  --validation-platform aws_spot \
+  --run >"$TMP/platform-spot-run.out" 2>"$TMP/platform-spot-run.err"; then
+  echo "expected selected non-local platform request to remain dry-run only under --run" >&2
+  exit 1
+fi
+assert_has "$TMP/platform-spot-run.err" "platform routing is dry-run only for non-local platforms"
+
+bash "$SCRIPT" \
+  --changed-files "$runtime" \
+  --validation-platform wuji \
+  --json >"$TMP/platform-wuji.json"
+python3 - <<'PY' "$TMP/platform-wuji.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+routing = profile["platform_routing"]
+assert routing["requested_platform"] == "wuji"
+assert routing["decision"] == "rejected"
+assert routing["selected_platform"] is None
+candidates = {item["platform"]: item for item in routing["candidates"]}
+wuji = candidates["wuji"]
+assert "ARM" in wuji["reason"]
+assert wuji["cache_posture"] == "linked_target_cache_warm_arm64"
+assert "arm64_builder_image_gap" in wuji["caveats"]
+PY
+
 scheduler_provider_policy="$TMP/scheduler-provider-policy.txt"
 cat >"$scheduler_provider_policy" <<'EOF'
 M	adl/src/provider/profiles.rs

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -17,6 +17,10 @@ SELECTOR = ROOT / "adl/tools/select_validation_lanes.sh"
 SLOW_PROOF_FAMILIES = ROOT / "adl/config/slow_proof_families.v0.91.6.json"
 DEFAULT_MANIFEST = ROOT / "adl/config/validation_lane_selector.v0.91.6.json"
 NESSUS_REMOTE_RUNNER = "bash adl/tools/run_nessus_remote_validation.sh"
+AWS_SPOT_REMOTE_RUNNER = "bash adl/tools/run_aws_spot_remote_validation_lane.sh"
+AWS_CODEFRIEND_BUILD_RUNNER = "bash adl/tools/run_aws_codefriend_build_lane.sh"
+AWS_CODEFRIEND_BUILD_RUNNER_PATH = ROOT / "adl/tools/run_aws_codefriend_build_lane.sh"
+VALIDATION_PLATFORMS = ("auto", "local", "nessus", "aws_spot", "codebuild", "wuji")
 
 
 def fail(message: str) -> None:
@@ -646,6 +650,349 @@ def shell_quote(value: str) -> str:
     return shlex.quote(value)
 
 
+def combined_run_command(profile: dict[str, Any]) -> str:
+    commands = [
+        str(item.get("command", "")).strip()
+        for item in profile.get("run", [])
+        if str(item.get("command", "")).strip()
+    ]
+    return " && ".join(commands)
+
+
+def deterministic_or_evidence_bound(profile: dict[str, Any]) -> tuple[bool, list[str]]:
+    allowed_determinism = {"deterministic", "evidence_bound"}
+    unsupported = [
+        surface.get("determinism_posture", "unknown")
+        for surface in profile.get("behavior_surfaces", [])
+        if surface.get("determinism_posture", "unknown") not in allowed_determinism
+    ]
+    return not unsupported, unsupported
+
+
+def base_platform_eligibility(profile: dict[str, Any]) -> dict[str, Any]:
+    selected_lane_count = int(profile["estimated_cost"]["selected_lane_count"])
+    runtime_class = str(profile["estimated_cost"]["runtime_class"])
+    deterministic_ok, unsupported_determinism = deterministic_or_evidence_bound(profile)
+    command = combined_run_command(profile)
+    return {
+        "status": profile["status"],
+        "escalation_required": bool(profile["escalation"]["required"]),
+        "selected_lane_count": selected_lane_count,
+        "runtime_class": runtime_class,
+        "deterministic_or_evidence_bound": deterministic_ok,
+        "unsupported_determinism": unsupported_determinism,
+        "command": command,
+    }
+
+
+def platform_candidate(
+    *,
+    platform: str,
+    decision: str,
+    reason: str,
+    command: str | None = None,
+    cache_posture: str,
+    cost_posture: str,
+    launch_posture: str = "dry_run_only",
+    wrapper: str | None = None,
+    caveats: list[str] | None = None,
+) -> dict[str, Any]:
+    candidate: dict[str, Any] = {
+        "platform": platform,
+        "decision": decision,
+        "reason": reason,
+        "cache_posture": cache_posture,
+        "cost_posture": cost_posture,
+        "launch_posture": launch_posture,
+    }
+    if command:
+        candidate["command"] = command
+    if wrapper:
+        candidate["wrapper"] = wrapper
+    if caveats:
+        candidate["caveats"] = caveats
+    return candidate
+
+
+def local_platform_candidate(profile: dict[str, Any], eligibility: dict[str, Any]) -> dict[str, Any]:
+    if eligibility["status"] not in {"ready_to_run", "no_validation_needed"}:
+        return platform_candidate(
+            platform="local",
+            decision="rejected",
+            reason=f"validation profile status {eligibility['status']} is not locally runnable",
+            cache_posture="local_target_or_repo_configured",
+            cost_posture="no_cloud_cost",
+        )
+    if eligibility["escalation_required"]:
+        return platform_candidate(
+            platform="local",
+            decision="rejected",
+            reason="validation profile requires escalation before local routing",
+            cache_posture="local_target_or_repo_configured",
+            cost_posture="no_cloud_cost",
+        )
+    command = eligibility["command"] or "true"
+    return platform_candidate(
+        platform="local",
+        decision="eligible",
+        reason="local platform can run the selected validation profile without cloud resources",
+        command=command,
+        cache_posture="local_target_or_repo_configured",
+        cost_posture="no_cloud_cost",
+    )
+
+
+def nessus_platform_candidate(profile: dict[str, Any], eligibility: dict[str, Any], command: str | None = None) -> dict[str, Any]:
+    remote_command = command or eligibility["command"]
+    if eligibility["status"] != "ready_to_run":
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason=f"validation profile status {eligibility['status']} is not remote-runnable",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+        )
+    if eligibility["escalation_required"]:
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason="validation profile already requires escalation",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+        )
+    if eligibility["selected_lane_count"] != 1:
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason=f"Nessus routing requires exactly 1 selected lane, observed {eligibility['selected_lane_count']}",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+        )
+    if eligibility["runtime_class"] in {"none", "tiny", "escalated"}:
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason=f"runtime_class {eligibility['runtime_class']} is not eligible for Nessus remote execution",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+        )
+    if not eligibility["deterministic_or_evidence_bound"]:
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason="Nessus routing supports deterministic or evidence-bound lanes only",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+            caveats=[f"unsupported_determinism={','.join(eligibility['unsupported_determinism'])}"],
+        )
+    if not remote_command:
+        return platform_candidate(
+            platform="nessus",
+            decision="rejected",
+            reason="Nessus routing requires a validation command",
+            cache_posture="remote_target_sccache_warm",
+            cost_posture="operator_host_no_cloud_cost",
+            wrapper=NESSUS_REMOTE_RUNNER,
+        )
+    return platform_candidate(
+        platform="nessus",
+        decision="eligible",
+        reason="single-lane non-tiny deterministic profile is eligible for Nessus remote execution",
+        command=f"{NESSUS_REMOTE_RUNNER} --command {shell_quote(remote_command)}",
+        cache_posture="remote_target_sccache_warm",
+        cost_posture="operator_host_no_cloud_cost",
+        wrapper=NESSUS_REMOTE_RUNNER,
+    )
+
+
+def aws_spot_platform_candidate(profile: dict[str, Any], eligibility: dict[str, Any]) -> dict[str, Any]:
+    command = eligibility["command"]
+    if eligibility["status"] != "ready_to_run":
+        return platform_candidate(
+            platform="aws_spot",
+            decision="rejected",
+            reason=f"validation profile status {eligibility['status']} is not remote-runnable",
+            cache_posture="warm_ebs_cache:/mnt/adl-cache",
+            cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+            wrapper=AWS_SPOT_REMOTE_RUNNER,
+        )
+    if eligibility["escalation_required"]:
+        return platform_candidate(
+            platform="aws_spot",
+            decision="rejected",
+            reason="validation profile already requires escalation",
+            cache_posture="warm_ebs_cache:/mnt/adl-cache",
+            cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+            wrapper=AWS_SPOT_REMOTE_RUNNER,
+        )
+    if eligibility["runtime_class"] in {"none", "tiny", "escalated"}:
+        return platform_candidate(
+            platform="aws_spot",
+            decision="rejected",
+            reason=f"runtime_class {eligibility['runtime_class']} is not cost-appropriate for AWS Spot",
+            cache_posture="warm_ebs_cache:/mnt/adl-cache",
+            cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+            wrapper=AWS_SPOT_REMOTE_RUNNER,
+        )
+    if not eligibility["deterministic_or_evidence_bound"]:
+        return platform_candidate(
+            platform="aws_spot",
+            decision="rejected",
+            reason="AWS Spot routing supports deterministic or evidence-bound lanes only",
+            cache_posture="warm_ebs_cache:/mnt/adl-cache",
+            cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+            wrapper=AWS_SPOT_REMOTE_RUNNER,
+            caveats=[f"unsupported_determinism={','.join(eligibility['unsupported_determinism'])}"],
+        )
+    if not command:
+        return platform_candidate(
+            platform="aws_spot",
+            decision="rejected",
+            reason="AWS Spot routing requires a validation command",
+            cache_posture="warm_ebs_cache:/mnt/adl-cache",
+            cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+            wrapper=AWS_SPOT_REMOTE_RUNNER,
+        )
+    return platform_candidate(
+        platform="aws_spot",
+        decision="eligible",
+        reason="non-tiny deterministic profile can use the warm-EBS AWS Spot lane when credentials and cache are available",
+        command=(
+            f"{AWS_SPOT_REMOTE_RUNNER} --command {shell_quote(command)} "
+            "--instance-type m7a.2xlarge --print-command"
+        ),
+        cache_posture="warm_ebs_cache:/mnt/adl-cache",
+        cost_posture="aws_spot_instance_plus_retained_ebs_storage",
+        wrapper=AWS_SPOT_REMOTE_RUNNER,
+        caveats=[
+            "requires Agent Logic AWS profile or GitHub OIDC role",
+            "requires retained EBS cache attachment for warm-cache proof",
+            "requires explicit --run outside validation-manager to launch paid resources",
+        ],
+    )
+
+
+def codebuild_platform_candidate(profile: dict[str, Any], eligibility: dict[str, Any]) -> dict[str, Any]:
+    wrapper_exists = AWS_CODEFRIEND_BUILD_RUNNER_PATH.exists()
+    if not wrapper_exists:
+        return platform_candidate(
+            platform="codebuild",
+            decision="rejected",
+            reason="CodeBuild wrapper is not present on this branch; merge or rebase the #4838 CodeFriend build lane first",
+            cache_posture="stable_local_target_cache_plus_s3_sccache_when_wrapper_available",
+            cost_posture="aws_codebuild_compute_minutes",
+            wrapper=AWS_CODEFRIEND_BUILD_RUNNER,
+            caveats=["dependency_issue=#4838", "dependency_pr=#4865"],
+        )
+    if eligibility["status"] != "ready_to_run":
+        return platform_candidate(
+            platform="codebuild",
+            decision="rejected",
+            reason=f"validation profile status {eligibility['status']} is not CodeBuild-runnable",
+            cache_posture="stable_local_target_cache_plus_s3_sccache",
+            cost_posture="aws_codebuild_compute_minutes",
+            wrapper=AWS_CODEFRIEND_BUILD_RUNNER,
+        )
+    if eligibility["escalation_required"]:
+        return platform_candidate(
+            platform="codebuild",
+            decision="rejected",
+            reason="validation profile already requires escalation",
+            cache_posture="stable_local_target_cache_plus_s3_sccache",
+            cost_posture="aws_codebuild_compute_minutes",
+            wrapper=AWS_CODEFRIEND_BUILD_RUNNER,
+        )
+    return platform_candidate(
+        platform="codebuild",
+        decision="eligible",
+        reason="profile can use the scalable CodeFriend CodeBuild lane when the wrapper, project, builder image, and caches are available",
+        command=f"{AWS_CODEFRIEND_BUILD_RUNNER} --git-ref <branch-or-ref> --compute-type BUILD_GENERAL1_XLARGE --dry-run",
+        cache_posture="stable_local_target_cache_plus_s3_sccache",
+        cost_posture="aws_codebuild_compute_minutes",
+        wrapper=AWS_CODEFRIEND_BUILD_RUNNER,
+        caveats=[
+            "requires Agent Logic AWS CodeBuild project and service role",
+            "requires builder image and S3 sccache to be configured",
+            "requires explicit live trigger outside validation-manager",
+        ],
+    )
+
+
+def wuji_platform_candidate(profile: dict[str, Any], eligibility: dict[str, Any]) -> dict[str, Any]:
+    if eligibility["status"] not in {"ready_to_run", "no_validation_needed"}:
+        reason = f"validation profile status {eligibility['status']} is not wuji-runnable"
+    elif eligibility["escalation_required"]:
+        reason = "validation profile requires escalation before wuji routing"
+    else:
+        reason = "wuji is ARM and requires a separate arm64 builder image before scheduler routing can claim parity"
+    return platform_candidate(
+        platform="wuji",
+        decision="rejected",
+        reason=reason,
+        cache_posture="linked_target_cache_warm_arm64",
+        cost_posture="operator_host_no_cloud_cost",
+        caveats=["arm64_builder_image_gap", "do_not_claim_x86_64_parity"],
+    )
+
+
+def platform_routing_decision(profile: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
+    if not args.platform_routing and not args.validation_platform:
+        return None
+    requested = args.validation_platform or "auto"
+    eligibility = base_platform_eligibility(profile)
+    candidates = [
+        local_platform_candidate(profile, eligibility),
+        nessus_platform_candidate(profile, eligibility),
+        aws_spot_platform_candidate(profile, eligibility),
+        codebuild_platform_candidate(profile, eligibility),
+        wuji_platform_candidate(profile, eligibility),
+    ]
+    by_platform = {candidate["platform"]: candidate for candidate in candidates}
+
+    selected: dict[str, Any] | None = None
+    if requested != "auto":
+        candidate = by_platform[requested]
+        selected = candidate if candidate["decision"] == "eligible" else None
+    else:
+        lane_ids = [item.get("lane_id") for item in profile.get("run", [])]
+        if by_platform["local"]["decision"] == "eligible" and eligibility["runtime_class"] in {"none", "tiny"}:
+            selected = by_platform["local"]
+        elif "aws_remote_validation_tooling" in lane_ids and by_platform["aws_spot"]["decision"] == "eligible":
+            selected = by_platform["aws_spot"]
+        elif eligibility["selected_lane_count"] > 1 and by_platform["codebuild"]["decision"] == "eligible":
+            selected = by_platform["codebuild"]
+        elif by_platform["nessus"]["decision"] == "eligible":
+            selected = by_platform["nessus"]
+        elif by_platform["aws_spot"]["decision"] == "eligible":
+            selected = by_platform["aws_spot"]
+        elif by_platform["local"]["decision"] == "eligible":
+            selected = by_platform["local"]
+
+    decision = "selected" if selected else "rejected"
+    reason = (
+        selected["reason"]
+        if selected
+        else by_platform[requested]["reason"]
+        if requested != "auto"
+        else "no eligible validation platform candidate for this profile"
+    )
+    return {
+        "schema_version": "adl.validation_platform_routing.v1",
+        "requested_platform": requested,
+        "decision": decision,
+        "selected_platform": selected["platform"] if selected else None,
+        "reason": reason,
+        "no_launch": True,
+        "launch_policy": "validation-manager only emits routing decisions and dry-run commands; live cloud runs require platform wrappers with explicit --run",
+        "candidates": candidates,
+    }
+
+
 def remote_runner_decision(profile: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
     if not args.remote_runner and not args.remote_command:
         return None
@@ -654,55 +1001,25 @@ def remote_runner_decision(profile: dict[str, Any], args: argparse.Namespace) ->
     if args.remote_runner != "nessus":
         fail(f"unsupported remote runner: {args.remote_runner}")
 
-    selected_lane_count = int(profile["estimated_cost"]["selected_lane_count"])
-    runtime_class = str(profile["estimated_cost"]["runtime_class"])
-    behavior_surfaces = profile.get("behavior_surfaces", [])
-    allowed_determinism = {"deterministic", "evidence_bound"}
-    unsupported_determinism = [
-        surface.get("determinism_posture", "unknown")
-        for surface in behavior_surfaces
-        if surface.get("determinism_posture", "unknown") not in allowed_determinism
-    ]
+    eligibility = base_platform_eligibility(profile)
+    candidate = nessus_platform_candidate(profile, eligibility, args.remote_command)
+    if candidate["decision"] != "eligible":
+        rejected = {
+            "requested": "nessus",
+            "decision": "rejected",
+            "reason": candidate["reason"],
+        }
+        if candidate.get("caveats"):
+            rejected["caveats"] = candidate["caveats"]
+        return rejected
 
-    if profile["status"] != "ready_to_run":
-        return {
-            "requested": "nessus",
-            "decision": "rejected",
-            "reason": f"validation profile status {profile['status']} is not remote-runnable",
-        }
-    if profile["escalation"]["required"]:
-        return {
-            "requested": "nessus",
-            "decision": "rejected",
-            "reason": "validation profile already requires escalation",
-        }
-    if selected_lane_count != 1:
-        return {
-            "requested": "nessus",
-            "decision": "rejected",
-            "reason": f"remote runner requires exactly 1 selected lane, observed {selected_lane_count}",
-        }
-    if runtime_class in {"none", "tiny", "escalated"}:
-        return {
-            "requested": "nessus",
-            "decision": "rejected",
-            "reason": f"runtime_class {runtime_class} is not eligible for Nessus remote execution",
-        }
-    if unsupported_determinism:
-        return {
-            "requested": "nessus",
-            "decision": "rejected",
-            "reason": "remote runner supports deterministic or evidence-bound lanes only",
-            "unsupported_determinism": unsupported_determinism,
-        }
-
-    remote_command = f"{NESSUS_REMOTE_RUNNER} --command {shell_quote(args.remote_command)}"
+    remote_command = candidate["command"]
     if args.remote_artifact_dir:
         remote_command += f" --local-artifact-dir {shell_quote(str(args.remote_artifact_dir.resolve()))}"
     return {
         "requested": "nessus",
         "decision": "selected",
-        "reason": "single-lane non-tiny deterministic profile is eligible for Nessus remote execution",
+        "reason": candidate["reason"],
         "command": remote_command,
     }
 
@@ -728,6 +1045,20 @@ def print_text(profile: dict[str, Any]) -> None:
         print(f"    reason={remote['reason']}")
         if remote.get("command"):
             print(f"    command={remote['command']}")
+    if profile.get("platform_routing"):
+        routing = profile["platform_routing"]
+        print("  platform_routing:")
+        print(f"    requested_platform={routing['requested_platform']}")
+        print(f"    decision={routing['decision']}")
+        print(f"    selected_platform={routing['selected_platform']}")
+        print(f"    reason={routing['reason']}")
+        for candidate in routing["candidates"]:
+            print(
+                f"    - platform={candidate['platform']} decision={candidate['decision']} "
+                f"cache={candidate['cache_posture']}"
+            )
+            if candidate.get("command"):
+                print(f"      command={candidate['command']}")
     if profile["escalation"]["required"]:
         print("  escalation:")
         for reason in profile["escalation"]["reasons"]:
@@ -770,6 +1101,17 @@ def write_report(path: Path, profile: dict[str, Any]) -> None:
 
 
 def run_profile(profile: dict[str, Any]) -> int:
+    platform_routing = profile.get("platform_routing")
+    if platform_routing:
+        selected_platform = platform_routing.get("selected_platform")
+        if platform_routing.get("decision") != "selected":
+            print_text(profile)
+            print("validation_manager: refusing --run because the requested validation platform is not eligible", file=sys.stderr)
+            return 1
+        if selected_platform != "local":
+            print_text(profile)
+            print("validation_manager: refusing --run because platform routing is dry-run only for non-local platforms", file=sys.stderr)
+            return 1
     remote_runner = profile.get("remote_runner")
     if remote_runner and remote_runner.get("decision") != "selected":
         print_text(profile)
@@ -805,6 +1147,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--remote-runner", choices=["nessus"])
     parser.add_argument("--remote-command")
     parser.add_argument("--remote-artifact-dir", type=Path)
+    parser.add_argument("--platform-routing", action="store_true")
+    parser.add_argument("--validation-platform", choices=VALIDATION_PLATFORMS)
     return parser.parse_args(argv)
 
 
@@ -814,6 +1158,9 @@ def main(argv: list[str]) -> int:
     manifest_path = args.manifest.resolve() if args.manifest else DEFAULT_MANIFEST
     guardrails = manager_guardrails(load_manifest(manifest_path), args.max_selected_lanes)
     profile = build_profile(plan, guardrails, manifest_path)
+    platform_routing = platform_routing_decision(profile, args)
+    if platform_routing:
+        profile["platform_routing"] = platform_routing
     remote = remote_runner_decision(profile, args)
     if remote:
         profile["remote_runner"] = remote

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -95,6 +95,10 @@ Important repo-local tooling surfaces include:
 - `bash adl/tools/run_validation_manager_nessus_lane.sh` — validation-manager
   wrapper that consumes one eligible local lane and routes it to the Nessus
   remote runner; see [Nessus Validation Manager Lane](NESSUS_VALIDATION_MANAGER_LANE.md)
+- `bash adl/tools/validation_manager.sh --platform-routing` — first-class
+  local, Nessus, AWS Spot, CodeBuild, and wuji routing decisions for scheduler
+  consumption without launching paid cloud resources; see
+  [Validation Platform Routing](VALIDATION_PLATFORM_ROUTING.md)
 - `bash adl/tools/run_aws_spot_remote_validation_lane.sh` — AWS Spot EC2
   remote validation wrapper that checks the `agent-logic-admin` account against
   retained Agent Logic proof before launch and reuses the retained warm EBS

--- a/docs/tooling/VALIDATION_PLATFORM_ROUTING.md
+++ b/docs/tooling/VALIDATION_PLATFORM_ROUTING.md
@@ -1,0 +1,111 @@
+# Validation Platform Routing
+
+`adl/tools/validation_manager.sh` can emit a first-class routing contract for
+the validation platform scheduler. The routing contract explains which platform
+should run a selected validation profile and why other platforms are rejected.
+
+The manager does not launch paid cloud resources. It only emits dry-run routing
+truth and wrapper commands. Live AWS Spot or CodeBuild runs still require the
+platform wrapper's explicit live-run flag or workflow trigger.
+
+## Command
+
+```bash
+bash adl/tools/validation_manager.sh \
+  --changed-files <changed-files> \
+  --platform-routing \
+  --json
+```
+
+To ask about one platform directly:
+
+```bash
+bash adl/tools/validation_manager.sh \
+  --changed-files <changed-files> \
+  --validation-platform aws_spot \
+  --json
+```
+
+Valid platform choices are:
+
+```text
+auto
+local
+nessus
+aws_spot
+codebuild
+wuji
+```
+
+## JSON Contract
+
+The output profile includes `platform_routing`:
+
+```json
+{
+  "schema_version": "adl.validation_platform_routing.v1",
+  "requested_platform": "auto",
+  "decision": "selected",
+  "selected_platform": "local",
+  "no_launch": true,
+  "launch_policy": "validation-manager only emits routing decisions and dry-run commands; live cloud runs require platform wrappers with explicit --run",
+  "candidates": []
+}
+```
+
+Each candidate records:
+
+- `platform`
+- `decision`
+- `reason`
+- `cache_posture`
+- `cost_posture`
+- optional `command`
+- optional `wrapper`
+- optional `caveats`
+
+## Platform Semantics
+
+Local:
+
+- default route for docs-only or tiny profiles
+- no cloud cost
+- uses the selected validation profile's local command
+
+Nessus:
+
+- eligible for one selected non-tiny deterministic or evidence-bound lane
+- uses `bash adl/tools/run_nessus_remote_validation.sh`
+- expects the remote target and sccache posture recorded in the Nessus wrapper
+  docs
+
+AWS Spot:
+
+- eligible for non-tiny deterministic or evidence-bound profiles
+- uses `bash adl/tools/run_aws_spot_remote_validation_lane.sh`
+- emits a dry-run command with `--print-command`
+- live proof must still show the retained warm EBS cache attached at
+  `/mnt/adl-cache`
+- live execution may incur Spot compute and retained EBS storage cost
+
+CodeBuild:
+
+- route for scalable repeated CodeFriend-style builds once `#4838` lands
+- expected wrapper: `bash adl/tools/run_aws_codefriend_build_lane.sh`
+- expected cache posture: stable target cache plus S3 `sccache`
+- on branches that do not yet contain the wrapper, the candidate fails closed
+  with dependency caveats for `#4838` / PR `#4865`
+
+Wuji:
+
+- currently fails closed for scheduler routing because wuji is ARM and requires
+  a separate arm64 builder image before parity can be claimed
+- uses linked local target cache posture once the arm64 image exists
+
+## Non-Claims
+
+- `platform_routing.no_launch=true` is routing proof only.
+- A Spot dry-run command is not warm-EBS proof.
+- A CodeBuild candidate is not live CodeBuild proof.
+- A cache posture label is not enough; retained summaries must prove cache
+  attachment or cache hits for live benchmark claims.


### PR DESCRIPTION
Closes #4928

## Summary
Implemented first-class validation platform routing in `adl/tools/validation_manager.py`. The manager now emits an `adl.validation_platform_routing.v1` JSON block for local, Nessus, AWS Spot, CodeBuild, and wuji, with explicit candidate decisions, cache posture, cost posture, dry-run launch posture, wrapper commands, and caveats. Focused tests prove local/docs routing, Nessus eligibility, AWS Spot warm-EBS dry-run routing, CodeBuild dependency fail-closed behavior while #4838 is unmerged, wuji arm64 image-gap rejection, and `--run` fail-closed behavior for rejected or non-local platform routes.

## Artifacts
- `.adl/v0.91.7/tasks/issue-4928__v0-91-7-wp-06-validation-operationalize-validation-platform-routing/srp.md`
- `.adl/v0.91.7/tasks/issue-4928__v0-91-7-wp-06-validation-operationalize-validation-platform-routing/sor.md`
- `adl/tools/validation_manager.py`
- `adl/tools/test_validation_manager.sh`
- `docs/tooling/README.md`
- `docs/tooling/VALIDATION_PLATFORM_ROUTING.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager routing behavior and regression coverage.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector compatibility.
  - `python3 -m py_compile adl/tools/validation_manager.py`
    Verified Python syntax.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4928__v0-91-7-wp-06-validation-operationalize-validation-platform-routing/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4928__v0-91-7-wp-06-validation-operationalize-validation-platform-routing/sor.md
- Idempotency-Key: v0-91-7-wp-06-validation-operationalize-validation-platform-routing-adl-tools-validation-manager-py-adl-tools-test-validation-manager-sh-docs-tooling-readme-md-docs-tooling-validation-platform-routing-md-adl-v0-91-7-tasks-issue-4928-v0-91-7-wp-06-validation-operationalize-validation-platform-routing-sip-md-adl-v0-91-7-tasks-issue-4928-v0-91-7-wp-06-validation-operationalize-validation-platform-routing-sor-md