### PR TITLE
[v0.91.7][WP-08] Remove retained full AWS account SHA from ACIP-SNS proof summaries

### DIFF
--- a/docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/acip_sns_summary.json
+++ b/docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/acip_sns_summary.json
@@ -12,7 +12,6 @@
     "trace_ref": "runtime/wp08/acip/traces/public-summary.json"
   },
   "aws_account_hash": "b05e1f4379b5c745",
-  "aws_account_sha256": "b05e1f4379b5c7457d1de357e21447526ecf418ed47176ead2868d0a2d6589c9",
   "aws_profile": "agent-logic-admin",
   "aws_region": "us-west-2",
   "issue": 4685,

--- a/docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/sns_resource_summary.json
+++ b/docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/sns_resource_summary.json
@@ -5,7 +5,6 @@
   "aws_profile": "agent-logic-admin",
   "aws_region": "us-west-2",
   "aws_account_hash": "b05e1f4379b5c745",
-  "aws_account_sha256": "b05e1f4379b5c7457d1de357e21447526ecf418ed47176ead2868d0a2d6589c9",
   "sns": {
     "topic_name": "adl-v0917-wp08-acip-sns-4685",
     "topic_arn_hash": "b94819d4477688a9",


### PR DESCRIPTION
Closes #5006

## Summary
Removed retained full `aws_account_sha256` values from the #4685 WP-08 ACIP-SNS retained proof summaries while preserving the short non-sensitive `aws_account_hash` and `topic_arn_hash` values used for reviewer correlation. No validator weakening was needed.

## Artifacts
- Tracked implementation artifacts:
  - `docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/acip_sns_summary.json`
  - `docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/sns_resource_summary.json`
- Additional proof artifacts: an unretained temporary negative validation copy was intentionally not kept because it contained a synthetic full digest used only to prove fail-closed behavior.

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/validate_wp08_acip_sns_live_proof.py docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/acip_sns_summary.json docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/sns_resource_summary.json`
    `Positive validator proof for repaired retained summaries.`
  - `rg -n "aws_account_sha256|\b[0-9a-f]{64}\b|123456789012|arn:aws:sns:|private runtime coordination content" docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685`
    `Redaction and retained-full-digest scan; no matches observed.`
  - `git diff --check`
    `Diff hygiene proof.`
  - `python3 adl/tools/validate_wp08_acip_sns_live_proof.py TEMPORARY_NEGATIVE_SUMMARY docs/milestones/v0.91.7/review/runtime/wp08_acip_sns_4685/sns_resource_summary.json`
    `Negative fail-closed proof; command intentionally exits nonzero with aws_account_sha256 rejection.`
  - `bash adl/tools/test_run_wp08_acip_sns_live_proof.sh`
    `Issue-specific proof script for ACIP-SNS retained-proof validation and account/profile guardrail fixture.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5006__v0-91-7-wp-08-acip-sns-remove-retained-full-aws-account-sha-from-proof-summaries/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5006__v0-91-7-wp-08-acip-sns-remove-retained-full-aws-account-sha-from-proof-summaries/sor.md
- Idempotency-Key: v0-91-7-wp-08-remove-retained-full-aws-account-sha-from-acip-sns-proof-summaries-docs-milestones-v0-91-7-review-runtime-wp08-acip-sns-4685-acip-sns-summary-json-docs-milestones-v0-91-7-review-runtime-wp08-acip-sns-4685-sns-resource-summary-json-adl-v0-91-7-tasks-issue-5006-v0-91-7-wp-08-acip-sns-remove-retained-full-aws-account-sha-from-proof-summaries-sip-md-adl-v0-91-7-tasks-issue-5006-v0-91-7-wp-08-acip-sns-remove-retained-full-aws-account-sha-from-proof-summaries-sor-md