### PR TITLE
[v0.91.7][tools][ci] Classify long-running adl-coverage wait states

### DIFF
--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -450,10 +450,67 @@ fn pr_validation_wait_emits_tail_friendly_events_for_terminal_and_pending_states
     assert!(log.contains("wait_reason=checks_not_reported"));
     assert!(log.contains("poll_count=3"));
     assert!(log.contains("next_poll_delay_ms=250"));
+    assert!(log.contains("wait_classification=pr_draft_gate"));
+    assert!(log.contains("wait_classification=checks_not_reported"));
+    assert!(log.contains("next_action=promote_ready_when_draft_gate_is_cleared"));
+    assert!(log.contains("next_action=continue_polling_until_checks_report_or_timeout"));
 
     unsafe {
         std::env::remove_var("ADL_OBSERVABILITY_STDERR");
         std::env::remove_var("ADL_OBSERVABILITY_LOG");
+    }
+}
+
+#[test]
+fn pr_validation_wait_classifies_long_running_required_coverage() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-validation-coverage-wait-log");
+    let log_path = temp.join("events.log");
+    unsafe {
+        std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+        std::env::set_var(
+            "ADL_OBSERVABILITY_LOG",
+            log_path.to_str().expect("log path utf8"),
+        );
+        std::env::set_var("ADL_PR_VALIDATION_ANOMALY_THRESHOLD_MS", "1");
+    }
+    let snapshot = PrValidationSnapshot {
+        pr_number: 4869,
+        commit_sha: "cccccccccccccccccccccccccccccccccccccccc".to_string(),
+        state: "OPEN".to_string(),
+        is_draft: false,
+        checks: vec![PrValidationCheckSnapshot {
+            name: "adl-coverage".to_string(),
+            status: "IN_PROGRESS".to_string(),
+            conclusion: "UNKNOWN".to_string(),
+            job_run_id: "9902".to_string(),
+        }],
+    };
+
+    emit_pr_validation_wait_snapshot(
+        &snapshot,
+        PrValidationDisposition::Pending,
+        Instant::now() - Duration::from_millis(10),
+        7,
+        Duration::from_millis(500),
+    );
+
+    let log = fs::read_to_string(&log_path).expect("read coverage wait log");
+    assert!(log.contains("stage=pr.validation.wait"));
+    assert!(log.contains("result=pending"));
+    assert!(log.contains("check_name=adl-coverage"));
+    assert!(log.contains("job_run_id=9902"));
+    assert!(log.contains("wait_reason=check_state"));
+    assert!(log.contains("wait_classification=long_running_required_coverage"));
+    assert!(log.contains("next_action=continue_waiting_and_inspect_coverage_job"));
+    assert!(log.contains("elapsed_ms="));
+    assert!(log.contains("poll_count=7"));
+    assert!(log.contains("next_poll_delay_ms=500"));
+
+    unsafe {
+        std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+        std::env::remove_var("ADL_OBSERVABILITY_LOG");
+        std::env::remove_var("ADL_PR_VALIDATION_ANOMALY_THRESHOLD_MS");
     }
 }
 

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -1523,11 +1523,15 @@ fn emit_pr_validation_wait_event(
     next_poll_delay: Duration,
 ) {
     let pr_number = snapshot.pr_number.to_string();
-    let elapsed_ms = started.elapsed().as_millis().to_string();
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis().to_string();
     let poll_count = poll_count.to_string();
     let next_poll_delay_ms = next_poll_delay.as_millis().to_string();
     let is_draft = snapshot.is_draft.to_string();
     let wait_reason = pr_validation_wait_reason(snapshot, disposition, check_name);
+    let wait_classification =
+        pr_validation_wait_classification(snapshot, disposition, check_name, elapsed);
+    let next_action = pr_validation_wait_next_action(wait_classification);
     observability::emit_event(
         "adl",
         "pr.validation.wait",
@@ -1540,6 +1544,8 @@ fn emit_pr_validation_wait_event(
             ("pr_state", snapshot.state.as_str()),
             ("is_draft", is_draft.as_str()),
             ("wait_reason", wait_reason),
+            ("wait_classification", wait_classification),
+            ("next_action", next_action),
             ("status", status),
             ("conclusion", conclusion),
             ("elapsed_ms", elapsed_ms.as_str()),
@@ -1562,6 +1568,41 @@ fn pr_validation_wait_reason(
         "aggregate"
     } else {
         "check_state"
+    }
+}
+
+fn pr_validation_wait_classification(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+    check_name: &str,
+    elapsed: Duration,
+) -> &'static str {
+    if snapshot.is_draft && disposition == PrValidationDisposition::Pending {
+        "pr_draft_gate"
+    } else if snapshot.checks.is_empty() && disposition == PrValidationDisposition::Pending {
+        "checks_not_reported"
+    } else if check_name == "adl-coverage"
+        && disposition == PrValidationDisposition::Pending
+        && elapsed >= pr_validation_anomaly_threshold()
+    {
+        "long_running_required_coverage"
+    } else if check_name == "adl-coverage" && disposition == PrValidationDisposition::Pending {
+        "required_coverage_wait"
+    } else if check_name == "aggregate" {
+        "aggregate"
+    } else {
+        "check_state"
+    }
+}
+
+fn pr_validation_wait_next_action(wait_classification: &str) -> &'static str {
+    match wait_classification {
+        "long_running_required_coverage" => "continue_waiting_and_inspect_coverage_job",
+        "required_coverage_wait" => "continue_waiting_required_check",
+        "checks_not_reported" => "continue_polling_until_checks_report_or_timeout",
+        "pr_draft_gate" => "promote_ready_when_draft_gate_is_cleared",
+        "aggregate" => "use_check_level_events_for_next_action",
+        _ => "continue_waiting_required_check",
     }
 }
 


