### PR TITLE
[v0.91.7][WP-07][csm] Implement governed emergency polis stop path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,20 +273,8 @@ jobs:
           tool: nextest
 
       - name: test
-        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required != 'true'
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
         run: bash adl/tools/run_pr_fast_test_lane.sh --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}"
-        working-directory: .
-
-      - name: test deferred to validation-manager escalation
-        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required == 'true'
-        run: |
-          echo "Ordinary PR-fast Rust test lane deferred because the validation manager selected an escalation profile."
-          echo "Selected profile: ${{ steps.path-policy.outputs.validation_profile_selected }}"
-          echo "Profile status: ${{ steps.path-policy.outputs.validation_profile_status }}"
-          echo "PR publication sufficient: ${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}"
-          echo "Run lanes: ${{ steps.path-policy.outputs.validation_profile_run_lanes }}"
-          echo "Escalation lanes: ${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}"
-          echo "Reason: ${{ steps.path-policy.outputs.validation_profile_primary_reason }}"
         working-directory: .
 
       - name: doc test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,8 +273,20 @@ jobs:
           tool: nextest
 
       - name: test
-        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required != 'true'
         run: bash adl/tools/run_pr_fast_test_lane.sh --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}"
+        working-directory: .
+
+      - name: test deferred to validation-manager escalation
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required == 'true'
+        run: |
+          echo "Ordinary PR-fast Rust test lane deferred because the validation manager selected an escalation profile."
+          echo "Selected profile: ${{ steps.path-policy.outputs.validation_profile_selected }}"
+          echo "Profile status: ${{ steps.path-policy.outputs.validation_profile_status }}"
+          echo "PR publication sufficient: ${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}"
+          echo "Run lanes: ${{ steps.path-policy.outputs.validation_profile_run_lanes }}"
+          echo "Escalation lanes: ${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}"
+          echo "Reason: ${{ steps.path-policy.outputs.validation_profile_primary_reason }}"
         working-directory: .
 
       - name: doc test

--- a/adl/src/cli/agent_cmd.rs
+++ b/adl/src/cli/agent_cmd.rs
@@ -188,6 +188,7 @@ fn real_daemon_with_config(args: &[String], config: &DaemonCommandConfig) -> Res
     let mut bounded_test_restart_limit: Option<u64> = None;
     let mut checkpoint_interval_secs: u64 = 3;
     let mut interval_secs: Option<u64> = None;
+    let mut api_bind: Option<String> = None;
     let mut no_sleep = false;
 
     let mut i = 0usize;
@@ -214,6 +215,10 @@ fn real_daemon_with_config(args: &[String], config: &DaemonCommandConfig) -> Res
                     required_value(args, i, "--interval-secs")?,
                     "--interval-secs",
                 )?);
+                i += 1;
+            }
+            "--api-bind" => {
+                api_bind = Some(required_value(args, i, "--api-bind")?.to_string());
                 i += 1;
             }
             "--no-sleep" => no_sleep = true,
@@ -266,6 +271,7 @@ fn real_daemon_with_config(args: &[String], config: &DaemonCommandConfig) -> Res
             bounded_test_restart_limit,
             checkpoint_interval_secs,
             interval_secs,
+            api_bind,
             no_sleep,
             recover_stale_lease: parsed.recover_stale_lease,
         },

--- a/adl/src/cli/csm_cmd.rs
+++ b/adl/src/cli/csm_cmd.rs
@@ -11,8 +11,9 @@ use ::adl::csm_continuity_capsule::{
 };
 use ::adl::csm_observatory::{write_observatory_outputs, ObservatoryFormat};
 use ::adl::csm_polis_storage::{prove_polis_storage, PolisStorageProofOptions};
-use ::adl::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
+use ::adl::long_lived_agent::{governed_stop, GovernedStopRequest};
 use ::adl::wp08_acip_sns_proof::run_wp08_acip_sns_live_proof;
+use chrono::{DateTime, Utc};
 
 pub(crate) enum CsmDispatchMode {
     StandaloneRuntime,
@@ -30,7 +31,7 @@ pub(crate) fn real_csm_standalone(args: &[String]) -> Result<()> {
 fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
     let Some(cmd) = args.first().map(|value| value.as_str()) else {
         eprintln!(
-            "csm requires subcommand: daemon | service | continuity | backpressure | api | aws-signal | storage | cloud-control | observatory"
+            "csm requires subcommand: daemon | service | governed-stop | continuity | backpressure | aws-signal | storage | cloud-control | observatory"
         );
         std::process::exit(2);
     };
@@ -48,6 +49,12 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
                 "csm service is owned by the standalone csm runtime binary; use `csm service`, not `adl csm service`"
             )),
         },
+        "governed-stop" => match mode {
+            CsmDispatchMode::StandaloneRuntime => real_governed_stop(&args[1..]),
+            CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
+                "csm governed-stop is owned by the standalone csm runtime binary; use `csm governed-stop`, not `adl csm governed-stop`"
+            )),
+        },
         "continuity" => match mode {
             CsmDispatchMode::StandaloneRuntime => real_continuity(&args[1..]),
             CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
@@ -58,12 +65,6 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
             CsmDispatchMode::StandaloneRuntime => real_backpressure(&args[1..]),
             CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
                 "csm backpressure is owned by the standalone csm runtime binary; use `csm backpressure`, not `adl csm backpressure`"
-            )),
-        },
-        "api" => match mode {
-            CsmDispatchMode::StandaloneRuntime => real_api(&args[1..]),
-            CsmDispatchMode::AdlControlPlane => Err(anyhow::anyhow!(
-                "csm api is owned by the standalone csm runtime binary; use `csm api`, not `adl csm api`"
             )),
         },
         "aws-signal" => match mode {
@@ -91,11 +92,90 @@ fn real_csm_with_mode(args: &[String], mode: CsmDispatchMode) -> Result<()> {
         }
         other => {
             eprintln!(
-                "unknown csm subcommand: {other} (expected daemon, service, continuity, backpressure, api, aws-signal, storage, cloud-control, or observatory)"
+                "unknown csm subcommand: {other} (expected daemon, service, governed-stop, continuity, backpressure, aws-signal, storage, cloud-control, or observatory)"
             );
             std::process::exit(2);
         }
     }
