### PR TITLE
[v0.91.7][provider][bedrock] Implement native AWS Bedrock provider adapter and tests

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
+ "aws-sdk-bedrockruntime",
  "aws-sdk-budgets",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-costexplorer",
@@ -280,6 +281,33 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.126.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a2249b926688f4fb3c687be770aad39d666a7757ebc83da08bab6d2ad59314"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -176,6 +176,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 aws-config = "1"
 aws-sdk-budgets = "1"
+aws-sdk-bedrockruntime = "1"
 aws-sdk-costexplorer = "1"
 aws-sdk-cloudwatchlogs = "1"
 aws-sdk-ec2 = "1"

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -208,6 +208,18 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
             endpoint_hint: None,
             notes: "Use this for the Rust-native OpenRouter provider path. The default endpoint is OpenRouter's chat completions API; override config.endpoint only for tests or a trusted compatible endpoint. OpenRouter capability support is model-dependent, so record model-specific lane evidence rather than assuming gateway-wide tool or JSON support.",
         },
+        "bedrock" | "aws-bedrock" | "aws_bedrock" => &ProviderSetupTemplate {
+            family: "bedrock",
+            profile: None,
+            kind: Some("bedrock"),
+            env_var: "ADL_AWS_PROFILE",
+            provider_id: "bedrock_primary",
+            agent_id: "bedrock_agent",
+            model_ref: "hosted:adl-bedrock:amazon.nova-lite-v1:0",
+            provider_model_id: "amazon.nova-lite-v1:0",
+            endpoint_hint: None,
+            notes: "Use this for the Rust-native AWS Bedrock provider path. ADL AWS work must use the Agent Logic business profile `agent-logic-admin`; set `ADL_AWS_REGION` or `AWS_REGION` when selecting a Bedrock region.",
+        },
         "http" | "generic-http" => &ProviderSetupTemplate {
             family: "http",
             profile: Some("http:gpt-4.1-mini"),
@@ -222,7 +234,7 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
         },
         other => {
             return Err(anyhow!(
-                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, openrouter, http)"
+                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, openrouter, bedrock, http)"
             ))
         }
     };
@@ -239,18 +251,26 @@ fn render_provider_yaml(template: &ProviderSetupTemplate, selected_model: &str) 
         .endpoint_hint
         .map(|endpoint| format!("      endpoint: \"{endpoint}\"\n"))
         .unwrap_or_default();
