### PR TITLE
[v0.91.7][tools][janitor] Expose repo-native pr janitor entrypoint or update janitor skill routing

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -28,6 +28,7 @@
 #   adl/tools/pr.sh finish  <issue> --title "<title>" [-f <input_card.md>] [--output-card <output_card.md>] [--body "<extra body>"] [--paths "<p1,p2,...>"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]
 #   adl/tools/pr.sh pr-inventory [-R owner/repo] [--json]
 #   adl/tools/pr.sh closing-linkage [--event-name <event>] [--event-path <path>] [--head-ref <branch>] [-R owner/repo]
+#   adl/tools/pr.sh janitor <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
 #   adl/tools/pr.sh open
 #   adl/tools/pr.sh status
 #
@@ -2034,6 +2035,17 @@ cmd_shepherd() {
   delegate_pr_command_to_rust shepherd "$@"
 }
 
+cmd_janitor() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_janitor
+    return 0
+  fi
+  adl_obs_event "pr.sh" "janitor" "started" "issue" "${1:-}"
+  note "Compatibility path: 'pr.sh janitor' delegates to the repo-native shepherd classifier." >&2
+  require_rust_pr_delegate shepherd
+  delegate_pr_command_to_rust shepherd "$@"
+}
+
 cmd_closing_linkage() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
     note "Usage: adl/tools/pr.sh closing-linkage [--event-name <event>] [--event-path <path>] [--head-ref <branch>] [-R owner/repo]"
@@ -2145,6 +2157,7 @@ main() {
     pr-inventory) cmd_pr_inventory "$@" ;;
     watch) cmd_watch "$@" ;;
     shepherd) cmd_shepherd "$@" ;;
+    janitor) cmd_janitor "$@" ;;
     closing-linkage) cmd_closing_linkage "$@" ;;
     issue) cmd_issue "$@" ;;
     projection-map) cmd_projection_map "$@" ;;

--- a/adl/tools/pr_usage.sh
+++ b/adl/tools/pr_usage.sh
@@ -17,6 +17,7 @@ Commands:
   pr-inventory [-R owner/repo] [--json]
   watch   <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
   shepherd <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
+  janitor <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
   closing-linkage [--event-name <event>] [--event-path <path>] [--head-ref <branch>] [-R owner/repo]
   issue   <list|search|view|create|comment|edit|close> ...
   projection-map [--json]
@@ -60,6 +61,7 @@ Notes:
 - `pr pr-inventory ...` is the typed release-tail PR inventory surface; use it instead of raw `gh pr list`.
 - `adl-pr-shepherd <issue> ...` is the owner lifecycle synthesis binary above readiness, watcher, janitor, and closeout.
 - `pr shepherd <issue> ...` remains a thin compatibility wrapper over `adl-pr-shepherd`.
+- `pr janitor <issue-or-pr> ...` is a compatibility wrapper over the same shepherd classifier for PR-tail blocker triage; use the returned `next_skill`/`tail_owner` to hand off to `pr-janitor`.
 - `pr closeout <issue> ...` finalizes a closed issue locally and safely prunes its execution worktree when possible.
 - `pr closing-linkage ...` is the Rust-owned CI/linkage guard and prefers live PR metadata over stale event payloads when token context exists.
 - `pr start <issue> ...` remains only as a legacy alias over the same Rust binding path and is no longer part of the taught public flow.
@@ -286,6 +288,20 @@ Behavior:
 - preserves the human authority boundary for review, merge, and final closeout truth
 - uses typed GitHub transport plus local doctor readiness; does not fall back to raw `gh`
 - emits a JSON lifecycle shepherd report when --json is set
+EOF
+}
+
+usage_janitor() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh janitor <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]
+
+Behavior:
+- delegates to the Rust-owned issue-lifecycle shepherd classifier
+- gives failed-check/conflict/review-blocker sessions a repo-native entrypoint instead of a missing command
+- preserves the no-gh path and typed GitHub transport used by `pr.sh shepherd`
+- reports canonical lifecycle routing such as janitor_active, pr_waiting, merged_needs_closeout, or blocked
+- use the returned `tail_owner` and `next_skill` fields to decide whether to invoke the `pr-janitor` skill for bounded repair
 EOF
 }
 

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -1217,6 +1217,11 @@ Use `pr-janitor` when:
 - the user wants help with conflicts or review blockers
 - the task is monitoring or narrow blocker remediation
 
+Use `bash adl/tools/pr.sh janitor <issue-or-pr> --json` when a session needs
+the repo-native command surface to classify the PR tail before handing off to
+the `pr-janitor` skill. The command is a compatibility wrapper over the
+shepherd classifier and preserves the no-`gh` transport path.
+
 Do not use it for:
 
 - initial issue setup

--- a/adl/tools/test_pr_help_and_card_open.sh
+++ b/adl/tools/test_pr_help_and_card_open.sh
@@ -26,6 +26,15 @@ cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
 cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
 cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
 chmod +x "$repo/adl/tools/pr.sh"
