### PR TITLE
[v0.91.7][tools][review] Remediate repo-native workflow stabilization sprint review findings

### DIFF
--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -311,6 +311,10 @@ rust_pr_issue_stale_primary_cached_bin() {
 }
 
 rust_pr_subcommand_primary_cached_bin_stale_last_resort() {
+  # Temporary operational compromise: when cargo fallback is intentionally
+  # disabled, allow an observable primary-checkout owner binary so finish/watch
+  # paths do not deadlock on a local rebuild. This is not proof that worktree
+  # Rust control-plane edits are represented by the binary being executed.
   rust_pr_cargo_fallback_allowed && return 1
   local subcommand="${1:-}"
   local root primary_root binary_name candidate

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
@@ -3,14 +3,54 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Any
 
 
-def run_json(cmd: list[str]) -> Any:
-    out = subprocess.check_output(cmd, text=True)
+def run_json(cmd: list[str], *, cwd: Path) -> Any:
+    out = subprocess.check_output(cmd, cwd=cwd, text=True)
     return json.loads(out)
+
+
+def default_issue_command(repo_root: Path, subcommand: str) -> list[str]:
+    issue_binary = repo_root / 'adl' / 'target' / 'debug' / 'adl-issue'
+    if issue_binary.is_file():
+        return [str(issue_binary), subcommand]
+    return ['bash', str(repo_root / 'adl' / 'tools' / 'pr.sh'), 'issue', subcommand]
+
+
+def default_pr_validation_command(repo_root: Path) -> list[str]:
+    validation_binary = repo_root / 'adl' / 'target' / 'debug' / 'adl-pr-validation'
+    if validation_binary.is_file():
+        return [str(validation_binary)]
+    return ['bash', str(repo_root / 'adl' / 'tools' / 'pr.sh'), 'validation']
+
+
+def command_with_override(env_var: str, default: list[str]) -> list[str]:
+    raw = os.environ.get(env_var)
+    if not raw:
+        return default
+    return shlex.split(raw)
+
+
+def issue_view(repo_root: Path, issue_number: int) -> dict[str, Any]:
+    cmd = command_with_override('ADL_SPRINT_ISSUE_VIEW_CMD', default_issue_command(repo_root, 'view'))
+    return run_json(cmd + [str(issue_number), '--json'], cwd=repo_root)
+
+
+def pr_validation(repo_root: Path, pr_url: str) -> dict[str, Any]:
+    cmd = command_with_override('ADL_SPRINT_PR_VALIDATION_CMD', default_pr_validation_command(repo_root))
+    payload = run_json(cmd + [pr_url, '--json'], cwd=repo_root)
+    if 'pr_state' in payload:
+        return {
+            'state': payload.get('pr_state'),
+            'isDraft': payload.get('is_draft'),
+            'url': payload.get('url') or pr_url,
+        }
+    return payload
 
 
 def main() -> int:
@@ -21,6 +61,7 @@ def main() -> int:
     parser.add_argument('--require-match', action='store_true')
     args = parser.parse_args()
 
+    repo_root = Path(args.repo_root).resolve()
     state_path = Path(args.state)
     state = json.loads(state_path.read_text())
     issue_records = state.get('issue_records', [])
@@ -31,26 +72,25 @@ def main() -> int:
     drift = False
 
     for issue_number in issue_numbers:
-        issue = run_json([
-            'gh', 'issue', 'view', str(issue_number), '--json', 'number,state,title,url'
-        ])
+        issue = issue_view(repo_root, issue_number)
         record = next((r for r in issue_records if r.get('issue_number') == issue_number), None)
         if record is None:
             continue
-        record['github_issue_state'] = issue.get('state')
-        if issue.get('state') == 'CLOSED' and record.get('status') not in {'closed_out'}:
+        issue_state = str(issue.get('state', '')).upper()
+        record['github_issue_state'] = issue_state
+        if issue_state == 'CLOSED' and record.get('status') not in {'closed_out'}:
             local_status = record.get('status')
             drift = True
             notes.append(
                 f'issue #{issue_number} is CLOSED on GitHub but local status is {local_status}; '
                 'record_child_issue_closeout.py must run before sprint state can advance'
             )
-        if issue.get('state') == 'OPEN' and record.get('status') == 'closed_out':
+        if issue_state == 'OPEN' and record.get('status') == 'closed_out':
             drift = True
             notes.append(f'issue #{issue_number} is OPEN on GitHub but local status is closed_out')
 
     for pr_url in pr_urls:
-        pr = run_json(['gh', 'pr', 'view', pr_url, '--json', 'state,isDraft,url'])
+        pr = pr_validation(repo_root, pr_url)
         matching = next((r for r in issue_records if r.get('pr_url') == pr_url), None)
         if matching is None:
             continue

--- a/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
@@ -3,8 +3,34 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import subprocess
 from pathlib import Path
+
+
+def default_issue_command(repo_root: Path, subcommand: str) -> list[str]:
+    issue_binary = repo_root / 'adl' / 'target' / 'debug' / 'adl-issue'
+    if issue_binary.is_file():
+        return [str(issue_binary), subcommand]
+    return ['bash', str(repo_root / 'adl' / 'tools' / 'pr.sh'), 'issue', subcommand]
+
+
+def command_with_override(env_var: str, default: list[str]) -> list[str]:
+    raw = os.environ.get(env_var)
+    if not raw:
+        return default
+    return shlex.split(raw)
+
+
+def issue_comment(repo_root: Path, issue_number: int, body: str) -> None:
+    cmd = command_with_override('ADL_SPRINT_ISSUE_COMMENT_CMD', default_issue_command(repo_root, 'comment'))
+    subprocess.check_call(cmd + [str(issue_number), '--body', body], cwd=repo_root)
+
+
+def issue_close(repo_root: Path, issue_number: int) -> None:
+    cmd = command_with_override('ADL_SPRINT_ISSUE_CLOSE_CMD', default_issue_command(repo_root, 'close'))
+    subprocess.check_call(cmd + [str(issue_number), '--reason', 'completed'], cwd=repo_root)
 
 
 def require_child_closeout_truth(state: dict) -> None:
@@ -56,11 +82,13 @@ def require_closeout_artifact(state: dict) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument('--repo-root', default='.')
     parser.add_argument('--state', required=True)
     parser.add_argument('--summary', required=True)
     parser.add_argument('--print-json', action='store_true')
     args = parser.parse_args()
 
+    repo_root = Path(args.repo_root).resolve()
     state_path = Path(args.state)
     state = json.loads(state_path.read_text())
     sprint_issue_number = state.get('sprint_issue_number')
@@ -70,16 +98,8 @@ def main() -> int:
     require_clean_close_boundary(state)
     require_closeout_artifact(state)
 
-    subprocess.check_call(
-        [
-            'gh',
-            'issue',
-            'close',
-            str(sprint_issue_number),
-            '--comment',
-            args.summary,
-        ]
-    )
+    issue_comment(repo_root, sprint_issue_number, args.summary)
+    issue_close(repo_root, sprint_issue_number)
 
     state['sprint_issue_closed'] = True
     state.setdefault('closeout', {})

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -234,7 +234,7 @@ args="$(cat "$TMP_ADL_ARGS")"
   exit 1
 }
 grep -F "freshness=stale_allowed_primary_owner_last_resort" "$finish_last_resort_log" >/dev/null || {
-  echo "assertion failed: stale primary owner-binary last resort should be observable" >&2
+  echo "assertion failed: temporary stale primary owner-binary last resort should be observable" >&2
   cat "$finish_last_resort_log" >&2
   exit 1
 }

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -95,6 +95,18 @@ case "${subcommand}" in
     echo '{"number":3001,"url":"https://github.com/danielbaustin/agent-design-language/issues/3001"}'
     exit 0
     ;;
