### PR TITLE
[v0.91.7][WP-06][aws] Reconcile remote builder proof

### DIFF
--- a/docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md
+++ b/docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md
@@ -18,8 +18,9 @@ The operator-selected lane covered:
 - `#4677` CI log archive to S3
 - `#4678` Nessus remote validation-lane consumption
 
-This packet does not claim all WP-06 work is finished. In particular, the
-`#4679` remote-builder work is already split into two bounded follow-up issues:
+This packet's original selected sprint lane did not claim all WP-06 work was
+finished. The `#4679` remote-builder work was split into bounded follow-up
+issues:
 
 - `#4837` finish/integrate the existing AWS Spot EC2 remote lane work
 - `#4838` create and test a GitHub Actions plus AWS CodeFriend build lane
@@ -86,7 +87,21 @@ Local closeout reconciliation is still needed for those closed issues where
 repo-native watch reports `closeout_needed`, but this packet no longer records
 an active failed or waiting-review PR tail for the selected sprint lane.
 
-## Remaining WP-06 Work
+## Remote-Builder Follow-Up Reconciliation
+
+`#4679` is now reconciled by the merged child lanes and the retained
+operational proof packet:
+
+- `#4837` integrated the AWS Spot EC2 remote validation lane.
+- `#4838` integrated the GitHub Actions plus AWS CodeFriend CodeBuild lane.
+- `#4879` added the reusable builder image path and current platform benchmark
+  rows.
+- `#4680` added the shared Rust cache/linker/target-dir helper used by local
+  and remote validation setup.
+- `docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md`
+  records the umbrella proof truth for `#4679`.
+
+## Historical Remaining WP-06 Work
 
 `#4679` has been split before execution:
 
@@ -111,6 +126,5 @@ Earlier evidence to reference when creating those issues:
 - This packet does not claim fresh live SSH Nessus proof for `#4678`; that
   issue proved the wrapper contract locally and referenced prior live Nessus
   evidence.
-- This packet does not claim AWS Spot or GitHub Actions plus AWS CodeFriend
-  build lanes are integrated; it records that follow-up issues `#4837` and
-  `#4838` own those proofs.
+- This packet does not claim Wuji image-backed parity; Wuji is ARM64 and needs
+  an arm64 or multi-arch builder image before that row is valid.

