### PR TITLE
[v0.91.7][WP-06][cache] Improve sccache linker and target-dir setup

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -192,7 +192,9 @@
         "adl/tools/test_run_ci_step_with_log.sh",
         "adl/tools/test_ci_runtime_contracts.sh",
         "adl/tools/setup_required_coverage_toolchain.sh",
-        "adl/tools/test_setup_required_coverage_toolchain.sh"
+        "adl/tools/test_setup_required_coverage_toolchain.sh",
+        "adl/tools/rust_cache_env.sh",
+        "adl/tools/test_rust_cache_env.sh"
       ],
       "path_hints": [
         "adl/config/validation_lane_selector.v0.91.6.json",
@@ -216,7 +218,9 @@
         "adl/tools/test_run_ci_step_with_log.sh",
         "adl/tools/test_ci_runtime_contracts.sh",
         "adl/tools/setup_required_coverage_toolchain.sh",
-        "adl/tools/test_setup_required_coverage_toolchain.sh"
+        "adl/tools/test_setup_required_coverage_toolchain.sh",
+        "adl/tools/rust_cache_env.sh",
+        "adl/tools/test_rust_cache_env.sh"
       ],
       "command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh",
       "run_command": "bash adl/tools/test_ci_path_policy.sh && bash adl/tools/test_ci_runtime_contracts.sh && bash adl/tools/test_select_validation_lanes.sh && bash adl/tools/test_validation_manager.sh && bash adl/tools/test_run_nessus_remote_validation.sh && bash adl/tools/test_run_validation_manager_nessus_lane.sh",

--- a/adl/tools/run_nessus_remote_validation.sh
+++ b/adl/tools/run_nessus_remote_validation.sh
@@ -446,6 +446,19 @@ RESOLVED_COMMIT="$(git -C "$REPO_DIR" rev-parse HEAD)"
 export CARGO_TARGET_DIR="$TARGET_DIR"
 export SCCACHE_DIR
 export RUSTC_WRAPPER="sccache"
+if [[ -z "$BUILDER_IMAGE" ]]; then
+  if [[ -x "$REPO_DIR/adl/tools/rust_cache_env.sh" ]]; then
+    ADL_RUST_CACHE_TARGET_DIR="$TARGET_DIR" \
+    ADL_RUST_CACHE_SCCACHE_DIR="$SCCACHE_DIR" \
+    ADL_RUST_CACHE_REQUIRE_SCCACHE=1 \
+    ADL_RUST_CACHE_USE_LLD=auto \
+      bash "$REPO_DIR/adl/tools/rust_cache_env.sh" write-shell-env "$RUN_ROOT/rust-cache-env.sh"
+    # shellcheck disable=SC1090
+    . "$RUN_ROOT/rust-cache-env.sh"
+  else
+    printf 'skipped: cloned ref does not contain adl/tools/rust_cache_env.sh\n' >"$RUN_ROOT/rust-cache-env.log"
+  fi
+fi
 
 if [[ -n "$BUILDER_IMAGE" ]]; then
   if run_in_builder_image "$COMMAND_STRING" >"$RUN_ROOT/command.log" 2>&1; then