+  comment)
+    issue_number="$1"
+    shift
+    printf 'issue comment %s %s\n' "${issue_number}" "$*" >> "${FAKE_GH_LOG}"
+    exit 0
+    ;;
+  close)
+    issue_number="$1"
+    shift
+    printf 'issue close %s %s\n' "${issue_number}" "$*" >> "${FAKE_GH_LOG}"
+    exit 0
+    ;;
   *)
     echo "unexpected adl-issue invocation: ${subcommand} $*" >&2
     exit 1
@@ -103,10 +115,23 @@ esac
 ADL_ISSUE_EOF
 chmod +x "${fakebin}/adl-issue"
 
+cat >"${fakebin}/adl-pr-validation" <<'ADL_PR_VALIDATION_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr_ref="$1"
+read -r pr_state pr_draft < "${FAKE_PR_4001_STATE}"
+printf 'pr validation %s %s\n' "${pr_ref}" "$*" >> "${FAKE_GH_LOG}"
+printf '{"pr_number":4001,"pr_state":"%s","is_draft":%s,"url":"https://github.com/danielbaustin/agent-design-language/pull/4001"}\n' "${pr_state}" "${pr_draft}"
+ADL_PR_VALIDATION_EOF
+chmod +x "${fakebin}/adl-pr-validation"
+
 fake_tool_repo="${tmpdir}/fake-tool-repo"
 mkdir -p "${fake_tool_repo}/adl/target/debug"
 cp "${fakebin}/adl-issue" "${fake_tool_repo}/adl/target/debug/adl-issue"