+    let auth_block = if template.family == "bedrock" {
+        "      profile: \"agent-logic-admin\"\n      region: \"us-west-2\"\n".to_string()
+    } else {
+        format!(
+            "      auth:\n        type: bearer\n        env: {}\n",
+            template.env_var
+        )
+    };
     let headers_line = if template.kind.is_some() {
         String::new()
     } else {
         "      headers:\n        X-Client: \"adl-provider-setup\"\n".to_string()
     };
     format!(
-        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    {provider_identity}\n    config:\n{endpoint_line}      auth:\n        type: bearer\n        env: {env_var}\n{headers_line}      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n# provider_model_id may be changed to any trusted model ID supported by this provider family.\n",
+        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    {provider_identity}\n    config:\n{endpoint_line}{auth_block}{headers_line}      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n# provider_model_id may be changed to any trusted model ID supported by this provider family.\n",
         provider_id = template.provider_id,
         provider_identity = provider_identity,
         endpoint_line = endpoint_line,
         headers_line = headers_line,
-        env_var = template.env_var,
+        auth_block = auth_block,
         model_ref = template.model_ref,
         provider_model_id = selected_model,
         agent_id = template.agent_id,
@@ -258,6 +278,9 @@ fn render_provider_yaml(template: &ProviderSetupTemplate, selected_model: &str) 
 }
 
 fn render_env_example(template: &ProviderSetupTemplate) -> String {
+    if template.family == "bedrock" {
+        return "ADL_AWS_PROFILE=agent-logic-admin\nADL_AWS_REGION=us-west-2\n".to_string();
+    }
     format!(
         "# Copy to a local env file and fill in your real secret.\n# Do not commit the filled-in file.\n{env_var}=replace-me\n",
         env_var = template.env_var
@@ -265,12 +288,16 @@ fn render_env_example(template: &ProviderSetupTemplate) -> String {
 }
 
 fn render_readme(template: &ProviderSetupTemplate, selected_model: &str) -> String {
-    let transport_note = if template.kind.is_some() {
+    let transport_note = if template.family == "bedrock" {
+        "- This family uses ADL's Rust-native AWS Bedrock adapter through the AWS SDK.\n- ADL AWS work must use the Agent Logic business AWS profile `agent-logic-admin`."
+    } else if template.kind.is_some() {
         "- This family uses ADL's Rust-native provider adapter for its vendor API.\n- Leave `config.endpoint` unset for the default vendor endpoint unless you are testing against a trusted compatible endpoint."
     } else {
         "- ADL's bounded HTTP provider expects a completion-style HTTP contract: request body with `{\"prompt\": ...}`, response body with `{\"output\": ...}`.\n- Raw vendor-native endpoints may require a compatibility gateway or adapter if they do not expose that contract directly."
     };
-    let endpoint_step = if template.kind.is_some() {
+    let endpoint_step = if template.family == "bedrock" {
+        "2. Confirm `ADL_AWS_PROFILE=agent-logic-admin` and set `ADL_AWS_REGION` to the Bedrock region you want to use."
+    } else if template.kind.is_some() {
         "2. Leave `config.endpoint` unset unless you are testing against a trusted compatible endpoint."
     } else {
         "2. Set `config.endpoint` in `provider.adl.yaml` to a real ADL-compatible completion endpoint."

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -349,6 +349,29 @@ mod tests {
     use std::env;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    struct TestDirLock {
+        path: PathBuf,
+    }
+
+    impl Drop for TestDirLock {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir(&self.path);
+        }
+    }
+
+    fn acquire_test_dir_lock(path: PathBuf) -> TestDirLock {
+        for _ in 0..500 {
+            match fs::create_dir(&path) {
+                Ok(()) => return TestDirLock { path },
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(err) => panic!("failed to create test lock {}: {err}", path.display()),
+            }
+        }
+        panic!("timed out waiting for test lock {}", path.display());
+    }
+
     fn temp_repo(name: &str) -> PathBuf {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -604,6 +627,10 @@ mod tests {
             .parent()
             .expect("adl crate lives under repo root")
             .to_path_buf();
+        fs::create_dir_all(repo_root.join(".adl/provider-setup"))
+            .expect("create provider setup root");
+        let _dir_guard =
+            acquire_test_dir_lock(repo_root.join(".adl/provider-setup/.deepseek-test.lock"));
         let prev_dir = env::current_dir().expect("cwd");
         env::set_current_dir(&repo_root).expect("switch to repo root");
         let out = repo_root.join(".adl/provider-setup/deepseek");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -138,6 +138,7 @@ Examples:
   adl provider setup chatgpt
   adl provider setup claude
   adl provider setup openrouter
+  adl provider setup bedrock
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic
   adl godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary \"step failed with deterministic parse error\" --evidence-ref runs/run-745-a/run_status.json
   adl godel inspect --run-id run-745-a --runs-dir .adl/runs

--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -2,6 +2,10 @@
 //!
 //! Supports OpenAI, Anthropic, DeepSeek, OpenRouter, generic HTTP, and Ollama-HTTP style backends.
 use super::*;
+use aws_config::{meta::region::RegionProviderChain, BehaviorVersion};
+use aws_sdk_bedrockruntime as bedrockruntime;
+use aws_sdk_sts as sts;
+use sha2::{Digest, Sha256};
 use std::thread;
 use std::time::Duration;
 
@@ -194,6 +198,93 @@ fn write_native_invocation_record(
     })
 }
 
+fn write_bedrock_invocation_record(
+    model: &str,
+    prompt: &str,
+    output: &str,
+    http_status: u16,
+    profile: &str,
+    region: &str,
+    account_id_sha256: Option<&str>,
+) -> Result<()> {
+    let Some(path) = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH") else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            runtime_error(
+                "bedrock",
+                format!("failed to create provider invocation artifact directory: {err}"),
+            )
+        })?;
+    }
+    let _artifact_lock = acquire_invocation_artifact_lock(&path).map_err(|err| {
+        runtime_error(
+            "bedrock",
+            format!("failed to acquire provider invocation artifact lock: {err}"),
+        )
+    })?;
+    let mut payload = if path.is_file() {
+        serde_json::from_slice::<Value>(&fs::read(&path).map_err(|err| {
+            runtime_error(
+                "bedrock",
+                format!("failed to read provider invocation artifact: {err}"),
+            )
+        })?)
+        .map_err(|err| {
+            runtime_error_non_retryable(
+                "bedrock",
+                format!("provider invocation artifact is invalid JSON: {err}"),
+            )
+        })?
+    } else {
+        serde_json::json!({
+            "schema_version": "adl.native_provider_invocations.v1",
+            "credential_policy": "operator_env_or_aws_profile_only_no_secret_material_recorded",
+            "invocations": []
+        })
+    };
+
+    let Some(invocations) = payload
+        .get_mut("invocations")
+        .and_then(|v| v.as_array_mut())
+    else {
+        return Err(runtime_error_non_retryable(
+            "bedrock",
+            "provider invocation artifact missing invocations array",
+        ));
+    };
+    let timestamp_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    invocations.push(serde_json::json!({
+        "family": "bedrock",
+        "model": model,
+        "http_status": http_status,
+        "timestamp_unix_ms": timestamp_unix_ms,
+        "prompt_chars": prompt.chars().count(),
+        "output_chars": output.chars().count(),
+        "aws_profile": profile,
+        "aws_region": region,
+        "account_id_sha256": account_id_sha256,
+        "account_profile_validation_status": "sts_verified"
+    }));
+    let bytes = serde_json::to_vec_pretty(&payload).map_err(|err| {
+        runtime_error_non_retryable(
+            "bedrock",
+            format!("failed to serialize provider invocation artifact: {err}"),
+        )
+    })?;
+    write_file_atomic(&path, &bytes).map_err(|err| {
+        runtime_error(
+            "bedrock",
+            format!("failed to write invocation artifact: {err}"),
+        )
+    })
+}
+
 fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let mut os = path.as_os_str().to_os_string();
     os.push(format!(
@@ -260,6 +351,27 @@ fn extract_deepseek_output_text(json: &Value) -> Option<String> {
 
 fn extract_openrouter_output_text(json: &Value) -> Option<String> {
     extract_deepseek_output_text(json)
+}
+
+fn extract_bedrock_nova_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    if let Some(content) = json
+        .pointer("/output/message/content")
+        .and_then(|v| v.as_array())
+    {
+        for part in content {
+            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                chunks.push(text);
+            }
+        }
+    }
+    if chunks.is_empty() {
+        if let Some(text) = json.get("outputText").and_then(|v| v.as_str()) {
+            chunks.push(text);
+        }
+    }
+    let joined = chunks.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
 }
 
 #[derive(Debug, Clone)]
@@ -554,6 +666,197 @@ impl Provider for OpenRouterProvider {
         write_native_invocation_record("openrouter", &self.model, prompt, &output, http_status)?;
         Ok(output)
     }
+}
+
+const DEFAULT_BEDROCK_PROFILE: &str = "agent-logic-admin";
+const DEFAULT_BEDROCK_REGION: &str = "us-west-2";
+
+#[derive(Debug, Clone)]
+/// AWS Bedrock native provider using Bedrock Runtime InvokeModel.
+pub struct AwsBedrockProvider {
+    model: String,
+    region: String,
+    profile: String,
+    max_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl AwsBedrockProvider {
+    /// Build an AWS Bedrock provider from normalized invocation target.
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        let region = cfg_string(&spec.config, "region")
+            .or_else(|| env::var("AWS_REGION").ok())
+            .or_else(|| env::var("AWS_DEFAULT_REGION").ok())
+            .unwrap_or_else(|| DEFAULT_BEDROCK_REGION.to_string());
+        let profile = cfg_string(&spec.config, "profile")
+            .or_else(|| env::var("ADL_AWS_PROFILE").ok())
+            .or_else(|| env::var("AWS_PROFILE").ok())
+            .unwrap_or_else(|| DEFAULT_BEDROCK_PROFILE.to_string());
+        if profile != DEFAULT_BEDROCK_PROFILE {
+            return Err(invalid_config(
+                "bedrock",
+                format!(
+                    "AWS Bedrock provider requires Agent Logic AWS profile '{DEFAULT_BEDROCK_PROFILE}' (got '{profile}')"
+                ),
+            ));
+        }
+        Ok(Self {
+            model: target.provider_model_id.clone(),
+            region,
+            profile,
+            max_tokens: cfg_u64(&spec.config, "max_tokens")
+                .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
+                .unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+
+    async fn complete_async(&self, prompt: &str) -> Result<String> {
+        let region_provider =
+            RegionProviderChain::first_try(Some(aws_config::Region::new(self.region.clone())));
+        let mut timeout_config = aws_config::timeout::TimeoutConfig::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .operation_timeout(Duration::from_secs(self.timeout_secs.unwrap_or(45)));
+        if let Some(secs) = self.timeout_secs {
+            timeout_config = timeout_config.operation_attempt_timeout(Duration::from_secs(secs));
+        }
+        let shared_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region_provider)
+            .profile_name(&self.profile)
+            .timeout_config(timeout_config.build())
+            .load()
+            .await;
+        let identity = sts::Client::new(&shared_config)
+            .get_caller_identity()
+            .send()
+            .await
+            .map_err(|err| bedrock_sdk_error(format!("{err:?}")))?;
+        let account_id_sha256 = identity.account().map(sha256_hex);
+        let body = bedrock_nova_request_body(prompt, self.max_tokens);
+        let response = bedrockruntime::Client::new(&shared_config)
+            .invoke_model()
+            .model_id(&self.model)
+            .content_type("application/json")
+            .accept("application/json")
+            .body(bedrockruntime::primitives::Blob::new(
+                serde_json::to_vec(&body).map_err(|err| {
+                    runtime_error_non_retryable(
+                        "bedrock",
+                        format!("failed to serialize Bedrock request: {err}"),
+                    )
+                })?,
+            ))
+            .send()
+            .await
+            .map_err(|err| bedrock_sdk_error(format!("{err:?}")))?;
+        let json: Value = serde_json::from_slice(response.body().as_ref()).map_err(|err| {
+            runtime_error_non_retryable("bedrock", format!("invalid Bedrock JSON: {err}"))
+        })?;
+        let output = extract_bedrock_nova_output_text(&json).ok_or_else(|| {
+            runtime_error_non_retryable("bedrock", "response missing Bedrock output text")
+        })?;
+        write_bedrock_invocation_record(
+            &self.model,
+            prompt,
+            &output,
+            200,
+            &self.profile,
+            &self.region,
+            account_id_sha256.as_deref(),
+        )?;
+        Ok(output)
+    }
+}
+
+impl Provider for AwsBedrockProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| runtime_error("bedrock", format!("failed to build runtime: {err}")))?
+            .block_on(self.complete_async(prompt))
+    }
+}
+
+fn cfg_string(cfg: &HashMap<String, Value>, key: &str) -> Option<String> {
+    cfg.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
+}
+
+fn bedrock_nova_request_body(prompt: &str, max_tokens: u64) -> Value {
+    serde_json::json!({
+        "schemaVersion": "messages-v1",
+        "messages": [{
+            "role": "user",
+            "content": [{"text": prompt}],
+        }],
+        "inferenceConfig": {
+            "maxTokens": max_tokens,
+        },
+    })
+}
+
+fn bedrock_sdk_error(message: String) -> anyhow::Error {
+    let sanitized = sanitize_bedrock_error(&message);
+    let retryable = sanitized.contains("Throttling")
+        || sanitized.contains("TooManyRequests")
+        || sanitized.contains("timeout")
+        || sanitized.contains("Timeout")
+        || sanitized.contains("ServiceUnavailable")
+        || sanitized.contains("InternalServer");
+    if retryable {
+        runtime_error("bedrock", sanitized)
+    } else {
+        runtime_error_non_retryable("bedrock", sanitized)
+    }
+}
+
+fn sanitize_bedrock_error(message: &str) -> String {
+    let mut out = message.replace('\n', " ");
+    for marker in [
+        "Authorization: ",
+        "Authorization=",
+        "Credential=",
+        "X-Amz-Signature=",
+        "SecretAccessKey=",
+    ] {
+        out = redact_aws_error_value(&out, marker);
+    }
+    truncate_provider_body(&out)
+}
+
+fn redact_aws_error_value(input: &str, marker: &str) -> String {
+    let mut redacted = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while let Some(relative_start) = input[cursor..].find(marker) {
+        let marker_start = cursor + relative_start;
+        let value_start = marker_start + marker.len();
+        redacted.push_str(&input[cursor..value_start]);
+        redacted.push_str("<redacted>");
+
+        let value_end = input[value_start..]
+            .char_indices()
+            .find_map(|(idx, ch)| {
+                matches!(ch, ' ' | ',' | '&' | ';' | '"' | '\'' | ')' | '}' | ']')
+                    .then_some(value_start + idx)
+            })
+            .unwrap_or(input.len());
+        cursor = value_end;
+    }
+    redacted.push_str(&input[cursor..]);
+    redacted
+}
+
+fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 #[derive(Debug, Clone)]

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -7,6 +7,7 @@ use crate::provider_substrate::{
 use serde_json::json;
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
@@ -207,6 +208,187 @@ fn bedrock_error_sanitizer_removes_signed_aws_values() {
     assert!(!sanitized.contains("AWS4-HMAC-SHA256"));
     assert!(!sanitized.contains("AKIAIOSFODNN7EXAMPLE"));
     assert!(!sanitized.contains("abc123def456"));
+}
+
+#[test]
+fn bedrock_invocation_artifact_records_profile_region_and_account_hash() {
+    let _guard = env_lock();
+    let artifact = std::env::temp_dir().join(format!(
+        "adl-bedrock-provider-invocations-{}-{}.json",
+        std::process::id(),
+        "record"
+    ));
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    let _ = fs::remove_file(&artifact);
+    let _ = fs::remove_dir(invocation_lock_path(&artifact));
+    env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", &artifact);
+
+    write_bedrock_invocation_record(
+        "amazon.nova-lite-v1:0",
+        "hello bedrock",
+        "bedrock ok",
+        200,
+        "agent-logic-admin",
+        "us-west-2",
+        Some("account-hash"),
+    )
+    .expect("first bedrock invocation record should write");
+    write_bedrock_invocation_record(
+        "amazon.nova-pro-v1:0",
+        "second",
+        "ok",
+        202,
+        "agent-logic-admin",
+        "us-east-1",
+        None,
+    )
+    .expect("second bedrock invocation record should append");
+
+    let payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(&artifact).expect("artifact should exist"))
+            .expect("artifact should be json");
+    assert_eq!(
+        payload["credential_policy"],
+        "operator_env_or_aws_profile_only_no_secret_material_recorded"
+    );
+    let invocations = payload["invocations"]
+        .as_array()
+        .expect("invocations array");
+    assert_eq!(invocations.len(), 2);
+    assert_eq!(invocations[0]["family"], "bedrock");
+    assert_eq!(invocations[0]["model"], "amazon.nova-lite-v1:0");
+    assert_eq!(invocations[0]["http_status"], 200);
+    assert_eq!(invocations[0]["aws_profile"], "agent-logic-admin");
+    assert_eq!(invocations[0]["aws_region"], "us-west-2");
+    assert_eq!(invocations[0]["account_id_sha256"], "account-hash");
+    assert_eq!(
+        invocations[0]["account_profile_validation_status"],
+        "sts_verified"
+    );
+    assert_eq!(invocations[1]["account_id_sha256"], serde_json::Value::Null);
+
+    restore_env_var("ADL_PROVIDER_INVOCATIONS_PATH", prev_artifact);
+    fs::remove_file(&artifact).expect("cleanup artifact");
+}
+
+#[test]
+fn bedrock_invocation_artifact_rejects_invalid_existing_payloads() {
+    let _guard = env_lock();
+    let artifact = std::env::temp_dir().join(format!(
+        "adl-bedrock-provider-invocations-{}-{}.json",
+        std::process::id(),
+        "invalid"
+    ));
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    let _ = fs::remove_file(&artifact);
+    let _ = fs::remove_dir(invocation_lock_path(&artifact));
+    env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", &artifact);
+
+    fs::write(&artifact, b"{not-json").expect("write invalid json");
+    let err = write_bedrock_invocation_record(
+        "amazon.nova-lite-v1:0",
+        "prompt",
+        "output",
+        200,
+        "agent-logic-admin",
+        "us-west-2",
+        Some("account-hash"),
+    )
+    .expect_err("invalid existing artifact should fail closed");
+    assert!(err
+        .to_string()
+        .contains("provider invocation artifact is invalid JSON"));
+
+    fs::write(&artifact, br#"{"schema_version":"x"}"#).expect("write missing array");
+    let err = write_bedrock_invocation_record(
+        "amazon.nova-lite-v1:0",
+        "prompt",
+        "output",
+        200,
+        "agent-logic-admin",
+        "us-west-2",
+        None,
+    )
+    .expect_err("missing invocations array should fail closed");
+    assert!(err
+        .to_string()
+        .contains("provider invocation artifact missing invocations array"));
+
+    restore_env_var("ADL_PROVIDER_INVOCATIONS_PATH", prev_artifact);
+    fs::remove_file(&artifact).expect("cleanup artifact");
+}
+
+#[test]
+fn bedrock_constructor_and_helpers_cover_default_safe_paths() {
+    let _guard = env_lock();
+    let prev_profile = env::var_os("ADL_AWS_PROFILE");
+    let prev_aws_profile = env::var_os("AWS_PROFILE");
+    let prev_region = env::var_os("AWS_REGION");
+    let prev_default_region = env::var_os("AWS_DEFAULT_REGION");
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    env::remove_var("ADL_AWS_PROFILE");
+    env::remove_var("AWS_PROFILE");
+    env::remove_var("AWS_REGION");
+    env::remove_var("AWS_DEFAULT_REGION");
+    env::remove_var("ADL_PROVIDER_INVOCATIONS_PATH");
+
+    let spec = adl::ProviderSpec {
+        id: Some("bedrock_primary".to_string()),
+        profile: None,
+        kind: "bedrock".to_string(),
+        base_url: None,
+        default_model: Some("hosted:adl-bedrock:amazon.nova-lite-v1:0".to_string()),
+        config: HashMap::from([
+            (
+                "provider_model_id".to_string(),
+                json!("amazon.nova-lite-v1:0"),
+            ),
+            ("max_output_tokens".to_string(), json!("321")),
+        ]),
+    };
+    let target = provider_target(
+        "bedrock",
+        "aws-bedrock-runtime".to_string(),
+        "amazon.nova-lite-v1:0",
+    );
+    let provider = AwsBedrockProvider::from_target(&spec, &target)
+        .expect("default Agent Logic profile should construct without AWS calls");
+    assert_eq!(provider.model, "amazon.nova-lite-v1:0");
+    assert_eq!(provider.region, DEFAULT_BEDROCK_REGION);
+    assert_eq!(provider.profile, DEFAULT_BEDROCK_PROFILE);
+    assert_eq!(provider.max_tokens, 321);
+    assert_eq!(provider.timeout_secs, None);
+
+    let fallback = extract_bedrock_nova_output_text(&json!({
+        "outputText": " fallback bedrock text "
+    }));
+    assert_eq!(fallback.as_deref(), Some("fallback bedrock text"));
+    assert!(extract_bedrock_nova_output_text(&json!({"output": {}})).is_none());
+
+    let retryable = bedrock_sdk_error("ServiceUnavailable: try later".to_string());
+    assert!(retryable.to_string().contains("ServiceUnavailable"));
+    let non_retryable = bedrock_sdk_error("ValidationException: bad model".to_string());
+    assert!(non_retryable.to_string().contains("ValidationException"));
+    let account_hash = sha256_hex("agent-logic-account");
+    assert_eq!(account_hash.len(), 64);
+    assert!(account_hash.chars().all(|ch| ch.is_ascii_hexdigit()));
+
+    write_bedrock_invocation_record(
+        "amazon.nova-lite-v1:0",
+        "prompt",
+        "output",
+        200,
+        DEFAULT_BEDROCK_PROFILE,
+        DEFAULT_BEDROCK_REGION,
+        None,
+    )
+    .expect("missing artifact path should be a no-op");
+
+    restore_env_var("ADL_AWS_PROFILE", prev_profile);
+    restore_env_var("AWS_PROFILE", prev_aws_profile);
+    restore_env_var("AWS_REGION", prev_region);
+    restore_env_var("AWS_DEFAULT_REGION", prev_default_region);
+    restore_env_var("ADL_PROVIDER_INVOCATIONS_PATH", prev_artifact);
 }
 
 fn provider_spec(

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -149,6 +149,66 @@ fn restore_env_var(key: &str, previous: Option<std::ffi::OsString>) {
     }
 }
 
+#[test]
+fn bedrock_request_and_response_shapes_cover_nova_messages() {
+    let body = bedrock_nova_request_body("hello bedrock", 123);
+    assert_eq!(body["schemaVersion"], "messages-v1");
+    assert!(body.get("model").is_none());
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"][0]["text"], "hello bedrock");
+    assert_eq!(body["inferenceConfig"]["maxTokens"], 123);
+
+    let output = extract_bedrock_nova_output_text(&json!({
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "bedrock ok"}]
+            }
+        }
+    }));
+    assert_eq!(output.as_deref(), Some("bedrock ok"));
+}
+
+#[test]
+fn bedrock_provider_requires_agent_logic_profile_before_live_call() {
+    let spec = adl::ProviderSpec {
+        id: Some("bedrock_primary".to_string()),
+        profile: None,
+        kind: "bedrock".to_string(),
+        base_url: None,
+        default_model: Some("hosted:adl-bedrock:amazon.nova-lite-v1:0".to_string()),
+        config: HashMap::from([
+            (
+                "provider_model_id".to_string(),
+                json!("amazon.nova-lite-v1:0"),
+            ),
+            ("profile".to_string(), json!("default")),
+        ]),
+    };
+    let target = provider_target(
+        "bedrock",
+        "aws-bedrock-runtime".to_string(),
+        "amazon.nova-lite-v1:0",
+    );
+    let err = AwsBedrockProvider::from_target(&spec, &target)
+        .expect_err("wrong profile should fail before AWS calls");
+    assert!(err.to_string().contains("agent-logic-admin"));
+}
+
+#[test]
+fn bedrock_error_sanitizer_removes_signed_aws_values() {
+    let sanitized = sanitize_bedrock_error(
+        "Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260707/us-west-2/bedrock/aws4_request, SignedHeaders=host, X-Amz-Signature=abc123def456",
+    );
+
+    assert!(sanitized.contains("Authorization: <redacted>"));
+    assert!(sanitized.contains("Credential=<redacted>"));
+    assert!(sanitized.contains("X-Amz-Signature=<redacted>"));
+    assert!(!sanitized.contains("AWS4-HMAC-SHA256"));
+    assert!(!sanitized.contains("AKIAIOSFODNN7EXAMPLE"));
+    assert!(!sanitized.contains("abc123def456"));
+}
+
 fn provider_spec(
     kind: &str,
     endpoint: &str,

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -23,7 +23,9 @@ mod http_family;
 mod local;
 mod profiles;
 
-pub use http_family::{AnthropicProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider};
+pub use http_family::{
+    AnthropicProvider, AwsBedrockProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider,
+};
 pub use http_family::{DeepSeekProvider, OpenRouterProvider};
 pub use local::{MockProvider, OllamaProvider};
 pub use profiles::{expand_provider_profiles, provider_profile_names};
@@ -71,8 +73,8 @@ impl ProviderError {
             kind: ProviderErrorKind::UnknownKind,
             provider: None,
             message: format!(
-                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter). \
-Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter. The remote provider surfaces are HTTPS-only."
+                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock). \
+Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock. The remote provider surfaces are HTTPS-only."
             ),
         }
     }
