### PR TITLE
[v0.91.7][tools][finish] Runtime command finish lane expands to unrelated pr_cmd nextest failures

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2072,6 +2072,20 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
         }
         if paths
             .iter()
+            .any(|path| finish_path_needs_runtime_v2_cmd_focused_validation(path))
+        {
+            mode = FinishValidationMode::LargerBinaryFocused;
+            push_finish_validation_command(
+                &mut commands,
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+            );
+            push_finish_validation_command(
+                &mut commands,
+                "cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture",
+            );
+        }
+        if paths
+            .iter()
             .any(|path| finish_path_needs_github_token_focused_validation(path))
         {
             mode = FinishValidationMode::LargerBinaryFocused;
@@ -2657,6 +2671,9 @@ pub(super) fn select_finish_validation_plan_for_finish_with_release_gate_disposi
     }
     if finish_paths_need_github_projection_watch_validation(changed_paths) {
         return Ok(build_github_projection_watch_validation_plan());
+    }
+    if finish_paths_need_runtime_v2_cmd_validation(changed_paths) {
+        return Ok(build_runtime_v2_cmd_validation_plan(changed_paths));
     }
     let changed_paths_need_finish_rust_validation = changed_paths
         .iter()
@@ -3472,6 +3489,43 @@ fn build_github_projection_watch_validation_plan() -> FinishValidationPlan {
     }
 }
 
+fn build_runtime_v2_cmd_validation_plan(changed_paths: &[String]) -> FinishValidationPlan {
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+    ];
+    push_finish_validation_command(
+        &mut commands,
+        "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+    );
+    if changed_paths
+        .iter()
+        .any(|path| finish_path_needs_runtime_v2_cmd_focused_validation(path))
+    {
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture",
+        );
+    }
+    if changed_paths
+        .iter()
+        .any(|path| finish_path_needs_pr_finish_rust_focused_validation(path))
+    {
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation",
+        );
+        push_finish_validation_command(
+            &mut commands,
+            "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation",
+        );
+    }
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
+}
+
 fn finish_issue_needs_unity_observatory_scaffold_validation(
     issue_number: u32,
     changed_paths: &[String],
@@ -3878,6 +3932,23 @@ fn finish_path_needs_pr_cmd_lifecycle_focused_validation(path: &str) -> bool {
         || trimmed.starts_with("adl/src/cli/pr_cmd_cards/")
         || (trimmed.starts_with("adl/src/cli/pr_cmd/")
             && trimmed != "adl/src/cli/pr_cmd/finish_support.rs")
+}
+
+fn finish_path_needs_runtime_v2_cmd_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/cli/runtime_v2_cmd.rs" || trimmed.starts_with("adl/src/cli/runtime_v2_cmd/")
+}
+
+fn finish_paths_need_runtime_v2_cmd_validation(changed_paths: &[String]) -> bool {
+    changed_paths
+        .iter()
+        .any(|path| finish_path_needs_runtime_v2_cmd_focused_validation(path))
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            finish_path_is_docs_only(trimmed)
+                || finish_path_needs_runtime_v2_cmd_focused_validation(trimmed)
+                || finish_path_needs_pr_finish_rust_focused_validation(trimmed)
+        })
 }
 
 fn finish_path_needs_github_token_focused_validation(path: &str) -> bool {
@@ -4877,6 +4948,21 @@ pub(super) fn run_finish_validation_rust(
                             "--bin",
                             "adl",
                             "github_release_octocrab_covers_absent_draft_present_publish",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl",
+                            "cli::runtime_v2_cmd",
+                            "--",
+                            "--nocapture",
                         ],
                     )?;
                 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -2871,6 +2871,83 @@ fn finish_validation_plan_integrated_runtime_soak_runner_hits_helper_classifiers
 }
 
 #[test]