--- a/adl/tools/rust_cache_env.sh
+++ b/adl/tools/rust_cache_env.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: rust_cache_env.sh write-shell-env <path>|write-github-env <path>|print-shell-env
+
+Environment:
+  ADL_RUST_CACHE_TARGET_DIR       Cargo target directory to export.
+  ADL_RUST_CACHE_SCCACHE_DIR      sccache directory. Defaults to $SCCACHE_DIR or $HOME/.cache/sccache.
+  ADL_RUST_CACHE_SCCACHE_SIZE     sccache cache size. Defaults to $SCCACHE_CACHE_SIZE or 2G.
+  ADL_RUST_CACHE_REQUIRE_SCCACHE  Require sccache to be installed. Defaults to 1.
+  ADL_RUST_CACHE_REQUIRE_LLD      Require ld.lld when lld is enabled. Defaults to 0.
+  ADL_RUST_CACHE_USE_LLD          1, 0, or auto. Defaults to auto.
+USAGE
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "rust_cache_env: required command is unavailable: $cmd" >&2
+    exit 1
+  fi
+}
+
+target_dir="${ADL_RUST_CACHE_TARGET_DIR:-${CARGO_TARGET_DIR:-}}"
+sccache_dir="${ADL_RUST_CACHE_SCCACHE_DIR:-${SCCACHE_DIR:-$HOME/.cache/sccache}}"
+sccache_size="${ADL_RUST_CACHE_SCCACHE_SIZE:-${SCCACHE_CACHE_SIZE:-2G}}"
+require_sccache="${ADL_RUST_CACHE_REQUIRE_SCCACHE:-1}"
+require_lld="${ADL_RUST_CACHE_REQUIRE_LLD:-0}"
+use_lld="${ADL_RUST_CACHE_USE_LLD:-auto}"
+
+if [[ "$require_sccache" == "1" ]]; then
+  require_cmd sccache
+fi
+
+lld_enabled=false
+case "$use_lld" in
+  1|true|yes)
+    require_cmd ld.lld
+    lld_enabled=true
+    ;;
+  0|false|no)
+    lld_enabled=false
+    ;;
+  auto)
+    if command -v ld.lld >/dev/null 2>&1; then
+      lld_enabled=true
+    elif [[ "$require_lld" == "1" ]]; then
+      require_cmd ld.lld
+    fi
+    ;;
+  *)
+    echo "rust_cache_env: unsupported ADL_RUST_CACHE_USE_LLD value: $use_lld" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$sccache_dir"
+if [[ -n "$target_dir" ]]; then
+  mkdir -p "$target_dir"
+fi
+
+rustflags="${RUSTFLAGS:-}"
+if [[ "$lld_enabled" == true ]]; then
+  case " $rustflags " in
+    *" -C link-arg=-fuse-ld=lld "*) ;;
+    *) rustflags="${rustflags:+$rustflags }-C link-arg=-fuse-ld=lld" ;;
+  esac
+fi
+
+write_shell_env() {
+  local destination="$1"
+  {
+    if [[ -n "$target_dir" ]]; then
+      printf 'export CARGO_TARGET_DIR=%s\n' "$(shell_quote "$target_dir")"
+    fi
+    printf 'export SCCACHE_DIR=%s\n' "$(shell_quote "$sccache_dir")"
+    printf 'export SCCACHE_CACHE_SIZE=%s\n' "$(shell_quote "$sccache_size")"
+    printf 'export RUSTC_WRAPPER=sccache\n'
+    if [[ "$lld_enabled" == true ]]; then
+      printf 'export RUSTFLAGS=%s\n' "$(shell_quote "$rustflags")"
+      printf 'export RUST_LINK_ACCEL=lld\n'
+    else
+      printf 'export RUST_LINK_ACCEL=default\n'
+    fi
+  } >"$destination"
+}
+
+write_github_env() {
+  local destination="$1"
+  {
+    if [[ -n "$target_dir" ]]; then
+      printf 'CARGO_TARGET_DIR=%s\n' "$target_dir"
+    fi
+    printf 'SCCACHE_DIR=%s\n' "$sccache_dir"
+    printf 'SCCACHE_CACHE_SIZE=%s\n' "$sccache_size"
+    printf 'RUSTC_WRAPPER=sccache\n'
+    if [[ "$lld_enabled" == true ]]; then
+      printf 'RUSTFLAGS=%s\n' "$rustflags"
+      printf 'RUST_LINK_ACCEL=lld\n'
+    else
+      printf 'RUST_LINK_ACCEL=default\n'
+    fi
+  } >>"$destination"
+}
+
+case "${1:-}" in
+  write-shell-env)
+    [[ -n "${2:-}" ]] || { usage; exit 2; }
+    write_shell_env "$2"
+    ;;
+  write-github-env)
+    [[ -n "${2:-}" ]] || { usage; exit 2; }
+    write_github_env "$2"
+    ;;
+  print-shell-env)
+    tmp_file="$(mktemp "${TMPDIR:-/tmp}/adl-rust-cache-env.XXXXXX")"
+    trap 'rm -f "$tmp_file"' EXIT
+    write_shell_env "$tmp_file"
+    cat "$tmp_file"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/adl/tools/setup_aws_codefriend_build_resources.sh
+++ b/adl/tools/setup_aws_codefriend_build_resources.sh
@@ -415,6 +415,8 @@ phases:
           install -m 0755 "/tmp/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" "$HOME/.cargo/bin/sccache"
         fi
       - export RUSTC_WRAPPER=sccache