@@ -237,7 +239,7 @@ pub fn build_provider_for_id(
 ) -> Result<Box<dyn Provider>> {
     match spec.kind.trim() {
         "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic"
-        | "deepseek" | "openrouter" => {}
+        | "deepseek" | "openrouter" | "bedrock" | "aws_bedrock" => {}
         other => return Err(unknown_kind(other)),
     }
 
@@ -252,6 +254,9 @@ pub fn build_provider_for_id(
             "anthropic" => Ok(Box::new(AnthropicProvider::from_target(spec, &target)?)),
             "deepseek" => Ok(Box::new(DeepSeekProvider::from_target(spec, &target)?)),
             "openrouter" => Ok(Box::new(OpenRouterProvider::from_target(spec, &target)?)),
+            "bedrock" | "aws_bedrock" => {
+                Ok(Box::new(AwsBedrockProvider::from_target(spec, &target)?))
+            }
             other => Err(unknown_kind(other)),
         },
         provider_substrate::ProviderTransportV1::LocalCli

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -9,6 +9,7 @@ use super::*;
 pub(crate) struct ProviderProfilePreset {
     pub(crate) kind: &'static str,
     pub(crate) default_model: Option<&'static str>,
+    pub(crate) provider_model_id: Option<&'static str>,
     pub(crate) endpoint: Option<&'static str>,
 }
 
@@ -70,6 +71,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ProviderProfilePreset {
             kind: "ollama",
             default_model: Some("phi4-mini"),
+            provider_model_id: None,
             endpoint: None,
         },
     );
