### PR TITLE
[v0.91.7][tools][watcher] Require watcher attachment for every issue-bound PR

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -543,6 +543,15 @@ struct PrInventoryRecord {
     queue: Option<String>,
     closing_issue_numbers: Vec<u32>,
     check_summary: PrInventoryCheckSummary,
+    watcher: PrInventoryWatcherStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PrInventoryWatcherStatus {
+    status: String,
+    packet_path: Option<String>,
+    terminal_disposition: Option<String>,
+    reason: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -653,13 +662,14 @@ fn print_pr_inventory(report: &PrInventoryReport) {
                 .join(",")
         };
         println!(
-            "- #{} [{}] [queue={}] {} -> {} closing={} checks={}/{} failed={} pending={} updated={} mergeable={} {} ({})",
+            "- #{} [{}] [queue={}] {} -> {} closing={} watcher={} checks={}/{} failed={} pending={} updated={} mergeable={} {} ({})",
             pr.number,
             draft,
             queue,
             pr.head_ref_name,
             pr.base_ref_name,
             closing,
+            pr.watcher.status,
             pr.check_summary.passed,
             pr.check_summary.total,
             pr.check_summary.failed,

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -145,8 +145,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
             let _ = pr_ready_finish_allow_failure(&repo, &existing)?;
             attach_pr_janitor(&repo_root, &repo, parsed.issue, &branch, &existing, "ready")?;
             attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &existing)?;
-            if let Err(err) = attach_issue_watcher(IssueWatcherAttachRequest {
+            attach_issue_watcher(IssueWatcherAttachRequest {
                 repo_root: &repo_root,
+                artifact_root: &primary_root,
                 repo: &repo,
                 issue: parsed.issue,
                 branch: &branch,
@@ -155,11 +156,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
                 classification: "checks_running",
                 tail_owner: "issue-watcher",
                 shepherd_state: "watcher_owned_checks_running",
-            }) {
-                eprintln!(
-                    "warning: issue watcher auto-attach failed after lightweight PR ready promotion; PR remains ready and other tail attachments succeeded. Resolve watcher setup separately: {err}"
-                );
-            }
+            })?;
             println!("{existing}");
             return Ok(());
         }
@@ -211,6 +208,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )?;
     validate_completed_sor(&repo_root, &output_path)?;
@@ -310,34 +308,20 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         parsed.no_close,
         &pr_body_file,
     )?;
-    record_sor_emitted_facts_for_finish(
-        &output_path,
-        &review_policy_path,
-        &changed_paths,
-        &finish_validation_plan,
-        SorFactEmissionContext {
-            validation_status: if parsed.no_checks { "NOT_RUN" } else { "PASS" },
-            pr_url: Some(pr_url.as_str()),
-            integration_state: "pr_open",
-            closing_linkage_repaired: _closing_linkage_repaired,
-        },
-    )?;
-    validate_completed_sor(&repo_root, &output_path)?;
-    let canonical_output = lifecycle::sync_completed_output_surfaces(
-        &repo_root,
-        &primary_root,
-        &issue_ref,
-        &output_path,
-    )?;
-    restage_finish_output_truth_paths(
-        &repo_root,
-        &primary_root,
-        &issue_ref,
-        &[output_path.clone(), canonical_output.clone()],
-    )?;
-    ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
 
     if parsed.merge_mode {
+        attach_issue_watcher(IssueWatcherAttachRequest {
+            repo_root: &repo_root,
+            artifact_root: &primary_root,
+            repo: &repo,
+            issue: parsed.issue,
+            branch: &branch,
+            pr_url: &pr_url,
+            expected_pr_state: if parsed.ready { "ready" } else { "draft" },
+            classification: "checks_running",
+            tail_owner: "issue-watcher",
+            shepherd_state: "watcher_owned_checks_running",
+        })?;
         if parsed.ready {
             let _ = pr_ready_finish_merge_allow_failure(&repo, &pr_url)?;
         }
@@ -376,8 +360,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     } else {
         ("pr_open", "issue-watcher", "watcher_owned_pr_open")
     };
