### PR TITLE
[v0.91.7][WP-07][observability][csm] Add CSM runtime observability API endpoints

### DIFF
--- a/adl/src/cli/csm_cmd.rs
+++ b/adl/src/cli/csm_cmd.rs
@@ -8,6 +8,7 @@ use ::adl::csm_continuity_capsule::{
     ContinuityRestoreOptions, ContinuityStageOptions,
 };
 use ::adl::csm_observatory::{write_observatory_outputs, ObservatoryFormat};
+use ::adl::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 
 pub(crate) enum CsmDispatchMode {
     StandaloneRuntime,
@@ -24,7 +25,7 @@ pub(crate) fn real_csm_standalone(args: &[String]) -> Result<()> {
 
 fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
     let Some(cmd) = args.first().map(|value| value.as_str()) else {
-        eprintln!("csm requires subcommand: daemon | service | continuity | observatory");
+        eprintln!("csm requires subcommand: daemon | service | continuity | api | observatory");
         std::process::exit(2);
     };
 
@@ -47,6 +48,12 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
                 "csm continuity is owned by the standalone csm runtime binary; use `csm continuity`, not `adl csm continuity`"
             )),
         },
+        "api" => match mode {
+            CsmDispatchMode::StandaloneRuntime => real_api(&args[1..]),
+            CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
+                "csm api is owned by the standalone csm runtime binary; use `csm api`, not `adl csm api`"
+            )),
+        },
         "observatory" => real_observatory(&args[1..]),
         "--help" | "-h" => {
             println!("{}", csm_usage());
@@ -54,11 +61,99 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
         }
         other => {
             eprintln!(
-                "unknown csm subcommand: {other} (expected daemon, service, continuity, or observatory)"
+                "unknown csm subcommand: {other} (expected daemon, service, continuity, api, or observatory)"
             );
             std::process::exit(2);
         }
     }