@@ -78,6 +80,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ProviderProfilePreset {
             kind: "ollama",
             default_model: Some("qwen2.5:7b"),
+            provider_model_id: None,
             endpoint: None,
         },
     );
@@ -86,6 +89,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ProviderProfilePreset {
             kind: "ollama",
             default_model: Some("llama3.1:8b"),
+            provider_model_id: None,
             endpoint: None,
         },
     );
@@ -94,6 +98,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ProviderProfilePreset {
             kind: "ollama",
             default_model: Some("mistral:7b"),
+            provider_model_id: None,
             endpoint: None,
         },
     );
@@ -103,9 +108,33 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ProviderProfilePreset {
             kind: "mock",
             default_model: Some("echo-v1"),
+            provider_model_id: None,
             endpoint: None,
         },
     );
+    // AWS Bedrock hosted presets.
+    for (name, stable_ref, provider_model_id) in [
+        (
+            "bedrock:nova-lite-v1",
+            "hosted:adl-bedrock:amazon.nova-lite-v1:0",
+            "amazon.nova-lite-v1:0",
+        ),
+        (
+            "bedrock:nova-pro-v1",
+            "hosted:adl-bedrock:amazon.nova-pro-v1:0",
+            "amazon.nova-pro-v1:0",
+        ),
+    ] {
+        m.insert(
+            name,
+            ProviderProfilePreset {
+                kind: "bedrock",
+                default_model: Some(stable_ref),
+                provider_model_id: Some(provider_model_id),
+                endpoint: None,
+            },
+        );
+    }
     // HTTP presets (explicit fixed endpoint placeholders; no secrets)
     for (name, model) in [
         ("http:gpt-4o-mini", "gpt-4o-mini"),
@@ -122,6 +151,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
             ProviderProfilePreset {
                 kind: "http",
                 default_model: Some(model),
+                provider_model_id: None,
                 endpoint: Some(HTTP_PROFILE_PLACEHOLDER_ENDPOINT),
             },
         );
@@ -138,6 +168,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
             ProviderProfilePreset {
                 kind: "http",
                 default_model: Some(model),
+                provider_model_id: None,
                 endpoint: Some(HTTP_PROFILE_PLACEHOLDER_ENDPOINT),
             },
         );
@@ -152,6 +183,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
             ProviderProfilePreset {
                 kind: "http",
                 default_model: Some(model),
+                provider_model_id: None,
                 endpoint: Some(HTTP_PROFILE_PLACEHOLDER_ENDPOINT),
             },
         );
@@ -202,6 +234,11 @@ pub fn expand_provider_profiles(doc: &adl::AdlDoc) -> Result<adl::AdlDoc> {
         };
 
         let mut config = spec.config.clone();