+cp "${fakebin}/adl-pr-validation" "${fake_tool_repo}/adl/target/debug/adl-pr-validation"
 chmod +x "${fake_tool_repo}/adl/target/debug/adl-issue"
+chmod +x "${fake_tool_repo}/adl/target/debug/adl-pr-validation"
 
 export PATH="${fakebin}:${PATH}"
 export FAKE_GH_LOG="${log_path}"
@@ -115,6 +140,9 @@ export FAKE_ISSUE_2828_STATE="${issue_2828_state_file}"
 export FAKE_PR_4001_STATE="${pr_4001_state_file}"
 export ADL_SPRINT_ISSUE_VIEW_CMD="${fakebin}/adl-issue view"
 export ADL_SPRINT_ISSUE_CREATE_CMD="${fakebin}/adl-issue create"
+export ADL_SPRINT_ISSUE_COMMENT_CMD="${fakebin}/adl-issue comment"
+export ADL_SPRINT_ISSUE_CLOSE_CMD="${fakebin}/adl-issue close"
+export ADL_SPRINT_PR_VALIDATION_CMD="${fakebin}/adl-pr-validation"
 
 state_path="${tmpdir}/sprint-state.json"
 fake_repo="${tmpdir}/fake-repo"
@@ -1142,6 +1170,7 @@ grep -Fq 'closure cleanliness: `clean_with_post_sprint_followups`' "${closeout_a
 grep -Fq '#5001' "${closeout_artifact}"
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+  --repo-root "${fake_repo}" \
   --state "${state_path}" \
   --summary "Sprint completed cleanly." >/dev/null
 
@@ -1160,8 +1189,53 @@ if grep -Fq "issue create" "${log_path}"; then
   echo "expected sprint helper bootstrap to avoid raw gh issue create in the default fixture path" >&2
   exit 1
 fi
-grep -Fq "issue close 3001 --comment Sprint completed cleanly." "${log_path}"
-grep -Fq "pr view https://github.com/danielbaustin/agent-design-language/pull/4001 --json state,isDraft,url" "${log_path}"
+grep -Fq "issue comment 3001 --body Sprint completed cleanly." "${log_path}"
+grep -Fq "issue close 3001 --reason completed" "${log_path}"
+grep -Fq "pr validation https://github.com/danielbaustin/agent-design-language/pull/4001" "${log_path}"
+if grep -Fq "pr view " "${log_path}"; then
+  echo "expected sprint truth checks to avoid raw gh pr view" >&2
+  exit 1
+fi
+
+default_state_path="${tmpdir}/sprint-state-default-repo-root.json"
+cp "${state_path}" "${default_state_path}"
+(
+  cd "${tmpdir}"
+  env \
+    -u ADL_SPRINT_ISSUE_VIEW_CMD \
+    -u ADL_SPRINT_ISSUE_COMMENT_CMD \
+    -u ADL_SPRINT_ISSUE_CLOSE_CMD \
+    -u ADL_SPRINT_PR_VALIDATION_CMD \
+    python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
+      --repo-root "${fake_tool_repo}" \
+      --state "${default_state_path}" \
+      --require-match >/dev/null
+)
+
+default_close_state_path="${tmpdir}/sprint-state-default-close.json"
+cp "${state_path}" "${default_close_state_path}"
+python3 - "${default_close_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+state["sprint_issue_closed"] = False
+state.pop("sprint_issue_close_summary", None)
+state.get("closeout", {}).pop("sprint_issue_close_summary", None)
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+(
+  cd "${tmpdir}"
+  env \
+    -u ADL_SPRINT_ISSUE_COMMENT_CMD \
+    -u ADL_SPRINT_ISSUE_CLOSE_CMD \
+    python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+      --repo-root "${fake_tool_repo}" \
+      --state "${default_close_state_path}" \
+      --summary "Default repo-root close path works." >/dev/null
+)
 
 tracked_skill_dir="${tmpdir}/tracked-skill"
 installed_skill_dir="${tmpdir}/installed-skill"