+}
+
+fn real_api(args: &[String]) -> Result<()> {
+    let Some(cmd) = args.first().map(|value| value.as_str()) else {
+        eprintln!("csm api requires subcommand: serve");
+        std::process::exit(2);
+    };
+    match cmd {
+        "serve" => real_api_serve(&args[1..]),
+        "--help" | "-h" => {
+            println!("{}", csm_usage());
+            Ok(())
+        }
+        other => {
+            eprintln!("unknown csm api subcommand: {other} (expected serve)");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn real_api_serve(args: &[String]) -> Result<()> {
+    let mut spec: Option<PathBuf> = None;
+    let mut bind = "127.0.0.1:0".to_string();
+    let mut max_requests = 1usize;
+    let mut idle_timeout_ms: Option<u64> = None;
+    let mut otel_status_path: Option<PathBuf> = None;
+    let mut otel_log_path: Option<PathBuf> = None;
+    let mut json_output = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--spec" => {
+                spec = Some(PathBuf::from(required_value(args, i, "--spec")?));
+                i += 1;
+            }
+            "--bind" => {
+                bind = required_value(args, i, "--bind")?.to_string();
+                i += 1;
+            }
+            "--max-requests" => {
+                max_requests = required_value(args, i, "--max-requests")?
+                    .parse()
+                    .context("csm api serve --max-requests must be an integer")?;
+                i += 1;
+            }
+            "--once" => {
+                max_requests = 1;
+            }
+            "--idle-timeout-ms" => {
+                idle_timeout_ms = Some(
+                    required_value(args, i, "--idle-timeout-ms")?
+                        .parse()
+                        .context("csm api serve --idle-timeout-ms must be an integer")?,
+                );
+                i += 1;
+            }
+            "--otel-status" => {
+                otel_status_path = Some(PathBuf::from(required_value(args, i, "--otel-status")?));
+                i += 1;
+            }
+            "--otel-log" => {
+                otel_log_path = Some(PathBuf::from(required_value(args, i, "--otel-log")?));
+                i += 1;
+            }
+            "--json" => json_output = true,
+            "--help" | "-h" => {
+                println!("{}", csm_usage());
+                return Ok(());
+            }
+            other => {
+                eprintln!("unknown csm api serve arg: {other}");
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+    let result = serve_runtime_api(CsmRuntimeApiOptions {
+        spec_path: spec.context("csm api serve requires --spec <agent-spec.yaml>")?,
+        bind,
+        max_requests,
+        idle_timeout_ms,
+        otel_status_path,
+        otel_log_path,
+    })?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    }
+    Ok(())
 }
 
 fn real_continuity(args: &[String]) -> Result<()> {
@@ -303,6 +398,7 @@ pub(crate) fn csm_usage() -> &'static str {
   csm daemon --spec <agent-spec.yaml> [--max-restarts <n>] [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--recover-stale-lease] [--no-sleep] [--json]
   csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--json]
   csm service start|status|stop|remove [--service-root <dir>] [--json]
+  csm api serve --spec <agent-spec.yaml> [--bind 127.0.0.1:0] [--once|--max-requests <n>] [--idle-timeout-ms <n>] [--otel-status <path>] [--otel-log <path>] [--json]
   csm continuity capture --spec <agent-spec.yaml> --out <bundle-dir> [--source-host wuji] [--target-host ec2-staging|ec2|local] [--json]
   csm continuity stage --bundle <bundle-dir> --out <stage-dir> [--target-host ec2-staging|ec2|local] [--json]
   csm continuity restore --bundle <bundle-dir> --out <runtime-dir> [--target-host ec2-staging|ec2|local] [--json]
@@ -313,6 +409,7 @@ Semantics:
   - csm is the dedicated runtime owner binary.
   - csm daemon owns long-lived runtime execution, partial checkpoints, restart accounting, recoverable terminal state, and runtime observability.
   - csm service owns host service-manager installation/status around csm daemon; launchd is the primary macOS target and local mode is a bounded proof fallback.
+  - csm api exposes local-by-default /status, /health, /ready, /metrics, and /events endpoints from retained runtime artifacts without leaking host-private paths or secrets.
   - csm continuity captures, stages, and restores portable continuity capsules with secrets excluded and host bindings explicit.
   - csm daemon emits ADL_OBSERVABILITY_LOG, ADL_OTEL_LOG, and ADL_OTEL_STATUS records through the shared observability contract.
   - Read-only CSM Observatory inspection.

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -450,11 +450,10 @@ fn classify_health(
     daemon_status: &Value,
     checkpoint_freshness: &Value,
 ) -> &'static str {
-    if matches!(state, AgentStatusState::Failed) {
-        "degraded"
-    } else if daemon_status.get("status").and_then(Value::as_str) != Some("serialized") {
-        "degraded"
-    } else if checkpoint_freshness.get("status").and_then(Value::as_str) == Some("stale") {
+    let degraded = matches!(state, AgentStatusState::Failed)
+        || daemon_status.get("status").and_then(Value::as_str) != Some("serialized")
+        || checkpoint_freshness.get("status").and_then(Value::as_str) == Some("stale");
+    if degraded {
         "degraded"
     } else {
         "healthy"
@@ -466,14 +465,12 @@ fn classify_ready(
     daemon_status: &Value,
     continuity_checkpoint: &Value,
 ) -> &'static str {
-    if matches!(
+    let not_ready = matches!(
         state,
         AgentStatusState::Failed | AgentStatusState::Leased | AgentStatusState::RunningCycle
-    ) {
-        "not_ready"
-    } else if daemon_status.get("status").and_then(Value::as_str) != Some("serialized") {
-        "not_ready"
-    } else if continuity_checkpoint.get("status").and_then(Value::as_str) != Some("serialized") {
+    ) || daemon_status.get("status").and_then(Value::as_str) != Some("serialized")
+        || continuity_checkpoint.get("status").and_then(Value::as_str) != Some("serialized");
+    if not_ready {
         "not_ready"
     } else {
         "ready"

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -1,0 +1,725 @@
+//! Local CSM runtime observability API.
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::long_lived_agent::{load_spec, AgentStatusState, LoadedAgentSpec, StatusRecord};
+
+pub const CSM_RUNTIME_API_SCHEMA: &str = "adl.csm.runtime_api.v1";
+pub const CSM_RUNTIME_API_STATUS_SCHEMA: &str = "adl.csm.runtime_api.status.v1";
+pub const CSM_RUNTIME_API_HEALTH_SCHEMA: &str = "adl.csm.runtime_api.health.v1";
+pub const CSM_RUNTIME_API_READY_SCHEMA: &str = "adl.csm.runtime_api.ready.v1";
+pub const CSM_RUNTIME_API_METRICS_SCHEMA: &str = "adl.csm.runtime_api.metrics.v1";
+pub const CSM_RUNTIME_API_EVENTS_SCHEMA: &str = "adl.csm.runtime_api.events.v1";
+
+#[derive(Debug, Clone)]
+pub struct CsmRuntimeApiOptions {
+    pub spec_path: PathBuf,
+    pub bind: String,
+    pub max_requests: usize,
+    pub idle_timeout_ms: Option<u64>,
+    pub otel_status_path: Option<PathBuf>,
+    pub otel_log_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CsmRuntimeApiServeResult {
+    pub schema: String,
+    pub status: String,
+    pub bind_addr: String,
+    pub served_requests: usize,
+}
+
+pub fn serve_runtime_api(options: CsmRuntimeApiOptions) -> Result<CsmRuntimeApiServeResult> {
+    if options.max_requests == 0 {
+        bail!("csm api serve requires --max-requests greater than zero");
+    }
+    let listener = TcpListener::bind(&options.bind)
+        .with_context(|| format!("failed binding CSM runtime API to {}", options.bind))?;
+    let addr = listener
+        .local_addr()
+        .context("read CSM API local address")?;
+    validate_loopback_bind(&addr)?;
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "schema": CSM_RUNTIME_API_SCHEMA,
+            "status": "listening",
+            "bind_addr": addr.to_string(),
+            "runtime_owner": "csm"
+        }))?
+    );
+    std::io::stdout().flush().ok();
+
+    let mut served = 0usize;
+    if let Some(idle_timeout_ms) = options.idle_timeout_ms {
+        listener
+            .set_nonblocking(true)
+            .context("set CSM runtime API listener nonblocking")?;
+        let idle_timeout = Duration::from_millis(idle_timeout_ms);
+        let mut last_activity = Instant::now();
+        while served < options.max_requests {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(5)))
+                        .context("set CSM runtime API read timeout")?;
+                    let request = read_request_path(&mut stream)?;
+                    let response = runtime_api_response(&options, &request)?;
+                    write_http_json(&mut stream, &response)?;
+                    served += 1;
+                    last_activity = Instant::now();
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    if last_activity.elapsed() >= idle_timeout {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => return Err(err).context("accept CSM runtime API connection"),
+            }
+        }
+    } else {
+        for stream in listener.incoming().take(options.max_requests) {
+            let mut stream = stream.context("accept CSM runtime API connection")?;
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .context("set CSM runtime API read timeout")?;
+            let request = read_request_path(&mut stream)?;
+            let response = runtime_api_response(&options, &request)?;
+            write_http_json(&mut stream, &response)?;
+            served += 1;
+        }
+    }
+    Ok(CsmRuntimeApiServeResult {
+        schema: CSM_RUNTIME_API_SCHEMA.to_string(),
+        status: "completed".to_string(),
+        bind_addr: addr.to_string(),
+        served_requests: served,
+    })
+}
+
+pub fn runtime_api_response(options: &CsmRuntimeApiOptions, path: &str) -> Result<Value> {
+    let loaded = load_spec(&options.spec_path)?;
+    let endpoint = path.split('?').next().unwrap_or(path);
+    match endpoint {
+        "/" | "/status" => status_response(&loaded, options),
+        "/health" => health_response(&loaded, options),
+        "/ready" => ready_response(&loaded, options),
+        "/metrics" => metrics_response(&loaded, options),
+        "/events" => events_response(&loaded),
+        other => Ok(json!({
+            "schema": CSM_RUNTIME_API_SCHEMA,
+            "status": "not_found",
+            "endpoint": other,
+            "supported_endpoints": ["/status", "/health", "/ready", "/metrics", "/events"]
+        })),
+    }
+}
+
+fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
+    let agent_status = read_agent_status_snapshot(loaded)?;
+    let daemon_status = read_json_artifact(&artifact_path(loaded, "daemon_status.json"));
+    let continuity_checkpoint =
+        read_json_artifact(&artifact_path(loaded, "continuity_checkpoint.json"));
+    let replay_manifest =
+        read_json_artifact(&artifact_path(loaded, "continuity_replay_manifest.json"));
+    let safe_fail_bundle = read_json_artifact(&artifact_path(loaded, "safe_fail_bundle.json"));
+    let otel_status = options
+        .otel_status_path
+        .as_deref()
+        .map(read_json_artifact)
+        .unwrap_or_else(|| json!({"status": "missing", "ref": "ADL_OTEL_STATUS"}));
+    let otel_log = options
+        .otel_log_path
+        .as_deref()
+        .map(|path| file_ref_status(path, "ADL_OTEL_LOG"))
+        .unwrap_or_else(|| json!({"status": "missing", "ref": "ADL_OTEL_LOG"}));
+    let checkpoint_freshness = checkpoint_freshness(&daemon_status, &continuity_checkpoint);
+    let health = classify_health(&agent_status.state, &daemon_status, &checkpoint_freshness);
+    let ready = classify_ready(&agent_status.state, &daemon_status, &continuity_checkpoint);
+    let runtime_capabilities = daemon_status
+        .get("value")
+        .and_then(|value| value.get("runtime_capabilities"))
+        .cloned()
+        .unwrap_or_else(|| json!({"status": "missing"}));
+    let response = json!({
+        "schema": CSM_RUNTIME_API_STATUS_SCHEMA,
+        "runtime_owner": "csm",
+        "adl_role": "tooling_control_plane",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "status": health,
+        "ready": ready,
+        "daemon_liveness": artifact_liveness(&daemon_status),
+        "agent_status": {
+            "state": agent_status.state,
+            "last_cycle_id": agent_status.last_cycle_id,
+            "last_cycle_status": agent_status.last_cycle_status,
+            "completed_cycle_count": agent_status.completed_cycle_count,
+            "consecutive_failure_count": agent_status.consecutive_failure_count,
+            "stop_requested": agent_status.stop_requested,
+            "updated_at": agent_status.updated_at
+        },
+        "scheduler": runtime_capabilities.get("scheduler_watcher").cloned().unwrap_or_else(|| json!({"status": "missing"})),
+        "chronosense": runtime_capabilities.get("chronosense").cloned().unwrap_or_else(|| json!({"status": "missing"})),
+        "aee_resilience": runtime_capabilities.get("aee").cloned().unwrap_or_else(|| json!({"status": "missing"})),
+        "resilience_middleware": runtime_capabilities.get("resilience_middleware").cloned().unwrap_or_else(|| json!({"status": "missing"})),
+        "checkpoint": checkpoint_freshness,
+        "continuity": {
+            "checkpoint": compact_artifact_status(&continuity_checkpoint, "continuity_checkpoint.json"),
+            "replay_manifest": compact_artifact_status(&replay_manifest, "continuity_replay_manifest.json"),
+            "safe_fail_bundle": compact_artifact_status(&safe_fail_bundle, "safe_fail_bundle.json")
+        },
+        "otel": {
+            "status": compact_artifact_status(&otel_status, "ADL_OTEL_STATUS"),
+            "log": otel_log
+        },
+        "events": file_ref_status(&artifact_path(loaded, "operator_events.jsonl"), "operator_events.jsonl"),
+        "redaction": {
+            "absolute_host_paths": "not_returned",
+            "secret_material": "not_returned",
+            "cloud_account_identifiers": "not_returned"
+        }
+    });
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn health_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
+    let status = status_response(loaded, options)?;
+    let response = json!({
+        "schema": CSM_RUNTIME_API_HEALTH_SCHEMA,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "status": status["status"],
+        "daemon_liveness": status["daemon_liveness"],
+        "checkpoint": status["checkpoint"],
+        "otel": status["otel"]
+    });
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn ready_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
+    let status = status_response(loaded, options)?;
+    let response = json!({
+        "schema": CSM_RUNTIME_API_READY_SCHEMA,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "ready": status["ready"],
+        "blocking_reasons": readiness_blockers(&status)
+    });
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn metrics_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
+    let status = status_response(loaded, options)?;
+    let daemon = read_json_artifact(&artifact_path(loaded, "daemon_status.json"));
+    let event_count = read_jsonl_tail(&artifact_path(loaded, "operator_events.jsonl"), usize::MAX)
+        .get("entries")
+        .and_then(Value::as_array)
+        .map(|entries| entries.len())
+        .unwrap_or(0);
+    let response = json!({
+        "schema": CSM_RUNTIME_API_METRICS_SCHEMA,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "gauges": {
+            "completed_cycle_count": status["agent_status"]["completed_cycle_count"],
+            "consecutive_failure_count": status["agent_status"]["consecutive_failure_count"],
+            "restart_count": daemon.pointer("/value/restart_count").cloned().unwrap_or(Value::Null),
+            "max_restarts": daemon.pointer("/value/max_restarts").cloned().unwrap_or(Value::Null),
+            "checkpoint_interval_secs": daemon.pointer("/value/checkpoint_interval_secs").cloned().unwrap_or(Value::Null),
+            "operator_event_count_observed": event_count
+        },
+        "states": {
+            "health": status["status"],
+            "ready": status["ready"],
+            "agent_state": status["agent_status"]["state"]
+        }
+    });
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn events_response(loaded: &LoadedAgentSpec) -> Result<Value> {
+    let events = read_jsonl_tail(&artifact_path(loaded, "operator_events.jsonl"), 40);
+    let response = json!({
+        "schema": CSM_RUNTIME_API_EVENTS_SCHEMA,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "events": events
+    });
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn artifact_path(loaded: &LoadedAgentSpec, name: &str) -> PathBuf {
+    loaded.state_root.join(name)
+}
+
+fn read_agent_status_snapshot(loaded: &LoadedAgentSpec) -> Result<StatusRecord> {
+    let path = artifact_path(loaded, "status.json");
+    if !path.exists() {
+        return Ok(StatusRecord {
+            schema: "adl.long_lived_agent_status.v1".to_string(),
+            agent_instance_id: loaded.spec.agent_instance_id.clone(),
+            state: AgentStatusState::NotStarted,
+            last_cycle_id: None,
+            last_cycle_status: None,
+            completed_cycle_count: 0,
+            consecutive_failure_count: 0,
+            active_lease: None,
+            stop_requested: false,
+            last_error: None,
+            safety_policy: Value::Null,
+            updated_at: Utc::now(),
+        });
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read CSM runtime API status snapshot {}", path.display()))?;
+    serde_json::from_str::<StatusRecord>(&raw)
+        .with_context(|| format!("parse CSM runtime API status snapshot {}", path.display()))
+}
+
+fn read_json_artifact(path: &Path) -> Value {
+    if !path.exists() {
+        return json!({"status": "missing"});
+    }
+    match fs::read_to_string(path) {
+        Ok(raw) => match serde_json::from_str::<Value>(&raw) {
+            Ok(value) => json!({"status": "serialized", "value": sanitize_json(value)}),
+            Err(err) => json!({"status": "unreadable", "reason": err.to_string()}),
+        },
+        Err(err) => json!({"status": "unreadable", "reason": err.to_string()}),
+    }
+}
+
+fn read_jsonl_tail(path: &Path, limit: usize) -> Value {
+    if !path.exists() {
+        return json!({"status": "missing", "entries": []});
+    }
+    let Ok(raw) = fs::read_to_string(path) else {
+        return json!({"status": "unreadable", "entries": []});
+    };
+    let lines = raw
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(limit);
+    let mut entries = Vec::new();
+    let mut unreadable = 0usize;
+    for line in &lines[start..] {
+        match serde_json::from_str::<Value>(line) {
+            Ok(value) => entries.push(sanitize_json(value)),
+            Err(_) => unreadable += 1,
+        }
+    }
+    json!({
+        "status": if unreadable == 0 { "serialized" } else { "partial" },
+        "tail_limit": limit,
+        "unreadable_lines": unreadable,
+        "entries": entries
+    })
+}
+
+fn sanitize_json(value: Value) -> Value {
+    match value {
+        Value::String(raw) => sanitize_string(&raw).into(),
+        Value::Array(values) => Value::Array(values.into_iter().map(sanitize_json).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, value)| {
+                    let lowered = key.to_ascii_lowercase();
+                    if lowered.contains("secret")
+                        || lowered.contains("token")
+                        || lowered.contains("authorization")
+                        || lowered.contains("credential")
+                    {
+                        (key, Value::String("[redacted]".to_string()))
+                    } else {
+                        (key, sanitize_json(value))
+                    }
+                })
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn sanitize_string(raw: &str) -> String {
+    if looks_like_host_private_path(raw)
+        || raw.contains("Authorization:")
+        || raw.to_ascii_lowercase().contains("bearer ")
+        || raw.to_ascii_lowercase().contains("aws_secret_access_key")
+        || raw.contains("arn:aws:")
+        || contains_cloud_account_identifier(raw)
+    {
+        "[redacted]".to_string()
+    } else {
+        raw.to_string()
+    }
+}
+
+fn contains_cloud_account_identifier(raw: &str) -> bool {
+    let mut digits = 0usize;
+    for byte in raw.bytes() {
+        if byte.is_ascii_digit() {
+            digits += 1;
+        } else {
+            if digits == 12 {
+                return true;
+            }
+            digits = 0;
+        }
+    }
+    digits == 12
+}
+
+fn looks_like_host_private_path(raw: &str) -> bool {
+    raw.contains("/Users/")
+        || raw.contains("/home/")
+        || raw.contains("/private/")
+        || raw.contains("/var/folders/")
+}
+
+fn file_ref_status(path: &Path, reference: &str) -> Value {
+    if path.exists() {
+        json!({"status": "retained", "ref": reference, "bytes": fs::metadata(path).map(|m| m.len()).ok()})
+    } else {
+        json!({"status": "missing", "ref": reference})
+    }
+}
+
+fn compact_artifact_status(artifact: &Value, reference: &str) -> Value {
+    json!({
+        "status": artifact.get("status").cloned().unwrap_or_else(|| json!("unknown")),
+        "ref": reference,
+        "schema": artifact.pointer("/value/schema").cloned().unwrap_or(Value::Null)
+    })
+}
+
+fn artifact_liveness(daemon_status: &Value) -> Value {
+    let status = daemon_status
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("missing");
+    json!({
+        "status": if status == "serialized" { "observed" } else { status },
+        "state": daemon_status.pointer("/value/state").cloned().unwrap_or(Value::Null),
+        "last_event": daemon_status.pointer("/value/last_event").cloned().unwrap_or(Value::Null),
+        "updated_at": daemon_status.pointer("/value/updated_at").cloned().unwrap_or(Value::Null)
+    })
+}
+
+fn checkpoint_freshness(daemon_status: &Value, continuity_checkpoint: &Value) -> Value {
+    let daemon_checkpoint = daemon_status.pointer("/value/last_checkpoint_at");
+    let checkpoint_status = continuity_checkpoint.get("status").and_then(Value::as_str);
+    let age_secs = daemon_checkpoint
+        .and_then(Value::as_str)
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+        .map(|time| {
+            Utc::now()
+                .signed_duration_since(time.with_timezone(&Utc))
+                .num_seconds()
+                .max(0)
+        });
+    let freshness = match (checkpoint_status, age_secs) {
+        (Some("serialized"), Some(age)) if age <= 300 => "fresh",
+        (Some("serialized"), Some(_)) => "stale",
+        (Some("serialized"), None) => "unknown",
+        (Some(other), _) => other,
+        (None, _) => "missing",
+    };
+    json!({
+        "status": freshness,
+        "last_checkpoint_at": daemon_checkpoint.cloned().unwrap_or(Value::Null),
+        "age_secs": age_secs,
+        "checkpoint_ref": "continuity_checkpoint.json"
+    })
+}
+
+fn classify_health(
+    state: &AgentStatusState,
+    daemon_status: &Value,
+    checkpoint_freshness: &Value,
+) -> &'static str {
+    if matches!(state, AgentStatusState::Failed) {
+        "degraded"
+    } else if daemon_status.get("status").and_then(Value::as_str) != Some("serialized") {
+        "degraded"
+    } else if checkpoint_freshness.get("status").and_then(Value::as_str) == Some("stale") {
+        "degraded"
+    } else {
+        "healthy"
+    }
+}
+
+fn classify_ready(
+    state: &AgentStatusState,
+    daemon_status: &Value,
+    continuity_checkpoint: &Value,
+) -> &'static str {
+    if matches!(
+        state,
+        AgentStatusState::Failed | AgentStatusState::Leased | AgentStatusState::RunningCycle
+    ) {
+        "not_ready"
+    } else if daemon_status.get("status").and_then(Value::as_str) != Some("serialized") {
+        "not_ready"
+    } else if continuity_checkpoint.get("status").and_then(Value::as_str) != Some("serialized") {
+        "not_ready"
+    } else {
+        "ready"
+    }
+}
+
+fn readiness_blockers(status: &Value) -> Vec<String> {
+    let mut blockers = Vec::new();
+    if status
+        .pointer("/daemon_liveness/status")
+        .and_then(Value::as_str)
+        != Some("observed")
+    {
+        blockers.push("daemon_status_missing".to_string());
+    }
+    if status
+        .pointer("/continuity/checkpoint/status")
+        .and_then(Value::as_str)
+        != Some("serialized")
+    {
+        blockers.push("continuity_checkpoint_missing".to_string());
+    }
+    if status
+        .pointer("/agent_status/state")
+        .and_then(Value::as_str)
+        == Some("failed")
+    {
+        blockers.push("agent_state_failed".to_string());
+    }
+    match status
+        .pointer("/agent_status/state")
+        .and_then(Value::as_str)
+    {
+        Some("leased") => blockers.push("agent_state_leased".to_string()),
+        Some("running_cycle") => blockers.push("agent_state_running_cycle".to_string()),
+        _ => {}
+    }
+    blockers
+}
+
+fn validate_loopback_bind(addr: &SocketAddr) -> Result<()> {
+    if !addr.ip().is_loopback() {
+        bail!("csm api serve requires a loopback bind address unless remote auth is implemented");
+    }
+    Ok(())
+}
+
+fn read_request_path(stream: &mut TcpStream) -> Result<String> {
+    let mut buf = [0_u8; 4096];
+    let n = stream
+        .read(&mut buf)
+        .context("read CSM runtime API request")?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let first_line = request.lines().next().unwrap_or_default();
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or("/");
+    if method != "GET" {
+        return Ok("/__method_not_allowed".to_string());
+    }
+    Ok(path.to_string())
+}
+
+fn write_http_json(stream: &mut TcpStream, body: &Value) -> Result<()> {
+    let status = if body.get("status").and_then(Value::as_str) == Some("not_found") {
+        "404 Not Found"
+    } else {
+        "200 OK"
+    };
+    let raw = serde_json::to_vec_pretty(body)?;
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        raw.len()
+    )?;
+    stream.write_all(&raw)?;
+    Ok(())
+}
+
+fn assert_api_response_redacted(value: &Value) -> Result<()> {
+    let raw = serde_json::to_string(value)?;
+    for forbidden in [
+        "/Users/",
+        "/home/",
+        "/private/",
+        "/var/folders/",
+        "Authorization:",
+        "Bearer ",
+        "arn:aws:",
+    ] {
+        if raw.contains(forbidden) {
+            return Err(anyhow!(
+                "CSM runtime API response leaked forbidden token: {forbidden}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root(name: &str) -> PathBuf {
+        let id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let root = std::env::temp_dir().join(format!("adl-csm-runtime-api-{name}-{id}"));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_spec(root: &Path) -> PathBuf {
+        let spec = root.join("agent.yaml");
+        fs::write(
+            &spec,
+            r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: api-agent
+display_name: API Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+heartbeat:
+  interval_secs: 1
+safety: {}
+memory: {}
+"#,
+        )
+        .unwrap();
+        spec
+    }
+
+    #[test]
+    fn runtime_api_reports_not_ready_when_runtime_artifacts_are_missing() {
+        let root = temp_root("missing");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: "127.0.0.1:0".to_string(),
+            max_requests: 1,
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let response = runtime_api_response(&options, "/ready").unwrap();
+        assert_eq!(response["schema"], CSM_RUNTIME_API_READY_SCHEMA);
+        assert_eq!(response["ready"], "not_ready");
+        assert!(response["blocking_reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("daemon_status_missing")));
+        assert!(
+            !state.exists(),
+            "read-only runtime API status must not initialize state"
+        );
+    }
+
+    #[test]
+    fn runtime_api_redacts_secret_and_host_path_event_payloads() {
+        let root = temp_root("redaction");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        fs::create_dir_all(&state).unwrap();
+        fs::write(
+            state.join("operator_events.jsonl"),
+            r#"{"schema":"adl.long_lived_agent_operator_event.v1","event":"probe","details":{"token":"abc","message":"failed opening /Users/example/secret from account 123456789012","arn":"arn:aws:iam::123456789012:role/example"}}"#,
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: "127.0.0.1:0".to_string(),
+            max_requests: 1,
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let response = runtime_api_response(&options, "/events").unwrap();
+        let raw = serde_json::to_string(&response).unwrap();
+        assert!(!raw.contains("abc"));
+        assert!(!raw.contains("/Users/"));
+        assert!(!raw.contains("123456789012"));
+        assert!(!raw.contains("arn:aws:"));
+        assert!(raw.contains("[redacted]"));
+    }
+
+    #[test]
+    fn runtime_api_explains_active_agent_not_ready_state() {
+        let root = temp_root("active-state");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        fs::create_dir_all(&state).unwrap();
+        fs::write(
+            state.join("status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_status.v1",
+                "agent_instance_id": "api-agent",
+                "state": "running_cycle",
+                "last_cycle_id": "cycle-000001",
+                "last_cycle_status": null,
+                "completed_cycle_count": 0,
+                "consecutive_failure_count": 0,
+                "active_lease": null,
+                "stop_requested": false,
+                "last_error": null,
+                "safety_policy": null,
+                "updated_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("daemon_status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.csm.daemon_status.v1",
+                "state": "running",
+                "last_event": "daemon_started",
+                "updated_at": Utc::now(),
+                "last_checkpoint_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("continuity_checkpoint.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.csm.continuity_checkpoint.v1"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: "127.0.0.1:0".to_string(),
+            max_requests: 1,
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let response = runtime_api_response(&options, "/ready").unwrap();
+        assert_eq!(response["ready"], "not_ready");
+        assert!(response["blocking_reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("agent_state_running_cycle")));
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -29,6 +29,7 @@ pub mod control_plane;
 pub mod csdlc_prompt_editor;
 pub mod csm_continuity_capsule;
 pub mod csm_observatory;
+pub mod csm_runtime_api;
 pub mod dangerous_negative_suite;
 pub mod delegation_policy;
 pub mod delegation_refusal_coordination;

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -85,6 +85,66 @@ fn content_length(headers: &[u8]) -> Option<usize> {
     })
 }
 
+fn read_http_response_body(stream: &mut std::net::TcpStream) -> String {
+    use std::io::Read;
+    let mut buf = Vec::new();
+    let mut temp = [0_u8; 4096];
+    loop {
+        let n = match stream.read(&mut temp) {
+            Ok(n) => n,
+            Err(err) if err.kind() == std::io::ErrorKind::ConnectionReset => break,
+            Err(err) => panic!("read response: {err}"),
+        };
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&temp[..n]);
+        if let Some(header_end) = find_header_end(&buf) {
+            let content_length = content_length(&buf[..header_end]).unwrap_or(0);
+            if buf.len() >= header_end + 4 + content_length {
+                break;
+            }
+        }
+    }
+    if let Some(header_end) = find_header_end(&buf) {
+        String::from_utf8_lossy(&buf[header_end + 4..]).to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn http_get_json(addr: &str, path: &str) -> serde_json::Value {
+    let started = std::time::Instant::now();
+    loop {
+        match std::net::TcpStream::connect(addr) {
+            Ok(mut stream) => {
+                stream
+                    .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                    .expect("set API read timeout");
+                write!(
+                    stream,
+                    "GET {path} HTTP/1.1\r\nhost: {addr}\r\nconnection: close\r\n\r\n"
+                )
+                .expect("write API request");
+                stream.flush().expect("flush API request");
+                let body = read_http_response_body(&mut stream);
+                if body.trim().is_empty() && started.elapsed() < std::time::Duration::from_secs(5) {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                    continue;
+                }
+                return serde_json::from_str(&body).unwrap_or_else(|err| {
+                    panic!("parse API response for {path}: {err}; body:\n{body}")
+                });
+            }
+            Err(err) if started.elapsed() < std::time::Duration::from_secs(5) => {
+                let _ = err;
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Err(err) => panic!("connect to CSM API {addr} for {path}: {err}"),
+        }
+    }
+}
+
 fn otlp_attr_string<'a>(attrs: &'a serde_json::Value, key: &str) -> Option<&'a str> {
     attrs.as_array()?.iter().find_map(|attr| {
         (attr.get("key")?.as_str()? == key)
@@ -524,6 +584,181 @@ memory:
     assert_eq!(otel_status["schema"], "adl.otel.monitor_status.v1");
     assert!(otel_status["event_count"].as_u64().expect("event count") >= 4);
     assert_eq!(otel_status["last_trace_id"], "agent.daemon-agent.daemon");
+}
+
+#[test]
+fn csm_runtime_api_serves_status_health_ready_metrics_and_events() {
+    let root = unique_test_temp_dir("csm-runtime-api");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: api-agent
+display_name: API Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: wp07_api_probe
+  run_args:
+    provider_id: local_ollama
+    model: gemma4:latest
+heartbeat:
+  interval_secs: 1
+  max_cycles: 2
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+  max_consecutive_failures: 2
+memory:
+  namespace: smoke/api-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write API agent spec");
+
+    let observability_log = root.join("observability.log");
+    let otel_log = root.join("otel.jsonl");
+    let otel_status = root.join("otel-status.json");
+    let spec_str = spec.to_str().expect("utf8 spec path");
+    let daemon = run_csm_with_env(
+        &[
+            "daemon",
+            "--spec",
+            spec_str,
+            "--max-restarts",
+            "1",
+            "--checkpoint-interval-secs",
+            "1",
+            "--no-sleep",
+            "--json",
+        ],
+        &[
+            ("ADL_OBSERVABILITY_STDERR", "0"),
+            (
+                "ADL_OBSERVABILITY_LOG",
+                observability_log.to_str().expect("utf8 observability path"),
+            ),
+            ("ADL_OBSERVABILITY_HEARTBEAT_MS", "25"),
+            (
+                "ADL_OTEL_LOG",
+                otel_log.to_str().expect("utf8 otel log path"),
+            ),
+            (
+                "ADL_OTEL_STATUS",
+                otel_status.to_str().expect("utf8 otel status path"),
+            ),
+        ],
+    );
+    assert!(
+        daemon.status.success(),
+        "expected daemon success, stderr:\n{}",
+        String::from_utf8_lossy(&daemon.stderr)
+    );
+
+    let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind API probe port");
+    let addr = probe.local_addr().expect("API probe addr");
+    drop(probe);
+    let mut child = std::process::Command::new(resolve_csm_exe())
+        .args([
+            "api",
+            "serve",
+            "--spec",
+            spec_str,
+            "--bind",
+            &addr.to_string(),
+            "--max-requests",
+            "100",
+            "--idle-timeout-ms",
+            "1000",
+            "--otel-status",
+            otel_status.to_str().expect("utf8 otel status path"),
+            "--otel-log",
+            otel_log.to_str().expect("utf8 otel log path"),
+            "--json",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn csm api");
+    let stdout = child.stdout.take().expect("api stdout pipe");
+    let mut stdout = std::io::BufReader::new(stdout);
+    let mut startup_line = String::new();
+    std::io::BufRead::read_line(&mut stdout, &mut startup_line).expect("read API startup");
+    assert!(
+        startup_line.contains("\"status\":\"listening\""),
+        "unexpected API startup line: {startup_line}"
+    );
+
+    let status = http_get_json(&addr.to_string(), "/status");
+    let health = http_get_json(&addr.to_string(), "/health");
+    let ready = http_get_json(&addr.to_string(), "/ready");
+    let metrics = http_get_json(&addr.to_string(), "/metrics");
+    let events = http_get_json(&addr.to_string(), "/events");
+
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stderr).expect("read API stderr");
+    }
+    let status_code = child.wait().expect("wait csm api");
+    let mut remaining_stdout = String::new();
+    use std::io::Read;
+    stdout
+        .read_to_string(&mut remaining_stdout)
+        .expect("read remaining API stdout");
+    assert!(
+        status_code.success(),
+        "api stdout:\n{startup_line}{remaining_stdout}\nstderr:\n{stderr}"
+    );
+
+    assert_eq!(status["schema"], "adl.csm.runtime_api.status.v1");
+    assert_eq!(status["runtime_owner"], "csm");
+    assert_eq!(status["agent_instance_id"], "api-agent");
+    assert_eq!(status["status"], "healthy");
+    assert_eq!(status["ready"], "ready");
+    assert_eq!(status["daemon_liveness"]["state"], "completed");
+    assert_eq!(status["scheduler"]["status"], "integrated");
+    assert_eq!(status["chronosense"]["status"], "integrated");
+    assert_eq!(status["aee_resilience"]["status"], "integrated");
+    assert_eq!(
+        status["otel"]["status"]["schema"],
+        "adl.otel.monitor_status.v1"
+    );
+    assert_eq!(health["schema"], "adl.csm.runtime_api.health.v1");
+    assert_eq!(health["status"], "healthy");
+    assert_eq!(ready["schema"], "adl.csm.runtime_api.ready.v1");
+    assert_eq!(ready["ready"], "ready");
+    assert_eq!(metrics["schema"], "adl.csm.runtime_api.metrics.v1");
+    assert!(
+        matches!(
+            metrics["states"]["agent_state"].as_str(),
+            Some("idle" | "completed")
+        ),
+        "unexpected metrics state: {}",
+        metrics["states"]["agent_state"]
+    );
+    assert_eq!(events["schema"], "adl.csm.runtime_api.events.v1");
+    assert!(events["events"]["entries"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .any(|event| event["event"] == "daemon_started"));
+
+    for response in [&status, &health, &ready, &metrics, &events] {
+        let raw = serde_json::to_string(response).expect("serialize API response");
+        assert!(!raw.contains("/Users/"), "leaked host path:\n{raw}");
+        assert!(
+            !raw.contains("Authorization:"),
+            "leaked auth header:\n{raw}"
+        );
+        assert!(!raw.contains("Bearer "), "leaked bearer token:\n{raw}");
+    }
 }
 
 #[test]

--- a/docs/milestones/v0.91.7/review/runtime/CSM_RUNTIME_API_4929.md
+++ b/docs/milestones/v0.91.7/review/runtime/CSM_RUNTIME_API_4929.md
@@ -127,9 +127,37 @@ Result:
 - status: passed
 - local artifact: `.adl/local-artifacts/build-platform/4929-wuji-summary.json`
 
-Nessus, AWS Spot, and CodeBuild live benchmark rows require a committed and
-pushed issue ref. They are intentionally pending until the #4929 branch has a
-review-clean commit for those remote lanes to fetch.
+Remote benchmark rows used pushed ref
+`codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints`
+at commit `cdaca6236`.
+
+| Platform | Cache posture | Build | Test | Benchmark total | Wrapper wall | Status |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| `wuji` | `local_warm_target` | `93s` | `0.40s` real | `93s` | `93s` | passed |
+| `nessus` | `persistent_remote_target_cache` | `177s` | `51s` | `228s` | `240s` | passed |
+| `codebuild` | `fixed_builder_image_stable_local_target_cache_s3_sccache` | `99s` | `76s` | `175s` | `204s` | passed |
+| `aws_spot` | `fixed_builder_image_warm_ebs_cache` | `103s` | `93s` | `196s` | `355s` | passed |
+
+Remote artifacts:
+
+- Nessus: `.adl/local-artifacts/remote-build/4929/nessus/summary.json` and
+  extracted `command.log`.
+- CodeBuild: `.adl/local-artifacts/remote-build/4929/codebuild-live-summary.json`,
+  `codebuild-status.json`, and fetched `codebuild-log.txt`.
+- AWS Spot: `.adl/local-artifacts/remote-build/4929/aws-spot-summary.json`
+  and `aws-spot/attempt-0/command-stdout.log`.
+
+Operational problems observed:
+
+- Nessus validation-manager routing rejected the full changed surface because
+  docs plus Rust selected two lanes; the benchmark was rerun with a Rust-only
+  changed-file list so the Nessus remote runner could select exactly one lane.
+- CodeBuild completed successfully but the wrapper summary did not retain the
+  nested benchmark JSON; the benchmark row was recovered from the specific
+  CodeBuild log stream.
+- AWS Spot terminated the instance but initially left the temporary IAM role
+  undeleted because an inline ECR-read policy remained attached. The inline
+  policy and role were deleted after the run.
 
 ## Non-Claims
 

--- a/docs/milestones/v0.91.7/review/runtime/CSM_RUNTIME_API_4929.md
+++ b/docs/milestones/v0.91.7/review/runtime/CSM_RUNTIME_API_4929.md
@@ -1,0 +1,141 @@
+# CSM Runtime Observability API Proof (#4929)
+
+This packet records the bounded v0.91.7 proof for the CSM-owned runtime
+observability API.
+
+## Implemented Surface
+
+- `csm api serve --spec <agent-spec.yaml>` is available only through the
+  standalone `csm` runtime binary.
+- `adl csm api` rejects with an ownership error because `adl` remains tooling
+  and control-plane support, not the runtime owner.
+- The API binds to loopback by default and rejects non-loopback bind addresses
+  until remote authorization is implemented.
+- The implemented endpoints are `/status`, `/health`, `/ready`, `/metrics`,
+  and `/events`.
+
+## Endpoint Truth
+
+`/status` reports:
+
+- runtime owner and agent instance id
+- retained daemon liveness from `daemon_status.json`
+- current agent status from a read-only `status.json` snapshot; missing status
+  returns a synthetic not-started snapshot without initializing state
+- scheduler watcher, ChronoSense, AEE, and resilience-middleware integration
+  states when present in daemon capabilities
+- checkpoint freshness from retained daemon and continuity checkpoint artifacts
+- continuity, replay-manifest, and safe-fail bundle artifact refs
+- OTel status/log artifact refs when supplied with `--otel-status` and
+  `--otel-log`
+- retained operator event stream ref
+
+`/health` and `/ready` classify degraded or not-ready states from missing
+daemon artifacts, missing checkpoints, stale checkpoints, and failed/running
+agent states instead of assuming success.
+
+`/metrics` exposes bounded machine-readable gauges and states from the same
+runtime artifacts.
+
+`/events` returns a bounded redacted tail of retained operator events.
+
+## Redaction And Bind Policy
+
+Responses return artifact refs and byte counts rather than absolute host-private
+paths. Response redaction rejects or redacts:
+
+- `/Users/`, `/home/`, `/private/`, and `/var/folders/` paths
+  even when embedded in larger event strings
+- authorization headers and bearer token strings
+- secret, token, authorization, and credential keyed fields
+- AWS secret access key strings
+- AWS ARN strings
+- embedded or standalone 12-digit cloud account identifier strings
+
+No remote/public API claim is made by this issue.
+
+## Local Proof
+
+Commands run from the bound #4929 worktree:
+
+```sh
+cargo fmt --manifest-path adl/Cargo.toml --all
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture
+```
+
+Result:
+
+- compile: `20.44s`
+- test body: `1.32s`
+- status: passed
+- proof: the smoke starts `csm daemon`, writes retained observability and OTel
+  status/log artifacts, starts `csm api serve`, and checks `/status`,
+  `/health`, `/ready`, `/metrics`, and `/events`.
+
+```sh
+cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture
+```
+
+Result:
+
+- initial compile: `24.62s`
+- post-review-fix compile: `36.68s`
+- unit tests: 3 passed
+- smoke filter: 1 passed
+- status: passed
+- proof: missing-artifact readiness classification and event redaction,
+  including embedded host-private path, secret token, AWS account id, and ARN
+  cases; active runtime states produce explicit readiness blockers; missing
+  runtime artifacts do not cause read-time state initialization.
+
+```sh
+cargo fmt --manifest-path adl/Cargo.toml --all --check
+git diff --check
+```
+
+Result: passed.
+
+## Bounded Review
+
+Pre-PR subagent review found three issues:
+
+- Embedded host paths, secrets, account ids, or ARN strings in larger retained
+  event messages could leak or cause the API response assertion to fail.
+- `/ready` could report `not_ready` for leased or running-cycle states without
+  a blocking reason.
+- `/status` originally used the mutating long-lived-agent status command, which
+  could initialize runtime state during a read.
+
+All three were fixed before publication and revalidated with
+`cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture`.
+
+## Build Platform Timing
+
+Comparable benchmark command:
+
+```sh
+bash adl/tools/run_build_platform_benchmark.sh --platform wuji --cache-posture local_warm_target --out .adl/local-artifacts/build-platform/4929-wuji-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-wuji
+```
+
+Result:
+
+- platform: `wuji`
+- cache posture: `local_warm_target`
+- build: `93s`
+- test: `0.40s` real
+- total: `93s`
+- status: passed
+- local artifact: `.adl/local-artifacts/build-platform/4929-wuji-summary.json`
+
+Nessus, AWS Spot, and CodeBuild live benchmark rows require a committed and
+pushed issue ref. They are intentionally pending until the #4929 branch has a
+review-clean commit for those remote lanes to fetch.
+
+## Non-Claims
+
+- This does not implement a remotely exposed or unauthenticated API.
+- This does not claim hosted telemetry backend readiness.
+- This does not claim protobuf OTLP/gRPC or metrics export beyond current
+  retained OTel status/log evidence.
+- This does not replace retained file/log artifacts; it provides a local API
+  view over them.


### PR DESCRIPTION
Closes #4929

## Summary
Implemented the standalone CSM runtime observability API and proved it locally against the CSM daemon, retained OTel/log artifacts, degraded readiness cases, redaction cases, and wuji/Nessus/AWS Spot/CodeBuild build-platform benchmark rows.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4929__v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints/sor.md`
- Tracked implementation artifacts: not_applicable until execution begins

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all` - format the CSM runtime API implementation and smoke test
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture` - prove csm daemon plus csm api serve expose /status, /health, /ready, /metrics, and /events with OTel/log evidence
  - `cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture` - prove missing-runtime readiness classification, read-only status snapshots, active-state readiness blockers, embedded redaction tests, and filtered API smoke coverage
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` - verify formatting remains stable after implementation
  - `git diff --check` - verify no whitespace errors in tracked diffs
  - `bash adl/tools/run_build_platform_benchmark.sh --platform wuji --cache-posture local_warm_target --out .adl/local-artifacts/build-platform/4929-wuji-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-wuji` - capture comparable wuji build-platform timing row for WP-07 issue work
  - `ADL_NESSUS_BUILDER_IMAGE=adl-builder:v0.91.7-fixed ADL_NESSUS_BUILDER_PULL_POLICY=never bash adl/tools/run_validation_manager_nessus_lane.sh --run --changed-files .adl/local-artifacts/remote-build/4929/nessus-rust-changed-files.txt --remote-git-ref codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --remote-command 'bash adl/tools/run_build_platform_benchmark.sh --platform nessus --cache-posture persistent_remote_target_cache --out .adl/local-artifacts/build-platform/4929-nessus-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-nessus' --remote-artifact-dir .adl/local-artifacts/remote-build/4929/nessus` - capture comparable Nessus remote build-platform timing row
  - `bash adl/tools/run_aws_codefriend_build_lane.sh --run --check-account --profile agent-logic-admin --project-name adl-codefriend-build --source-version codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --region us-west-2 --env 'ADL_CODEFRIEND_BUILD_COMMAND=bash adl/tools/run_build_platform_benchmark.sh --platform codebuild --cache-posture fixed_builder_image_stable_local_target_cache_s3_sccache --out .adl/local-artifacts/build-platform/4929-codebuild-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-codebuild' --out .adl/local-artifacts/remote-build/4929/codebuild-live-summary.json --artifact-dir .adl/local-artifacts/remote-build/4929/codebuild-live --wait --poll-seconds 15 --timeout-seconds 900` - capture comparable CodeBuild build-platform timing row
  - `bash adl/tools/run_aws_spot_remote_validation_lane.sh --run --check-account --issue 4929 --run-id adl-wp07-4929-spot-20260706 --git-ref codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --command 'bash adl/tools/run_build_platform_benchmark.sh --platform aws_spot --cache-posture fixed_builder_image_warm_ebs_cache --out .adl/local-artifacts/build-platform/4929-aws-spot-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-aws-spot' --out .adl/local-artifacts/remote-build/4929/aws-spot-summary.json --artifact-dir .adl/local-artifacts/remote-build/4929/aws-spot` - capture comparable AWS Spot build-platform timing row

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`: PASS
  - `git diff --check`: PASS
  - `bash adl/tools/run_build_platform_benchmark.sh --platform wuji --cache-posture local_warm_target --out .adl/local-artifacts/build-platform/4929-wuji-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-wuji`: PASS
  - `ADL_NESSUS_BUILDER_IMAGE=adl-builder:v0.91.7-fixed ADL_NESSUS_BUILDER_PULL_POLICY=never bash adl/tools/run_validation_manager_nessus_lane.sh --run --changed-files .adl/local-artifacts/remote-build/4929/nessus-rust-changed-files.txt --remote-git-ref codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --remote-command 'bash adl/tools/run_build_platform_benchmark.sh --platform nessus --cache-posture persistent_remote_target_cache --out .adl/local-artifacts/build-platform/4929-nessus-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-nessus' --remote-artifact-dir .adl/local-artifacts/remote-build/4929/nessus`: PASS
  - `bash adl/tools/run_aws_codefriend_build_lane.sh --run --check-account --profile agent-logic-admin --project-name adl-codefriend-build --source-version codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --region us-west-2 --env 'ADL_CODEFRIEND_BUILD_COMMAND=bash adl/tools/run_build_platform_benchmark.sh --platform codebuild --cache-posture fixed_builder_image_stable_local_target_cache_s3_sccache --out .adl/local-artifacts/build-platform/4929-codebuild-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-codebuild' --out .adl/local-artifacts/remote-build/4929/codebuild-live-summary.json --artifact-dir .adl/local-artifacts/remote-build/4929/codebuild-live --wait --poll-seconds 15 --timeout-seconds 900`: PASS
  - `bash adl/tools/run_aws_spot_remote_validation_lane.sh --run --check-account --issue 4929 --run-id adl-wp07-4929-spot-20260706 --git-ref codex/4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints --command 'bash adl/tools/run_build_platform_benchmark.sh --platform aws_spot --cache-posture fixed_builder_image_warm_ebs_cache --out .adl/local-artifacts/build-platform/4929-aws-spot-summary.json --artifact-dir .adl/local-artifacts/build-platform/4929-aws-spot' --out .adl/local-artifacts/remote-build/4929/aws-spot-summary.json --artifact-dir .adl/local-artifacts/remote-build/4929/aws-spot`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4929__v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4929__v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints/sor.md
- Idempotency-Key: v0-91-7-wp-07-observability-csm-add-csm-runtime-observability-api-endpoints-adl-v0-91-7-tasks-issue-4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints-sip-md-adl-v0-91-7-tasks-issue-4929-v0-91-7-wp-07-observability-csm-runtime-observability-api-endpoints-sor-md