+cat >"$repo/fake-adl-pr-shepherd" <<'EOF'
+#!/usr/bin/env bash
+printf 'fake shepherd args:'
+for arg in "$@"; do
+  printf ' <%s>' "$arg"
+done
+printf '\n'
+EOF
+chmod +x "$repo/fake-adl-pr-shepherd"
 
 (
   cd "$repo"
@@ -54,6 +63,7 @@ assert_contains() {
   assert_contains "Compatibility / maintenance commands:" "$help_out" "compatibility section"
   assert_contains "  run     <issue>" "$help_out" "canonical run help"
   assert_contains "  doctor  <issue>" "$help_out" "canonical doctor help"
+  assert_contains "  janitor <issue-number-or-url>" "$help_out" "janitor compatibility help"
   if grep -Fq "  new     " <<<"$help_out"; then
     echo "assertion failed: help should not advertise retired pr new command" >&2
     exit 1
@@ -61,6 +71,19 @@ assert_contains() {
 
   card_help_out="$("$BASH_BIN" adl/tools/pr.sh card --help)"
   assert_contains "Usage:" "$card_help_out" "card --help"
+
+  janitor_help_out="$("$BASH_BIN" adl/tools/pr.sh janitor --help)"
+  assert_contains "Usage:" "$janitor_help_out" "janitor --help"
+  assert_contains "delegates to the Rust-owned issue-lifecycle shepherd classifier" "$janitor_help_out" "janitor delegates"
+
+  janitor_delegate_out="$(ADL_PR_SHEPHERD_BIN="$repo/fake-adl-pr-shepherd" "$BASH_BIN" adl/tools/pr.sh janitor 5017 --json 2>&1)"
+  assert_contains "stage=command_start result=started subcommand=janitor" "$janitor_delegate_out" "janitor command_start observability"
+  assert_contains "stage=janitor result=started issue=5017" "$janitor_delegate_out" "janitor observability"
+  assert_contains "fake shepherd args: <5017> <--json>" "$janitor_delegate_out" "janitor delegates to shepherd args"
+  if grep -Fq "Unknown command: janitor" <<<"$janitor_delegate_out"; then
+    echo "assertion failed: janitor command should not hit unknown-command path" >&2
+    exit 1
+  fi
 
   in_path="$("$BASH_BIN" adl/tools/pr.sh card 271 input --no-fetch-issue --slug demo-title)"
   [[ "$in_path" == *"/.adl/v0.86/tasks/issue-0271__demo-title/sip.md" ]] || {

--- a/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
+++ b/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
@@ -34,6 +34,13 @@ The owner repo-native entrypoint for this contract is:
 The compatibility shell wrapper remains available at:
 
 - `adl/tools/pr.sh shepherd <issue-number-or-url> [--json]`
+- `adl/tools/pr.sh janitor <issue-number-or-url> [--json]`
+
+`pr.sh janitor` is a compatibility entrypoint for PR-tail blocker triage. It
+delegates to the same owner shepherd classifier as `pr.sh shepherd`, then uses
+the returned `tail_owner` and `next_skill` fields to decide whether the next
+bounded skill handoff is `pr-janitor`, `issue-watcher`, `pr-closeout`, or human
+review.
 
 The owner binary should synthesize the current tracked issue into one canonical
 shepherd state using local doctor readiness plus the authoritative watcher/PR


### PR DESCRIPTION
Closes #5017

## Summary
Implemented the smallest operational fix for issue #5017: `bash adl/tools/pr.sh janitor ...` is now a real repo-native compatibility route that delegates to the existing shepherd classifier instead of failing with `Unknown command: janitor`.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-5017__v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing/sor.md`
- Tracked implementation artifacts: `adl/tools/pr.sh`; `adl/tools/pr_usage.sh`; `adl/tools/test_pr_help_and_card_open.sh`; `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`; `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
- Additional proof artifacts: `.adl/reviews/5017-pre-pr-review.md` local pre-PR review artifact

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_help_and_card_open.sh`
    `Verified focused shell coverage for help/card flows and janitor fake-shepherd delegation.`
  - `bash adl/tools/pr.sh janitor --help`
    `Verified the documented janitor help path.`
  - `bash adl/tools/pr.sh janitor 5015 --json`
    `Verified live repo-native command shape for the originally failing invocation family.`
  - `git diff --check`
    `Verified whitespace hygiene.`
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    `Verified focused owner C-SDLC control-plane lane.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5017__v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5017__v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing/sor.md
- Idempotency-Key: v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing-adl-tools-pr-sh-adl-tools-pr-usage-sh-adl-tools-test-pr-help-and-card-open-sh-adl-tools-skills-docs-operational-skills-guide-md-docs-tooling-issue-lifecycle-shepherd-contract-md-adl-v0-91-7-tasks-issue-5017-v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing-sip-md-adl-v0-91-7-tasks-issue-5017-v0-91-7-tools-janitor-expose-repo-native-pr-janitor-entrypoint-or-update-janitor-skill-routing-sor-md