+      - ADL_RUST_CACHE_TARGET_DIR="/codebuild/adl-target" ADL_RUST_CACHE_SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}" ADL_RUST_CACHE_SCCACHE_SIZE="${SCCACHE_CACHE_SIZE:-20G}" ADL_RUST_CACHE_REQUIRE_SCCACHE=1 ADL_RUST_CACHE_REQUIRE_LLD=1 ADL_RUST_CACHE_USE_LLD=1 bash adl/tools/rust_cache_env.sh write-shell-env /tmp/adl-rust-cache-env.sh
+      - . /tmp/adl-rust-cache-env.sh
       - sccache --start-server || true
       - sccache --zero-stats || true
   build:
@@ -434,6 +436,8 @@ phases:
       - export CARGO_INCREMENTAL=0
       - export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=lld --remap-path-prefix=/codebuild/adl-source=/workspace --remap-path-prefix=/root=/home"
       - export RUSTC_WRAPPER=sccache
+      - ADL_RUST_CACHE_TARGET_DIR="/codebuild/adl-target" ADL_RUST_CACHE_SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}" ADL_RUST_CACHE_SCCACHE_SIZE="${SCCACHE_CACHE_SIZE:-20G}" ADL_RUST_CACHE_REQUIRE_SCCACHE=1 ADL_RUST_CACHE_REQUIRE_LLD=1 ADL_RUST_CACHE_USE_LLD=1 bash adl/tools/rust_cache_env.sh write-shell-env /tmp/adl-rust-cache-env.sh
+      - . /tmp/adl-rust-cache-env.sh
       - test -n "${ADL_CODEFRIEND_BUILD_COMMAND:-}"
       - |
         if [ -z "${ADL_CODEFRIEND_TARGET_CACHE_KEY:-}" ]; then

