### PR TITLE
[v0.91.7][WP-07][csm] Make CSM daemon service mode permanent and classify any exit

### DIFF
--- a/adl/src/cli/csm_cmd.rs
+++ b/adl/src/cli/csm_cmd.rs
@@ -666,8 +666,9 @@ pub(crate) fn csm_usage() -> &'static str {
 
 Semantics:
   - csm is the dedicated runtime owner binary.
-  - csm daemon owns long-lived runtime execution, partial checkpoints, restart accounting, recoverable terminal state, and runtime observability.
-  - csm service owns host service-manager installation/status around csm daemon; launchd is the primary macOS target and local mode is a bounded proof fallback.
+  - csm daemon owns permanent restart-always runtime execution, partial checkpoints, restart accounting, recoverable terminal state, and runtime observability.
+  - csm daemon service mode ignores agent max_cycles as a service lifetime boundary; --no-sleep is a test-only bounded harness boundary.
+  - csm service owns host service-manager installation/status around csm daemon; launchd KeepAlive is the primary macOS target, systemd Restart=always compatible service metadata is retained, and local mode is a bounded proof fallback.
   - csm api exposes local-by-default /status, /health, /ready, /metrics, and /events endpoints from retained runtime artifacts without leaking host-private paths or secrets.
   - csm aws-signal owns runtime AWS signal proof execution, including ACIP-to-SNS live publication under the Agent Logic account guard.
   - csm backpressure proves bounded overload policy, retained metrics, and safe-fail serialization triggers for capacity-degraded runtime paths.

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -91,6 +91,10 @@ struct ServiceManifest {
     label: String,
     manager: ServiceManager,
     runtime_owner: String,
+    #[serde(default)]
+    restart_policy: String,
+    #[serde(default)]
+    service_mode: String,
     csm_bin: PathBuf,
     spec: PathBuf,
     service_root: PathBuf,
@@ -124,6 +128,8 @@ struct ServiceStatus {
     label: String,
     manager: String,
     runtime_owner: &'static str,
+    restart_policy: String,
+    service_mode: String,
     service_state: String,
     pid: Option<u32>,
     pid_liveness: String,
@@ -418,6 +424,8 @@ fn build_manifest(
         label: parsed.label,
         manager: parsed.manager,
         runtime_owner: "csm".to_string(),
+        restart_policy: service_restart_policy(parsed.manager, parsed.no_sleep),
+        service_mode: service_mode(parsed.manager, parsed.no_sleep),
         csm_bin,
         spec,
         service_root: service_root.clone(),
@@ -641,6 +649,8 @@ fn service_status(
         label: manifest.label.clone(),
         manager: manifest.manager.as_str().to_string(),
         runtime_owner: "csm",
+        restart_policy: manifest.restart_policy.clone(),
+        service_mode: manifest.service_mode.clone(),
         service_state: state.to_string(),
         pid,
         pid_liveness: pid_liveness.clone(),
@@ -678,7 +688,9 @@ fn service_status(
 fn read_manifest(service_root: &Path) -> Result<ServiceManifest> {
     let path = manifest_path(service_root);
     let raw = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
-    serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))
+    let manifest: ServiceManifest =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    Ok(normalize_service_manifest_metadata(manifest))
 }
 
 fn write_status(manifest: &ServiceManifest, status: &ServiceStatus) -> Result<()> {
@@ -1372,6 +1384,32 @@ fn unsupported_permanence_claims() -> Vec<String> {
     ]
 }
 
+fn normalize_service_manifest_metadata(mut manifest: ServiceManifest) -> ServiceManifest {
+    manifest.restart_policy = service_restart_policy(manifest.manager, manifest.no_sleep);
+    manifest.service_mode = service_mode(manifest.manager, manifest.no_sleep);
+    manifest
+}
+
+fn service_restart_policy(manager: ServiceManager, no_sleep: bool) -> String {
+    if no_sleep {
+        "bounded_test_only".to_string()
+    } else if manager == ServiceManager::Launchd {
+        "always".to_string()
+    } else {
+        "external_supervisor_required".to_string()
+    }
+}
+
+fn service_mode(manager: ServiceManager, no_sleep: bool) -> String {
+    if no_sleep {
+        "bounded_test_only".to_string()
+    } else if manager == ServiceManager::Launchd {
+        "permanent".to_string()
+    } else {
+        "local_proof_only".to_string()
+    }
+}
+
 pub(crate) fn service_usage() -> &'static str {
     "Usage:
   csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--max-restarts <n>] [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--otlp-endpoint <url>] [--otlp-timeout-ms <n>] [--no-recover-stale-lease] [--no-sleep] [--json]
@@ -1382,8 +1420,10 @@ pub(crate) fn service_usage() -> &'static str {
 
 Semantics:
   - csm service is the host-service envelope for the standalone csm runtime owner.
-  - launchd is the primary macOS service-manager target; local mode is a bounded proof fallback.
+  - launchd service mode records restart_policy=always and service_mode=permanent; launchd KeepAlive is the primary macOS service-manager target and systemd Restart=always compatible metadata is retained.
+  - local mode is a bounded proof fallback and records external_supervisor_required/local_proof_only.
   - the managed command is always csm daemon, never adl agent daemon.
+  - --no-sleep is an explicit test-only bounded harness boundary, not production service mode.
   - service artifacts include service_manifest.json, service_status.json, csm.launchd.plist, logs, OTel status/export paths, daemon_status.json, continuity checkpoints, and operator events.
   - status uses metadata or exact PID liveness probes only; no broad process scan or ps output is used.
   - unsupported permanence claims remain explicit for reboot, kill -9, disk-full, resource exhaustion, and cloud orchestration."

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -146,6 +146,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
         &loaded,
         DaemonStatusInput {
             state: "starting",
+            bounded_test_mode: options.no_sleep,
             restart_count,
             max_restarts: options.max_restarts,
             checkpoint_interval_secs,
@@ -162,9 +163,14 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
         "started",
         restart_count,
         json!({
-            "checkpoint_interval_secs": checkpoint_interval_secs,
-            "agent_checkpoint_policy": agent_checkpoint_policy(&loaded),
-            "max_restarts": options.max_restarts,
+                "checkpoint_interval_secs": checkpoint_interval_secs,
+                "agent_checkpoint_policy": agent_checkpoint_policy(&loaded),
+                "max_restarts": options.max_restarts,
+                "restart_policy": daemon_restart_policy(),
+                "service_mode": daemon_service_mode(options.no_sleep),
+                "bounded_test_mode": options.no_sleep,
+            "agent_configured_max_cycles": loaded.spec.heartbeat.max_cycles,
+            "agent_max_cycles_lifetime_boundary": "ignored_in_daemon_service_mode",
             "unsupported_permanence_claims": unsupported_permanence_claims()
         }),
     )?;
@@ -178,6 +184,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                 &loaded,
                 DaemonStatusInput {
                     state: "stopped",
+                    bounded_test_mode: options.no_sleep,
                     restart_count,
                     max_restarts: options.max_restarts,
                     checkpoint_interval_secs,
@@ -225,6 +232,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
             &loaded,
             DaemonStatusInput {
                 state: "running",
+                bounded_test_mode: options.no_sleep,
                 restart_count,
                 max_restarts: options.max_restarts,
                 checkpoint_interval_secs,
@@ -259,6 +267,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                     &loaded,
                     DaemonStatusInput {
                         state: "running",
+                        bounded_test_mode: options.no_sleep,
                         restart_count,
                         max_restarts: options.max_restarts,
                         checkpoint_interval_secs,
@@ -323,6 +332,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                         &loaded,
                         DaemonStatusInput {
                             state: "failed",
+                            bounded_test_mode: options.no_sleep,
                             restart_count,
                             max_restarts: options.max_restarts,
                             checkpoint_interval_secs,
@@ -366,6 +376,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                     &loaded,
                     DaemonStatusInput {
                         state: "restarting",
+                        bounded_test_mode: options.no_sleep,
                         restart_count,
                         max_restarts: options.max_restarts,
                         checkpoint_interval_secs,
@@ -437,6 +448,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                 &loaded,
                 DaemonStatusInput {
                     state: "completed",
+                    bounded_test_mode: true,
                     restart_count,
                     max_restarts: options.max_restarts,
                     checkpoint_interval_secs,
@@ -451,7 +463,12 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                 "daemon_completed",
                 "completed",
                 restart_count,
-                json!({"reason": "no_sleep_test_boundary"}),
+                json!({
+                    "reason": "no_sleep_test_boundary",
+                    "restart_policy": daemon_restart_policy(),
+                    "service_mode": "bounded_test_only",
+                    "bounded_test_mode": true
+                }),
             )?;
             return Ok(daemon_status);
         }
@@ -2017,6 +2034,7 @@ fn safe_fail_existing_ref(path: &Path) -> Value {
 
 struct DaemonStatusInput<'a> {
     state: &'a str,
+    bounded_test_mode: bool,
     restart_count: u64,
     max_restarts: u64,
     checkpoint_interval_secs: u64,
@@ -2063,6 +2081,9 @@ fn write_daemon_status(
         runtime_capabilities: csm_runtime_capabilities(runtime_context),
         state: input.state.to_string(),
         supervisor_pid: std::process::id(),
+        restart_policy: daemon_restart_policy().to_string(),
+        service_mode: daemon_status_service_mode(input.state, input.bounded_test_mode).to_string(),
+        bounded_test_mode: input.bounded_test_mode,
         restart_count: input.restart_count,
         max_restarts: input.max_restarts,
         checkpoint_interval_secs: input.checkpoint_interval_secs,
@@ -2100,6 +2121,7 @@ fn sleep_with_partial_checkpoints(
             loaded,
             DaemonStatusInput {
                 state: daemon_status.state.as_str(),
+                bounded_test_mode: sleep.no_sleep,
                 restart_count: sleep.restart_count,
                 max_restarts: sleep.max_restarts,
                 checkpoint_interval_secs: sleep.checkpoint_interval_secs,
@@ -2170,6 +2192,7 @@ fn sleep_with_partial_checkpoints(
             loaded,
             DaemonStatusInput {
                 state: daemon_status.state.as_str(),
+                bounded_test_mode: sleep.no_sleep,
                 restart_count: sleep.restart_count,
                 max_restarts: sleep.max_restarts,
                 checkpoint_interval_secs: sleep.checkpoint_interval_secs,
@@ -2293,6 +2316,19 @@ fn csm_runtime_capabilities(runtime_context: &CsmRuntimeContext) -> Value {
         "runtime_owner": "csm",
         "adl_role": "tooling_control_plane",
         "process_class": "csm_runtime_daemon",
+        "supervisor": {
+            "status": "integrated",
+            "restart_policy": daemon_restart_policy(),
+            "service_mode": "permanent",
+            "bounded_test_mode": "explicit_only",
+            "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+            ],
+            "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only"
+        },
         "chronosense": {
             "status": "integrated",
             "service_schema": runtime_context.chronosense.config().schema_version,
@@ -2358,6 +2394,26 @@ fn daemon_span_id(event: &str, restart_count: u64) -> String {
 
 fn restart_backoff_secs(restart_count: u64) -> u64 {
     2u64.saturating_pow(restart_count.min(4) as u32).min(30)
+}
+
+fn daemon_restart_policy() -> &'static str {
+    "always"
+}
+
+fn daemon_service_mode(bounded_test_mode: bool) -> &'static str {
+    if bounded_test_mode {
+        "bounded_test_only"
+    } else {
+        "permanent"
+    }
+}
+
+fn daemon_status_service_mode(state: &str, bounded_test_mode: bool) -> &'static str {
+    if bounded_test_mode || state == "completed" {
+        "bounded_test_only"
+    } else {
+        "permanent"
+    }
 }
 
 fn unsupported_permanence_claims() -> Vec<String> {

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1075,6 +1075,7 @@ fn daemon_partial_checkpoint_preserves_recoverable_failure_reason() {
         &loaded,
         DaemonStatusInput {
             state: "restarting",
+            bounded_test_mode: true,
             restart_count: 1,
             max_restarts: 1,
             checkpoint_interval_secs: 1,
@@ -1230,6 +1231,63 @@ fn daemon_interval_defaults_positive_and_rejects_zero_cadence() {
 }
 
 #[test]
+fn daemon_status_records_restart_always_permanent_service_contract() {
+    let root = temp_dir("daemon-restart-always-contract");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+
+    let running = write_daemon_status(
+        &runtime_context,
+        &loaded,
+        DaemonStatusInput {
+            state: "running",
+            bounded_test_mode: false,
+            restart_count: 0,
+            max_restarts: 10,
+            checkpoint_interval_secs: 1,
+            last_event: "daemon_started",
+            last_child_exit: None,
+            next_backoff_secs: 0,
+        },
+    )
+    .expect("running daemon status");
+
+    assert_eq!(running.restart_policy, "always");
+    assert_eq!(running.service_mode, "permanent");
+    assert!(!running.bounded_test_mode);
+    assert_eq!(
+        running.runtime_capabilities["supervisor"]["restart_policy"],
+        "always"
+    );
+    assert_eq!(
+        running.runtime_capabilities["supervisor"]["lifetime_boundary"],
+        "operator_stop_or_fatal_supervisor_failure_only"
+    );
+
+    let bounded = write_daemon_status(
+        &runtime_context,
+        &loaded,
+        DaemonStatusInput {
+            state: "completed",
+            bounded_test_mode: true,
+            restart_count: 0,
+            max_restarts: 10,
+            checkpoint_interval_secs: 1,
+            last_event: "daemon_completed",
+            last_child_exit: Some("success".to_string()),
+            next_backoff_secs: 0,
+        },
+    )
+    .expect("bounded daemon status");
+
+    assert_eq!(bounded.restart_policy, "always");
+    assert_eq!(bounded.service_mode, "bounded_test_only");
+    assert!(bounded.bounded_test_mode);
+}
+
+#[test]
 fn agent_checkpoint_policy_clamps_cadence_and_governs_requests() {
     let root = temp_dir("agent-checkpoint-policy");
     let spec = root.join("agent.yaml");
@@ -1339,6 +1397,7 @@ fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
         &loaded,
         DaemonStatusInput {
             state: "running",
+            bounded_test_mode: false,
             restart_count: 0,
             max_restarts: 1,
             checkpoint_interval_secs: 1,
@@ -1389,6 +1448,7 @@ fn daemon_partial_checkpoint_reports_stop_observed_before_restart_attempt() {
         &loaded,
         DaemonStatusInput {
             state: "restarting",
+            bounded_test_mode: false,
             restart_count: 1,
             max_restarts: 1,
             checkpoint_interval_secs: 1,

--- a/adl/src/long_lived_agent/types.rs
+++ b/adl/src/long_lived_agent/types.rs
@@ -131,6 +131,12 @@ pub struct DaemonStatusRecord {
     pub runtime_capabilities: Value,
     pub state: String,
     pub supervisor_pid: u32,
+    #[serde(default)]
+    pub restart_policy: String,
+    #[serde(default)]
+    pub service_mode: String,
+    #[serde(default)]
+    pub bounded_test_mode: bool,
     pub restart_count: u64,
     pub max_restarts: u64,
     pub checkpoint_interval_secs: u64,

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -552,6 +552,18 @@ memory:
         stdout.contains("\"state\": \"completed\""),
         "stdout:\n{stdout}"
     );
+    assert!(
+        stdout.contains("\"restart_policy\": \"always\""),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"service_mode\": \"bounded_test_only\""),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"bounded_test_mode\": true"),
+        "stdout:\n{stdout}"
+    );
     assert!(root.join("state/daemon_status.json").exists());
     assert!(root.join("state/continuity_checkpoint.json").exists());
     assert!(root.join("state/continuity_replay_manifest.json").exists());
@@ -563,6 +575,17 @@ memory:
     assert_eq!(
         daemon_status["unsupported_permanence_claims"][0],
         "not_os_boot_persistent"
+    );
+    assert_eq!(daemon_status["restart_policy"], "always");
+    assert_eq!(daemon_status["service_mode"], "bounded_test_only");
+    assert_eq!(daemon_status["bounded_test_mode"], true);
+    assert_eq!(
+        daemon_status["runtime_capabilities"]["supervisor"]["restart_policy"],
+        "always"
+    );
+    assert_eq!(
+        daemon_status["runtime_capabilities"]["supervisor"]["service_mode"],
+        "permanent"
     );
     assert_eq!(daemon_status["trace_id"], "agent.daemon-agent.daemon");
 
@@ -585,6 +608,21 @@ memory:
     assert_text_contains(
         &operator_events,
         "\"trace_id\":\"agent.daemon-agent.daemon\"",
+        "operator events",
+    );
+    assert_text_contains(
+        &operator_events,
+        "\"restart_policy\":\"always\"",
+        "operator events",
+    );
+    assert_text_contains(
+        &operator_events,
+        "\"service_mode\":\"bounded_test_only\"",
+        "operator events",
+    );
+    assert_text_contains(
+        &operator_events,
+        "\"agent_max_cycles_lifetime_boundary\":\"ignored_in_daemon_service_mode\"",
         "operator events",
     );
     assert_text_contains(&operator_events, "\"otel\"", "operator events");
@@ -1916,6 +1954,8 @@ memory:
     .expect("parse manifest");
     assert_eq!(manifest["schema"], "adl.csm.service_manifest.v1");
     assert_eq!(manifest["runtime_owner"], "csm");
+    assert_eq!(manifest["restart_policy"], "always");
+    assert_eq!(manifest["service_mode"], "permanent");
     assert_eq!(manifest["manager"], "launchd");
     assert_eq!(manifest["checkpoint_interval_secs"], 1);
     assert_eq!(manifest["otlp_endpoint"], "http://127.0.0.1:4318/v1/traces");
@@ -1948,6 +1988,8 @@ memory:
     )
     .expect("parse service status");
     assert_eq!(status["schema"], "adl.csm.service_status.v1");
+    assert_eq!(status["restart_policy"], "always");
+    assert_eq!(status["service_mode"], "permanent");
     assert_eq!(status["service_state"], "installed");
     assert_eq!(status["broad_process_scan"], false);
     assert_eq!(status["uses_ps"], false);
@@ -1964,6 +2006,136 @@ memory:
         .as_str()
         .expect("startup ledger ref")
         .ends_with("logs/startup_ledger.jsonl"));
+}
+
+#[test]
+fn csm_service_install_classifies_local_and_no_sleep_modes_truthfully() {
+    let root = unique_test_temp_dir("csm-service-mode-truth");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: service-mode-agent
+display_name: Service Mode Agent
+state_root: runtime-state
+workflow:
+  kind: demo_adapter
+  name: service_mode_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 1
+  max_cycles: 3
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+memory:
+  namespace: smoke/service-mode-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+    let csm_bin = resolve_csm_exe();
+
+    let local_root = root.join("local-service");
+    let local = run_csm(&[
+        "service",
+        "install",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--service-root",
+        local_root.to_str().expect("utf8 local service root"),
+        "--manager",
+        "local",
+        "--csm-bin",
+        csm_bin.to_str().expect("utf8 csm bin"),
+        "--json",
+    ]);
+    assert!(
+        local.status.success(),
+        "expected local service install success, stderr:\n{}",
+        String::from_utf8_lossy(&local.stderr)
+    );
+    let local_manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(local_root.join("service_manifest.json")).expect("local manifest"),
+    )
+    .expect("parse local manifest");
+    assert_eq!(
+        local_manifest["restart_policy"],
+        "external_supervisor_required"
+    );
+    assert_eq!(local_manifest["service_mode"], "local_proof_only");
+    let mut legacy_local_manifest = local_manifest.clone();
+    legacy_local_manifest
+        .as_object_mut()
+        .expect("local manifest object")
+        .remove("restart_policy");
+    legacy_local_manifest
+        .as_object_mut()
+        .expect("local manifest object")
+        .remove("service_mode");
+    fs::write(
+        local_root.join("service_manifest.json"),
+        serde_json::to_string_pretty(&legacy_local_manifest).expect("serialize legacy manifest"),
+    )
+    .expect("write legacy local manifest");
+    let local_status = run_csm(&[
+        "service",
+        "status",
+        "--service-root",
+        local_root.to_str().expect("utf8 local service root"),
+        "--json",
+    ]);
+    assert!(
+        local_status.status.success(),
+        "expected local service status success, stderr:\n{}",
+        String::from_utf8_lossy(&local_status.stderr)
+    );
+    let legacy_status: serde_json::Value =
+        serde_json::from_slice(&local_status.stdout).expect("parse local status stdout");
+    assert_eq!(
+        legacy_status["restart_policy"],
+        "external_supervisor_required"
+    );
+    assert_eq!(legacy_status["service_mode"], "local_proof_only");
+
+    let bounded_root = root.join("bounded-service");
+    let bounded = run_csm(&[
+        "service",
+        "install",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--service-root",
+        bounded_root.to_str().expect("utf8 bounded service root"),
+        "--manager",
+        "launchd",
+        "--csm-bin",
+        csm_bin.to_str().expect("utf8 csm bin"),
+        "--no-sleep",
+        "--json",
+    ]);
+    assert!(
+        bounded.status.success(),
+        "expected bounded service install success, stderr:\n{}",
+        String::from_utf8_lossy(&bounded.stderr)
+    );
+    let bounded_manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(bounded_root.join("service_manifest.json")).expect("bounded manifest"),
+    )
+    .expect("parse bounded manifest");
+    assert_eq!(bounded_manifest["restart_policy"], "bounded_test_only");
+    assert_eq!(bounded_manifest["service_mode"], "bounded_test_only");
+    let bounded_status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(bounded_root.join("service_status.json")).expect("bounded status"),
+    )
+    .expect("parse bounded status");
+    assert_eq!(bounded_status["restart_policy"], "bounded_test_only");
+    assert_eq!(bounded_status["service_mode"], "bounded_test_only");
 }
 
 #[test]
@@ -2707,6 +2879,8 @@ memory:
     )
     .expect("parse daemon status");
     assert_eq!(daemon_status["state"], "failed");
+    assert_eq!(daemon_status["service_mode"], "bounded_test_only");
+    assert_eq!(daemon_status["bounded_test_mode"], true);
     assert_eq!(daemon_status["restart_count"], 1);
     assert_eq!(daemon_status["last_event"], "restart_budget_exhausted");
     assert!(root.join("state/continuity_checkpoint.json").exists());

--- a/docs/milestones/v0.91.7/review/runtime/csm_daemon_permanence_4997/README.md
+++ b/docs/milestones/v0.91.7/review/runtime/csm_daemon_permanence_4997/README.md
@@ -1,0 +1,75 @@
+# CSM Daemon Permanence Proof - Issue #4997
+
+## Scope
+
+Issue #4997 fixes the CSM daemon/service contract after the #4976 direct liveness rerun stopped with recoverable state but without a durable service-permanence classification.
+
+This packet records the implementation proof for the local CSM contract only. It does not close #4976 and does not claim a 24-hour soak.
+
+## Failure Input
+
+Observed retained #4976 rerun evidence:
+
+- Direct daemon PID became stale.
+- Last successful local cycle was `cycle-002500`.
+- Agent status was recoverable `idle`, with `last_error: null` and `stop_requested: false`.
+- Safe-fail state classified the agent as recoverable sleeping.
+- OTel retained event count was present.
+- AWS heartbeat cursor reached `next_heartbeat_seq: 10000`.
+
+The old evidence left the service lifetime boundary ambiguous enough that a finite heartbeat/cycle envelope could look like a daemon lifetime policy.
+
+## Implemented Contract
+
+- CSM daemon status now records `restart_policy: "always"`.
+- CSM daemon status now records `service_mode: "permanent"` for service operation.
+- Bounded test harness returns are explicitly marked with `service_mode: "bounded_test_only"` and `bounded_test_mode: true`.
+- Daemon startup events record `agent_max_cycles_lifetime_boundary: "ignored_in_daemon_service_mode"`.
+- Runtime capabilities expose supervisor metadata for launchd KeepAlive, systemd Restart=always-compatible service metadata, Rustysd service-manager compatibility, and rinit service-manager compatibility.
+- CSM launchd service manifests and service status records retain `restart_policy: "always"` and `service_mode: "permanent"`.
+- CSM local service manifests are classified as `restart_policy: "external_supervisor_required"` and `service_mode: "local_proof_only"`.
+- CSM `--no-sleep` service manifests are classified as `restart_policy: "bounded_test_only"` and `service_mode: "bounded_test_only"`.
+- CSM service status normalizes legacy manifests that are missing these fields instead of echoing stale permanence defaults.
+
+## Non-Claims
+
+- No 24-hour soak completion is claimed here.
+- No OS reboot survival is claimed here.
+- No kill -9 recovery is claimed here.
+- No disk-full or host resource-exhaustion recovery is claimed here.
+- No CloudFront, ACIP/SNS, or outbound shutdown notice delivery is claimed here.
+
+Outbound shutdown/degradation notices are scheduled separately in #4998.
+
+## Local Validation
+
+Commands run from the #4997 worktree:
+
+```sh
+cargo fmt --manifest-path adl/Cargo.toml
+cargo check --manifest-path adl/Cargo.toml
+cargo test --manifest-path adl/Cargo.toml daemon_status_records_restart_always_permanent_service_contract --lib
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm_daemon_writes_status_checkpoints_and_otel_observability -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm_service_install_writes_launchd_envelope_without_adl_runtime_owner -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm_service_install_classifies_local_and_no_sleep_modes_truthfully -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm_daemon_restart_budget_failure_leaves_recoverable_checkpoint -- --nocapture
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm -- --nocapture
+git diff --check
+```
+
+Observed result:
+
+- `cargo check`: passed.
+- Unit permanence contract test: passed.
+- Focused daemon smoke: passed.
+- Focused service install smoke: passed.
+- Local/no-sleep service metadata regression: passed.
+- Restart-budget bounded-test metadata regression: passed.
+- Broader CSM smoke slice: 15 passed, 0 failed.
+- `git diff --check`: passed.
+
+## Follow-On
+
+#4976 must remain open until a post-fix liveness run survives at least 24 hours.
+
+#4998 owns governed shutdown/degradation outbound notices through CloudFront/control-plane hooks, ACIP/SNS, and other configured channels.


### PR DESCRIPTION
Closes #4997

## Summary
Implemented the #4997 CSM daemon permanence contract. The CSM daemon now records restart-always metadata, classifies permanent service mode separately from bounded test mode, ignores agent `max_cycles` as a daemon lifetime boundary, and exposes supervisor capability metadata for launchd KeepAlive, systemd Restart=always-compatible metadata, Rustysd, and rinit service-manager compatibility. Service manifests/status records now distinguish launchd permanent mode from local proof mode and explicit `--no-sleep` bounded test mode.

This record does not claim #4976 is closed, does not claim a 24-hour soak has completed, and does not claim outbound CloudFront/ACIP/SNS shutdown notices; that notification fan-out is scheduled in #4998.

## Artifacts
- Tracked implementation artifacts:
  - `adl/src/cli/csm_cmd.rs`
  - `adl/src/cli/csm_service_cmd.rs`
  - `adl/src/long_lived_agent.rs`
  - `adl/src/long_lived_agent/types.rs`
  - `adl/src/long_lived_agent/tests.rs`
  - `adl/tests/cli_smoke/agent.rs`
- Additional proof artifacts:
  - `docs/milestones/v0.91.7/review/runtime/csm_daemon_permanence_4997/README.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent::csm -- --nocapture`
    `Verified the broader CSM CLI smoke slice; 15 tests passed. Focused command-level proof is retained in docs/milestones/v0.91.7/review/runtime/csm_daemon_permanence_4997/README.md.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4997__v0-91-7-wp-07-csm-make-csm-daemon-service-mode-permanent-and-classify-any-exit/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4997__v0-91-7-wp-07-csm-make-csm-daemon-service-mode-permanent-and-classify-any-exit/sor.md
- Idempotency-Key: v0-91-7-wp-07-csm-make-csm-daemon-service-mode-permanent-and-classify-any-exit-adl-src-cli-csm-cmd-rs-adl-src-cli-csm-service-cmd-rs-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-types-rs-adl-src-long-lived-agent-tests-rs-adl-tests-cli-smoke-agent-rs-docs-milestones-v0-91-7-review-runtime-csm-daemon-permanence-4997-readme-md-adl-v0-91-7-tasks-issue-4997-v0-91-7-wp-07-csm-make-csm-daemon-service-mode-permanent-and-classify-any-exit-sip-md-adl-v0-91-7-tasks-issue-4997-v0-91-7-wp-07-csm-make-csm-daemon-service-mode-permanent-and-classify-any-exit-sor-md