### PR TITLE
[v0.91.7][tools][workflow] Resolve shepherd repo-owned binary fallback

### DIFF
--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -171,7 +171,7 @@ rust_pr_delegate_primary_cached_bin() {
 
 rust_pr_subcommand_allows_primary_generic_last_resort() {
   case "${1:-}" in
-    watch)
+    watch|shepherd)
       return 0
       ;;
   esac
@@ -653,6 +653,33 @@ delegate_pr_command_to_rust() {
   if [[ -n "$direct_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "freshness" "stale_allowed_primary_owner_last_resort"
     exec "$direct_bin" "$@"
+  fi
+  if rust_pr_subcommand_allows_primary_generic_last_resort "$subcommand"; then
+    cached_bin="$(rust_pr_delegate_cached_bin || true)"
+    if [[ -n "$cached_bin" ]]; then
+      adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
+      exec "$cached_bin" pr "$subcommand" "$@"
+    fi
+    cached_bin="$(rust_pr_delegate_primary_cached_bin || true)"
+    if [[ -n "$cached_bin" ]]; then
+      adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
+      exec "$cached_bin" pr "$subcommand" "$@"
+    fi
+    cached_bin="$(rust_pr_delegate_path_bin || true)"
+    if [[ -n "$cached_bin" ]]; then
+      adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin"
+      exec "$cached_bin" pr "$subcommand" "$@"
+    fi
+    cached_bin="$(rust_pr_delegate_cached_bin_last_resort || true)"
+    if [[ -n "$cached_bin" ]]; then
+      adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin" "freshness" "generic_adl_last_resort"
+      exec "$cached_bin" pr "$subcommand" "$@"
+    fi
+    cached_bin="$(rust_pr_delegate_primary_cached_bin_last_resort "$subcommand" || true)"
+    if [[ -n "$cached_bin" ]]; then
+      adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$cached_bin" "freshness" "generic_adl_primary_last_resort"
+      exec "$cached_bin" pr "$subcommand" "$@"
+    fi
   fi
   if rust_pr_subcommand_requires_dedicated_owner_binary "$subcommand"; then
     if ! rust_pr_cargo_fallback_allowed; then

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -259,30 +259,29 @@ touch "$repo/adl/target/debug/adl"
 : >"$TMP_ADL_ARGS"
 : >"$TMP_CARGO_ARGS"
 
-set +e
-shepherd_output="$(
-  (
-    cd "$worktree" && \
-    ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
-    "$BASH_BIN" adl/tools/pr.sh shepherd 4413 --slug rust-start --version v0.91.6 --json
-  ) 2>&1
-)"
-shepherd_status="$?"
-set -e
+shepherd_log="$tmpdir/shepherd-generic-fallback.log"
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh shepherd 4413 --slug rust-start --version v0.91.6 --json >"$shepherd_log" 2>&1
+)
 
-if [[ "$shepherd_status" -eq 0 ]]; then
-  echo "assertion failed: shepherd should not silently fall through to the generic primary checkout adl binary" >&2
-  exit 1
-fi
-[[ ! -s "$TMP_ADL_ARGS" ]] || {
-  echo "assertion failed: generic primary checkout adl binary should not be used for shepherd when the dedicated owner binary is missing" >&2
-  cat "$TMP_ADL_ARGS" >&2
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == "pr shepherd 4413 --slug rust-start --version v0.91.6 --json" ]] || {
+  echo "assertion failed: shepherd should use repo-owned generic adl fallback when dedicated owner binary is missing" >&2
+  echo "$args" >&2
+  cat "$shepherd_log" >&2
   exit 1
 }
-grep -F "missing dedicated ADL PR owner binary for subcommand 'shepherd'" <<<"$shepherd_output" >/dev/null || {
-  echo "assertion failed: expected missing dedicated owner binary guidance for shepherd" >&2
-  echo "$shepherd_output" >&2
+grep -F "stage=rust_delegate result=exec subcommand=shepherd" "$shepherd_log" >/dev/null || {
+  echo "assertion failed: generic primary checkout adl delegation should be observable for shepherd" >&2
+  cat "$shepherd_log" >&2
+  exit 1
+}
+[[ ! -s "$TMP_CARGO_ARGS" ]] || {
+  echo "assertion failed: cargo should not run when shepherd uses generic primary checkout adl fallback" >&2
+  cat "$TMP_CARGO_ARGS" >&2
   exit 1
 }
 
-echo "pr.sh shepherd requires dedicated owner binary when generic adl is stale: ok"
+echo "pr.sh shepherd uses generic primary checkout adl fallback when dedicated owner binary is missing: ok"


### PR DESCRIPTION
Closes #4907

## Summary
Implemented the `pr.sh shepherd` repo-owned fallback repair. The wrapper now allows `shepherd` to use a repo-owned generic `adl pr shepherd` binary before failing closed, while preserving the no-raw-`gh` and no-implicit-cargo-build policy. The focused delegate regression test was updated to prove the fallback path and to assert cargo remains unused.

## Artifacts
- `adl/tools/pr_delegate.sh`
- `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
- `.adl/v0.91.7/tasks/issue-4907__v0-91-7-tools-workflow-pr-shepherd-should-resolve-repo-owned-fallback-binary-without-requiring-a-local-build/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified the focused shepherd fallback behavior and no-cargo invariant.
  - `git diff --check`
    Verified diff hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the owner validation lane selected by finish.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Summary\n\n- Allows pr.sh shepherd to use the repo-owned generic adl binary as a no-build fallback when the dedicated adl-pr-shepherd binary is unavailable.\n- Keeps cargo fallback gated behind ADL_PR_RUST_ALLOW_CARGO_FALLBACK and does not add gh fallback.\n- Updates the focused delegate regression test.\n\nValidation\n\n- bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh\n- git diff --check\n- bash adl/tools/run_owner_validation_lane.sh csdlc\n\nReview\n\n- Bounded subagent review found no blocking findings.\n- Residual risk: no new negative test for total absence of both dedicated and generic repo-owned binaries; existing fail-closed path is unchanged.\n\nCloses #4907

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4907__v0-91-7-tools-workflow-pr-shepherd-should-resolve-repo-owned-fallback-binary-without-requiring-a-local-build/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4907__v0-91-7-tools-workflow-pr-shepherd-should-resolve-repo-owned-fallback-binary-without-requiring-a-local-build/sor.md
- Idempotency-Key: v0-91-7-tools-workflow-resolve-shepherd-repo-owned-binary-fallback-adl-tools-pr-delegate-sh-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-adl-v0-91-7-tasks-issue-4907-v0-91-7-tools-workflow-pr-shepherd-should-resolve-repo-owned-fallback-binary-without-requiring-a-local-build-sip-md-adl-v0-91-7-tasks-issue-4907-v0-91-7-tools-workflow-pr-shepherd-should-resolve-repo-owned-fallback-binary-without-requiring-a-local-build-sor-md