+        if let Some(provider_model_id) = preset.provider_model_id {
+            config
+                .entry("provider_model_id".to_string())
+                .or_insert_with(|| Value::String(provider_model_id.to_string()));
+        }
         if let Some(endpoint) = preset.endpoint {
             match config.get("endpoint").and_then(|v| v.as_str()) {
                 Some(explicit) => validate_profile_endpoint(&provider_id, profile_name, explicit)?,

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -1,10 +1,10 @@
 use crate::provider_communication::{
-    hosted_model_identity, ollama_model_identity, provider_attempt_policy_as_resilience_policy,
-    provider_failure_classification_from_failure, provider_failure_from_classification,
-    provider_failure_from_note, validate_provider_request, ProviderAttemptPolicyV1,
-    ProviderAttemptStatusV1, ProviderAttemptV1, ProviderFailureKindV1, ProviderFailureV1,
-    ProviderInvocationFinalStatusV1, ProviderInvocationRequestV1, ProviderInvocationResultV1,
-    ProviderRunLogEventV1, ProviderRunLoggerV1, RuntimeSurfaceV1,
+    classify_provider_failure, hosted_model_identity, ollama_model_identity,
+    provider_attempt_policy_as_resilience_policy, provider_failure_classification_from_failure,
+    provider_failure_from_classification, provider_failure_from_note, validate_provider_request,
+    ProviderAttemptPolicyV1, ProviderAttemptStatusV1, ProviderAttemptV1, ProviderFailureKindV1,
+    ProviderFailureV1, ProviderInvocationFinalStatusV1, ProviderInvocationRequestV1,
+    ProviderInvocationResultV1, ProviderRunLogEventV1, ProviderRunLoggerV1, RuntimeSurfaceV1,
     PROVIDER_COMMUNICATION_SCHEMA_VERSION,
 };
 use crate::resilience::{
@@ -14,6 +14,9 @@ use crate::resilience::{
     RetryExecutionTraceV1, TimeoutBreachKindV1, TimeoutObservation,
 };
 use anyhow::{anyhow, Result};
+use aws_config::{meta::region::RegionProviderChain, BehaviorVersion};
+use aws_sdk_bedrockruntime as bedrockruntime;
+use aws_sdk_sts as sts;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 use std::cell::RefCell;
@@ -28,6 +31,8 @@ const DEFAULT_DEEPSEEK_CHAT_COMPLETIONS_URL: &str = "https://api.deepseek.com/ch
 const DEFAULT_OPENROUTER_CHAT_COMPLETIONS_URL: &str =
     "https://openrouter.ai/api/v1/chat/completions";
 const DEFAULT_OPENROUTER_MAX_TOKENS: u64 = 2048;
+const DEFAULT_BEDROCK_PROFILE: &str = "agent-logic-admin";
+const DEFAULT_BEDROCK_REGION: &str = "us-west-2";
 const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
 static OLLAMA_RUNTIME_BULKHEADS: OnceLock<Mutex<HashMap<String, &'static Mutex<()>>>> =
@@ -609,6 +614,7 @@ fn execute_hosted(
         "anthropic" | "claude" => execute_hosted_anthropic(request, policy),
         "deepseek" => execute_hosted_deepseek(request, policy),
         "openrouter" => execute_hosted_openrouter(request, policy),
+        "bedrock" | "aws_bedrock" => execute_hosted_bedrock(request, policy),
         "google" | "gemini" => execute_hosted_gemini(request, policy),
         _ => Err(ProviderFailureV1 {
             kind: ProviderFailureKindV1::ProviderError,
@@ -770,6 +776,202 @@ fn openrouter_request_body(request: &ProviderInvocationRequestV1) -> Value {
         "max_tokens": output_token_budget_or_default(request, DEFAULT_OPENROUTER_MAX_TOKENS),
         "stream": false,
     })
+}
+
+fn execute_hosted_bedrock(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| provider_failure_from_note(&format!("bedrock runtime init: {err}"), None))?
+        .block_on(execute_hosted_bedrock_async(request, policy))
+}
+
+async fn execute_hosted_bedrock_async(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let profile = bedrock_profile()?;
+    let region = bedrock_region();
+    let region_provider =
+        RegionProviderChain::first_try(Some(aws_config::Region::new(region.clone())));
+    let timeout_config = aws_config::timeout::TimeoutConfig::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .operation_timeout(Duration::from_millis(policy.timeout_ms.max(1)))
+        .operation_attempt_timeout(Duration::from_millis(policy.timeout_ms.max(1)))
+        .build();
+    let shared_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(region_provider)
+        .profile_name(&profile)
+        .timeout_config(timeout_config)
+        .load()
+        .await;
+    sts::Client::new(&shared_config)
+        .get_caller_identity()
+        .send()
+        .await
+        .map_err(|err| bedrock_failure(format!("{err:?}"), None))?;
+    let body = bedrock_nova_request_body(request);
+    let response = bedrockruntime::Client::new(&shared_config)
+        .invoke_model()
+        .model_id(&request.route.provider_model_id)
+        .content_type("application/json")
+        .accept("application/json")
+        .body(bedrockruntime::primitives::Blob::new(
+            serde_json::to_vec(&body).map_err(|err| {
+                provider_failure_from_note(&format!("bedrock request serialization: {err}"), None)
+            })?,
+        ))
+        .send()
+        .await
+        .map_err(|err| bedrock_failure(format!("{err:?}"), None))?;
+    let json: Value = serde_json::from_slice(response.body().as_ref()).map_err(|err| {
+        provider_failure_from_note(&format!("bedrock invalid_json: {err}"), Some(200))
+    })?;
+    let output_text = extract_bedrock_nova_output_text(&json)
+        .ok_or_else(|| provider_failure_from_note("empty Bedrock provider output", Some(200)))?;
+    Ok(ProviderTextResponse {
+        output_text,
+        http_status: 200,
+        observed_provider_model_id: Some(request.route.provider_model_id.clone()),
+    })
+}
+
+fn bedrock_profile() -> std::result::Result<String, ProviderFailureV1> {
+    let profile = env::var("ADL_AWS_PROFILE")
+        .or_else(|_| env::var("AWS_PROFILE"))
+        .unwrap_or_else(|_| DEFAULT_BEDROCK_PROFILE.to_string());
+    if profile != DEFAULT_BEDROCK_PROFILE {
+        return Err(ProviderFailureV1 {
+            kind: ProviderFailureKindV1::ProviderError,
+            retryable: false,
+            message: format!(
+                "bedrock requires Agent Logic AWS profile '{DEFAULT_BEDROCK_PROFILE}'"
+            ),
+            provider_error_excerpt: Some("bedrock requires Agent Logic AWS profile".to_string()),
+            http_status: None,
+        });
+    }
+    Ok(profile)
+}
+
+fn bedrock_region() -> String {
+    env::var("ADL_AWS_REGION")
+        .or_else(|_| env::var("AWS_REGION"))
+        .or_else(|_| env::var("AWS_DEFAULT_REGION"))
+        .unwrap_or_else(|_| DEFAULT_BEDROCK_REGION.to_string())
+}
+
+fn bedrock_nova_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    json!({
+        "schemaVersion": "messages-v1",
+        "messages": [{
+            "role": "user",
+            "content": [{"text": request.input_text.as_deref().unwrap_or_default()}],
+        }],
+        "inferenceConfig": {
+            "maxTokens": output_token_budget_or_default(request, 256),
+        },
+    })
+}
+
+fn extract_bedrock_nova_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    if let Some(content) = json
+        .pointer("/output/message/content")
+        .and_then(Value::as_array)
+    {
+        for item in content {
+            if let Some(text) = item.get("text").and_then(Value::as_str) {
+                chunks.push(text);
+            }
+        }
+    }
+    let joined = chunks.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
+}
+
+fn bedrock_failure(message: String, http_status: Option<u16>) -> ProviderFailureV1 {
+    let sanitized = sanitize_bedrock_error(&message);
+    let retryable = sanitized.contains("Throttling")
+        || sanitized.contains("TooManyRequests")
+        || sanitized.contains("timeout")
+        || sanitized.contains("Timeout")
+        || sanitized.contains("ServiceUnavailable")
+        || sanitized.contains("InternalServer");
+    let kind = bedrock_failure_kind(&sanitized, http_status);
+    ProviderFailureV1 {
+        kind,
+        retryable,
+        message: sanitized.clone(),
+        provider_error_excerpt: Some(sanitized),
+        http_status,
+    }
+}
+
+fn bedrock_failure_kind(message: &str, http_status: Option<u16>) -> ProviderFailureKindV1 {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("accessdenied")
+        || lower.contains("access denied")
+        || lower.contains("not authorized")
+        || lower.contains("unauthorized")
+    {
+        return ProviderFailureKindV1::ProviderAuthError;
+    }
+    if lower.contains("modelnotready")
+        || lower.contains("model not ready")
+        || lower.contains("resourcenotfound")
+        || lower.contains("resource not found")
+        || lower.contains("model is not supported")
+        || lower.contains("on-demand throughput isn't supported")
+    {
+        return ProviderFailureKindV1::ProviderModelUnavailable;
+    }
+    if lower.contains("throttling") || lower.contains("toomanyrequests") {
+        return ProviderFailureKindV1::ProviderRateLimited;
+    }
+    if lower.contains("timeout") {
+        return ProviderFailureKindV1::ProviderTimeout;
+    }
+    classify_provider_failure(message, http_status)
+}
+
+fn sanitize_bedrock_error(message: &str) -> String {
+    let mut out = message.replace('\n', " ");
+    for marker in [
+        "Authorization: ",
+        "Authorization=",
+        "Credential=",
+        "X-Amz-Signature=",
+        "SecretAccessKey=",
+    ] {
+        out = redact_aws_error_value(&out, marker);
+    }
+    out.chars().take(200).collect()
+}
+
+fn redact_aws_error_value(input: &str, marker: &str) -> String {
+    let mut redacted = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while let Some(relative_start) = input[cursor..].find(marker) {
+        let marker_start = cursor + relative_start;
+        let value_start = marker_start + marker.len();
+        redacted.push_str(&input[cursor..value_start]);
+        redacted.push_str("<redacted>");
+
+        let value_end = input[value_start..]
+            .char_indices()
+            .find_map(|(idx, ch)| {
+                matches!(ch, ' ' | ',' | '&' | ';' | '"' | '\'' | ')' | '}' | ']')
+                    .then_some(value_start + idx)
+            })
+            .unwrap_or(input.len());
+        cursor = value_end;
+    }
+    redacted.push_str(&input[cursor..]);
+    redacted
 }
 
 fn execute_hosted_gemini(
@@ -1295,6 +1497,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
+    use std::sync::{Mutex, OnceLock};
     use std::thread;
 
     static TEMP_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1308,6 +1511,13 @@ mod tests {
         ));
         let _ = fs::remove_file(&path);
         path
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock")
     }
 
     fn request(
@@ -1420,6 +1630,10 @@ mod tests {
         assert_eq!(deepseek_request_body(&req)["max_tokens"], json!(1_024));
         assert_eq!(openrouter_request_body(&req)["max_tokens"], json!(1_024));
         assert_eq!(
+            bedrock_nova_request_body(&req).pointer("/inferenceConfig/maxTokens"),
+            Some(&json!(1_024))
+        );
+        assert_eq!(
             gemini_request_body(&req)
                 .pointer("/generationConfig/maxOutputTokens")
                 .cloned(),
@@ -1451,6 +1665,10 @@ mod tests {
             openrouter_request_body(&req)["max_tokens"],
             json!(DEFAULT_OPENROUTER_MAX_TOKENS)
         );
+        assert_eq!(
+            bedrock_nova_request_body(&req).pointer("/inferenceConfig/maxTokens"),
+            Some(&json!(256))
+        );
         assert!(gemini_request_body(&req).get("generationConfig").is_none());
 
         let ollama_req = request(
@@ -1458,6 +1676,71 @@ mod tests {
             "http://127.0.0.1:11434".to_string(),
         );
         assert!(ollama_request_body(&ollama_req).get("options").is_none());
+    }
+
+    #[test]
+    fn bedrock_profile_guard_rejects_default_profile() {
+        let _guard = env_lock();
+        let prev_adl = env::var_os("ADL_AWS_PROFILE");
+        let prev_aws = env::var_os("AWS_PROFILE");
+        env::remove_var("ADL_AWS_PROFILE");
+        env::set_var("AWS_PROFILE", "default");
+
+        let err = bedrock_profile().expect_err("wrong profile should fail closed");
+        assert_eq!(err.kind, ProviderFailureKindV1::ProviderError);
+        assert!(!err.retryable);
+        assert!(err.message.contains("agent-logic-admin"));
+
+        match prev_adl {
+            Some(value) => env::set_var("ADL_AWS_PROFILE", value),
+            None => env::remove_var("ADL_AWS_PROFILE"),
+        }
+        match prev_aws {
+            Some(value) => env::set_var("AWS_PROFILE", value),
+            None => env::remove_var("AWS_PROFILE"),
+        }
+    }
+
+    #[test]
+    fn bedrock_request_body_uses_nova_messages_shape() {
+        let mut req = request(RuntimeSurfaceV1::HostedApi, "bedrock-runtime".to_string());
+        req.route.provider = "bedrock".to_string();
+        req.route.provider_model_id = "amazon.nova-lite-v1:0".to_string();
+        req.input_text = Some("hello nova".to_string());
+        req.max_output_tokens = Some(99);
+
+        let body = bedrock_nova_request_body(&req);
+        assert_eq!(body["schemaVersion"], json!("messages-v1"));
+        assert_eq!(body["messages"][0]["role"], json!("user"));
+        assert_eq!(
+            body["messages"][0]["content"][0]["text"],
+            json!("hello nova")
+        );
+        assert_eq!(body["inferenceConfig"]["maxTokens"], json!(99));
+
+        let parsed = extract_bedrock_nova_output_text(&json!({
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "nova ok"}]
+                }
+            }
+        }));
+        assert_eq!(parsed.as_deref(), Some("nova ok"));
+    }
+
+    #[test]
+    fn bedrock_error_sanitizer_removes_signed_aws_values() {
+        let sanitized = sanitize_bedrock_error(
+            "Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260707/us-west-2/bedrock/aws4_request, SignedHeaders=host, X-Amz-Signature=abc123def456",
+        );
+
+        assert!(sanitized.contains("Authorization: <redacted>"));
+        assert!(sanitized.contains("Credential=<redacted>"));
+        assert!(sanitized.contains("X-Amz-Signature=<redacted>"));
+        assert!(!sanitized.contains("AWS4-HMAC-SHA256"));
+        assert!(!sanitized.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(!sanitized.contains("abc123def456"));
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -125,6 +125,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
                 "mock" => return "mock".to_string(),
                 "chatgpt" => return "openai".to_string(),
                 "claude" => return "anthropic".to_string(),
+                "bedrock" => return "aws_bedrock".to_string(),
                 "openrouter" => return "openrouter".to_string(),
                 "http" => return "generic_http".to_string(),
                 _ => {}
@@ -156,6 +157,9 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         if lower.contains("openrouter") {
             return "openrouter".to_string();
         }
+        if lower.contains("bedrock-runtime") || lower.contains("bedrock") {
+            return "aws_bedrock".to_string();
+        }
         if lower.contains("ollama") || lower.contains("11434") {
             return "ollama".to_string();
         }
@@ -167,6 +171,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         "openai" => "openai".to_string(),
         "anthropic" => "anthropic".to_string(),
         "deepseek" => "deepseek".to_string(),
+        "bedrock" | "aws_bedrock" => "aws_bedrock".to_string(),
         "openrouter" => "openrouter".to_string(),
         "http" | "http_remote" => "generic_http".to_string(),
         other if !other.is_empty() => other.to_lowercase(),
@@ -183,9 +188,8 @@ fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
                 Ok(ProviderTransportV1::LocalCli)
             }
         }
