### PR TITLE
[v0.91.7][tools][validation] Make PR fast-lane warm-cache failures residue-free

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -99,9 +99,14 @@ changed_rows() {
     echo "run_pr_fast_test_lane: --base and --head are required unless --changed-files is supplied" >&2
     exit 2
   fi
-  git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" 2>/dev/null \
-    || git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
-    || true
+  if git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" 2>/dev/null; then
+    return
+  fi
+  if git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" 2>/dev/null; then
+    return
+  fi
+  echo "run_pr_fast_test_lane: failed to determine changed files for $BASE_SHA..$HEAD_SHA" >&2
+  exit 2
 }
 
 is_relevant_fast_lane_surface() {
@@ -754,12 +759,29 @@ if [ "$mode" = "full" ] && [ "${ADL_PR_FAST_ALLOW_FULL_NEXTEST:-0}" != "1" ]; th
 fi
 
 cd "$ROOT_DIR/adl"
-ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_TEST_WARM_SOURCE_TARGET:-}" \
-ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
-ADL_RUST_WARM_CACHE_OUTPUT="${ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT:-$ROOT_DIR/adl/pr-fast-test-warm-cache.json}" \
-  bash "$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
+
+warm_cache_output_path="${ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT:-}"
+warm_cache_temp_output=""
+cleanup_warm_cache_temp_output() {
+  if [ -n "$warm_cache_temp_output" ]; then
+    rm -f "$warm_cache_temp_output"
+  fi
+}
+trap cleanup_warm_cache_temp_output EXIT
+
+run_warm_cache() {
+  if [ -z "$warm_cache_output_path" ]; then
+    warm_cache_temp_output="$(mktemp "${TMPDIR:-/tmp}/adl-pr-fast-warm-cache.XXXXXX.json")"
+    warm_cache_output_path="$warm_cache_temp_output"
+  fi
+  ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_TEST_WARM_SOURCE_TARGET:-}" \
+  ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
+  ADL_RUST_WARM_CACHE_OUTPUT="$warm_cache_output_path" \
+    bash "$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
+}
 
 if [ "$mode" = "focused" ] || [ "$mode" = "family" ]; then
+  run_warm_cache
   echo "Running $mode nextest lane: $filter_expression"
   cargo nextest run --status-level all --final-status-level slow -E "$filter_expression"
 elif [ "$mode" = "contract_only" ]; then
@@ -767,6 +789,7 @@ elif [ "$mode" = "contract_only" ]; then
 elif [ "$mode" = "skip" ]; then
   echo "Skipping ordinary nextest lane: no Rust test surface was detected for this PR-fast lane."
 else
+  run_warm_cache
   echo "Running full nextest lane by explicit opt-in: $reason"
   cargo nextest run --status-level all --final-status-level slow
 fi

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -76,6 +76,18 @@ assert_has "$shell_policy_only_output" "mode=skip"
 assert_has "$shell_policy_only_output" "reason=no_rust_surface_detected_for_fast_lane"
 assert_has "$shell_policy_only_output" "rust_surface_count=0"
 assert_has "$shell_policy_only_output" "structural_surface_count=0"
+rm -f "$ROOT/adl/pr-fast-test-warm-cache.json"
+shell_policy_only_run_output="$(bash "$SCRIPT" --changed-files "$shell_policy_only" 2>&1)"
+grep -Fq "Skipping ordinary nextest lane: no Rust test surface was detected for this PR-fast lane." <<<"$shell_policy_only_run_output" || {
+  echo "expected skip lane message" >&2
+  echo "$shell_policy_only_run_output" >&2
+  exit 1
+}
+if [ -e "$ROOT/adl/pr-fast-test-warm-cache.json" ]; then
+  echo "skip/no-op PR-fast lane must not leave default warm-cache residue" >&2
+  cat "$ROOT/adl/pr-fast-test-warm-cache.json" >&2
+  exit 1
+fi
 
 broad_runtime="$TMP/broad_runtime.txt"
 printf 'M\tadl/src/lib.rs\n' >"$broad_runtime"

