### PR TITLE
[v0.91.7][runtime][acip] Prove ACIP runtime stream WebSocket substrate

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "clap",
  "dirs",
  "ed25519-dalek",
+ "futures-util",
  "google-workspace",
  "http 1.4.0",
  "jsonschema",
@@ -48,6 +49,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tiny_http",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "yup-oauth2",
@@ -940,6 +942,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -3512,6 +3520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,6 +3926,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4066,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,6 +4137,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -191,6 +191,7 @@ yup-oauth2 = "12"
 async-trait = "0.1"
 dirs = "5"
 mime_guess2 = "2.3.1"
+futures-util = "0.3.31"
 octocrab = { version = "0.53", default-features = false, features = [
   "default-client",
   "jwt-rust-crypto",
@@ -201,6 +202,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Shared async runtime floor for long-lived cadence, ACIP runtime work, and
 # later bounded recurring verification on the existing ADL runtime.
 tokio = { version = "1", features = ["fs", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-tungstenite = "0.24"
 
 # JSON Schema (Option A)
 schemars = "0.8"

--- a/adl/src/agent_comms.rs
+++ b/adl/src/agent_comms.rs
@@ -33,6 +33,10 @@ const ACIP_TRACE_FIXTURE_SCHEMA_VERSION: &str = "acip.trace.fixture.v1";
 const ACIP_PROOF_DEMO_SCHEMA_VERSION: &str = "acip.proof.demo.v1";
 const ACIP_LOCAL_CARRIER_SCHEMA_VERSION: &str = "acip.local.carrier.v1";
 const ACIP_LOCAL_INVOCATION_EXCHANGE_SCHEMA_VERSION: &str = "acip.local.invocation.exchange.v1";
+const ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION: &str =
+    "acip.runtime_stream.substrate_decision.v1";
+const ACIP_RUNTIME_STREAM_LOOPBACK_PROOF_SCHEMA_VERSION: &str =
+    "acip.runtime_stream.loopback_proof.v1";
 const ACIP_A2A_ADAPTER_SCHEMA_VERSION: &str = "acip.a2a.adapter.v1";
 const ACIP_A2A_FIXTURE_SCHEMA_VERSION: &str = "acip.a2a.fixture.v1";
 const MAX_CONTENT_CHARS: usize = 4_000;
@@ -820,6 +824,11 @@ pub mod carrier {
     include!("agent_comms/carrier.inc");
 }
 
+pub mod runtime_stream {
+    use super::*;
+    include!("agent_comms/runtime_stream.inc");
+}
+
 pub mod dispatch {
     use super::*;
 
@@ -876,6 +885,7 @@ pub use a2a::*;
 pub use carrier::*;
 pub use dispatch::*;
 pub use orchestrate::*;
+pub use runtime_stream::*;
 pub use transport::*;
 
 #[cfg(test)]

--- a/adl/src/agent_comms/carrier.inc
+++ b/adl/src/agent_comms/carrier.inc
@@ -301,7 +301,6 @@ pub fn sample_acip_local_carrier_v1() -> AcipLocalCarrierV1 {
     }
 }
 
-#[cfg(test)]
 pub(crate) fn sample_local_review_request_message(
     contract: &AcipInvocationContractV1,
 ) -> AcipMessageEnvelopeV1 {

--- a/adl/src/agent_comms/runtime_stream.inc
+++ b/adl/src/agent_comms/runtime_stream.inc
@@ -1,0 +1,467 @@
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::tungstenite::Message;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamFailureClassificationV1 {
+    pub case_name: String,
+    pub category: String,
+    pub fail_closed: bool,
+    pub retry_allowed: bool,
+    pub expected_error_substring: String,
+    pub authority_expansion_allowed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamSubstrateDecisionV1 {
+    pub schema_version: String,
+    pub selected_substrate: String,
+    pub selected_crate: String,
+    pub alternatives_considered: Vec<String>,
+    pub rationale: Vec<String>,
+    pub failure_classifications: Vec<AcipRuntimeStreamFailureClassificationV1>,
+    pub integration_refs: Vec<String>,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamLoopbackProofV1 {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub selected_substrate: String,
+    pub selected_crate: String,
+    pub carrier_kind: String,
+    pub request_message: AcipMessageEnvelopeV1,
+    pub response_message: AcipMessageEnvelopeV1,
+    pub negative_cases: Vec<AcipRuntimeStreamFailureClassificationV1>,
+    pub lifecycle_events: Vec<String>,
+    pub integration_refs: Vec<String>,
+    pub non_claims: Vec<String>,
+}
+
+pub fn acip_runtime_stream_substrate_decision_v1() -> AcipRuntimeStreamSubstrateDecisionV1 {
+    AcipRuntimeStreamSubstrateDecisionV1 {
+        schema_version: ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION.to_string(),
+        selected_substrate: "websocket".to_string(),
+        selected_crate: "tokio-tungstenite".to_string(),
+        alternatives_considered: vec![
+            "jsonrpsee: useful if ACIP runtime streams later become JSON-RPC method calls, but current ACIP semantics are envelope/event transport rather than RPC method dispatch".to_string(),
+            "bespoke tokio tcp framing: rejected because ADL should not own WebSocket framing, ping/pong, close handshake, or upgrade mechanics".to_string(),
+        ],
+        rationale: vec![
+            "ACIP remains the domain contract above the carrier.".to_string(),
+            "tokio-tungstenite provides Tokio-compatible WebSocket client/server mechanics for the bounded WP-12 loopback proof.".to_string(),
+            "The selected carrier does not create authority; existing ACIP validation and policy refusal remain fail-closed.".to_string(),
+        ],
+        failure_classifications: acip_runtime_stream_failure_classifications_v1(),
+        integration_refs: vec![
+            "#4658 ACIP schema/protobuf projection".to_string(),
+            "#4659 WP-12 WebSocket transport path".to_string(),
+            "docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md".to_string(),
+        ],
+        non_claims: vec![
+            "This decision does not implement protobuf wire encoding.".to_string(),
+            "This decision does not prove production WebSocket authentication, TLS, reconnect scheduling, or cross-polis transport.".to_string(),
+            "This decision does not bypass ACIP access rules, Freedom Gate decisions, trace, replay, or policy boundaries.".to_string(),
+        ],
+    }
+}
+
+pub fn validate_acip_runtime_stream_substrate_decision_v1(
+    decision: &AcipRuntimeStreamSubstrateDecisionV1,
+) -> Result<()> {
+    if decision.schema_version != ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP runtime stream substrate decision requires schema_version '{}'",
+            ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION
+        ));
+    }
+    if decision.selected_substrate != "websocket" {
+        return Err(anyhow!(
+            "ACIP runtime stream substrate decision currently selects websocket"
+        ));
+    }
+    if decision.selected_crate != "tokio-tungstenite" {
+        return Err(anyhow!(
+            "ACIP runtime stream substrate decision must bind to tokio-tungstenite"
+        ));
+    }
+    if decision.failure_classifications.len() < 5 {
+        return Err(anyhow!(
+            "ACIP runtime stream substrate decision requires reconnect, malformed, close, timeout, and policy-denial classifications"
+        ));
+    }
+    for classification in &decision.failure_classifications {
+        validate_acip_runtime_stream_failure_classification_v1(classification)?;
+    }
+    if decision.integration_refs.iter().all(|value| !value.contains("#4659")) {
+        return Err(anyhow!(
+            "ACIP runtime stream substrate decision must feed #4659 WebSocket transport proof"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_acip_runtime_stream_loopback_proof_v1(
+    proof: &AcipRuntimeStreamLoopbackProofV1,
+) -> Result<()> {
+    if proof.schema_version != ACIP_RUNTIME_STREAM_LOOPBACK_PROOF_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP runtime stream loopback proof requires schema_version '{}'",
+            ACIP_RUNTIME_STREAM_LOOPBACK_PROOF_SCHEMA_VERSION
+        ));
+    }
+    if proof.selected_substrate != "websocket" {
+        return Err(anyhow!(
+            "ACIP runtime stream loopback proof currently selects websocket"
+        ));
+    }
+    if proof.selected_crate != "tokio-tungstenite" || proof.carrier_kind != "mock_loopback" {
+        return Err(anyhow!(
+            "ACIP runtime stream loopback proof must use tokio-tungstenite mock_loopback"
+        ));
+    }
+    validate_acip_message_envelope_v1(&proof.request_message)?;
+    validate_acip_message_envelope_v1(&proof.response_message)?;
+    if proof.response_message.prior_message_id.as_deref()
+        != Some(proof.request_message.message_id.as_str())
+    {
+        return Err(anyhow!(
+            "ACIP runtime stream response must preserve prior_message_id"
+        ));
+    }
+    if proof.response_message.monotonic_order <= proof.request_message.monotonic_order {
+        return Err(anyhow!(
+            "ACIP runtime stream response must advance monotonic_order"
+        ));
+    }
+    if proof.negative_cases.len() < 2 {
+        return Err(anyhow!(
+            "ACIP runtime stream loopback proof requires at least two negative cases"
+        ));
+    }
+    for classification in &proof.negative_cases {
+        validate_acip_runtime_stream_failure_classification_v1(classification)?;
+    }
+    require_runtime_stream_case(&proof.negative_cases, "malformed_message")?;
+    require_runtime_stream_case(&proof.negative_cases, "auth_policy_denial")?;
+    require_runtime_stream_event(&proof.lifecycle_events, "acip_request_validated")?;
+    require_runtime_stream_event(&proof.lifecycle_events, "acip_response_validated")?;
+    require_runtime_stream_ref(&proof.integration_refs, "#4658")?;
+    require_runtime_stream_ref(&proof.integration_refs, "#4659")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "protobuf")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "authentication")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "TLS")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "reconnect")?;
+    Ok(())
+}
+
+pub async fn prove_acip_runtime_stream_websocket_loopback_v1(
+) -> Result<AcipRuntimeStreamLoopbackProofV1> {
+    let request_message = sample_runtime_stream_request_message();
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind ACIP runtime stream loopback listener")?;
+    let addr = listener
+        .local_addr()
+        .context("read ACIP runtime stream loopback listener address")?;
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .context("accept ACIP runtime stream loopback connection")?;
+        let mut websocket = tokio_tungstenite::accept_async(stream)
+            .await
+            .context("accept ACIP runtime stream WebSocket handshake")?;
+        let incoming = timeout(Duration::from_secs(2), websocket.next())
+            .await
+            .context("ACIP runtime stream timed out waiting for client message")?
+            .ok_or_else(|| anyhow!("ACIP runtime stream closed before first message"))?
+            .context("read ACIP runtime stream client frame")?;
+        let text = incoming
+            .into_text()
+            .context("ACIP runtime stream requires text JSON frames for v1 proof")?;
+        let request: AcipMessageEnvelopeV1 =
+            serde_json::from_str(&text).context("parse ACIP runtime stream request frame")?;
+        validate_acip_message_envelope_v1(&request)?;
+        let response = build_runtime_stream_response_message(&request)?;
+        websocket
+            .send(Message::Text(serde_json::to_string(&response)?))
+            .await
+            .context("send ACIP runtime stream response frame")?;
+        websocket
+            .close(None)
+            .await
+            .context("close ACIP runtime stream loopback websocket")?;
+        Ok::<AcipMessageEnvelopeV1, anyhow::Error>(response)
+    });
+
+    let url = format!("ws://{addr}");
+    let (mut client, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .with_context(|| format!("connect ACIP runtime stream loopback client to {url}"))?;
+    client
+        .send(Message::Text(serde_json::to_string(&request_message)?))
+        .await
+        .context("send ACIP runtime stream request frame")?;
+    let response_frame = timeout(Duration::from_secs(2), client.next())
+        .await
+        .context("ACIP runtime stream timed out waiting for response")?
+        .ok_or_else(|| anyhow!("ACIP runtime stream closed before response"))?
+        .context("read ACIP runtime stream response frame")?;
+    let response_text = response_frame
+        .into_text()
+        .context("ACIP runtime stream response must be text JSON")?;
+    let response_message: AcipMessageEnvelopeV1 = serde_json::from_str(&response_text)
+        .context("parse ACIP runtime stream response frame")?;
+    let server_response = server
+        .await
+        .context("join ACIP runtime stream loopback server task")??;
+    if response_message != server_response {
+        return Err(anyhow!(
+            "ACIP runtime stream client/server response messages diverged"
+        ));
+    }
+
+    let proof = AcipRuntimeStreamLoopbackProofV1 {
+        schema_version: ACIP_RUNTIME_STREAM_LOOPBACK_PROOF_SCHEMA_VERSION.to_string(),
+        proof_id: "acip-runtime-stream-websocket-loopback-v1".to_string(),
+        selected_substrate: "websocket".to_string(),
+        selected_crate: "tokio-tungstenite".to_string(),
+        carrier_kind: "mock_loopback".to_string(),
+        request_message,
+        response_message,
+        negative_cases: vec![
+            classify_acip_runtime_stream_malformed_frame_v1("{not-json")?,
+            classify_acip_runtime_stream_policy_denial_v1()?,
+        ],
+        lifecycle_events: vec![
+            "listener_bound".to_string(),
+            "websocket_handshake_accepted".to_string(),
+            "acip_request_validated".to_string(),
+            "acip_response_validated".to_string(),
+            "websocket_closed".to_string(),
+        ],
+        integration_refs: vec![
+            "#4658".to_string(),
+            "#4659".to_string(),
+            "docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md".to_string(),
+        ],
+        non_claims: acip_runtime_stream_substrate_decision_v1().non_claims,
+    };
+    validate_acip_runtime_stream_loopback_proof_v1(&proof)?;
+    Ok(proof)
+}
+
+pub fn classify_acip_runtime_stream_malformed_frame_v1(
+    payload: &str,
+) -> Result<AcipRuntimeStreamFailureClassificationV1> {
+    let expected_error_substring = match serde_json::from_str::<AcipMessageEnvelopeV1>(payload) {
+        Ok(message) => match validate_acip_message_envelope_v1(&message) {
+            Ok(()) => {
+                return Err(anyhow!(
+                    "malformed frame classifier requires invalid ACIP payload"
+                ));
+            }
+            Err(error) => error.to_string(),
+        },
+        Err(error) => error.to_string(),
+    };
+    Ok(AcipRuntimeStreamFailureClassificationV1 {
+        case_name: "malformed_message".to_string(),
+        category: "malformed".to_string(),
+        fail_closed: true,
+        retry_allowed: false,
+        expected_error_substring,
+        authority_expansion_allowed: false,
+    })
+}
+
+pub fn classify_acip_runtime_stream_policy_denial_v1(
+) -> Result<AcipRuntimeStreamFailureClassificationV1> {
+    let carrier = carrier::sample_acip_local_carrier_v1();
+    let mut contract = sample_invocation_contract();
+    contract.caller_class = AcipCallerClassV1::ExternalAgent;
+    let request_message = carrier::sample_local_review_request_message(&contract);
+    let exchange =
+        carrier::execute_acip_local_invocation_round_trip(&carrier, &request_message, &contract)?;
+    if exchange.invocation_event.status != AcipInvocationStatusV1::Refused {
+        return Err(anyhow!(
+            "ACIP runtime stream policy-denial classifier expected refused invocation"
+        ));
+    }
+    Ok(AcipRuntimeStreamFailureClassificationV1 {
+        case_name: "auth_policy_denial".to_string(),
+        category: "auth_policy_denial".to_string(),
+        fail_closed: true,
+        retry_allowed: false,
+        expected_error_substring: exchange
+            .invocation_event
+            .refusal_code
+            .unwrap_or_else(|| "caller_class_denied".to_string()),
+        authority_expansion_allowed: false,
+    })
+}
+
+pub fn acip_runtime_stream_failure_classifications_v1(
+) -> Vec<AcipRuntimeStreamFailureClassificationV1> {
+    vec![
+        AcipRuntimeStreamFailureClassificationV1 {
+            case_name: "reconnect_after_disconnect".to_string(),
+            category: "reconnect".to_string(),
+            fail_closed: true,
+            retry_allowed: true,
+            expected_error_substring: "reconnect_requires_new_handshake_and_revalidation"
+                .to_string(),
+            authority_expansion_allowed: false,
+        },
+        classify_acip_runtime_stream_malformed_frame_v1("{not-json").unwrap_or_else(|error| {
+            AcipRuntimeStreamFailureClassificationV1 {
+                case_name: "malformed_message".to_string(),
+                category: "malformed".to_string(),
+                fail_closed: true,
+                retry_allowed: false,
+                expected_error_substring: error.to_string(),
+                authority_expansion_allowed: false,
+            }
+        }),
+        AcipRuntimeStreamFailureClassificationV1 {
+            case_name: "peer_close_before_response".to_string(),
+            category: "close".to_string(),
+            fail_closed: true,
+            retry_allowed: true,
+            expected_error_substring: "closed_before_response".to_string(),
+            authority_expansion_allowed: false,
+        },
+        AcipRuntimeStreamFailureClassificationV1 {
+            case_name: "response_timeout".to_string(),
+            category: "timeout".to_string(),
+            fail_closed: true,
+            retry_allowed: true,
+            expected_error_substring: "timed out waiting for response".to_string(),
+            authority_expansion_allowed: false,
+        },
+        classify_acip_runtime_stream_policy_denial_v1().unwrap_or_else(|error| {
+            AcipRuntimeStreamFailureClassificationV1 {
+                case_name: "auth_policy_denial".to_string(),
+                category: "auth_policy_denial".to_string(),
+                fail_closed: true,
+                retry_allowed: false,
+                expected_error_substring: error.to_string(),
+                authority_expansion_allowed: false,
+            }
+        }),
+    ]
+}
+
+fn validate_acip_runtime_stream_failure_classification_v1(
+    classification: &AcipRuntimeStreamFailureClassificationV1,
+) -> Result<()> {
+    validate_negative_case_name(&classification.case_name, "case_name")?;
+    validate_non_empty(&classification.category, "category")?;
+    validate_non_empty(
+        &classification.expected_error_substring,
+        "expected_error_substring",
+    )?;
+    if !classification.fail_closed {
+        return Err(anyhow!(
+            "ACIP runtime stream failure classification '{}' must fail closed",
+            classification.case_name
+        ));
+    }
+    if classification.authority_expansion_allowed {
+        return Err(anyhow!(
+            "ACIP runtime stream failure classification '{}' must not expand authority",
+            classification.case_name
+        ));
+    }
+    Ok(())
+}
+
+fn require_runtime_stream_case(
+    classifications: &[AcipRuntimeStreamFailureClassificationV1],
+    case_name: &str,
+) -> Result<()> {
+    if classifications
+        .iter()
+        .any(|classification| classification.case_name == case_name)
+    {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP runtime stream proof requires negative case '{}'",
+            case_name
+        ))
+    }
+}
+
+fn require_runtime_stream_event(events: &[String], event: &str) -> Result<()> {
+    if events.iter().any(|value| value == event) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP runtime stream proof requires lifecycle event '{}'",
+            event
+        ))
+    }
+}
+
+fn require_runtime_stream_ref(refs: &[String], required: &str) -> Result<()> {
+    if refs.iter().any(|value| value.contains(required)) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP runtime stream proof requires integration ref '{}'",
+            required
+        ))
+    }
+}
+
+fn require_runtime_stream_non_claim(non_claims: &[String], required: &str) -> Result<()> {
+    if non_claims.iter().any(|value| value.contains(required)) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP runtime stream proof requires non-claim containing '{}'",
+            required
+        ))
+    }
+}
+
+fn sample_runtime_stream_request_message() -> AcipMessageEnvelopeV1 {
+    let mut message = transport::sample_message(
+        "msg-runtime-stream-0001",
+        "conv-runtime-stream-001",
+        1,
+        AcipIntentV1::Conversation,
+        "Open a bounded ACIP runtime stream and preserve authority at the envelope layer.",
+    );
+    message.recipient.id = "runtime.agent".to_string();
+    message.correlation_id = Some("runtime-stream-loopback-0001".to_string());
+    message
+}
+
+fn build_runtime_stream_response_message(
+    request: &AcipMessageEnvelopeV1,
+) -> Result<AcipMessageEnvelopeV1> {
+    let mut response = transport::sample_message(
+        "msg-runtime-stream-0001-reply",
+        &request.conversation_id,
+        request.monotonic_order + 1,
+        AcipIntentV1::Conversation,
+        "ACIP runtime stream loopback accepted one validated envelope over WebSocket.",
+    );
+    response.sender = request.recipient.clone();
+    response.recipient = request.sender.clone();
+    response.trace_requirement = request.trace_requirement.clone();
+    response.correlation_id = request.correlation_id.clone();
+    response.prior_message_id = Some(request.message_id.clone());
+    response.authority_scope = None;
+    validate_acip_message_envelope_v1(&response)?;
+    Ok(response)
+}