--- a/docs/milestones/v0.91.7/review/V0917_SPRINT_REVIEW_REGISTER.md
+++ b/docs/milestones/v0.91.7/review/V0917_SPRINT_REVIEW_REGISTER.md
@@ -29,6 +29,9 @@ closed out in the issue/card/PR surfaces.
 - WP-08 through WP-20 are not yet release-review-clean.
 - WP-21 is closed; WP-22 and WP-23 remain open for next-milestone review and
   release ceremony.
+- Tools sprint #4806 is closed and has a second-pass remediation packet under
+  #4961 for stale child card truth, tracked review evidence, and remaining
+  sprint-conductor raw-`gh` helper paths.
 
 ## Review Status Table
 
@@ -57,6 +60,12 @@ closed out in the issue/card/PR surfaces.
 | WP-21 | #4648 | closed | none found as a review packet | Next milestone planning closed early relative to open implementation WPs; consume cautiously. | Recheck during WP-22. |
 | WP-22 | #4649 | open | none yet | Next milestone review pass not yet complete. | Review v0.92 planning after WP-21/WP-20 truth is stable. |
 | WP-23 | #4650 | open | none yet | Release ceremony not yet complete. | Run only after all required review/remediation gates are clean or explicitly blocked with operator approval. |
+
+## Tools Sprint Review Records
+
+| Sprint | Status | Review / Remediation Packet | Findings / Residuals | Next Action |
+| --- | --- | --- | --- | --- |
+| Repo-native workflow stabilization | #4806 closed | `docs/milestones/v0.91.7/review/V0917_TOOLS_SPRINT_4806_REVIEW_REMEDIATION_4961.md` | #4961 repairs stale child card truth, tracked release-visible review evidence, remaining sprint-conductor raw-`gh` helper paths, and owner-binary fallback wording. #4950 remains open for watcher `closeout_needed` ambiguity. | Merge #4961, keep #4950 visible until resolved. |
 
 ## WP-05 Repair Record
 