-    if let Err(err) = attach_issue_watcher(IssueWatcherAttachRequest {
+    attach_issue_watcher(IssueWatcherAttachRequest {
         repo_root: &repo_root,
+        artifact_root: &primary_root,
         repo: &repo,
         issue: parsed.issue,
         branch: &branch,
@@ -386,11 +371,42 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         classification: initial_watcher_state.0,
         tail_owner: initial_watcher_state.1,
         shepherd_state: initial_watcher_state.2,
-    }) {
-        eprintln!(
-            "warning: issue watcher auto-attach failed after PR publication; PR remains published and other tail attachments succeeded. Resolve watcher setup separately: {err}"
-        );
-    }
+    })?;
+    record_sor_emitted_facts_for_finish(
+        &output_path,
+        &review_policy_path,
+        &changed_paths,
+        &finish_validation_plan,
+        SorFactEmissionContext {
+            validation_status: if parsed.no_checks { "NOT_RUN" } else { "PASS" },
+            pr_url: Some(pr_url.as_str()),
+            integration_state: "pr_open",
+            closing_linkage_repaired: _closing_linkage_repaired,
+            issue_watcher: Some(SorFactIssueWatcherContext {
+                packet_path: &issue_watcher_packet_path_for_sor(
+                    &primary_root,
+                    parsed.issue,
+                    &pr_url,
+                ),
+                last_pr_state: if parsed.ready { "ready" } else { "draft" },
+                terminal_disposition: "pending",
+            }),
+        },
+    )?;
+    validate_completed_sor(&repo_root, &output_path)?;
+    let canonical_output = lifecycle::sync_completed_output_surfaces(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &output_path,
+    )?;
+    restage_finish_output_truth_paths(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &[output_path.clone(), canonical_output.clone()],
+    )?;
+    ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
 
     println!("{pr_url}");
     if !parsed.no_open {
@@ -1038,6 +1054,15 @@ struct SorFactFinish {
     pr_url: Option<String>,
     blocking_notes: Vec<String>,
     fix_notes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue_watcher: Option<SorFactIssueWatcher>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SorFactIssueWatcher {
+    packet_path: String,
+    last_pr_state: String,
+    terminal_disposition: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1060,6 +1085,14 @@ pub(super) struct SorFactEmissionContext<'a> {
     pub pr_url: Option<&'a str>,
     pub integration_state: &'a str,
     pub closing_linkage_repaired: bool,
+    pub issue_watcher: Option<SorFactIssueWatcherContext<'a>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SorFactIssueWatcherContext<'a> {
+    pub packet_path: &'a str,
+    pub last_pr_state: &'a str,
+    pub terminal_disposition: &'a str,
 }
 
 fn record_sor_emitted_facts_for_finish(
@@ -1086,6 +1119,7 @@ fn record_sor_emitted_facts_for_finish(
             context.pr_url,
             context.integration_state,
             context.closing_linkage_repaired,
+            context.issue_watcher,
         ),
     )?;
     if normalized != original {
@@ -1107,6 +1141,7 @@ fn build_sor_facts(
     pr_url: Option<&str>,
     integration_state: &str,
     closing_linkage_repaired: bool,
+    issue_watcher: Option<SorFactIssueWatcherContext<'_>>,
 ) -> SorFacts {
     let validation_commands = if validation_status == "NOT_RUN" {
         Vec::new()
@@ -1138,6 +1173,11 @@ fn build_sor_facts(
             pr_url: pr_url.map(str::to_string),
             blocking_notes: vec!["none".to_string()],
             fix_notes,
+            issue_watcher: issue_watcher.map(|watcher| SorFactIssueWatcher {
+                packet_path: watcher.packet_path.to_string(),
+                last_pr_state: watcher.last_pr_state.to_string(),
+                terminal_disposition: watcher.terminal_disposition.to_string(),
+            }),
         },
         integration: SorFactIntegration {
             state: integration_state.to_string(),
@@ -1351,8 +1391,18 @@ pub(super) fn normalize_sor_emitted_facts_fixture(
         context.pr_url,
         context.integration_state,
         context.closing_linkage_repaired,
+        context.issue_watcher,
     );
     normalize_sor_emitted_facts_text(text, &facts)
+}
+
+fn issue_watcher_packet_path_for_sor(repo_root: &Path, issue: u32, pr_url: &str) -> String {
+    let packet_path = super::github::issue_watcher_attachment_record_path(repo_root, issue, pr_url);
+    packet_path
+        .strip_prefix(repo_root)
+        .unwrap_or(packet_path.as_path())
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 pub(super) fn restage_finish_output_truth_paths(
@@ -2849,9 +2899,9 @@ fn release_gate_disposition_backed_finish_validation_plan(
     profile: &FinishValidationProfile,
     release_gate_disposition: Option<&Path>,
 ) -> Result<Option<FinishValidationPlan>> {
-    if !finish_validation_profile_requires_release_gate_disposition(profile) {
+    if !finish_validation_profile_accepts_explicit_disposition(profile) {
         if release_gate_disposition.is_some() {
-            bail!("finish: --release-gate-disposition was supplied, but validation manager did not report a release-gate escalation");
+            bail!("finish: --release-gate-disposition was supplied, but validation manager did not report a release-gate or explicit slow-lane escalation");
         }
         return Ok(None);
     }
@@ -2890,6 +2940,25 @@ fn finish_validation_profile_requires_release_gate_disposition(
             reason.lane_id == "release_gate_review" && reason.status == "release_gate_required"
         })
         && !profile.escalation.reasons.is_empty()
+}
+
+fn finish_validation_profile_requires_slow_lane_disposition(
+    profile: &FinishValidationProfile,
+) -> bool {
+    profile.escalation.required
+        && profile.escalation.reasons.iter().all(|reason| {
+            reason.lane_id == "rust_pr_fast"
+                && reason.status == "escalated"
+                && reason.reason == "slow_pr_cmd_e2e_surface_requires_explicit_slow_lane"
+        })
+        && !profile.escalation.reasons.is_empty()
+}
+
+fn finish_validation_profile_accepts_explicit_disposition(
+    profile: &FinishValidationProfile,
+) -> bool {
+    finish_validation_profile_requires_release_gate_disposition(profile)
+        || finish_validation_profile_requires_slow_lane_disposition(profile)
 }
 
 pub(super) fn validate_release_gate_disposition(
@@ -3017,7 +3086,12 @@ fn ensure_release_gate_disposition_is_in_index(repo_root: &Path, path: &Path) ->
 fn release_gate_matched_paths(profile: &FinishValidationProfile) -> Vec<String> {
     let mut paths = Vec::new();
     for reason in &profile.escalation.reasons {
-        if reason.lane_id == "release_gate_review" && reason.status == "release_gate_required" {
+        let release_gate_required =
+            reason.lane_id == "release_gate_review" && reason.status == "release_gate_required";
+        let slow_lane_required = reason.lane_id == "rust_pr_fast"
+            && reason.status == "escalated"
+            && reason.reason == "slow_pr_cmd_e2e_surface_requires_explicit_slow_lane";
+        if release_gate_required || slow_lane_required {
             for path in &reason.matched_paths {
                 if !paths.iter().any(|existing| existing == path) {
                     paths.push(path.clone());

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -1111,16 +1111,16 @@ fn record_sor_emitted_facts_for_finish(
     let review = read_sor_review_evidence(review_policy_path)?;
     let normalized = normalize_sor_emitted_facts_text(
         &original,
-        &build_sor_facts(
+        &build_sor_facts(SorFactBuildInput {
             changed_paths,
             plan,
-            context.validation_status,
-            &review,
-            context.pr_url,
-            context.integration_state,
-            context.closing_linkage_repaired,
-            context.issue_watcher,
-        ),
+            validation_status: context.validation_status,
+            review: &review,
+            pr_url: context.pr_url,
+            integration_state: context.integration_state,
+            closing_linkage_repaired: context.closing_linkage_repaired,
+            issue_watcher: context.issue_watcher,
+        }),
     )?;
     if normalized != original {
         fs::write(output_path, normalized).with_context(|| {
@@ -1133,55 +1133,59 @@ fn record_sor_emitted_facts_for_finish(
     Ok(())
 }
 
-fn build_sor_facts(
-    changed_paths: &[String],
-    plan: &FinishValidationPlan,
-    validation_status: &str,
-    review: &SorReviewEvidence,
-    pr_url: Option<&str>,
-    integration_state: &str,
+struct SorFactBuildInput<'a> {
+    changed_paths: &'a [String],
+    plan: &'a FinishValidationPlan,
+    validation_status: &'a str,
+    review: &'a SorReviewEvidence,
+    pr_url: Option<&'a str>,
+    integration_state: &'a str,
     closing_linkage_repaired: bool,
-    issue_watcher: Option<SorFactIssueWatcherContext<'_>>,
-) -> SorFacts {
-    let validation_commands = if validation_status == "NOT_RUN" {
+    issue_watcher: Option<SorFactIssueWatcherContext<'a>>,
+}
+
+fn build_sor_facts(input: SorFactBuildInput<'_>) -> SorFacts {
+    let validation_commands = if input.validation_status == "NOT_RUN" {
         Vec::new()
     } else {
-        plan.commands
+        input
+            .plan
+            .commands
             .iter()
             .map(|command| sanitize_validation_profile_command(command))
             .collect()
     };
-    let fix_notes = if closing_linkage_repaired {
+    let fix_notes = if input.closing_linkage_repaired {
         vec!["repaired missing PR closing linkage".to_string()]
     } else {
         vec!["none".to_string()]
     };
     SorFacts {
         schema_version: "adl.sor_facts.v1",
-        changed_paths: changed_paths.to_vec(),
+        changed_paths: input.changed_paths.to_vec(),
         validation: SorFactValidation {
-            status: validation_status.to_string(),
+            status: input.validation_status.to_string(),
             commands: validation_commands,
         },
         review: SorFactReview {
-            findings_status: review.findings_status.clone(),
-            recommended_outcome: review.recommended_outcome.clone(),
-            findings: review.findings.clone(),
-            fixes: review.fixes.clone(),
+            findings_status: input.review.findings_status.clone(),
+            recommended_outcome: input.review.recommended_outcome.clone(),
+            findings: input.review.findings.clone(),
+            fixes: input.review.fixes.clone(),
         },
         finish: SorFactFinish {
-            pr_url: pr_url.map(str::to_string),
+            pr_url: input.pr_url.map(str::to_string),
             blocking_notes: vec!["none".to_string()],
             fix_notes,
-            issue_watcher: issue_watcher.map(|watcher| SorFactIssueWatcher {
+            issue_watcher: input.issue_watcher.map(|watcher| SorFactIssueWatcher {
                 packet_path: watcher.packet_path.to_string(),
                 last_pr_state: watcher.last_pr_state.to_string(),
                 terminal_disposition: watcher.terminal_disposition.to_string(),
             }),
         },
         integration: SorFactIntegration {
-            state: integration_state.to_string(),
-            main_repo_paths: changed_paths.to_vec(),
+            state: input.integration_state.to_string(),
+            main_repo_paths: input.changed_paths.to_vec(),
         },
     }
 }
@@ -1383,16 +1387,16 @@ pub(super) fn normalize_sor_emitted_facts_fixture(
         commands: commands.to_vec(),
     };
     let review = parse_sor_review_evidence(review_text);
-    let facts = build_sor_facts(
+    let facts = build_sor_facts(SorFactBuildInput {
         changed_paths,
-        &plan,
-        context.validation_status,
-        &review,
-        context.pr_url,
-        context.integration_state,
-        context.closing_linkage_repaired,
-        context.issue_watcher,
-    );
+        plan: &plan,
+        validation_status: context.validation_status,
+        review: &review,
+        pr_url: context.pr_url,
+        integration_state: context.integration_state,
+        closing_linkage_repaired: context.closing_linkage_repaired,
+        issue_watcher: context.issue_watcher,
+    });
     normalize_sor_emitted_facts_text(text, &facts)
 }
 

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -16,7 +16,7 @@ use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -1567,6 +1567,7 @@ pub(super) fn format_open_pr_wave(prs: &[OpenPullRequest]) -> String {
 }
 
 pub(super) fn pr_inventory(repo: &str) -> Result<Vec<PrInventoryRecord>> {
+    let repo_root = resolve_primary_checkout_root(Path::new("."), None);
     list_prs_octocrab(repo)?
         .into_iter()
         .map(|mut pr| {
@@ -1584,6 +1585,11 @@ pub(super) fn pr_inventory(repo: &str) -> Result<Vec<PrInventoryRecord>> {
                         )
                     },
                 )?;
+            let watcher = issue_pr_watcher_status_for_inventory(
+                &repo_root,
+                closing_issue_numbers.first().copied(),
+                &pr.url,
+            );
             Ok(PrInventoryRecord {
                 number: pr.number,
                 title: pr.title,
@@ -1597,6 +1603,7 @@ pub(super) fn pr_inventory(repo: &str) -> Result<Vec<PrInventoryRecord>> {
                 queue: pr.queue,
                 closing_issue_numbers,
                 check_summary: PrInventoryCheckSummary::from_validation_report(&validation),
+                watcher,
             })
         })
         .collect()
@@ -1733,6 +1740,7 @@ pub(super) fn attach_pr_janitor(
 
 pub(super) struct IssueWatcherAttachRequest<'a> {
     pub repo_root: &'a Path,
+    pub artifact_root: &'a Path,
     pub repo: &'a str,
     pub issue: u32,
     pub branch: &'a str,
@@ -1743,10 +1751,263 @@ pub(super) struct IssueWatcherAttachRequest<'a> {
     pub shepherd_state: &'a str,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct IssueWatcherAttachmentRecord {
+    schema: String,
+    issue: u32,
+    repo: String,
+    branch: String,
+    pr_url: String,
+    pr_number: Option<u32>,
+    expected_pr_state: String,
+    classification: String,
+    tail_owner: String,
+    shepherd_state: String,
+    status: String,
+    packet_path: String,
+    input_path: String,
+    prompt_path: String,
+    log_path: String,
+    pid_path: String,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    terminal_disposition: Option<String>,
+    #[serde(default)]
+    terminal_recorded_at: Option<String>,
+}
+
+fn issue_watcher_artifact_root(repo_root: &Path, issue: u32) -> PathBuf {
+    repo_root
+        .join(".adl")
+        .join("logs")
+        .join("issue-watcher")
+        .join(format!("issue-{issue}"))
+}
+
+fn issue_watcher_repo_relative_path(repo_root: &Path, path: &Path) -> String {
+    path.strip_prefix(repo_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn pr_number_from_url(pr_url: &str) -> Option<u32> {
+    pr_url
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|value| value.parse::<u32>().ok())
+}
+
+pub(crate) fn issue_watcher_attachment_record_path(
+    repo_root: &Path,
+    issue: u32,
+    pr_url: &str,
+) -> PathBuf {
+    let pr_number = pr_number_from_url(pr_url)
+        .map(|number| number.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    issue_watcher_artifact_root(repo_root, issue).join(format!("pr-{pr_number}-attachment.json"))
+}
+
+fn write_issue_watcher_attachment_record(
+    request: &IssueWatcherAttachRequest<'_>,
+    input_file: &Path,
+    prompt_file: &Path,
+    run_log: &Path,
+    pid_file: &Path,
+    pid: Option<u32>,
+) -> Result<()> {
+    let packet_path =
+        issue_watcher_attachment_record_path(request.artifact_root, request.issue, request.pr_url);
+    let record = IssueWatcherAttachmentRecord {
+        schema: "adl.issue_watcher.attachment.v1".to_string(),
+        issue: request.issue,
+        repo: request.repo.to_string(),
+        branch: request.branch.to_string(),
+        pr_url: request.pr_url.to_string(),
+        pr_number: pr_number_from_url(request.pr_url),
+        expected_pr_state: request.expected_pr_state.to_string(),
+        classification: request.classification.to_string(),
+        tail_owner: request.tail_owner.to_string(),
+        shepherd_state: request.shepherd_state.to_string(),
+        status: "attached".to_string(),
+        packet_path: issue_watcher_repo_relative_path(request.artifact_root, &packet_path),
+        input_path: issue_watcher_repo_relative_path(request.artifact_root, input_file),
+        prompt_path: issue_watcher_repo_relative_path(request.artifact_root, prompt_file),
+        log_path: issue_watcher_repo_relative_path(request.artifact_root, run_log),
+        pid_path: issue_watcher_repo_relative_path(request.artifact_root, pid_file),
+        pid,
+        terminal_disposition: None,
+        terminal_recorded_at: None,
+    };
+    let json = serde_json::to_string_pretty(&record)?;
+    fs::write(&packet_path, format!("{json}\n")).with_context(|| {
+        format!(
+            "finish: failed to write issue watcher attachment packet '{}'",
+            packet_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn read_issue_watcher_attachment_record(
+    repo_root: &Path,
+    issue: u32,
+    pr_url: &str,
+) -> Result<Option<(PathBuf, IssueWatcherAttachmentRecord)>> {
+    let packet_path = issue_watcher_attachment_record_path(repo_root, issue, pr_url);
+    if !packet_path.is_file() {
+        return Ok(None);
+    }
+    let record: IssueWatcherAttachmentRecord =
+        serde_json::from_str(&fs::read_to_string(&packet_path).with_context(|| {
+            format!(
+                "watcher: failed to read issue watcher packet '{}'",
+                packet_path.display()
+            )
+        })?)
+        .with_context(|| {
+            format!(
+                "watcher: failed to parse issue watcher packet '{}'",
+                packet_path.display()
+            )
+        })?;
+    Ok(Some((packet_path, record)))
+}
+
+pub(crate) fn issue_pr_watcher_status_for_inventory(
+    repo_root: &Path,
+    issue: Option<u32>,
+    pr_url: &str,
+) -> PrInventoryWatcherStatus {
+    let Some(issue) = issue else {
+        return PrInventoryWatcherStatus {
+            status: "not_issue_bound".to_string(),
+            packet_path: None,
+            terminal_disposition: None,
+            reason: "pr_has_no_closing_issue_reference".to_string(),
+        };
+    };
+    match read_issue_watcher_attachment_record(repo_root, issue, pr_url) {
+        Ok(Some((packet_path, record))) => {
+            let terminal = record.terminal_disposition.clone();
+            PrInventoryWatcherStatus {
+                status: if terminal.is_some() {
+                    "terminal".to_string()
+                } else {
+                    "attached_nonterminal".to_string()
+                },
+                packet_path: Some(issue_watcher_repo_relative_path(repo_root, &packet_path)),
+                terminal_disposition: terminal,
+                reason: "issue_watcher_packet_present".to_string(),
+            }
+        }
+        Ok(None) => PrInventoryWatcherStatus {
+            status: "missing".to_string(),
+            packet_path: Some(issue_watcher_repo_relative_path(
+                repo_root,
+                &issue_watcher_attachment_record_path(repo_root, issue, pr_url),
+            )),
+            terminal_disposition: None,
+            reason: "issue_bound_pr_has_no_watcher_packet".to_string(),
+        },
+        Err(err) => PrInventoryWatcherStatus {
+            status: "invalid".to_string(),
+            packet_path: None,
+            terminal_disposition: None,
+            reason: err.to_string(),
+        },
+    }
+}
+
+pub(crate) fn ensure_issue_watcher_terminal_disposition(
+    repo_root: &Path,
+    issue: u32,
+    pr_url: Option<&str>,
+    fallback_disposition: &str,
+) -> Result<()> {
+    let Some(pr_url) = pr_url.filter(|value| !value.trim().is_empty()) else {
+        let artifact_root = issue_watcher_artifact_root(repo_root, issue);
+        fs::create_dir_all(&artifact_root).with_context(|| {
+            format!(
+                "closeout: failed to create issue watcher artifact root '{}'",
+                artifact_root.display()
+            )
+        })?;
+        let packet_path = artifact_root.join("closed-without-pr-attachment.json");
+        let record = serde_json::json!({
+            "schema": "adl.issue_watcher.attachment.v1",
+            "issue": issue,
+            "repo": "unknown",
+            "branch": "unknown",
+            "pr_url": null,
+            "pr_number": null,
+            "expected_pr_state": "closed",
+            "classification": fallback_disposition,
+            "tail_owner": "pr-closeout",
+            "shepherd_state": "terminal_closeout",
+            "status": "terminal",
+            "packet_path": issue_watcher_repo_relative_path(repo_root, &packet_path),
+            "terminal_disposition": fallback_disposition,
+            "terminal_recorded_at": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "reason": "closeout_completed_without_linked_pr_url"
+        });
+        fs::write(
+            &packet_path,
+            format!("{}\n", serde_json::to_string_pretty(&record)?),
+        )
+        .with_context(|| {
+            format!(
+                "closeout: failed to write watcher terminal packet '{}'",
+                packet_path.display()
+            )
+        })?;
+        return Ok(());
+    };
+
+    let (packet_path, mut record) =
+        read_issue_watcher_attachment_record(repo_root, issue, pr_url)?.ok_or_else(|| {
+            anyhow!(
+                "closeout: issue-bound PR '{}' for issue #{} has no watcher attachment packet; rerun pr finish or pr watch/shepherd before closeout",
+                pr_url,
+                issue
+            )
+        })?;
+    if record.terminal_disposition.is_none() {
+        record.status = "terminal".to_string();
+        record.terminal_disposition = Some(fallback_disposition.to_string());
+        record.terminal_recorded_at =
+            Some(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+        let json = serde_json::to_string_pretty(&record)?;
+        fs::write(&packet_path, format!("{json}\n")).with_context(|| {
+            format!(
+                "closeout: failed to update watcher terminal packet '{}'",
+                packet_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
 pub(super) fn attach_issue_watcher(request: IssueWatcherAttachRequest<'_>) -> Result<()> {
     if std::env::var("ADL_ISSUE_WATCHER_DISABLE").ok().as_deref() == Some("1") {
-        return Ok(());
+        bail!("finish: issue watcher attachment is required for issue-bound PRs; ADL_ISSUE_WATCHER_DISABLE=1 is not allowed");
     }
+
+    let artifact_root = issue_watcher_artifact_root(request.artifact_root, request.issue);
+    fs::create_dir_all(&artifact_root).with_context(|| {
+        format!(
+            "finish: failed to create issue watcher artifact root '{}'",
+            artifact_root.display()
+        )
+    })?;
+    let input_file = artifact_root.join("input.yaml");
+    let prompt_file = artifact_root.join("prompt.md");
+    let run_log = artifact_root.join("codex.log");
+    let last_message_file = artifact_root.join("last_message.md");
+    let pid_file = artifact_root.join("pid");
 
     if let Some(command_path) = std::env::var("ADL_ISSUE_WATCHER_CMD")
         .ok()
@@ -1791,6 +2052,14 @@ pub(super) fn attach_issue_watcher(request: IssueWatcherAttachRequest<'_>) -> Re
                 }
             );
         }
+        write_issue_watcher_attachment_record(
+            &request,
+            &input_file,
+            &prompt_file,
+            &run_log,
+            &pid_file,
+            None,
+        )?;
         return Ok(());
     }
 
@@ -1820,24 +2089,6 @@ pub(super) fn attach_issue_watcher(request: IssueWatcherAttachRequest<'_>) -> Re
             }
         );
     }
-
-    let artifact_root = request
-        .repo_root
-        .join(".adl")
-        .join("logs")
-        .join("issue-watcher")
-        .join(format!("issue-{}", request.issue));
-    fs::create_dir_all(&artifact_root).with_context(|| {
-        format!(
-            "finish: failed to create issue watcher artifact root '{}'",
-            artifact_root.display()
-        )
-    })?;
-    let input_file = artifact_root.join("input.yaml");
-    let prompt_file = artifact_root.join("prompt.md");
-    let run_log = artifact_root.join("codex.log");
-    let last_message_file = artifact_root.join("last_message.md");
-    let pid_file = artifact_root.join("pid");
 
     fs::write(
         &input_file,
@@ -1908,6 +2159,14 @@ pub(super) fn attach_issue_watcher(request: IssueWatcherAttachRequest<'_>) -> Re
             pid_file.display()
         )
     })?;
+    write_issue_watcher_attachment_record(
+        &request,
+        &input_file,
+        &prompt_file,
+        &run_log,
+        &pid_file,
+        Some(child.id()),
+    )?;
     Ok(())
 }
 

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -318,6 +318,140 @@ fn helper_attach_commands_cover_disabled_success_failure_and_fallback_paths() {
 }
 
 #[test]
+fn issue_watcher_attachment_is_required_and_records_terminal_packet() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-github-issue-watcher-required");
+    let repo = temp.join("worktree");
+    let primary = temp.join("primary");
+    fs::create_dir_all(&repo).expect("repo dir");
+    fs::create_dir_all(&primary).expect("primary dir");
+    let watcher_cmd = temp.join("watcher-helper.sh");
+    let watcher_log = temp.join("watcher-helper.log");
+    write_executable(
+        &watcher_cmd,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            watcher_log.display()
+        ),
+    );
+
+    let old_disable = std::env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
+    let old_cmd = std::env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    unsafe {
+        std::env::set_var("ADL_ISSUE_WATCHER_DISABLE", "1");
+        std::env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_cmd);
+    }
+    let disabled = attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo,
+        artifact_root: &primary,
+        repo: "owner/repo",
+        issue: 1153,
+        branch: "codex/1153-branch",
+        pr_url: "https://github.com/owner/repo/pull/1159",
+        expected_pr_state: "draft",
+        classification: "pr_open",
+        tail_owner: "issue-watcher",
+        shepherd_state: "watcher_owned_pr_open",
+    })
+    .expect_err("disabled watcher must fail closed");
+    assert!(disabled
+        .to_string()
+        .contains("issue watcher attachment is required"));
+
+    unsafe {
+        std::env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+    }
+    attach_issue_watcher(IssueWatcherAttachRequest {
+        repo_root: &repo,
+        artifact_root: &primary,
+        repo: "owner/repo",
+        issue: 1153,
+        branch: "codex/1153-branch",
+        pr_url: "https://github.com/owner/repo/pull/1159",
+        expected_pr_state: "draft",
+        classification: "pr_open",
+        tail_owner: "issue-watcher",
+        shepherd_state: "watcher_owned_pr_open",
+    })
+    .expect("watcher helper should attach");
+
+    let status = issue_pr_watcher_status_for_inventory(
+        &primary,
+        Some(1153),
+        "https://github.com/owner/repo/pull/1159",
+    );
+    assert_eq!(status.status, "attached_nonterminal");
+    assert!(status
+        .packet_path
+        .as_deref()
+        .unwrap_or_default()
+        .contains(".adl/logs/issue-watcher/issue-1153/pr-1159-attachment.json"));
+    assert!(!repo
+        .join(".adl/logs/issue-watcher/issue-1153/pr-1159-attachment.json")
+        .exists());
+    assert!(primary
+        .join(".adl/logs/issue-watcher/issue-1153/pr-1159-attachment.json")
+        .exists());
+    assert!(fs::read_to_string(&watcher_log)
+        .expect("watcher helper log")
+        .contains("--pr-url https://github.com/owner/repo/pull/1159"));
+
+    ensure_issue_watcher_terminal_disposition(
+        &primary,
+        1153,
+        Some("https://github.com/owner/repo/pull/1159"),
+        "green_merged",
+    )
+    .expect("terminal watcher disposition should update attached packet");
+    let terminal = issue_pr_watcher_status_for_inventory(
+        &primary,
+        Some(1153),
+        "https://github.com/owner/repo/pull/1159",
+    );
+    assert_eq!(terminal.status, "terminal");
+    assert_eq!(
+        terminal.terminal_disposition.as_deref(),
+        Some("green_merged")
+    );
+
+    let missing_terminal = ensure_issue_watcher_terminal_disposition(
+        &repo,
+        1154,
+        Some("https://github.com/owner/repo/pull/1160"),
+        "closed_without_merge",
+    )
+    .expect_err("PR-backed closeout without watcher packet must fail");
+    assert!(missing_terminal
+        .to_string()
+        .contains("has no watcher attachment packet"));
+
+    restore_env("ADL_ISSUE_WATCHER_DISABLE", old_disable);
+    restore_env("ADL_ISSUE_WATCHER_CMD", old_cmd);
+}
+
+#[test]
+fn issue_pr_watcher_inventory_reports_missing_packet_for_issue_bound_pr() {
+    let temp = unique_temp_dir("adl-github-issue-watcher-inventory-missing");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+
+    let missing = issue_pr_watcher_status_for_inventory(
+        &repo,
+        Some(1410),
+        "https://github.com/owner/repo/pull/1410",
+    );
+    assert_eq!(missing.status, "missing");
+    assert_eq!(missing.reason, "issue_bound_pr_has_no_watcher_packet");
+
+    let not_issue_bound = issue_pr_watcher_status_for_inventory(
+        &repo,
+        None,
+        "https://github.com/owner/repo/pull/1411",
+    );
+    assert_eq!(not_issue_bound.status, "not_issue_bound");
+}
+
+#[test]
 fn helper_attach_failures_redact_token_like_output() {
     let _guard = env_lock();
     let policy_env = clear_github_policy_env();

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -149,6 +149,49 @@ fn closeout_sor_names_linked_pr(text: &str, linked_pr_url: &str, _linked_pr_numb
     })
 }
 
+fn closeout_sor_pr_url(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let line = line.trim().trim_start_matches("- ").trim();
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().trim_matches('`');
+        if !matches!(key, "pr_url" | "PR URL" | "Pull Request URL") {
+            continue;
+        }
+        let value = value.trim().trim_matches('`').trim_matches('"');
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn ensure_terminal_watcher_for_closeout(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    canonical_output: &Path,
+) -> Result<()> {
+    let sor_text = fs::read_to_string(canonical_output).with_context(|| {
+        format!(
+            "closeout: failed to read canonical SOR for watcher terminal disposition '{}'",
+            canonical_output.display()
+        )
+    })?;
+    let pr_url = closeout_sor_pr_url(&sor_text);
+    let terminal_disposition =
+        match line_value_after_prefix(&sor_text, "- Integration state:").as_deref() {
+            Some("merged") => "green_merged",
+            _ => "closed_without_merge",
+        };
+    super::super::github::ensure_issue_watcher_terminal_disposition(
+        repo_root,
+        issue_ref.issue_number(),
+        pr_url.as_deref(),
+        terminal_disposition,
+    )
+}
+
 fn closeout_marker_timestamp_covers_issue_closed_at(
     repo_root: &Path,
     issue_ref: &IssueRef,
@@ -401,6 +444,7 @@ pub(crate) fn closeout_closed_completed_issue_bundle(
                     issue_ref.issue_number()
                 )
             })?;
+        ensure_terminal_watcher_for_closeout(primary_root, issue_ref, canonical_output)?;
         write_validated_closeout_marker(primary_root, issue_ref, canonical_output)?;
         return Ok(());
     }
@@ -413,6 +457,7 @@ pub(crate) fn closeout_closed_completed_issue_bundle(
                 issue_ref.issue_number()
             )
         })?;
+    ensure_terminal_watcher_for_closeout(primary_root, issue_ref, canonical_output)?;
     write_validated_closeout_marker(primary_root, issue_ref, canonical_output)?;
     Ok(())
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -19,6 +19,7 @@ use crate::cli::pr_cmd::finish_support::{
     FinishValidationProfileSurfaceItem, FinishValidationSplit, FinishValidationSplitFailClosed,
     FinishValidationSplitFanoutPolicy, FinishValidationSplitFastLane,
     FinishValidationSplitSlowFamily, FinishValidationVppRecord, SorFactEmissionContext,
+    SorFactIssueWatcherContext,
 };
 use crate::cli::pr_cmd::git_support::commits_behind_origin_main;
 use crate::cli::pr_cmd::github::{PrValidationCheckReport, PrValidationReport};
@@ -729,6 +730,11 @@ review_results:
             pr_url: Some("https://github.com/danielbaustin/agent-design-language/pull/9999"),
             integration_state: "pr_open",
             closing_linkage_repaired: true,
+            issue_watcher: Some(SorFactIssueWatcherContext {
+                packet_path: ".adl/logs/issue-watcher/issue-5009/pr-9999-attachment.json",
+                last_pr_state: "draft",
+                terminal_disposition: "pending",
+            }),
         },
     )
     .expect("normalize sor emitted facts");
@@ -741,6 +747,11 @@ review_results:
     assert!(normalized.contains("Added focused SOR fact merge test coverage."));
     assert!(normalized
         .contains("pr_url: https://github.com/danielbaustin/agent-design-language/pull/9999"));
+    assert!(normalized.contains("issue_watcher:"));
+    assert!(normalized
+        .contains("packet_path: .adl/logs/issue-watcher/issue-5009/pr-9999-attachment.json"));
+    assert!(normalized.contains("last_pr_state: draft"));
+    assert!(normalized.contains("terminal_disposition: pending"));
     assert!(normalized.contains("state: pr_open"));
     assert!(normalized.contains("repaired missing PR closing linkage"));
 }
@@ -788,6 +799,7 @@ review_results:
             pr_url: Some("https://example.test/pr/1"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("first normalize");
@@ -801,6 +813,7 @@ review_results:
             pr_url: Some("https://example.test/pr/1"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("second normalize");
@@ -837,6 +850,7 @@ review_results:
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize no-checks sor emitted facts");
@@ -878,6 +892,7 @@ review_results:
             pr_url: Some("https://example.test/pr/2"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize with fallback");
@@ -920,6 +935,7 @@ review_results:
             pr_url: Some("https://example.test/pr/2"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize with missing verification summary");
@@ -963,6 +979,7 @@ review_results:
             pr_url: Some("https://example.test/pr/2"),
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("first fallback normalize");
@@ -976,6 +993,7 @@ review_results:
             pr_url: Some("https://example.test/pr/2"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("second fallback normalize");
@@ -1011,6 +1029,7 @@ review_results:
             pr_url: Some("https://example.test/pr/3"),
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("first empty-body fallback normalize");
@@ -1024,6 +1043,7 @@ review_results:
             pr_url: Some("https://example.test/pr/3"),
             integration_state: "pr_open",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("second empty-body fallback normalize");
@@ -1058,6 +1078,7 @@ review_results:
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize with sanitized changed-files command");
@@ -1094,6 +1115,7 @@ verification_summary:
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize without srp front matter");
@@ -1118,6 +1140,7 @@ fn sor_emitted_facts_parse_review_truth_from_crlf_front_matter() {
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize crlf srp front matter");
@@ -1160,6 +1183,7 @@ review_results:
             pr_url: None,
             integration_state: "worktree_only",
             closing_linkage_repaired: false,
+            issue_watcher: None,
         },
     )
     .expect("normalize numbered finding review evidence");
@@ -5659,6 +5683,61 @@ residual_ci_proof_required_before_merge: required
         Path::new("docs/review/release-gate.yaml"),
     )
     .expect("valid release-gate disposition should pass");
+}
+
+#[test]
+fn slow_pr_cmd_disposition_validates_tracked_publishable_surface() {
+    let repo = unique_temp_dir("adl-pr-finish-slow-pr-cmd-disposition-valid");
+    fs::create_dir_all(repo.join("docs/review")).expect("review dir");
+    init_finish_helper_git_repo(&repo);
+    fs::write(
+        repo.join("docs/review/slow-pr-cmd.yaml"),
+        r#"issue: 5009
+disposition: approved_with_focused_local_proof
+changed_release_gate_surfaces:
+  - adl/src/cli/pr_cmd/finish_support.rs
+reviewer_or_review_mode: bounded slow PR-command review
+focused_validation_run: focused issue_watcher tests and owner binary checks passed locally
+residual_ci_proof_required_before_merge: required
+"#,
+    )
+    .expect("slow PR-command disposition");
+    assert!(Command::new("git")
+        .args(["add", "docs/review/slow-pr-cmd.yaml"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    let profile = FinishValidationProfile {
+        selected_profile: "escalated_3_lane_profile".to_string(),
+        status: "escalation_required".to_string(),
+        pr_publication_sufficient: false,
+        validation_split: None,
+        run: Vec::new(),
+        not_run: Vec::new(),
+        deferred: Vec::new(),
+        escalation: FinishValidationProfileEscalation {
+            required: true,
+            reasons: vec![FinishValidationProfileEscalationReason {
+                lane_id: "rust_pr_fast".to_string(),
+                status: "escalated".to_string(),
+                reason: "slow_pr_cmd_e2e_surface_requires_explicit_slow_lane".to_string(),
+                matched_paths: vec!["adl/src/cli/pr_cmd/finish_support.rs".to_string()],
+                manifest_rule: Some("special_surfaces.rust_pr_fast".to_string()),
+                remediation_hint: Some(
+                    "Record an explicit slow-lane disposition before publication.".to_string(),
+                ),
+            }],
+        },
+    };
+
+    validate_release_gate_disposition(
+        &repo,
+        5009,
+        &profile,
+        Path::new("docs/review/slow-pr-cmd.yaml"),
+    )
+    .expect("valid slow PR-command disposition should pass");
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1335,6 +1335,43 @@ impl Drop for FinishHelperObservabilityEnvGuard {
     }
 }
 
+struct EnvVarGuard {
+    key: &'static str,
+    old: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let old = std::env::var(key).ok();
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, old }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(value) = &self.old {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+fn write_issue_watcher_stub(path: &Path, log: &Path) {
+    write_executable(
+        path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            log.display()
+        ),
+    );
+}
+
 fn read_finish_helper_log_until(log: &Path, needle: &str) -> String {
     for _ in 0..10 {
         let contents = fs::read_to_string(log).unwrap_or_default();
@@ -7450,9 +7487,11 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
     let closeout_log = temp.join("closeout.log");
+    let watcher_log = temp.join("issue-watcher.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
     let closeout_path = bin_dir.join("closeout");
+    let watcher_path = bin_dir.join("issue-watcher");
     write_executable(
         &gh_path,
         &format!(
@@ -7460,7 +7499,6 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
             gh_log.display()
         ),
     );
-    let _fixture = GithubCliFixtureGuard::set(&gh_path);
     write_executable(
         &janitor_path,
         &format!(
@@ -7475,8 +7513,11 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
             closeout_log.display()
         ),
     );
+    write_issue_watcher_stub(&watcher_path, &watcher_log);
     let _fixture = GithubCliFixtureGuard::set(&gh_path);
 
+    let _watcher_disable_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_DISABLE", "0");
+    let _watcher_cmd_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
@@ -7561,6 +7602,8 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
     let closeout_log = fs::read_to_string(&closeout_log).expect("closeout log");
     assert!(janitor_log.contains("--issue 1153"));
     assert!(closeout_log.contains("--issue 1153"));
+    let watcher_log = fs::read_to_string(&watcher_log).expect("watcher log");
+    assert!(watcher_log.contains("--issue 1153"));
 }
 
 #[test]
@@ -7838,9 +7881,11 @@ verification_summary:
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
     let closeout_log = temp.join("closeout.log");
+    let watcher_log = temp.join("issue-watcher.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
     let closeout_path = bin_dir.join("closeout");
+    let watcher_path = bin_dir.join("issue-watcher");
     write_executable(
         &gh_path,
         &format!(
@@ -7862,7 +7907,10 @@ verification_summary:
             closeout_log.display()
         ),
     );
+    write_issue_watcher_stub(&watcher_path, &watcher_log);
 
+    let _watcher_disable_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_DISABLE", "0");
+    let _watcher_cmd_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
@@ -8086,9 +8134,11 @@ fn real_pr_finish_updates_existing_pr_marks_ready_and_keeps_non_closing_commit_t
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
     let closeout_log = temp.join("closeout.log");
+    let watcher_log = temp.join("issue-watcher.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
     let closeout_path = bin_dir.join("closeout");
+    let watcher_path = bin_dir.join("issue-watcher");
     write_executable(
         &gh_path,
         &format!(
@@ -8110,7 +8160,10 @@ fn real_pr_finish_updates_existing_pr_marks_ready_and_keeps_non_closing_commit_t
             closeout_log.display()
         ),
     );
+    write_issue_watcher_stub(&watcher_path, &watcher_log);
 
+    let _watcher_disable_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_DISABLE", "0");
+    let _watcher_cmd_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
@@ -8782,8 +8835,10 @@ fn real_pr_finish_opener_failure_is_nonblocking_when_no_open_is_false() {
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
+    let watcher_log = temp.join("issue-watcher.log");
     let gh_path = bin_dir.join("gh");
     let open_path = bin_dir.join("open");
+    let watcher_path = bin_dir.join("issue-watcher");
     write_executable(
         &gh_path,
         &format!(
@@ -8796,8 +8851,11 @@ fn real_pr_finish_opener_failure_is_nonblocking_when_no_open_is_false() {
         &open_path,
         "#!/usr/bin/env bash\nset -euo pipefail\necho 'synthetic open failure' >&2\nexit 42\n",
     );
+    write_issue_watcher_stub(&watcher_path, &watcher_log);
     let _fixture = GithubCliFixtureGuard::set(&gh_path);
 
+    let _watcher_disable_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_DISABLE", "0");
+    let _watcher_cmd_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     let old_path = env::var("PATH").unwrap_or_default();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
@@ -8975,8 +9033,10 @@ print(json.dumps({
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
     let issue_state_file = temp.join("issue_state.txt");
+    let watcher_log = temp.join("issue-watcher.log");
     fs::write(&issue_state_file, "open\n").expect("seed issue state");
     let gh_path = bin_dir.join("gh");
+    let watcher_path = bin_dir.join("issue-watcher");
     write_executable(
         &gh_path,
         &format!(
@@ -8986,7 +9046,10 @@ print(json.dumps({
             issue_state_file.display()
         ),
     );
+    write_issue_watcher_stub(&watcher_path, &watcher_log);
 
+    let _watcher_disable_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_DISABLE", "0");
+    let _watcher_cmd_guard = EnvVarGuard::set("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     let old_path = env::var("PATH").unwrap_or_default();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -535,7 +535,7 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
 }
 
 #[test]
-fn real_pr_finish_warns_but_succeeds_when_issue_watcher_auto_attach_fails() {
+fn real_pr_finish_fails_when_issue_watcher_auto_attach_fails() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-watcher-fail");
     let origin = temp.join("origin.git");
@@ -745,7 +745,8 @@ fn real_pr_finish_warns_but_succeeds_when_issue_watcher_auto_attach_fails() {
         }
     }
 
-    result.expect("watcher attach failure should not block finish");
+    let err = result.expect_err("watcher attach failure must block finish");
+    assert!(err.to_string().contains("issue watcher auto-attach failed"));
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
     assert!(gh_calls.contains("pr create"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -1085,7 +1085,9 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
+    let watcher_log = temp.join("watcher.log");
     let gh_path = bin_dir.join("gh");
+    let watcher_path = bin_dir.join("watcher");
     write_executable(
             &gh_path,
             &format!(
@@ -1093,6 +1095,13 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
                 gh_log.display()
             ),
         );
+    write_executable(
+        &watcher_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            watcher_log.display()
+        ),
+    );
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind validation server");
     let addr = listener.local_addr().expect("validation server addr");
@@ -1186,11 +1195,15 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     let old_path = env::var("PATH").unwrap_or_default();
     let old_base_uri = env::var_os("ADL_GITHUB_OCTOCRAB_BASE_URI");
     let old_github_token = env::var_os("GITHUB_TOKEN");
+    let old_watcher_cmd = env::var("ADL_ISSUE_WATCHER_CMD").ok();
+    let old_watcher_disable = env::var("ADL_ISSUE_WATCHER_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_GITHUB_OCTOCRAB_BASE_URI", format!("http://{addr}"));
         env::set_var("GITHUB_TOKEN", "test-token-for-mock-octocrab");
+        env::set_var("ADL_ISSUE_WATCHER_DISABLE", "0");
+        env::set_var("ADL_ISSUE_WATCHER_CMD", &watcher_path);
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -1223,6 +1236,16 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
         } else {
             env::remove_var("GITHUB_TOKEN");
         }
+        if let Some(value) = old_watcher_cmd {
+            env::set_var("ADL_ISSUE_WATCHER_CMD", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_CMD");
+        }
+        if let Some(value) = old_watcher_disable {
+            env::set_var("ADL_ISSUE_WATCHER_DISABLE", value);
+        } else {
+            env::remove_var("ADL_ISSUE_WATCHER_DISABLE");
+        }
     }
     validation_handle.join().expect("validation server join");
     result.expect("real_pr finish edit");
@@ -1232,4 +1255,8 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     assert!(gh_calls.contains("danielbaustin/agent-design-language"));
     assert!(gh_calls.contains("https://github.com/danielbaustin/agent-design-language/pull/1160"));
     assert!(gh_calls.contains("pr ready"));
+    let watcher_calls = fs::read_to_string(&watcher_log).expect("read watcher log");
+    assert!(watcher_calls.contains("--issue 1153"));
+    assert!(watcher_calls.contains("--expected-pr-state ready"));
+    assert!(watcher_calls.contains("--shepherd-state watcher_owned_checks_running"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
@@ -212,6 +212,7 @@ fn attach_issue_watcher_reports_failure_output() {
 
     let err = attach_issue_watcher(IssueWatcherAttachRequest {
         repo_root: &repo,
+        artifact_root: &repo,
         repo: "owner/repo",
         issue: 1153,
         branch: "codex/1153-rust-finish-test",
@@ -243,7 +244,7 @@ fn attach_issue_watcher_reports_failure_output() {
 }
 
 #[test]
-fn attach_issue_watcher_returns_early_when_disabled() {
+fn attach_issue_watcher_fails_when_disabled() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-attach-watcher-disabled");
     let repo = temp.join("repo");
@@ -255,8 +256,9 @@ fn attach_issue_watcher_returns_early_when_disabled() {
         env::remove_var("ADL_ISSUE_WATCHER_CMD");
     }
 
-    attach_issue_watcher(IssueWatcherAttachRequest {
+    let err = attach_issue_watcher(IssueWatcherAttachRequest {
         repo_root: &repo,
+        artifact_root: &repo,
         repo: "owner/repo",
         issue: 1153,
         branch: "codex/1153-rust-finish-test",
@@ -266,7 +268,10 @@ fn attach_issue_watcher_returns_early_when_disabled() {
         tail_owner: "issue-watcher",
         shepherd_state: "watcher_owned_pr_open",
     })
-    .expect("disabled watcher helper should be skipped");
+    .expect_err("disabled watcher helper must fail closed");
+    assert!(err
+        .to_string()
+        .contains("issue watcher attachment is required"));
 
     unsafe {
         if let Some(value) = old_disable {
@@ -306,6 +311,7 @@ fn attach_issue_watcher_invokes_helper_successfully() {
 
     attach_issue_watcher(IssueWatcherAttachRequest {
         repo_root: &repo,
+        artifact_root: &repo,
         repo: "owner/repo",
         issue: 1153,
         branch: "codex/1153-rust-finish-test",

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5009_WATCHER_RELEASE_GATE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5009_WATCHER_RELEASE_GATE_DISPOSITION.yaml
@@ -1,0 +1,28 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 5009
+decision: publishable_with_focused_local_proof_and_required_ci_before_merge
+reviewer_or_review_mode: pre_pr_subagent_review_plus_focused_local_tooling_validation
+changed_release_gate_surfaces:
+  - adl/src/cli/pr_cmd.rs
+  - adl/src/cli/pr_cmd/finish_support.rs
+  - adl/src/cli/pr_cmd/github.rs
+  - adl/src/cli/pr_cmd/github/tests/helpers.rs
+  - adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+  - adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+  - adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+  - adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs
+focused_validation_run: >
+  Focused local proof passed after review fixes and rebase: cargo fmt
+  --manifest-path adl/Cargo.toml --all -- --check; cargo check
+  --manifest-path adl/Cargo.toml --bin adl-pr-inventory --bin
+  adl-pr-finish --bin adl-pr-closeout --quiet; cargo test
+  --manifest-path adl/Cargo.toml issue_watcher; git diff --check; SRP and
+  SOR structured prompt validation.
+residual_ci_proof_required_before_merge: >
+  GitHub PR checks must pass before merge. If adl-ci or adl-coverage fails,
+  route the PR to pr-janitor and keep the issue watcher attached until the
+  failed check is resolved or an operator-approved blocker is recorded.
+notes:
+  - This issue changes PR lifecycle tooling and therefore triggers the slow PR-command release-gate posture.
+  - The release-gate disposition is scoped to watcher attachment, PR inventory watcher status, closeout terminal watcher disposition, and SOR watcher facts.
+  - The bounded pre-PR review found three issues; all were fixed before this disposition was written.

--- a/docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md
+++ b/docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md
@@ -29,6 +29,10 @@ lane by accident.
   mergeability, dependency truth, or operator decision is not abandoned; it is
   watcher-owned until it routes to `pr-janitor`, `pr-closeout`, human review, or
   the next issue.
+- Issue-bound PR publication must attach a watcher packet during `pr finish`.
+  Disabling watcher attachment is fail-closed, PR inventory reports missing
+  watcher packets, and closeout must record or update a terminal watcher
+  disposition before the issue bundle is considered clean.
 - Use prep scouts only for read-only next-issue readiness while the current
   issue is in a truthful wait state. Prep scouts do not bind worktrees, mutate
   cards, or start implementation.
@@ -62,6 +66,14 @@ Current routing keys come from the watch packet's top-level classification:
 
 Watchers do not implement issue scope. They classify, route, retain evidence,
 and stop.
+
+For issue-bound PRs, watcher evidence is durable under the primary checkout at
+`.adl/logs/issue-watcher/issue-<issue>/` so it survives issue-worktree pruning.
+The PR attachment packet records the PR URL, expected state,
+watcher input/prompt/log/pid paths, and terminal disposition once closeout
+observes the completed tail. If the packet is missing for an issue-bound PR,
+closeout stops and routes the defect back through finish, watch, or shepherd
+repair instead of silently completing.
 
 ## Prep-Scout Routing
 

--- a/docs/tooling/PR_INVENTORY_COMMAND.md
+++ b/docs/tooling/PR_INVENTORY_COMMAND.md
@@ -33,14 +33,23 @@ Each pull-request record includes:
 - PR number, title, URL, state, draft status, head branch, and base branch
 - inferred workflow queue, when known
 - closing issue numbers discovered from live GitHub PR metadata
+- issue-watcher attachment status for issue-bound PRs, including the expected
+  packet path and terminal disposition when recorded
 - updated timestamp and mergeability when exposed by the GitHub API
 - validation check summary derived from the repo-native PR validation path using
   the same effective-check view that removes stale duplicate check runs
 
+Watcher status is part of the inventory contract. An issue-bound PR without an
+attachment packet is reported as `missing`, not silently treated as healthy.
+This lets release-tail review find PRs that were published without a durable
+watcher handoff.
+
 ## Failure Behavior
 
 The command fails closed when GitHub authentication, repository lookup, PR
-inventory, closing-issue lookup, or validation-status lookup fails. It must not
+inventory, closing-issue lookup, or validation-status lookup fails. Invalid
+watcher packets are surfaced in the affected PR record as `watcher=invalid`
+with a redacted reason so the rest of the inventory remains useful. It must not
 print token contents or credential material.
 
 ## Validation


### PR DESCRIPTION
Closes #5009

## Summary
Implemented mandatory watcher attachment for issue-bound PR publication. `pr finish` now fails closed when watcher attachment is disabled or fails, PR inventory reports watcher packet status, closeout requires terminal watcher disposition for issue-bound PRs, and SOR facts can record watcher packet path/state after successful attachment.

## Artifacts
- Local output card at `.adl/v0.91.7/tasks/issue-5009__v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr/sor.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/tests/helpers.rs`
  - `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/publication/janitor.rs`
  - `docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md`
  - `docs/tooling/PR_INVENTORY_COMMAND.md`
- Additional proof artifacts: `focused cargo test output and pre-PR subagent review result recorded in SRP`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    `Verified Rust formatting after implementation and review fixes.`
  - `cargo check --manifest-path adl/Cargo.toml --bin adl-pr-inventory --bin adl-pr-finish --bin adl-pr-closeout --quiet`
    `Verified the touched owner binaries compile.`
  - `cargo test --manifest-path adl/Cargo.toml issue_watcher`
    `Verified focused watcher publication, inventory, closeout, and SOR fact behavior.`
  - `git diff --check`
    `Verified whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5009__v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5009__v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr/sor.md
- Idempotency-Key: v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-helpers-rs-adl-src-cli-pr-cmd-lifecycle-reconciliation-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-adl-src-cli-tests-pr-cmd-inline-finish-publication-flow-rs-adl-src-cli-tests-pr-cmd-inline-finish-publication-janitor-rs-docs-tooling-c-sdlc-rescue-sprint-operating-contract-md-docs-tooling-pr-inventory-command-md-docs-milestones-v0-91-7-review-pr-finish-release-gate-disposition-issue-5009-watcher-release-gate-disposition-yaml-adl-v0-91-7-tasks-issue-5009-v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr-sip-md-adl-v0-91-7-tasks-issue-5009-v0-91-7-tools-watcher-require-watcher-attachment-for-every-issue-bound-pr-sor-md