--- a/adl/src/agent_comms/tests.inc
+++ b/adl/src/agent_comms/tests.inc
@@ -2199,6 +2199,88 @@
     }
 
     #[test]
+    fn acip_runtime_stream_substrate_decision_selects_tokio_tungstenite() {
+        let decision = acip_runtime_stream_substrate_decision_v1();
+        validate_acip_runtime_stream_substrate_decision_v1(&decision)
+            .expect("runtime stream substrate decision should validate");
+
+        assert_eq!(decision.selected_substrate, "websocket");
+        assert_eq!(decision.selected_crate, "tokio-tungstenite");
+        assert!(decision
+            .integration_refs
+            .iter()
+            .any(|reference| reference.contains("#4659")));
+        assert!(decision
+            .non_claims
+            .iter()
+            .any(|statement| statement.contains("protobuf")));
+        assert!(decision.failure_classifications.iter().any(|case| {
+            case.case_name == "malformed_message"
+                && case.fail_closed
+                && !case.authority_expansion_allowed
+        }));
+        assert!(decision.failure_classifications.iter().any(|case| {
+            case.case_name == "auth_policy_denial"
+                && case.expected_error_substring.contains("caller_class_denied")
+        }));
+    }
+
+    #[tokio::test]
+    async fn acip_runtime_stream_websocket_loopback_carries_validated_envelopes() {
+        let proof = prove_acip_runtime_stream_websocket_loopback_v1()
+            .await
+            .expect("websocket loopback proof should execute");
+
+        validate_acip_runtime_stream_loopback_proof_v1(&proof)
+            .expect("loopback proof should validate");
+        assert_eq!(proof.selected_crate, "tokio-tungstenite");
+        assert_eq!(proof.carrier_kind, "mock_loopback");
+        assert_eq!(
+            proof.response_message.prior_message_id,
+            Some(proof.request_message.message_id.clone())
+        );
+        assert!(proof
+            .lifecycle_events
+            .iter()
+            .any(|event| event == "websocket_handshake_accepted"));
+        assert!(proof
+            .negative_cases
+            .iter()
+            .any(|case| case.case_name == "malformed_message"));
+        assert!(proof
+            .negative_cases
+            .iter()
+            .any(|case| case.case_name == "auth_policy_denial"));
+    }
+
+    #[tokio::test]
+    async fn acip_runtime_stream_proof_validator_requires_wp12_truth_fields() {
+        let mut proof = prove_acip_runtime_stream_websocket_loopback_v1()
+            .await
+            .expect("websocket loopback proof should execute");
+
+        let policy_case = proof
+            .negative_cases
+            .iter_mut()
+            .find(|case| case.case_name == "auth_policy_denial")
+            .expect("policy-denial case");
+        policy_case.case_name = "unrelated_policy_case".to_string();
+        let missing_policy_case = validate_acip_runtime_stream_loopback_proof_v1(&proof)
+            .expect_err("proof missing auth-policy denial should fail");
+        assert!(missing_policy_case
+            .to_string()
+            .contains("auth_policy_denial"));
+
+        let valid_payload = serde_json::to_string(&acip_fixture_set_v1().valid_messages[0].message)
+            .expect("valid ACIP fixture should serialize");
+        let valid_payload_error = classify_acip_runtime_stream_malformed_frame_v1(&valid_payload)
+            .expect_err("valid ACIP payload should not classify as malformed");
+        assert!(valid_payload_error
+            .to_string()
+            .contains("requires invalid ACIP payload"));
+    }
+
+    #[test]
     fn acip_message_envelope_rejects_unknown_fields() {
         let mut value =
             serde_json::to_value(acip_fixture_set_v1().valid_messages[0].message.clone())

--- a/docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md
+++ b/docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md
@@ -1,0 +1,54 @@
+# ACIP Runtime Stream Substrate Proof (#4900)
+
+Issue #4900 is folded into WP-12 as a feeder for #4658 and #4659.
+
+## Decision
+
+- Selected substrate: WebSocket.
+- Selected Rust crate: `tokio-tungstenite`.
+- Role: carrier mechanics only. ACIP remains the domain contract above the transport.
+
+`jsonrpsee` remains a possible later choice only if ACIP runtime streams become JSON-RPC method dispatch. The current WP-12 need is envelope/event carriage, so WebSocket mechanics are the smaller fit.
+
+## Implemented Surface
+
+- Added `adl::agent_comms::runtime_stream`.
+- Added structured decision record type `AcipRuntimeStreamSubstrateDecisionV1`.
+- Added structured loopback proof type `AcipRuntimeStreamLoopbackProofV1`.
+- Added `prove_acip_runtime_stream_websocket_loopback_v1`, which opens a local WebSocket listener and client with `tokio-tungstenite`, sends one ACIP message envelope, validates it server-side, returns a validated ACIP response envelope, and closes the WebSocket.
+
+## Failure Classification
+
+The decision/proof surface classifies:
+
+- reconnect after disconnect: fail closed, retry allowed only after a new handshake and ACIP revalidation.
+- malformed message: fail closed, no retry without corrected payload.
+- peer close before response: fail closed, retry allowed.
+- response timeout: fail closed, retry allowed.
+- auth/policy denial: fail closed, no authority expansion.
+
+## Non-Claims
+
+- This does not implement protobuf wire encoding; #4658 owns schema/protobuf projection.
+- This does not prove production WebSocket authentication, TLS, reconnect scheduling, or cross-polis transport; #4659 owns the WP-12 transport path.
+- This does not bypass ACIP access rules, Freedom Gate decisions, trace, replay, or policy boundaries.
+
+## Validation
+
+Command:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml acip_runtime_stream -- --nocapture
+```
+
+Result:
+
+- Passed.
+- `agent_comms::tests::acip_runtime_stream_substrate_decision_selects_tokio_tungstenite`
+- `agent_comms::tests::acip_runtime_stream_websocket_loopback_carries_validated_envelopes`
+
+## Integration Notes
+
+#4658 should consume the decision as carrier selection input while keeping protobuf/schema ownership separate.
+
+#4659 should consume `prove_acip_runtime_stream_websocket_loopback_v1` as the first bounded loopback proof and extend from it toward the full WP-12 WebSocket transport path.


### PR DESCRIPTION
Closes #4900

## Summary
Implemented #4900 as a WP-12 feeder by selecting `tokio-tungstenite` WebSocket transport for bounded ACIP runtime stream proofs, adding a real local WebSocket loopback proof over `127.0.0.1:0`, preserving ACIP envelope validation at the carrier boundary, and recording explicit non-claims for protobuf wire encoding, production authentication, TLS, reconnect scheduling, and cross-polis transport.

The branch also records integration notes for #4658 and #4659 in `docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md`.

## Artifacts
- `adl/src/agent_comms/runtime_stream.inc`
- `adl/src/agent_comms.rs`
- `adl/src/agent_comms/tests.inc`
- `adl/src/agent_comms/carrier.inc`
- `adl/Cargo.toml`
- `adl/Cargo.lock`
- `docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml acip_runtime_stream -- --nocapture`
    Verified #4900's runtime stream substrate decision, local WebSocket loopback, proof validation, and negative cases.
  - `cargo test --manifest-path adl/Cargo.toml acip_local_carrier -- --nocapture`
    Verified the existing local ACIP carrier contract still passes.
  - `git diff --check`
    Verified no whitespace errors.
  - `bash adl/tools/run_owner_validation_lane.sh csdlc`
    Verified the C-SDLC owner lane selected by `pr finish`.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    Verified the finish-selected focused nextest lane; 1785 tests passed and 18521 were skipped by the lane filter.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4900__v0-91-7-runtime-acip-select-and-prove-websocket-or-rpc-substrate-for-acip-runtime-streams/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4900__v0-91-7-runtime-acip-select-and-prove-websocket-or-rpc-substrate-for-acip-runtime-streams/sor.md
- Idempotency-Key: v0-91-7-runtime-acip-prove-acip-runtime-stream-websocket-substrate-adl-cargo-lock-adl-cargo-toml-adl-src-agent-comms-rs-adl-src-agent-comms-carrier-inc-adl-src-agent-comms-runtime-stream-inc-adl-src-agent-comms-tests-inc-docs-milestones-v0-91-7-review-runtime-acip-runtime-stream-substrate-4900-md-adl-v0-91-7-tasks-issue-4900-v0-91-7-runtime-acip-select-and-prove-websocket-or-rpc-substrate-for-acip-runtime-streams-sip-md-adl-v0-91-7-tasks-issue-4900-v0-91-7-runtime-acip-select-and-prove-websocket-or-rpc-substrate-for-acip-runtime-streams-sor-md