### PR TITLE
[v0.91.7][tools][sprint] Remove remaining raw gh usage from sprint-conductor helpers

### DIFF
--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -80,6 +80,13 @@ Within this bundle, the operational details live in:
 - `scripts/write_sprint_closeout_artifact.py`
 - `scripts/validate_review_subagent_policy.py`
 
+GitHub transport boundary:
+- sprint-conductor helper scripts must use repo-native ADL issue/PR surfaces, not raw `gh` calls
+- `check_sprint_truth.py` uses `adl-issue view` and `adl-pr-validation` by default
+- `close_sprint_issue.py` uses `adl-issue comment` and `adl-issue close` by default
+- tests may override those covered surfaces with `ADL_SPRINT_ISSUE_VIEW_CMD`, `ADL_SPRINT_PR_VALIDATION_CMD`, `ADL_SPRINT_ISSUE_CREATE_CMD`, `ADL_SPRINT_ISSUE_COMMENT_CMD`, or `ADL_SPRINT_ISSUE_CLOSE_CMD`
+
+
 ## Entry Conditions
 
 Use this skill when all of the following are true:

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
@@ -10,9 +10,22 @@ from pathlib import Path
 from typing import Any
 
 
+def first_json_payload(text: str) -> Any:
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char not in '{[':
+            continue
+        try:
+            payload, _ = decoder.raw_decode(text[index:])
+            return payload
+        except json.JSONDecodeError:
+            continue
+    raise ValueError('command did not emit a JSON payload')
+
+
 def run_json(cmd: list[str], *, cwd: Path) -> Any:
     out = subprocess.check_output(cmd, cwd=cwd, text=True)
-    return json.loads(out)
+    return first_json_payload(out)
 
 
 def default_issue_command(repo_root: Path, subcommand: str) -> list[str]:
@@ -94,6 +107,10 @@ def main() -> int:
         matching = next((r for r in issue_records if r.get('pr_url') == pr_url), None)
         if matching is None:
             continue
+        live_url = pr.get('url') or pr_url
+        if live_url != pr_url:
+            drift = True
+            notes.append(f'PR URL drift for {pr_url}; repo-native validation returned {live_url}')
         matching['github_pr_state'] = pr.get('state')
         matching['github_pr_is_draft'] = pr.get('isDraft')
 

--- a/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
@@ -67,6 +67,15 @@ def require_clean_close_boundary(state: dict) -> None:
         )
 
 
+def require_ready_to_close(state: dict) -> None:
+    readiness = (state.get('closeout') or {}).get('readiness')
+    if readiness != 'ready_to_close':
+        raise SystemExit(
+            'Cannot close sprint-management issue because closeout readiness is not ready_to_close; '
+            f'actual: {readiness}. Run check_sprint_closeout_readiness.py first.'
+        )
+
+
 def require_closeout_artifact(state: dict) -> None:
     closeout = state.get('closeout') or {}
     closeout_artifact_path = closeout.get('closeout_artifact_path')
@@ -97,6 +106,7 @@ def main() -> int:
     require_child_closeout_truth(state)
     require_clean_close_boundary(state)
     require_closeout_artifact(state)
+    require_ready_to_close(state)
 
     issue_comment(repo_root, sprint_issue_number, args.summary)
     issue_close(repo_root, sprint_issue_number)

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1169,6 +1169,37 @@ python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/write_sprint_clo
 grep -Fq 'closure cleanliness: `clean_with_post_sprint_followups`' "${closeout_artifact}"
 grep -Fq '#5001' "${closeout_artifact}"
 
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+state = json.loads(path.read_text())
+state["review"] = {
+    "status": "done",
+    "packet_path": "docs/review/packet.md",
+    "code_review_path": "docs/review/code.md",
+    "test_review_path": "docs/review/tests.md",
+    "synthesis_path": "docs/review/synthesis.md",
+}
+state["coverage"] = {
+    "source": "existing_quality_gate",
+    "summary": "Existing quality gate reused for sprint closeout.",
+}
+state["rust_tracker"] = {
+    "source": "existing_quality_gate",
+    "watch_count": 3,
+    "review_count": 2,
+    "rationale_count": 1,
+}
+path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+PY
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_closeout_readiness.py" \
+  --state "${state_path}" \
+  >/dev/null
+
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
   --repo-root "${fake_repo}" \
   --state "${state_path}" \