--- a/adl/tools/test_warm_rust_dependency_cache.py
+++ b/adl/tools/test_warm_rust_dependency_cache.py
@@ -30,7 +30,7 @@ def run_helper(*args: str) -> dict:
     return json.loads(result.stdout)
 
 
-def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+def write_fixture(root: Path, multiline_workspace_members: bool = False) -> tuple[Path, Path, Path]:
     project = root / "project"
     adl = project / "adl"
     member = adl / "crates" / "helper"
@@ -44,6 +44,11 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     build.mkdir(parents=True)
     fingerprint.mkdir(parents=True)
 
+    workspace_members = (
+        "\n".join(["members = [", '  "crates/helper",', "]"])
+        if multiline_workspace_members
+        else 'members = ["crates/helper"]'
+    )
     (adl / "Cargo.toml").write_text(
         "\n".join(
             [
@@ -53,7 +58,7 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                 'edition = "2021"',
                 "",
                 "[workspace]",
-                'members = ["crates/helper"]',
+                workspace_members,
                 "",
             ]
         )
@@ -205,9 +210,119 @@ def test_replace_semantics_are_explicit() -> None:
         assert_same_inode(source_target / "debug" / "deps" / "libserde-abc.rlib", existing)
 
 
+def test_minimal_manifest_fallback_handles_missing_tomllib_path() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        manifest, source_target, dest_target = write_fixture(Path(temp), multiline_workspace_members=True)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--source-target",
+                str(source_target),
+                "--dest-target",
+                str(dest_target),
+                "--manifest-path",
+                str(manifest),
+                "--json",
+            ],
+            env={**os.environ, "ADL_WARM_CACHE_FORCE_MINIMAL_TOML": "1"},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"fallback helper failed with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        summary = json.loads(result.stdout)
+        if summary["status"] != "ok":
+            raise AssertionError(summary)
+        if summary["linked_files"] != 4:
+            raise AssertionError(f"expected fallback parser to preserve dependency linking: {summary}")
+        if (dest_target / "debug" / "deps" / "libhelper-bbb.rlib").exists():
+            raise AssertionError("fallback parser must not treat workspace member artifacts as dependencies")
+
+
+def test_runtime_link_failure_rolls_back_created_links() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        manifest, source_target, dest_target = write_fixture(Path(temp))
+        blocking_parent = dest_target / "debug" / ".fingerprint"
+        blocking_parent.parent.mkdir(parents=True)
+        blocking_parent.write_text("not a directory")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--source-target",
+                str(source_target),
+                "--dest-target",
+                str(dest_target),
+                "--manifest-path",
+                str(manifest),
+                "--json",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 2:
+            raise AssertionError(
+                f"expected helper to report completed_with_errors with exit 2\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        summary = json.loads(result.stdout)
+        if summary["status"] != "completed_with_errors":
+            raise AssertionError(summary)
+        if summary["rolled_back_files"] < 1:
+            raise AssertionError(f"expected successful links to be rolled back after later failure: {summary}")
+        if (dest_target / "debug" / "deps" / "libserde-abc.rlib").exists():
+            raise AssertionError("runtime warm-cache failure must not leave partially linked dependency residue")
+
+
+def test_runtime_link_failure_restores_replaced_destinations() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        manifest, source_target, dest_target = write_fixture(Path(temp))
+        dest_deps = dest_target / "debug" / "deps"
+        dest_deps.mkdir(parents=True)
+        existing = dest_deps / "libserde-abc.rlib"
+        existing.write_text("original destination")
+        blocking_parent = dest_target / "debug" / ".fingerprint"
+        blocking_parent.write_text("not a directory")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--source-target",
+                str(source_target),
+                "--dest-target",
+                str(dest_target),
+                "--manifest-path",
+                str(manifest),
+                "--replace",
+                "--json",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 2:
+            raise AssertionError(
+                f"expected helper to report completed_with_errors with exit 2\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        if existing.read_text() != "original destination":
+            raise AssertionError("runtime warm-cache failure must restore replaced destination files")
+
+
 def main() -> int:
     test_links_only_external_dependency_deps()
     test_replace_semantics_are_explicit()
+    test_minimal_manifest_fallback_handles_missing_tomllib_path()
+    test_runtime_link_failure_rolls_back_created_links()
+    test_runtime_link_failure_restores_replaced_destinations()
     print("PASS test_warm_rust_dependency_cache")
     return 0
 

--- a/adl/tools/warm_rust_dependency_cache.py
+++ b/adl/tools/warm_rust_dependency_cache.py
@@ -11,11 +11,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
-import tomllib
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Iterable
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - covered through forced fallback.
+    tomllib = None
 
 
 @dataclass
@@ -35,6 +40,7 @@ class Summary:
     skipped_existing: int = 0
     skipped_unmatched: int = 0
     errors: int = 0
+    rolled_back_files: int = 0
 
 
 def normalize_target_name(name: str) -> str:
@@ -42,8 +48,52 @@ def normalize_target_name(name: str) -> str:
 
 
 def read_toml(path: Path) -> dict:
+    if tomllib is None or os.environ.get("ADL_WARM_CACHE_FORCE_MINIMAL_TOML") == "1":
+        return read_minimal_cargo_manifest(path)
     with path.open("rb") as handle:
         return tomllib.load(handle)
+
+
+def read_minimal_cargo_manifest(path: Path) -> dict:
+    """Parse the Cargo manifest fields this helper needs when tomllib is absent.
+
+    The warm-cache helper only needs `[package].name` and `[workspace].members`.
+    Keeping this fallback narrow lets Python 3.10-era runners fail less often
+    without pretending to be a general TOML parser.
+    """
+    data: dict[str, dict[str, object]] = {}
+    section = ""
+    in_workspace_members = False
+    workspace_members: list[str] = []
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if in_workspace_members:
+            workspace_members.extend(re.findall(r'"([^"]+)"', line))
+            if "]" in line:
+                data.setdefault("workspace", {})["members"] = workspace_members
+                in_workspace_members = False
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line.strip("[]").strip()
+            data.setdefault(section, {})
+            continue
+        if "=" not in line or section not in {"package", "workspace"}:
+            continue
+        key, value = (part.strip() for part in line.split("=", 1))
+        if section == "package" and key == "name":
+            match = re.fullmatch(r'"([^"]+)"', value)
+            if match:
+                data.setdefault("package", {})["name"] = match.group(1)
+        elif section == "workspace" and key == "members":
+            members = re.findall(r'"([^"]+)"', value)
+            if "[" in value and "]" not in value:
+                workspace_members = members
+                in_workspace_members = True
+            else:
+                data.setdefault("workspace", {})["members"] = members
+    return data
 
 
 def read_workspace_package_names(manifest_path: Path) -> set[str]:
@@ -145,7 +195,13 @@ def same_inode(a: Path, b: Path) -> bool:
         return False
 
 
-def hardlink_file(source: Path, dest: Path, summary: Summary) -> None:
+def hardlink_file(
+    source: Path,
+    dest: Path,
+    summary: Summary,
+    linked_destinations: list[Path],
+    replaced_destinations: list[tuple[Path, Path]],
+) -> None:
     summary.candidate_files += 1
     if dest.exists() or dest.is_symlink():
         if same_inode(source, dest):
@@ -157,15 +213,23 @@ def hardlink_file(source: Path, dest: Path, summary: Summary) -> None:
         if summary.dry_run:
             summary.linked_files += 1
             return
-        dest.unlink()
+        backup = dest.with_name(f"{dest.name}.adl-warm-backup.{os.getpid()}")
+        try:
+            os.replace(dest, backup)
+            replaced_destinations.append((dest, backup))
+        except OSError as exc:
+            summary.errors += 1
+            print(f"error: failed to replace existing destination {dest}: {exc}", file=sys.stderr)
+            return
 
     if summary.dry_run:
         summary.linked_files += 1
         return
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
     try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
         os.link(source, dest)
+        linked_destinations.append(dest)
         summary.linked_files += 1
     except OSError as exc:
         summary.errors += 1
@@ -196,8 +260,35 @@ def warm_cache(args: argparse.Namespace) -> Summary:
         external_target_prefixes=len(prefixes),
     )
 
+    linked_destinations: list[Path] = []
+    replaced_destinations: list[tuple[Path, Path]] = []
     for source, relative in iter_dependency_artifacts(source_profile, prefixes, summary):
-        hardlink_file(source, dest_profile / relative, summary)
+        hardlink_file(source, dest_profile / relative, summary, linked_destinations, replaced_destinations)
+
+    if summary.errors:
+        for dest in reversed(linked_destinations):
+            try:
+                dest.unlink()
+                summary.rolled_back_files += 1
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                print(f"error: failed to roll back linked artifact {dest}: {exc}", file=sys.stderr)
+        for dest, backup in reversed(replaced_destinations):
+            try:
+                if dest.exists() or dest.is_symlink():
+                    dest.unlink()
+                if backup.exists():
+                    os.replace(backup, dest)
+            except OSError as exc:
+                print(f"error: failed to restore replaced artifact {dest}: {exc}", file=sys.stderr)
+    else:
+        for _, backup in replaced_destinations:
+            try:
+                if backup.exists():
+                    backup.unlink()
+            except OSError as exc:
+                print(f"error: failed to remove replacement backup {backup}: {exc}", file=sys.stderr)
 
     return summary
 


### PR DESCRIPTION
Closes #4916

## Summary
Implemented the `#4916` warm-cache residue fix for PR-fast validation. The runner now fails closed when changed-file discovery fails, only runs warm-cache setup when a Rust nextest lane will actually execute, uses temporary default warm-cache output instead of leaving `adl/pr-fast-test-warm-cache.json`, and preserves explicit warm-cache output paths for callers that request them. The warm-cache Python helper now has a narrow fallback parser for Python runtimes without `tomllib` and rolls back partial/replaced hardlinks if a runtime link failure occurs.

## Artifacts
- Updated `adl/tools/run_pr_fast_test_lane.sh` with fail-closed changed-file discovery and residue-free warm-cache invocation.
- Updated `adl/tools/warm_rust_dependency_cache.py` with Python fallback manifest parsing and rollback for partial or replaced hardlinks.
- Updated `adl/tools/test_run_pr_fast_test_lane.sh` with skip/no-op residue regression coverage.
- Updated `adl/tools/test_warm_rust_dependency_cache.py` with fallback-parser and rollback regression coverage.

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/warm_rust_dependency_cache.py adl/tools/test_warm_rust_dependency_cache.py`
    Verified the changed Python helper and focused test file compile.
  - `python3 adl/tools/test_warm_rust_dependency_cache.py`
    Verified dependency artifact selection, explicit replace semantics, Python fallback parsing without `tomllib`, rollback of partial links, and restoration of replaced destinations on failure.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified PR-fast lane selection and no default `adl/pr-fast-test-warm-cache.json` residue after skip/no-op lanes.
  - `bash adl/tools/test_rust_validation_warm_cache.sh`
    Verified shared warm-cache wrapper skip semantics, trusted-source detection, and runner integration.
  - `git diff --check`
    Verified patch whitespace hygiene.
  - `adl pr finish 4916 --no-open` selected validation profile before SOR repair
    Verified `check_no_tracked_adl_issue_record_residue`, `git diff --check`, `cargo fmt --manifest-path adl/Cargo.toml --all --check`, CI path policy contracts, validation-manager contracts, Nessus validation contracts, warm-cache tests, authoritative coverage runner contracts, and PR-fast runner tests before stopping on this SOR bootstrap-state repair.
- Results:
  - PASS for all commands above.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4916__v0-91-7-tools-validation-make-pr-fast-lane-warm-cache-python-runtime-failures-residue-free/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4916__v0-91-7-tools-validation-make-pr-fast-lane-warm-cache-python-runtime-failures-residue-free/sor.md
- Idempotency-Key: v0-91-7-tools-validation-make-pr-fast-lane-warm-cache-failures-residue-free-adl-v0-91-7-tasks-issue-4916-v0-91-7-tools-validation-make-pr-fast-lane-warm-cache-python-runtime-failures-residue-free-sip-md-adl-v0-91-7-tasks-issue-4916-v0-91-7-tools-validation-make-pr-fast-lane-warm-cache-python-runtime-failures-residue-free-sor-md