--- a/docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md
+++ b/docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md
@@ -1,0 +1,106 @@
+# Remote Builder Operational Proof for `#4679`
+
+Status: `satisfied_by_merged_child_lanes_with_operational_runbooks`
+Issue: `#4679`
+Date: 2026-07-06
+
+## Scope
+
+Issue `#4679` asked WP-06 to prove EC2 Spot or an alternate remote builder as a
+concrete validation/build path. The work was intentionally split into bounded
+child issues, then reconciled here:
+
+- `#4837`: AWS Spot EC2 remote validation lane with retained warm EBS cache.
+- `#4838`: GitHub Actions plus AWS CodeFriend CodeBuild lane.
+- `#4879`: reusable ADL builder image for CodeBuild, Spot, Nessus, and local
+  Docker-compatible runners.
+- `#4680`: shared Rust cache/linker/target-dir setup for local and remote
+  validation surfaces.
+
+This packet records that `#4679` is satisfied by those merged child lanes and
+the retained proof surfaces below. It does not add a fifth remote-builder lane
+or rerun paid AWS jobs.
+
+## Operational Entry Points
+
+The merged repo now has first-class operator entry points:
+
+- AWS Spot: `adl/tools/run_aws_spot_remote_validation_lane.sh`
+- CodeBuild: `adl/tools/run_aws_codefriend_build_lane.sh`
+- CodeBuild setup: `adl/tools/setup_aws_codefriend_build_resources.sh`
+- Builder image setup/import: `adl/tools/setup_adl_builder_image.sh` and
+  `adl/tools/import_adl_builder_image_from_s3_to_ecr.sh`
+- Nessus remote lane: `adl/tools/run_nessus_remote_validation.sh`
+- Shared benchmark: `adl/tools/run_build_platform_benchmark.sh`
+- Cache/linker helper: `adl/tools/rust_cache_env.sh`
+- Platform routing: `adl/tools/validation_manager.py`
+
+Operator docs:
+
+- `docs/tooling/AWS_SPOT_REMOTE_VALIDATION_LANE.md`
+- `docs/tooling/AWS_CODEFRIEND_BUILD_LANE.md`
+- `docs/tooling/ADL_BUILDER_IMAGE.md`
+- `docs/tooling/BUILD_PLATFORM_BENCHMARKS.md`
+
+## Retained Proof Surfaces
+
+- Spot proof: `docs/milestones/v0.91.7/review/build_throughput/AWS_SPOT_REMOTE_VALIDATION_LANE_4837.md`
+- CodeBuild proof: `docs/milestones/v0.91.7/review/build_throughput/AWS_CODEFRIEND_BUILD_LANE_4838.md`
+- Builder image proof: `docs/milestones/v0.91.7/review/build_throughput/ADL_BUILDER_IMAGE_4879.md`
+- CodeBuild xlarge native S3 cache proof:
+  `docs/milestones/v0.91.7/review/build_throughput/codebuild-xlarge-native-sccache-s3-repeat-20260704.md`
+- Retained Spot hot-cache summary:
+  `docs/milestones/v0.91.7/review/build_throughput/remote_validation_4603/live_run_summary_retry11_agentlogic_hotcache.json`
+
+## Current Platform Results
+
+These are retained WP-06 benchmark rows for the shared workload in
+`adl/tools/run_build_platform_benchmark.sh`.
+
+| Platform | Current proof posture | Build | Test | Total | Operational note |
+| --- | --- | ---: | ---: | ---: | --- |
+| AWS Spot EC2 | fixed builder image plus retained warm EBS cache | 24s | 49s | 73s | Fastest retained AWS/EC2 row; AWS summary recorded cache volume attached and cleanup terminated. |
+| CodeBuild XLARGE | fixed builder image plus stable local target cache and S3 `sccache` | 43-45s | 77-79s | 120-124s | Two repeated live runs completed without manual intervention. |
+| Nessus | fixed builder image plus warm target/cache after disk cleanup | 34.08s | 0.39s | 34.476s | Operator host, no cloud compute cost; not a fresh cold-cache result. |
+| Wuji | no valid image-backed row yet | not_claimed | not_claimed | not_claimed | Wuji is ARM64 and needs an arm64 or multi-arch builder image before parity can be claimed. |
+
+Historical non-image local rows remain useful diagnostics, but current
+remote-builder planning should use the image-backed rows above.
+
+## Routing Truth
+
+`adl/tools/validation_manager.py` now exposes platform candidates for:
+
+- `nessus`, with `remote_target_sccache_warm`
+- `aws_spot`, with `warm_ebs_cache:/mnt/adl-cache`
+- `codebuild`, with `stable_local_target_cache_plus_s3_sccache`
+- `wuji`, rejected until an arm64 builder image exists
+
+The validation manager deliberately dry-runs paid AWS launch surfaces. Live
+Spot and CodeBuild execution still requires explicit operator launch through
+the lane wrappers or manual GitHub workflow dispatch.
+
+## Cost And Safety Boundaries
+
+- AWS work defaults to the Agent Logic business profile `agent-logic-admin`.
+- Spot uses the retained EBS cache volume
+  `adl-aws-remote-validation-cache-volume`; that volume has a standing storage
+  cost while retained.
+- Spot live runs serialize around the retained EBS cache volume and fail closed
+  when the volume is already in use.
+- CodeBuild uses the `adl-codefriend-build` project, the fixed builder image,
+  stable `/codebuild/adl-source` and `/codebuild/adl-target` paths, CodeBuild
+  local target cache, and S3 `sccache`.
+- GitHub Actions paths are manual `workflow_dispatch` only; they do not run on
+  every PR or push.
+
+## Result Truth
+
+`#4679` is satisfied as an umbrella proof by the merged child lanes. The
+repository now has operational remote-builder paths for Spot, CodeBuild, and
+Nessus, plus truthful routing that rejects Wuji image parity until an ARM64
+builder image exists.
+
+No fresh live AWS job was launched for this reconciliation issue. The retained
+proof packets above are the authority for live timings, cache posture, cleanup,
+and cost caveats.

