### PR TITLE
[v0.91.7][WP-08][storage] Prove 12-nines-class durable storage for Polis state

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -689,6 +689,37 @@
       "reason": "wp08_aws_signal_integration_surface_requires_integrated_heartbeat_and_acip_sns_wrapper_contract_checks; retained live summary validation runs through adl/tools/validate_wp08_aws_signal_integration_live_proof.py"
     },
     {
+      "id": "wp08_polis_durable_storage_proof",
+      "lane_class": "cli_workflow",
+      "default_surface": "runtime",
+      "owner": "runtime",
+      "proof_role": "runtime_polis_durable_storage_contract",
+      "requirement_ids": [
+        "wp08_polis_durable_storage_proof"
+      ],
+      "path_selectors": [
+        "adl/src/csm_polis_storage.rs",
+        "adl/src/cli/csm_cmd.rs",
+        "adl/tools/run_wp08_polis_storage_live_proof.sh",
+        "adl/tools/test_run_wp08_polis_storage_live_proof.sh",
+        "adl/tools/validate_wp08_polis_storage_live_proof.py",
+        "docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md",
+        "docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/**"
+      ],
+      "path_hints": [
+        "adl/src/csm_polis_storage.rs",
+        "adl/src/cli/csm_cmd.rs",
+        "adl/tools/run_wp08_polis_storage_live_proof.sh",
+        "adl/tools/test_run_wp08_polis_storage_live_proof.sh",
+        "adl/tools/validate_wp08_polis_storage_live_proof.py",
+        "docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md",
+        "docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/**"
+      ],
+      "command": "bash adl/tools/test_run_wp08_polis_storage_live_proof.sh",
+      "run_command": "bash adl/tools/test_run_wp08_polis_storage_live_proof.sh",
+      "reason": "wp08_polis_storage_surface_requires_runtime_command_and_wrapper_contract_checks; issue-local retained live summary validation runs through adl/tools/validate_wp08_polis_storage_live_proof.py"
+    },
+    {
       "id": "v0917_soak2_status_contracts",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/src/cli/csm_cmd.rs
+++ b/adl/src/cli/csm_cmd.rs
@@ -9,6 +9,7 @@ use ::adl::csm_continuity_capsule::{
     ContinuityFireDrillOptions, ContinuityRestoreOptions, ContinuityStageOptions,
 };
 use ::adl::csm_observatory::{write_observatory_outputs, ObservatoryFormat};
+use ::adl::csm_polis_storage::{prove_polis_storage, PolisStorageProofOptions};
 use ::adl::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 use ::adl::wp08_acip_sns_proof::run_wp08_acip_sns_live_proof;
 
@@ -28,7 +29,7 @@ pub(crate) fn real_csm_standalone(args: &[String]) -> Result<()> {
 fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
     let Some(cmd) = args.first().map(|value| value.as_str()) else {
         eprintln!(
-            "csm requires subcommand: daemon | service | continuity | backpressure | api | aws-signal | observatory"
+            "csm requires subcommand: daemon | service | continuity | backpressure | api | aws-signal | storage | observatory"
         );
         std::process::exit(2);
     };
@@ -70,6 +71,12 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
                 "csm aws-signal is owned by the standalone csm runtime binary; use `csm aws-signal`, not `adl csm aws-signal`"
             )),
         },
+        "storage" => match mode {
+            CsmDispatchMode::StandaloneRuntime => real_storage(&args[1..]),
+            CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
+                "csm storage is owned by the standalone csm runtime binary; use `csm storage`, not `adl csm storage`"
+            )),
+        },
         "observatory" => real_observatory(&args[1..]),
         "--help" | "-h" => {
             println!("{}", csm_usage());
@@ -77,7 +84,7 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
         }
         other => {
             eprintln!(
-                "unknown csm subcommand: {other} (expected daemon, service, continuity, backpressure, api, aws-signal, or observatory)"
+                "unknown csm subcommand: {other} (expected daemon, service, continuity, backpressure, api, aws-signal, storage, or observatory)"
             );
             std::process::exit(2);
         }
@@ -100,6 +107,107 @@ fn real_aws_signal(args: &[String]) -> Result<()> {
             std::process::exit(2);
         }
     }
