### PR TITLE
[v0.91.7][resilience] Implement PR and CI shepherding resilience

### DIFF
--- a/adl/src/cli/pr_cmd/github/tests/validation.rs
+++ b/adl/src/cli/pr_cmd/github/tests/validation.rs
@@ -637,6 +637,210 @@ fn pr_validation_wait_reports_folded_slow_anomaly_packets_with_safe_body_files()
 }
 
 #[test]
+fn pr_validation_wait_writes_durable_attempt_log_for_pending_then_success() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-pr-validation-attempt-log");
+    let attempt_log = temp.join("attempts.jsonl");
+    let (base_uri, server) = spawn_validation_status_pending_then_success_server();
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("ADL_PR_VALIDATION_WAIT_POLL_MS", "1");
+        std::env::set_var("ADL_PR_VALIDATION_ATTEMPT_LOG", &attempt_log);
+    }
+
+    let report =
+        wait_for_pr_validation_report("owner/repo", "1159").expect("validation wait report");
+    assert_eq!(report.disposition, "success");
+
+    let log = fs::read_to_string(&attempt_log).expect("read attempt log");
+    let records = log
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("attempt record json"))
+        .collect::<Vec<_>>();
+    assert_eq!(records.len(), 2, "attempt log should record each poll");
+    assert_eq!(records[0]["schema"], "adl.pr_validation_attempt.v1");
+    assert_eq!(records[0]["command_class"], "pr.validation.wait");
+    assert_eq!(records[0]["pr_number"], 1159);
+    assert_eq!(records[0]["disposition"], "pending");
+    assert_eq!(records[0]["projection_status"], "checks_pending");
+    assert_eq!(records[0]["poll_count"], 1);
+    assert_eq!(records[0]["poll_retry_count"], 0);
+    assert_eq!(
+        records[0]["transport_retry_evidence"],
+        "observe stage=github_octocrab result=retry operation=pr.validation.status events"
+    );
+    assert_eq!(records[0]["terminal"], false);
+    assert_eq!(records[0]["next_poll_delay_ms"], 1);
+    assert_eq!(records[0]["pending_checks"][0]["name"], "adl-ci");
+    assert_eq!(records[1]["disposition"], "success");
+    assert_eq!(records[1]["projection_status"], "ready_to_merge_or_review");
+    assert_eq!(records[1]["poll_count"], 2);
+    assert_eq!(records[1]["poll_retry_count"], 1);
+    assert_eq!(records[1]["terminal"], true);
+    assert_eq!(records[1]["next_poll_delay_ms"], 0);
+    assert_eq!(records[1]["checks"][0]["name"], "adl-ci");
+
+    let seen = server.join().expect("server join");
+    assert!(
+        seen.iter()
+            .filter(|call| call.contains("statusCheckRollup"))
+            .count()
+            >= 2,
+        "validation wait should poll until terminal success: {seen:#?}"
+    );
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        std::env::remove_var("ADL_PR_VALIDATION_WAIT_POLL_MS");
+        std::env::remove_var("ADL_PR_VALIDATION_ATTEMPT_LOG");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
+fn pr_validation_wait_attempt_log_records_timeout_once_for_one_poll() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-pr-validation-attempt-log-timeout");
+    let attempt_log = temp.join("attempts.jsonl");
+    let (base_uri, server) =
+        spawn_validation_status_once_server("IN_PROGRESS", Some("UNKNOWN"), "adl-ci");
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("ADL_PR_VALIDATION_WAIT_TIMEOUT_MS", "0");
+        std::env::set_var("ADL_PR_VALIDATION_WAIT_POLL_MS", "1");
+        std::env::set_var("ADL_PR_VALIDATION_ATTEMPT_LOG", &attempt_log);
+    }
+
+    let report =
+        wait_for_pr_validation_report("owner/repo", "1159").expect("timeout report returned");
+    assert_eq!(report.disposition, "timed_out");
+
+    let log = fs::read_to_string(&attempt_log).expect("read attempt log");
+    let records = log
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("attempt record json"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        records.len(),
+        1,
+        "timeout should write one terminal record for one poll"
+    );
+    assert_eq!(records[0]["disposition"], "timed_out");
+    assert_eq!(records[0]["projection_status"], "checks_failed");
+    assert_eq!(records[0]["poll_count"], 1);
+    assert_eq!(records[0]["poll_retry_count"], 0);
+    assert_eq!(records[0]["terminal"], true);
+    assert_eq!(records[0]["next_poll_delay_ms"], 0);
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1);
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        std::env::remove_var("ADL_PR_VALIDATION_WAIT_TIMEOUT_MS");
+        std::env::remove_var("ADL_PR_VALIDATION_WAIT_POLL_MS");
+        std::env::remove_var("ADL_PR_VALIDATION_ATTEMPT_LOG");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
+fn pr_validation_wait_attempt_log_failure_event_omits_raw_sink_path() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-pr-validation-attempt-log-failure");
+    let blocker = temp.join("not-a-directory");
+    let attempt_log = blocker.join("attempts.jsonl");
+    let log_path = temp.join("events.log");
+    fs::write(&blocker, "occupied").expect("write blocker");
+    let (base_uri, server) =
+        spawn_validation_status_once_server("COMPLETED", Some("SUCCESS"), "adl-ci");
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("ADL_PR_VALIDATION_ATTEMPT_LOG", &attempt_log);
+        std::env::set_var("ADL_OBSERVABILITY_STDERR", "0");
+        std::env::set_var("ADL_OBSERVABILITY_LOG", &log_path);
+    }
+
+    let report =
+        wait_for_pr_validation_report("owner/repo", "1159").expect("validation result should win");
+    assert_eq!(report.disposition, "success");
+
+    let log = fs::read_to_string(&log_path).expect("read observability log");
+    assert!(log.contains("stage=pr.validation.wait.attempt_log"));
+    assert!(log.contains("result=failed"));
+    assert!(log.contains("detail=create PR validation attempt log dir"));
+    assert!(
+        !log.contains(temp.to_str().expect("temp path utf8")),
+        "attempt-log failure event must not leak raw local temp path: {log}"
+    );
+
+    let seen = server.join().expect("server join");
+    assert_eq!(seen.len(), 1);
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        std::env::remove_var("ADL_PR_VALIDATION_ATTEMPT_LOG");
+        std::env::remove_var("ADL_OBSERVABILITY_STDERR");
+        std::env::remove_var("ADL_OBSERVABILITY_LOG");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
+fn pr_validation_wait_attempt_log_records_terminal_failed_check_without_extra_polling() {
+    let _guard = env_lock();
+    let policy_env = clear_github_policy_env();
+    let temp = unique_temp_dir("adl-pr-validation-attempt-log-failed");
+    let attempt_log = temp.join("attempts.jsonl");
+    let (base_uri, server) =
+        spawn_validation_status_once_server("COMPLETED", Some("FAILURE"), "adl-ci");
+    unsafe {
+        std::env::set_var("ADL_GITHUB_CLIENT", "octocrab");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        std::env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", &base_uri);
+        std::env::set_var("ADL_PR_VALIDATION_ATTEMPT_LOG", &attempt_log);
+    }
+
+    let report =
+        wait_for_pr_validation_report("owner/repo", "1159").expect("failed report returned");
+    assert_eq!(report.disposition, "failed");
+
+    let log = fs::read_to_string(&attempt_log).expect("read attempt log");
+    let records = log
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("attempt record json"))
+        .collect::<Vec<_>>();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["disposition"], "failed");
+    assert_eq!(records[0]["projection_status"], "checks_failed");
+    assert_eq!(records[0]["terminal"], true);
+    assert_eq!(records[0]["failed_checks"][0]["name"], "adl-ci");
+    assert_eq!(records[0]["poll_retry_count"], 0);
+
+    let seen = server.join().expect("server join");
+    assert_eq!(
+        seen.len(),
+        1,
+        "red check should stop without burning another validation poll"
+    );
+
+    unsafe {
+        std::env::remove_var("ADL_GITHUB_OCTOCRAB_BASE_URI");
+        std::env::remove_var("ADL_PR_VALIDATION_ATTEMPT_LOG");
+    }
+    restore_github_policy_env(policy_env);
+}
+
+#[test]
 fn pr_validation_wait_keeps_validation_result_when_anomaly_capture_fails() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -190,6 +191,30 @@ struct ToolingAnomalyPacket {
     remediation_route: String,
     first_observed_at_epoch_ms: u128,
     last_observed_at_epoch_ms: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PrValidationAttemptLogRecord {
+    schema: String,
+    command_class: String,
+    pr_number: u64,
+    commit_sha: String,
+    pr_state: String,
+    is_draft: bool,
+    disposition: String,
+    projection_status: String,
+    wait_reason: String,
+    wait_classification: String,
+    next_action: String,
+    elapsed_ms: u128,
+    poll_count: usize,
+    poll_retry_count: usize,
+    transport_retry_evidence: String,
+    terminal: bool,
+    next_poll_delay_ms: u128,
+    pending_checks: Vec<PrValidationCheckReport>,
+    failed_checks: Vec<PrValidationCheckReport>,
+    checks: Vec<PrValidationCheckReport>,
 }
 
 pub(super) fn current_pr_url_octocrab(repo: &str, branch: &str) -> Result<Option<String>> {
@@ -680,7 +705,39 @@ pub(super) fn wait_for_pr_validation_report(
         } else {
             poll_delay
         };
+
+        if !wait_terminal && started.elapsed() >= timeout {
+            emit_pr_validation_wait_timeout(&snapshot, started, poll_count, Duration::ZERO);
+            capture_pr_validation_attempt_log_best_effort(
+                &snapshot,
+                PrValidationDisposition::TimedOut,
+                started,
+                poll_count,
+                Duration::ZERO,
+                true,
+            );
+            capture_pr_validation_wait_anomaly_best_effort(
+                repo,
+                &snapshot,
+                PrValidationDisposition::TimedOut,
+                started,
+                poll_count,
+            );
+            return Ok(pr_validation_report_from_snapshot_with_disposition(
+                &snapshot,
+                PrValidationDisposition::TimedOut,
+            ));
+        }
+
         emit_pr_validation_wait_snapshot(&snapshot, disposition, started, poll_count, next_delay);
+        capture_pr_validation_attempt_log_best_effort(
+            &snapshot,
+            disposition,
+            started,
+            poll_count,
+            next_delay,
+            wait_terminal,
+        );
         capture_pr_validation_wait_anomaly_best_effort(
             repo,
             &snapshot,
@@ -693,21 +750,6 @@ pub(super) fn wait_for_pr_validation_report(
             return Ok(pr_validation_report_from_snapshot_with_disposition(
                 &snapshot,
                 disposition,
-            ));
-        }
-
-        if started.elapsed() >= timeout {
-            emit_pr_validation_wait_timeout(&snapshot, started, poll_count, Duration::ZERO);
-            capture_pr_validation_wait_anomaly_best_effort(
-                repo,
-                &snapshot,
-                PrValidationDisposition::TimedOut,
-                started,
-                poll_count,
-            );
-            return Ok(pr_validation_report_from_snapshot_with_disposition(
-                &snapshot,
-                PrValidationDisposition::TimedOut,
             ));
         }
         std::thread::sleep(poll_delay);
@@ -985,6 +1027,111 @@ fn capture_pr_validation_wait_anomaly_best_effort(
     {
         emit_pr_validation_wait_anomaly_capture_failure(repo, snapshot, disposition, &err);
     }
+}
+
+fn capture_pr_validation_attempt_log(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+    started: Instant,
+    poll_count: usize,
+    next_poll_delay: Duration,
+    terminal: bool,
+) -> Result<()> {
+    let Some(path) = std::env::var_os("ADL_PR_VALIDATION_ATTEMPT_LOG") else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).context("create PR validation attempt log dir")?;
+    }
+
+    let report = pr_validation_report_from_snapshot_with_disposition(snapshot, disposition);
+    let wait_reason = pr_validation_wait_reason(snapshot, disposition, "aggregate").to_string();
+    let wait_classification =
+        pr_validation_wait_classification(snapshot, disposition, "aggregate", started.elapsed())
+            .to_string();
+    let next_action = pr_validation_wait_next_action(&wait_classification).to_string();
+    let record = PrValidationAttemptLogRecord {
+        schema: "adl.pr_validation_attempt.v1".to_string(),
+        command_class: "pr.validation.wait".to_string(),
+        pr_number: snapshot.pr_number,
+        commit_sha: snapshot.commit_sha.clone(),
+        pr_state: snapshot.state.clone(),
+        is_draft: snapshot.is_draft,
+        disposition: disposition.as_event_result().to_string(),
+        projection_status: report.projection_status.clone(),
+        wait_reason,
+        wait_classification,
+        next_action,
+        elapsed_ms: started.elapsed().as_millis(),
+        poll_count,
+        poll_retry_count: poll_count.saturating_sub(1),
+        transport_retry_evidence:
+            "observe stage=github_octocrab result=retry operation=pr.validation.status events"
+                .to_string(),
+        terminal,
+        next_poll_delay_ms: next_poll_delay.as_millis(),
+        pending_checks: report.pending_checks,
+        failed_checks: report.failed_checks,
+        checks: report.checks,
+    };
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .context("open PR validation attempt log")?;
+    serde_json::to_writer(&mut file, &record).context("write PR validation attempt log")?;
+    file.write_all(b"\n")
+        .context("terminate PR validation attempt log")?;
+    Ok(())
+}
+
+fn capture_pr_validation_attempt_log_best_effort(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+    started: Instant,
+    poll_count: usize,
+    next_poll_delay: Duration,
+    terminal: bool,
+) {
+    if let Err(err) = capture_pr_validation_attempt_log(
+        snapshot,
+        disposition,
+        started,
+        poll_count,
+        next_poll_delay,
+        terminal,
+    ) {
+        emit_pr_validation_attempt_log_failure(snapshot, disposition, &err);
+    }
+}
+
+fn emit_pr_validation_attempt_log_failure(
+    snapshot: &PrValidationSnapshot,
+    disposition: PrValidationDisposition,
+    err: &anyhow::Error,
+) {
+    let pr_number = snapshot.pr_number.to_string();
+    let is_draft = snapshot.is_draft.to_string();
+    let fields = vec![
+        ("pr_number".to_string(), pr_number),
+        ("commit_sha".to_string(), snapshot.commit_sha.clone()),
+        ("pr_state".to_string(), snapshot.state.clone()),
+        ("is_draft".to_string(), is_draft),
+        (
+            "disposition".to_string(),
+            disposition.as_event_result().to_string(),
+        ),
+        ("detail".to_string(), err.to_string()),
+    ];
+    let borrowed = fields
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    observability::emit_event("adl", "pr.validation.wait.attempt_log", "failed", &borrowed);
 }
 
 fn emit_pr_validation_wait_anomaly_capture_failure(

--- a/adl/src/cli/pr_cmd/github/transport.rs
+++ b/adl/src/cli/pr_cmd/github/transport.rs
@@ -1116,7 +1116,7 @@ fn emit_pr_validation_attempt_log_failure(
 ) {
     let pr_number = snapshot.pr_number.to_string();
     let is_draft = snapshot.is_draft.to_string();
-    let fields = vec![
+    let fields = [
         ("pr_number".to_string(), pr_number),
         ("commit_sha".to_string(), snapshot.commit_sha.clone()),
         ("pr_state".to_string(), snapshot.state.clone()),

--- a/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
+++ b/docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md
@@ -84,6 +84,20 @@ transport retries remain separate `stage=github_octocrab result=retry` events
 with `operation=pr.validation.status`, so a check failure and a GitHub transport
 failure are distinguishable in the same tail.
 
+For durable shepherding and closeout evidence, set
+`ADL_PR_VALIDATION_ATTEMPT_LOG=<jsonl-path>`. The validation wait path appends
+one `adl.pr_validation_attempt.v1` JSON record per poll. Each record includes
+the PR, head commit, aggregate disposition, projection status, wait
+classification, next action, elapsed time, poll count, poll retry count,
+transport retry evidence, terminal flag, next poll delay, and the
+pending/failed/all check snapshots. Transport retries remain authoritative in
+`stage=github_octocrab result=retry operation=pr.validation.status` events; the
+attempt record points consumers at that event stream instead of folding
+transport retries into the poll counter. The attempt log is best-effort
+evidence: a broken log sink emits
+`stage=pr.validation.wait.attempt_log result=failed` without changing the
+underlying PR validation result.
+
 For direct PR validation diagnosis without `gh pr checks`, use the Rust-owned
 status surface:
 


### PR DESCRIPTION
Closes #4780

## Summary
Implemented bounded PR validation wait attempt logging for the PR/CI shepherding path. The existing Rust-owned `pr.validation.wait` path already stopped on terminal red/cancelled/timed-out states and retried transient `pr.validation.status` transport failures through the existing octocrab retry policy. This issue added durable opt-in JSONL evidence via `ADL_PR_VALIDATION_ATTEMPT_LOG`, set to an operator-chosen JSONL path, so shepherding and closeout can retain per-poll disposition, elapsed time, retry/poll counts, terminal truth, next action, and check snapshots without relying on transient terminal output.

## Artifacts
- `adl/src/cli/pr_cmd/github/transport.rs`
  - Added `adl.pr_validation_attempt.v1` JSONL attempt records for `wait_for_pr_validation_report` when `ADL_PR_VALIDATION_ATTEMPT_LOG` is set.
  - Attempt logging is best effort and emits `stage=pr.validation.wait.attempt_log result=failed` if the sink cannot be written.
- `adl/src/cli/pr_cmd/github/tests/validation.rs`
  - Added focused pending-then-success, timeout, sink-failure, and terminal-red-check attempt-log tests.
- `docs/milestones/v0.91.5/CONTROL_PLANE_OBSERVABILITY_CONTRACT_3609.md`
  - Documented the attempt-log environment variable, record shape, and best-effort failure behavior.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl pr_validation_wait_ -- --nocapture`
    Verified the PR validation wait behavior affected by this issue, including durable attempt logs, timeout logging, sink-failure path hygiene, and stop-on-red behavior.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl pr_validation_status_query_retries_transient_transport_and_returns_success_snapshot -- --nocapture`
    Verified transient GitHub transport failures retry within the existing octocrab retry budget.
  - `bash adl/tools/test_pr_json_observability.sh`
    Verified JSON-safe repo-native PR command observability surfaces.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified validation lane selection contract coverage for touched paths.
  - `bash adl/tools/test_check_coverage_impact.sh`
    Verified coverage-impact classification for PR validation/shepherding paths.
  - `git diff --check`
    Verified diff hygiene.
- Results:
  - PASS: 9 Rust PR validation wait tests passed; 0 failed.
  - PASS: transient transport retry test passed; 0 failed.
  - PASS: `test_pr_json_observability`.
  - PASS: `test_select_validation_lanes`.
  - PASS: `test_check_coverage_impact`.
  - PASS: `git diff --check`.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4780__v0-91-7-resilience-workflow-implement-pr-and-ci-shepherding-resilience/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4780__v0-91-7-resilience-workflow-implement-pr-and-ci-shepherding-resilience/sor.md
- Idempotency-Key: v0-91-7-resilience-implement-pr-and-ci-shepherding-resilience-adl-src-cli-pr-cmd-github-transport-rs-adl-src-cli-pr-cmd-github-tests-validation-rs-docs-milestones-v0-91-5-control-plane-observability-contract-3609-md-adl-v0-91-7-tasks-issue-4780-v0-91-7-resilience-workflow-implement-pr-and-ci-shepherding-resilience-sip-md-adl-v0-91-7-tasks-issue-4780-v0-91-7-resilience-workflow-implement-pr-and-ci-shepherding-resilience-sor-md