### PR DESCRIPTION
Closes #4905

## Summary
Implemented additive PR-validation wait observability for long-running required `adl-coverage` checks. Pending coverage remains pending/fail-closed; wait events now include `wait_classification` and `next_action` fields so watchers can distinguish ordinary required-check waits from long-running coverage waits with bounded liveness evidence.

## Artifacts
- Updated PR-validation wait event fields in `adl/src/cli/pr_cmd/github/transport.rs`.
- Added focused regression coverage in `adl/src/cli/pr_cmd/github/tests/validation.rs`.
- Updated this SOR with truthful execution, validation, review, and integration state.

## Validation
- Validation commands and their purpose:
  - `ADL_RUST_WARM_CACHE_SOURCE_TARGET=<repo-root>/adl/target ADL_RUST_WARM_CACHE_DEST_TARGET=<repo-root>/.worktrees/adl-wp-4905/adl/target ADL_RUST_WARM_CACHE_MANIFEST_PATH=<repo-root>/.worktrees/adl-wp-4905/adl/Cargo.toml bash adl/tools/rust_validation_warm_cache.sh`
    Warmed Rust dependency artifacts for the issue worktree; build acceleration only, not proof.
  - `git diff --check`
    Verified whitespace hygiene.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl pr_validation_wait -- --nocapture`
    Verified focused PR-validation wait behavior; after an initial stale warmed archive error, the retry passed with 5 focused tests.
  - `ADL_GITHUB_TOKEN_FILE="$HOME/keys/github.token" adl pr finish 4905 --no-open`
    Ran configured finish validation, including GitHub helper tests and pending/failure disposition checks; failed only on stale SOR bootstrap state before this repair.
- Results:
  - PASS for focused implementation validation.
  - PASS for configured finish validation before SOR bootstrap guard.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4905__v0-91-7-tools-ci-classify-long-running-adl-coverage-wait-states-with-bounded-liveness-evidence/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4905__v0-91-7-tools-ci-classify-long-running-adl-coverage-wait-states-with-bounded-liveness-evidence/sor.md
- Idempotency-Key: v0-91-7-tools-ci-classify-long-running-adl-coverage-wait-states-adl-v0-91-7-tasks-issue-4905-v0-91-7-tools-ci-classify-long-running-adl-coverage-wait-states-with-bounded-liveness-evidence-sip-md-adl-v0-91-7-tasks-issue-4905-v0-91-7-tools-ci-classify-long-running-adl-coverage-wait-states-with-bounded-liveness-evidence-sor-md