--- a/adl/tools/setup_required_coverage_toolchain.sh
+++ b/adl/tools/setup_required_coverage_toolchain.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 usage() {
   cat >&2 <<'USAGE'
 usage: setup_required_coverage_toolchain.sh install-lld|configure <github-env>|verify|stats
@@ -52,14 +54,12 @@ configure() {
   fi
   require_cmd sccache
   require_cmd ld.lld
-  mkdir -p "$HOME/.cache/sccache"
-  {
-    echo "SCCACHE_DIR=$HOME/.cache/sccache"
-    echo "SCCACHE_CACHE_SIZE=2G"
-    echo "RUSTC_WRAPPER=sccache"
-    echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld"
-    echo "RUST_LINK_ACCEL=lld"
-  } >> "$github_env"
+  ADL_RUST_CACHE_SCCACHE_DIR="$HOME/.cache/sccache" \
+  ADL_RUST_CACHE_SCCACHE_SIZE=2G \
+  ADL_RUST_CACHE_REQUIRE_SCCACHE=1 \
+  ADL_RUST_CACHE_REQUIRE_LLD=1 \
+  ADL_RUST_CACHE_USE_LLD=1 \
+    bash "$ROOT_DIR/adl/tools/rust_cache_env.sh" write-github-env "$github_env"
   if ! sccache --start-server 2>/tmp/adl-sccache-start.err; then
     if ! sccache --show-stats >/dev/null 2>&1; then
       cat /tmp/adl-sccache-start.err >&2

--- a/adl/tools/test_run_aws_codefriend_build_lane.sh
+++ b/adl/tools/test_run_aws_codefriend_build_lane.sh
@@ -231,6 +231,8 @@ assert_has "$SETUP_SCRIPT" "apt-get install -y lld clang zstd"
 assert_has "$SETUP_SCRIPT" "ld.lld --version"
 assert_has "$SETUP_SCRIPT" "zstd --version"
 assert_has "$SETUP_SCRIPT" 'export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=lld --remap-path-prefix=/codebuild/adl-source=/workspace --remap-path-prefix=/root=/home"'
+assert_has "$SETUP_SCRIPT" "bash adl/tools/rust_cache_env.sh write-shell-env /tmp/adl-rust-cache-env.sh"
+assert_has "$SETUP_SCRIPT" ". /tmp/adl-rust-cache-env.sh"
 assert_has "$SETUP_SCRIPT" 'export ADL_CODEFRIEND_TARGET_CACHE_MODE="${ADL_CODEFRIEND_TARGET_CACHE_MODE:-local}"'
 assert_has "$SETUP_SCRIPT" 'export ADL_CODEFRIEND_TARGET_CACHE_BUCKET="${ADL_CODEFRIEND_TARGET_CACHE_BUCKET:-__SCCACHE_BUCKET__}"'
 assert_has "$SETUP_SCRIPT" 'export ADL_CODEFRIEND_TARGET_CACHE_PREFIX="${ADL_CODEFRIEND_TARGET_CACHE_PREFIX:-__SCCACHE_PREFIX__/target/x86_64-unknown-linux-gnu}"'

--- a/adl/tools/test_rust_cache_env.sh
+++ b/adl/tools/test_rust_cache_env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/adl/tools/rust_cache_env.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fake_bin="$TMP/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --version|--start-server|--zero-stats|--show-stats)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+cat >"$fake_bin/ld.lld" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "LLD fixture"
+EOF
+chmod +x "$fake_bin/"*
+
+shell_env="$TMP/cache-env.sh"
+PATH="$fake_bin:$PATH" \
+ADL_RUST_CACHE_TARGET_DIR="$TMP/target dir" \
+ADL_RUST_CACHE_SCCACHE_DIR="$TMP/sccache dir" \
+ADL_RUST_CACHE_SCCACHE_SIZE=9G \
+ADL_RUST_CACHE_USE_LLD=1 \
+RUSTFLAGS="-C debuginfo=1" \
+  bash "$SCRIPT" write-shell-env "$shell_env"
+
+grep -F "export RUSTC_WRAPPER=sccache" "$shell_env" >/dev/null
+grep -F "export RUST_LINK_ACCEL=lld" "$shell_env" >/dev/null
+
+# shellcheck disable=SC1090
+. "$shell_env"
+[[ "$CARGO_TARGET_DIR" == "$TMP/target dir" ]]
+[[ "$SCCACHE_DIR" == "$TMP/sccache dir" ]]
+[[ "$SCCACHE_CACHE_SIZE" == "9G" ]]
+[[ "$RUSTC_WRAPPER" == "sccache" ]]
+[[ "$RUST_LINK_ACCEL" == "lld" ]]
+[[ "$RUSTFLAGS" == "-C debuginfo=1 -C link-arg=-fuse-ld=lld" ]]
+
+github_env="$TMP/github-env"
+PATH="$fake_bin:$PATH" \
+ADL_RUST_CACHE_TARGET_DIR="$TMP/github-target" \
+ADL_RUST_CACHE_SCCACHE_DIR="$TMP/github-sccache" \
+ADL_RUST_CACHE_USE_LLD=auto \
+  bash "$SCRIPT" write-github-env "$github_env"
+
+grep -Fx "CARGO_TARGET_DIR=$TMP/github-target" "$github_env" >/dev/null
+grep -Fx "SCCACHE_DIR=$TMP/github-sccache" "$github_env" >/dev/null
+grep -Fx "RUSTC_WRAPPER=sccache" "$github_env" >/dev/null
+grep -Fx "RUST_LINK_ACCEL=lld" "$github_env" >/dev/null
+
+no_lld_bin="$TMP/no-lld-bin"
+mkdir -p "$no_lld_bin"
+cp "$fake_bin/sccache" "$no_lld_bin/sccache"
+if PATH="$no_lld_bin:/bin:/usr/bin" ADL_RUST_CACHE_USE_LLD=definitely-not-valid bash "$SCRIPT" print-shell-env >/dev/null 2>"$TMP/no-lld.err"; then
+  echo "expected required lld mode to fail when ld.lld is unavailable" >&2
+  exit 1
+fi
+grep -F "unsupported ADL_RUST_CACHE_USE_LLD value" "$TMP/no-lld.err" >/dev/null
+
+echo "PASS test_rust_cache_env"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -83,6 +83,26 @@ assert surface["resource_class"] == "small"
 assert profile["validation_dag"]["nodes"][0]["proof_role"] == "ci_contract"
 PY
 
+rust_cache_tooling="$TMP/rust-cache-tooling.txt"
+cat >"$rust_cache_tooling" <<'EOF'
+A	adl/tools/rust_cache_env.sh
+A	adl/tools/test_rust_cache_env.sh
+EOF
+bash "$SCRIPT" --changed-files "$rust_cache_tooling" --json >"$TMP/rust-cache-tooling.json"
+python3 - <<'PY' "$TMP/rust-cache-tooling.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["status"] == "ready_to_run"
+assert [item["lane_id"] for item in profile["run"]] == ["ci_path_policy_contracts"]
+surface = profile["behavior_surfaces"][0]
+assert surface["id"] == "ci_contract_ci_path_policy_contracts"
+assert "adl/tools/rust_cache_env.sh" in surface["matched_paths"]
+assert "adl/tools/test_rust_cache_env.sh" in surface["matched_paths"]
+PY
+
 unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
 M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json

--- a/docs/tooling/ADL_BUILDER_IMAGE.md
+++ b/docs/tooling/ADL_BUILDER_IMAGE.md
@@ -133,6 +133,23 @@ may place later runs on a different host, but when the host is reused it is the
 closest CodeBuild analogue to Nessus local target cache and Spot EBS target
 cache.
 
+Use `adl/tools/rust_cache_env.sh` to apply the shared Rust cache and linker
+environment in validation lanes. The helper writes either a shell env file or a
+GitHub env file and normalizes `CARGO_TARGET_DIR`, `SCCACHE_DIR`,
+`SCCACHE_CACHE_SIZE`, `RUSTC_WRAPPER`, and optional `lld` linker flags:
+
+```sh
+ADL_RUST_CACHE_TARGET_DIR=/codebuild/adl-target \
+ADL_RUST_CACHE_REQUIRE_SCCACHE=1 \
+ADL_RUST_CACHE_REQUIRE_LLD=1 \
+ADL_RUST_CACHE_USE_LLD=1 \
+  bash adl/tools/rust_cache_env.sh write-shell-env /tmp/adl-rust-cache-env.sh
+. /tmp/adl-rust-cache-env.sh
+```
+
+The helper is configuration, not proof. Keep lane summaries and
+`sccache --show-stats` as the evidence for whether a run was actually warm.
+
 `ADL_CODEFRIEND_TARGET_CACHE_MODE` defaults to `local`. Set
 `ADL_CODEFRIEND_TARGET_CACHE_MODE=disabled` for cold-cache measurements. The
 buildspec still has an explicit `s3-tar` diagnostic mode, keyed by


### PR DESCRIPTION
Closes #4680

## Summary
Implemented a shared Rust cache/linker environment helper for WP-06 validation lanes. The helper writes shell or GitHub env files for `CARGO_TARGET_DIR`, `SCCACHE_DIR`, `SCCACHE_CACHE_SIZE`, `RUSTC_WRAPPER`, and optional `lld` linker flags. Coverage setup, Nessus remote validation, and generated CodeFriend CodeBuild buildspecs now consume the helper. Operator docs describe the helper and keep `sccache --show-stats` as the evidence surface for warm-cache truth.

No live AWS build was run for this issue. The CodeFriend change is proven through the existing fake-AWS build-lane contract test and generated buildspec assertions.

## Artifacts
- `adl/tools/rust_cache_env.sh`
- `adl/tools/test_rust_cache_env.sh`
- `adl/tools/setup_required_coverage_toolchain.sh`
- `adl/tools/run_nessus_remote_validation.sh`
- `adl/tools/setup_aws_codefriend_build_resources.sh`
- `adl/tools/test_run_aws_codefriend_build_lane.sh`
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/tools/test_validation_manager.sh`
- `docs/tooling/ADL_BUILDER_IMAGE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_rust_cache_env.sh`
    Verified the new helper contract.
  - `bash adl/tools/test_setup_required_coverage_toolchain.sh`
    Verified coverage setup consumes the helper and preserves expected GitHub env values.
  - `bash adl/tools/test_run_nessus_remote_validation.sh`
    Verified Nessus remote validation remains compatible with local executor, builder-image mode, failure summaries, and transport-failure summaries.
  - `bash -n adl/tools/rust_cache_env.sh adl/tools/test_rust_cache_env.sh adl/tools/setup_required_coverage_toolchain.sh adl/tools/run_nessus_remote_validation.sh`
    Verified shell syntax for changed shell scripts.
  - `bash adl/tools/test_run_aws_codefriend_build_lane.sh`
    Verified CodeFriend fake-AWS and generated buildspec contracts.
  - `bash adl/tools/test_validation_manager.sh`
    Verified selector coverage for the new helper/test paths.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified the integrated CI path-policy contract after the cache helper integration.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4680__v0-91-7-wp-06-cache-improve-sccache-linker-and-target-dir-setup/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4680__v0-91-7-wp-06-cache-improve-sccache-linker-and-target-dir-setup/sor.md
- Idempotency-Key: v0-91-7-wp-06-cache-improve-sccache-linker-and-target-dir-setup-adl-v0-91-7-tasks-issue-4680-v0-91-7-wp-06-cache-improve-sccache-linker-and-target-dir-setup-sip-md-adl-v0-91-7-tasks-issue-4680-v0-91-7-wp-06-cache-improve-sccache-linker-and-target-dir-setup-sor-md