### PR TITLE
[v0.91.7][tools][pr-finish] Align finish wrapper flags

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -86,6 +86,18 @@ die_with_usage() {
   exit 1
 }
 
+usage_finish() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh finish <issue> --title "<title>" [-f <input_card.md>] [--output-card <output_card.md>] [--body "<extra body>"] [--paths "<p1,p2,...>"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open] [--version <version>] [--allow-open-pr-wave]
+
+Notes:
+  --version and --allow-open-pr-wave are wrapper compatibility flags. pr.sh
+  accepts them for lifecycle command symmetry and strips them before delegating
+  to the strict adl-pr-finish binary.
+EOF
+}
+
 #
 # Replace the first line that begins with "<Key>:" with "<Key>: <Value>".
 # Portable (no GNU/BSD sed -i differences).
@@ -1922,10 +1934,40 @@ cmd_finish() {
     usage_finish
     return 0
   fi
+  local -a original_finish_args normalized_finish_args finish_delegate_args
+  original_finish_args=("$@")
+  normalized_finish_args=()
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --version)
+        shift
+        if [[ "$#" -eq 0 ]]; then
+          die_with_usage "finish: --version requires a value" usage_finish
+        fi
+        shift
+        ;;
+      --version=*)
+        shift
+        ;;
+      --allow-open-pr-wave)
+        shift
+        ;;
+      *)
+        normalized_finish_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+  if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
+    finish_delegate_args=("${original_finish_args[@]}")
+  else
+    finish_delegate_args=("${normalized_finish_args[@]}")
+  fi
+
   local finish_arg previous_arg title_value_seen
   previous_arg=""
   title_value_seen=0
-  for finish_arg in "$@"; do
+  for finish_arg in "${finish_delegate_args[@]}"; do
     if [[ "$previous_arg" == "--title" ]]; then
       if [[ -n "$finish_arg" && "$finish_arg" != --* ]]; then
         title_value_seen=1