--- a/docs/milestones/v0.91.7/review/V0917_TOOLS_SPRINT_4806_REVIEW_REMEDIATION_4961.md
+++ b/docs/milestones/v0.91.7/review/V0917_TOOLS_SPRINT_4806_REVIEW_REMEDIATION_4961.md
@@ -1,0 +1,81 @@
+# v0.91.7 Tools Sprint #4806 Review Remediation
+
+Status: active_remediation_packet
+
+Issue: #4961
+
+Source sprint: #4806
+
+## Purpose
+
+This packet records the second-pass remediation for the repo-native workflow
+stabilization sprint review. It exists because the first sprint review packet
+was retained under the ignored `.adl/` sprint bundle, while release-tail review
+needs a tracked, release-visible summary of the findings, fixes, residuals, and
+validation.
+
+## Findings And Dispositions
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| Child SRP/SOR truth drift remained after #4806 closeout. Several closed child issues still had top-level `Card Status: ready` or `pr_open` scaffold facts despite merged PRs and closed issues. | P1 | Repaired local `.adl` card truth for #4737, #4738, #4787, #4788, #4713, #4836, and #4806. Terminal records now align with merged or `closed_no_pr` integration truth. |
+| Sprint review evidence was local-only under `.adl/v0.91.7/sprints/...`, making release review depend on ignored records. | P1 | Added this tracked remediation packet as the release-visible review/remediation record. The `.adl` sprint packet remains the detailed local bundle. |
+| Sprint-conductor helper scripts still contained raw `gh` calls for issue close and issue/PR state checks. | P2 | Replaced those paths with repo-native `adl-issue` / `adl-pr-validation` commands, with explicit environment overrides for tests and compatibility. |
+| Sprint review synthesis said no follow-up issue was required even though #4950 remains open for watcher `closeout_needed` ambiguity. | P2 | Updated local sprint synthesis/review truth to keep #4950 visible as an open residual. This issue does not close or supersede #4950. |
+| Owner-binary stale-primary fallback was operationally useful but not final "one repo binary" policy. | P2 | Tightened code/test wording to name the fallback as a temporary observable operational compromise, not final binary architecture proof. |
+
+## Tracked Code Changes
+
+- `adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py`
+  now comments and closes sprint issues through repo-native issue commands
+  instead of raw `gh issue close`.
+- `adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
+  now reads issue state and PR validation through repo-native commands instead
+  of raw `gh issue view` / `gh pr view`.
+- `adl/tools/test_sprint_conductor_helpers.sh` now provides repo-native fake
+  issue and PR-validation binaries and fails if the checked paths invoke raw PR
+  view fallback.
+- `adl/tools/pr_delegate.sh` and
+  `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh` now describe
+  the stale primary owner-binary path as a temporary observable last resort.
+
+## Local Card Repairs
+
+The following ignored local lifecycle records were repaired in the root `.adl`
+bundle for release-tail truth alignment:
+
+- #4737 SOR: completed/merged truth aligned with the already-approved SRP.
+- #4738 SOR: completed/merged truth aligned; stale PR-publication follow-up
+  replaced with merged closeout truth.
+- #4787 SOR: completed/merged truth aligned.
+- #4788 SOR: completed/merged truth aligned.
+- #4713 SOR: completed/merged truth aligned.
+- #4836 SOR: already terminal; checked for stale `pr_open` remnants.
+- #4806 SOR and sprint synthesis: `closed_no_pr` umbrella truth preserved and
+  #4950 kept visible as a residual.
+
+These local records are not staged as tracked release artifacts. This packet is
+the tracked release-visible summary of the repair.
+
+## Validation
+
+Focused validation for #4961:
+
+- `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
+- `bash adl/tools/test_sprint_conductor_helpers.sh`
+- `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
+- `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
+- `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
+- `git diff --check`
+
+The sprint helper contract test includes both explicit-command override coverage
+and a default repo-root resolution check from outside the repository directory.
+
+## Residuals
+
+- #4950 remains open for watcher `closeout_needed` classification ambiguity.
+- This remediation does not implement the final one-binary distribution policy.
+  It only keeps the temporary stale-primary fallback observable and explicitly
+  non-final.
+- This remediation does not claim broad Rust validation or milestone release
+  readiness.


### PR DESCRIPTION
Closes #4961

## Summary
Remediated the second-pass review findings for tools sprint #4806. The change removes remaining raw-`gh` sprint-conductor helper paths from the production scripts, adds repo-native helper fixtures, records the temporary owner-binary fallback as non-final, repairs ignored local card truth for the affected closed child issues, and adds a tracked release-visible remediation packet for the sprint review.

## Artifacts
- Updated `adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py`
- Updated `adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
- Updated `adl/tools/test_sprint_conductor_helpers.sh`
- Updated `adl/tools/pr_delegate.sh`
- Updated `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
- Updated `docs/milestones/v0.91.7/review/V0917_SPRINT_REVIEW_REGISTER.md`
- Added `docs/milestones/v0.91.7/review/V0917_TOOLS_SPRINT_4806_REVIEW_REMEDIATION_4961.md`
- Repaired ignored local `.adl` card/sprint truth in the root bundle for #4737, #4738, #4787, #4788, #4713, #4836, and #4806.

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
    Verified Python syntax for changed sprint-conductor helper scripts.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified repo-native sprint helper paths, including issue comment/close wrappers, PR validation wrapper behavior, and default target-repo resolution from outside the repo with override variables unset.
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
    Verified primary checkout owner-binary behavior and observable temporary stale-primary last-resort wording.
  - `bash adl/tools/test_pr_delegate_cargo_fallback_liveness.sh`
    Verified cargo fallback liveness and timeout behavior remains explicit and bounded.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified workflow-conductor contract tests still pass.
  - `git diff --check`
    Verified whitespace/diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4961__v0-91-7-tools-review-remediate-repo-native-workflow-stabilization-sprint-review-findings/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4961__v0-91-7-tools-review-remediate-repo-native-workflow-stabilization-sprint-review-findings/sor.md
- Idempotency-Key: v0-91-7-tools-review-remediate-repo-native-workflow-stabilization-sprint-review-findings-adl-tools-pr-delegate-sh-adl-tools-skills-sprint-conductor-scripts-check-sprint-truth-py-adl-tools-skills-sprint-conductor-scripts-close-sprint-issue-py-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-adl-tools-test-sprint-conductor-helpers-sh-docs-milestones-v0-91-7-review-v0917-sprint-review-register-md-docs-milestones-v0-91-7-review-v0917-tools-sprint-4806-review-remediation-4961-md-adl-v0-91-7-tasks-issue-4961-v0-91-7-tools-review-remediate-repo-native-workflow-stabilization-sprint-review-findings-sip-md-adl-v0-91-7-tasks-issue-4961-v0-91-7-tools-review-remediate-repo-native-workflow-stabilization-sprint-review-findings-sor-md