### PR TITLE
[v0.91.7][resilience][remote] Integrate AWS SSM EC2 and remote-builder resilience

### DIFF
--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -144,7 +144,13 @@ impl AwsRemoteValidationConfig {
             || self.cache_volume_throughput_mbps.is_some()
             || self.cache_volume_device_name.is_some()
             || self.cache_volume_mount_path.is_some();
-        if cache_volume_enabled && self.cache_volume_name.as_deref().unwrap_or("").trim().is_empty()
+        if cache_volume_enabled
+            && self
+                .cache_volume_name
+                .as_deref()
+                .unwrap_or("")
+                .trim()
+                .is_empty()
         {
             return Err(anyhow!(
                 "cache_volume_name is required when cache-volume options are set"
@@ -289,6 +295,58 @@ pub struct LaunchSurfaceCleanupRecord {
     pub notes: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AwsRemoteResilienceFaultClass {
+    None,
+    QuotaBlocked,
+    CapacityUnavailable,
+    AuthPermissionFailure,
+    TransientNetwork,
+    SsmUnavailable,
+    SpotInterrupted,
+    RemoteCommandFailure,
+    CleanupPartialFailure,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AwsRemoteResilienceDisposition {
+    Succeeded,
+    Retryable,
+    Terminal,
+    OperatorActionRequired,
+    Interrupted,
+    CleanupReviewRequired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AwsRemoteResiliencePolicyRecord {
+    pub policy_id: String,
+    pub max_launch_attempts: u32,
+    pub spot_fallback_enabled: bool,
+    pub cleanup_required: bool,
+    pub cost_evidence_required: bool,
+    pub retryable_classes: Vec<AwsRemoteResilienceFaultClass>,
+    pub operator_gated_classes: Vec<AwsRemoteResilienceFaultClass>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AwsRemoteResilienceRecord {
+    pub schema_version: String,
+    pub policy: AwsRemoteResiliencePolicyRecord,
+    pub fault_class: AwsRemoteResilienceFaultClass,
+    pub disposition: AwsRemoteResilienceDisposition,
+    pub retryable: bool,
+    pub cleanup_recorded: bool,
+    pub cleanup_complete: bool,
+    pub cost_evidence_recorded: bool,
+    pub summary: String,
+    pub evidence_refs: Vec<String>,
+    pub operator_action: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SpotTerminationEvidence {
     pub instance_id: String,
@@ -357,6 +415,7 @@ pub struct AwsRemoteValidationSummary {
     pub cleanup: CleanupRecord,
     pub launch_surface: Option<LaunchSurfaceRecord>,
     pub launch_surface_cleanup: Option<LaunchSurfaceCleanupRecord>,
+    pub resilience: AwsRemoteResilienceRecord,
     pub spot_termination_evidence: Option<SpotTerminationEvidence>,
     pub timings: TimingRecord,
     pub remote_summary: Option<RemoteCommandSummary>,
@@ -401,6 +460,191 @@ fn is_valid_spot_interruption_notice(notice: Option<&str>) -> bool {
 fn remote_summary_reports_valid_interruption(summary: &RemoteCommandSummary) -> bool {
     summary.interruption_detected
         && is_valid_spot_interruption_notice(summary.interruption_notice.as_deref())
+}
+
+fn remote_resilience_policy(config: &AwsRemoteValidationConfig) -> AwsRemoteResiliencePolicyRecord {
+    AwsRemoteResiliencePolicyRecord {
+        policy_id: "adl.aws_remote_validation.resilience.v1".to_string(),
+        max_launch_attempts: (config.instance_types.len() as u32).saturating_mul(2),
+        spot_fallback_enabled: true,
+        cleanup_required: true,
+        cost_evidence_required: true,
+        retryable_classes: vec![
+            AwsRemoteResilienceFaultClass::CapacityUnavailable,
+            AwsRemoteResilienceFaultClass::TransientNetwork,
+            AwsRemoteResilienceFaultClass::SsmUnavailable,
+            AwsRemoteResilienceFaultClass::Unknown,
+        ],
+        operator_gated_classes: vec![
+            AwsRemoteResilienceFaultClass::QuotaBlocked,
+            AwsRemoteResilienceFaultClass::AuthPermissionFailure,
+            AwsRemoteResilienceFaultClass::CleanupPartialFailure,
+        ],
+    }
+}
+
+fn classify_aws_remote_failure(
+    status: &RemoteRunStatus,
+    attempts: &[AttemptRecord],
+    cleanup: &CleanupRecord,
+    failure_reason: Option<&str>,
+    remote_summary: Option<&RemoteCommandSummary>,
+    cost_explorer: Option<&CostExplorerSnapshot>,
+    budget_snapshot: Option<&BudgetSnapshot>,
+    config: &AwsRemoteValidationConfig,
+) -> AwsRemoteResilienceRecord {
+    let launched_resource = attempts.iter().any(|attempt| attempt.status == "launched");
+    let cleanup_recorded = cleanup.termination_attempted || !launched_resource;
+    let cleanup_complete = if !launched_resource {
+        true
+    } else {
+        cleanup.termination_error.is_none()
+            && cleanup
+                .final_instance_state
+                .as_deref()
+                .is_some_and(|state| state.eq_ignore_ascii_case("terminated"))
+    };
+    let cost_evidence_recorded = cost_explorer.is_some() || budget_snapshot.is_some();
+    let failure_text = attempts
+        .iter()
+        .map(|attempt| attempt.message.as_str())
+        .chain(failure_reason.into_iter())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let mut evidence_refs = vec![
+        "attempts".to_string(),
+        "cleanup".to_string(),
+        "timings".to_string(),
+    ];
+    if cost_evidence_recorded {
+        evidence_refs.push("cost_or_budget".to_string());
+    }
+    if remote_summary.is_some() {
+        evidence_refs.push("remote_summary".to_string());
+    }
+
+    let (fault_class, disposition, retryable, operator_action, summary) = if !cleanup_complete {
+        (
+            AwsRemoteResilienceFaultClass::CleanupPartialFailure,
+            AwsRemoteResilienceDisposition::CleanupReviewRequired,
+            false,
+            Some(
+                "inspect termination_error/final_instance_state before launching another paid run"
+                    .to_string(),
+            ),
+            "cleanup did not reach a complete terminated state; resource state is recorded for review"
+                .to_string(),
+        )
+    } else if matches!(status, RemoteRunStatus::Passed) {
+        (
+            AwsRemoteResilienceFaultClass::None,
+            AwsRemoteResilienceDisposition::Succeeded,
+            false,
+            None,
+            "remote validation completed and cleanup evidence was recorded".to_string(),
+        )
+    } else if matches!(status, RemoteRunStatus::InterruptedByAws) {
+        (
+            AwsRemoteResilienceFaultClass::SpotInterrupted,
+            AwsRemoteResilienceDisposition::Interrupted,
+            true,
+            None,
+            "AWS Spot interruption was classified separately from implementation failure"
+                .to_string(),
+        )
+    } else if failure_text.contains("maxspotinstancecountexceeded")
+        || failure_text.contains("vcpu limit")
+        || failure_text.contains("vCPU limit")
+        || failure_text.contains("quota")
+        || failure_text.contains("limitexceeded")
+    {
+        (
+            AwsRemoteResilienceFaultClass::QuotaBlocked,
+            AwsRemoteResilienceDisposition::OperatorActionRequired,
+            false,
+            Some("request quota or choose a smaller validation shape before retrying".to_string()),
+            "AWS quota or account limit blocked the remote-builder attempt".to_string(),
+        )
+    } else if failure_text.contains("insufficientinstancecapacity")
+        || failure_text.contains("unfulfillablecapacity")
+        || failure_text.contains("spotmaxpricetoolow")
+        || failure_text.contains("capacity")
+    {
+        (
+            AwsRemoteResilienceFaultClass::CapacityUnavailable,
+            AwsRemoteResilienceDisposition::Retryable,
+            true,
+            None,
+            "AWS capacity was unavailable; retry may use fallback or a different instance type"
+                .to_string(),
+        )
+    } else if failure_text.contains("unauthorized")
+        || failure_text.contains("accessdenied")
+        || failure_text.contains("auth")
+        || failure_text.contains("permission")
+        || failure_text.contains("not authorized")
+    {
+        (
+            AwsRemoteResilienceFaultClass::AuthPermissionFailure,
+            AwsRemoteResilienceDisposition::OperatorActionRequired,
+            false,
+            Some("fix Agent Logic AWS permissions or account binding before retrying".to_string()),
+            "AWS authentication or permission failure requires operator action".to_string(),
+        )
+    } else if failure_text.contains("ssm") {
+        (
+            AwsRemoteResilienceFaultClass::SsmUnavailable,
+            AwsRemoteResilienceDisposition::Retryable,
+            true,
+            None,
+            "SSM readiness or command dispatch failed and is classified separately".to_string(),
+        )
+    } else if failure_text.contains("timeout")
+        || failure_text.contains("timed out")
+        || failure_text.contains("network")
+        || failure_text.contains("connection")
+        || failure_text.contains("temporar")
+    {
+        (
+            AwsRemoteResilienceFaultClass::TransientNetwork,
+            AwsRemoteResilienceDisposition::Retryable,
+            true,
+            None,
+            "transient network or timeout failure is retryable within the bounded policy"
+                .to_string(),
+        )
+    } else if remote_summary.is_some() {
+        (
+            AwsRemoteResilienceFaultClass::RemoteCommandFailure,
+            AwsRemoteResilienceDisposition::Terminal,
+            false,
+            Some("inspect remote command stdout/stderr artifacts before retrying".to_string()),
+            "remote command failed after infrastructure setup succeeded".to_string(),
+        )
+    } else {
+        (
+            AwsRemoteResilienceFaultClass::Unknown,
+            AwsRemoteResilienceDisposition::Retryable,
+            true,
+            None,
+            "remote-builder failure was recorded but did not match a narrower class".to_string(),
+        )
+    };
+
+    AwsRemoteResilienceRecord {
+        schema_version: "adl.aws_remote_validation.resilience.v1".to_string(),
+        policy: remote_resilience_policy(config),
+        fault_class,
+        disposition,
+        retryable,
+        cleanup_recorded,
+        cleanup_complete,
+        cost_evidence_recorded,
+        summary,
+        evidence_refs,
+        operator_action,
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -991,7 +1235,45 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
     {
         status = RemoteRunStatus::Passed;
     }
+    let launched_resource = attempts.iter().any(|attempt| attempt.status == "launched");
+    let cleanup_complete = if !launched_resource {
+        true
+    } else {
+        cleanup.termination_error.is_none()
+            && cleanup
+                .final_instance_state
+                .as_deref()
+                .is_some_and(|state| state.eq_ignore_ascii_case("terminated"))
+    };
+    if !cleanup_complete {
+        status = RemoteRunStatus::Failed;
+        let cleanup_detail = cleanup
+            .termination_error
+            .as_deref()
+            .or(cleanup.final_instance_state.as_deref())
+            .unwrap_or("unknown cleanup state");
+        failure_reason = Some(format!(
+            "cleanup did not reach a complete terminated state: {cleanup_detail}"
+        ));
+        record_event(
+            &mut events,
+            "cleanup",
+            "failed",
+            "cleanup did not reach a complete terminated state; failing remote validation"
+                .to_string(),
+        );
+    }
     let finished_at = Utc::now();
+    let resilience = classify_aws_remote_failure(
+        &status,
+        &attempts,
+        &cleanup,
+        failure_reason.as_deref(),
+        remote_summary.as_ref(),
+        cost_explorer.as_ref(),
+        budget_snapshot.as_ref(),
+        config,
+    );
     let summary = AwsRemoteValidationSummary {
         schema_version: "adl.aws_remote_validation_run.v1".to_string(),
         issue: config.issue,
@@ -1010,6 +1292,7 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
         cleanup,
         launch_surface: None,
         launch_surface_cleanup: None,
+        resilience,
         spot_termination_evidence,
         timings: TimingRecord {
             total_seconds: total_timer.elapsed().as_secs(),
@@ -1509,7 +1792,12 @@ impl LiveAwsRemoteValidationAdapter {
             .tag_specifications(
                 ec2::types::TagSpecification::builder()
                     .resource_type(ec2::types::ResourceType::Volume)
-                    .tags(ec2::types::Tag::builder().key("Name").value(&request.name).build())
+                    .tags(
+                        ec2::types::Tag::builder()
+                            .key("Name")
+                            .value(&request.name)
+                            .build(),
+                    )
                     .build(),
             );
         if let Some(iops) = request.iops {
@@ -2073,7 +2361,10 @@ impl LiveAwsRemoteValidationAdapter {
             let availability_zone = subnet_entry
                 .availability_zone()
                 .ok_or_else(|| {
-                    anyhow!("subnet '{}' did not report an availability zone", config.subnet_id)
+                    anyhow!(
+                        "subnet '{}' did not report an availability zone",
+                        config.subnet_id
+                    )
                 })?
                 .to_string();
             return Ok((vpc_id, config.subnet_id.clone(), availability_zone, notes));
@@ -3236,13 +3527,31 @@ mod tests {
             }),
             terminate_result: Ok(()),
             final_state: Ok(Some("terminated".to_string())),
-            cost: None,
+            cost: Some(CostExplorerSnapshot {
+                start: "2026-07-01".to_string(),
+                end: "2026-07-06".to_string(),
+                service: "Amazon Elastic Compute Cloud - Compute".to_string(),
+                amount: Some("0.03".to_string()),
+                unit: Some("USD".to_string()),
+                delayed_billing_boundary: true,
+                note: "fixture observed cost evidence".to_string(),
+            }),
             budget: None,
         };
         let (summary, events) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
             .await
             .expect("summary");
         assert_eq!(summary.status, RemoteRunStatus::Passed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::None
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::Succeeded
+        );
+        assert!(summary.resilience.cleanup_complete);
+        assert!(summary.resilience.cost_evidence_recorded);
         assert_eq!(
             summary
                 .launch
@@ -3325,6 +3634,244 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn remote_validation_classifies_quota_blockers_as_operator_gated() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-quota-{}",
+            std::process::id()
+        ));
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(0.0),
+                on_demand_vcpu_quota: Some(0.0),
+                notes: vec!["quota fixture".to_string()],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![Err(AwsAdapterError {
+                code: Some("MaxSpotInstanceCountExceeded".to_string()),
+                message: "MaxSpotInstanceCountExceeded: vCPU limit exceeded".to_string(),
+                spot_fallback_permitted: false,
+            })])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-unused".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, _) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::QuotaBlocked
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::OperatorActionRequired
+        );
+        assert!(!summary.resilience.retryable);
+        assert!(summary.resilience.cleanup_recorded);
+        assert!(summary.resilience.cleanup_complete);
+        assert!(summary.resilience.operator_action.is_some());
+    }
+
+    #[tokio::test]
+    async fn remote_validation_classifies_ssm_failures_as_retryable() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-ssm-{}",
+            std::process::id()
+        ));
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![Ok(LaunchResult {
+                instance_id: "i-ssm-timeout".to_string(),
+                initial_state: "pending".to_string(),
+                cache_volume: None,
+            })])),
+            ssm_ready: Err(AwsAdapterError {
+                code: Some("SsmError".to_string()),
+                message: "SSM online wait timed out".to_string(),
+                spot_fallback_permitted: false,
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-unused".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, _) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::SsmUnavailable
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::Retryable
+        );
+        assert!(summary.resilience.retryable);
+        assert!(summary.resilience.cleanup_complete);
+    }
+
+    #[tokio::test]
+    async fn remote_validation_classifies_auth_permission_failures_as_operator_gated() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-auth-{}",
+            std::process::id()
+        ));
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![Err(AwsAdapterError {
+                code: Some("UnauthorizedOperation".to_string()),
+                message: "UnauthorizedOperation: not authorized to RunInstances".to_string(),
+                spot_fallback_permitted: false,
+            })])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-unused".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, _) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::AuthPermissionFailure
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::OperatorActionRequired
+        );
+        assert!(!summary.resilience.retryable);
+        assert!(summary.resilience.operator_action.is_some());
+    }
+
+    #[tokio::test]
+    async fn remote_validation_records_cleanup_partial_failure_even_after_command_success() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-cleanup-{}",
+            std::process::id()
+        ));
+        let stdout = "ADL_AWS_REMOTE_SUMMARY_BEGIN\n{\"status\":\"passed\",\"bootstrap_seconds\":1,\"command_seconds\":2,\"interruption_detected\":false,\"interruption_notice\":null,\"resolved_commit\":\"abc\",\"rustc_version\":null,\"cargo_version\":null,\"sccache_version\":null,\"sccache_degraded\":false,\"sccache_degraded_reason\":null,\"sccache_stats\":null}\nADL_AWS_REMOTE_SUMMARY_END\n";
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![Ok(LaunchResult {
+                instance_id: "i-cleanup".to_string(),
+                initial_state: "pending".to_string(),
+                cache_volume: None,
+            })])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-cleanup".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+            }),
+            terminate_result: Err(AwsAdapterError {
+                code: Some("Ec2Error".to_string()),
+                message: "temporary terminate-instance network failure".to_string(),
+                spot_fallback_permitted: false,
+            }),
+            final_state: Ok(Some("running".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, _) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::CleanupPartialFailure
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::CleanupReviewRequired
+        );
+        assert!(!summary.resilience.cleanup_complete);
+        assert!(summary.resilience.operator_action.is_some());
+        assert!(summary
+            .failure_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cleanup did not reach a complete terminated state"));
+    }
+
+    #[tokio::test]
     async fn remote_validation_classifies_spot_interruptions_truthfully() {
         let tmp = std::env::temp_dir().join(format!(
             "adl-aws-remote-validation-interruption-{}",
@@ -3369,6 +3916,15 @@ mod tests {
             .expect("summary");
 
         assert_eq!(summary.status, RemoteRunStatus::InterruptedByAws);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::SpotInterrupted
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::Interrupted
+        );
+        assert!(summary.resilience.retryable);
         assert!(summary
             .failure_reason
             .as_deref()
@@ -3504,6 +4060,14 @@ mod tests {
             .expect("summary");
 
         assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::RemoteCommandFailure
+        );
+        assert_eq!(
+            summary.resilience.disposition,
+            AwsRemoteResilienceDisposition::Terminal
+        );
         assert!(summary
             .failure_reason
             .as_deref()

--- a/tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs
@@ -12,8 +12,9 @@ mod aws_remote_validation;
 mod observability;
 
 use aws_remote_validation::{
-    run_aws_remote_validation, write_summary_artifacts, AwsRemoteValidationConfig,
-    LiveAwsRemoteValidationAdapter, RemoteRunStatus,
+    run_aws_remote_validation, write_summary_artifacts, AwsRemoteResilienceFaultClass,
+    AwsRemoteValidationConfig, AwsRemoteValidationSummary, LiveAwsRemoteValidationAdapter,
+    RemoteRunStatus,
 };
 use observability::ProgressHeartbeat;
 
@@ -43,6 +44,22 @@ struct ResumeState {
     attempts: Vec<ResumeAttemptRecord>,
     next_action: String,
     final_status: Option<String>,
+}
+
+fn should_retry_remote_validation(
+    summary: &AwsRemoteValidationSummary,
+    provider_interruption_confirmed: bool,
+    attempt_index: u32,
+    max_retries: u32,
+) -> bool {
+    if attempt_index >= max_retries || !summary.resilience.retryable {
+        return false;
+    }
+    if summary.resilience.fault_class == AwsRemoteResilienceFaultClass::SpotInterrupted {
+        return matches!(summary.status, RemoteRunStatus::InterruptedByAws)
+            && provider_interruption_confirmed;
+    }
+    true
 }
 
 struct EnvVarGuard {
@@ -631,9 +648,12 @@ fn main() -> Result<()> {
                     .map(|launch| launch.instance_id.clone()),
                 provider_interruption_confirmed,
             });
-            let should_retry = matches!(summary.status, RemoteRunStatus::InterruptedByAws)
-                && provider_interruption_confirmed
-                && attempt_index < max_spot_retries;
+            let should_retry = should_retry_remote_validation(
+                &summary,
+                provider_interruption_confirmed,
+                attempt_index,
+                max_spot_retries,
+            );
             if should_retry {
                 resume_state.next_action =
                     format!("retry_after_interruption_{}", attempt_index + 1);
@@ -680,6 +700,109 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn retry_summary(
+        status: RemoteRunStatus,
+        fault_class: AwsRemoteResilienceFaultClass,
+        retryable: bool,
+    ) -> AwsRemoteValidationSummary {
+        AwsRemoteValidationSummary {
+            schema_version: "adl.aws_remote_validation_run.v1".to_string(),
+            issue: Some(4782),
+            run_id: "retry-test".to_string(),
+            status,
+            region: "us-west-2".to_string(),
+            profile: Some("agent-logic-admin".to_string()),
+            started_at: "2026-07-06T00:00:00Z".to_string(),
+            finished_at: "2026-07-06T00:00:01Z".to_string(),
+            account_identity: None,
+            quota_snapshot: aws_remote_validation::QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            attempts: vec![],
+            launch: None,
+            cache_volume: None,
+            command: None,
+            cleanup: aws_remote_validation::CleanupRecord {
+                termination_attempted: false,
+                final_instance_state: None,
+                termination_error: None,
+            },
+            launch_surface: None,
+            launch_surface_cleanup: None,
+            resilience: aws_remote_validation::AwsRemoteResilienceRecord {
+                schema_version: "adl.aws_remote_validation.resilience.v1".to_string(),
+                policy: aws_remote_validation::AwsRemoteResiliencePolicyRecord {
+                    policy_id: "test".to_string(),
+                    max_launch_attempts: 2,
+                    spot_fallback_enabled: true,
+                    cleanup_required: true,
+                    cost_evidence_required: true,
+                    retryable_classes: vec![fault_class.clone()],
+                    operator_gated_classes: vec![],
+                },
+                fault_class,
+                disposition: aws_remote_validation::AwsRemoteResilienceDisposition::Retryable,
+                retryable,
+                cleanup_recorded: true,
+                cleanup_complete: true,
+                cost_evidence_recorded: false,
+                summary: "retry test".to_string(),
+                evidence_refs: vec![],
+                operator_action: None,
+            },
+            spot_termination_evidence: None,
+            timings: aws_remote_validation::TimingRecord {
+                total_seconds: 1,
+                launch_seconds: 0,
+                ssm_ready_seconds: None,
+                remote_command_seconds: None,
+                teardown_seconds: None,
+            },
+            remote_summary: None,
+            cost_explorer: None,
+            budget_snapshot: None,
+            expected_max_cost_usd: None,
+            artifact_dir: "artifacts".to_string(),
+            event_log_path: "events.jsonl".to_string(),
+            non_claims: vec![],
+            failure_reason: Some("retry fixture".to_string()),
+        }
+    }
+
+    #[test]
+    fn retry_decision_uses_retryable_resilience_classes() {
+        let summary = retry_summary(
+            RemoteRunStatus::Failed,
+            AwsRemoteResilienceFaultClass::SsmUnavailable,
+            true,
+        );
+        assert!(should_retry_remote_validation(&summary, false, 0, 2));
+        assert!(!should_retry_remote_validation(&summary, false, 2, 2));
+    }
+
+    #[test]
+    fn retry_decision_requires_confirmed_provider_interruption_for_spot() {
+        let summary = retry_summary(
+            RemoteRunStatus::InterruptedByAws,
+            AwsRemoteResilienceFaultClass::SpotInterrupted,
+            true,
+        );
+        assert!(!should_retry_remote_validation(&summary, false, 0, 2));
+        assert!(should_retry_remote_validation(&summary, true, 0, 2));
+    }
+
+    #[test]
+    fn retry_decision_stops_operator_gated_failures() {
+        let summary = retry_summary(
+            RemoteRunStatus::Failed,
+            AwsRemoteResilienceFaultClass::AuthPermissionFailure,
+            false,
+        );
+        assert!(!should_retry_remote_validation(&summary, false, 0, 2));
+    }
 
     fn parse_ok(args: &[&str]) -> ParsedArgs {
         parse_args(


### PR DESCRIPTION
Closes #4782

## Summary
Implemented AWS remote validation resilience recording and retry routing for issue #4782. The remote validation summary now includes a machine-readable resilience record with fault class, disposition, retryability, cleanup state, cost-evidence state, evidence refs, and operator action. The CLI retry loop now uses that resilience retryability for bounded retries while still requiring provider-confirmed Spot interruption for Spot retry. Incomplete cleanup after a launched resource fails the run instead of allowing a passing lane while a paid resource may still be live.

## Artifacts
- `tools/aws_remote_validation/src/aws_remote_validation.rs`
  Added resilience schema, classification, cleanup fail-closed status, observed cost-evidence truth, and focused unit coverage.
- `tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs`
  Added retry-decision helper and tests so retryable resilience classes drive bounded CLI retry.
- `.adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/spp.md`
  Updated ignored lifecycle planning truth for completed execution steps.
- `.adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/vpp.md`
  Updated ignored validation-planning truth for the focused checks selected.
- `.adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/srp.md`
  Records pre-PR review result after subagent review.

## Validation
- Validation commands and their purpose:
  - `cargo check --manifest-path tools/aws_remote_validation/Cargo.toml --bin adl-aws-remote-validation`
    Verified the binary compiles after summary schema and CLI retry changes.
  - `cargo test --manifest-path tools/aws_remote_validation/Cargo.toml --bin adl-aws-remote-validation -- --nocapture`
    Verified the focused test suite: 31 passed, 0 failed.
  - `bash adl/tools/test_run_aws_spot_remote_validation_lane.sh`
    Verified the Spot remote validation lane wrapper remained operational.
  - `bash -n tools/aws_remote_validation/scripts/remote_validation_runner.sh`
    Verified remote runner script syntax.
  - `bash -n tools/aws_remote_validation/scripts/ssh_debug_control.sh`
    Verified SSH debug control script syntax.
  - `git diff --check`
    Verified diff cleanliness.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/spp.md`
    Verified updated SPP card structure.
  - `bash adl/tools/validate_structured_prompt.sh --type vpp --input .adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/vpp.md`
    Verified updated VPP card structure.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4782__v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience/sor.md
- Idempotency-Key: v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience-adl-v0-91-7-tasks-issue-4782-v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience-sip-md-adl-v0-91-7-tasks-issue-4782-v0-91-7-resilience-remote-integrate-aws-ssm-ec2-and-remote-builder-resilience-sor-md