@@ -1945,9 +1987,9 @@ cmd_finish() {
   if [[ "$title_value_seen" != "1" ]]; then
     die_with_usage "finish: --title is required" usage_finish
   fi
-  adl_obs_event "pr.sh" "finish" "started" "issue" "${1:-}"
+  adl_obs_event "pr.sh" "finish" "started" "issue" "${finish_delegate_args[0]:-}"
   require_rust_pr_delegate finish
-  delegate_pr_command_to_rust finish "$@"
+  delegate_pr_command_to_rust finish "${finish_delegate_args[@]}"
 }
 
 cmd_validation() {

--- a/adl/tools/test_pr_small_binary_delegation.sh
+++ b/adl/tools/test_pr_small_binary_delegation.sh
@@ -165,6 +165,28 @@ if [[ "$flag_as_title_output" != *"finish: --title is required"* ]]; then
   echo "assertion failed: finish with --title followed by a flag should report missing title" >&2
   exit 1
 fi
+bare_version_log="$tmpdir/finish-bare-version.log"
+set +e
+bare_version_output="$(
+  cd "$repo"
+  ADL_TEST_LOG="$bare_version_log" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 --version 2>&1
+)"
+bare_version_status=$?
+set -e
+if [[ "$bare_version_status" -eq 0 ]]; then
+  echo "assertion failed: finish with bare --version should fail before delegate" >&2
+  exit 1
+fi
+if [[ -e "$bare_version_log" ]]; then
+  echo "assertion failed: finish with bare --version should not invoke delegated Rust binary" >&2
+  exit 1
+fi
+if [[ "$bare_version_output" != *"finish: --version requires a value"* ]]; then
+  echo "assertion failed: finish with bare --version should report missing version value" >&2
+  exit 1
+fi
 (
   cd "$repo"
   ADL_TEST_LOG="$finish_log" \
@@ -173,6 +195,43 @@ fi
 )
 grep -Fqx 'finish:3838 --title demo finish --output-card demo-output.md' "$finish_log" || {
   echo "assertion failed: finish should delegate directly to adl-pr-finish without broad 'pr finish' argv" >&2
+  exit 1
+}
+
+finish_wrapper_flags_log="$tmpdir/finish-wrapper-flags.log"
+(
+  cd "$repo"
+  ADL_TEST_LOG="$finish_wrapper_flags_log" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 --version v0.91.7 --allow-open-pr-wave --no-checks --title "demo finish" --output-card demo-output.md >/dev/null
+)
+grep -Fqx 'finish:3838 --no-checks --title demo finish --output-card demo-output.md' "$finish_wrapper_flags_log" || {
+  echo "assertion failed: finish should strip wrapper-only lifecycle flags before delegating to adl-pr-finish" >&2
+  exit 1
+}
+
+finish_wrapper_equals_flags_log="$tmpdir/finish-wrapper-equals-flags.log"
+(
+  cd "$repo"
+  ADL_TEST_LOG="$finish_wrapper_equals_flags_log" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 --version=v0.91.7 --allow-open-pr-wave --title "demo finish" --output-card demo-output.md >/dev/null
+)
+grep -Fqx 'finish:3838 --title demo finish --output-card demo-output.md' "$finish_wrapper_equals_flags_log" || {
+  echo "assertion failed: finish should strip --version=<value> before delegating to adl-pr-finish" >&2
+  exit 1
+}
+
+broad_finish_log="$tmpdir/broad-finish.log"
+(
+  cd "$repo"
+  ADL_TEST_LOG="$broad_finish_log" \
+    ADL_PR_RUST_BIN="$broad_bin" \
+    ADL_PR_FINISH_BIN="$finish_bin" \
+    "$BASH_BIN" adl/tools/pr.sh finish 3838 --version v0.91.7 --allow-open-pr-wave --no-checks --title "demo finish" --output-card demo-output.md >/dev/null
+)
+grep -Fqx 'broad:pr finish 3838 --version v0.91.7 --allow-open-pr-wave --no-checks --title demo finish --output-card demo-output.md' "$broad_finish_log" || {
+  echo "assertion failed: ADL_PR_RUST_BIN finish path must retain broad wrapper argv" >&2
   exit 1
 }
 


### PR DESCRIPTION
Closes #5001

## Summary
Implemented a focused `pr.sh finish` compatibility repair. The shell wrapper now accepts `--version` and `--allow-open-pr-wave` for lifecycle command symmetry, strips those wrapper-only flags before strict `adl-pr-finish` delegation, preserves `--no-checks`, and preserves broad `ADL_PR_RUST_BIN` argv semantics. Added focused regression coverage for the original failure shape and the review-found edge cases.

## Artifacts
- Local issue output card at `.adl/v0.91.7/tasks/issue-5001__v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support/sor.md`
- Tracked implementation artifacts: `adl/tools/pr.sh`, `adl/tools/test_pr_small_binary_delegation.sh`
- Additional proof artifacts: focused validation command output recorded below

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.7/tasks/issue-5001__v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support/sor.md`
    `Earlier bootstrap validation for the generated SOR scaffold.`
  - `bash adl/tools/test_pr_small_binary_delegation.sh`
    `Verified strict finish binary delegation strips wrapper-only lifecycle flags while preserving `--no-checks`, and broad `ADL_PR_RUST_BIN` finish delegation preserves original argv.`
  - `bash -n adl/tools/pr.sh adl/tools/test_pr_small_binary_delegation.sh`
    `Verified shell syntax for touched files.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5001__v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5001__v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support/sor.md
- Idempotency-Key: v0-91-7-tools-pr-finish-align-finish-wrapper-flags-adl-tools-pr-sh-adl-tools-test-pr-small-binary-delegation-sh-adl-v0-91-7-tasks-issue-5001-v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support-sip-md-adl-v0-91-7-tasks-issue-5001-v0-91-7-tools-pr-finish-align-finish-wrapper-flags-with-delegated-binary-argument-support-sor-md