### PR TITLE
[v0.91.7][tools][validation] Add scoped gitignore guardrail finish lane

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2649,6 +2649,9 @@ pub(super) fn select_finish_validation_plan_for_finish_with_release_gate_disposi
     if finish_issue_needs_locked_cargo_fallback_validation(issue_number, changed_paths) {
         return Ok(build_locked_cargo_fallback_validation_plan());
     }
+    if finish_issue_needs_gitignore_guardrail_validation(issue_number, changed_paths) {
+        return Ok(build_gitignore_guardrail_validation_plan());
+    }
     if finish_issue_needs_native_gws_runtime_validation(issue_number, changed_paths) {
         return Ok(build_native_gws_runtime_validation_plan());
     }
@@ -4175,6 +4178,22 @@ fn finish_issue_needs_wuji_ddns_installer_validation(
         })
 }
 
+fn finish_issue_needs_gitignore_guardrail_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4882 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            trimmed == ".gitignore"
+                || trimmed == "adl/.gitignore"
+                || trimmed.starts_with("docs/milestones/v0.91.7/review/gitignore_guardrail/")
+        })
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -4214,6 +4233,19 @@ fn build_locked_cargo_fallback_validation_plan() -> FinishValidationPlan {
     );
     commands.push("bash adl/tools/test_ci_path_policy.sh".to_string());
     commands.push("bash adl/tools/run_owner_validation_lane.sh csdlc".to_string());
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
+}
+
+fn build_gitignore_guardrail_validation_plan() -> FinishValidationPlan {
+    let commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+        "bash adl/tools/test_ci_path_policy.sh".to_string(),
+        "bash adl/tools/test_validation_manager.sh".to_string(),
+    ];
     FinishValidationPlan {
         mode: FinishValidationMode::LargerBinaryFocused,
         commands,

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4030,6 +4030,46 @@ fn finish_validation_profile_classifies_wuji_ddns_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_explicit_gitignore_guardrail_slice() {
+    let changed_paths = vec![
+        ".gitignore".to_string(),
+        "docs/milestones/v0.91.7/review/gitignore_guardrail/GITIGNORE_GUARDRAIL_PROOF_4882.md"
+            .to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(4882, &requested_paths, &changed_paths)
+        .expect("explicit gitignore guardrail focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_validation_manager.sh".to_string()));
+
+    let unrelated_err =
+        select_finish_validation_plan_for_finish(4883, &requested_paths, &changed_paths)
+            .expect_err("unrelated issue should not inherit gitignore guardrail allowance");
+    assert!(unrelated_err
+        .to_string()
+        .contains("selector left changed paths without validation-lane coverage"));
+}
+
+#[test]
+fn finish_validation_profile_rejects_unscoped_gitignore_guardrail_slice() {
+    let changed_paths = vec![".gitignore".to_string(), "docs/random-proof.md".to_string()];
+    let requested_paths = changed_paths.join(",");
+
+    let err = select_finish_validation_plan_for_finish(4882, &requested_paths, &changed_paths)
+        .expect_err("unscoped gitignore proof should fail closed");
+    assert!(err
+        .to_string()
+        .contains("selector left changed paths without validation-lane coverage"));
+}
+
+#[test]
 fn finish_validation_profile_classifies_wuji_ddns_installer_slice() {
     let changed_paths = vec![
         "adl/src/cli/pr_cmd/finish_support.rs".to_string(),

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1967,15 +1967,18 @@ fn load_finish_validation_profile_cleans_tempfile_when_profile_only_needs_render
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-finish-load-profile-render-cleanup");
     let tmpdir = repo.join("tmp");
+    let observed_changed_file = tmpdir.join("observed-changed-file.txt");
     fs::create_dir_all(repo.join("adl/tools")).expect("tools dir");
     fs::create_dir_all(&tmpdir).expect("tmp dir");
     write_executable(
         &repo.join("adl/tools/validation_manager.py"),
-        r#"#!/usr/bin/env python3
+        &r#"#!/usr/bin/env python3
 import json
 import sys
 
 changed_files = sys.argv[2]
+with open(r"__OBSERVED_CHANGED_FILE__", "w", encoding="utf-8") as f:
+    f.write(changed_files)
 print(json.dumps({
     "selected_profile": "selected_1_lane_profile",
     "status": "ready_to_run",
@@ -1991,7 +1994,11 @@ print(json.dumps({
     "deferred": [],
     "escalation": {"required": False, "reasons": []},
 }))
-"#,
+"#
+        .replace(
+            "__OBSERVED_CHANGED_FILE__",
+            &observed_changed_file.display().to_string(),
+        ),
     );
 
     let old_tmpdir = env::var("TMPDIR").ok();
@@ -2012,20 +2019,10 @@ print(json.dumps({
     assert!(profile.run[0]
         .command
         .contains("run_pr_fast_test_lane.sh --changed-files"));
-    let retained_manifests = fs::read_dir(&tmpdir)
-        .expect("read temp dir")
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            entry
-                .file_name()
-                .to_string_lossy()
-                .starts_with("finish-validation-profile-")
-        })
-        .filter_map(|entry| fs::read_to_string(entry.path()).ok())
-        .filter(|body| body.contains("adl/src/cli/pr_cmd/doctor.rs"))
-        .count();
-    assert_eq!(
-        retained_manifests, 0,
+    let observed_changed_file_path =
+        fs::read_to_string(&observed_changed_file).expect("observed changed-file path");
+    assert!(
+        !Path::new(observed_changed_file_path.trim()).exists(),
         "render-time profile loads should not retain this test's changed-file manifest"
     );
 }


### PR DESCRIPTION
Closes #4882

## Summary
Implemented a bounded finish-validation mapping for explicit `.gitignore` guardrail changes. Issue `#4882` now has an issue-scoped validation profile for `.gitignore` or `adl/.gitignore` plus review proof packets under `docs/milestones/v0.91.7/review/gitignore_guardrail/`, while unrelated issue numbers and unscoped proof paths still fail closed.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `.adl/v0.91.7/tasks/issue-4882__v0-91-7-tools-validation-map-explicit-gitignore-guardrail-changes-to-a-finish-validation-lane/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish gitignore_guardrail -- --nocapture`
    Verified scoped lane selection and fail-closed behavior.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Summary

- Adds an issue-scoped finish validation plan for explicit .gitignore guardrail changes in #4882.
- Allows only .gitignore / adl/.gitignore plus docs/milestones/v0.91.7/review/gitignore_guardrail/ proof packets.
- Keeps unrelated issue numbers and unscoped .gitignore proof paths fail-closed.

Validation

- cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish gitignore_guardrail -- --nocapture
- git diff --check

Review

- Bounded subagent review found no blocking findings.
- Residual risk: this issue proves selector-level fail-closed behavior; it does not independently re-audit the underlying ci_path_policy or validation_manager scripts.

Closes #4882

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4882__v0-91-7-tools-validation-map-explicit-gitignore-guardrail-changes-to-a-finish-validation-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4882__v0-91-7-tools-validation-map-explicit-gitignore-guardrail-changes-to-a-finish-validation-lane/sor.md
- Idempotency-Key: v0-91-7-tools-validation-add-scoped-gitignore-guardrail-finish-lane-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-v0-91-7-tasks-issue-4882-v0-91-7-tools-validation-map-explicit-gitignore-guardrail-changes-to-a-finish-validation-lane-sip-md-adl-v0-91-7-tasks-issue-4882-v0-91-7-tools-validation-map-explicit-gitignore-guardrail-changes-to-a-finish-validation-lane-sor-md