@@ -2540,3 +2571,70 @@ fallback_only_summary = issue_goal_metrics.summarize_issue_goal_metrics(fallback
 assert fallback_only_summary["goal_instance_count"] == 2
 assert fallback_only_summary["cumulative_metrics"]["goal_instance_count"] == 2
 PY
+
+# Default repo-native GitHub helper surfaces should work without raw `gh` fallbacks
+# and should tolerate human observability lines before JSON payloads.
+no_gh_repo="${tmpdir}/no-gh-repo"
+no_gh_state="${tmpdir}/no-gh-state.json"
+no_gh_log="${tmpdir}/no-gh-calls.log"
+no_gh_issue_state="${tmpdir}/no-gh-issue-state"
+mkdir -p "${no_gh_repo}/adl/tools" "${no_gh_repo}/adl/target/debug"
+printf 'CLOSED\n' > "${no_gh_issue_state}"
+cat > "${no_gh_repo}/adl/target/debug/adl-issue" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+subcommand="$1"
+shift
+case "${subcommand}" in
+  view)
+    issue_number="$1"
+    state="$(cat "${ISSUE_STATE_FILE}")"
+    echo 'adl_event schema=adl.observability.event.v1 command=fake issue=view'
+    printf '{"number":%s,"state":"%s","title":"child","url":"https://example.test/issues/%s"}\n' "${issue_number}" "${state}" "${issue_number}"
+    ;;
+  comment)
+    printf 'issue-comment %s %s\n' "$1" "${*:2}" >> "${CALL_LOG}"
+    ;;
+  close)
+    printf 'issue-close %s %s\n' "$1" "${*:2}" >> "${CALL_LOG}"
+    ;;
+  *) exit 9 ;;
+esac
+SH
+chmod +x "${no_gh_repo}/adl/target/debug/adl-issue"
+cat > "${no_gh_repo}/adl/target/debug/adl-pr-validation" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+pr_url="$1"
+printf 'pr-validation %s\n' "${pr_url}" >> "${CALL_LOG}"
+echo 'adl_event schema=adl.observability.event.v1 command=fake pr-validation=started'
+printf '{"pr_state":"MERGED","is_draft":false,"url":"%s"}\n' "${pr_url}"
+SH
+chmod +x "${no_gh_repo}/adl/target/debug/adl-pr-validation"
+cat > "${no_gh_state}" <<JSON
+{
+  "sprint_issue_number": 3001,
+  "ordered_issue_numbers": [2827],
+  "issue_records": [{"issue_number": 2827, "status": "closed_out", "pr_url": "https://example.test/pr/1"}],
+  "blocked_issue_number": null,
+  "deferred_issue_numbers": [],
+  "follow_up_issues": [],
+  "closeout": {"closeout_artifact_path": "${tmpdir}/no-gh-closeout.md", "readiness": "ready_to_close"}
+}
+JSON
+touch "${tmpdir}/no-gh-closeout.md"
+(
+  unset ADL_SPRINT_ISSUE_VIEW_CMD ADL_SPRINT_PR_VALIDATION_CMD ADL_SPRINT_ISSUE_COMMENT_CMD ADL_SPRINT_ISSUE_CLOSE_CMD
+  export ISSUE_STATE_FILE="${no_gh_issue_state}"
+  export CALL_LOG="${no_gh_log}"
+  python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" --repo-root "${no_gh_repo}" --state "${no_gh_state}" --require-match >/dev/null
+  python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" --repo-root "${no_gh_repo}" --state "${no_gh_state}" --summary "done" >/dev/null
+)
+grep -Fq 'pr-validation https://example.test/pr/1' "${no_gh_log}"
+grep -Fq 'issue-comment 3001 --body done' "${no_gh_log}"
+grep -Fq 'issue-close 3001 --reason completed' "${no_gh_log}"
+if grep -Eq '(^| )gh( |$)|gh issue|gh pr|pr view|^issue close 3001' "${no_gh_log}"; then
+  echo "raw gh-like fallback detected" >&2
+  cat "${no_gh_log}" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #4960

## Summary
Removed remaining raw `gh` subprocess calls from the sprint-conductor helper scripts in scope. `check_sprint_truth.py` now resolves issue truth through repo-native `adl-issue view` commands and PR truth through repo-native `adl-pr-validation` output. `close_sprint_issue.py` now resolves sprint issue comments and closure through repo-native `adl-issue comment` / `adl-issue close` commands. The focused sprint-conductor fixture and dedicated no-gh helper test prove these paths through deterministic fake repo-native commands, mixed-output JSON handling, default command construction, closeout readiness enforcement, PR URL drift detection, and raw `gh pr view` / `gh issue close` guardrails.

## Artifacts
- Updated helper: `adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
- Updated helper: `adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py`
- Updated focused fixture: `adl/tools/test_sprint_conductor_helpers.sh`
- Updated skill docs: `adl/tools/skills/sprint-conductor/SKILL.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    `Focused proof for sprint-conductor helper behavior and repo-native GitHub transport fixtures.`
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    `Shared conductor policy regression proof.`
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
    `Python syntax proof for edited helper scripts.`
  - `! rg -n "'gh'|\\[\\s*\\\"gh\\\"|gh issue|gh pr" adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py`
    `Focused guard proving no raw gh command blocks remain in the in-scope helper scripts.`
  - `git diff --check`
    `Diff hygiene proof.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4960__v0-91-7-tools-sprint-remove-remaining-raw-gh-usage-from-sprint-conductor-helpers/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4960__v0-91-7-tools-sprint-remove-remaining-raw-gh-usage-from-sprint-conductor-helpers/sor.md
- Idempotency-Key: v0-91-7-tools-sprint-remove-remaining-raw-gh-usage-from-sprint-conductor-helpers-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sprint-conductor-scripts-check-sprint-truth-py-adl-tools-skills-sprint-conductor-scripts-close-sprint-issue-py-adl-tools-test-sprint-conductor-helpers-sh-adl-v0-91-7-tasks-issue-4960-v0-91-7-tools-sprint-remove-remaining-raw-gh-usage-from-sprint-conductor-helpers-sip-md-adl-v0-91-7-tasks-issue-4960-v0-91-7-tools-sprint-remove-remaining-raw-gh-usage-from-sprint-conductor-helpers-sor-md