+fn finish_validation_profile_classifies_runtime_v2_cmd_slice_without_pr_cmd_expansion() {
+    let plan = select_finish_validation_plan_for_finish(
+        4848,
+        ".",
+        &[
+            "adl/src/cli/runtime_v2_cmd/commands.rs".to_string(),
+            "adl/src/cli/runtime_v2_cmd/tests.rs".to_string(),
+        ],
+    )
+    .expect("runtime v2 command finish plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture"
+            .to_string()
+    ));
+    assert!(
+        !plan.commands.iter().any(|command| {
+            command.contains("cli::pr_cmd")
+                || command.contains("adl-pr-finish")
+                || command.contains("cargo nextest")
+                || command.contains("run_pr_fast_test_lane.sh")
+                || command.contains("test(commands)")
+                || command.contains("test(tests)")
+        }),
+        "runtime command finish routing must not expand into unrelated pr_cmd/generic fast-lane commands: {:?}",
+        plan.commands
+    );
+}
+
+#[test]
+fn finish_validation_profile_keeps_pr_finish_proof_for_mixed_runtime_v2_cmd_slice() {
+    let plan = select_finish_validation_plan_for_finish(
+        4848,
+        ".",
+        &[
+            "adl/src/cli/runtime_v2_cmd/commands.rs".to_string(),
+            "adl/src/cli/runtime_v2_cmd/tests.rs".to_string(),
+            "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+            "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        ],
+    )
+    .expect("mixed runtime v2 command and finish helper plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation"
+            .to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_helper_paths_run_focused_local_ci_gated_validation"
+            .to_string()
+    ));
+    assert!(
+        !plan.commands.iter().any(|command| {
+            command.contains("cargo nextest")
+                || command.contains("run_pr_fast_test_lane.sh")
+                || command.contains("test(commands)")
+                || command.contains("test(tests)")
+        }),
+        "mixed runtime command finish routing must retain pr-finish proof without generic fast-lane expansion: {:?}",
+        plan.commands
+    );
+}
+
+#[test]
 fn finish_validation_plan_classifies_rust_refactor_slices() {
     let lib_plan = select_finish_validation_plan("adl/src/lib.rs").expect("lib plan");
     assert_eq!(lib_plan.mode, FinishValidationMode::LargerBinaryFocused);


### PR DESCRIPTION
Closes #4848

## Summary
Implemented the runtime-command finish validation routing fix for `#4848`.
Runtime command changes under `adl/src/cli/runtime_v2_cmd/` now get a bounded runtime command validation plan instead of falling through to generic basename-derived fast-lane tokens such as `commands` or `tests`. The fix also preserves pr-finish validation when finish helper files are part of the same change set.

## Artifacts
- Updated finish planner: `adl/src/cli/pr_cmd/finish_support.rs`
- Updated regression tests: `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- No durable generated artifacts were added.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/rust_validation_warm_cache.sh`
    Accelerated Rust validation by hardlinking dependency artifacts; not counted as proof.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_runtime_v2_cmd_slice_without_pr_cmd_expansion -- --exact --nocapture`
    Proved runtime command paths do not select unrelated pr-finish, nextest, or generic fast-lane commands.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::runtime_v2_cmd -- --nocapture`
    Proved the selected runtime command lane runs.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish runtime_v2_cmd -- --nocapture`
    Proved both runtime-only and mixed runtime/pr-finish planner regressions.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting.
  - `git diff --check`
    Verified whitespace hygiene.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Proved the C-SDLC owner lane selected by finish for `finish_support.rs` changes.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    Proved the finish-selected pr-fast focused lane for the actual changed finish planner/test files.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4848__v0-91-7-tools-finish-runtime-command-finish-lane-expands-to-unrelated-pr-cmd-nextest-failures/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4848__v0-91-7-tools-finish-runtime-command-finish-lane-expands-to-unrelated-pr-cmd-nextest-failures/sor.md
- Idempotency-Key: v0-91-7-tools-finish-runtime-command-finish-lane-expands-to-unrelated-pr-cmd-nextest-failures-adl-v0-91-7-tasks-issue-4848-v0-91-7-tools-finish-runtime-command-finish-lane-expands-to-unrelated-pr-cmd-nextest-failures-sip-md-adl-v0-91-7-tasks-issue-4848-v0-91-7-tools-finish-runtime-command-finish-lane-expands-to-unrelated-pr-cmd-nextest-failures-sor-md