### PR TITLE
[v0.91.7][tools][pr] Fix adl pr watch/shepherd --help dispatch

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -233,7 +233,15 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "finish" => finish_support::real_pr_finish(&args[1..]),
         "validation" => real_pr_validation(&args[1..]),
         "pr-inventory" => real_pr_inventory(&args[1..]),
+        "watch" if pr_subcommand_help_requested(&args[1..]) => {
+            println!("{}", pr_watch_usage());
+            Ok(())
+        }
         "watch" => real_pr_watch(&args[1..]),
+        "shepherd" if pr_subcommand_help_requested(&args[1..]) => {
+            println!("{}", pr_shepherd_usage());
+            Ok(())
+        }
         "shepherd" => real_pr_shepherd(&args[1..]),
         "closing-linkage" => real_pr_closing_linkage(&args[1..]),
         "issue" => real_pr_issue(&args[1..]),
@@ -241,6 +249,21 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
+}
+
+fn pr_subcommand_help_requested(args: &[String]) -> bool {
+    matches!(
+        args,
+        [arg] if matches!(arg.as_str(), "--help" | "-h" | "help")
+    )
+}
+
+fn pr_watch_usage() -> &'static str {
+    "Usage:\n  adl pr watch <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]\n\nClassify the issue-bound PR tail and report the next watcher, shepherd, janitor, or closeout owner."
+}
+
+fn pr_shepherd_usage() -> &'static str {
+    "Usage:\n  adl pr shepherd <issue-number-or-url> [--slug <slug>] [--version <v>] [-R owner/repo] [--json]\n\nSynthesize the issue lifecycle tail state above readiness, watcher, janitor, and closeout routing."
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -3128,6 +3128,18 @@ fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     real_pr(&["--help".to_string()]).expect("top-level pr help should succeed");
     real_pr(&["-h".to_string()]).expect("short top-level pr help should succeed");
     real_pr(&["help".to_string()]).expect("help alias should succeed");
+    real_pr(&["watch".to_string(), "--help".to_string()])
+        .expect("watch help should not parse --help as an issue number");
+    real_pr(&["watch".to_string(), "-h".to_string()])
+        .expect("watch short help should not parse -h as an issue number");
+    real_pr(&["watch".to_string(), "help".to_string()])
+        .expect("watch help alias should not parse help as an issue number");
+    real_pr(&["shepherd".to_string(), "--help".to_string()])
+        .expect("shepherd help should not parse --help as an issue number");
+    real_pr(&["shepherd".to_string(), "-h".to_string()])
+        .expect("shepherd short help should not parse -h as an issue number");
+    real_pr(&["shepherd".to_string(), "help".to_string()])
+        .expect("shepherd help alias should not parse help as an issue number");
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown pr subcommand: bogus"));

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5012_PR_WATCH_SHEPHERD_HELP_DISPATCH_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5012_PR_WATCH_SHEPHERD_HELP_DISPATCH_DISPOSITION.yaml
@@ -1,0 +1,25 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 5012
+decision: publishable_with_focused_local_proof_and_required_ci_before_merge
+reviewer_or_review_mode: pre_pr_subagent_review_plus_focused_local_tooling_validation
+changed_release_gate_surfaces:
+  - adl/src/cli/pr_cmd.rs
+  - adl/src/cli/tests/pr_cmd_inline/basics.rs
+focused_validation_run: >
+  Focused local proof passed after review and rebase: cargo fmt
+  --manifest-path adl/Cargo.toml; cargo test --manifest-path adl/Cargo.toml
+  --bin adl cli::pr_cmd::tests::basics::real_pr_dispatch_rejects_missing_and_unknown_subcommands
+  -- --exact --nocapture; cargo build --manifest-path adl/Cargo.toml
+  --bin adl; direct adl pr watch/shepherd --help and help checks; missing
+  issue-number negative checks for watch and shepherd; bash adl/tools/pr.sh
+  watch/shepherd --help wrapper checks; SRP and SOR structured prompt
+  validation; git diff --check.
+residual_ci_proof_required_before_merge: >
+  GitHub PR checks must pass before merge. If adl-ci, coverage, or validation
+  manager checks fail, route the PR to pr-janitor and keep the watcher/shepherd
+  tail attached until the failed check is resolved or an operator-approved
+  blocker is recorded.
+notes:
+  - This issue changes PR lifecycle command dispatch and therefore triggers the slow PR-command release-gate posture.
+  - The disposition is scoped to help dispatch for adl pr watch and adl pr shepherd, preserving normal missing issue-number failures.
+  - A broad cargo test attempt initially failed because the issue worktree target directory exhausted local disk; the generated target directory was removed and focused proof was rerun successfully.


### PR DESCRIPTION
Closes #5012

## Summary
Implemented the #5012 PR command dispatch fix so `adl pr watch --help`,
`adl pr watch help`, `adl pr shepherd --help`, and `adl pr shepherd help`
return subcommand help before issue-number parsing. Normal missing-argument
execution still fails clearly.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-5012__v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch/sor.md`
- Tracked implementation artifacts: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- Additional proof artifacts: focused command outputs retained in this SOR; release-gate disposition at `docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5012_PR_WATCH_SHEPHERD_HELP_DISPATCH_DISPOSITION.yaml`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::tests::basics::real_pr_dispatch_rejects_missing_and_unknown_subcommands -- --exact --nocapture`
    `Verified focused PR dispatch regression coverage.`
  - `cargo build --manifest-path adl/Cargo.toml --bin adl`
    `Built the local ADL binary used for direct command proof.`
  - `./adl/target/debug/adl pr watch --help`
    `Verified watch help exits successfully.`
  - `./adl/target/debug/adl pr shepherd --help`
    `Verified shepherd help exits successfully.`
  - `./adl/target/debug/adl pr watch help`
    `Verified watch help alias exits successfully.`
  - `./adl/target/debug/adl pr shepherd help`
    `Verified shepherd help alias exits successfully.`
  - `./adl/target/debug/adl pr watch`
    `Verified missing watch issue argument still fails with status 1.`
  - `./adl/target/debug/adl pr shepherd`
    `Verified missing shepherd issue argument still fails with status 1.`
  - `bash adl/tools/pr.sh watch --help`
    `Verified repo-native wrapper watch help exits successfully.`
  - `bash adl/tools/pr.sh shepherd --help`
    `Verified repo-native wrapper shepherd help exits successfully.`
  - `bash adl/tools/validate_structured_prompt.sh --type srp --input .adl/v0.91.7/tasks/issue-5012__v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch/srp.md`
    `Verified SRP structured prompt validity after review recording.`
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.91.7/tasks/issue-5012__v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch/sor.md`
    `Verified SOR structured prompt validity after validation and disposition recording.`
  - `git diff --check`
    `Verified whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5012__v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5012__v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch/sor.md
- Idempotency-Key: v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-docs-milestones-v0-91-7-review-pr-finish-release-gate-disposition-issue-5012-pr-watch-shepherd-help-dispatch-disposition-yaml-adl-v0-91-7-tasks-issue-5012-v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch-sip-md-adl-v0-91-7-tasks-issue-5012-v0-91-7-tools-pr-fix-adl-pr-watch-shepherd-help-dispatch-sor-md