-        "http" | "http_remote" | "openai" | "anthropic" | "deepseek" | "openrouter" => {
-            Ok(ProviderTransportV1::Http)
-        }
+        "http" | "http_remote" | "openai" | "anthropic" | "deepseek" | "openrouter" | "bedrock"
+        | "aws_bedrock" => Ok(ProviderTransportV1::Http),
         "local_ollama" => Ok(ProviderTransportV1::LocalCli),
         "mock" => Ok(ProviderTransportV1::InProcess),
         other => Err(anyhow!(
@@ -274,7 +278,7 @@ fn infer_capability_defaults(
     }
 
     if matches!(transport, ProviderTransportV1::Http)
-        && (vendor == "deepseek" || vendor == "openrouter")
+        && (vendor == "deepseek" || vendor == "openrouter" || vendor == "aws_bedrock")
     {
         return ProviderCapabilitiesV1 {
             tool_calling: CapabilitySupportV1 {
@@ -596,6 +600,31 @@ mod tests {
             openrouter_substrate.capabilities.structured_json.mode,
             CapabilityModeV1::PromptBased
         );
+
+        let mut bedrock = provider_spec("bedrock");
+        bedrock.default_model = Some("hosted:adl-bedrock:amazon.nova-lite-v1:0".to_string());
+        bedrock.config.insert(
+            "provider_model_id".to_string(),
+            json!("amazon.nova-lite-v1:0"),
+        );
+        let bedrock_substrate =
+            provider_substrate_v1("bedrock_primary", &bedrock).expect("bedrock substrate");
+        assert_eq!(bedrock_substrate.vendor, "aws_bedrock");
+        assert_eq!(bedrock_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(bedrock_substrate.provider_kind, "bedrock");
+        assert!(!bedrock_substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            bedrock_substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
+
+        let bedrock_target =
+            provider_invocation_target_v1("bedrock_primary", &bedrock, None).expect("target");
+        assert_eq!(
+            bedrock_target.model_ref,
+            "hosted:adl-bedrock:amazon.nova-lite-v1:0"
+        );
+        assert_eq!(bedrock_target.provider_model_id, "amazon.nova-lite-v1:0");
     }
 
     #[test]

--- a/adl/tests/provider_tests/http_family.rs
+++ b/adl/tests/provider_tests/http_family.rs
@@ -90,6 +90,22 @@ config:
 }
 
 #[test]
+fn bedrock_provider_builds_without_network_and_preserves_model_id() {
+    let spec = provider_spec_from_yaml(
+        r#"
+type: bedrock
+default_model: "hosted:adl-bedrock:amazon.nova-lite-v1:0"
+config:
+  region: "us-east-1"
+  profile: "agent-logic-admin"
+  provider_model_id: "amazon.nova-lite-v1:0"
+"#,
+    );
+
+    let _provider = build_provider(&spec, None).expect("bedrock provider should build");
+}
+
+#[test]
 fn anthropic_provider_translates_native_response() {
     let server = match std::net::TcpListener::bind("127.0.0.1:0") {
         Ok(s) => s,

--- a/adl/tests/provider_tests/profiles.rs
+++ b/adl/tests/provider_tests/profiles.rs
@@ -204,6 +204,46 @@ run:
 }
 
 #[test]
+fn expand_provider_profiles_accepts_bedrock_nova_lite_profile() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  bedrock_primary:
+    profile: "bedrock:nova-lite-v1"
+agents:
+  a1:
+    provider: "bedrock_primary"
+    model: "hosted:adl-bedrock:amazon.nova-lite-v1:0"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let expanded = expand_provider_profiles(&doc).expect("expand bedrock profile");
+    let provider = &expanded.providers["bedrock_primary"];
+    assert_eq!(provider.kind, "bedrock");
+    assert_eq!(
+        provider.default_model.as_deref(),
+        Some("hosted:adl-bedrock:amazon.nova-lite-v1:0")
+    );
+    assert_eq!(
+        provider
+            .config
+            .get("provider_model_id")
+            .and_then(|v| v.as_str()),
+        Some("amazon.nova-lite-v1:0")
+    );
+}
+
+#[test]
 fn expand_provider_profiles_accepts_chatgpt_profile_with_endpoint_override() {
     let doc = adl_doc_from_yaml(
         r#"

--- a/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
+++ b/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
@@ -77,8 +77,8 @@ ADL should model provider execution with four explicit layers:
 4. provider-native `provider_model_id`
 
 Key capabilities:
-- define first-class provider adapters for OpenAI, Anthropic, Gemini, Ollama,
-  compatible HTTP, optional WebSocket, and mock
+- define first-class provider adapters for OpenAI, Anthropic, AWS Bedrock,
+  Gemini, Ollama, compatible HTTP, optional WebSocket, and mock
 - isolate unstable provider model names behind stable ADL-facing references
 - provide a configuration surface that lets agents target vendors and models without brittle string coupling
 - integrate cleanly with declared, observed, and effective capability envelopes

--- a/docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md
+++ b/docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md
@@ -1,0 +1,155 @@
+# AWS Bedrock Native Provider Proof - Issue #5024
+
+Issue: `#5024 [v0.91.7][provider][bedrock] Implement native AWS Bedrock provider adapter and tests`
+
+Date: 2026-07-07
+
+## Implementation Surface
+
+- Added Rust-native AWS Bedrock provider support through the provider family path.
+- Added provider profile presets for:
+  - `bedrock:nova-lite-v1` -> `amazon.nova-lite-v1:0`
+  - `bedrock:nova-pro-v1` -> `amazon.nova-pro-v1:0`
+- Integrated `bedrock` / `aws_bedrock` into provider substrate inference, provider construction, hosted adapter routing, and `adl provider setup bedrock`.
+- Added profile/region guardrails:
+  - default AWS profile: `agent-logic-admin`
+  - default AWS region: `us-west-2`
+  - non-`agent-logic-admin` profiles fail before live Bedrock calls.
+- Bedrock calls use the AWS SDK credential chain, STS profile verification, and Bedrock Runtime `InvokeModel`.
+- Request shape uses the Amazon Nova messages schema with `schemaVersion: "messages-v1"`.
+- Diagnostics classify Bedrock auth, model-unavailable, rate-limit, timeout, and generic provider failures without logging credentials or raw account identifiers.
+
+## Local Focused Validation
+
+Commands run from the issue worktree:
+
+```text
+cargo fmt --manifest-path adl/Cargo.toml
+cargo test --manifest-path adl/Cargo.toml bedrock -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_adapter -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_substrate -- --nocapture
+git diff --check
+```
+
+Results:
+
+- `bedrock`: passed, including local request/response shape tests, profile guardrail tests, and provider profile integration tests.
+- `provider_adapter`: passed, including Bedrock hosted adapter request construction and profile guardrail tests.
+- `provider_setup`: passed, including `adl provider setup bedrock` support.
+- `provider_substrate`: passed, including Bedrock substrate inference.
+- `git diff --check`: passed.
+
+Broad lane note:
+
+- `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/local-artifacts/provider-bedrock-5024/changed-files-5024.txt` compiled the full lane and ran 8,952 tests before failing in two `adl-pr-doctor` validation-profile tests.
+- The failed tests passed when rerun directly:
+  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-doctor finish_validation_profile_classifies_slow_proof_family_split_slice -- --nocapture`
+  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-doctor finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused -- --nocapture`
+- Classification: broad-lane parallel validation-manager/temp-file anomaly, not a Bedrock provider regression.
+
+## Live AWS Verification
+
+AWS profile used: `agent-logic-admin`.
+
+Profile verification was performed with STS and recorded without account id disclosure:
+
+- Artifact: `.adl/local-artifacts/provider-bedrock-5024/aws/sts_agent_logic_admin_sanitized.json`
+- Recorded fields include `profile`, `sts_verified`, `account_id_sha256`, redacted ARN shape, and `user_id_present`.
+- No AWS credentials, raw account id, authorization headers, or secret material are recorded.
+
+Model discovery:
+
+- `us-east-1` artifact: `.adl/local-artifacts/provider-bedrock-5024/aws/bedrock_nova_models_us_east_1.json`
+- `us-west-2` artifact: `.adl/local-artifacts/provider-bedrock-5024/aws/bedrock_nova_models_us_west_2.json`
+- `amazon.nova-lite-v1:0` was visible in both regions.
+- `us-east-1` returned a live daily-token throttle for the tiny smoke call: `Too many tokens per day, please wait before trying again.`
+- `us-west-2` successfully invoked the same Nova Lite model, so `us-west-2` is the default Bedrock region in this implementation.
+
+## Live Adapter Smoke
+
+Command shape:
+
+```text
+env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION \
+  ADL_AWS_PROFILE=agent-logic-admin \
+  AWS_PROFILE=agent-logic-admin \
+  adl/target/debug/adl-provider-adapter \
+    --request .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_request.json \
+    --out .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_result_default_region.json \
+    --log .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_log_default_region.jsonl
+```
+
+Result:
+
+- `final_status`: `ok`
+- attempts: `1`
+- HTTP status: `200`
+- output text: `bedrock ok`
+- default region path: proven, because all region env vars were unset.
+
+Artifacts:
+
+- Request: `.adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_request.json`
+- Result: `.adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_result_default_region.json`
+- Log: `.adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_log_default_region.jsonl`
+
+## Provider Setup Smoke
+
+Command:
+
+```text
+adl/target/debug/adl provider setup bedrock --out .adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock --force
+```
+
+Result:
+
+- Generated provider family: `bedrock`
+- Generated model: `amazon.nova-lite-v1:0`
+- Generated profile: `agent-logic-admin`
+- Generated region: `us-west-2`
+
+Artifacts:
+
+- `.adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock/provider.adl.yaml`
+- `.adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock/env.example`
+- `.adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock/README.md`
+
+## UTS Benchmark Proof
+
+Command shape:
+
+```text
+env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION \
+  ADL_HOME=<ADL_WORKTREE> \
+  ADL_AWS_PROFILE=agent-logic-admin \
+  AWS_PROFILE=agent-logic-admin \
+  python3 tools/uts_benchmark_runner.py hosted \
+    <ADL_WORKTREE>/.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_selector.txt \
+    <ADL_WORKTREE>/.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results.json \
+    --lanes regular,uts_only
+```
+
+Result:
+
+- Model: `amazon.nova-lite-v1:0`
+- Route: `hosted:adl-bedrock:amazon.nova-lite-v1:0`
+- Regular lane: `11/11`
+- UTS-only lane: `11/11`
+- Provider failures: `0`
+- Semantic failures: `0`
+- Deterministic self-check: passed
+
+Artifacts:
+
+- Summary: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_summary.md`
+- Results JSON: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results.json`
+- Provider status: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_provider_status.json`
+- Details: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_details.md`
+- Run log: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_run.jsonl`
+- Self-check: `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_self_check.json`
+
+## Residual Truth
+
+- Nova Pro profile support is implemented, but live UTS proof for this issue used Nova Lite only to keep live Bedrock usage bounded.
+- `us-east-1` model visibility was proven, but the live `us-east-1` smoke hit a daily token throttle. The operational default is therefore `us-west-2`, which passed the default-region live smoke and full UTS panel.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -10,6 +10,7 @@ Current supported families:
 - `anthropic`
 - `gemini`
 - `deepseek`
+- `bedrock`
 - `http`
 
 Related shared proof-surface docs:
@@ -30,10 +31,12 @@ The generated bundle is intentionally local-only:
 - users are expected to copy/fill a local env file and source it before running ADL
 
 Important transport note:
-- `openai`, `anthropic`, and `deepseek` now use Rust-native provider adapters by default:
+- `openai`, `anthropic`, `deepseek`, `openrouter`, and `bedrock` now use Rust-native provider adapters by default:
   - `type: "openai"` targets the OpenAI Responses API unless `config.endpoint` is explicitly overridden
   - `type: "anthropic"` targets the Anthropic Messages API unless `config.endpoint` is explicitly overridden
   - `type: "deepseek"` targets the DeepSeek chat completions API unless `config.endpoint` is explicitly overridden
+  - `type: "openrouter"` targets the OpenRouter chat completions API unless `config.endpoint` is explicitly overridden
+  - `type: "bedrock"` targets AWS Bedrock Runtime through the AWS SDK and defaults to `ADL_AWS_PROFILE=agent-logic-admin`
 - ADL's bounded HTTP provider expects a completion-style contract:
   - request JSON with `{"prompt": "..."}`
   - response JSON with `{"output": "..."}`
@@ -50,7 +53,13 @@ adl provider setup chatgpt
 adl provider setup claude
 adl provider setup openai --out ./.adl/provider-setup/openai
 adl provider setup deepseek
+adl provider setup bedrock
 ```
+
+AWS Bedrock native note:
+- `adl provider setup bedrock` emits `type: "bedrock"`, defaults to `profile: "agent-logic-admin"` and `region: "us-west-2"`, and uses AWS SDK credential resolution rather than bearer-token auth
+- ADL AWS work must use the Agent Logic business profile unless the operator explicitly authorizes a bounded personal-account diagnostic
+- the initial provider mini-sprint target is `amazon.nova-lite-v1:0`; `amazon.nova-pro-v1:0` is the secondary target when access and cost posture allow
 
 DeepSeek native note:
 - `adl provider setup deepseek` emits `type: "deepseek"`, reads `DEEPSEEK_API_KEY`, and uses `https://api.deepseek.com/chat/completions` by default


### PR DESCRIPTION
Closes #5024

## Summary
Implemented a Rust-native AWS Bedrock provider path for the provider mini-sprint. The issue now supports Bedrock/Nova provider profiles, Bedrock substrate inference, native provider construction, hosted provider-adapter invocation through AWS SDK Bedrock Runtime, provider setup generation, docs, focused tests, live AWS proof, and a UTS benchmark panel run.

Live proof used the Agent Logic AWS profile `agent-logic-admin`. STS profile verification recorded only a SHA-256 account id digest and redacted ARN shape. `amazon.nova-lite-v1:0` was discovered in `us-east-1` and `us-west-2`; `us-east-1` returned a daily-token throttle for the tiny smoke, while `us-west-2` passed both the direct adapter smoke and UTS benchmark panel. The implementation default is therefore `us-west-2`.

## Artifacts
- Tracked implementation artifacts:
  - `adl/Cargo.toml`
  - `adl/Cargo.lock`
  - `adl/src/provider/http_family.rs`
  - `adl/src/provider/http_family/tests.rs`
  - `adl/src/provider/mod.rs`
  - `adl/src/provider/profiles.rs`
  - `adl/src/provider_adapter.rs`
  - `adl/src/provider_substrate.rs`
  - `adl/src/cli/provider_cmd.rs`
  - `adl/src/cli/usage.rs`
  - `adl/tests/provider_tests/http_family.rs`
  - `adl/tests/provider_tests/profiles.rs`
  - `docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md`
  - `docs/tooling/PROVIDER_SETUP.md`
  - `docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md`
- Local ignored proof artifacts:
  - `.adl/local-artifacts/provider-bedrock-5024/aws/sts_agent_logic_admin_sanitized.json`
  - `.adl/local-artifacts/provider-bedrock-5024/aws/bedrock_nova_models_us_east_1.json`
  - `.adl/local-artifacts/provider-bedrock-5024/aws/bedrock_nova_models_us_west_2.json`
  - `.adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_result_default_region.json`
  - `.adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_log_default_region.jsonl`
  - `.adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock/provider.adl.yaml`
  - `.adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock/env.example`
  - `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results.json`
  - `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_summary.md`
  - `.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results_provider_status.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Verified Rust formatting after Bedrock provider changes.`
  - `cargo test --manifest-path adl/Cargo.toml bedrock -- --nocapture`
    `Verified Bedrock request/response shape, profile guardrails, profile expansion, and no-network provider construction.`
  - `cargo test --manifest-path adl/Cargo.toml provider_adapter -- --nocapture`
    `Verified hosted provider adapter behavior including Bedrock request construction and profile guardrails.`
  - `cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture`
    `Verified provider setup command coverage including Bedrock setup generation.`
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate -- --nocapture`
    `Verified provider substrate inference including Bedrock provider identity/capability defaults.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
  - `adl/target/debug/adl provider setup bedrock --out .adl/local-artifacts/provider-bedrock-5024/setup-smoke/bedrock --force`
    `Verified repo binary emits a Bedrock provider setup bundle with profile agent-logic-admin, region us-west-2, and Nova Lite model identity.`
  - `env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION ADL_AWS_PROFILE=agent-logic-admin AWS_PROFILE=agent-logic-admin adl/target/debug/adl-provider-adapter --request .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_request.json --out .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_result_default_region.json --log .adl/local-artifacts/provider-bedrock-5024/live/bedrock_nova_lite_log_default_region.jsonl`
    `Verified the default-region Bedrock adapter path live against Amazon Nova Lite.`
  - `env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION ADL_HOME=<ADL_WORKTREE> ADL_AWS_PROFILE=agent-logic-admin AWS_PROFILE=agent-logic-admin python3 tools/uts_benchmark_runner.py hosted <ADL_WORKTREE>/.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_selector.txt <ADL_WORKTREE>/.adl/local-artifacts/provider-bedrock-5024/uts/bedrock_nova_lite_results.json --lanes regular,uts_only`
    `Verified Bedrock Nova Lite through the UTS regular and UTS-only benchmark lanes via the ADL provider adapter.`
  - `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/local-artifacts/provider-bedrock-5024/changed-files-5024.txt`
    `Compiled the broad full-nextest lane and ran 8,952 tests before failing in two adl-pr-doctor validation-profile tests; the two failed tests passed when rerun directly, so this is recorded as a broad-lane validation-manager/temp-file anomaly rather than Bedrock provider regression proof.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-doctor finish_validation_profile_classifies_slow_proof_family_split_slice -- --nocapture`
    `Direct rerun of the first broad-lane adl-pr-doctor failure passed.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-doctor finish_validation_profile_classifies_sprint_shell_helper_tests_as_small_binary_focused -- --nocapture`
    `Direct rerun of the second broad-lane adl-pr-doctor failure passed.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-preflight provider_cmd::tests::real_provider_uses_repo_root_for_default_output -- --nocapture`
    `Verified the provider setup default-output test no longer races across copied binary test harnesses when run from the adl-pr-preflight binary.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl provider_cmd::tests::real_provider_uses_repo_root_for_default_output -- --nocapture`
    `Verified the same provider setup default-output behavior through the top-level adl binary test harness.`
  - `cargo test --manifest-path adl/Cargo.toml --lib provider::http_family::tests::bedrock_invocation_artifact_records_profile_region_and_account_hash -- --nocapture`
    `Verified Bedrock invocation artifacts record profile, region, status, account digest field, and no secret material.`
  - `cargo test --manifest-path adl/Cargo.toml --lib provider::http_family::tests::bedrock_invocation_artifact_rejects_invalid_existing_payloads -- --nocapture`
    `Verified Bedrock invocation artifact write paths fail closed for invalid JSON and missing invocations arrays.`
  - `cargo test --manifest-path adl/Cargo.toml --lib provider::http_family::tests::bedrock_constructor_and_helpers_cover_default_safe_paths -- --nocapture`
    `Verified deterministic Bedrock constructor defaults, outputText fallback parsing, SDK error sanitization/classification, account digest helper coverage, and missing-artifact-path no-op behavior.`
  - `bash adl/tools/run_pr_fast_coverage_lane.sh --filter-expression 'test(provider_cmd) or binary_id(adl::cli_smoke) and test(/^basics::/) or test(http_family) or test(mod) or test(profiles) or test(provider_adapter) or test(provider_substrate)'`
    `Verified the PR-fast coverage nextest expression for the Bedrock provider PR: 1,184 tests passed and 19,150 were skipped by the filter.`
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --head HEAD --summary adl/target/coverage-impact-summary.json`
    `Verified changed Rust source files satisfy the coverage-impact preflight; this specifically fixed the PR #5048 adl-coverage failure on adl/src/provider/http_family.rs.`
  - `adl tooling validate-structured-prompt --type sor --input .adl/v0.91.7/tasks/issue-5024__v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests/sor.md`
    `Verified the SOR contract validator accepts the updated output record.`
  - `adl tooling prompt-template validate-structure --kind sor --input .adl/v0.91.7/tasks/issue-5024__v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests/sor.md`
    `Non-proving: strict template-structure validation still reports pre-existing locked-text drift in the Main Repo Integration section. This janitor did not fully re-render the SOR because the SOR contract validator passes and the current patch is scoped to the PR #5048 coverage repair.`
- Results:
  - `PASS for focused Rust, setup, live AWS, UTS provider proof, PR-fast coverage, and changed-file coverage-impact preflight. Broad full-nextest was attempted and is non-proving because it hit an unrelated validation-manager/temp-file anomaly; exact broad-lane failures passed on direct rerun.`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the recorded command uses portable `<ADL_WORKTREE>` placeholders for the cross-repo UTS invocation.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5024__v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5024__v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests/sor.md
- Idempotency-Key: v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests-adl-cargo-lock-adl-cargo-toml-adl-src-cli-provider-cmd-rs-adl-src-cli-usage-rs-adl-src-provider-http-family-rs-adl-src-provider-http-family-tests-rs-adl-src-provider-mod-rs-adl-src-provider-profiles-rs-adl-src-provider-adapter-rs-adl-src-provider-substrate-rs-adl-tests-provider-tests-http-family-rs-adl-tests-provider-tests-profiles-rs-docs-architecture-provider-capability-and-transport-architecture-md-docs-milestones-v0-91-7-review-provider-aws-bedrock-native-provider-proof-5024-md-docs-tooling-provider-setup-md-adl-v0-91-7-tasks-issue-5024-v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests-sip-md-adl-v0-91-7-tasks-issue-5024-v0-91-7-provider-bedrock-implement-native-aws-bedrock-provider-adapter-and-tests-sor-md