+}
+
+fn real_storage(args: &[String]) -> Result<()> {
+    let Some(cmd) = args.first().map(|value| value.as_str()) else {
+        eprintln!("csm storage requires subcommand: prove-s3");
+        std::process::exit(2);
+    };
+    match cmd {
+        "prove-s3" => real_storage_prove_s3(&args[1..]),
+        "--help" | "-h" => {
+            println!("{}", csm_usage());
+            Ok(())
+        }
+        other => {
+            eprintln!("unknown csm storage subcommand: {other} (expected prove-s3)");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn real_storage_prove_s3(args: &[String]) -> Result<()> {
+    let mut out_dir: Option<PathBuf> = None;
+    let mut bucket: Option<String> = None;
+    let mut prefix = "community-memory/".to_string();
+    let mut profile = std::env::var("ADL_AWS_PROFILE")
+        .or_else(|_| std::env::var("AWS_PROFILE"))
+        .unwrap_or_else(|_| "agent-logic-admin".to_string());
+    let mut region = std::env::var("ADL_AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+    let mut expected_account_sha256 =
+        std::env::var("ADL_AWS_POLIS_STORAGE_ACCOUNT_SHA256").unwrap_or_default();
+    let mut run_id = "wp08-4913-polis-storage".to_string();
+    let mut aws_bin = std::env::var("AWS_BIN").unwrap_or_else(|_| "aws".to_string());
+    let mut json_output = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_dir = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--bucket" => {
+                bucket = Some(required_value(args, i, "--bucket")?.to_string());
+                i += 1;
+            }
+            "--prefix" => {
+                prefix = required_value(args, i, "--prefix")?.to_string();
+                i += 1;
+            }
+            "--profile" => {
+                profile = required_value(args, i, "--profile")?.to_string();
+                i += 1;
+            }
+            "--region" => {
+                region = required_value(args, i, "--region")?.to_string();
+                i += 1;
+            }
+            "--expected-account-sha256" => {
+                expected_account_sha256 =
+                    required_value(args, i, "--expected-account-sha256")?.to_string();
+                i += 1;
+            }
+            "--run-id" => {
+                run_id = required_value(args, i, "--run-id")?.to_string();
+                i += 1;
+            }
+            "--aws-bin" => {
+                aws_bin = required_value(args, i, "--aws-bin")?.to_string();
+                i += 1;
+            }
+            "--json" => json_output = true,
+            "--help" | "-h" => {
+                println!("{}", csm_usage());
+                return Ok(());
+            }
+            other => {
+                eprintln!("unknown csm storage prove-s3 arg: {other}");
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+
+    let result = prove_polis_storage(PolisStorageProofOptions {
+        out_dir: out_dir.context("csm storage prove-s3 requires --out <proof-dir>")?,
+        bucket: bucket.context("csm storage prove-s3 requires --bucket <bucket>")?,
+        prefix,
+        profile,
+        region,
+        expected_account_sha256,
+        run_id,
+        aws_bin,
+    })?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "CSM_POLIS_STORAGE ok status={} key={}",
+            result.status, result.object.key
+        );
+    }
+    Ok(())
 }
 
 fn real_backpressure(args: &[String]) -> Result<()> {
@@ -548,6 +656,7 @@ pub(crate) fn csm_usage() -> &'static str {
   csm api serve --spec <agent-spec.yaml> [--bind 127.0.0.1:0] [--once|--max-requests <n>] [--idle-timeout-ms <n>] [--otel-status <path>] [--otel-log <path>] [--json]
   csm aws-signal acip-sns-proof --out <proof-dir> [--run-id <id>] [--projection-level delivery_metadata|content_summary]
   csm backpressure prove --spec <agent-spec.yaml> --out <proof-dir> [--profile local|soak2|pre-v0.92] [--json]
+  csm storage prove-s3 --out <proof-dir> --bucket <bucket> --expected-account-sha256 <sha256> [--prefix community-memory/] [--profile agent-logic-admin] [--region us-west-2] [--run-id <id>] [--json]
   csm continuity capture --spec <agent-spec.yaml> --out <bundle-dir> [--source-host wuji] [--target-host ec2-staging|ec2|local] [--json]
   csm continuity stage --bundle <bundle-dir> --out <stage-dir> [--target-host ec2-staging|ec2|local] [--json]
   csm continuity restore --bundle <bundle-dir> --out <runtime-dir> [--target-host ec2-staging|ec2|local] [--json]
@@ -562,6 +671,7 @@ Semantics:
   - csm api exposes local-by-default /status, /health, /ready, /metrics, and /events endpoints from retained runtime artifacts without leaking host-private paths or secrets.
   - csm aws-signal owns runtime AWS signal proof execution, including ACIP-to-SNS live publication under the Agent Logic account guard.
   - csm backpressure proves bounded overload policy, retained metrics, and safe-fail serialization triggers for capacity-degraded runtime paths.
+  - csm storage proves Polis durable-state write/read/restore semantics against the approved S3 backend with checksum, immutable reference, and negative-case evidence.
   - csm continuity captures, stages, restores, and fire-drills portable continuity capsules with secrets excluded and host bindings explicit.
   - csm daemon emits ADL_OBSERVABILITY_LOG, ADL_OTEL_LOG, and ADL_OTEL_STATUS records through the shared observability contract.
   - Read-only CSM Observatory inspection.
@@ -586,6 +696,22 @@ mod tests {
     fn adl_control_plane_rejects_aws_signal_runtime_surface() {
         let args = vec!["aws-signal".to_string(), "--help".to_string()];
         let error = real_csm(&args).expect_err("adl csm must not own aws-signal runtime surface");
+        assert!(
+            error.to_string().contains("standalone csm runtime binary"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn standalone_csm_accepts_storage_help() {
+        let args = vec!["storage".to_string(), "--help".to_string()];
+        real_csm_standalone(&args).expect("standalone csm owns storage");
+    }
+
+    #[test]
+    fn adl_control_plane_rejects_storage_runtime_surface() {
+        let args = vec!["storage".to_string(), "--help".to_string()];
+        let error = real_csm(&args).expect_err("adl csm must not own storage runtime surface");
         assert!(
             error.to_string().contains("standalone csm runtime binary"),
             "{error}"

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -2681,6 +2681,9 @@ pub(super) fn select_finish_validation_plan_for_finish_with_release_gate_disposi
     if finish_issue_needs_wp08_aws_signal_integration_validation(issue_number, changed_paths) {
         return Ok(build_wp08_aws_signal_integration_validation_plan());
     }
+    if finish_issue_needs_wp08_polis_storage_validation(issue_number, changed_paths) {
+        return Ok(build_wp08_polis_storage_validation_plan());
+    }
     if finish_issue_needs_native_gws_runtime_validation(issue_number, changed_paths) {
         return Ok(build_native_gws_runtime_validation_plan());
     }
@@ -3286,6 +3289,7 @@ fn registered_validation_atom_supported(command: &str) -> bool {
                 | "adl/tools/test_run_wp08_local_polis_ssm_proof.sh"
                 | "adl/tools/test_setup_wp08_s3_obsmem_archive_policy.sh"
                 | "adl/tools/test_run_wp08_aws_signal_integration_live_proof.sh"
+                | "adl/tools/test_run_wp08_polis_storage_live_proof.sh"
                 | "adl/tools/test_validation_manager.sh"
                 | "adl/tools/test_adl_builder_image.sh"
                 | "adl/tools/test_import_adl_builder_image_from_s3_to_ecr.sh"
@@ -4614,6 +4618,68 @@ fn build_wp08_aws_signal_integration_validation_plan() -> FinishValidationPlan {
     }
 }
 
+fn finish_issue_needs_wp08_polis_storage_validation(
+    issue_number: u32,
+    changed_paths: &[String],
+) -> bool {
+    if issue_number != 4913 {
+        return false;
+    }
+    !changed_paths.is_empty()
+        && changed_paths.iter().all(|path| {
+            let trimmed = path.trim().trim_matches('/');
+            matches!(
+                trimmed,
+                "adl/config/validation_lane_selector.v0.91.6.json"
+                    | "adl/src/cli/csm_cmd.rs"
+                    | "adl/src/cli/pr_cmd/finish_support.rs"
+                    | "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs"
+                    | "adl/src/csm_polis_storage.rs"
+                    | "adl/src/lib.rs"
+                    | "adl/tools/run_wp08_polis_storage_live_proof.sh"
+                    | "adl/tools/test_run_wp08_polis_storage_live_proof.sh"
+                    | "adl/tools/validate_wp08_polis_storage_live_proof.py"
+                    | "docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md"
+            ) || trimmed
+                .starts_with("docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/")
+        })
+}
+
+fn build_wp08_polis_storage_validation_plan() -> FinishValidationPlan {
+    let mut commands = vec![
+        "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+        "git diff --check".to_string(),
+    ];
+    push_finish_validation_command(
+        &mut commands,
+        "cargo fmt --manifest-path adl/Cargo.toml --all --check",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml csm_polis_storage -- --nocapture",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_wp08_polis_storage_slice -- --exact --nocapture",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "bash adl/tools/test_select_validation_lanes.sh",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "bash adl/tools/test_run_wp08_polis_storage_live_proof.sh",
+    );
+    push_finish_validation_command(
+        &mut commands,
+        "python3 adl/tools/validate_wp08_polis_storage_live_proof.py docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json",
+    );
+    FinishValidationPlan {
+        mode: FinishValidationMode::LargerBinaryFocused,
+        commands,
+    }
+}
+
 fn build_tokio_manifest_runtime_validation_plan() -> FinishValidationPlan {
     let mut commands = Vec::new();
     push_finish_validation_command(
@@ -5543,6 +5609,35 @@ pub(super) fn run_finish_validation_rust(
                         ],
                     )?;
                 }
+                "cargo test --manifest-path adl/Cargo.toml csm_polis_storage -- --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "csm_polis_storage",
+                            "--",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_wp08_polis_storage_slice -- --exact --nocapture" => {
+                    run_finish_validation_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--bin",
+                            "adl-pr-finish",
+                            "cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_wp08_polis_storage_slice",
+                            "--",
+                            "--exact",
+                            "--nocapture",
+                        ],
+                    )?;
+                }
                 "cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1" => {
                     run_finish_validation_status(
                         "cargo",
@@ -5902,6 +5997,11 @@ pub(super) fn run_finish_validation_rust(
                         repo_root.join("adl/tools/test_run_wp08_aws_signal_integration_live_proof.sh");
                     run_finish_validation_status("bash", &[path_str(&script)?])?;
                 }
+                "bash adl/tools/test_run_wp08_polis_storage_live_proof.sh" => {
+                    let script =
+                        repo_root.join("adl/tools/test_run_wp08_polis_storage_live_proof.sh");
+                    run_finish_validation_status("bash", &[path_str(&script)?])?;
+                }
                 "python3 adl/tools/validate_wp08_heartbeat_live_proof.py docs/milestones/v0.91.7/review/runtime/wp08_heartbeat_4684/live_heartbeat_summary.json" => {
                     let script =
                         repo_root.join("adl/tools/validate_wp08_heartbeat_live_proof.py");
@@ -5958,6 +6058,17 @@ pub(super) fn run_finish_validation_rust(
                         repo_root.join("adl/tools/validate_wp08_aws_signal_integration_live_proof.py");
                     let summary = repo_root.join(
                         "docs/milestones/v0.91.7/review/runtime/wp08_aws_signal_integration_4686/aws_signal_integration_summary.json",
+                    );
+                    run_finish_validation_status(
+                        "python3",
+                        &[path_str(&script)?, path_str(&summary)?],
+                    )?;
+                }
+                "python3 adl/tools/validate_wp08_polis_storage_live_proof.py docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json" => {
+                    let script =
+                        repo_root.join("adl/tools/validate_wp08_polis_storage_live_proof.py");
+                    let summary = repo_root.join(
+                        "docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json",
                     );
                     run_finish_validation_status(
                         "python3",

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -4367,6 +4367,53 @@ fn finish_validation_profile_classifies_wp08_aws_signal_integration_slice() {
 }
 
 #[test]
+fn finish_validation_profile_classifies_wp08_polis_storage_slice() {
+    let changed_paths = vec![
+        "adl/config/validation_lane_selector.v0.91.6.json".to_string(),
+        "adl/src/cli/csm_cmd.rs".to_string(),
+        "adl/src/cli/pr_cmd/finish_support.rs".to_string(),
+        "adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs".to_string(),
+        "adl/src/csm_polis_storage.rs".to_string(),
+        "adl/src/lib.rs".to_string(),
+        "adl/tools/run_wp08_polis_storage_live_proof.sh".to_string(),
+        "adl/tools/test_run_wp08_polis_storage_live_proof.sh".to_string(),
+        "adl/tools/validate_wp08_polis_storage_live_proof.py".to_string(),
+        "docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json"
+            .to_string(),
+        "docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md".to_string(),
+    ];
+    let requested_paths = changed_paths.join(",");
+
+    let plan = select_finish_validation_plan_for_finish(4913, &requested_paths, &changed_paths)
+        .expect("WP-08 Polis storage focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::LargerBinaryFocused);
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml csm_polis_storage -- --nocapture".to_string()
+    ));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_wp08_polis_storage_slice -- --exact --nocapture"
+            .to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_run_wp08_polis_storage_live_proof.sh".to_string()));
+    assert!(plan.commands.contains(
+        &"python3 adl/tools/validate_wp08_polis_storage_live_proof.py docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json"
+            .to_string()
+    ));
+
+    if let Ok(unrelated_plan) =
+        select_finish_validation_plan_for_finish(4688, &requested_paths, &changed_paths)
+    {
+        assert!(!unrelated_plan.commands.contains(
+            &"python3 adl/tools/validate_wp08_polis_storage_live_proof.py docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json"
+                .to_string()
+        ));
+    }
+}
+
+#[test]
 fn finish_validation_profile_classifies_wuji_ddns_installer_slice() {
     let changed_paths = vec![
         "adl/src/cli/pr_cmd/finish_support.rs".to_string(),

--- a/adl/src/csm_polis_storage.rs
+++ b/adl/src/csm_polis_storage.rs
@@ -1,0 +1,716 @@
+//! CSM Polis durable storage proof support.
+//!
+//! This module intentionally drives the live S3 proof through the AWS CLI. The
+//! runtime command owns the proof semantics and retained evidence, while the AWS
+//! CLI remains the operator-approved transport for the Agent Logic account.
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const PROOF_SCHEMA: &str = "adl.csm.polis_durable_storage_proof.v1";
+const PAYLOAD_SCHEMA: &str = "adl.csm.polis_state_storage_payload.v1";
+const TAXONOMY_SCHEMA: &str = "adl.csm.polis_artifact_durability_taxonomy.v1";
+
+#[derive(Debug, Clone)]
+pub struct PolisStorageProofOptions {
+    pub out_dir: PathBuf,
+    pub bucket: String,
+    pub prefix: String,
+    pub profile: String,
+    pub region: String,
+    pub expected_account_sha256: String,
+    pub run_id: String,
+    pub aws_bin: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolisStorageProofResult {
+    pub schema: String,
+    pub issue: u64,
+    pub status: String,
+    pub run_id: String,
+    pub checked_at_utc: String,
+    pub aws_profile: String,
+    pub aws_region: String,
+    pub aws_account_hash: String,
+    pub aws_account_matches_expected: bool,
+    pub bucket_name: String,
+    pub bucket_name_hash: String,
+    pub object: StoredObjectProof,
+    pub restored_artifact: RestoredArtifactProof,
+    pub negative_cases: NegativeCases,
+    pub durability_contract: DurabilityContract,
+    pub retained_artifacts: Vec<String>,
+    pub non_claims: Vec<String>,
+    pub redaction: RedactionProof,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredObjectProof {
+    pub key: String,
+    pub version_id: Option<String>,
+    pub payload_sha256: String,
+    pub payload_bytes: u64,
+    pub metadata_sha256_matches: bool,
+    pub server_side_encryption: Option<String>,
+    pub object_lock_mode: Option<String>,
+    pub object_lock_retain_until_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestoredArtifactProof {
+    pub restore_ref: String,
+    pub restored_sha256: String,
+    pub checksum_matches: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NegativeCases {
+    pub missing_object: NegativeCaseProof,
+    pub corrupted_restore: NegativeCaseProof,
+    pub unsigned_access_denial: NegativeCaseProof,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NegativeCaseProof {
+    pub status: String,
+    pub expected_failure: String,
+    pub observed_failure_class: String,
+    pub raw_error_retained: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DurabilityContract {
+    pub target_class: String,
+    pub backend: String,
+    pub artifact_taxonomy_ref: String,
+    pub selected_backend_assumptions: Vec<String>,
+    pub local_proof_scope: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RedactionProof {
+    pub raw_account_id_retained: bool,
+    pub full_account_digest_retained: bool,
+    pub aws_credentials_retained: bool,
+    pub raw_aws_errors_retained: bool,
+}
+
+pub fn prove_polis_storage(options: PolisStorageProofOptions) -> Result<PolisStorageProofResult> {
+    validate_nonempty(&options.bucket, "bucket")?;
+    validate_nonempty(&options.profile, "profile")?;
+    validate_nonempty(&options.region, "region")?;
+    validate_sha256(&options.expected_account_sha256, "expected-account-sha256")?;
+    let run_id = validate_path_segment(&options.run_id, "run-id")?;
+    let prefix = normalize_prefix(&options.prefix)?;
+
+    fs::create_dir_all(&options.out_dir)
+        .with_context(|| format!("create proof output dir {}", options.out_dir.display()))?;
+    let restore_dir = options.out_dir.join("restore");
+    fs::create_dir_all(&restore_dir)
+        .with_context(|| format!("create restore dir {}", restore_dir.display()))?;
+
+    let account = signed_aws_text(
+        &options,
+        &[
+            "sts",
+            "get-caller-identity",
+            "--query",
+            "Account",
+            "--output",
+            "text",
+        ],
+    )
+    .context("resolve AWS account for Agent Logic profile")?;
+    let account = account.trim();
+    let account_sha256 = sha256_hex(account.as_bytes());
+    if account_sha256 != options.expected_account_sha256 {
+        bail!("AWS profile account hash does not match expected Agent Logic account hash");
+    }
+    let account_hash = account_sha256[..16].to_string();
+
+    let key = format!("{prefix}polis-state/{run_id}/snapshot.json");
+    let payload_path = options.out_dir.join("polis_state_snapshot.json");
+    let payload = build_payload(&run_id);
+    let payload_bytes = serde_json::to_vec_pretty(&payload)?;
+    fs::write(&payload_path, &payload_bytes)
+        .with_context(|| format!("write payload {}", payload_path.display()))?;
+    let payload_sha256 = sha256_hex(&payload_bytes);
+    let retain_until =
+        (Utc::now() + Duration::days(365)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    signed_aws(
+        &options,
+        &[
+            "s3api",
+            "put-object",
+            "--bucket",
+            &options.bucket,
+            "--key",
+            &key,
+            "--body",
+            path_str(&payload_path)?,
+            "--metadata",
+            &format!(
+                "sha256={payload_sha256},artifact-kind=polis-snapshot,durability-class=s3-standard-vendor-11-nines-non-12-nines-claim,issue=4913"
+            ),
+            "--object-lock-mode",
+            "GOVERNANCE",
+            "--object-lock-retain-until-date",
+            &retain_until,
+            "--output",
+            "json",
+        ],
+    )
+    .context("put Polis state proof object")?;
+
+    let head_value = signed_aws_json(
+        &options,
+        &[
+            "s3api",
+            "head-object",
+            "--bucket",
+            &options.bucket,
+            "--key",
+            &key,
+            "--output",
+            "json",
+        ],
+    )
+    .context("head Polis state proof object")?;
+    let metadata_sha256 = head_value
+        .pointer("/Metadata/sha256")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if metadata_sha256 != payload_sha256 {
+        bail!("S3 object metadata sha256 mismatch");
+    }
+    let payload_len = payload_bytes.len() as u64;
+    let content_length = head_value
+        .get("ContentLength")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    if content_length != payload_len {
+        bail!("S3 object content length mismatch");
+    }
+    let version_id = string_field(&head_value, "VersionId")
+        .filter(|value| !value.trim().is_empty())
+        .context("S3 object version id missing")?;
+    let server_side_encryption = string_field(&head_value, "ServerSideEncryption")
+        .filter(|value| matches!(value.as_str(), "AES256" | "aws:kms"))
+        .context("S3 object server-side encryption missing or unsupported")?;
+    let object_lock_mode = string_field(&head_value, "ObjectLockMode")
+        .filter(|value| value == "GOVERNANCE")
+        .context("S3 object governance lock missing")?;
+    let object_lock_retain_until_date = string_field(&head_value, "ObjectLockRetainUntilDate")
+        .context("S3 object lock retain-until date missing")?;
+    enforce_minimum_retention(&object_lock_retain_until_date)?;
+
+    let restore_path = restore_dir.join("polis_state_snapshot.restored.json");
+    signed_aws(
+        &options,
+        &[
+            "s3api",
+            "get-object",
+            "--bucket",
+            &options.bucket,
+            "--key",
+            &key,
+            path_str(&restore_path)?,
+            "--output",
+            "json",
+        ],
+    )
+    .context("restore Polis state proof object")?;
+    let restored_bytes = fs::read(&restore_path)
+        .with_context(|| format!("read restored payload {}", restore_path.display()))?;
+    let restored_sha256 = sha256_hex(&restored_bytes);
+    let checksum_matches = restored_sha256 == payload_sha256;
+    if !checksum_matches {
+        bail!("restored payload checksum mismatch");
+    }
+
+    let missing_case = prove_missing_object(&options, &prefix, &run_id)?;
+    let corrupted_case =
+        prove_corrupted_restore(&options.out_dir, &payload_sha256, &restored_bytes)?;
+    let unsigned_case = prove_unsigned_access_denial(&options, &key)?;
+
+    let taxonomy_path = options.out_dir.join("artifact_durability_taxonomy.json");
+    write_taxonomy(&taxonomy_path, &options.bucket, &prefix)?;
+
+    let bucket_name_hash = sha256_hex(options.bucket.as_bytes())[..16].to_string();
+    let proof = PolisStorageProofResult {
+        schema: PROOF_SCHEMA.to_string(),
+        issue: 4913,
+        status: "passed".to_string(),
+        run_id,
+        checked_at_utc: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        aws_profile: options.profile,
+        aws_region: options.region,
+        aws_account_hash: account_hash,
+        aws_account_matches_expected: true,
+        bucket_name: options.bucket,
+        bucket_name_hash,
+        object: StoredObjectProof {
+            key,
+            version_id: Some(version_id),
+            payload_sha256,
+            payload_bytes: payload_len,
+            metadata_sha256_matches: metadata_sha256 == restored_sha256,
+            server_side_encryption: Some(server_side_encryption),
+            object_lock_mode: Some(object_lock_mode),
+            object_lock_retain_until_date: Some(object_lock_retain_until_date),
+        },
+        restored_artifact: RestoredArtifactProof {
+            restore_ref: "restore/polis_state_snapshot.restored.json".to_string(),
+            restored_sha256,
+            checksum_matches,
+        },
+        negative_cases: NegativeCases {
+            missing_object: missing_case,
+            corrupted_restore: corrupted_case,
+            unsigned_access_denial: unsigned_case,
+        },
+        durability_contract: DurabilityContract {
+            target_class: "12-nines-class target; selected S3 backend is vendor 11-nines per-object durability and is therefore a non-12-nines mathematical claim".to_string(),
+            backend: "AWS S3 Standard with versioning, default governance object lock, SSE-S3 encryption, public access block, and lifecycle transition policy from #4688".to_string(),
+            artifact_taxonomy_ref: "artifact_durability_taxonomy.json".to_string(),
+            selected_backend_assumptions: vec![
+                "AWS S3 Standard vendor durability is treated as 11 nines per object for the selected single-region backend.".to_string(),
+                "Object Lock governance retention and versioning provide immutable reference and recovery semantics for retained proof objects.".to_string(),
+                "The #4688 bucket policy supplies public access block, encryption, versioning, lifecycle, and default retention controls.".to_string(),
+            ],
+            local_proof_scope: vec![
+                "write object with checksum metadata".to_string(),
+                "read object metadata including version/lock/encryption posture".to_string(),
+                "restore object to clean staging directory".to_string(),
+                "verify restored checksum".to_string(),
+                "prove missing object, corrupted local restore, and unsigned access denial negative cases".to_string(),
+            ],
+        },
+        retained_artifacts: vec![
+            "polis_state_snapshot.json".to_string(),
+            "restore/polis_state_snapshot.restored.json".to_string(),
+            "artifact_durability_taxonomy.json".to_string(),
+            "polis_storage_proof_summary.json".to_string(),
+        ],
+        non_claims: vec![
+            "This proof does not claim mathematical 12-nines durability from a single-region S3 bucket.".to_string(),
+            "This proof does not retain AWS credentials, raw account ids, or raw AWS error payloads.".to_string(),
+            "This proof validates one live write/read/restore cycle and bounded negative cases; it does not prove all future Polis artifacts are automatically archived.".to_string(),
+        ],
+        redaction: RedactionProof {
+            raw_account_id_retained: false,
+            full_account_digest_retained: false,
+            aws_credentials_retained: false,
+            raw_aws_errors_retained: false,
+        },
+    };
+
+    let summary_path = options.out_dir.join("polis_storage_proof_summary.json");
+    fs::write(&summary_path, serde_json::to_vec_pretty(&proof)?)
+        .with_context(|| format!("write proof summary {}", summary_path.display()))?;
+    Ok(proof)
+}
+
+fn prove_missing_object(
+    options: &PolisStorageProofOptions,
+    prefix: &str,
+    run_id: &str,
+) -> Result<NegativeCaseProof> {
+    let missing_key = format!("{prefix}polis-state/{run_id}/missing-object.json");
+    let output = signed_aws_output(
+        options,
+        &[
+            "s3api",
+            "head-object",
+            "--bucket",
+            &options.bucket,
+            "--key",
+            &missing_key,
+            "--output",
+            "json",
+        ],
+    )?;
+    if output.status.success() {
+        bail!("missing-object negative case unexpectedly succeeded");
+    }
+    let failure_class = classify_aws_failure(&output);
+    if failure_class != "not_found" {
+        bail!(
+            "missing-object negative case failed with unexpected class: {}",
+            failure_class
+        );
+    }
+    Ok(NegativeCaseProof {
+        status: "passed".to_string(),
+        expected_failure: "missing object must not restore as valid state".to_string(),
+        observed_failure_class: "s3_head_object_missing_or_not_found".to_string(),
+        raw_error_retained: false,
+    })
+}
+
+fn prove_corrupted_restore(
+    out_dir: &Path,
+    expected_sha256: &str,
+    restored_bytes: &[u8],
+) -> Result<NegativeCaseProof> {
+    let mut corrupt = restored_bytes.to_vec();
+    corrupt.extend_from_slice(b"\ncorruption-for-negative-proof\n");
+    let corrupt_path = out_dir
+        .join("restore")
+        .join("polis_state_snapshot.corrupt.json");
+    fs::write(&corrupt_path, &corrupt)
+        .with_context(|| format!("write corrupted restore {}", corrupt_path.display()))?;
+    let corrupt_sha = sha256_hex(&corrupt);
+    if corrupt_sha == expected_sha256 {
+        bail!("corrupted restore negative case did not alter checksum");
+    }
+    Ok(NegativeCaseProof {
+        status: "passed".to_string(),
+        expected_failure: "local corrupted restore must fail checksum validation".to_string(),
+        observed_failure_class: "checksum_mismatch_detected".to_string(),
+        raw_error_retained: false,
+    })
+}
+
+fn prove_unsigned_access_denial(
+    options: &PolisStorageProofOptions,
+    key: &str,
+) -> Result<NegativeCaseProof> {
+    let output = unsigned_aws_output(
+        options,
+        &[
+            "s3api",
+            "head-object",
+            "--bucket",
+            &options.bucket,
+            "--key",
+            key,
+            "--output",
+            "json",
+        ],
+    )?;
+    if output.status.success() {
+        bail!("unsigned access negative case unexpectedly succeeded");
+    }
+    let failure_class = classify_aws_failure(&output);
+    if failure_class != "access_denied" {
+        bail!(
+            "unsigned access negative case failed with unexpected class: {}",
+            failure_class
+        );
+    }
+    Ok(NegativeCaseProof {
+        status: "passed".to_string(),
+        expected_failure: "unsigned/public access must be denied for retained Polis state"
+            .to_string(),
+        observed_failure_class: "unsigned_access_denied_or_forbidden".to_string(),
+        raw_error_retained: false,
+    })
+}
+
+fn write_taxonomy(path: &Path, bucket: &str, prefix: &str) -> Result<()> {
+    let taxonomy = json!({
+        "schema": TAXONOMY_SCHEMA,
+        "issue": 4913,
+        "backend": {
+            "kind": "aws_s3",
+            "bucket_name": bucket,
+            "prefix": prefix,
+            "durability_posture": "vendor_11_nines_per_object_non_12_nines_claim",
+            "controls": [
+                "versioning",
+                "object_lock_governance_retention",
+                "sse_s3_encryption",
+                "public_access_block",
+                "lifecycle_transition_policy"
+            ]
+        },
+        "artifact_classes": [
+            {"artifact_kind":"checkpoint","durability_class":"critical_runtime_state","retention":"365d_minimum_governance_retention","integrity":"sha256_manifest_plus_s3_metadata","restore_required":true},
+            {"artifact_kind":"event_log","durability_class":"audit_replay_evidence","retention":"365d_minimum_governance_retention","integrity":"append_order_manifest_plus_sha256","restore_required":true},
+            {"artifact_kind":"snapshot","durability_class":"critical_runtime_state","retention":"365d_minimum_governance_retention","integrity":"sha256_manifest_plus_s3_version_id","restore_required":true},
+            {"artifact_kind":"diff","durability_class":"replay_delta","retention":"365d_minimum_governance_retention","integrity":"sha256_manifest_plus_parent_snapshot_ref","restore_required":true},
+            {"artifact_kind":"freeze_dry_bundle","durability_class":"survival_contract_bundle","retention":"365d_minimum_governance_retention","integrity":"bundle_manifest_sha256_plus_member_hashes","restore_required":true},
+            {"artifact_kind":"security_evidence","durability_class":"governance_audit_evidence","retention":"365d_minimum_governance_retention","integrity":"sha256_manifest_and_redacted_summary","restore_required":true}
+        ],
+        "non_claims": [
+            "single-region S3 Standard is not recorded as mathematical 12-nines durability",
+            "taxonomy does not make public access acceptable for any Polis state artifact"
+        ]
+    });
+    fs::write(path, serde_json::to_vec_pretty(&taxonomy)?)
+        .with_context(|| format!("write taxonomy {}", path.display()))
+}
+
+fn build_payload(run_id: &str) -> Value {
+    json!({
+        "schema": PAYLOAD_SCHEMA,
+        "issue": 4913,
+        "run_id": run_id,
+        "artifact_kind": "snapshot",
+        "agent_instance_id": "polis-durable-storage-proof",
+        "cycle_id": "cycle-000001",
+        "created_at_utc": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "state": {
+            "checkpoint_ref": "checkpoint-000001",
+            "event_log_ref": "event-log-000001",
+            "snapshot_ref": "snapshot-000001",
+            "diff_ref": "diff-000001",
+            "freeze_dry_bundle_ref": "freeze-dry-000001"
+        },
+        "privacy": {
+            "contains_secret": false,
+            "contains_private_user_content": false,
+            "content_class": "synthetic_proof_payload"
+        }
+    })
+}
+
+fn signed_aws_json(options: &PolisStorageProofOptions, args: &[&str]) -> Result<Value> {
+    let text = signed_aws_text(options, args)?;
+    serde_json::from_str(&text).context("parse AWS JSON output")
+}
+
+fn signed_aws_text(options: &PolisStorageProofOptions, args: &[&str]) -> Result<String> {
+    let output = signed_aws_output(options, args)?;
+    if !output.status.success() {
+        bail!("AWS command failed: {}", sanitized_failure(&output));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn signed_aws(options: &PolisStorageProofOptions, args: &[&str]) -> Result<()> {
+    let output = signed_aws_output(options, args)?;
+    if !output.status.success() {
+        bail!("AWS command failed: {}", sanitized_failure(&output));
+    }
+    Ok(())
+}
+
+fn signed_aws_output(options: &PolisStorageProofOptions, args: &[&str]) -> Result<Output> {
+    let mut command = Command::new(&options.aws_bin);
+    command.args(args);
+    command.args(["--profile", &options.profile, "--region", &options.region]);
+    run_command(command)
+}
+
+fn unsigned_aws_output(options: &PolisStorageProofOptions, args: &[&str]) -> Result<Output> {
+    let mut command = Command::new(&options.aws_bin);
+    command.arg("--no-sign-request");
+    command.args(args);
+    command.args(["--region", &options.region]);
+    run_command(command)
+}
+
+fn run_command(mut command: Command) -> Result<Output> {
+    command
+        .output()
+        .with_context(|| format!("run command {:?}", command.get_program()))
+}
+
+fn sanitized_failure(output: &Output) -> String {
+    let code = output
+        .status
+        .code()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+    let failure_class = classify_aws_failure(output);
+    if failure_class == "not_found" {
+        format!("exit={code} class=not_found")
+    } else if failure_class == "access_denied" {
+        format!("exit={code} class=access_denied")
+    } else {
+        format!("exit={code} class=aws_command_failed")
+    }
+}
+
+fn classify_aws_failure(output: &Output) -> &'static str {
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    text.push('\n');
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    if text.contains("NoSuchKey")
+        || text.contains("NoSuchBucket")
+        || text.contains("Not Found")
+        || text.contains("NotFound")
+        || text.contains("404")
+    {
+        "not_found"
+    } else if text.contains("AccessDenied")
+        || text.contains("Forbidden")
+        || text.contains("403")
+        || text.contains("Unable to locate credentials")
+        || text.contains("InvalidAccessKeyId")
+    {
+        "access_denied"
+    } else {
+        "aws_command_failed"
+    }
+}
+
+fn enforce_minimum_retention(value: &str) -> Result<()> {
+    let retain_until = DateTime::parse_from_rfc3339(value)
+        .with_context(|| format!("parse object lock retain-until date {value:?}"))?
+        .with_timezone(&Utc);
+    let minimum = Utc::now() + Duration::days(360);
+    if retain_until < minimum {
+        bail!("S3 object lock retain-until date is shorter than required proof horizon");
+    }
+    Ok(())
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn path_str(path: &Path) -> Result<&str> {
+    path.to_str()
+        .ok_or_else(|| anyhow!("path is not valid UTF-8: {}", path.display()))
+}
+
+fn validate_nonempty(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, field: &str) -> Result<()> {
+    if value.len() != 64 || !value.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("{field} must be a 64-character sha256 hex digest");
+    }
+    Ok(())
+}
+
+fn validate_path_segment(value: &str, field: &str) -> Result<String> {
+    validate_nonempty(value, field)?;
+    if value == "." || value == ".." || value.contains('/') || value.contains('\\') {
+        bail!("{field} must be a single path segment");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        bail!("{field} contains unsupported characters");
+    }
+    Ok(value.to_string())
+}
+
+fn normalize_prefix(value: &str) -> Result<String> {
+    validate_nonempty(value, "prefix")?;
+    if value.starts_with('/') || value.contains("..") {
+        bail!("prefix must be a relative S3 key prefix without parent traversal");
+    }
+    let mut prefix = value.trim().trim_start_matches("./").to_string();
+    if !prefix.ends_with('/') {
+        prefix.push('/');
+    }
+    Ok(prefix)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+
+    #[test]
+    fn validates_prefix_and_run_id() {
+        assert_eq!(
+            normalize_prefix("community-memory").unwrap(),
+            "community-memory/"
+        );
+        assert_eq!(
+            validate_path_segment("run-001", "run-id").unwrap(),
+            "run-001"
+        );
+        assert!(normalize_prefix("../bad").is_err());
+        assert!(validate_path_segment("../bad", "run-id").is_err());
+    }
+
+    #[test]
+    fn corrupted_restore_negative_detects_checksum_change() {
+        let dir = std::env::temp_dir().join(format!(
+            "adl-csm-polis-storage-test-{}",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(dir.join("restore")).unwrap();
+        let payload = br#"{"ok":true}"#;
+        let digest = sha256_hex(payload);
+        let proof = prove_corrupted_restore(&dir, &digest, payload).unwrap();
+        assert_eq!(proof.status, "passed");
+        assert_eq!(proof.observed_failure_class, "checksum_mismatch_detected");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn taxonomy_records_non_12_nines_claim() {
+        let dir = std::env::temp_dir().join(format!(
+            "adl-csm-polis-storage-taxonomy-{}",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("taxonomy.json");
+        write_taxonomy(&path, "bucket", "community-memory/").unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("vendor_11_nines_per_object_non_12_nines_claim"));
+        assert!(text.contains("freeze_dry_bundle"));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn enforces_retention_horizon() {
+        let valid =
+            (Utc::now() + Duration::days(365)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let too_short =
+            (Utc::now() + Duration::days(30)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        assert!(enforce_minimum_retention(&valid).is_ok());
+        assert!(enforce_minimum_retention(&too_short).is_err());
+        assert!(enforce_minimum_retention("not-a-date").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classifies_expected_aws_failure_shapes() {
+        let not_found = Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr: b"An error occurred (404) when calling the HeadObject operation: Not Found"
+                .to_vec(),
+        };
+        assert_eq!(classify_aws_failure(&not_found), "not_found");
+
+        let denied = Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr: b"An error occurred (AccessDenied) when calling the HeadObject operation"
+                .to_vec(),
+        };
+        assert_eq!(classify_aws_failure(&denied), "access_denied");
+
+        let throttled = Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr:
+                b"An error occurred (ThrottlingException) when calling the HeadObject operation"
+                    .to_vec(),
+        };
+        assert_eq!(classify_aws_failure(&throttled), "aws_command_failed");
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -30,6 +30,7 @@ pub mod csdlc_prompt_editor;
 pub mod csm_backpressure;
 pub mod csm_continuity_capsule;
 pub mod csm_observatory;
+pub mod csm_polis_storage;
 pub mod csm_runtime_api;
 pub mod dangerous_negative_suite;
 pub mod delegation_policy;

--- a/adl/tools/run_wp08_polis_storage_live_proof.sh
+++ b/adl/tools/run_wp08_polis_storage_live_proof.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash adl/tools/run_wp08_polis_storage_live_proof.sh --out <dir> --expected-account-sha256 <sha256> [options]
+
+Runs the WP-08 Polis durable-storage proof through the standalone csm runtime
+binary against the Agent Logic S3 archive bucket from #4688.
+
+Options:
+  --out <dir>                       Required proof output directory.
+  --expected-account-sha256 <sha>   Required approved Agent Logic account hash.
+  --profile <name>                  AWS profile. Default: agent-logic-admin.
+  --region <region>                 AWS region. Default: us-west-2.
+  --bucket <name>                   Override S3 bucket name. Default derives from account hash.
+  --prefix <prefix>                 S3 key prefix. Default: community-memory/.
+  --run-id <id>                     Proof run id. Default: wp08-4913-polis-storage.
+  --csm-bin <path>                  csm binary. Default: adl/target/debug/csm.
+USAGE
+}
+
+OUT=""
+EXPECTED="${ADL_AWS_POLIS_STORAGE_ACCOUNT_SHA256:-}"
+PROFILE="${ADL_AWS_PROFILE:-agent-logic-admin}"
+REGION="${ADL_AWS_REGION:-us-west-2}"
+BUCKET=""
+PREFIX="community-memory/"
+RUN_ID="wp08-4913-polis-storage"
+CSM_BIN="${CSM_BIN:-adl/target/debug/csm}"
+AWS_BIN="${AWS_BIN:-aws}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out) OUT="${2:?--out requires a value}"; shift ;;
+    --expected-account-sha256) EXPECTED="${2:?--expected-account-sha256 requires a value}"; shift ;;
+    --profile) PROFILE="${2:?--profile requires a value}"; shift ;;
+    --region) REGION="${2:?--region requires a value}"; shift ;;
+    --bucket) BUCKET="${2:?--bucket requires a value}"; shift ;;
+    --prefix) PREFIX="${2:?--prefix requires a value}"; shift ;;
+    --run-id) RUN_ID="${2:?--run-id requires a value}"; shift ;;
+    --csm-bin) CSM_BIN="${2:?--csm-bin requires a value}"; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "$OUT" ] || [ -z "$EXPECTED" ]; then
+  usage >&2
+  exit 2
+fi
+
+mkdir -p "$OUT"
+
+ACCOUNT="$("$AWS_BIN" sts get-caller-identity --profile "$PROFILE" --region "$REGION" --query Account --output text)"
+ACCOUNT_SHA="$(printf '%s' "$ACCOUNT" | shasum -a 256 | awk '{print $1}')"
+ACCOUNT_HASH="$(printf '%s' "$ACCOUNT_SHA" | cut -c1-16)"
+if [ "$ACCOUNT_SHA" != "$EXPECTED" ]; then
+  echo "AWS profile account hash does not match expected Agent Logic account hash" >&2
+  exit 1
+fi
+echo "PASS account_profile_resolved profile=$PROFILE account_matches_expected=true" >&2
+
+if [ -z "$BUCKET" ]; then
+  BUCKET="adl-wp08-obsmem-community-archive-${ACCOUNT_HASH}-${REGION}"
+fi
+
+"$CSM_BIN" storage prove-s3 \
+  --out "$OUT" \
+  --bucket "$BUCKET" \
+  --prefix "$PREFIX" \
+  --profile "$PROFILE" \
+  --region "$REGION" \
+  --expected-account-sha256 "$EXPECTED" \
+  --run-id "$RUN_ID" \
+  --aws-bin "$AWS_BIN" \
+  --json >"$OUT/csm_storage_command_result.json"
+
+echo "PASS wp08_polis_storage_live_proof bucket=$BUCKET run_id=$RUN_ID"

--- a/adl/tools/test_run_wp08_polis_storage_live_proof.sh
+++ b/adl/tools/test_run_wp08_polis_storage_live_proof.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+
+cat >"$BIN/aws" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "aws $*" >>"${FAKE_AWS_LOG:?}"
+case "$1 $2" in
+  "sts get-caller-identity")
+    printf '%s\n' "fixture-agent-logic-account"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$BIN/aws"
+
+cat >"$BIN/csm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = "storage"
+test "$2" = "prove-s3"
+OUT=""
+BUCKET=""
+PREFIX=""
+PROFILE=""
+REGION=""
+EXPECTED=""
+RUN_ID=""
+AWS_BIN_ARG=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out) OUT="${2:?--out requires a value}"; shift ;;
+    --bucket) BUCKET="${2:?--bucket requires a value}"; shift ;;
+    --prefix) PREFIX="${2:?--prefix requires a value}"; shift ;;
+    --profile) PROFILE="${2:?--profile requires a value}"; shift ;;
+    --region) REGION="${2:?--region requires a value}"; shift ;;
+    --expected-account-sha256) EXPECTED="${2:?--expected-account-sha256 requires a value}"; shift ;;
+    --run-id) RUN_ID="${2:?--run-id requires a value}"; shift ;;
+    --aws-bin) AWS_BIN_ARG="${2:?--aws-bin requires a value}"; shift ;;
+  esac
+  shift
+done
+test "$PROFILE" = "agent-logic-admin"
+test "$REGION" = "us-west-2"
+test "$PREFIX" = "community-memory/"
+test "$EXPECTED" = "${EXPECTED_FIXTURE_ACCOUNT_SHA256:?}"
+test "$RUN_ID" = "fixture-run"
+test -n "$AWS_BIN_ARG"
+mkdir -p "$OUT/restore"
+cat >"$OUT/polis_state_snapshot.json" <<JSON
+{
+  "schema": "adl.csm.polis_state_storage_payload.v1",
+  "issue": 4913,
+  "run_id": "$RUN_ID",
+  "artifact_kind": "snapshot",
+  "state": {"checkpoint_ref": "checkpoint-fixture"}
+}
+JSON
+cp "$OUT/polis_state_snapshot.json" "$OUT/restore/polis_state_snapshot.restored.json"
+printf '%s\ncorruption-for-negative-proof\n' "$(cat "$OUT/polis_state_snapshot.json")" >"$OUT/restore/polis_state_snapshot.corrupt.json"
+PAYLOAD_SHA="$(shasum -a 256 "$OUT/polis_state_snapshot.json" | awk '{print $1}')"
+PAYLOAD_BYTES="$(wc -c <"$OUT/polis_state_snapshot.json" | tr -d ' ')"
+cat >"$OUT/artifact_durability_taxonomy.json" <<JSON
+{
+  "schema": "adl.csm.polis_artifact_durability_taxonomy.v1",
+  "issue": 4913,
+  "backend": {
+    "kind": "aws_s3",
+    "bucket_name": "$BUCKET",
+    "prefix": "$PREFIX",
+    "durability_posture": "vendor_11_nines_per_object_non_12_nines_claim",
+    "controls": ["versioning", "object_lock_governance_retention", "sse_s3_encryption", "public_access_block", "lifecycle_transition_policy"]
+  },
+  "artifact_classes": [
+    {"artifact_kind":"checkpoint"},
+    {"artifact_kind":"event_log"},
+    {"artifact_kind":"snapshot"},
+    {"artifact_kind":"diff"},
+    {"artifact_kind":"freeze_dry_bundle"},
+    {"artifact_kind":"security_evidence"}
+  ],
+  "non_claims": ["single-region S3 Standard is not recorded as mathematical 12-nines durability"]
+}
+JSON
+cat >"$OUT/polis_storage_proof_summary.json" <<JSON
+{
+  "schema": "adl.csm.polis_durable_storage_proof.v1",
+  "issue": 4913,
+  "status": "passed",
+  "run_id": "$RUN_ID",
+  "checked_at_utc": "2026-07-06T00:00:00Z",
+  "aws_profile": "$PROFILE",
+  "aws_region": "$REGION",
+  "aws_account_hash": "2a33349e7e606a8a",
+  "aws_account_matches_expected": true,
+  "bucket_name": "$BUCKET",
+  "bucket_name_hash": "abc123abc123abcd",
+  "object": {
+    "key": "community-memory/polis-state/fixture-run/snapshot.json",
+    "version_id": "version-fixture",
+    "payload_sha256": "$PAYLOAD_SHA",
+    "payload_bytes": $PAYLOAD_BYTES,
+    "metadata_sha256_matches": true,
+    "server_side_encryption": "AES256",
+    "object_lock_mode": "GOVERNANCE",
+    "object_lock_retain_until_date": "2027-07-06T00:00:00Z"
+  },
+  "restored_artifact": {
+    "restore_ref": "restore/polis_state_snapshot.restored.json",
+    "restored_sha256": "$PAYLOAD_SHA",
+    "checksum_matches": true
+  },
+  "negative_cases": {
+    "missing_object": {"status": "passed", "expected_failure": "missing", "observed_failure_class": "s3_head_object_missing_or_not_found", "raw_error_retained": false},
+    "corrupted_restore": {"status": "passed", "expected_failure": "corrupt", "observed_failure_class": "checksum_mismatch_detected", "raw_error_retained": false},
+    "unsigned_access_denial": {"status": "passed", "expected_failure": "deny", "observed_failure_class": "unsigned_access_denied_or_forbidden", "raw_error_retained": false}
+  },
+  "durability_contract": {
+    "target_class": "12-nines-class target; selected S3 backend is vendor 11-nines per-object durability and is therefore a non-12-nines mathematical claim",
+    "backend": "AWS S3 Standard",
+    "artifact_taxonomy_ref": "artifact_durability_taxonomy.json",
+    "selected_backend_assumptions": ["vendor 11 nines", "object lock"],
+    "local_proof_scope": ["write", "read", "restore", "missing", "corrupt", "deny"]
+  },
+  "retained_artifacts": ["polis_storage_proof_summary.json"],
+  "non_claims": ["This proof does not claim mathematical 12-nines durability from a single-region S3 bucket."],
+  "redaction": {
+    "raw_account_id_retained": false,
+    "full_account_digest_retained": false,
+    "aws_credentials_retained": false,
+    "raw_aws_errors_retained": false
+  }
+}
+JSON
+printf '{"status":"passed"}\n'
+SH
+chmod +x "$BIN/csm"
+
+export PATH="$BIN:$PATH"
+export FAKE_AWS_LOG="$TMP/aws.log"
+export EXPECTED_FIXTURE_ACCOUNT_SHA256
+EXPECTED_FIXTURE_ACCOUNT_SHA256="$(
+  printf '%s' "fixture-agent-logic-account" | shasum -a 256 | awk '{print $1}'
+)"
+
+bash "$ROOT/adl/tools/run_wp08_polis_storage_live_proof.sh" \
+  --out "$TMP/proof" \
+  --profile agent-logic-admin \
+  --region us-west-2 \
+  --run-id fixture-run \
+  --csm-bin "$BIN/csm" \
+  --expected-account-sha256 "$EXPECTED_FIXTURE_ACCOUNT_SHA256" \
+  >/tmp/wp08-polis-storage-test-output.json
+
+python3 "$ROOT/adl/tools/validate_wp08_polis_storage_live_proof.py" \
+  "$TMP/proof/polis_storage_proof_summary.json" >/dev/null
+
+grep -F "sts get-caller-identity" "$FAKE_AWS_LOG" >/dev/null
+grep -F "agent-logic-admin" "$FAKE_AWS_LOG" >/dev/null
+
+if bash "$ROOT/adl/tools/run_wp08_polis_storage_live_proof.sh" \
+  --out "$TMP/bad-proof" \
+  --profile agent-logic-admin \
+  --region us-west-2 \
+  --run-id bad-fixture-run \
+  --csm-bin "$BIN/csm" \
+  --expected-account-sha256 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
+  >"$TMP/bad.out" 2>"$TMP/bad.err"; then
+  echo "expected mismatched account hash to fail" >&2
+  exit 1
+fi
+grep -F "AWS profile account hash does not match expected Agent Logic account hash" "$TMP/bad.err" >/dev/null
+
+echo "PASS test_run_wp08_polis_storage_live_proof"

--- a/adl/tools/validate_wp08_polis_storage_live_proof.py
+++ b/adl/tools/validate_wp08_polis_storage_live_proof.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import json
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+
+def fail(msg):
+    raise SystemExit(f"validate_wp08_polis_storage_live_proof: {msg}")
+
+
+if len(sys.argv) != 2:
+    fail("usage: validate_wp08_polis_storage_live_proof.py <polis_storage_proof_summary.json>")
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+text = path.read_text()
+proof_dir = path.parent
+
+if data.get("schema") != "adl.csm.polis_durable_storage_proof.v1":
+    fail("bad schema")
+if data.get("issue") != 4913 or data.get("status") != "passed":
+    fail("bad issue/status")
+if data.get("aws_profile") != "agent-logic-admin":
+    fail("bad AWS profile")
+if data.get("aws_region") != "us-west-2":
+    fail("bad AWS region")
+if data.get("aws_account_matches_expected") is not True:
+    fail("account match not recorded")
+if not re.fullmatch(r"[0-9a-f]{16}", data.get("aws_account_hash", "")):
+    fail("missing redacted account hash")
+if re.search(r"\b\d{12}\b", text):
+    fail("raw account id retained")
+if re.search(r"\b[0-9a-f]{64}\b", data.get("aws_account_hash", "")):
+    fail("full account digest retained as account hash")
+if data.get("redaction", {}).get("aws_credentials_retained") is not False:
+    fail("credential redaction not proven")
+if data.get("redaction", {}).get("raw_account_id_retained") is not False:
+    fail("raw account id redaction not proven")
+if data.get("redaction", {}).get("full_account_digest_retained") is not False:
+    fail("full account digest redaction not proven")
+
+obj = data.get("object", {})
+if not obj.get("key", "").startswith("community-memory/"):
+    fail("object key does not use community-memory prefix")
+if not obj.get("version_id"):
+    fail("missing S3 version id")
+if not re.fullmatch(r"[0-9a-f]{64}", obj.get("payload_sha256", "")):
+    fail("missing payload sha256")
+if obj.get("payload_bytes", 0) <= 0:
+    fail("payload size not recorded")
+if obj.get("metadata_sha256_matches") is not True:
+    fail("metadata sha256 did not match payload")
+if obj.get("server_side_encryption") not in ("AES256", "aws:kms"):
+    fail("unexpected or missing server-side encryption")
+if obj.get("object_lock_mode") != "GOVERNANCE":
+    fail("object lock governance retention missing")
+
+restored = data.get("restored_artifact", {})
+if restored.get("checksum_matches") is not True:
+    fail("restore checksum did not match")
+if restored.get("restored_sha256") != obj.get("payload_sha256"):
+    fail("restore sha mismatch")
+
+contract = data.get("durability_contract", {})
+if "non-12-nines" not in contract.get("target_class", ""):
+    fail("target class does not record non-12-nines truth")
+if contract.get("artifact_taxonomy_ref") != "artifact_durability_taxonomy.json":
+    fail("missing taxonomy ref")
+
+payload_path = proof_dir / "polis_state_snapshot.json"
+restore_ref = restored.get("restore_ref")
+if not restore_ref:
+    fail("missing restore ref")
+restore_path = proof_dir / restore_ref
+taxonomy_path = proof_dir / contract.get("artifact_taxonomy_ref", "")
+
+for artifact in (payload_path, restore_path, taxonomy_path):
+    if not artifact.is_file():
+        fail(f"missing retained artifact: {artifact.relative_to(proof_dir)}")
+
+payload_bytes = payload_path.read_bytes()
+restored_bytes = restore_path.read_bytes()
+payload_sha = hashlib.sha256(payload_bytes).hexdigest()
+restored_sha = hashlib.sha256(restored_bytes).hexdigest()
+if payload_sha != obj.get("payload_sha256"):
+    fail("payload artifact sha mismatch")
+if restored_sha != restored.get("restored_sha256"):
+    fail("restored artifact sha mismatch")
+if payload_bytes != restored_bytes:
+    fail("restored artifact content differs from payload")
+
+payload_data = json.loads(payload_bytes.decode("utf-8"))
+if payload_data.get("schema") != "adl.csm.polis_state_storage_payload.v1":
+    fail("payload artifact schema mismatch")
+if payload_data.get("issue") != 4913:
+    fail("payload artifact issue mismatch")
+if payload_data.get("run_id") != data.get("run_id"):
+    fail("payload artifact run id mismatch")
+
+neg = data.get("negative_cases", {})
+for name in ("missing_object", "corrupted_restore", "unsigned_access_denial"):
+    case = neg.get(name, {})
+    if case.get("status") != "passed":
+        fail(f"{name} negative case did not pass")
+    if case.get("raw_error_retained") is not False:
+        fail(f"{name} retained raw error")
+
+taxonomy = json.loads(taxonomy_path.read_text())
+if taxonomy.get("schema") != "adl.csm.polis_artifact_durability_taxonomy.v1":
+    fail("taxonomy schema mismatch")
+if taxonomy.get("issue") != 4913:
+    fail("taxonomy issue mismatch")
+if taxonomy.get("backend", {}).get("durability_posture") != "vendor_11_nines_per_object_non_12_nines_claim":
+    fail("taxonomy durability posture mismatch")
+if len(taxonomy.get("artifact_classes", [])) < 6:
+    fail("taxonomy artifact coverage too weak")
+if len(contract.get("selected_backend_assumptions", [])) < 2:
+    fail("backend assumptions too weak")
+if len(contract.get("local_proof_scope", [])) < 5:
+    fail("local proof scope too weak")
+if not any("does not claim mathematical 12-nines" in item for item in data.get("non_claims", [])):
+    fail("missing explicit 12-nines non-claim")
+
+print("PASS validate_wp08_polis_storage_live_proof")

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/artifact_durability_taxonomy.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/artifact_durability_taxonomy.json
@@ -1,0 +1,65 @@
+{
+  "artifact_classes": [
+    {
+      "artifact_kind": "checkpoint",
+      "durability_class": "critical_runtime_state",
+      "integrity": "sha256_manifest_plus_s3_metadata",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    },
+    {
+      "artifact_kind": "event_log",
+      "durability_class": "audit_replay_evidence",
+      "integrity": "append_order_manifest_plus_sha256",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    },
+    {
+      "artifact_kind": "snapshot",
+      "durability_class": "critical_runtime_state",
+      "integrity": "sha256_manifest_plus_s3_version_id",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    },
+    {
+      "artifact_kind": "diff",
+      "durability_class": "replay_delta",
+      "integrity": "sha256_manifest_plus_parent_snapshot_ref",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    },
+    {
+      "artifact_kind": "freeze_dry_bundle",
+      "durability_class": "survival_contract_bundle",
+      "integrity": "bundle_manifest_sha256_plus_member_hashes",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    },
+    {
+      "artifact_kind": "security_evidence",
+      "durability_class": "governance_audit_evidence",
+      "integrity": "sha256_manifest_and_redacted_summary",
+      "restore_required": true,
+      "retention": "365d_minimum_governance_retention"
+    }
+  ],
+  "backend": {
+    "bucket_name": "adl-wp08-obsmem-community-archive-b05e1f4379b5c745-us-west-2",
+    "controls": [
+      "versioning",
+      "object_lock_governance_retention",
+      "sse_s3_encryption",
+      "public_access_block",
+      "lifecycle_transition_policy"
+    ],
+    "durability_posture": "vendor_11_nines_per_object_non_12_nines_claim",
+    "kind": "aws_s3",
+    "prefix": "community-memory/"
+  },
+  "issue": 4913,
+  "non_claims": [
+    "single-region S3 Standard is not recorded as mathematical 12-nines durability",
+    "taxonomy does not make public access acceptable for any Polis state artifact"
+  ],
+  "schema": "adl.csm.polis_artifact_durability_taxonomy.v1"
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/csm_storage_command_result.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/csm_storage_command_result.json
@@ -1,0 +1,82 @@
+{
+  "schema": "adl.csm.polis_durable_storage_proof.v1",
+  "issue": 4913,
+  "status": "passed",
+  "run_id": "wp08-4913-polis-storage",
+  "checked_at_utc": "2026-07-06T20:02:09Z",
+  "aws_profile": "agent-logic-admin",
+  "aws_region": "us-west-2",
+  "aws_account_hash": "b05e1f4379b5c745",
+  "aws_account_matches_expected": true,
+  "bucket_name": "adl-wp08-obsmem-community-archive-b05e1f4379b5c745-us-west-2",
+  "bucket_name_hash": "f9890bd0400e85f3",
+  "object": {
+    "key": "community-memory/polis-state/wp08-4913-polis-storage/snapshot.json",
+    "version_id": "WWqV1whfgh1CoMfO6z2iji8.VIJkKkoj",
+    "payload_sha256": "d4d44780b21ef7905740c5054bdd1d71ab4fabb26da0e10f2d86f78c344d5b03",
+    "payload_bytes": 633,
+    "metadata_sha256_matches": true,
+    "server_side_encryption": "AES256",
+    "object_lock_mode": "GOVERNANCE",
+    "object_lock_retain_until_date": "2027-07-06T20:02:06+00:00"
+  },
+  "restored_artifact": {
+    "restore_ref": "restore/polis_state_snapshot.restored.json",
+    "restored_sha256": "d4d44780b21ef7905740c5054bdd1d71ab4fabb26da0e10f2d86f78c344d5b03",
+    "checksum_matches": true
+  },
+  "negative_cases": {
+    "missing_object": {
+      "status": "passed",
+      "expected_failure": "missing object must not restore as valid state",
+      "observed_failure_class": "s3_head_object_missing_or_not_found",
+      "raw_error_retained": false
+    },
+    "corrupted_restore": {
+      "status": "passed",
+      "expected_failure": "local corrupted restore must fail checksum validation",
+      "observed_failure_class": "checksum_mismatch_detected",
+      "raw_error_retained": false
+    },
+    "unsigned_access_denial": {
+      "status": "passed",
+      "expected_failure": "unsigned/public access must be denied for retained Polis state",
+      "observed_failure_class": "unsigned_access_denied_or_forbidden",
+      "raw_error_retained": false
+    }
+  },
+  "durability_contract": {
+    "target_class": "12-nines-class target; selected S3 backend is vendor 11-nines per-object durability and is therefore a non-12-nines mathematical claim",
+    "backend": "AWS S3 Standard with versioning, default governance object lock, SSE-S3 encryption, public access block, and lifecycle transition policy from #4688",
+    "artifact_taxonomy_ref": "artifact_durability_taxonomy.json",
+    "selected_backend_assumptions": [
+      "AWS S3 Standard vendor durability is treated as 11 nines per object for the selected single-region backend.",
+      "Object Lock governance retention and versioning provide immutable reference and recovery semantics for retained proof objects.",
+      "The #4688 bucket policy supplies public access block, encryption, versioning, lifecycle, and default retention controls."
+    ],
+    "local_proof_scope": [
+      "write object with checksum metadata",
+      "read object metadata including version/lock/encryption posture",
+      "restore object to clean staging directory",
+      "verify restored checksum",
+      "prove missing object, corrupted local restore, and unsigned access denial negative cases"
+    ]
+  },
+  "retained_artifacts": [
+    "polis_state_snapshot.json",
+    "restore/polis_state_snapshot.restored.json",
+    "artifact_durability_taxonomy.json",
+    "polis_storage_proof_summary.json"
+  ],
+  "non_claims": [
+    "This proof does not claim mathematical 12-nines durability from a single-region S3 bucket.",
+    "This proof does not retain AWS credentials, raw account ids, or raw AWS error payloads.",
+    "This proof validates one live write/read/restore cycle and bounded negative cases; it does not prove all future Polis artifacts are automatically archived."
+  ],
+  "redaction": {
+    "raw_account_id_retained": false,
+    "full_account_digest_retained": false,
+    "aws_credentials_retained": false,
+    "raw_aws_errors_retained": false
+  }
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_state_snapshot.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_state_snapshot.json
@@ -1,0 +1,21 @@
+{
+  "agent_instance_id": "polis-durable-storage-proof",
+  "artifact_kind": "snapshot",
+  "created_at_utc": "2026-07-06T20:02:06Z",
+  "cycle_id": "cycle-000001",
+  "issue": 4913,
+  "privacy": {
+    "contains_private_user_content": false,
+    "contains_secret": false,
+    "content_class": "synthetic_proof_payload"
+  },
+  "run_id": "wp08-4913-polis-storage",
+  "schema": "adl.csm.polis_state_storage_payload.v1",
+  "state": {
+    "checkpoint_ref": "checkpoint-000001",
+    "diff_ref": "diff-000001",
+    "event_log_ref": "event-log-000001",
+    "freeze_dry_bundle_ref": "freeze-dry-000001",
+    "snapshot_ref": "snapshot-000001"
+  }
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json
@@ -1,0 +1,82 @@
+{
+  "schema": "adl.csm.polis_durable_storage_proof.v1",
+  "issue": 4913,
+  "status": "passed",
+  "run_id": "wp08-4913-polis-storage",
+  "checked_at_utc": "2026-07-06T20:02:09Z",
+  "aws_profile": "agent-logic-admin",
+  "aws_region": "us-west-2",
+  "aws_account_hash": "b05e1f4379b5c745",
+  "aws_account_matches_expected": true,
+  "bucket_name": "adl-wp08-obsmem-community-archive-b05e1f4379b5c745-us-west-2",
+  "bucket_name_hash": "f9890bd0400e85f3",
+  "object": {
+    "key": "community-memory/polis-state/wp08-4913-polis-storage/snapshot.json",
+    "version_id": "WWqV1whfgh1CoMfO6z2iji8.VIJkKkoj",
+    "payload_sha256": "d4d44780b21ef7905740c5054bdd1d71ab4fabb26da0e10f2d86f78c344d5b03",
+    "payload_bytes": 633,
+    "metadata_sha256_matches": true,
+    "server_side_encryption": "AES256",
+    "object_lock_mode": "GOVERNANCE",
+    "object_lock_retain_until_date": "2027-07-06T20:02:06+00:00"
+  },
+  "restored_artifact": {
+    "restore_ref": "restore/polis_state_snapshot.restored.json",
+    "restored_sha256": "d4d44780b21ef7905740c5054bdd1d71ab4fabb26da0e10f2d86f78c344d5b03",
+    "checksum_matches": true
+  },
+  "negative_cases": {
+    "missing_object": {
+      "status": "passed",
+      "expected_failure": "missing object must not restore as valid state",
+      "observed_failure_class": "s3_head_object_missing_or_not_found",
+      "raw_error_retained": false
+    },
+    "corrupted_restore": {
+      "status": "passed",
+      "expected_failure": "local corrupted restore must fail checksum validation",
+      "observed_failure_class": "checksum_mismatch_detected",
+      "raw_error_retained": false
+    },
+    "unsigned_access_denial": {
+      "status": "passed",
+      "expected_failure": "unsigned/public access must be denied for retained Polis state",
+      "observed_failure_class": "unsigned_access_denied_or_forbidden",
+      "raw_error_retained": false
+    }
+  },
+  "durability_contract": {
+    "target_class": "12-nines-class target; selected S3 backend is vendor 11-nines per-object durability and is therefore a non-12-nines mathematical claim",
+    "backend": "AWS S3 Standard with versioning, default governance object lock, SSE-S3 encryption, public access block, and lifecycle transition policy from #4688",
+    "artifact_taxonomy_ref": "artifact_durability_taxonomy.json",
+    "selected_backend_assumptions": [
+      "AWS S3 Standard vendor durability is treated as 11 nines per object for the selected single-region backend.",
+      "Object Lock governance retention and versioning provide immutable reference and recovery semantics for retained proof objects.",
+      "The #4688 bucket policy supplies public access block, encryption, versioning, lifecycle, and default retention controls."
+    ],
+    "local_proof_scope": [
+      "write object with checksum metadata",
+      "read object metadata including version/lock/encryption posture",
+      "restore object to clean staging directory",
+      "verify restored checksum",
+      "prove missing object, corrupted local restore, and unsigned access denial negative cases"
+    ]
+  },
+  "retained_artifacts": [
+    "polis_state_snapshot.json",
+    "restore/polis_state_snapshot.restored.json",
+    "artifact_durability_taxonomy.json",
+    "polis_storage_proof_summary.json"
+  ],
+  "non_claims": [
+    "This proof does not claim mathematical 12-nines durability from a single-region S3 bucket.",
+    "This proof does not retain AWS credentials, raw account ids, or raw AWS error payloads.",
+    "This proof validates one live write/read/restore cycle and bounded negative cases; it does not prove all future Polis artifacts are automatically archived."
+  ],
+  "redaction": {
+    "raw_account_id_retained": false,
+    "full_account_digest_retained": false,
+    "aws_credentials_retained": false,
+    "raw_aws_errors_retained": false
+  }
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/restore/polis_state_snapshot.corrupt.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/restore/polis_state_snapshot.corrupt.json
@@ -1,0 +1,22 @@
+{
+  "agent_instance_id": "polis-durable-storage-proof",
+  "artifact_kind": "snapshot",
+  "created_at_utc": "2026-07-06T20:02:06Z",
+  "cycle_id": "cycle-000001",
+  "issue": 4913,
+  "privacy": {
+    "contains_private_user_content": false,
+    "contains_secret": false,
+    "content_class": "synthetic_proof_payload"
+  },
+  "run_id": "wp08-4913-polis-storage",
+  "schema": "adl.csm.polis_state_storage_payload.v1",
+  "state": {
+    "checkpoint_ref": "checkpoint-000001",
+    "diff_ref": "diff-000001",
+    "event_log_ref": "event-log-000001",
+    "freeze_dry_bundle_ref": "freeze-dry-000001",
+    "snapshot_ref": "snapshot-000001"
+  }
+}
+corruption-for-negative-proof

--- a/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/restore/polis_state_snapshot.restored.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/restore/polis_state_snapshot.restored.json
@@ -1,0 +1,21 @@
+{
+  "agent_instance_id": "polis-durable-storage-proof",
+  "artifact_kind": "snapshot",
+  "created_at_utc": "2026-07-06T20:02:06Z",
+  "cycle_id": "cycle-000001",
+  "issue": 4913,
+  "privacy": {
+    "contains_private_user_content": false,
+    "contains_secret": false,
+    "content_class": "synthetic_proof_payload"
+  },
+  "run_id": "wp08-4913-polis-storage",
+  "schema": "adl.csm.polis_state_storage_payload.v1",
+  "state": {
+    "checkpoint_ref": "checkpoint-000001",
+    "diff_ref": "diff-000001",
+    "event_log_ref": "event-log-000001",
+    "freeze_dry_bundle_ref": "freeze-dry-000001",
+    "snapshot_ref": "snapshot-000001"
+  }
+}

--- a/docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md
+++ b/docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md
@@ -1,0 +1,91 @@
+# Runtime Polis Durable Storage Proof
+
+This is the WP-08 runtime path for proving Polis state artifact storage against
+the Agent Logic S3 archive bucket created by `#4688`.
+
+The runtime-owned command is:
+
+```bash
+csm storage prove-s3 \
+  --out docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913 \
+  --bucket <wp08-obsmem-archive-bucket> \
+  --prefix community-memory/ \
+  --profile agent-logic-admin \
+  --region us-west-2 \
+  --expected-account-sha256 <approved-agent-logic-account-sha256> \
+  --run-id wp08-4913-polis-storage \
+  --json
+```
+
+For normal issue execution, use the wrapper from a bound worktree:
+
+```bash
+ADL_AWS_PROFILE=agent-logic-admin \
+AWS_PROFILE=agent-logic-admin \
+ADL_AWS_POLIS_STORAGE_ACCOUNT_SHA256=<approved-agent-logic-account-sha256> \
+bash adl/tools/run_wp08_polis_storage_live_proof.sh \
+  --out docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913 \
+  --profile agent-logic-admin \
+  --region us-west-2
+```
+
+The wrapper derives the default bucket from the approved account hash:
+
+```text
+adl-wp08-obsmem-community-archive-<account-hash>-us-west-2
+```
+
+## Proof Scope
+
+The proof writes one synthetic Polis snapshot artifact under
+`community-memory/polis-state/<run-id>/snapshot.json`, records SHA-256 metadata,
+reads S3 object metadata, restores the object to a clean local staging path, and
+checks the restored checksum. It also records bounded negative cases for a
+missing object, corrupted local restore, and unsigned/public access denial.
+
+The retained summary is:
+
+```text
+polis_storage_proof_summary.json
+```
+
+The proof also writes:
+
+```text
+artifact_durability_taxonomy.json
+polis_state_snapshot.json
+restore/polis_state_snapshot.restored.json
+```
+
+## Validation
+
+Wrapper contract:
+
+```bash
+bash adl/tools/test_run_wp08_polis_storage_live_proof.sh
+```
+
+Retained live proof validation:
+
+```bash
+python3 adl/tools/validate_wp08_polis_storage_live_proof.py \
+  docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json
+```
+
+Focused Rust proof:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml csm_polis_storage -- --nocapture
+```
+
+## Claim Boundary
+
+This is a live object-level proof, not a mathematical proof of AWS durability.
+The selected single-region S3 backend is recorded as vendor 11-nines
+per-object durability with versioning, governance Object Lock, SSE-S3,
+public-access block, and lifecycle controls. The summary must explicitly retain
+the non-claim that this is not a mathematical 12-nines proof.
+
+Do not use a personal/default AWS profile for this proof. Do not retain raw AWS
+account ids, credentials, raw ARNs, or raw AWS error payloads in tracked
+evidence.


### PR DESCRIPTION
Closes #4913

## Summary
Implemented the #4913 Polis durable-storage proof as a runtime-owned `csm storage prove-s3` path. The proof writes a synthetic Polis snapshot to the #4688 Agent Logic S3 archive bucket, records checksum metadata and S3 version/Object Lock/encryption posture, restores the artifact locally, validates integrity, records missing/corrupt/unsigned-access negative cases, and retains explicit non-12-nines claim boundaries.

## Artifacts
- Runtime module: `adl/src/csm_polis_storage.rs`
- Runtime CLI integration: `adl/src/cli/csm_cmd.rs`
- Finish/validation lane routing: `adl/src/cli/pr_cmd/finish_support.rs`, `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`, `adl/config/validation_lane_selector.v0.91.6.json`
- Proof wrappers and validator: `adl/tools/run_wp08_polis_storage_live_proof.sh`, `adl/tools/test_run_wp08_polis_storage_live_proof.sh`, `adl/tools/validate_wp08_polis_storage_live_proof.py`
- Operator documentation: `docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md`
- Retained live proof artifacts under `docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Checked tracked `.adl` issue-record residue.
  - `git diff --check`
    Checked whitespace and patch hygiene.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Checked Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml csm_polis_storage -- --nocapture`
    Checked storage proof helper behavior.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::csm_cmd::tests:: -- --nocapture`
    Checked runtime/control-plane CLI ownership.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-finish cli::pr_cmd::tests::finish::arg_render::finish_validation_profile_classifies_wp08_polis_storage_slice -- --exact --nocapture`
    Checked finish validation profile selection.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Checked validation lane registration.
  - `bash adl/tools/test_run_wp08_polis_storage_live_proof.sh`
    Checked proof wrapper contract.
  - `cargo build --manifest-path adl/Cargo.toml --bin csm`
    Checked standalone runtime binary compilation.
  - `ADL_AWS_PROFILE=agent-logic-admin AWS_PROFILE=agent-logic-admin ADL_AWS_POLIS_STORAGE_ACCOUNT_SHA256=<redacted-approved-hash> bash adl/tools/run_wp08_polis_storage_live_proof.sh --out docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913 --profile agent-logic-admin --region us-west-2 --csm-bin adl/target/debug/csm`
    Checked live Agent Logic S3 proof.
  - `python3 adl/tools/validate_wp08_polis_storage_live_proof.py docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913/polis_storage_proof_summary.json`
    Checked retained proof artifacts.
  - `rg -n 'AKIA|ASIA|aws_secret|secret_access|[0-9]{12}' docs/milestones/v0.91.7/review/runtime/csm_polis_storage_4913 adl/tools/run_wp08_polis_storage_live_proof.sh adl/tools/test_run_wp08_polis_storage_live_proof.sh adl/tools/validate_wp08_polis_storage_live_proof.py adl/src/csm_polis_storage.rs docs/tooling/RUNTIME_POLIS_DURABLE_STORAGE.md`
    Checked redaction hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4913__v0-91-7-wp-08-storage-prove-12-nines-class-durable-storage-for-polis-state/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4913__v0-91-7-wp-08-storage-prove-12-nines-class-durable-storage-for-polis-state/sor.md
- Idempotency-Key: v0-91-7-wp-08-storage-prove-12-nines-class-durable-storage-for-polis-state-adl-v0-91-7-tasks-issue-4913-v0-91-7-wp-08-storage-prove-12-nines-class-durable-storage-for-polis-state-sip-md-adl-v0-91-7-tasks-issue-4913-v0-91-7-wp-08-storage-prove-12-nines-class-durable-storage-for-polis-state-sor-md