### PR TITLE
[v0.91.7][WP-07][csm] Harden canonical runtime API permanence

### DIFF
--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/agent.yaml
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/agent.yaml
@@ -1,0 +1,26 @@
+schema: adl.long_lived_agent_spec.v1
+agent_instance_id: csm-live-4980
+display_name: CSM Live 4980
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: wp07_csm_live_4980
+  run_args:
+    provider_id: local_ollama
+    model: gemma4:latest
+heartbeat:
+  interval_secs: 1
+  max_cycles: 1000000
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+  max_consecutive_failures: 5
+memory:
+  namespace: wp07/csm-live-4980
+  write_policy: append_only

--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/events.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/events.json
@@ -1,0 +1,4872 @@
+{
+  "agent_instance_id": "csm-live-4980",
+  "events": {
+    "entries": [
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:18.563697Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 817570,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:18.563+00:00",
+            "monotonic_elapsed_ms": 817570,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:18.563+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:18",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:18.563+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:18.563+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000591",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 591,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000591.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:18.589183Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 817596,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:18.589+00:00",
+            "monotonic_elapsed_ms": 817596,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:18.589+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:18",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:18.589+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:18.589+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:18.802732Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 817809,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:18.802+00:00",
+            "monotonic_elapsed_ms": 817809,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:18.802+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:18",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:18.802+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:18.802+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:19.855626Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 818862,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:19.855+00:00",
+            "monotonic_elapsed_ms": 818862,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:19.855+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:19",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:19.855+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:19.855+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:20.122772Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 819129,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:20.122+00:00",
+            "monotonic_elapsed_ms": 819129,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:20.122+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:20",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:20.122+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:20.122+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000592",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 592,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000592.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:20.126647Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 819133,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:20.126+00:00",
+            "monotonic_elapsed_ms": 819133,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:20.126+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:20",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:20.126+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:20.126+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:20.250504Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 819257,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:20.250+00:00",
+            "monotonic_elapsed_ms": 819257,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:20.250+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:20",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:20.250+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:20.250+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:21.297170Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 820304,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:21.297+00:00",
+            "monotonic_elapsed_ms": 820304,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:21.297+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:21",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:21.297+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:21.297+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:21.635863Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 820642,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:21.635+00:00",
+            "monotonic_elapsed_ms": 820642,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:21.635+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:21",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:21.635+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:21.635+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000593",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 593,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000593.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:21.640653Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 820647,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:21.640+00:00",
+            "monotonic_elapsed_ms": 820647,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:21.640+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:21",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:21.640+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:21.640+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:21.745023Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 820751,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:21.744+00:00",
+            "monotonic_elapsed_ms": 820751,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:21.744+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:21",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:21.744+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:21.744+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:22.796602Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 821803,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:22.796+00:00",
+            "monotonic_elapsed_ms": 821803,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:22.796+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:22",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:22.796+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:22.796+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:23.046389Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 822053,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:23.046+00:00",
+            "monotonic_elapsed_ms": 822053,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:23.046+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:23",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:23.046+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:23.046+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000594",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 594,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000594.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:23.049193Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 822056,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:23.049+00:00",
+            "monotonic_elapsed_ms": 822056,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:23.049+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:23",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:23.049+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:23.049+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:23.280566Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 822287,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:23.280+00:00",
+            "monotonic_elapsed_ms": 822287,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:23.280+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:23",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:23.280+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:23.280+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:24.339707Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 823346,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:24.339+00:00",
+            "monotonic_elapsed_ms": 823346,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:24.339+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:24",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:24.339+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:24.339+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:24.637351Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 823644,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:24.637+00:00",
+            "monotonic_elapsed_ms": 823644,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:24.637+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:24",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:24.637+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:24.637+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000595",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 595,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000595.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:24.641647Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 823648,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:24.641+00:00",
+            "monotonic_elapsed_ms": 823648,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:24.641+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:24",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:24.641+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:24.641+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:24.836204Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 823843,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:24.836+00:00",
+            "monotonic_elapsed_ms": 823843,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:24.836+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:24",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:24.836+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:24.836+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:25.896906Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 824903,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:25.896+00:00",
+            "monotonic_elapsed_ms": 824903,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:25.896+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:25",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:25.896+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:25.896+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:26.552008Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 825558,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:26.551+00:00",
+            "monotonic_elapsed_ms": 825558,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:26.551+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:26",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:26.551+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:26.551+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000596",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 596,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000596.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:26.555663Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 825562,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:26.555+00:00",
+            "monotonic_elapsed_ms": 825562,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:26.555+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:26",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:26.555+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:26.555+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:26.812169Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 825819,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:26.812+00:00",
+            "monotonic_elapsed_ms": 825819,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:26.812+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:26",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:26.812+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:26.812+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:27.885232Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 826892,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:27.885+00:00",
+            "monotonic_elapsed_ms": 826892,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:27.885+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:27",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:27.885+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:27.885+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:28.286165Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 827293,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:28.286+00:00",
+            "monotonic_elapsed_ms": 827293,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:28.286+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:28",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:28.286+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:28.286+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000597",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 597,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000597.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:28.302277Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 827309,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:28.302+00:00",
+            "monotonic_elapsed_ms": 827309,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:28.302+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:28",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:28.302+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:28.302+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:28.518701Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 827525,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:28.518+00:00",
+            "monotonic_elapsed_ms": 827525,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:28.518+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:28",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:28.518+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:28.518+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:29.578067Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 828585,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:29.578+00:00",
+            "monotonic_elapsed_ms": 828585,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:29.578+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:29",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:29.578+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:29.578+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:29.927353Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 828934,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:29.927+00:00",
+            "monotonic_elapsed_ms": 828934,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:29.927+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:29",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:29.927+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:29.927+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000598",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 598,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000598.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:29.930265Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 828937,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:29.930+00:00",
+            "monotonic_elapsed_ms": 828937,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:29.930+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:29",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:29.930+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:29.930+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:30.194959Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 829201,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:30.194+00:00",
+            "monotonic_elapsed_ms": 829201,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:30.194+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:30",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:30.194+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:30.194+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:31.265607Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 830272,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:31.265+00:00",
+            "monotonic_elapsed_ms": 830272,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:31.265+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:31",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:31.265+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:31.265+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:31.584709Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 830591,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:31.584+00:00",
+            "monotonic_elapsed_ms": 830591,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:31.584+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:31",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:31.584+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:31.584+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000599",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 599,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000599.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:31.590174Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 830597,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:31.590+00:00",
+            "monotonic_elapsed_ms": 830597,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:31.590+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:31",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:31.590+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:31.590+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:31.718508Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 830725,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:31.718+00:00",
+            "monotonic_elapsed_ms": 830725,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:31.718+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:31",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:31.718+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:31.718+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:32.779877Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 831786,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:32.779+00:00",
+            "monotonic_elapsed_ms": 831786,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:32.779+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:32",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:32.779+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:32.779+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:33.112502Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 832119,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:33.112+00:00",
+            "monotonic_elapsed_ms": 832119,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:33.112+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:33",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:33.112+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:33.112+00:00"
+          },
+          "details": {
+            "agent_outcome": {
+              "action_allowed_without_review": false,
+              "last_cycle_id": "cycle-000600",
+              "last_cycle_status": "success",
+              "reason": "no active cycle is running; next heartbeat may decide whether to wake",
+              "source_status_state": "idle",
+              "state": "sleeping"
+            },
+            "bundle_ref": "safe_fail_bundle.json",
+            "recoverability": {
+              "allowed_next_actions": [
+                "inspect",
+                "wake_after_policy_check"
+              ],
+              "class": "recoverable_sleeping",
+              "last_error": null
+            },
+            "safe_fail_sequence": 600,
+            "schema": "adl.csm.safe_fail_bundle.v1",
+            "sequence_ref": "safe_fail_artifacts/safe-fail-000600.json",
+            "status": "serialized"
+          },
+          "event": "safe_fail_serialization",
+          "otel": {
+            "event_name": "safe_fail_serialization",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:safe_fail_serialization:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:safe_fail_serialization:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "safe_fail_serialization",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:33.115545Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 832122,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:33.115+00:00",
+            "monotonic_elapsed_ms": 832122,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:33.115+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:33",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:33.115+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:33.115+00:00"
+          },
+          "details": {
+            "supervised_unit": "long_lived_agent_tick"
+          },
+          "event": "child_spawn",
+          "otel": {
+            "event_name": "child_spawn",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_spawn:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "started",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_spawn:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_spawn",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:33.227134Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 832234,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:33.227+00:00",
+            "monotonic_elapsed_ms": 832234,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:33.227+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:33",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:33.227+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:33.227+00:00"
+          },
+          "details": {
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "exit_class": "success",
+            "recoverable_state": "idle"
+          },
+          "event": "child_exit",
+          "otel": {
+            "event_name": "child_exit",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:child_exit:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:child_exit:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "child_exit",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      },
+      {
+        "agent_instance_id": "csm-live-4980",
+        "at": "2026-07-07T03:30:34.286217Z",
+        "details": {
+          "chronosense_clock_stack": {
+            "lifetime_elapsed_ms": 833293,
+            "local_timestamp_rfc3339": "2026-07-07T03:30:34.286+00:00",
+            "monotonic_elapsed_ms": 833293,
+            "reference_frames": [
+              "utc_epoch_millis",
+              "local_civil_time",
+              "runtime_lifetime",
+              "runtime_monotonic_elapsed"
+            ],
+            "schema_version": "chronosense_clock_stack.v1",
+            "temporal_context": {
+              "age_days_since_birthday": null,
+              "captured_at_rfc3339": "2026-07-07T03:30:34.286+00:00",
+              "identity_agent_id": null,
+              "identity_display_name": null,
+              "local_date": "2026-07-07",
+              "local_time": "03:30:34",
+              "local_timestamp_rfc3339": "2026-07-07T03:30:34.286+00:00",
+              "local_weekday": "Tuesday",
+              "schema_version": "temporal_context.v1",
+              "timezone": "UTC",
+              "utc_offset": "+00:00"
+            },
+            "timezone": "UTC",
+            "utc_offset": "+00:00",
+            "utc_timestamp_rfc3339": "2026-07-07T03:30:34.286+00:00"
+          },
+          "details": {
+            "checkpoint_reason": "daemon_partial_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "remaining_sleep_secs": 0,
+            "status_ref": "status.json",
+            "trigger": "daemon_heartbeat"
+          },
+          "event": "checkpoint_write",
+          "otel": {
+            "event_name": "checkpoint_write",
+            "parent_span_id": "daemon:csm-live-4980:supervisor",
+            "service_name": "csm-runtime-daemon",
+            "span_id": "daemon:checkpoint_write:0",
+            "trace_id": "agent.csm-live-4980.daemon"
+          },
+          "parent_span_id": "daemon:csm-live-4980:supervisor",
+          "result": "completed",
+          "runtime_capabilities": {
+            "adl_role": "tooling_control_plane",
+            "aee": {
+              "failure_recovery": "restart_always_and_checkpoint_restore",
+              "recoverable_states": [
+                "idle",
+                "completed",
+                "failed",
+                "stopped",
+                "leased"
+              ],
+              "status": "integrated"
+            },
+            "chronosense": {
+              "clock_stack_capture": "daemon_event_time",
+              "clock_stack_schema": "chronosense_clock_stack.v1",
+              "service_schema": "chronosense_runtime_service.v1",
+              "status": "integrated"
+            },
+            "observability": {
+              "event_command": "csm",
+              "otel_service_name": "csm-runtime-daemon",
+              "retained_outputs": [
+                "operator_events.jsonl",
+                "daemon_status.json",
+                "safe_fail_bundle.json",
+                "safe_fail_artifacts/",
+                "ADL_OBSERVABILITY_LOG",
+                "ADL_OTEL_LOG",
+                "ADL_OTEL_STATUS"
+              ],
+              "status": "integrated"
+            },
+            "process_class": "csm_runtime_daemon",
+            "resilience_middleware": {
+              "lease_policy": "active_stale_recoverable_blocked",
+              "partial_checkpoints": "daemon_partial_checkpoint",
+              "restart_backoff": "bounded_exponential",
+              "safe_fail_serialization": "integrated_safe_fail_bundle",
+              "status": "integrated"
+            },
+            "runtime_owner": "csm",
+            "scheduler_watcher": {
+              "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+              "partial_checkpoint_interval": "checkpoint_interval_secs",
+              "status": "integrated",
+              "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+            },
+            "schema": "adl.csm.runtime_capabilities.v1",
+            "supervisor": {
+              "bounded_test_mode": "explicit_only",
+              "host_supervisor_compatibility": [
+                "launchd_keepalive",
+                "systemd_restart_always",
+                "rustysd_service_manager",
+                "rinit_service_manager"
+              ],
+              "lifetime_boundary": "operator_stop_or_fatal_supervisor_failure_only",
+              "restart_policy": "always",
+              "service_mode": "permanent",
+              "status": "integrated"
+            }
+          },
+          "span_id": "daemon:checkpoint_write:0",
+          "trace_id": "agent.csm-live-4980.daemon"
+        },
+        "event": "checkpoint_write",
+        "operator": "local",
+        "schema": "adl.long_lived_agent_operator_event.v1"
+      }
+    ],
+    "status": "serialized",
+    "tail_limit": 40,
+    "unreadable_lines": 0
+  },
+  "runtime_owner": "csm",
+  "schema": "adl.csm.runtime_api.events.v1"
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/metrics.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/metrics.json
@@ -1,0 +1,25 @@
+{
+  "agent_instance_id": "csm-live-4980",
+  "gauges": {
+    "backpressure_deferred_count": null,
+    "backpressure_lag_ms": null,
+    "backpressure_queue_depth": null,
+    "backpressure_shed_count": null,
+    "checkpoint_interval_secs": 2,
+    "completed_cycle_count": 601,
+    "consecutive_failure_count": 0,
+    "operator_event_count_observed": 2404,
+    "restart_count": 0
+  },
+  "runtime_owner": "csm",
+  "schema": "adl.csm.runtime_api.metrics.v1",
+  "states": {
+    "agent_state": "idle",
+    "backpressure_health": null,
+    "backpressure_safe_fail_action": null,
+    "health": "healthy",
+    "ready": "ready",
+    "restart_policy": "always",
+    "service_mode": "permanent"
+  }
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/ready.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/ready.json
@@ -1,0 +1,7 @@
+{
+  "agent_instance_id": "csm-live-4980",
+  "blocking_reasons": [],
+  "ready": "ready",
+  "runtime_owner": "csm",
+  "schema": "adl.csm.runtime_api.ready.v1"
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/status.json
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/status.json
@@ -1,0 +1,104 @@
+{
+  "adl_role": "tooling_control_plane",
+  "aee_resilience": {
+    "failure_recovery": "restart_always_and_checkpoint_restore",
+    "recoverable_states": [
+      "idle",
+      "completed",
+      "failed",
+      "stopped",
+      "leased"
+    ],
+    "status": "integrated"
+  },
+  "agent_instance_id": "csm-live-4980",
+  "agent_status": {
+    "completed_cycle_count": 601,
+    "consecutive_failure_count": 0,
+    "last_cycle_id": "cycle-000601",
+    "last_cycle_status": "success",
+    "last_error": null,
+    "state": "idle",
+    "stop_requested": false,
+    "updated_at": "2026-07-07T03:30:34.263044Z"
+  },
+  "backpressure": {
+    "ref": "csm_backpressure_state.json",
+    "schema": null,
+    "status": "missing"
+  },
+  "checkpoint": {
+    "age_secs": 0,
+    "checkpoint_ref": "continuity_checkpoint.json",
+    "last_checkpoint_at": "2026-07-07T03:30:34.285026Z",
+    "status": "fresh"
+  },
+  "chronosense": {
+    "clock_stack_capture": "daemon_event_time",
+    "clock_stack_schema": "chronosense_clock_stack.v1",
+    "service_schema": "chronosense_runtime_service.v1",
+    "status": "integrated"
+  },
+  "continuity": {
+    "checkpoint": {
+      "ref": "continuity_checkpoint.json",
+      "schema": "adl.long_lived_agent_continuity_checkpoint.v1",
+      "status": "serialized"
+    },
+    "replay_manifest": {
+      "ref": "continuity_replay_manifest.json",
+      "schema": "adl.long_lived_agent_continuity_replay_manifest.v1",
+      "status": "serialized"
+    },
+    "safe_fail_bundle": {
+      "ref": "safe_fail_bundle.json",
+      "schema": null,
+      "status": "unreadable"
+    }
+  },
+  "daemon_liveness": {
+    "last_event": "checkpoint_write",
+    "state": "running",
+    "status": "observed",
+    "updated_at": "2026-07-07T03:30:34.285026Z"
+  },
+  "events": {
+    "bytes": 7516862,
+    "ref": "operator_events.jsonl",
+    "status": "retained"
+  },
+  "otel": {
+    "log": {
+      "bytes": 1256,
+      "ref": "ADL_OTEL_LOG",
+      "status": "retained"
+    },
+    "status": {
+      "ref": "ADL_OTEL_STATUS",
+      "schema": "adl.otel.monitor_status.v1",
+      "status": "serialized"
+    }
+  },
+  "ready": "ready",
+  "redaction": {
+    "absolute_host_paths": "not_returned",
+    "cloud_account_identifiers": "not_returned",
+    "secret_material": "not_returned"
+  },
+  "resilience_middleware": {
+    "lease_policy": "active_stale_recoverable_blocked",
+    "partial_checkpoints": "daemon_partial_checkpoint",
+    "restart_backoff": "bounded_exponential",
+    "safe_fail_serialization": "integrated_safe_fail_bundle",
+    "status": "integrated"
+  },
+  "runtime_owner": "csm",
+  "scheduler": {
+    "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+    "partial_checkpoint_interval": "checkpoint_interval_secs",
+    "status": "integrated",
+    "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+  },
+  "schema": "adl.csm.runtime_api.status.v1",
+  "status": "healthy"
+}

--- a/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/proof_summary.md
+++ b/docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/proof_summary.md
@@ -1,0 +1,25 @@
+# CSM Liveness 4980 Live Proof
+
+Issue: #4980
+Captured: 2026-07-07T03:22:00Z
+Bind: 127.0.0.1:19997
+Runtime owner: csm
+
+## Result
+
+- `csm daemon` was started from the rebuilt #4980 `csm` binary without `--no-sleep` and without public restart or kill controls.
+- `csm api serve` was started from the rebuilt #4980 `csm` binary on canonical port `127.0.0.1:19997`.
+- `/ready` returned `ready` with no blocking reasons.
+- `/metrics` returned `service_mode: permanent`, `restart_policy: always`, `restart_count: 0`, `completed_cycle_count: 601`, and `operator_event_count_observed: 2404` at capture time.
+- A scan of the retained API responses and touched runtime surfaces found no deprecated cap-control vocabulary.
+
+## Retained Response Snapshots
+
+- `api/ready.json`
+- `api/status.json`
+- `api/metrics.json`
+- `api/events.json`
+
+## Local Runtime Artifacts
+
+The live runtime also emitted append-oriented state, checkpoint, safe-fail, observability, and OTel artifacts under this directory. Those artifacts are intentionally retained locally for operator inspection; only the compact proof packet is intended for PR review.


### PR DESCRIPTION
Closes #4980

## Summary
Implemented CSM API permanence and runtime read-race resilience for issue #4980. `csm api serve` is now permanent by default; `--once` remains as the explicit single-request probe control. The API now degrades instead of exiting when it reads a partially written `status.json`. Permanent daemon mode uses restart-always semantics and does not expose or enforce operator-visible shutdown caps. Bounded termination remains private to the `--no-sleep` test harness. The live WP-07 runtime API was restarted on canonical port `127.0.0.1:19997` from the fixed binary and verified healthy/ready with no cap vocabulary in retained API responses.

## Artifacts
- `adl/src/cli/csm_cmd.rs`: CSM API CLI default changed to permanent service and usage text updated.
- `adl/src/csm_runtime_api.rs`: API request bounds made optional; status snapshot parsing made retry/degrade-safe; metrics remove budget-shaped public fields.
- `adl/src/long_lived_agent.rs`: daemon restart-always semantics preserved for permanent mode; bounded termination remains private to `--no-sleep` harnesses.
- `adl/src/long_lived_agent/types.rs`: daemon option naming normalized to bounded-test-only semantics.
- `adl/src/cli/agent_cmd.rs`, `adl/src/cli/csm_service_cmd.rs`, `adl/src/cli/usage.rs`: public CLI/status/service surfaces no longer expose daemon restart-cap controls.
- `adl/src/long_lived_agent/tests.rs`, `adl/tests/cli_smoke/agent.rs`: permanent daemon restart-count regression and bounded-test recoverable checkpoint proof updated.
- Runtime evidence: `docs/milestones/v0.91.7/review/runtime/csm_liveness_4980/live/api/ready.json`, `status.json`, `metrics.json`, `events.json`, plus live daemon/API sessions retained in the current operator run.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml csm_cmd -- --nocapture` - verified current-main CSM command tests after rebasing PR #5013; 13 csm_cmd tests passed across runtime-owned boundaries and local parser/proof paths
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --head HEAD --threshold 80` - verified the rebased PR diff has no changed production adl/src Rust files, removing the stale csm_cmd changed-source coverage failure mode
  - `git diff --check` - verified the janitor diff has no whitespace errors
  - `./adl/target/debug/adl tooling code-review --out .adl/v0.91.7/tasks/issue-4980__v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract/artifacts/janitor_code_review --backend fixture --visibility packet-only --base e74a9399b6562f53aef3a63fdd6e0f7887107238 --include-working-tree --issue 4980 --writer-session janitor-5013 --reviewer-session janitor-5013-review --file adl/src/cli/csm_cmd.rs --fixture-case clean` - ran repo-native bounded fixture review over the janitor change and retained the non-proving no-findings review packet

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - `cargo test --manifest-path adl/Cargo.toml csm_cmd -- --nocapture`: PASS
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --head HEAD --threshold 80`: PASS
  - `git diff --check`: PASS
  - `./adl/target/debug/adl tooling code-review --out .adl/v0.91.7/tasks/issue-4980__v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract/artifacts/janitor_code_review --backend fixture --visibility packet-only --base e74a9399b6562f53aef3a63fdd6e0f7887107238 --include-working-tree --issue 4980 --writer-session janitor-5013 --reviewer-session janitor-5013-review --file adl/src/cli/csm_cmd.rs --fixture-case clean`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4980__v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4980__v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract/sor.md
- Idempotency-Key: v0-91-7-wp-07-csm-harden-canonical-runtime-api-permanence-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-agent-yaml-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-api-events-json-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-api-metrics-json-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-api-ready-json-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-api-status-json-docs-milestones-v0-91-7-review-runtime-csm-liveness-4980-live-proof-summary-md-adl-v0-91-7-tasks-issue-4980-v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract-sip-md-adl-v0-91-7-tasks-issue-4980-v0-91-7-wp-07-csm-define-canonical-csm-runtime-api-port-and-bind-contract-sor-md