+}
+
+fn real_governed_stop(args: &[String]) -> Result<()> {
+    let mut spec: Option<PathBuf> = None;
+    let mut reason: Option<String> = None;
+    let mut operator_identity: Option<String> = None;
+    let mut authorization: Option<String> = None;
+    let mut intent: Option<String> = None;
+    let mut requested_at: Option<DateTime<Utc>> = None;
+    let mut json_output = false;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--spec" => {
+                spec = Some(PathBuf::from(required_value(args, i, "--spec")?));
+                i += 1;
+            }
+            "--reason" => {
+                reason = Some(required_value(args, i, "--reason")?.to_string());
+                i += 1;
+            }
+            "--operator" => {
+                operator_identity = Some(required_value(args, i, "--operator")?.to_string());
+                i += 1;
+            }
+            "--authorization" => {
+                authorization = Some(required_value(args, i, "--authorization")?.to_string());
+                i += 1;
+            }
+            "--intent" => {
+                intent = Some(required_value(args, i, "--intent")?.to_string());
+                i += 1;
+            }
+            "--requested-at" => {
+                let raw = required_value(args, i, "--requested-at")?;
+                let parsed = DateTime::parse_from_rfc3339(raw)
+                    .with_context(|| {
+                        format!(
+                            "csm governed-stop requires --requested-at to be RFC3339, got {raw}"
+                        )
+                    })?
+                    .with_timezone(&Utc);
+                requested_at = Some(parsed);
+                i += 1;
+            }
+            "--json" => json_output = true,
+            "--help" | "-h" => {
+                println!("{}", csm_usage());
+                return Ok(());
+            }
+            other => {
+                eprintln!("unknown csm governed-stop arg: {other}");
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+    let result = governed_stop(
+        &spec.context("csm governed-stop requires --spec <agent-spec.yaml>")?,
+        GovernedStopRequest {
+            reason: reason.context("csm governed-stop requires --reason <text>")?,
+            operator_identity: operator_identity
+                .context("csm governed-stop requires --operator <identity>")?,
+            authorization: authorization
+                .context("csm governed-stop requires --authorization <metadata>")?,
+            intent: intent.context("csm governed-stop requires --intent <intent>")?,
+            requested_at: requested_at
+                .context("csm governed-stop requires --requested-at <RFC3339>")?,
+        },
+    )?;
+    if json_output {
+        println!("{}", serde_json::to_string(&result)?);
+    } else {
+        println!(
+            "governed stop recorded: {}",
+            result["governed_stop_id"].as_str().unwrap_or("unknown")
+        );
+    }
+    Ok(())
 }
 
 fn real_cloud_control(args: &[String]) -> Result<()> {
@@ -390,93 +470,6 @@ fn real_backpressure_prove(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn real_api(args: &[String]) -> Result<()> {
-    let Some(cmd) = args.first().map(|value| value.as_str()) else {
-        eprintln!("csm api requires subcommand: serve");
-        std::process::exit(2);
-    };
-    match cmd {
-        "serve" => real_api_serve(&args[1..]),
-        "--help" | "-h" => {
-            println!("{}", csm_usage());
-            Ok(())
-        }
-        other => {
-            eprintln!("unknown csm api subcommand: {other} (expected serve)");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn real_api_serve(args: &[String]) -> Result<()> {
-    let mut spec: Option<PathBuf> = None;
-    let mut bind = "127.0.0.1:0".to_string();
-    let mut test_max_requests: Option<usize> = None;
-    let mut idle_timeout_ms: Option<u64> = None;
-    let mut otel_status_path: Option<PathBuf> = None;
-    let mut otel_log_path: Option<PathBuf> = None;
-    let mut json_output = false;
-    let mut i = 0;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--spec" => {
-                spec = Some(PathBuf::from(required_value(args, i, "--spec")?));
-                i += 1;
-            }
-            "--bind" => {
-                bind = required_value(args, i, "--bind")?.to_string();
-                i += 1;
-            }
-            "--test-max-requests" => {
-                test_max_requests = Some(
-                    required_value(args, i, "--test-max-requests")?
-                        .parse()
-                        .context("csm api serve --test-max-requests must be an integer")?,
-                );
-                i += 1;
-            }
-            "--test-idle-timeout-ms" => {
-                idle_timeout_ms = Some(
-                    required_value(args, i, "--test-idle-timeout-ms")?
-                        .parse()
-                        .context("csm api serve --test-idle-timeout-ms must be an integer")?,
-                );
-                i += 1;
-            }
-            "--otel-status" => {
-                otel_status_path = Some(PathBuf::from(required_value(args, i, "--otel-status")?));
-                i += 1;
-            }
-            "--otel-log" => {
-                otel_log_path = Some(PathBuf::from(required_value(args, i, "--otel-log")?));
-                i += 1;
-            }
-            "--json" => json_output = true,
-            "--help" | "-h" => {
-                println!("{}", csm_usage());
-                return Ok(());
-            }
-            other => {
-                eprintln!("unknown csm api serve arg: {other}");
-                std::process::exit(2);
-            }
-        }
-        i += 1;
-    }
-    let result = serve_runtime_api(CsmRuntimeApiOptions {
-        spec_path: spec.context("csm api serve requires --spec <agent-spec.yaml>")?,
-        bind,
-        test_max_requests,
-        idle_timeout_ms,
-        otel_status_path,
-        otel_log_path,
-    })?;
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&result)?);
-    }
-    Ok(())
-}
-
 fn real_continuity(args: &[String]) -> Result<()> {
     let Some(cmd) = args.first().map(|value| value.as_str()) else {
         eprintln!("csm continuity requires subcommand: capture | stage | restore | drill");
@@ -763,10 +756,10 @@ fn real_observatory(args: &[String]) -> Result<()> {
 
 pub(crate) fn csm_usage() -> &'static str {
     "Usage:
-  csm daemon --spec <agent-spec.yaml> [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--recover-stale-lease] [--no-sleep] [--json]
-  csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--json]
+  csm daemon --spec <agent-spec.yaml> [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--api-bind 127.0.0.1:19997] [--recover-stale-lease] [--no-sleep] [--json]
+  csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--api-bind 127.0.0.1:19997] [--json]
   csm service start|status|stop|remove [--service-root <dir>] [--json]
-  csm api serve --spec <agent-spec.yaml> [--bind 127.0.0.1:0] [--otel-status <path>] [--otel-log <path>] [--json]
+  csm governed-stop --spec <agent-spec.yaml> --reason <text> --operator <identity> --authorization <metadata> --intent emergency_polis_stop|operator_safety_stop|recoverability_drill --requested-at <RFC3339> [--json]
   csm aws-signal acip-sns-proof --out <proof-dir> [--run-id <id>] [--projection-level delivery_metadata|content_summary]
   csm cloud-control cloudfront-status --out <proof-dir> [--profile agent-logic-admin] [--region us-west-2] [--distribution-id <id>] [--expected-account-sha256 <hash>]
   csm backpressure prove --spec <agent-spec.yaml> --out <proof-dir> [--profile local|soak2|pre-v0.92] [--json]
@@ -781,9 +774,11 @@ pub(crate) fn csm_usage() -> &'static str {
 Semantics:
   - csm is the dedicated runtime owner binary.
   - csm daemon owns permanent restart-always runtime execution, partial checkpoints, restart accounting telemetry, recoverable terminal state, and runtime observability.
-  - csm daemon service mode ignores agent max_cycles as a service lifetime boundary; --no-sleep is a test-only bounded harness boundary.
-  - csm service owns host service-manager installation/status around csm daemon; launchd KeepAlive is the primary macOS target, systemd Restart=always compatible service metadata is retained, and local mode is a bounded proof fallback.
-  - csm api exposes local-by-default /status, /health, /ready, /metrics, and /events endpoints from retained runtime artifacts without leaking host-private paths or secrets.
+  - csm daemon owns the runtime API as an embedded module in the daemon process; the API is not a separate service process.
+  - csm daemon service mode has no cycle-count lifetime boundary; --no-sleep is a test-only bounded harness boundary.
+  - csm service owns CSM runtime supervision around csm daemon; local mode is the portable Rust supervisor path, while launchd/systemd metadata are host integration targets.
+  - csm governed-stop is the only emergency polis stop path; it requires explicit operator metadata, checkpoints and safe-fail serialization before stop, lifecycle lifelog DB rows, and governed notice fan-out.
+  - csm daemon embeds the local-by-default runtime API at --api-bind and exposes /status, /health, /ready, /metrics, and /events from retained runtime artifacts without leaking host-private paths or secrets.
   - csm aws-signal owns runtime AWS signal proof execution, including ACIP-to-SNS live publication under the Agent Logic account guard.
   - csm cloud-control owns read-only AWS cloud-control observation hooks, including CloudFront status proof under the Agent Logic account guard.
   - csm backpressure proves bounded overload policy, retained metrics, and safe-fail serialization triggers for capacity-degraded runtime paths.
@@ -943,8 +938,8 @@ memory: {}
     fn standalone_csm_help_paths_cover_runtime_owned_surfaces() {
         for subcommand in [
             "backpressure",
-            "api",
             "continuity",
+            "governed-stop",
             "observatory",
             "service",
         ] {
@@ -956,7 +951,13 @@ memory: {}
 
     #[test]
     fn adl_control_plane_rejects_runtime_owned_surfaces() {
-        for subcommand in ["daemon", "service", "continuity", "backpressure", "api"] {
+        for subcommand in [
+            "daemon",
+            "service",
+            "governed-stop",
+            "continuity",
+            "backpressure",
+        ] {
             let args = vec![subcommand.to_string(), "--help".to_string()];
             let error = real_csm(&args)
                 .err()
@@ -973,8 +974,11 @@ memory: {}
         let usage = csm_usage();
         assert!(usage.contains("csm is the dedicated runtime owner binary"));
         assert!(usage.contains("permanent restart-always runtime execution"));
+        assert!(usage.contains("csm governed-stop --spec"));
+        assert!(usage.contains("only emergency polis stop path"));
         assert!(usage.contains("ADL_OBSERVABILITY_LOG"));
         assert!(usage.contains("ADL_OTEL_STATUS"));
+        assert!(!usage.contains("csm api serve"));
         assert!(!usage.contains("--max-restarts"));
         assert!(!usage.contains("--max-requests"));
         assert!(!usage.contains("--once"));
@@ -986,6 +990,29 @@ memory: {}
         let args = vec!["--spec".to_string()];
         let error = required_value(&args, 0, "--spec").expect_err("missing value must fail");
         assert_eq!(error.to_string(), "--spec requires a value");
+    }
+
+    #[test]
+    fn governed_stop_parser_fails_closed_without_required_metadata() {
+        let root = temp_root("governed-stop-missing");
+        let spec = write_runtime_spec(&root);
+        let args = vec![
+            "governed-stop".to_string(),
+            "--spec".to_string(),
+            spec.display().to_string(),
+            "--reason".to_string(),
+            "operator safety".to_string(),
+            "--json".to_string(),
+        ];
+        let error = real_csm_standalone(&args).expect_err("missing operator metadata must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("csm governed-stop requires --operator"),
+            "{error}"
+        );
+        assert!(!root.join("state/governed_stop.json").exists());
+        assert!(!root.join("state/stop.json").exists());
     }
 
     #[test]
@@ -1006,21 +1033,6 @@ memory: {}
             "--json".to_string(),
         ];
         real_csm_standalone(&backpressure).expect("backpressure proof parser path");
-
-        let api = vec![
-            "api".to_string(),
-            "serve".to_string(),
-            "--spec".to_string(),
-            spec.display().to_string(),
-            "--bind".to_string(),
-            "127.0.0.1:0".to_string(),
-            "--test-max-requests".to_string(),
-            "1".to_string(),
-            "--test-idle-timeout-ms".to_string(),
-            "1".to_string(),
-            "--json".to_string(),
-        ];
-        real_csm_standalone(&api).expect("api idle parser path");
 
         let bundle = root.join("bundle");
         let capture = vec![

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -293,7 +293,11 @@ fn start(args: &[String]) -> Result<()> {
         observation.pid,
         None,
     )?;
-    let status = service_status(&manifest, state, "start", None)?;
+    let mut status = service_status(&manifest, state, "start", None)?;
+    if observation.healthy {
+        status.service_state = "running".to_string();
+        status.startup_classification = observation.classification.to_string();
+    }
     write_status(&manifest, &status)?;
     print_status(&status, manifest.service_root.as_path(), args);
     if !observation.healthy || status.service_state != "running" {

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -1,10 +1,14 @@
 use std::env;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use ::adl::long_lived_agent;
 use anyhow::{anyhow, Context, Result};
@@ -17,6 +21,7 @@ use crate::cli::observability;
 const SERVICE_MANIFEST_SCHEMA: &str = "adl.csm.service_manifest.v1";
 const SERVICE_STATUS_SCHEMA: &str = "adl.csm.service_status.v1";
 const DEFAULT_LABEL: &str = "com.agentlogic.csm.runtime";
+const DEFAULT_API_BIND: &str = "127.0.0.1:19997";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -57,6 +62,7 @@ struct ServiceArgs {
     no_sleep: bool,
     otlp_endpoint: Option<String>,
     otlp_timeout_ms: Option<u64>,
+    api_bind: String,
     json: bool,
 }
 
@@ -78,6 +84,7 @@ impl Default for ServiceArgs {
                 .ok()
                 .and_then(|value| value.parse::<u64>().ok())
                 .filter(|value| *value > 0),
+            api_bind: DEFAULT_API_BIND.to_string(),
             json: false,
         }
     }
@@ -104,6 +111,10 @@ struct ServiceManifest {
     otel_log: PathBuf,
     otel_status: PathBuf,
     startup_ledger: PathBuf,
+    #[serde(default)]
+    supervisor_status: PathBuf,
+    #[serde(default)]
+    api_bind: String,
     daemon_status: PathBuf,
     continuity_checkpoint: PathBuf,
     continuity_replay_manifest: PathBuf,
@@ -144,6 +155,7 @@ struct ServiceStatus {
     first_daemon_record_observed: bool,
     continuity_checkpoint_observed: bool,
     cycle_ledger_observed: bool,
+    runtime_api_observed: bool,
     otlp_exporter_configured: bool,
     otlp_endpoint_ref: Option<&'static str>,
     last_action: String,
@@ -171,6 +183,7 @@ pub(crate) fn real_service(args: &[String]) -> Result<()> {
         "stop" => stop(&args[1..]),
         "status" => status(&args[1..]),
         "remove" => remove(&args[1..]),
+        "supervise" => supervise(&args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", service_usage());
             Ok(())
@@ -212,6 +225,23 @@ fn start(args: &[String]) -> Result<()> {
     let manifest = read_manifest(&service_root)?;
     let start_requested_at = Utc::now();
     record_startup_event(&manifest, "start_requested", "started", None, None)?;
+    let clear_stop =
+        long_lived_agent::clear_stop_for_service_start(&manifest.spec, "csm service start")?;
+    record_startup_event(
+        &manifest,
+        if clear_stop
+            .get("had_stop_intent")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "service_start_cleared_stop_intent"
+        } else {
+            "service_start_no_stop_intent"
+        },
+        "completed",
+        None,
+        None,
+    )?;
     let mut local_start = None;
     match manifest.manager {
         ServiceManager::Local => {
@@ -266,10 +296,10 @@ fn start(args: &[String]) -> Result<()> {
     let status = service_status(&manifest, state, "start", None)?;
     write_status(&manifest, &status)?;
     print_status(&status, manifest.service_root.as_path(), args);
-    if !observation.healthy {
+    if !observation.healthy || status.service_state != "running" {
         return Err(anyhow!(
-            "csm service startup failed before first daemon record: {}",
-            observation.classification
+            "csm service startup failed before runtime readiness: {}",
+            status.startup_classification
         ));
     }
     Ok(())
@@ -296,6 +326,114 @@ fn stop(args: &[String]) -> Result<()> {
     write_status(&manifest, &status)?;
     print_status(&status, manifest.service_root.as_path(), args);
     Ok(())
+}
+
+fn supervise(args: &[String]) -> Result<()> {
+    let parsed = parse_service_args(args, false)?;
+    let service_root = absolutize(&parsed.service_root)?;
+    let manifest = read_manifest(&service_root)?;
+    if manifest.manager != ServiceManager::Local {
+        return Err(anyhow!(
+            "csm service supervise is the portable Rust supervisor for --manager local services"
+        ));
+    }
+    fs::write(&manifest.pid_file, std::process::id().to_string())?;
+    record_supervisor_status(&manifest, "running", None, None, 0)?;
+    record_startup_event(
+        &manifest,
+        "rust_supervisor_started",
+        "started",
+        Some(std::process::id()),
+        None,
+    )?;
+    let mut restart_count = 0u64;
+    loop {
+        if long_lived_agent::stop_requested(&manifest.spec)? {
+            record_supervisor_status(&manifest, "stopped", None, None, restart_count)?;
+            record_startup_event(
+                &manifest,
+                "rust_supervisor_stop_observed",
+                "completed",
+                Some(std::process::id()),
+                None,
+            )?;
+            let _ = fs::remove_file(&manifest.pid_file);
+            return Ok(());
+        }
+        let mut child = spawn_daemon_child(&manifest, restart_count)?;
+        record_supervisor_status(
+            &manifest,
+            "child_running",
+            Some(child.id()),
+            None,
+            restart_count,
+        )?;
+        record_startup_event(
+            &manifest,
+            "rust_supervisor_child_spawn",
+            "started",
+            Some(child.id()),
+            None,
+        )?;
+        loop {
+            if long_lived_agent::stop_requested(&manifest.spec)? {
+                record_startup_event(
+                    &manifest,
+                    "rust_supervisor_stop_forwarded",
+                    "requested",
+                    Some(child.id()),
+                    None,
+                )?;
+                let _ = child.wait();
+                break;
+            }
+            if let Some(status) = child.try_wait().context("poll csm daemon child")? {
+                let exit = format!("{status}");
+                record_supervisor_status(
+                    &manifest,
+                    "child_exited",
+                    Some(child.id()),
+                    Some(exit.as_str()),
+                    restart_count,
+                )?;
+                record_startup_event(
+                    &manifest,
+                    "rust_supervisor_child_exit",
+                    if status.success() {
+                        "completed"
+                    } else {
+                        "failed"
+                    },
+                    Some(child.id()),
+                    None,
+                )?;
+                restart_count += 1;
+                let backoff_secs = rust_supervisor_backoff_secs(restart_count);
+                record_supervisor_status(
+                    &manifest,
+                    "restart_scheduled",
+                    None,
+                    Some(exit.as_str()),
+                    restart_count,
+                )?;
+                record_startup_event(
+                    &manifest,
+                    "rust_supervisor_restart_scheduled",
+                    "scheduled",
+                    None,
+                    None,
+                )?;
+                for _ in 0..backoff_secs.saturating_mul(5).max(1) {
+                    if long_lived_agent::stop_requested(&manifest.spec)? {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(200));
+                }
+                break;
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+    }
 }
 
 fn status(args: &[String]) -> Result<()> {
@@ -383,6 +521,10 @@ fn parse_service_args(args: &[String], require_spec: bool) -> Result<ServiceArgs
                 )?);
                 i += 1;
             }
+            "--api-bind" => {
+                parsed.api_bind = required_value(args, i, "--api-bind")?.to_string();
+                i += 1;
+            }
             "--json" => parsed.json = true,
             "--help" | "-h" => {
                 println!("{}", service_usage());
@@ -430,6 +572,8 @@ fn build_manifest(
         otel_log: service_root.join("logs/otel.jsonl"),
         otel_status: service_root.join("logs/otel_status.json"),
         startup_ledger: service_root.join("logs/startup_ledger.jsonl"),
+        supervisor_status: service_root.join("logs/rust_supervisor_status.json"),
+        api_bind: parsed.api_bind,
         daemon_status: state_root.join("daemon_status.json"),
         continuity_checkpoint: state_root.join("continuity_checkpoint.json"),
         continuity_replay_manifest: state_root.join("continuity_replay_manifest.json"),
@@ -454,6 +598,8 @@ fn write_launchd_plist(manifest: &ServiceManifest) -> Result<()> {
         manifest.spec.display().to_string(),
         "--checkpoint-interval-secs".to_string(),
         manifest.checkpoint_interval_secs.to_string(),
+        "--api-bind".to_string(),
+        manifest.api_bind.clone(),
         "--json".to_string(),
     ];
     if let Some(interval_secs) = manifest.interval_secs {
@@ -535,7 +681,7 @@ fn start_local(manifest: &ServiceManifest) -> Result<LocalStartOutcome> {
         let pid = read_pid_file(&manifest.pid_file)?;
         if pid_liveness(pid) != "live_pid" {
             let _ = fs::remove_file(&manifest.pid_file);
-        } else if daemon_status_matches_pid_and_spec(manifest, pid)? {
+        } else if supervisor_status_matches_pid_and_spec(manifest, pid)? {
             return Ok(LocalStartOutcome {
                 pid,
                 reused_existing: true,
@@ -556,6 +702,42 @@ fn start_local(manifest: &ServiceManifest) -> Result<LocalStartOutcome> {
         .open(&manifest.stderr_log)?;
     let mut command = Command::new(&manifest.csm_bin);
     command
+        .arg("service")
+        .arg("supervise")
+        .arg("--service-root")
+        .arg(&manifest.service_root)
+        .arg("--json")
+        .env("ADL_OBSERVABILITY_LOG", &manifest.observability_log)
+        .env("ADL_OBSERVABILITY_STDERR", "0")
+        .env("ADL_OTEL_LOG", &manifest.otel_log)
+        .env("ADL_OTEL_STATUS", &manifest.otel_status)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    configure_local_service_process(&mut command);
+    let child = command.spawn().context("spawn local csm daemon service")?;
+    let pid = child.id();
+    fs::write(&manifest.pid_file, pid.to_string())?;
+    Ok(LocalStartOutcome {
+        pid,
+        reused_existing: false,
+    })
+}
+
+fn spawn_daemon_child(
+    manifest: &ServiceManifest,
+    restart_count: u64,
+) -> Result<std::process::Child> {
+    let stdout = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&manifest.stdout_log)?;
+    let stderr = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&manifest.stderr_log)?;
+    let mut command = Command::new(&manifest.csm_bin);
+    command
         .arg("daemon")
         .arg("--spec")
         .arg(&manifest.spec)
@@ -566,6 +748,11 @@ fn start_local(manifest: &ServiceManifest) -> Result<LocalStartOutcome> {
         .env("ADL_OBSERVABILITY_STDERR", "0")
         .env("ADL_OTEL_LOG", &manifest.otel_log)
         .env("ADL_OTEL_STATUS", &manifest.otel_status)
+        .env(
+            "ADL_CSM_RUST_SUPERVISOR_RESTART_COUNT",
+            restart_count.to_string(),
+        )
+        .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
     if let Some(endpoint) = manifest.otlp_endpoint.as_deref() {
@@ -579,20 +766,33 @@ fn start_local(manifest: &ServiceManifest) -> Result<LocalStartOutcome> {
             .arg("--interval-secs")
             .arg(interval_secs.to_string());
     }
+    command.arg("--api-bind").arg(&manifest.api_bind);
     if manifest.recover_stale_lease {
         command.arg("--recover-stale-lease");
     }
     if manifest.no_sleep {
         command.arg("--no-sleep");
     }
-    let child = command.spawn().context("spawn local csm daemon service")?;
-    let pid = child.id();
-    fs::write(&manifest.pid_file, pid.to_string())?;
-    Ok(LocalStartOutcome {
-        pid,
-        reused_existing: false,
-    })
+    command.spawn().context("spawn csm daemon child")
 }
+
+#[cfg(unix)]
+fn configure_local_service_process(command: &mut Command) {
+    unsafe {
+        command.pre_exec(|| {
+            unsafe extern "C" {
+                fn setsid() -> i32;
+            }
+            if setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_local_service_process(_command: &mut Command) {}
 
 fn stop_local(manifest: &ServiceManifest) -> Result<()> {
     let _ = long_lived_agent::stop(&manifest.spec, "csm service stop requested");
@@ -600,7 +800,7 @@ fn stop_local(manifest: &ServiceManifest) -> Result<()> {
         return Ok(());
     }
     let pid = read_pid_file(&manifest.pid_file)?;
-    if daemon_status_matches_pid_and_spec(manifest, pid)? {
+    if supervisor_status_matches_pid_and_spec(manifest, pid)? {
         for _ in 0..30 {
             if pid_liveness(pid) != "live_pid" {
                 break;
@@ -612,6 +812,45 @@ fn stop_local(manifest: &ServiceManifest) -> Result<()> {
         let _ = fs::remove_file(&manifest.pid_file);
     }
     Ok(())
+}
+
+fn record_supervisor_status(
+    manifest: &ServiceManifest,
+    state: &str,
+    child_pid: Option<u32>,
+    last_child_exit: Option<&str>,
+    restart_count: u64,
+) -> Result<()> {
+    write_json_pretty(
+        &manifest.supervisor_status,
+        &json!({
+            "schema": "adl.csm.rust_supervisor_status.v1",
+            "runtime_owner": "csm",
+            "manager": manifest.manager.as_str(),
+            "label": manifest.label,
+            "state": state,
+            "supervisor_pid": std::process::id(),
+            "child_pid": child_pid,
+            "daemon_child_pid": child_pid,
+            "runtime_api": {
+                "status": "embedded_in_daemon",
+                "bind": manifest.api_bind,
+                "pid_model": "same_process_as_csm_daemon_child"
+            },
+            "restart_policy": "always",
+            "restart_count": restart_count,
+            "daemon_restart_count": restart_count,
+            "last_child_exit": last_child_exit,
+            "stop_policy": "explicit_stop_intent_only",
+            "max_cycles": "not_applicable",
+            "request_budget": "not_applicable",
+            "updated_at": Utc::now().to_rfc3339()
+        }),
+    )
+}
+
+fn rust_supervisor_backoff_secs(restart_count: u64) -> u64 {
+    2u64.saturating_pow(restart_count.min(4) as u32).min(30)
 }
 
 fn service_status(
@@ -632,6 +871,18 @@ fn service_status(
         last_failed_startup_at(manifest).unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
     let first_daemon_record_observed =
         verified_daemon_record_observed(manifest, pid, daemon_record_not_before);
+    let runtime_api_observed = runtime_api_bind_observed(manifest);
+    let startup_classification = startup_classification(
+        manifest,
+        pid.as_ref().copied(),
+        &pid_liveness,
+        first_daemon_record_observed,
+    );
+    let service_state = if state == "running" && startup_classification != "startup_runtime_ready" {
+        "startup_failed"
+    } else {
+        state
+    };
     Ok(ServiceStatus {
         schema: SERVICE_STATUS_SCHEMA,
         label: manifest.label.clone(),
@@ -639,7 +890,7 @@ fn service_status(
         runtime_owner: "csm",
         restart_policy: manifest.restart_policy.clone(),
         service_mode: manifest.service_mode.clone(),
-        service_state: state.to_string(),
+        service_state: service_state.to_string(),
         pid,
         pid_liveness: pid_liveness.clone(),
         broad_process_scan: false,
@@ -655,15 +906,11 @@ fn service_status(
         otel_log_ref: ref_for(&manifest.service_root, &manifest.otel_log),
         otel_status_ref: ref_for(&manifest.service_root, &manifest.otel_status),
         startup_ledger_ref: ref_for(&manifest.service_root, &manifest.startup_ledger),
-        startup_classification: startup_classification(
-            manifest,
-            pid.as_ref().copied(),
-            &pid_liveness,
-            first_daemon_record_observed,
-        ),
+        startup_classification,
         first_daemon_record_observed,
         continuity_checkpoint_observed: manifest.continuity_checkpoint.exists(),
         cycle_ledger_observed: cycle_ledger_path(manifest).exists(),
+        runtime_api_observed,
         otlp_exporter_configured: manifest.otlp_endpoint.is_some(),
         otlp_endpoint_ref: manifest.otlp_endpoint.as_ref().map(|_| "<configured>"),
         last_action: action.to_string(),
@@ -748,17 +995,21 @@ fn observe_startup(
             verified_daemon_record_observed(manifest, pid, not_before);
         let cycle_ledger_observed = cycle_ledger_path(manifest).exists();
         let continuity_checkpoint_observed = manifest.continuity_checkpoint.exists();
+        let runtime_api_observed = runtime_api_bind_observed(manifest);
+        let last_daemon_event = daemon_last_event(manifest);
         let classification = classify_startup(
             pid.as_ref().copied(),
             &pid_liveness,
             first_daemon_record_observed,
             cycle_ledger_observed,
             continuity_checkpoint_observed,
+            runtime_api_observed,
+            last_daemon_event.as_deref(),
         );
         last = StartupObservation {
             pid,
             classification,
-            healthy: classification == "startup_first_daemon_record_observed",
+            healthy: classification == "startup_runtime_ready",
         };
         record_startup_probe(
             manifest,
@@ -769,10 +1020,12 @@ fn observe_startup(
                 first_daemon_record_observed,
                 cycle_ledger_observed,
                 continuity_checkpoint_observed,
+                runtime_api_observed,
+                last_daemon_event: last_daemon_event.as_deref(),
                 classification,
             },
         )?;
-        if last.healthy || classification == "startup_stale_before_first_daemon_record" {
+        if last.healthy || classification == "startup_stale_before_runtime_ready" {
             return Ok(last);
         }
         thread::sleep(Duration::from_millis(100));
@@ -796,6 +1049,39 @@ fn cycle_ledger_path(manifest: &ServiceManifest) -> PathBuf {
         .join("cycle_ledger.jsonl")
 }
 
+fn runtime_api_bind_observed(manifest: &ServiceManifest) -> bool {
+    let Ok(addr) = manifest.api_bind.parse::<SocketAddr>() else {
+        return false;
+    };
+    if !addr.ip().is_loopback() {
+        return false;
+    }
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(100)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(200)));
+    let request = format!(
+        "GET /ready HTTP/1.1\r\nhost: {}\r\nconnection: close\r\n\r\n",
+        manifest.api_bind
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    let Some((_, body)) = response.split_once("\r\n\r\n") else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return false;
+    };
+    value.get("schema").and_then(Value::as_str) == Some("adl.csm.runtime_api.ready.v1")
+        && value.get("ready").and_then(Value::as_str) == Some("ready")
+}
+
 fn startup_classification(
     manifest: &ServiceManifest,
     pid: Option<u32>,
@@ -808,8 +1094,10 @@ fn startup_classification(
         first_daemon_record_observed,
         cycle_ledger_path(manifest).exists(),
         manifest.continuity_checkpoint.exists(),
+        runtime_api_bind_observed(manifest),
+        daemon_last_event(manifest).as_deref(),
     );
-    if current == "startup_first_daemon_record_observed" {
+    if current == "startup_runtime_ready" {
         return current.to_string();
     }
     if let Some(classification) = last_startup_classification(manifest) {
@@ -820,10 +1108,11 @@ fn startup_classification(
 
 fn verified_daemon_record_observed(
     manifest: &ServiceManifest,
-    pid: Option<u32>,
+    _pid: Option<u32>,
     not_before: DateTime<Utc>,
 ) -> bool {
-    pid.and_then(|pid| daemon_status_matches_pid_spec_and_time(manifest, pid, not_before).ok())
+    daemon_status_matches_spec_time_and_live_child(manifest, not_before)
+        .ok()
         .unwrap_or(false)
 }
 
@@ -847,6 +1136,29 @@ fn fresh_daemon_pid_after(manifest: &ServiceManifest, not_before: DateTime<Utc>)
         .get("supervisor_pid")
         .and_then(Value::as_u64)
         .and_then(|pid| u32::try_from(pid).ok())
+}
+
+fn supervisor_status_matches_pid_and_spec(manifest: &ServiceManifest, pid: u32) -> Result<bool> {
+    if !manifest.supervisor_status.exists() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(&manifest.supervisor_status)?;
+    let value: Value = serde_json::from_str(&raw)?;
+    let supervisor_pid = value
+        .get("supervisor_pid")
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok());
+    let label = value.get("label").and_then(Value::as_str);
+    Ok(supervisor_pid == Some(pid) && label == Some(manifest.label.as_str()))
+}
+
+fn daemon_last_event(manifest: &ServiceManifest) -> Option<String> {
+    let raw = fs::read_to_string(&manifest.daemon_status).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
+    value
+        .get("last_event")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 fn last_startup_classification(manifest: &ServiceManifest) -> Option<String> {
@@ -900,19 +1212,36 @@ fn classify_startup(
     pid: Option<u32>,
     pid_liveness: &str,
     first_daemon_record_observed: bool,
-    _cycle_ledger_observed: bool,
-    _continuity_checkpoint_observed: bool,
+    cycle_ledger_observed: bool,
+    continuity_checkpoint_observed: bool,
+    runtime_api_observed: bool,
+    last_daemon_event: Option<&str>,
 ) -> &'static str {
-    if first_daemon_record_observed && pid_liveness == "live_pid" {
-        "startup_first_daemon_record_observed"
+    if matches!(last_daemon_event, Some("stop_completed")) {
+        "startup_daemon_stopped_during_start"
+    } else if first_daemon_record_observed
+        && pid_liveness == "live_pid"
+        && cycle_ledger_observed
+        && continuity_checkpoint_observed
+        && runtime_api_observed
+    {
+        "startup_runtime_ready"
+    } else if first_daemon_record_observed
+        && pid_liveness == "live_pid"
+        && cycle_ledger_observed
+        && continuity_checkpoint_observed
+    {
+        "startup_daemon_live_waiting_for_runtime_api"
+    } else if first_daemon_record_observed && pid_liveness == "live_pid" {
+        "startup_daemon_live_waiting_for_runtime_evidence"
     } else if first_daemon_record_observed {
         "startup_daemon_record_without_live_pid"
     } else if matches!(pid_liveness, "stale_pid") {
-        "startup_stale_before_first_daemon_record"
+        "startup_stale_before_runtime_ready"
     } else if pid.is_none() {
         "startup_missing_pid_metadata"
     } else {
-        "startup_waiting_for_first_daemon_record"
+        "startup_waiting_for_runtime_ready"
     }
 }
 
@@ -923,6 +1252,8 @@ struct StartupProbeRecord<'a> {
     first_daemon_record_observed: bool,
     cycle_ledger_observed: bool,
     continuity_checkpoint_observed: bool,
+    runtime_api_observed: bool,
+    last_daemon_event: Option<&'a str>,
     classification: &'a str,
 }
 
@@ -932,6 +1263,8 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
     let first_s = probe.first_daemon_record_observed.to_string();
     let cycle_s = probe.cycle_ledger_observed.to_string();
     let checkpoint_s = probe.continuity_checkpoint_observed.to_string();
+    let api_s = probe.runtime_api_observed.to_string();
+    let daemon_event_s = probe.last_daemon_event.unwrap_or("");
     append_startup_ledger(
         manifest,
         "startup_probe",
@@ -942,7 +1275,10 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             "pid_liveness": probe.pid_liveness,
             "first_daemon_record_observed": probe.first_daemon_record_observed,
             "cycle_ledger_observed": probe.cycle_ledger_observed,
-            "continuity_checkpoint_observed": probe.continuity_checkpoint_observed
+            "continuity_checkpoint_observed": probe.continuity_checkpoint_observed,
+            "runtime_api_observed": probe.runtime_api_observed,
+            "runtime_api_bind": manifest.api_bind,
+            "last_daemon_event": probe.last_daemon_event
         })),
     )?;
     emit_service_event(
@@ -956,6 +1292,9 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             ("first_daemon_record_observed", &first_s),
             ("cycle_ledger_observed", &cycle_s),
             ("continuity_checkpoint_observed", &checkpoint_s),
+            ("runtime_api_observed", &api_s),
+            ("runtime_api_bind", &manifest.api_bind),
+            ("last_daemon_event", daemon_event_s),
         ],
     )?;
     Ok(())
@@ -1279,7 +1618,10 @@ fn read_daemon_pid(path: &Path) -> Result<Option<u32>> {
         .and_then(|pid| u32::try_from(pid).ok()))
 }
 
-fn daemon_status_matches_pid_and_spec(manifest: &ServiceManifest, pid: u32) -> Result<bool> {
+fn daemon_status_matches_spec_time_and_live_child(
+    manifest: &ServiceManifest,
+    not_before: DateTime<Utc>,
+) -> Result<bool> {
     if !manifest.daemon_status.exists() {
         return Ok(false);
     }
@@ -1291,25 +1633,15 @@ fn daemon_status_matches_pid_and_spec(manifest: &ServiceManifest, pid: u32) -> R
         .and_then(Value::as_u64)
         .and_then(|pid| u32::try_from(pid).ok());
     let agent_id = value.get("agent_instance_id").and_then(Value::as_str);
-    Ok(daemon_pid == Some(pid) && agent_id == Some(loaded.spec.agent_instance_id.as_str()))
-}
-
-fn daemon_status_matches_pid_spec_and_time(
-    manifest: &ServiceManifest,
-    pid: u32,
-    not_before: DateTime<Utc>,
-) -> Result<bool> {
-    if !manifest.daemon_status.exists() {
-        return Ok(false);
-    }
-    let raw = fs::read_to_string(&manifest.daemon_status)?;
-    let value: Value = serde_json::from_str(&raw)?;
     let updated_at = value
         .get("updated_at")
         .and_then(Value::as_str)
         .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
         .map(|value| value.with_timezone(&Utc));
-    Ok(daemon_status_matches_pid_and_spec(manifest, pid)?
+    Ok(agent_id == Some(loaded.spec.agent_instance_id.as_str())
+        && daemon_pid
+            .map(|pid| pid_liveness(pid) == "live_pid")
+            .unwrap_or(false)
         && updated_at
             .map(|updated_at| updated_at >= not_before)
             .unwrap_or(false))
@@ -1375,13 +1707,21 @@ fn unsupported_permanence_claims() -> Vec<String> {
 fn normalize_service_manifest_metadata(mut manifest: ServiceManifest) -> ServiceManifest {
     manifest.restart_policy = service_restart_policy(manifest.manager, manifest.no_sleep);
     manifest.service_mode = service_mode(manifest.manager, manifest.no_sleep);
+    if manifest.supervisor_status.as_os_str().is_empty() {
+        manifest.supervisor_status = manifest
+            .service_root
+            .join("logs/rust_supervisor_status.json");
+    }
+    if manifest.api_bind.trim().is_empty() {
+        manifest.api_bind = DEFAULT_API_BIND.to_string();
+    }
     manifest
 }
 
 fn service_restart_policy(manager: ServiceManager, no_sleep: bool) -> String {
     if no_sleep {
         "bounded_test_only".to_string()
-    } else if manager == ServiceManager::Launchd {
+    } else if matches!(manager, ServiceManager::Launchd | ServiceManager::Local) {
         "always".to_string()
     } else {
         "external_supervisor_required".to_string()
@@ -1394,13 +1734,13 @@ fn service_mode(manager: ServiceManager, no_sleep: bool) -> String {
     } else if manager == ServiceManager::Launchd {
         "permanent".to_string()
     } else {
-        "local_proof_only".to_string()
+        "rust_supervisor".to_string()
     }
 }
 
 pub(crate) fn service_usage() -> &'static str {
     "Usage:
-  csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--otlp-endpoint <url>] [--otlp-timeout-ms <n>] [--no-recover-stale-lease] [--no-sleep] [--json]
+  csm service install --spec <agent-spec.yaml> [--service-root <dir>] [--manager launchd|local] [--label <label>] [--csm-bin <path>] [--checkpoint-interval-secs <n>] [--interval-secs <n>] [--api-bind 127.0.0.1:19997] [--otlp-endpoint <url>] [--otlp-timeout-ms <n>] [--no-recover-stale-lease] [--no-sleep] [--json]
   csm service start [--service-root <dir>] [--json]
   csm service status [--service-root <dir>] [--json]
   csm service stop [--service-root <dir>] [--json]
@@ -1408,8 +1748,9 @@ pub(crate) fn service_usage() -> &'static str {
 
 Semantics:
   - csm service is the host-service envelope for the standalone csm runtime owner.
-  - launchd service mode records restart_policy=always and service_mode=permanent; launchd KeepAlive is the primary macOS service-manager target and systemd Restart=always compatible metadata is retained.
-  - local mode is a bounded proof fallback and records external_supervisor_required/local_proof_only.
+  - launchd service mode records restart_policy=always and service_mode=permanent; launchd KeepAlive is a host service-manager target and systemd Restart=always compatible metadata is retained for Linux packaging.
+  - local mode is the portable Rust supervisor path and records restart_policy=always/service_mode=rust_supervisor; startup is healthy only after live supervisor pid, live daemon child status, cycle-ledger, and continuity-checkpoint evidence.
+  - runtime API binding is passed into csm daemon and runs as an embedded runtime module, not as a separate API service process.
   - the managed command is always csm daemon, never adl agent daemon.
   - --no-sleep is an explicit test-only bounded harness boundary, not production service mode.
   - service artifacts include service_manifest.json, service_status.json, csm.launchd.plist, logs, OTel status/export paths, daemon_status.json, continuity checkpoints, and operator events.

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -878,11 +878,12 @@ fn service_status(
         &pid_liveness,
         first_daemon_record_observed,
     );
-    let service_state = if state == "running" && startup_classification != "startup_runtime_ready" {
-        "startup_failed"
-    } else {
-        state
-    };
+    let service_state =
+        if state == "running" && !startup_classification_is_healthy(&startup_classification) {
+            "startup_failed"
+        } else {
+            state
+        };
     Ok(ServiceStatus {
         schema: SERVICE_STATUS_SCHEMA,
         label: manifest.label.clone(),
@@ -997,6 +998,7 @@ fn observe_startup(
         let continuity_checkpoint_observed = manifest.continuity_checkpoint.exists();
         let runtime_api_observed = runtime_api_bind_observed(manifest);
         let last_daemon_event = daemon_last_event(manifest);
+        let bounded_test_restart_observed = bounded_test_supervisor_restart_observed(manifest);
         let classification = classify_startup(
             pid.as_ref().copied(),
             &pid_liveness,
@@ -1004,12 +1006,13 @@ fn observe_startup(
             cycle_ledger_observed,
             continuity_checkpoint_observed,
             runtime_api_observed,
+            bounded_test_restart_observed,
             last_daemon_event.as_deref(),
         );
         last = StartupObservation {
             pid,
             classification,
-            healthy: classification == "startup_runtime_ready",
+            healthy: startup_classification_is_healthy(classification),
         };
         record_startup_probe(
             manifest,
@@ -1021,6 +1024,7 @@ fn observe_startup(
                 cycle_ledger_observed,
                 continuity_checkpoint_observed,
                 runtime_api_observed,
+                bounded_test_restart_observed,
                 last_daemon_event: last_daemon_event.as_deref(),
                 classification,
             },
@@ -1095,9 +1099,10 @@ fn startup_classification(
         cycle_ledger_path(manifest).exists(),
         manifest.continuity_checkpoint.exists(),
         runtime_api_bind_observed(manifest),
+        bounded_test_supervisor_restart_observed(manifest),
         daemon_last_event(manifest).as_deref(),
     );
-    if current == "startup_runtime_ready" {
+    if startup_classification_is_healthy(current) {
         return current.to_string();
     }
     if let Some(classification) = last_startup_classification(manifest) {
@@ -1215,6 +1220,7 @@ fn classify_startup(
     cycle_ledger_observed: bool,
     continuity_checkpoint_observed: bool,
     runtime_api_observed: bool,
+    bounded_test_restart_observed: bool,
     last_daemon_event: Option<&str>,
 ) -> &'static str {
     if matches!(last_daemon_event, Some("stop_completed")) {
@@ -1226,6 +1232,13 @@ fn classify_startup(
         && runtime_api_observed
     {
         "startup_runtime_ready"
+    } else if first_daemon_record_observed
+        && pid_liveness == "live_pid"
+        && cycle_ledger_observed
+        && continuity_checkpoint_observed
+        && bounded_test_restart_observed
+    {
+        "startup_bounded_test_supervisor_restart_observed"
     } else if first_daemon_record_observed
         && pid_liveness == "live_pid"
         && cycle_ledger_observed
@@ -1245,6 +1258,44 @@ fn classify_startup(
     }
 }
 
+fn startup_classification_is_healthy(classification: &str) -> bool {
+    matches!(
+        classification,
+        "startup_runtime_ready" | "startup_bounded_test_supervisor_restart_observed"
+    )
+}
+
+fn bounded_test_supervisor_restart_observed(manifest: &ServiceManifest) -> bool {
+    if !manifest.no_sleep || manifest.manager != ServiceManager::Local {
+        return false;
+    }
+    let supervisor_restart_observed = fs::read_to_string(&manifest.supervisor_status)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|value| value.get("restart_count").and_then(Value::as_u64))
+        .map(|restart_count| restart_count >= 1)
+        .unwrap_or(false);
+    if !supervisor_restart_observed {
+        return false;
+    }
+    let Ok(raw) = fs::read_to_string(&manifest.startup_ledger) else {
+        return false;
+    };
+    let mut child_exit_observed = false;
+    let mut restart_scheduled_observed = false;
+    for line in raw.lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        match value.get("event").and_then(Value::as_str) {
+            Some("rust_supervisor_child_exit") => child_exit_observed = true,
+            Some("rust_supervisor_restart_scheduled") => restart_scheduled_observed = true,
+            _ => {}
+        }
+    }
+    child_exit_observed && restart_scheduled_observed
+}
+
 struct StartupProbeRecord<'a> {
     attempt: u32,
     pid: Option<u32>,
@@ -1253,6 +1304,7 @@ struct StartupProbeRecord<'a> {
     cycle_ledger_observed: bool,
     continuity_checkpoint_observed: bool,
     runtime_api_observed: bool,
+    bounded_test_restart_observed: bool,
     last_daemon_event: Option<&'a str>,
     classification: &'a str,
 }
@@ -1264,6 +1316,7 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
     let cycle_s = probe.cycle_ledger_observed.to_string();
     let checkpoint_s = probe.continuity_checkpoint_observed.to_string();
     let api_s = probe.runtime_api_observed.to_string();
+    let bounded_restart_s = probe.bounded_test_restart_observed.to_string();
     let daemon_event_s = probe.last_daemon_event.unwrap_or("");
     append_startup_ledger(
         manifest,
@@ -1278,6 +1331,7 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             "continuity_checkpoint_observed": probe.continuity_checkpoint_observed,
             "runtime_api_observed": probe.runtime_api_observed,
             "runtime_api_bind": manifest.api_bind,
+            "bounded_test_restart_observed": probe.bounded_test_restart_observed,
             "last_daemon_event": probe.last_daemon_event
         })),
     )?;
@@ -1294,6 +1348,7 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             ("continuity_checkpoint_observed", &checkpoint_s),
             ("runtime_api_observed", &api_s),
             ("runtime_api_bind", &manifest.api_bind),
+            ("bounded_test_restart_observed", &bounded_restart_s),
             ("last_daemon_event", daemon_event_s),
         ],
     )?;

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -966,6 +966,18 @@ struct StartupObservation {
     healthy: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct StartupEvidence<'a> {
+    pid: Option<u32>,
+    pid_liveness: &'a str,
+    first_daemon_record_observed: bool,
+    cycle_ledger_observed: bool,
+    continuity_checkpoint_observed: bool,
+    runtime_api_observed: bool,
+    bounded_test_restart_observed: bool,
+    last_daemon_event: Option<&'a str>,
+}
+
 fn observe_startup(
     manifest: &ServiceManifest,
     local_start: Option<LocalStartOutcome>,
@@ -999,16 +1011,17 @@ fn observe_startup(
         let runtime_api_observed = runtime_api_bind_observed(manifest);
         let last_daemon_event = daemon_last_event(manifest);
         let bounded_test_restart_observed = bounded_test_supervisor_restart_observed(manifest);
-        let classification = classify_startup(
-            pid.as_ref().copied(),
-            &pid_liveness,
+        let evidence = StartupEvidence {
+            pid,
+            pid_liveness: &pid_liveness,
             first_daemon_record_observed,
             cycle_ledger_observed,
             continuity_checkpoint_observed,
             runtime_api_observed,
             bounded_test_restart_observed,
-            last_daemon_event.as_deref(),
-        );
+            last_daemon_event: last_daemon_event.as_deref(),
+        };
+        let classification = classify_startup(evidence);
         last = StartupObservation {
             pid,
             classification,
@@ -1092,16 +1105,16 @@ fn startup_classification(
     pid_liveness: &str,
     first_daemon_record_observed: bool,
 ) -> String {
-    let current = classify_startup(
+    let current = classify_startup(StartupEvidence {
         pid,
         pid_liveness,
         first_daemon_record_observed,
-        cycle_ledger_path(manifest).exists(),
-        manifest.continuity_checkpoint.exists(),
-        runtime_api_bind_observed(manifest),
-        bounded_test_supervisor_restart_observed(manifest),
-        daemon_last_event(manifest).as_deref(),
-    );
+        cycle_ledger_observed: cycle_ledger_path(manifest).exists(),
+        continuity_checkpoint_observed: manifest.continuity_checkpoint.exists(),
+        runtime_api_observed: runtime_api_bind_observed(manifest),
+        bounded_test_restart_observed: bounded_test_supervisor_restart_observed(manifest),
+        last_daemon_event: daemon_last_event(manifest).as_deref(),
+    });
     if startup_classification_is_healthy(current) {
         return current.to_string();
     }
@@ -1213,45 +1226,36 @@ fn last_failed_startup_at(manifest: &ServiceManifest) -> Option<DateTime<Utc>> {
         .flatten()
 }
 
-fn classify_startup(
-    pid: Option<u32>,
-    pid_liveness: &str,
-    first_daemon_record_observed: bool,
-    cycle_ledger_observed: bool,
-    continuity_checkpoint_observed: bool,
-    runtime_api_observed: bool,
-    bounded_test_restart_observed: bool,
-    last_daemon_event: Option<&str>,
-) -> &'static str {
-    if matches!(last_daemon_event, Some("stop_completed")) {
+fn classify_startup(evidence: StartupEvidence<'_>) -> &'static str {
+    if matches!(evidence.last_daemon_event, Some("stop_completed")) {
         "startup_daemon_stopped_during_start"
-    } else if first_daemon_record_observed
-        && pid_liveness == "live_pid"
-        && cycle_ledger_observed
-        && continuity_checkpoint_observed
-        && runtime_api_observed
+    } else if evidence.first_daemon_record_observed
+        && evidence.pid_liveness == "live_pid"
+        && evidence.cycle_ledger_observed
+        && evidence.continuity_checkpoint_observed
+        && evidence.runtime_api_observed
     {
         "startup_runtime_ready"
-    } else if first_daemon_record_observed
-        && pid_liveness == "live_pid"
-        && cycle_ledger_observed
-        && continuity_checkpoint_observed
-        && bounded_test_restart_observed
+    } else if evidence.first_daemon_record_observed
+        && evidence.pid_liveness == "live_pid"
+        && evidence.cycle_ledger_observed
+        && evidence.continuity_checkpoint_observed
+        && evidence.bounded_test_restart_observed
     {
         "startup_bounded_test_supervisor_restart_observed"
-    } else if first_daemon_record_observed
-        && pid_liveness == "live_pid"
-        && cycle_ledger_observed
-        && continuity_checkpoint_observed
+    } else if evidence.first_daemon_record_observed
+        && evidence.pid_liveness == "live_pid"
+        && evidence.cycle_ledger_observed
+        && evidence.continuity_checkpoint_observed
     {
         "startup_daemon_live_waiting_for_runtime_api"
-    } else if first_daemon_record_observed && pid_liveness == "live_pid" {
+    } else if evidence.first_daemon_record_observed && evidence.pid_liveness == "live_pid" {
         "startup_daemon_live_waiting_for_runtime_evidence"
-    } else if first_daemon_record_observed {
+    } else if evidence.first_daemon_record_observed {
         "startup_daemon_record_without_live_pid"
-    } else if matches!(pid_liveness, "stale_pid") {
+    } else if matches!(evidence.pid_liveness, "stale_pid") {
         "startup_stale_before_runtime_ready"
-    } else if pid.is_none() {
+    } else if evidence.pid.is_none() {
         "startup_missing_pid_metadata"
     } else {
         "startup_waiting_for_runtime_ready"

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -643,12 +643,11 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
     {
         blockers.push("agent_state_failed".to_string());
     }
-    match status
+    if let Some("leased") = status
         .pointer("/agent_status/state")
         .and_then(Value::as_str)
     {
-        Some("leased") => blockers.push("agent_state_leased".to_string()),
-        _ => {}
+        blockers.push("agent_state_leased".to_string());
     }
     match status
         .pointer("/daemon_liveness/state")

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -2,6 +2,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
+use std::env;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -37,7 +38,7 @@ pub struct CsmRuntimeApiServeResult {
 
 pub fn serve_runtime_api(options: CsmRuntimeApiOptions) -> Result<CsmRuntimeApiServeResult> {
     if options.test_max_requests == Some(0) {
-        bail!("csm api serve test request limit must be greater than zero");
+        bail!("CSM runtime API test request limit must be greater than zero");
     }
     let listener = TcpListener::bind(&options.bind)
         .with_context(|| format!("failed binding CSM runtime API to {}", options.bind))?;
@@ -141,19 +142,33 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
     let safe_fail_bundle = read_json_artifact(&artifact_path(loaded, "safe_fail_bundle.json"));
     let backpressure_state =
         read_json_artifact(&artifact_path(loaded, "csm_backpressure_state.json"));
-    let otel_status = options
-        .otel_status_path
+    let otel_status_path = resolve_otel_status_path(loaded, options);
+    let otel_log_path = resolve_otel_log_path(loaded, options);
+    let otel_status = otel_status_path
         .as_deref()
         .map(read_json_artifact)
         .unwrap_or_else(|| json!({"status": "missing", "ref": "ADL_OTEL_STATUS"}));
-    let otel_log = options
-        .otel_log_path
+    let otel_log = otel_log_path
         .as_deref()
         .map(|path| file_ref_status(path, "ADL_OTEL_LOG"))
         .unwrap_or_else(|| json!({"status": "missing", "ref": "ADL_OTEL_LOG"}));
     let checkpoint_freshness = checkpoint_freshness(&daemon_status, &continuity_checkpoint);
-    let health = classify_health(&agent_status.state, &daemon_status, &checkpoint_freshness);
-    let ready = classify_ready(&agent_status.state, &daemon_status, &continuity_checkpoint);
+    let daemon_state = daemon_lifecycle_state(&daemon_status);
+    let daemon_pid_liveness = daemon_supervisor_pid_liveness(&daemon_status);
+    let health = classify_health(
+        &agent_status.state,
+        &daemon_status,
+        &checkpoint_freshness,
+        daemon_state,
+        daemon_pid_liveness.as_deref(),
+    );
+    let ready = classify_ready(
+        &agent_status.state,
+        &daemon_status,
+        &continuity_checkpoint,
+        daemon_state,
+        daemon_pid_liveness.as_deref(),
+    );
     let runtime_capabilities = daemon_status
         .get("value")
         .and_then(|value| value.get("runtime_capabilities"))
@@ -282,6 +297,46 @@ fn events_response(loaded: &LoadedAgentSpec) -> Result<Value> {
 
 fn artifact_path(loaded: &LoadedAgentSpec, name: &str) -> PathBuf {
     loaded.state_root.join(name)
+}
+
+fn resolve_otel_status_path(
+    loaded: &LoadedAgentSpec,
+    options: &CsmRuntimeApiOptions,
+) -> Option<PathBuf> {
+    options
+        .otel_status_path
+        .clone()
+        .or_else(|| env_path("ADL_OTEL_STATUS"))
+        .or_else(|| env_path("OTEL_STATUS"))
+        .or_else(|| sibling_service_log_path(loaded, "otel_status.json"))
+        .filter(|path| path.exists())
+}
+
+fn resolve_otel_log_path(
+    loaded: &LoadedAgentSpec,
+    options: &CsmRuntimeApiOptions,
+) -> Option<PathBuf> {
+    options
+        .otel_log_path
+        .clone()
+        .or_else(|| env_path("ADL_OTEL_LOG"))
+        .or_else(|| sibling_service_log_path(loaded, "otel.jsonl"))
+        .filter(|path| path.exists())
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn sibling_service_log_path(loaded: &LoadedAgentSpec, file_name: &str) -> Option<PathBuf> {
+    loaded
+        .state_root
+        .parent()
+        .map(|runtime_root| runtime_root.join("service").join("logs").join(file_name))
 }
 
 fn read_agent_status_snapshot(loaded: &LoadedAgentSpec) -> Result<StatusRecord> {
@@ -430,9 +485,11 @@ fn artifact_liveness(daemon_status: &Value) -> Value {
         .get("status")
         .and_then(Value::as_str)
         .unwrap_or("missing");
+    let pid_liveness = daemon_supervisor_pid_liveness(daemon_status);
     json!({
         "status": if status == "serialized" { "observed" } else { status },
         "state": daemon_status.pointer("/value/state").cloned().unwrap_or(Value::Null),
+        "supervisor_pid_liveness": pid_liveness.unwrap_or_else(|| "missing_pid_metadata".to_string()),
         "last_event": daemon_status.pointer("/value/last_event").cloned().unwrap_or(Value::Null),
         "updated_at": daemon_status.pointer("/value/updated_at").cloned().unwrap_or(Value::Null)
     })
@@ -469,10 +526,14 @@ fn classify_health(
     state: &AgentStatusState,
     daemon_status: &Value,
     checkpoint_freshness: &Value,
+    daemon_state: Option<&str>,
+    daemon_pid_liveness: Option<&str>,
 ) -> &'static str {
     let degraded = matches!(state, AgentStatusState::Failed)
         || daemon_status.get("status").and_then(Value::as_str) != Some("serialized")
-        || checkpoint_freshness.get("status").and_then(Value::as_str) == Some("stale");
+        || checkpoint_freshness.get("status").and_then(Value::as_str) == Some("stale")
+        || is_terminal_daemon_state(daemon_state)
+        || daemon_pid_liveness == Some("stale_pid");
     if degraded {
         "degraded"
     } else {
@@ -484,17 +545,72 @@ fn classify_ready(
     state: &AgentStatusState,
     daemon_status: &Value,
     continuity_checkpoint: &Value,
+    daemon_state: Option<&str>,
+    daemon_pid_liveness: Option<&str>,
 ) -> &'static str {
     let not_ready = matches!(
         state,
-        AgentStatusState::Failed | AgentStatusState::Leased | AgentStatusState::RunningCycle
+        AgentStatusState::Failed | AgentStatusState::Leased | AgentStatusState::Stopped
     ) || daemon_status.get("status").and_then(Value::as_str) != Some("serialized")
-        || continuity_checkpoint.get("status").and_then(Value::as_str) != Some("serialized");
+        || continuity_checkpoint.get("status").and_then(Value::as_str) != Some("serialized")
+        || is_terminal_daemon_state(daemon_state)
+        || daemon_pid_liveness == Some("stale_pid");
     if not_ready {
         "not_ready"
     } else {
         "ready"
     }
+}
+
+fn daemon_lifecycle_state(daemon_status: &Value) -> Option<&str> {
+    daemon_status
+        .pointer("/value/state")
+        .and_then(Value::as_str)
+}
+
+fn is_terminal_daemon_state(state: Option<&str>) -> bool {
+    matches!(
+        state,
+        Some("governed_stopped" | "stopped" | "stop_requested" | "startup_failed")
+    )
+}
+
+fn daemon_supervisor_pid_liveness(daemon_status: &Value) -> Option<String> {
+    let pid = daemon_status
+        .pointer("/value/supervisor_pid")
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())?;
+    Some(match exact_pid_is_live(pid) {
+        Some(true) => "live_pid".to_string(),
+        Some(false) => "stale_pid".to_string(),
+        None => "unknown".to_string(),
+    })
+}
+
+#[cfg(unix)]
+fn exact_pid_is_live(pid: u32) -> Option<bool> {
+    const EPERM: i32 = 1;
+    const ESRCH: i32 = 3;
+    unsafe extern "C" {
+        fn kill(pid: i32, sig: i32) -> i32;
+    }
+    if pid > i32::MAX as u32 {
+        return Some(false);
+    }
+    let result = unsafe { kill(pid as i32, 0) };
+    if result == 0 {
+        return Some(true);
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(EPERM) => Some(true),
+        Some(ESRCH) => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(not(unix))]
+fn exact_pid_is_live(_pid: u32) -> Option<bool> {
+    None
 }
 
 fn readiness_blockers(status: &Value) -> Vec<String> {
@@ -514,6 +630,13 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
         blockers.push("continuity_checkpoint_missing".to_string());
     }
     if status
+        .pointer("/daemon_liveness/supervisor_pid_liveness")
+        .and_then(Value::as_str)
+        == Some("stale_pid")
+    {
+        blockers.push("daemon_supervisor_pid_stale".to_string());
+    }
+    if status
         .pointer("/agent_status/state")
         .and_then(Value::as_str)
         == Some("failed")
@@ -525,7 +648,16 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
         .and_then(Value::as_str)
     {
         Some("leased") => blockers.push("agent_state_leased".to_string()),
-        Some("running_cycle") => blockers.push("agent_state_running_cycle".to_string()),
+        _ => {}
+    }
+    match status
+        .pointer("/daemon_liveness/state")
+        .and_then(Value::as_str)
+    {
+        Some("governed_stopped") => blockers.push("daemon_state_governed_stopped".to_string()),
+        Some("stopped") => blockers.push("daemon_state_stopped".to_string()),
+        Some("stop_requested") => blockers.push("daemon_state_stop_requested".to_string()),
+        Some("startup_failed") => blockers.push("daemon_state_startup_failed".to_string()),
         _ => {}
     }
     blockers
@@ -533,7 +665,7 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
 
 fn validate_loopback_bind(addr: &SocketAddr) -> Result<()> {
     if !addr.ip().is_loopback() {
-        bail!("csm api serve requires a loopback bind address unless remote auth is implemented");
+        bail!("CSM runtime API requires a loopback bind address unless remote auth is implemented");
     }
     Ok(())
 }
@@ -625,6 +757,11 @@ memory: {}
         spec
     }
 
+    fn test_api_bind(offset: u64) -> String {
+        let port = 19950 + (offset % 47);
+        format!("127.0.0.1:{port}")
+    }
+
     #[test]
     fn runtime_api_reports_not_ready_when_runtime_artifacts_are_missing() {
         let root = temp_root("missing");
@@ -632,7 +769,7 @@ memory: {}
         let state = root.join("state");
         let options = CsmRuntimeApiOptions {
             spec_path: spec,
-            bind: "127.0.0.1:0".to_string(),
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
             test_max_requests: Some(1),
             idle_timeout_ms: None,
             otel_status_path: None,
@@ -664,7 +801,7 @@ memory: {}
         .unwrap();
         let options = CsmRuntimeApiOptions {
             spec_path: spec,
-            bind: "127.0.0.1:0".to_string(),
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
             test_max_requests: Some(1),
             idle_timeout_ms: None,
             otel_status_path: None,
@@ -680,7 +817,7 @@ memory: {}
     }
 
     #[test]
-    fn runtime_api_explains_active_agent_not_ready_state() {
+    fn runtime_api_reports_ready_during_active_agent_cycle() {
         let root = temp_root("active-state");
         let spec = write_spec(&root);
         let state = root.join("state");
@@ -726,17 +863,163 @@ memory: {}
         .unwrap();
         let options = CsmRuntimeApiOptions {
             spec_path: spec,
-            bind: "127.0.0.1:0".to_string(),
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
             test_max_requests: Some(1),
             idle_timeout_ms: None,
             otel_status_path: None,
             otel_log_path: None,
         };
         let response = runtime_api_response(&options, "/ready").unwrap();
-        assert_eq!(response["ready"], "not_ready");
-        assert!(response["blocking_reasons"]
+        assert_eq!(response["ready"], "ready");
+        assert!(response["blocking_reasons"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn runtime_api_discovers_sibling_service_otel_artifacts() {
+        let root = temp_root("service-otel");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        let service_logs = root.join("service/logs");
+        fs::create_dir_all(&state).unwrap();
+        fs::create_dir_all(&service_logs).unwrap();
+        fs::write(
+            state.join("status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_status.v1",
+                "agent_instance_id": "api-agent",
+                "state": "idle",
+                "last_cycle_id": "cycle-000001",
+                "last_cycle_status": "success",
+                "completed_cycle_count": 1,
+                "consecutive_failure_count": 0,
+                "active_lease": null,
+                "stop_requested": false,
+                "last_error": null,
+                "safety_policy": null,
+                "updated_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("daemon_status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_daemon_status.v1",
+                "state": "running",
+                "last_event": "child_exit",
+                "updated_at": Utc::now(),
+                "last_checkpoint_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("continuity_checkpoint.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_continuity_checkpoint.v1"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            service_logs.join("otel_status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.otel.monitor_status.v1",
+                "event_count": 3,
+                "last_event": "csm.startup_runtime_ready"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            service_logs.join("otel.jsonl"),
+            "{\"schema\":\"adl.otel.event.v1\"}\n",
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let response = runtime_api_response(&options, "/status").unwrap();
+        assert_eq!(response["status"], "healthy");
+        assert_eq!(response["otel"]["status"]["status"], "serialized");
+        assert_eq!(
+            response["otel"]["status"]["schema"],
+            "adl.otel.monitor_status.v1"
+        );
+        assert_eq!(response["otel"]["log"]["status"], "retained");
+    }
+
+    #[test]
+    fn runtime_api_marks_governed_stopped_runtime_not_ready() {
+        let root = temp_root("governed-stopped");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        fs::create_dir_all(&state).unwrap();
+        fs::write(
+            state.join("status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_status.v1",
+                "agent_instance_id": "api-agent",
+                "state": "stopped",
+                "last_cycle_id": "cycle-000001",
+                "last_cycle_status": "success",
+                "completed_cycle_count": 1,
+                "consecutive_failure_count": 0,
+                "active_lease": null,
+                "stop_requested": true,
+                "last_error": null,
+                "safety_policy": null,
+                "updated_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("daemon_status.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_daemon_status.v1",
+                "state": "governed_stopped",
+                "supervisor_pid": u32::MAX,
+                "last_event": "governed_stop",
+                "updated_at": Utc::now(),
+                "last_checkpoint_at": Utc::now()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            state.join("continuity_checkpoint.json"),
+            serde_json::to_string_pretty(&json!({
+                "schema": "adl.long_lived_agent_continuity_checkpoint.v1"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let status = runtime_api_response(&options, "/status").unwrap();
+        assert_eq!(status["status"], "degraded");
+        assert_eq!(status["ready"], "not_ready");
+        let ready = runtime_api_response(&options, "/ready").unwrap();
+        assert_eq!(ready["ready"], "not_ready");
+        assert!(ready["blocking_reasons"]
             .as_array()
             .unwrap()
-            .contains(&json!("agent_state_running_cycle")));
+            .contains(&json!("daemon_state_governed_stopped")));
+        assert!(ready["blocking_reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("daemon_supervisor_pid_stale")));
     }
 }

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -670,15 +670,28 @@ fn validate_loopback_bind(addr: &SocketAddr) -> Result<()> {
 }
 
 fn read_request_path(stream: &mut TcpStream) -> Result<String> {
-    let mut buf = [0_u8; 4096];
-    let n = stream
-        .read(&mut buf)
-        .context("read CSM runtime API request")?;
-    let request = String::from_utf8_lossy(&buf[..n]);
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 256];
+    loop {
+        let n = stream
+            .read(&mut chunk)
+            .context("read CSM runtime API request")?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(2).any(|window| window == b"\r\n")
+            || buf.windows(1).any(|window| window == b"\n")
+            || buf.len() >= 4096
+        {
+            break;
+        }
+    }
+    let request = String::from_utf8_lossy(&buf);
     let first_line = request.lines().next().unwrap_or_default();
     let mut parts = first_line.split_whitespace();
     let method = parts.next().unwrap_or_default();
-    let path = parts.next().unwrap_or("/");
+    let path = parts.next().unwrap_or("/__bad_request");
     if method != "GET" {
         return Ok("/__method_not_allowed".to_string());
     }

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1,14 +1,17 @@
 //! Long-lived agent orchestration surfaces.
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::thread;
 use std::time::Duration;
 
 use crate::chronosense::{ChronosenseRuntimeService, ChronosenseRuntimeServiceConfig};
+use crate::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 use crate::runtime_aws_signal::publish_csm_governed_notice_signal;
 use crate::{adl, execute, resolve, trace};
 
@@ -140,6 +143,7 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
     let checkpoint_interval_secs =
         effective_checkpoint_interval_secs(&loaded, options.checkpoint_interval_secs)?;
     let runtime_context = CsmRuntimeContext::new()?;
+    let runtime_api_status = start_embedded_runtime_api_module(spec_path, &options);
     let mut restart_count = 0u64;
     let mut last_child_exit = None;
     let _ = write_daemon_status(
@@ -170,8 +174,8 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
                 "restart_policy": daemon_restart_policy(),
                 "service_mode": daemon_service_mode(options.no_sleep),
                 "bounded_test_mode": options.no_sleep,
-            "agent_configured_max_cycles": loaded.spec.heartbeat.max_cycles,
-            "agent_max_cycles_lifetime_boundary": "ignored_in_daemon_service_mode",
+            "cycle_count_lifetime_boundary": "not_applicable",
+            "runtime_api": runtime_api_status,
             "unsupported_permanence_claims": unsupported_permanence_claims()
         }),
     )?;
@@ -533,6 +537,51 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
     }
 }
 
+fn start_embedded_runtime_api_module(spec_path: &Path, options: &DaemonOptions) -> Value {
+    let Some(bind) = options.api_bind.clone() else {
+        return json!({
+            "status": "disabled",
+            "reason": "api_bind_not_configured"
+        });
+    };
+    let api_options = CsmRuntimeApiOptions {
+        spec_path: spec_path.to_path_buf(),
+        bind: bind.clone(),
+        test_max_requests: None,
+        idle_timeout_ms: None,
+        otel_status_path: None,
+        otel_log_path: None,
+    };
+    thread::Builder::new()
+        .name("csm-runtime-api".to_string())
+        .spawn(move || {
+            if let Err(err) = serve_runtime_api(api_options) {
+                let error = err
+                    .to_string()
+                    .replace(['\n', '\r', '\t'], " ")
+                    .replace(' ', "_");
+                eprintln!(
+                    "adl_event schema=adl.observability.event.v1 command=csm stage=runtime_api_embedded result=failed error={error}"
+                );
+            }
+        })
+        .map(|_| {
+            json!({
+                "status": "embedded",
+                "bind": bind,
+                "thread": "csm-runtime-api",
+                "pid_model": "same_process_as_csm_daemon"
+            })
+        })
+        .unwrap_or_else(|err| {
+            json!({
+                "status": "failed_to_start",
+                "bind": bind,
+                "error": err.to_string()
+            })
+        })
+}
+
 fn daemon_interval_secs(loaded: &LoadedAgentSpec, override_secs: Option<u64>) -> Result<u64> {
     match override_secs.or(loaded.spec.heartbeat.interval_secs) {
         Some(0) => Err(anyhow!(
@@ -718,6 +767,366 @@ pub fn stop(spec_path: &Path, reason: &str) -> Result<StatusRecord> {
         "operator",
         "operator_stop_requested",
     )
+}
+
+pub fn stop_requested(spec_path: &Path) -> Result<bool> {
+    let loaded = load_spec(spec_path)?;
+    ensure_state_root(&loaded)?;
+    Ok(read_stop(&loaded)?.is_some())
+}
+
+pub fn clear_stop_for_service_start(spec_path: &Path, requested_by: &str) -> Result<Value> {
+    let loaded = load_spec(spec_path)?;
+    ensure_state_root(&loaded)?;
+    let existing = read_stop(&loaded)?;
+    if existing.is_some() {
+        remove_stop(&loaded)?;
+    }
+    append_operator_event(
+        &loaded,
+        "service_start_cleared_stop_intent",
+        json!({
+            "requested_by": requested_by,
+            "had_stop_intent": existing.is_some(),
+            "stop_ref": "stop.json",
+            "reason": "csm service start requested a new runtime lifetime"
+        }),
+    )?;
+    if existing.is_some() {
+        let status = status_with_state(
+            &loaded,
+            AgentStatusState::Idle,
+            None,
+            None,
+            None,
+            false,
+            None,
+        );
+        persist_status(&loaded, &status, "service_start_cleared_stop")?;
+    }
+    Ok(json!({
+        "schema": "adl.csm.service_start_clear_stop.v1",
+        "status": "completed",
+        "had_stop_intent": existing.is_some(),
+        "stop_ref": "stop.json"
+    }))
+}
+
+#[derive(Debug, Clone)]
+pub struct GovernedStopRequest {
+    pub reason: String,
+    pub operator_identity: String,
+    pub authorization: String,
+    pub intent: String,
+    pub requested_at: DateTime<Utc>,
+}
+
+pub fn governed_stop(spec_path: &Path, request: GovernedStopRequest) -> Result<Value> {
+    validate_governed_stop_request(&request)?;
+    let loaded = load_spec(spec_path)?;
+    ensure_state_root(&loaded)?;
+    let runtime_context = CsmRuntimeContext::new()?;
+    let restart_count = daemon_restart_count_hint(&loaded);
+    let governed_stop_id = governed_stop_id(&loaded, &request);
+
+    let mut checkpoint_status = status(spec_path)?;
+    checkpoint_status.stop_requested = false;
+    persist_status(
+        &loaded,
+        &checkpoint_status,
+        "governed_emergency_stop_pre_stop_checkpoint",
+    )?;
+    emit_daemon_event(
+        &runtime_context,
+        &loaded,
+        "governed_emergency_stop_checkpoint",
+        "completed",
+        restart_count,
+        json!({
+            "governed_stop_id": governed_stop_id,
+            "checkpoint_reason": "governed_emergency_stop_pre_stop_checkpoint",
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "status_ref": "status.json"
+        }),
+    )?;
+
+    let safe_fail = record_safe_fail_event(
+        &runtime_context,
+        &loaded,
+        SafeFailRecord {
+            status: &checkpoint_status,
+            trigger: "governed_emergency_stop_pre_stop",
+            restart_count,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            details: json!({
+                "governed_stop_id": governed_stop_id,
+                "checkpoint_reason": "governed_emergency_stop_pre_stop_checkpoint",
+                "requested_by": request.operator_identity.clone(),
+                "authorization_ref": governed_authorization_ref(&request.authorization),
+                "intent": request.intent.clone(),
+                "recoverability_requirement": "checkpoint_and_safe_fail_before_stop"
+            }),
+        },
+    )?;
+
+    let governed_stop = json!({
+        "schema": "adl.csm.governed_stop.v1",
+        "governed_stop_id": governed_stop_id,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id.clone(),
+        "classification": "governed_emergency_stop",
+        "distinguishes_from": [
+            "crash",
+            "budget_exhaustion",
+            "test_harness_termination",
+            "service_manager_failure",
+            "ordinary_api_request"
+        ],
+        "operator_intent": {
+            "reason": request.reason.clone(),
+            "operator_identity": request.operator_identity.clone(),
+            "authorization_ref": governed_authorization_ref(&request.authorization),
+            "intent": request.intent.clone(),
+            "requested_at": request.requested_at,
+            "recorded_at": Utc::now()
+        },
+        "pre_stop_checkpoint": {
+            "status": "completed",
+            "status_ref": "status.json",
+            "continuity_checkpoint_ref": "continuity_checkpoint.json",
+            "continuity_replay_manifest_ref": "continuity_replay_manifest.json"
+        },
+        "safe_fail": safe_fail,
+        "agent_recoverability": {
+            "state_before_stop": checkpoint_status.state.clone(),
+            "recoverability_class": "recoverable_checkpointed",
+            "recovery_refs": [
+                "status.json",
+                "continuity_checkpoint.json",
+                "continuity_replay_manifest.json",
+                "safe_fail_bundle.json"
+            ]
+        },
+        "authorization_policy": {
+            "required_fields": ["reason", "operator_identity", "authorization", "intent", "requested_at"],
+            "ordinary_api_requests_can_stop_runtime": false,
+            "runtime_budget": "not_applicable"
+        }
+    });
+    write_json_pretty(&governed_stop_path(&loaded), &governed_stop)?;
+    record_lifecycle_lifelog(
+        &loaded,
+        "governed_emergency_stop_requested",
+        &governed_stop_id,
+        &governed_stop,
+    )?;
+    append_operator_event(
+        &loaded,
+        "governed_emergency_stop_requested",
+        json!({
+            "governed_stop_id": governed_stop_id,
+            "reason": governed_stop["operator_intent"]["reason"].clone(),
+            "operator_identity": governed_stop["operator_intent"]["operator_identity"].clone(),
+            "authorization_ref": governed_stop["operator_intent"]["authorization_ref"].clone(),
+            "intent": governed_stop["operator_intent"]["intent"].clone(),
+            "checkpoint_ref": "continuity_checkpoint.json",
+            "safe_fail_ref": "safe_fail_bundle.json",
+            "governed_stop_ref": "governed_stop.json"
+        }),
+    )?;
+
+    let stopped = write_stop_record(
+        &loaded,
+        governed_stop["operator_intent"]["reason"]
+            .as_str()
+            .unwrap_or("governed emergency stop requested"),
+        governed_stop["operator_intent"]["operator_identity"]
+            .as_str()
+            .unwrap_or("operator"),
+        "governed_emergency_stop_recorded",
+    )?;
+    let daemon_status = write_daemon_status(
+        &runtime_context,
+        &loaded,
+        DaemonStatusInput {
+            state: "governed_stopped",
+            bounded_test_mode: false,
+            restart_count,
+            bounded_test_restart_limit: None,
+            checkpoint_interval_secs: loaded.spec.checkpoint.interval_secs.unwrap_or(1).max(1),
+            last_event: "governed_emergency_stop_recorded",
+            last_child_exit: None,
+            next_backoff_secs: 0,
+        },
+    )?;
+    emit_daemon_event(
+        &runtime_context,
+        &loaded,
+        "governed_emergency_stop_recorded",
+        "completed",
+        restart_count,
+        json!({
+            "governed_stop_id": governed_stop_id,
+            "governed_stop_ref": "governed_stop.json",
+            "stop_ref": "stop.json",
+            "daemon_status_ref": "daemon_status.json"
+        }),
+    )?;
+    record_lifecycle_lifelog(
+        &loaded,
+        "governed_emergency_stop_recorded",
+        &governed_stop_id,
+        &json!({
+            "status": "completed",
+            "stop_ref": "stop.json",
+            "daemon_status_ref": "daemon_status.json"
+        }),
+    )?;
+    let notice = record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "governed_emergency_stop",
+            severity: "critical",
+            trigger: "governed_emergency_stop",
+            status: &stopped,
+            restart_count,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: governed_stop["safe_fail"].clone(),
+            details: json!({
+                "governed_stop_id": governed_stop_id,
+                "governed_stop_ref": "governed_stop.json",
+                "stop_ref": "stop.json",
+                "daemon_status_ref": "daemon_status.json",
+                "lifecycle_lifelog_db_ref": "csm_lifecycle_lifelog.db.jsonl",
+                "operator_identity": governed_stop["operator_intent"]["operator_identity"].clone(),
+                "authorization_ref": governed_stop["operator_intent"]["authorization_ref"].clone()
+            }),
+        },
+    )?;
+
+    Ok(json!({
+        "schema": "adl.csm.governed_stop.result.v1",
+        "status": "completed",
+        "runtime_owner": "csm",
+        "governed_stop_id": governed_stop_id,
+        "classification": "governed_emergency_stop",
+        "governed_stop_ref": "governed_stop.json",
+        "stop_ref": "stop.json",
+        "status_ref": "status.json",
+        "daemon_status_ref": "daemon_status.json",
+        "continuity_checkpoint_ref": "continuity_checkpoint.json",
+        "safe_fail_ref": "safe_fail_bundle.json",
+        "lifecycle_lifelog_db_ref": "csm_lifecycle_lifelog.db.jsonl",
+        "notice": notice,
+        "agent_recoverability": governed_stop["agent_recoverability"].clone(),
+        "daemon_status": daemon_status
+    }))
+}
+
+fn validate_governed_stop_request(request: &GovernedStopRequest) -> Result<()> {
+    let fields = [
+        ("--reason", request.reason.as_str()),
+        ("--operator", request.operator_identity.as_str()),
+        ("--authorization", request.authorization.as_str()),
+        ("--intent", request.intent.as_str()),
+    ];
+    for (name, value) in fields {
+        if value.trim().is_empty() {
+            return Err(anyhow!("csm governed-stop requires non-empty {name}"));
+        }
+    }
+    let intent = request.intent.trim();
+    if !matches!(
+        intent,
+        "emergency_polis_stop" | "operator_safety_stop" | "recoverability_drill"
+    ) {
+        return Err(anyhow!(
+            "csm governed-stop unsupported --intent '{intent}' (expected emergency_polis_stop, operator_safety_stop, or recoverability_drill)"
+        ));
+    }
+    Ok(())
+}
+
+fn governed_stop_id(loaded: &LoadedAgentSpec, request: &GovernedStopRequest) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(loaded.spec.agent_instance_id.as_bytes());
+    hasher.update([0xff]);
+    hasher.update(request.reason.trim().as_bytes());
+    hasher.update([0xff]);
+    hasher.update(request.operator_identity.trim().as_bytes());
+    hasher.update([0xff]);
+    hasher.update(request.intent.trim().as_bytes());
+    hasher.update([0xff]);
+    hasher.update(request.requested_at.to_rfc3339().as_bytes());
+    format!("csm-governed-stop-{:x}", hasher.finalize())
+}
+
+fn governed_authorization_ref(authorization: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(authorization.trim().as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn daemon_restart_count_hint(loaded: &LoadedAgentSpec) -> u64 {
+    read_json_optional::<Value>(&daemon_status_path(loaded))
+        .ok()
+        .flatten()
+        .and_then(|value| value.get("restart_count").and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+fn record_lifecycle_lifelog<T: Serialize>(
+    loaded: &LoadedAgentSpec,
+    event: &str,
+    event_id: &str,
+    payload: &T,
+) -> Result<()> {
+    let payload = serde_json::to_value(payload).context("serialize lifecycle lifelog payload")?;
+    let sequence = lifecycle_lifelog_sequence(loaded)?;
+    let record = json!({
+        "schema": "adl.csm.lifecycle_lifelog.row.v1",
+        "database_schema": "adl.csm.lifecycle_lifelog.db.v1",
+        "sequence": sequence,
+        "event_id": event_id,
+        "event": event,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id.clone(),
+        "recorded_at": Utc::now(),
+        "payload": payload
+    });
+    append_jsonl(&csm_lifecycle_lifelog_db_path(loaded), &record)?;
+    write_json_pretty(
+        &csm_lifecycle_lifelog_index_path(loaded),
+        &json!({
+            "schema": "adl.csm.lifecycle_lifelog.index.v1",
+            "database_schema": "adl.csm.lifecycle_lifelog.db.v1",
+            "database_ref": "csm_lifecycle_lifelog.db.jsonl",
+            "latest_sequence": sequence,
+            "latest_event_id": event_id,
+            "latest_event": event,
+            "retention_policy": "permanent_local_runtime_lifecycle_log",
+            "backend": "jsonl_database",
+            "future_backends": ["sqlite", "immutable_ledger"],
+            "updated_at": Utc::now()
+        }),
+    )?;
+    Ok(())
+}
+
+fn lifecycle_lifelog_sequence(loaded: &LoadedAgentSpec) -> Result<u64> {
+    let path = csm_lifecycle_lifelog_db_path(loaded);
+    if !path.exists() {
+        return Ok(1);
+    }
+    let file = File::open(&path).with_context(|| format!("failed opening {}", path.display()))?;
+    let count = BufReader::new(file)
+        .lines()
+        .filter(|line| line.is_ok())
+        .count();
+    Ok(count as u64 + 1)
 }
 
 pub fn inspect(spec_path: &Path, options: InspectOptions) -> Result<Value> {

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -46,6 +46,18 @@ pub(super) fn csm_notice_latest_path(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join("csm_governed_notice_latest.json")
 }
 
+pub(super) fn governed_stop_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("governed_stop.json")
+}
+
+pub(super) fn csm_lifecycle_lifelog_db_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("csm_lifecycle_lifelog.db.jsonl")
+}
+
+pub(super) fn csm_lifecycle_lifelog_index_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("csm_lifecycle_lifelog.index.json")
+}
+
 pub(super) fn checkpoint_request_path(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join("checkpoint_request.json")
 }
@@ -113,6 +125,15 @@ pub(super) fn read_stop(loaded: &LoadedAgentSpec) -> Result<Option<StopRecord>> 
     read_json_optional(&stop_path(loaded))
 }
 
+pub(super) fn remove_stop(loaded: &LoadedAgentSpec) -> Result<()> {
+    let path = stop_path(loaded);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("failed removing stop {}", path.display())),
+    }
+}
+
 pub(super) fn remove_lease(loaded: &LoadedAgentSpec) -> Result<()> {
     let path = lease_path(loaded);
     match fs::remove_file(&path) {
@@ -151,14 +172,31 @@ where
         fs::create_dir_all(parent)
             .with_context(|| format!("failed creating {}", parent.display()))?;
     }
-    let file = File::create(path).with_context(|| format!("failed creating {}", path.display()))?;
-    serde_json::to_writer_pretty(&file, value)
-        .with_context(|| format!("failed writing {}", path.display()))?;
-    fs::OpenOptions::new()
-        .append(true)
-        .open(path)?
-        .write_all(b"\n")
-        .with_context(|| format!("failed finalizing {}", path.display()))?;
+    let tmp_path = path.with_extension(format!(
+        "{}tmp-{}",
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| format!("{extension}."))
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    {
+        let mut file = File::create(&tmp_path)
+            .with_context(|| format!("failed creating {}", tmp_path.display()))?;
+        serde_json::to_writer_pretty(&mut file, value)
+            .with_context(|| format!("failed writing {}", tmp_path.display()))?;
+        file.write_all(b"\n")
+            .with_context(|| format!("failed finalizing {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed syncing {}", tmp_path.display()))?;
+    }
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed replacing {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/adl/src/long_lived_agent/types.rs
+++ b/adl/src/long_lived_agent/types.rs
@@ -189,11 +189,12 @@ pub struct RunOptions {
 }
 
 /// Supervisor options for daemon-style foreground runtime execution.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DaemonOptions {
     pub bounded_test_restart_limit: Option<u64>,
     pub checkpoint_interval_secs: u64,
     pub interval_secs: Option<u64>,
+    pub api_bind: Option<String>,
     pub no_sleep: bool,
     pub recover_stale_lease: bool,
 }

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -1044,7 +1044,7 @@ memory:
     assert!(
         matches!(
             metrics["states"]["agent_state"].as_str(),
-            Some("idle" | "completed")
+            Some("idle" | "running_cycle" | "completed")
         ),
         "unexpected metrics state: {}",
         metrics["states"]["agent_state"]

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -156,6 +156,58 @@ fn http_get_json(addr: &str, path: &str) -> serde_json::Value {
     }
 }
 
+fn reserve_csm_test_port(label: &str) -> (std::net::TcpListener, String) {
+    for port in 19950..=19999 {
+        if port == 19997 {
+            continue;
+        }
+        let addr = format!("127.0.0.1:{port}");
+        if let Ok(listener) = std::net::TcpListener::bind(&addr) {
+            return (listener, addr);
+        }
+    }
+    panic!("no reserved CSM test port available for {label} in 19950-19999");
+}
+
+fn request_governed_stop_and_wait(spec: &std::path::Path, child: &mut std::process::Child) {
+    let stop = run_csm(&[
+        "governed-stop",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--reason",
+        "test cleanup requested governed runtime stop",
+        "--operator",
+        "cli-smoke",
+        "--authorization",
+        "test-governed-stop",
+        "--intent",
+        "recoverability_drill",
+        "--requested-at",
+        "2026-07-07T16:00:00Z",
+        "--json",
+    ]);
+    assert!(
+        stop.status.success(),
+        "governed stop stderr:\n{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    let started = std::time::Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .expect("check governed CSM daemon child")
+            .is_some()
+        {
+            break;
+        }
+        if started.elapsed() > std::time::Duration::from_secs(8) {
+            let _ = child.kill();
+            panic!("CSM daemon did not exit after governed stop request");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 fn otlp_attr_string<'a>(attrs: &'a serde_json::Value, key: &str) -> Option<&'a str> {
     attrs.as_array()?.iter().find_map(|attr| {
         (attr.get("key")?.as_str()? == key)
@@ -622,7 +674,7 @@ memory:
     );
     assert_text_contains(
         &operator_events,
-        "\"agent_max_cycles_lifetime_boundary\":\"ignored_in_daemon_service_mode\"",
+        "\"cycle_count_lifetime_boundary\":\"not_applicable\"",
         "operator events",
     );
     assert_text_contains(&operator_events, "\"otel\"", "operator events");
@@ -901,68 +953,62 @@ memory:
     assert!(String::from_utf8_lossy(&bad_profile.stderr)
         .contains("unsupported csm backpressure profile"));
 
-    let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind API probe port");
-    let addr = probe.local_addr().expect("API probe addr");
+    let (probe, addr) = reserve_csm_test_port("runtime API smoke");
     drop(probe);
     let mut child = std::process::Command::new(resolve_csm_exe())
         .args([
-            "api",
-            "serve",
+            "daemon",
             "--spec",
             spec_str,
-            "--bind",
-            &addr.to_string(),
-            "--test-max-requests",
-            "100",
-            "--test-idle-timeout-ms",
-            "1000",
-            "--otel-status",
-            otel_status.to_str().expect("utf8 otel status path"),
-            "--otel-log",
-            otel_log.to_str().expect("utf8 otel log path"),
-            "--json",
+            "--api-bind",
+            &addr,
+            "--checkpoint-interval-secs",
+            "1",
+            "--interval-secs",
+            "1",
         ])
-        .stdout(std::process::Stdio::piped())
+        .env(
+            "ADL_OTEL_STATUS",
+            otel_status.to_str().expect("utf8 otel status path"),
+        )
+        .env(
+            "ADL_OTEL_LOG",
+            otel_log.to_str().expect("utf8 otel log path"),
+        )
+        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .expect("spawn csm api");
-    let stdout = child.stdout.take().expect("api stdout pipe");
-    let mut stdout = std::io::BufReader::new(stdout);
-    let mut startup_line = String::new();
-    std::io::BufRead::read_line(&mut stdout, &mut startup_line).expect("read API startup");
-    assert!(
-        startup_line.contains("\"status\":\"listening\""),
-        "unexpected API startup line: {startup_line}"
-    );
+        .expect("spawn csm daemon with embedded API");
 
-    let status = http_get_json(&addr.to_string(), "/status");
-    let health = http_get_json(&addr.to_string(), "/health");
-    let ready = http_get_json(&addr.to_string(), "/ready");
-    let metrics = http_get_json(&addr.to_string(), "/metrics");
-    let events = http_get_json(&addr.to_string(), "/events");
-
-    let mut stderr = String::new();
-    if let Some(mut pipe) = child.stderr.take() {
-        use std::io::Read;
-        pipe.read_to_string(&mut stderr).expect("read API stderr");
+    let mut status = http_get_json(&addr, "/status");
+    let status_wait_started = std::time::Instant::now();
+    while status["daemon_liveness"]["state"] != "running" || status["ready"] != "ready" {
+        if status_wait_started.elapsed() > std::time::Duration::from_secs(5) {
+            panic!(
+                "embedded CSM API did not report ready running daemon state:\n{}",
+                serde_json::to_string_pretty(&status).expect("serialize status")
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        status = http_get_json(&addr, "/status");
     }
-    let status_code = child.wait().expect("wait csm api");
-    let mut remaining_stdout = String::new();
-    use std::io::Read;
-    stdout
-        .read_to_string(&mut remaining_stdout)
-        .expect("read remaining API stdout");
-    assert!(
-        status_code.success(),
-        "api stdout:\n{startup_line}{remaining_stdout}\nstderr:\n{stderr}"
-    );
+    let health = http_get_json(&addr, "/health");
+    let ready = http_get_json(&addr, "/ready");
+    let metrics = http_get_json(&addr, "/metrics");
+    let events = http_get_json(&addr, "/events");
+
+    request_governed_stop_and_wait(&spec, &mut child);
 
     assert_eq!(status["schema"], "adl.csm.runtime_api.status.v1");
     assert_eq!(status["runtime_owner"], "csm");
     assert_eq!(status["agent_instance_id"], "api-agent");
     assert_eq!(status["status"], "healthy");
     assert_eq!(status["ready"], "ready");
-    assert_eq!(status["daemon_liveness"]["state"], "completed");
+    assert_eq!(status["daemon_liveness"]["state"], "running");
+    assert_eq!(
+        status["daemon_liveness"]["supervisor_pid_liveness"],
+        "live_pid"
+    );
     assert_eq!(
         status["backpressure"]["schema"],
         "adl.csm.backpressure_state.v1"
@@ -978,6 +1024,10 @@ memory:
     assert_eq!(health["status"], "healthy");
     assert_eq!(ready["schema"], "adl.csm.runtime_api.ready.v1");
     assert_eq!(ready["ready"], "ready");
+    assert!(ready["blocking_reasons"]
+        .as_array()
+        .expect("ready blockers")
+        .is_empty());
     assert_eq!(metrics["schema"], "adl.csm.runtime_api.metrics.v1");
     assert_eq!(metrics["gauges"]["backpressure_queue_depth"], 12);
     assert_eq!(metrics["gauges"]["backpressure_lag_ms"], 3100);
@@ -1977,6 +2027,8 @@ memory:
     let plist = fs::read_to_string(service_root.join("csm.launchd.plist")).expect("plist");
     assert!(plist.contains("<key>KeepAlive</key>"));
     assert!(plist.contains("<string>daemon</string>"));
+    assert!(plist.contains("<string>--api-bind</string>"));
+    assert!(plist.contains("<string>127.0.0.1:19997</string>"));
     assert!(plist.contains("ADL_OTEL_STATUS"));
     assert!(plist.contains("ADL_OTEL_EXPORTER_OTLP_ENDPOINT"));
     assert!(plist.contains("http://127.0.0.1:4318/v1/traces"));
@@ -2041,6 +2093,8 @@ memory:
     )
     .expect("write agent spec");
     let csm_bin = resolve_csm_exe();
+    let (api_probe, api_bind) = reserve_csm_test_port("service mode manifest");
+    drop(api_probe);
 
     let local_root = root.join("local-service");
     let local = run_csm(&[
@@ -2052,6 +2106,8 @@ memory:
         local_root.to_str().expect("utf8 local service root"),
         "--manager",
         "local",
+        "--api-bind",
+        &api_bind,
         "--csm-bin",
         csm_bin.to_str().expect("utf8 csm bin"),
         "--json",
@@ -2065,11 +2121,8 @@ memory:
         &fs::read_to_string(local_root.join("service_manifest.json")).expect("local manifest"),
     )
     .expect("parse local manifest");
-    assert_eq!(
-        local_manifest["restart_policy"],
-        "external_supervisor_required"
-    );
-    assert_eq!(local_manifest["service_mode"], "local_proof_only");
+    assert_eq!(local_manifest["restart_policy"], "always");
+    assert_eq!(local_manifest["service_mode"], "rust_supervisor");
     let mut legacy_local_manifest = local_manifest.clone();
     legacy_local_manifest
         .as_object_mut()
@@ -2098,11 +2151,8 @@ memory:
     );
     let legacy_status: serde_json::Value =
         serde_json::from_slice(&local_status.stdout).expect("parse local status stdout");
-    assert_eq!(
-        legacy_status["restart_policy"],
-        "external_supervisor_required"
-    );
-    assert_eq!(legacy_status["service_mode"], "local_proof_only");
+    assert_eq!(legacy_status["restart_policy"], "always");
+    assert_eq!(legacy_status["service_mode"], "rust_supervisor");
 
     let bounded_root = root.join("bounded-service");
     let bounded = run_csm(&[
@@ -2289,6 +2339,8 @@ memory:
     .expect("write agent spec");
     let service_root = root.join("service");
     let csm_bin = resolve_csm_exe();
+    let (api_probe, api_bind) = reserve_csm_test_port("service API smoke");
+    drop(api_probe);
     let install = run_csm(&[
         "service",
         "install",
@@ -2298,6 +2350,8 @@ memory:
         service_root.to_str().expect("utf8 service root"),
         "--manager",
         "local",
+        "--api-bind",
+        &api_bind,
         "--label",
         "com.agentlogic.csm.test-local",
         "--csm-bin",
@@ -2346,7 +2400,7 @@ memory:
     assert_eq!(service_status["uses_ps"], false);
     assert_eq!(
         service_status["startup_classification"],
-        "startup_first_daemon_record_observed"
+        "startup_runtime_ready"
     );
     assert_eq!(service_status["first_daemon_record_observed"], true);
     assert_eq!(service_status["continuity_checkpoint_observed"], true);
@@ -2359,8 +2413,40 @@ memory:
         fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
     assert!(startup_ledger.contains("\"event\":\"start_requested\""));
     assert!(startup_ledger.contains("\"event\":\"local_spawn\""));
+    assert!(startup_ledger.contains("\"event\":\"rust_supervisor_started\""));
+    assert!(startup_ledger.contains("\"event\":\"rust_supervisor_child_spawn\""));
     assert!(startup_ledger.contains("\"event\":\"startup_probe\""));
-    assert!(startup_ledger.contains("startup_first_daemon_record_observed"));
+    assert!(startup_ledger.contains("startup_runtime_ready"));
+    let supervisor_status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(service_root.join("logs/rust_supervisor_status.json"))
+            .expect("supervisor status"),
+    )
+    .expect("parse supervisor status");
+    assert_eq!(
+        supervisor_status["schema"],
+        "adl.csm.rust_supervisor_status.v1"
+    );
+    assert_eq!(supervisor_status["restart_policy"], "always");
+    assert_eq!(
+        supervisor_status["runtime_api"]["status"],
+        "embedded_in_daemon"
+    );
+    assert_eq!(
+        supervisor_status["runtime_api"]["pid_model"],
+        "same_process_as_csm_daemon_child"
+    );
+    assert_eq!(
+        supervisor_status["stop_policy"],
+        "explicit_stop_intent_only"
+    );
+    assert_eq!(supervisor_status["max_cycles"], "not_applicable");
+    assert_eq!(supervisor_status["request_budget"], "not_applicable");
+    let api_bind = supervisor_status["runtime_api"]["bind"]
+        .as_str()
+        .expect("runtime API bind")
+        .to_string();
+    let ready = http_get_json(&api_bind, "/ready");
+    assert_eq!(ready["ready"], "ready");
     let observability =
         fs::read_to_string(service_root.join("logs/observability.log")).expect("observability log");
     assert!(observability.contains("stage=start_requested"));
@@ -2386,7 +2472,7 @@ memory:
     assert_eq!(second_status["service_state"], "running");
     assert_eq!(
         second_status["startup_classification"],
-        "startup_first_daemon_record_observed"
+        "startup_runtime_ready"
     );
     let startup_ledger =
         fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
@@ -2407,6 +2493,44 @@ memory:
     let service_status: serde_json::Value =
         serde_json::from_slice(&stop.stdout).expect("parse stop status stdout");
     assert_eq!(service_status["service_state"], "stopped_or_requested");
+    let restart = run_csm(&[
+        "service",
+        "start",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        restart.status.success(),
+        "restart after stop stderr:\n{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert!(
+        !root.join("state/stop.json").exists(),
+        "service start must clear durable stop intent before creating a new runtime lifetime"
+    );
+    let restart_status: serde_json::Value =
+        serde_json::from_slice(&restart.stdout).expect("parse restart stdout");
+    assert_eq!(restart_status["service_state"], "running");
+    assert_eq!(
+        restart_status["startup_classification"],
+        "startup_runtime_ready"
+    );
+    let restart_ledger =
+        fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
+    assert!(restart_ledger.contains("\"event\":\"service_start_cleared_stop_intent\""));
+    let stop = run_csm(&[
+        "service",
+        "stop",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        stop.status.success(),
+        "second stop stderr:\n{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
     let stale_pid = u32::MAX;
     fs::write(service_root.join("csm-service.pid"), stale_pid.to_string())
         .expect("write stale pid metadata");
@@ -2445,7 +2569,7 @@ memory:
         serde_json::from_slice(&stale_status.stdout).expect("parse stale status stdout");
     assert_ne!(
         stale_status["startup_classification"],
-        "startup_first_daemon_record_observed"
+        "startup_runtime_ready"
     );
     assert_eq!(stale_status["pid_liveness"], "stale_pid");
     let agent_status: serde_json::Value =
@@ -2455,6 +2579,329 @@ memory:
     assert_eq!(
         agent_status["last_error"]["class"],
         "operator_stop_requested"
+    );
+}
+
+#[test]
+fn csm_governed_stop_records_checkpoint_safe_fail_lifelog_and_notices() {
+    let root = unique_test_temp_dir("csm-governed-stop");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: governed-stop-agent
+display_name: Governed Stop Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: governed_stop_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 10
+  max_cycles: 3
+  stale_lease_after_secs: 60
+checkpoint:
+  interval_secs: 1
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+memory:
+  namespace: smoke/governed-stop-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+    let service_root = root.join("service");
+    let csm_bin = resolve_csm_exe();
+    let (api_probe, api_bind) = reserve_csm_test_port("governed API smoke");
+    drop(api_probe);
+    let install = run_csm(&[
+        "service",
+        "install",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--manager",
+        "local",
+        "--api-bind",
+        &api_bind,
+        "--label",
+        "com.agentlogic.csm.test-governed-stop",
+        "--csm-bin",
+        csm_bin.to_str().expect("utf8 csm bin"),
+        "--checkpoint-interval-secs",
+        "1",
+        "--json",
+    ]);
+    assert!(
+        install.status.success(),
+        "install stderr:\n{}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let start = run_csm(&[
+        "service",
+        "start",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        start.status.success(),
+        "start stderr:\n{}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    let stop = run_csm_with_env(
+        &[
+            "governed-stop",
+            "--spec",
+            spec.to_str().expect("utf8 spec"),
+            "--reason",
+            "operator requested recoverable polis stop",
+            "--operator",
+            "codex-test-operator",
+            "--authorization",
+            "test-approval-ticket-5005",
+            "--intent",
+            "emergency_polis_stop",
+            "--requested-at",
+            "2026-07-07T16:00:00Z",
+            "--json",
+        ],
+        &[
+            ("ADL_AWS_SIGNAL_MODE", "mock"),
+            ("ADL_AWS_SIGNAL_APPROVED", "1"),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+            (
+                "ADL_AWS_SNS_TOPIC_ARN",
+                "arn:aws:sns:us-west-2:000000000000:mock",
+            ),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "mock"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "eventbridge"),
+            ("ADL_CSM_NOTICE_EVENT_BUS", "adl-csm-notice-bus-5005"),
+        ],
+    );
+    assert!(
+        stop.status.success(),
+        "governed-stop stderr:\n{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&stop.stdout).expect("parse governed stop stdout");
+    assert_eq!(result["schema"], "adl.csm.governed_stop.result.v1");
+    assert_eq!(result["classification"], "governed_emergency_stop");
+    assert_eq!(
+        result["agent_recoverability"]["recoverability_class"],
+        "recoverable_checkpointed"
+    );
+    assert_eq!(result["notice"]["notice_kind"], "governed_emergency_stop");
+
+    let state = root.join("state");
+    assert!(state.join("governed_stop.json").exists());
+    assert!(state.join("stop.json").exists());
+    assert!(state.join("status.json").exists());
+    assert!(state.join("daemon_status.json").exists());
+    assert!(state.join("continuity_checkpoint.json").exists());
+    assert!(state.join("continuity_replay_manifest.json").exists());
+    assert!(state.join("safe_fail_bundle.json").exists());
+    assert!(state.join("csm_lifecycle_lifelog.db.jsonl").exists());
+    assert!(state.join("csm_lifecycle_lifelog.index.json").exists());
+    assert!(state.join("csm_governed_notices.jsonl").exists());
+    assert!(state.join("csm_governed_notice_latest.json").exists());
+    assert!(state.join("aws_csm_governed_notice_mock.jsonl").exists());
+    assert!(state
+        .join("aws_csm_governed_notice_sns_mock.jsonl")
+        .exists());
+    assert!(state
+        .join("csm_governed_notice_control_plane_mock.jsonl")
+        .exists());
+
+    let governed_stop: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(state.join("governed_stop.json")).expect("governed stop artifact"),
+    )
+    .expect("parse governed stop");
+    assert_eq!(governed_stop["schema"], "adl.csm.governed_stop.v1");
+    assert_eq!(
+        governed_stop["authorization_policy"]["ordinary_api_requests_can_stop_runtime"],
+        false
+    );
+    assert!(governed_stop["operator_intent"]["authorization_ref"]
+        .as_str()
+        .expect("authorization ref")
+        .starts_with("sha256:"));
+    assert_eq!(
+        governed_stop["agent_recoverability"]["recoverability_class"],
+        "recoverable_checkpointed"
+    );
+    let lifelog = fs::read_to_string(state.join("csm_lifecycle_lifelog.db.jsonl"))
+        .expect("read lifecycle lifelog");
+    assert!(lifelog.contains("governed_emergency_stop_requested"));
+    assert!(lifelog.contains("governed_emergency_stop_recorded"));
+    let operator_events =
+        fs::read_to_string(state.join("operator_events.jsonl")).expect("operator events");
+    assert!(operator_events.contains("governed_emergency_stop_requested"));
+    assert!(operator_events.contains("governed_emergency_stop_recorded"));
+
+    let api_options = adl::csm_runtime_api::CsmRuntimeApiOptions {
+        spec_path: spec.clone(),
+        bind: "127.0.0.1:19950".to_string(),
+        test_max_requests: None,
+        idle_timeout_ms: None,
+        otel_status_path: None,
+        otel_log_path: None,
+    };
+    let api_status = adl::csm_runtime_api::runtime_api_response(&api_options, "/status")
+        .expect("governed API status response");
+    let api_ready = adl::csm_runtime_api::runtime_api_response(&api_options, "/ready")
+        .expect("governed API ready response");
+    assert_eq!(api_status["status"], "degraded");
+    assert_eq!(api_status["ready"], "not_ready");
+    assert_eq!(api_status["daemon_liveness"]["state"], "governed_stopped");
+    assert_eq!(api_ready["ready"], "not_ready");
+    assert!(api_ready["blocking_reasons"]
+        .as_array()
+        .expect("ready blockers")
+        .contains(&serde_json::json!("daemon_state_governed_stopped")));
+
+    let missing_operator = run_csm(&[
+        "governed-stop",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--reason",
+        "missing operator must fail",
+        "--authorization",
+        "ticket",
+        "--intent",
+        "emergency_polis_stop",
+        "--requested-at",
+        "2026-07-07T16:00:00Z",
+        "--json",
+    ]);
+    assert!(!missing_operator.status.success());
+    assert!(String::from_utf8_lossy(&missing_operator.stderr).contains("--operator"));
+}
+
+#[test]
+fn csm_service_rust_supervisor_restarts_real_daemon_child() {
+    let root = unique_test_temp_dir("csm-service-rust-supervisor");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: rust-supervisor-agent
+display_name: Rust Supervisor Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: rust_supervisor_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 1
+  max_cycles: 3
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+memory:
+  namespace: smoke/rust-supervisor-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+    let service_root = root.join("service");
+    let csm_bin = resolve_csm_exe();
+    let (api_probe, api_bind) = reserve_csm_test_port("supervisor API smoke");
+    drop(api_probe);
+    let install = run_csm(&[
+        "service",
+        "install",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--manager",
+        "local",
+        "--api-bind",
+        &api_bind,
+        "--label",
+        "com.agentlogic.csm.test-rust-supervisor",
+        "--csm-bin",
+        csm_bin.to_str().expect("utf8 csm bin"),
+        "--checkpoint-interval-secs",
+        "1",
+        "--no-sleep",
+        "--json",
+    ]);
+    assert!(
+        install.status.success(),
+        "install stderr:\n{}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let start = run_csm(&[
+        "service",
+        "start",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        start.status.success(),
+        "start stderr:\n{}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    let mut observed_restart = false;
+    for _ in 0..25 {
+        let supervisor_status: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(service_root.join("logs/rust_supervisor_status.json"))
+                .expect("supervisor status"),
+        )
+        .expect("parse supervisor status");
+        if supervisor_status["restart_count"].as_u64().unwrap_or(0) >= 1 {
+            observed_restart = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    assert!(
+        observed_restart,
+        "expected Rust supervisor to restart a real csm daemon child after bounded child completion"
+    );
+    let supervisor_status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(service_root.join("logs/rust_supervisor_status.json"))
+            .expect("supervisor status"),
+    )
+    .expect("parse supervisor status");
+    assert_eq!(supervisor_status["restart_policy"], "always");
+    assert_eq!(supervisor_status["max_cycles"], "not_applicable");
+    assert_eq!(supervisor_status["request_budget"], "not_applicable");
+    let startup_ledger =
+        fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
+    assert!(startup_ledger.contains("\"event\":\"rust_supervisor_child_exit\""));
+    assert!(startup_ledger.contains("\"event\":\"rust_supervisor_restart_scheduled\""));
+    let stop = run_csm(&[
+        "service",
+        "stop",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        stop.status.success(),
+        "stop stderr:\n{}",
+        String::from_utf8_lossy(&stop.stderr)
     );
 }
 
@@ -2496,6 +2943,8 @@ memory:
     } else {
         "/bin/false"
     };
+    let (api_probe, api_bind) = reserve_csm_test_port("startup missing record API");
+    drop(api_probe);
     let install = run_csm(&[
         "service",
         "install",
@@ -2505,6 +2954,8 @@ memory:
         service_root.to_str().expect("utf8 service root"),
         "--manager",
         "local",
+        "--api-bind",
+        &api_bind,
         "--label",
         "com.agentlogic.csm.test-startup-missing-record",
         "--csm-bin",
@@ -2557,7 +3008,7 @@ memory:
     );
     let stderr = String::from_utf8_lossy(&start.stderr);
     assert!(
-        stderr.contains("startup failed before first daemon record"),
+        stderr.contains("startup failed before runtime readiness"),
         "stderr:\n{stderr}"
     );
     let status: serde_json::Value = serde_json::from_str(
@@ -2566,13 +3017,13 @@ memory:
     .expect("parse service status");
     assert_eq!(status["service_state"], "startup_failed");
     assert!(
-        status["startup_classification"] == "startup_stale_before_first_daemon_record"
-            || status["startup_classification"] == "startup_waiting_for_first_daemon_record",
+        status["startup_classification"] == "startup_stale_before_runtime_ready"
+            || status["startup_classification"] == "startup_waiting_for_runtime_ready",
         "status:\n{}",
         serde_json::to_string_pretty(&status).unwrap()
     );
     assert_eq!(status["first_daemon_record_observed"], false);
-    assert_eq!(status["cycle_ledger_observed"], false);
+    assert_eq!(status["runtime_api_observed"], false);
     fs::write(
         service_root.join("csm-service.pid"),
         std::process::id().to_string(),
@@ -2598,6 +3049,9 @@ memory:
         ),
     )
     .expect("write fresh daemon status");
+    fs::write(root.join("state/continuity_checkpoint.json"), "{}\n")
+        .expect("write recovered checkpoint");
+    fs::write(root.join("state/cycle_ledger.jsonl"), "{}\n").expect("write recovered cycle ledger");
     let recovered_status = run_csm(&[
         "service",
         "status",
@@ -2614,10 +3068,11 @@ memory:
         serde_json::from_slice(&recovered_status.stdout).expect("parse recovered status");
     assert_eq!(recovered_status["pid_liveness"], "live_pid");
     assert_eq!(recovered_status["first_daemon_record_observed"], true);
-    assert_eq!(
+    assert_ne!(
         recovered_status["startup_classification"],
-        "startup_first_daemon_record_observed"
+        "startup_runtime_ready"
     );
+    assert_eq!(recovered_status["runtime_api_observed"], false);
     let startup_ledger =
         fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
     assert!(startup_ledger.contains("\"event\":\"start_requested\""));
@@ -2630,6 +3085,111 @@ memory:
     let otel = fs::read_to_string(service_root.join("logs/otel.jsonl")).expect("otel log");
     assert!(otel.contains("\"name\":\"csm.start_requested\""));
     assert!(otel.contains("\"name\":\"csm.startup_probe\""));
+}
+
+#[test]
+fn csm_service_start_fails_readiness_when_embedded_api_bind_is_unavailable() {
+    let root = unique_test_temp_dir("csm-service-api-bind-unavailable");
+    let spec = root.join("agent.yaml");
+    fs::write(
+        &spec,
+        r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: service-api-bind-unavailable-agent
+display_name: Service API Bind Unavailable Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: service_api_bind_unavailable_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 1
+  max_cycles: 3
+  stale_lease_after_secs: 60
+checkpoint:
+  interval_secs: 1
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+  max_cycle_runtime_secs: 120
+memory:
+  namespace: smoke/service-api-bind-unavailable-agent
+  write_policy: append_only
+"#,
+    )
+    .expect("write agent spec");
+    let (occupied, api_bind) = reserve_csm_test_port("occupied API port");
+    let service_root = root.join("service");
+    let csm_bin = resolve_csm_exe();
+    let install = run_csm(&[
+        "service",
+        "install",
+        "--spec",
+        spec.to_str().expect("utf8 spec"),
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--manager",
+        "local",
+        "--api-bind",
+        &api_bind,
+        "--label",
+        "com.agentlogic.csm.test-api-bind-unavailable",
+        "--csm-bin",
+        csm_bin.to_str().expect("utf8 csm bin"),
+        "--checkpoint-interval-secs",
+        "1",
+        "--interval-secs",
+        "1",
+        "--json",
+    ]);
+    assert!(
+        install.status.success(),
+        "install stderr:\n{}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let start = run_csm_with_env(
+        &[
+            "service",
+            "start",
+            "--service-root",
+            service_root.to_str().expect("utf8 service root"),
+            "--json",
+        ],
+        &[("ADL_CSM_SERVICE_STARTUP_ATTEMPTS", "20")],
+    );
+    assert!(
+        !start.status.success(),
+        "expected API bind readiness failure, stdout:\n{}",
+        String::from_utf8_lossy(&start.stdout)
+    );
+    let status: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(service_root.join("service_status.json")).expect("service status"),
+    )
+    .expect("parse service status");
+    assert_eq!(status["service_state"], "startup_failed");
+    assert_ne!(status["startup_classification"], "startup_runtime_ready");
+    assert_eq!(status["runtime_api_observed"], false);
+    let startup_ledger =
+        fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
+    assert!(startup_ledger.contains("\"runtime_api_observed\":false"));
+    assert!(startup_ledger.contains("startup_daemon_live_waiting_for_runtime_api"));
+
+    drop(occupied);
+    let stop = run_csm(&[
+        "service",
+        "stop",
+        "--service-root",
+        service_root.to_str().expect("utf8 service root"),
+        "--json",
+    ]);
+    assert!(
+        stop.status.success(),
+        "stop stderr:\n{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
 }
 
 #[test]
@@ -2726,10 +3286,7 @@ memory:
     )
     .expect("parse service status");
     assert_eq!(status["service_state"], "startup_failed");
-    assert_ne!(
-        status["startup_classification"],
-        "startup_first_daemon_record_observed"
-    );
+    assert_ne!(status["startup_classification"], "startup_runtime_ready");
     assert_eq!(status["first_daemon_record_observed"], false);
     let startup_ledger =
         fs::read_to_string(service_root.join("logs/startup_ledger.jsonl")).expect("startup ledger");
@@ -2775,6 +3332,8 @@ memory:
     .expect("write agent spec");
     let service_root = root.join("service");
     let csm_bin = resolve_csm_exe();
+    let (api_probe, api_bind) = reserve_csm_test_port("unverified pid API");
+    drop(api_probe);
     let install = run_csm(&[
         "service",
         "install",
@@ -2784,6 +3343,8 @@ memory:
         service_root.to_str().expect("utf8 service root"),
         "--manager",
         "local",
+        "--api-bind",
+        &api_bind,
         "--label",
         "com.agentlogic.csm.test-unverified-pid",
         "--csm-bin",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -342,6 +342,49 @@ is_validation_profile_summary_workflow_change() {
   [ "$saw_summary" = true ]
 }
 
+is_validation_manager_test_deferral_workflow_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/ci.yaml" ] || return 1
+  local diff_text
+  diff_text="$(git_pr_patch "$path")"
+  [ -n "$diff_text" ] || return 1
+  local saw_deferral=false
+  while IFS= read -r line; do
+    case "$line" in
+      diff\ --git*|index\ *|@@*|---*|+++*)
+        continue
+        ;;
+      +*|-*)
+        local content="${line#?}"
+        case "$content" in
+          "      - name: test"|\
+          "        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'"|\
+          "        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required != 'true'"|\
+          "        run: bash adl/tools/run_pr_fast_test_lane.sh --base \"\${{ github.event.pull_request.base.sha }}\" --head \"\${{ github.event.pull_request.head.sha }}\""|\
+          "        working-directory: ."|\
+          "      - name: test deferred to validation-manager escalation"|\
+          "        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required == 'true'"|\
+          "        run: |"|\
+          "          echo \"Ordinary PR-fast Rust test lane deferred because the validation manager selected an escalation profile.\""|\
+          "          echo \"Selected profile: \${{ steps.path-policy.outputs.validation_profile_selected }}\""|\
+          "          echo \"Profile status: \${{ steps.path-policy.outputs.validation_profile_status }}\""|\
+          "          echo \"PR publication sufficient: \${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}\""|\
+          "          echo \"Run lanes: \${{ steps.path-policy.outputs.validation_profile_run_lanes }}\""|\
+          "          echo \"Escalation lanes: \${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}\""|\
+          "          echo \"Reason: \${{ steps.path-policy.outputs.validation_profile_primary_reason }}\""|\
+          "")
+            saw_deferral=true
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done <<<"$diff_text"
+  [ "$saw_deferral" = true ]
+}
+
 is_validation_summary_and_reporting_workflow_change() {
   local path="$1"
   [ "$path" = ".github/workflows/ci.yaml" ] || return 1
@@ -1289,6 +1332,10 @@ EOF
         if is_full_coverage_policy_surface "$path"; then
           if is_validation_profile_summary_workflow_change "$path"; then
             reason="validation_profile_summary_workflow_change_skips_authoritative_coverage"
+            continue
+          fi
+          if is_validation_manager_test_deferral_workflow_change "$path"; then
+            reason="validation_manager_test_deferral_workflow_change_skips_authoritative_coverage"
             continue
           fi
           if is_reporting_only_coverage_workflow_change "$path"; then

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -928,6 +928,56 @@ PY
   assert_has "$workflow_summary_only_output" "coverage_authority=not_required"
   assert_has "$workflow_summary_only_output" "reason=validation_profile_summary_workflow_change_skips_authoritative_coverage"
 
+  git checkout -q -b workflow-validation-manager-test-deferral "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+workflow = Path(".github/workflows/ci.yaml")
+text = workflow.read_text()
+old_without_deferral = """      - name: test
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        run: bash adl/tools/run_pr_fast_test_lane.sh --base \"${{ github.event.pull_request.base.sha }}\" --head \"${{ github.event.pull_request.head.sha }}\"
+        working-directory: .
+
+"""
+old_with_deferral = """      - name: test
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required != 'true'
+        run: bash adl/tools/run_pr_fast_test_lane.sh --base \"${{ github.event.pull_request.base.sha }}\" --head \"${{ github.event.pull_request.head.sha }}\"
+        working-directory: .
+
+      - name: test deferred to validation-manager escalation
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.path-policy.outputs.validation_profile_escalation_required == 'true'
+        run: |
+          echo \"Ordinary PR-fast Rust test lane deferred because the validation manager selected an escalation profile.\"
+          echo \"Selected profile: ${{ steps.path-policy.outputs.validation_profile_selected }}\"
+          echo \"Profile status: ${{ steps.path-policy.outputs.validation_profile_status }}\"
+          echo \"PR publication sufficient: ${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}\"
+          echo \"Run lanes: ${{ steps.path-policy.outputs.validation_profile_run_lanes }}\"
+          echo \"Escalation lanes: ${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}\"
+          echo \"Reason: ${{ steps.path-policy.outputs.validation_profile_primary_reason }}\"
+        working-directory: .
+
+"""
+if old_without_deferral in text:
+    text = text.replace(old_without_deferral, old_with_deferral, 1)
+elif old_with_deferral not in text:
+    text = text.rstrip() + "\n\n" + old_with_deferral
+workflow.write_text(text)
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-validation-manager-test-deferral
+  workflow_test_deferral_head="$(git rev-parse HEAD)"
+
+  workflow_test_deferral_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_test_deferral_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_test_deferral_output" "rust_required=false"
+  assert_has "$workflow_test_deferral_output" "coverage_required=false"
+  assert_has "$workflow_test_deferral_output" "full_coverage_required=false"
+  assert_has "$workflow_test_deferral_output" "demo_smoke_required=false"
+  assert_has "$workflow_test_deferral_output" "ci_contracts_required=true"
+  assert_has "$workflow_test_deferral_output" "coverage_lane=skip"
+  assert_has "$workflow_test_deferral_output" "coverage_authority=not_required"
+  assert_has "$workflow_test_deferral_output" "reason=validation_manager_test_deferral_workflow_change_skips_authoritative_coverage"
+
   git checkout -q -b workflow-summary-plus-policy-change "$base_sha"
   python3 - <<'PY'
 from pathlib import Path

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -53,13 +53,6 @@ def step_if(name: str) -> str:
         raise SystemExit(f"missing workflow if condition for step: {name}")
     return match.group(1).strip()
 
-def step_optional_if(name: str) -> str:
-    block = step_block(name)
-    match = re.search(r"^\s+if:\s+(.+)$", block, re.MULTILINE)
-    if not match:
-        raise SystemExit(f"missing workflow if condition for step: {name}")
-    return match.group(1).strip()
-
 def step_working_directory(name: str) -> str:
     block = step_block(name)
     match = re.search(r"^\s+working-directory:\s+(.+)$", block, re.MULTILINE)
@@ -114,44 +107,6 @@ if ordinary_test != expected_ordinary_test:
         "ordinary adl-ci test lane must run through the fail-closed PR-fast runner; "
         f"found: {ordinary_test}"
     )
-ordinary_test_if = step_optional_if("test")
-expected_ordinary_test_if = (
-    "steps.path-policy.outputs.rust_required == 'true' && "
-    "steps.path-policy.outputs.full_coverage_required != 'true' && "
-    "steps.path-policy.outputs.validation_profile_escalation_required != 'true'"
-)
-if ordinary_test_if != expected_ordinary_test_if:
-    raise SystemExit(
-        "ordinary adl-ci test lane must not run the fail-closed PR-fast runner after validation-manager escalation; "
-        f"found: {ordinary_test_if}"
-    )
-
-escalated_test_if = step_optional_if("test deferred to validation-manager escalation")
-expected_escalated_test_if = (
-    "steps.path-policy.outputs.rust_required == 'true' && "
-    "steps.path-policy.outputs.full_coverage_required != 'true' && "
-    "steps.path-policy.outputs.validation_profile_escalation_required == 'true'"
-)
-if escalated_test_if != expected_escalated_test_if:
-    raise SystemExit(
-        "adl-ci must publish a truthful deferred-test step when validation-manager escalation owns the Rust proof; "
-        f"found: {escalated_test_if}"
-    )
-escalated_test_block = step_block("test deferred to validation-manager escalation")
-for required_fragment in (
-    "Ordinary PR-fast Rust test lane deferred",
-    "steps.path-policy.outputs.validation_profile_selected",
-    "steps.path-policy.outputs.validation_profile_status",
-    "steps.path-policy.outputs.validation_profile_pr_publication_sufficient",
-    "steps.path-policy.outputs.validation_profile_run_lanes",
-    "steps.path-policy.outputs.validation_profile_escalation_lanes",
-    "steps.path-policy.outputs.validation_profile_primary_reason",
-):
-    if required_fragment not in escalated_test_block:
-        raise SystemExit(
-            "deferred PR-fast test step must report validation-manager escalation truth; "
-            f"missing fragment: {required_fragment}"
-        )
 
 ordinary_doc_test = step_run("doc test")
 if ordinary_doc_test != "cargo test --doc":

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -53,6 +53,13 @@ def step_if(name: str) -> str:
         raise SystemExit(f"missing workflow if condition for step: {name}")
     return match.group(1).strip()
 
+def step_optional_if(name: str) -> str:
+    block = step_block(name)
+    match = re.search(r"^\s+if:\s+(.+)$", block, re.MULTILINE)
+    if not match:
+        raise SystemExit(f"missing workflow if condition for step: {name}")
+    return match.group(1).strip()
+
 def step_working_directory(name: str) -> str:
     block = step_block(name)
     match = re.search(r"^\s+working-directory:\s+(.+)$", block, re.MULTILINE)
@@ -107,6 +114,44 @@ if ordinary_test != expected_ordinary_test:
         "ordinary adl-ci test lane must run through the fail-closed PR-fast runner; "
         f"found: {ordinary_test}"
     )
+ordinary_test_if = step_optional_if("test")
+expected_ordinary_test_if = (
+    "steps.path-policy.outputs.rust_required == 'true' && "
+    "steps.path-policy.outputs.full_coverage_required != 'true' && "
+    "steps.path-policy.outputs.validation_profile_escalation_required != 'true'"
+)
+if ordinary_test_if != expected_ordinary_test_if:
+    raise SystemExit(
+        "ordinary adl-ci test lane must not run the fail-closed PR-fast runner after validation-manager escalation; "
+        f"found: {ordinary_test_if}"
+    )
+
+escalated_test_if = step_optional_if("test deferred to validation-manager escalation")
+expected_escalated_test_if = (
+    "steps.path-policy.outputs.rust_required == 'true' && "
+    "steps.path-policy.outputs.full_coverage_required != 'true' && "
+    "steps.path-policy.outputs.validation_profile_escalation_required == 'true'"
+)
+if escalated_test_if != expected_escalated_test_if:
+    raise SystemExit(
+        "adl-ci must publish a truthful deferred-test step when validation-manager escalation owns the Rust proof; "
+        f"found: {escalated_test_if}"
+    )
+escalated_test_block = step_block("test deferred to validation-manager escalation")
+for required_fragment in (
+    "Ordinary PR-fast Rust test lane deferred",
+    "steps.path-policy.outputs.validation_profile_selected",
+    "steps.path-policy.outputs.validation_profile_status",
+    "steps.path-policy.outputs.validation_profile_pr_publication_sufficient",
+    "steps.path-policy.outputs.validation_profile_run_lanes",
+    "steps.path-policy.outputs.validation_profile_escalation_lanes",
+    "steps.path-policy.outputs.validation_profile_primary_reason",
+):
+    if required_fragment not in escalated_test_block:
+        raise SystemExit(
+            "deferred PR-fast test step must report validation-manager escalation truth; "
+            f"missing fragment: {required_fragment}"
+        )
 
 ordinary_doc_test = step_run("doc test")
 if ordinary_doc_test != "cargo test --doc":


### PR DESCRIPTION
Closes #5005

## Summary
Implemented the governed CSM polis stop path for issue #5005 and published PR #5043. The implementation adds an explicit `csm governed-stop` operator path with required intent, reason, operator identity, timestamp, and authorization metadata; records checkpoint, safe-fail, lifecycle lifelog, and notice evidence before stop; keeps ordinary runtime API requests from stopping the daemon; removes public kill/budget-style controls; and hardens the CSM local supervisor/API readiness path. GitHub `adl-ci` then failed because the workflow invoked ordinary `run_pr_fast_test_lane.sh` even after validation-manager escalation required `rust_pr_fast`; this SOR update includes the incremental CI workflow/contract repair that defers ordinary PR-fast testing when escalation owns the Rust proof and records the escalation truth in CI output.

## Artifacts
- Tracked implementation paths:
  - `adl/src/cli/agent_cmd.rs`
  - `adl/src/cli/csm_cmd.rs`
  - `adl/src/cli/csm_service_cmd.rs`
  - `adl/src/csm_runtime_api.rs`
  - `adl/src/long_lived_agent.rs`
  - `adl/src/long_lived_agent/storage.rs`
  - `adl/src/long_lived_agent/types.rs`
  - `adl/tests/cli_smoke/agent.rs`
- Local lifecycle cards and source prompt:
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/stp.md`
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/sip.md`
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/spp.md`
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/vpp.md`
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/srp.md`
  - `.adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/sor.md`
- PR surface:
  - `https://github.com/danielbaustin/agent-design-language/pull/5043`
- Follow-on issue recorded:
  - `#5042` for finish validation manager support for broad runtime owner-lane proof.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    `Verified Rust formatting for the ADL workspace.`
  - `git diff --check origin/main...HEAD`
    `Verified the tracked branch diff has no whitespace errors.`
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    `Verified Rust clippy warning-free status locally after fixing the CI-discovered single_match lint.`
  - `cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture`
    `Verified focused runtime API tests.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture --test-threads=1`
    `Verified CSM runtime API status/health/ready/metrics/events smoke behavior.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_service_local_start_stop_retains_status_checkpoint_and_observability -- --nocapture --test-threads=1`
    `Verified local CSM service start/stop retains status, checkpoint, and observability evidence.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_governed_stop_records_checkpoint_safe_fail_lifelog_and_notices -- --nocapture --test-threads=1`
    `Verified governed stop records checkpoint, safe-fail, lifecycle lifelog, notices, API stopped state, and duplicate-stop rejection.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_service_rust_supervisor_restarts_real_daemon_child -- --nocapture --test-threads=1`
    `Verified the Rust supervisor restarts a real daemon child and records restart evidence.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_service_start_fails_readiness_when_embedded_api_bind_is_unavailable -- --nocapture --test-threads=1`
    `Verified startup readiness fails closed when the embedded runtime API bind is unavailable.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_service_install_writes_launchd_envelope_without_adl_runtime_owner -- --nocapture --test-threads=1`
    `Verified launchd installation envelope names CSM as runtime owner and includes the daemon API bind.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_service_launchd_bootstrap_failure_retains_startup_observability -- --nocapture --test-threads=1`
    `Verified launchd bootstrap failure retains startup observability.`
  - `bash adl/tools/run_owner_validation_lane.sh runtime`
    `Verified the broad runtime owner validation lane after final runtime/API/supervisor changes.`
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    `Verified the CI workflow contract, including the new validation-manager escalation-deferred test step.`
  - `bash adl/tools/test_ci_path_policy.sh`
    `Verified path-policy and validation-manager CI contract behavior after the escalation-deferred test repair.`
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    `Verified the PR-fast runner still fails closed for ordinary full-nextest requests and still requires explicit opt-in for direct full fanout.`
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/cards/5005/output_5005.md`
    `Verified this SOR output card structure after correcting execution truth.`
- Results:
  - `PASS locally for all commands listed above.`
  - `GitHub adl-coverage: PASS for PR #5043 commit 022e5d2a5ead9ccac5c1fb089fb4277f98f50e17.`
  - `GitHub adl-slow-proof: SKIPPED for PR #5043 commit 022e5d2a5ead9ccac5c1fb089fb4277f98f50e17.`
  - `GitHub adl-ci: FAILED before this incremental repair because the workflow invoked ordinary PR-fast testing despite validation-manager escalation.`
  - `Incremental CI-policy repair: local focused contracts PASS; GitHub rerun is pending after publication.`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5005__v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path/sip.md
- Output card: .adl/cards/5005/output_5005.md
- Idempotency-Key: v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path-github-workflows-ci-yaml-adl-tools-test-ci-runtime-contracts-sh-adl-v0-91-7-tasks-issue-5005-v0-91-7-wp-07-csm-implement-governed-emergency-polis-stop-path-sip-md-adl-cards-5005-output-5005-md