--- a/docs/tooling/BUILD_PLATFORM_BENCHMARKS.md
+++ b/docs/tooling/BUILD_PLATFORM_BENCHMARKS.md
@@ -45,7 +45,7 @@ AWS Spot:
 bash adl/tools/run_aws_spot_remote_validation_lane.sh \
   --run \
   --check-account \
-  --command 'bash adl/tools/run_build_platform_benchmark.sh --platform aws_spot --cache-posture warm_ebs_cache --out .adl/tmp/build-platform-benchmark/aws-spot-ebs/summary.json --artifact-dir .adl/tmp/build-platform-benchmark/aws-spot-ebs' \
+  --command 'bash adl/tools/run_build_platform_benchmark.sh --platform aws_spot --cache-posture fixed_builder_image_warm_ebs_cache --out .adl/tmp/build-platform-benchmark/aws-spot-ebs/summary.json --artifact-dir .adl/tmp/build-platform-benchmark/aws-spot-ebs' \
   --git-ref <branch-or-ref> \
   --out .adl/tmp/aws-spot-remote-validation/<run-id>/summary.json \
   --artifact-dir .adl/tmp/aws-spot-remote-validation/<run-id>/artifacts \
@@ -53,9 +53,20 @@ bash adl/tools/run_aws_spot_remote_validation_lane.sh \
   --json
 ```
 
-CodeBuild is owned by `#4838`. Do not use this `#4837` Spot branch as the
-source of CodeBuild operational commands; merge or inspect the CodeBuild issue
-branch for that lane's wrapper and current proof.
+CodeBuild:
+
+```bash
+ADL_AWS_PROFILE=agent-logic-admin \
+bash adl/tools/run_aws_codefriend_build_lane.sh \
+  --run \
+  --check-account \
+  --wait \
+  --project-name adl-codefriend-build \
+  --source-version <branch-or-ref> \
+  --env ADL_CODEFRIEND_BUILD_COMMAND='bash adl/tools/run_build_platform_benchmark.sh --platform codebuild --cache-posture fixed_builder_image_stable_local_target_cache_s3_sccache --out .adl/tmp/build-platform-benchmark/codebuild-xlarge/summary.json --artifact-dir .adl/tmp/build-platform-benchmark/codebuild-xlarge' \
+  --out .adl/tmp/aws-codefriend-build/<run-id>/summary.json \
+  --artifact-dir .adl/tmp/aws-codefriend-build/<run-id>
+```
 
 ## Cache Postures
 
@@ -65,9 +76,11 @@ branch for that lane's wrapper and current proof.
 - `aws_spot`: retained warm EBS cache mounted at `/mnt/adl-cache`; this volume
   has a standing AWS storage cost and the run summary must show
   `cache_volume.attachment_state: "attached"`.
-- `codebuild`: tracked separately by `#4838`; this `#4837` branch does not
-  contain the CodeBuild wrapper and should not be used as CodeBuild runbook
-  truth.
+- `codebuild`: fixed ECR builder image, stable `/codebuild/adl-source` and
+  `/codebuild/adl-target` paths, CodeBuild local target cache, and S3
+  `sccache`.
+- `wuji`: ARM64; do not claim image-backed parity until an arm64 or multi-arch
+  builder image is published and proven.
 
 ## Current Comparison Snapshot
 
@@ -75,11 +88,11 @@ These are WP-06 working measurements, not universal performance claims:
 
 | Platform | Cache posture | Build | Test | Total | Notes |
 | --- | --- | ---: | ---: | ---: | --- |
-| Wuji | `linked_target_cache_warm` | 11s | 0s | 11s | Shared helper, warm local linked target cache. |
-| Nessus | `remote_target_sccache_warm` | 3s | 0s | 3s | Shared helper through Nessus SSH wrapper with `CC=clang`. |
-| AWS Spot | `warm_ebs_cache` | 65s | 55s | 120s | Accepted warm-EBS proof; summary records `cache_volume.attachment_state: attached`; this run recorded `ssh_debug_degraded`, and the wrapper default was then updated to the matching retained key. |
+| AWS Spot | `fixed_builder_image_warm_ebs_cache` | 24s | 49s | 73s | Fastest retained AWS/EC2 row; run summary recorded retained EBS cache attached and instance cleanup terminated. |
+| CodeBuild XLARGE | `fixed_builder_image_stable_local_target_cache_s3_sccache` | 43-45s | 77-79s | 120-124s | Two repeated live runs completed with stable local target cache and 100% Rust `sccache` hit rate. |
+| Nessus | `fixed_builder_image_warm_target_cache` | 34.08s | 0.39s | 34.476s | Millisecond-timed warm image-backed row after disk cleanup; no cloud compute cost. |
+| Wuji | `linked_target_cache_warm_arm64` | not_claimed | not_claimed | not_claimed | ARM64 host needs an arm64 or multi-arch builder image before image-backed parity can be claimed. |
 | AWS Spot baseline | `no_explicit_ebs_cache` | 221s | 190s | 411s | Historical baseline run completed and cleaned up; not accepted as warm-EBS proof. |
-| CodeBuild | tracked by `#4838` | pending in this branch | pending in this branch | pending in this branch | This Spot branch does not contain the CodeBuild wrapper or current CodeBuild proof. |
 
 Refresh this table only from retained summaries or logs. Do not infer a cache
 posture from command labels alone.


### PR DESCRIPTION
Closes #4679

## Summary
Issue `#4679` was resolved as an umbrella reconciliation/proof issue. The
original remote-builder work was split into child issues and is now satisfied by
merged operational lanes: `#4837` for AWS Spot EC2, `#4838` for CodeBuild,
`#4879` for the reusable builder image, and `#4680` for shared Rust
cache/linker/target-dir setup.

This issue added the retained proof packet
`docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md`,
refreshed `docs/tooling/BUILD_PLATFORM_BENCHMARKS.md`, and corrected the WP-06
sprint packet so it no longer claims Spot or CodeBuild integration is unproven.
No fresh paid AWS job was launched for this reconciliation issue.

## Artifacts
- `docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md`
- `docs/tooling/BUILD_PLATFORM_BENCHMARKS.md`
- `docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md`
- `.adl/v0.91.7/tasks/issue-4679__v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder/sor.md`
- `.adl/v0.91.7/tasks/issue-4679__v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder/srp.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene for docs and card edits.
  - `rg -n "CodeBuild.*pending|pending in this branch|does not claim AWS Spot|does not claim.*CodeFriend|AWS Spot.*not.*integrated|CodeBuild.*not.*integrated" docs/tooling/BUILD_PLATFORM_BENCHMARKS.md docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md`
    Verified stale non-claims and pending CodeBuild wording are absent from the touched proof surfaces.
  - `rg -n "REMOTE_BUILDER_OPERATIONAL_PROOF_4679|fixed_builder_image_warm_ebs_cache|fixed_builder_image_stable_local_target_cache_s3_sccache|arm64 or multi-arch" docs/tooling/BUILD_PLATFORM_BENCHMARKS.md docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md docs/milestones/v0.91.7/review/build_throughput/REMOTE_BUILDER_OPERATIONAL_PROOF_4679.md`
    Verified the replacement proof and current benchmark posture are present.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.7/tasks/issue-4679__v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder/sor.md`
    Verified final SOR contract compliance.

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4679__v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4679__v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder/sor.md
- Idempotency-Key: v0-91-7-wp-06-aws-reconcile-remote-builder-proof-adl-v0-91-7-tasks-issue-4679-v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder-sip-md-adl-v0-91-7-tasks-issue-4679-v0-91-7-wp-06-aws-prove-ec2-spot-or-alternate-remote-builder-sor-md