### PR TITLE
[v0.91.7][provider][anthropic] Run Fable 5 UTS provider acceptance panel

### DIFF
--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -231,15 +231,20 @@ fn extract_openai_output_text(json: &Value) -> Option<String> {
 
 fn extract_anthropic_output_text(json: &Value) -> Option<String> {
     let mut chunks = Vec::new();
-    for content in json.get("content")?.as_array()? {
-        let content_type = content.get("type").and_then(|v| v.as_str());
-        if content_type == Some("text") {
-            if let Some(text) = content.get("text").and_then(|v| v.as_str()) {
-                chunks.push(text);
+    if let Some(contents) = json.get("content").and_then(|v| v.as_array()) {
+        for content in contents {
+            let content_type = content.get("type").and_then(|v| v.as_str());
+            if content_type == Some("text") {
+                if let Some(text) = content.get("text").and_then(|v| v.as_str()) {
+                    chunks.push(text);
+                }
             }
         }
     }
     let joined = chunks.join("\n").trim().to_string();
+    if joined.is_empty() && json.get("stop_reason").and_then(|v| v.as_str()) == Some("refusal") {
+        return Some(r#"{"refusal":"provider refused the request"}"#.to_string());
+    }
     (!joined.is_empty()).then_some(joined)
 }
 

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -447,6 +447,42 @@ fn anthropic_provider_complete_records_output_and_version_header() {
 }
 
 #[test]
+fn anthropic_provider_complete_normalizes_empty_refusal_response() {
+    let _guard = env_lock();
+    let Some((endpoint, _captured, handle)) =
+        spawn_json_server(200, r#"{"content":[],"stop_reason":"refusal"}"#)
+    else {
+        return;
+    };
+
+    let prev_key = env::var_os("ANTHROPIC_API_KEY");
+    env::set_var("ANTHROPIC_API_KEY", "test-anthropic-token");
+
+    let spec = provider_spec(
+        "anthropic",
+        &format!("{endpoint}/v1/messages"),
+        Some("ANTHROPIC_API_KEY"),
+        &[],
+    );
+    let target = provider_target(
+        "anthropic",
+        format!("{endpoint}/v1/messages"),
+        "claude-test",
+    );
+    let provider = AnthropicProvider::from_target(&spec, &target).expect("provider");
+
+    let output = provider.complete("hello anthropic").expect("completion");
+    assert_eq!(output, r#"{"refusal":"provider refused the request"}"#);
+
+    match prev_key {
+        Some(v) => env::set_var("ANTHROPIC_API_KEY", v),
+        None => env::remove_var("ANTHROPIC_API_KEY"),
+    }
+
+    let _ = handle.join();
+}
+
+#[test]
 fn deepseek_provider_complete_records_chat_completion_request() {
     let _guard = env_lock();
     let Some((endpoint, captured, handle)) = spawn_json_server(

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -1147,6 +1147,9 @@ fn extract_anthropic_output_text(json: &Value) -> Option<String> {
             }
         }
     }
+    if chunks.is_empty() && json.get("stop_reason").and_then(Value::as_str) == Some("refusal") {
+        return Some(r#"{"refusal":"provider refused the request"}"#.to_string());
+    }
     (!chunks.is_empty()).then(|| {
         chunks.join(
             "
@@ -2086,6 +2089,34 @@ mod tests {
         assert!(!log.contains("claude success"));
         let _ = fs::remove_file(path);
         env::remove_var("ADL_PROVIDER_ADAPTER_CLAUDE_KEY");
+    }
+
+    #[test]
+    fn claude_hosted_adapter_normalizes_empty_refusal_response() {
+        env::set_var("ADL_PROVIDER_ADAPTER_CLAUDE_REFUSAL_KEY", "test-key");
+        let endpoint = one_shot_server(r#"{"content":[],"stop_reason":"refusal"}"#, "200 OK");
+        let path = temp_log("claude-refusal");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "anthropic".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_CLAUDE_REFUSAL_KEY".to_string());
+        req.model_identity = hosted_model_identity(
+            "anthropic",
+            "claude-test",
+            "test-model",
+            Some("test".to_string()),
+        );
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(
+            result.output_text.as_deref(),
+            Some(r#"{"refusal":"provider refused the request"}"#)
+        );
+
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_CLAUDE_REFUSAL_KEY");
     }
 
     #[test]

--- a/adl/tools/adl_provider_adapter_with_budget.py
+++ b/adl/tools/adl_provider_adapter_with_budget.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Run adl-provider-adapter after adding a portable output-token budget.
+
+The UTS hosted ADL bridge owns temporary provider request files. This wrapper
+keeps the upstream runner unchanged while allowing an issue or operator to
+require a larger `max_output_tokens` budget for models that need it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--adapter", required=True)
+    parser.add_argument("--max-output-tokens", type=int, required=True)
+    parser.add_argument("adapter_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.max_output_tokens <= 0:
+        parser.error("--max-output-tokens must be greater than zero")
+    if args.adapter_args and args.adapter_args[0] == "--":
+        args.adapter_args = args.adapter_args[1:]
+    if "--request" not in args.adapter_args:
+        parser.error("adapter args must include --request <path>")
+    return args
+
+
+def request_path(adapter_args: list[str]) -> Path:
+    for index, arg in enumerate(adapter_args):
+        if arg == "--request" and index + 1 < len(adapter_args):
+            return Path(adapter_args[index + 1])
+    raise SystemExit("missing --request <path>")
+
+
+def update_request(path: Path, max_output_tokens: int) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("provider request must be a JSON object")
+    payload["max_output_tokens"] = max_output_tokens
+    fingerprint = payload.get("inference_parameter_fingerprint")
+    budget_note = f"max_output_tokens={max_output_tokens}"
+    if isinstance(fingerprint, str) and fingerprint:
+        if "max_output_tokens=" not in fingerprint:
+            payload["inference_parameter_fingerprint"] = f"{fingerprint};{budget_note}"
+    else:
+        payload["inference_parameter_fingerprint"] = budget_note
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    update_request(request_path(args.adapter_args), args.max_output_tokens)
+    completed = subprocess.run([args.adapter, *args.adapter_args], check=False, env=os.environ.copy())
+    return int(completed.returncode)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/adl/tools/run_fable5_uts_acceptance.sh
+++ b/adl/tools/run_fable5_uts_acceptance.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_UTS_ROOT="$(cd "$ROOT/.." && pwd)/universal-tool-schema"
+if [ ! -d "$DEFAULT_UTS_ROOT" ] && [ "$(basename "$(dirname "$ROOT")")" = ".worktrees" ]; then
+  DEFAULT_UTS_ROOT="$(cd "$ROOT/../../.." && pwd)/universal-tool-schema"
+fi
+UTS_ROOT="${UTS_ROOT:-$DEFAULT_UTS_ROOT}"
+ARTIFACT_DIR="$ROOT/.adl/local-artifacts/provider-fable5-5044"
+MODEL_ID="claude-fable-5"
+MAX_OUTPUT_TOKENS="${UTS_FABLE5_MAX_OUTPUT_TOKENS:-1024}"
+RUN_ID="${UTS_FABLE5_RUN_ID:-issue-5044-fable5-uts}"
+KEY_FILE="${ADL_ANTHROPIC_API_KEY_FILE:-}"
+RUN_PROBE=1
+RUN_PANEL=1
+OVERWRITE=1
+
+usage() {
+  cat <<'USAGE'
+Usage: run_fable5_uts_acceptance.sh [options]
+
+Options:
+  --uts-root <path>          universal-tool-schema checkout path.
+  --artifact-dir <path>      Output artifact directory.
+  --key-file <path>          Approved Anthropic key file to map to ANTHROPIC_API_KEY.
+  --model <id>               Anthropic model id. Default: claude-fable-5.
+  --max-output-tokens <n>    ADL provider-adapter output token budget. Default: 1024.
+  --run-id <id>              Stable UTS run id. Default: issue-5044-fable5-uts.
+  --skip-probe               Skip hosted availability probe.
+  --skip-panel               Skip full regular,uts_only panel.
+  --no-overwrite             Do not pass --overwrite to the UTS runner.
+  -h, --help                 Show this help.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --uts-root) UTS_ROOT="$2"; shift 2 ;;
+    --artifact-dir) ARTIFACT_DIR="$2"; shift 2 ;;
+    --key-file) KEY_FILE="$2"; shift 2 ;;
+    --model) MODEL_ID="$2"; shift 2 ;;
+    --max-output-tokens) MAX_OUTPUT_TOKENS="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --skip-probe) RUN_PROBE=0; shift ;;
+    --skip-panel) RUN_PANEL=0; shift ;;
+    --no-overwrite) OVERWRITE=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$MAX_OUTPUT_TOKENS" in
+  ''|*[!0-9]*) echo "--max-output-tokens must be a positive integer" >&2; exit 2 ;;
+esac
+if [ "$MAX_OUTPUT_TOKENS" -le 0 ]; then
+  echo "--max-output-tokens must be a positive integer" >&2
+  exit 2
+fi
+
+if [ ! -d "$UTS_ROOT" ]; then
+  echo "missing UTS checkout: $UTS_ROOT" >&2
+  exit 2
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+SELECTOR="$ARTIFACT_DIR/fable5_selector.txt"
+printf 'hosted:adl-anthropic:%s\n' "$MODEL_ID" >"$SELECTOR"
+
+ADAPTER_BIN="${ADL_PROVIDER_ADAPTER_BIN:-$ROOT/adl/target/debug/adl-provider-adapter}"
+if [ ! -x "$ADAPTER_BIN" ]; then
+  echo "missing executable provider adapter: $ADAPTER_BIN" >&2
+  exit 2
+fi
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  if [ -z "$KEY_FILE" ]; then
+    echo "ANTHROPIC_API_KEY is unset and --key-file was not provided" >&2
+    exit 2
+  fi
+  if [ ! -r "$KEY_FILE" ]; then
+    echo "Anthropic key file is not readable" >&2
+    exit 2
+  fi
+  ANTHROPIC_API_KEY="$(tr -d '\r\n' < "$KEY_FILE")"
+  export ANTHROPIC_API_KEY
+fi
+
+export ADL_HOME="$ROOT"
+export UTS_ADL_PROVIDER_ADAPTER_COMMAND="python3 $ROOT/adl/tools/adl_provider_adapter_with_budget.py --adapter $ADAPTER_BIN --max-output-tokens $MAX_OUTPUT_TOKENS --"
+
+OVERWRITE_ARGS=()
+if [ "$OVERWRITE" -eq 1 ]; then
+  OVERWRITE_ARGS=(--overwrite)
+fi
+
+python3 "$UTS_ROOT/tools/benchmark/deterministic_self_check.py" >"$ARTIFACT_DIR/fable5_self_check.json"
+
+if [ "$RUN_PROBE" -eq 1 ]; then
+  python3 "$UTS_ROOT/tools/uts_benchmark_runner.py" \
+    probe-hosted \
+    "$SELECTOR" \
+    "$ARTIFACT_DIR/fable5_probe_results.json" \
+    --run-id "${RUN_ID}-probe" \
+    "${OVERWRITE_ARGS[@]}"
+fi
+
+if [ "$RUN_PANEL" -eq 1 ]; then
+  python3 "$UTS_ROOT/tools/uts_benchmark_runner.py" \
+    hosted \
+    "$SELECTOR" \
+    "$ARTIFACT_DIR/fable5_uts_results.json" \
+    --lanes regular,uts_only \
+    --run-id "$RUN_ID" \
+    "${OVERWRITE_ARGS[@]}"
+fi
+
+echo "PASS fable5_uts_acceptance model=$MODEL_ID artifact_dir=$ARTIFACT_DIR max_output_tokens=$MAX_OUTPUT_TOKENS"

--- a/adl/tools/test_fable5_uts_acceptance.sh
+++ b/adl/tools/test_fable5_uts_acceptance.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/uts/tools/benchmark" "$TMP/adl-bin"
+
+cat >"$TMP/uts/tools/benchmark/deterministic_self_check.py" <<'PY'
+#!/usr/bin/env python3
+print('{"passed": true, "fixture_count": 22, "task_count": 11}')
+PY
+chmod +x "$TMP/uts/tools/benchmark/deterministic_self_check.py"
+
+cat >"$TMP/uts/tools/uts_benchmark_runner.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+mode = sys.argv[1]
+selector = Path(sys.argv[2]).read_text(encoding="utf-8").strip()
+out = Path(sys.argv[3])
+out.parent.mkdir(parents=True, exist_ok=True)
+
+request = out.with_suffix(".request.json")
+result = out.with_suffix(".adapter-result.json")
+log = out.with_suffix(".jsonl")
+request.write_text(json.dumps({
+    "route": {
+        "provider_kind": "hosted",
+        "provider": "anthropic",
+        "runtime_surface": "hosted_api",
+        "provider_model_id": selector.split(":")[-1],
+        "credential_ref": "env:ANTHROPIC_API_KEY"
+    },
+    "model_identity": {
+        "provider_kind": "hosted",
+        "provider": "anthropic",
+        "model_ref": selector.split(":")[-1],
+        "provider_model_id": selector.split(":")[-1],
+        "runtime_surface": "hosted_api",
+        "identity_strength": "provider_asserted",
+        "observed_at": "2026-07-07T00:00:00Z",
+        "source_registry": "test",
+        "inference_parameter_fingerprint": "provider_default",
+        "tool_surface": "uts.v1.1",
+        "evaluator_ref": "test",
+        "benchmark_ref": "test"
+    },
+    "prompt_contract_ref": "test",
+    "lane_ref": "test",
+    "attempt_policy": {"max_attempts": 1, "timeout_ms": 1000},
+    "input_text": "return json"
+}), encoding="utf-8")
+cmd = os.environ["UTS_ADL_PROVIDER_ADAPTER_COMMAND"].split() + ["--request", str(request), "--out", str(result), "--log", str(log)]
+completed = subprocess.run(cmd, check=False)
+if completed.returncode != 0:
+    raise SystemExit(completed.returncode)
+payload = json.loads(request.read_text(encoding="utf-8"))
+out.write_text(json.dumps({
+    "mode": mode,
+    "selector": selector,
+    "max_output_tokens": payload.get("max_output_tokens"),
+    "inference_parameter_fingerprint": payload.get("inference_parameter_fingerprint"),
+}), encoding="utf-8")
+PY
+chmod +x "$TMP/uts/tools/uts_benchmark_runner.py"
+
+cat >"$TMP/adl-bin/adl-provider-adapter" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+request=""
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --request) request="$2"; shift 2 ;;
+    --out) out="$2"; shift 2 ;;
+    --log) shift 2 ;;
+    *) shift ;;
+  esac
+done
+python3 - "$request" "$out" <<'PY'
+import json
+import sys
+from pathlib import Path
+request = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert request["max_output_tokens"] == 1024
+Path(sys.argv[2]).write_text(json.dumps({"final_status": "ok", "output_text": "{}"}), encoding="utf-8")
+PY
+SH
+chmod +x "$TMP/adl-bin/adl-provider-adapter"
+
+printf 'test-key\n' >"$TMP/key"
+
+ADL_PROVIDER_ADAPTER_BIN="$TMP/adl-bin/adl-provider-adapter" \
+bash "$ROOT/adl/tools/run_fable5_uts_acceptance.sh" \
+  --uts-root "$TMP/uts" \
+  --artifact-dir "$TMP/artifacts" \
+  --key-file "$TMP/key" \
+  --skip-probe >"$TMP/run.out"
+
+grep -F "PASS fable5_uts_acceptance" "$TMP/run.out" >/dev/null
+grep -F "hosted:adl-anthropic:claude-fable-5" "$TMP/artifacts/fable5_selector.txt" >/dev/null
+python3 - <<'PY' "$TMP/artifacts/fable5_uts_results.json"
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["max_output_tokens"] == 1024
+assert "max_output_tokens=1024" in payload["inference_parameter_fingerprint"]
+PY
+
+REQ="$TMP/request.json"
+OUT="$TMP/out.json"
+LOG="$TMP/log.jsonl"
+printf '{"route":{},"attempt_policy":{"max_attempts":1,"timeout_ms":1}}\n' >"$REQ"
+python3 "$ROOT/adl/tools/adl_provider_adapter_with_budget.py" \
+  --adapter "$TMP/adl-bin/adl-provider-adapter" \
+  --max-output-tokens 1024 \
+  -- --request "$REQ" --out "$OUT" --log "$LOG"
+python3 - <<'PY' "$REQ"
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["max_output_tokens"] == 1024
+assert payload["inference_parameter_fingerprint"] == "max_output_tokens=1024"
+PY

--- a/docs/milestones/v0.91.7/review/provider/FABLE5_UTS_ACCEPTANCE_5044.md
+++ b/docs/milestones/v0.91.7/review/provider/FABLE5_UTS_ACCEPTANCE_5044.md
@@ -1,0 +1,123 @@
+# Fable 5 UTS Acceptance Proof - Issue #5044
+
+Issue: `#5044 [v0.91.7][provider][anthropic] Run Fable 5 UTS provider acceptance panel`
+
+Date: 2026-07-07
+
+## Scope
+
+This issue makes Claude Fable 5 repeatable as an ADL provider-adapter UTS
+acceptance target.
+
+- Provider route: `hosted:adl-anthropic:claude-fable-5`
+- Provider model id: `claude-fable-5`
+- Credential source used for live proof: operator-approved
+  `$HOME/keys/claude2.key`, mapped command-locally to `ANTHROPIC_API_KEY`
+- Output-token budget used by the ADL adapter request: `1024`
+- UTS lanes: `regular,uts_only`
+
+## Implementation Surface
+
+- Added `adl/tools/adl_provider_adapter_with_budget.py`, a generic wrapper that
+  inserts `max_output_tokens` into a UTS-owned ADL provider request before
+  invoking `adl-provider-adapter`.
+- Added `adl/tools/run_fable5_uts_acceptance.sh`, a reusable Fable 5 UTS runner
+  that writes the ad-hoc selector, runs deterministic self-check, optionally
+  runs hosted availability probe, and runs the regular plus UTS-only panel.
+- Added `adl/tools/test_fable5_uts_acceptance.sh`, a non-live wrapper contract
+  test proving selector generation and request-budget injection.
+- Updated Anthropic response normalization so an Anthropic HTTP 200 response
+  with `stop_reason: "refusal"` and no text content is recorded as a model
+  refusal JSON instead of a provider empty-output failure.
+
+## Focused Validation
+
+Commands run from the issue worktree:
+
+```text
+cargo fmt --manifest-path adl/Cargo.toml
+bash adl/tools/test_fable5_uts_acceptance.sh
+cargo test --manifest-path adl/Cargo.toml anthropic_provider_complete_normalizes_empty_refusal_response -- --nocapture
+cargo test --manifest-path adl/Cargo.toml claude_hosted_adapter_normalizes_empty_refusal_response -- --nocapture
+cargo test --manifest-path adl/Cargo.toml optional_output_token_budget_maps_to_provider_native_fields -- --nocapture
+git diff --check
+ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/local-artifacts/provider-fable5-5044-changed-files.txt
+```
+
+Focused result: passed.
+
+Broad lane result: non-proving, failed outside the Fable 5 provider surface.
+The PR-fast opt-in lane escalated to full nextest for unmapped Rust-surface
+coverage and stopped at
+`finish_validation_profile_classifies_bounded_cav_tokio_paths`. The failure
+reported missing validation-lane coverage for an unrelated bounded CAV/tokio
+selector fixture involving `adl/tools/observability.sh`, after `9992` tests had
+passed and `18` were skipped. This issue does not claim a green full-nextest
+run; publication relies on the focused provider proof above plus the live UTS
+acceptance run.
+
+## Live UTS Proof
+
+Command shape:
+
+```text
+ADL_PROVIDER_ADAPTER_BIN=<ADL_WORKTREE>/adl/target/debug/adl-provider-adapter \
+ADL_ANTHROPIC_API_KEY_FILE=$HOME/keys/claude2.key \
+UTS_HOSTED_MAX_ATTEMPTS=2 \
+UTS_HOSTED_RETRY_BACKOFF_SECONDS=1 \
+bash adl/tools/run_fable5_uts_acceptance.sh \
+  --artifact-dir .adl/local-artifacts/provider-fable5-5044-normalized \
+  --key-file $HOME/keys/claude2.key \
+  --max-output-tokens 1024 \
+  --run-id issue-5044-fable5-uts-normalized
+```
+
+Availability probe:
+
+- Model: `claude-fable-5`
+- Route: `adl-anthropic`
+- Classification: `listed_and_invokable`
+- HTTP: `200`
+- Note: model listing is not supported for the ADL Anthropic route.
+
+UTS panel result:
+
+| Model | Route | Regular | UTS-only | Provider failures | Semantic failures |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `claude-fable-5` | `hosted:adl-anthropic:claude-fable-5` | `10/11` | `11/11` | `0` | `1` |
+
+The single regular-lane semantic failure was `update_inventory_basic`: Fable 5
+returned a model refusal for the ordinary tool-call prompt. The same task passed
+in the UTS-only lane because the UTS proposal format carries an explicit
+`dry_run_requested: true` boundary.
+
+## Artifacts
+
+Retained local artifacts:
+
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_selector.txt`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_self_check.json`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_probe_results.json`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_probe_results_summary.md`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results.json`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_summary.md`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_provider_status.json`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_details.md`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_run.jsonl`
+- `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_self_check.json`
+
+Diagnostic local artifacts from earlier runs are retained under
+`.adl/local-artifacts/provider-fable5-5044*` and show why the Anthropic refusal
+normalization was necessary. They are not claimed as the final accepted run.
+
+## Boundaries
+
+- No provider secret was printed, copied, committed, or retained in tracked
+  artifacts.
+- This proof does not claim broad Fable 5 quality, benchmark superiority,
+  release authority, merge authority, or autonomous repository mutation ability.
+- The row is an ad-hoc model acceptance target, not a canonical UTS model-panel
+  member.
+- The useful result is that Fable 5 is invokable through ADL, has zero provider
+  failures after refusal normalization, and performs better with the UTS dry-run
+  boundary than with ordinary tool-call prompting on mutation-shaped tasks.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -65,6 +65,12 @@ ChatGPT demo note:
 Claude family note:
 - the first-class Claude setup surface uses `claude:claude-3-7-sonnet` plus the same bounded ADL completion contract; it is distinct from the generic `anthropic` compatibility setup so Claude can be referenced symmetrically with ChatGPT in multi-agent workflows
 
+Fable 5 UTS acceptance note:
+- use `adl/tools/run_fable5_uts_acceptance.sh` to run Claude Fable 5 through the ADL provider adapter and the sibling UTS benchmark runner
+- the script writes an ad-hoc selector for `hosted:adl-anthropic:claude-fable-5`, injects a portable `max_output_tokens` budget through `adl/tools/adl_provider_adapter_with_budget.py`, runs the UTS deterministic self-check, runs an optional hosted probe, and then runs the `regular,uts_only` lanes
+- provide credentials with `--key-file "$HOME/keys/claude2.key"` or an already-set `ANTHROPIC_API_KEY`; the script must not print or retain the key value
+- proof for issue #5044 is recorded in `docs/milestones/v0.91.7/review/provider/FABLE5_UTS_ACCEPTANCE_5044.md`
+
 Live multi-agent demo note:
 - `adl/tools/demo_v0871_real_multi_agent_discussion.sh` is the operator-run live-provider companion to the deterministic multi-agent demo
 - `adl/tools/test_demo_v0871_real_multi_agent_discussion.sh` preserves local ergonomics by exiting successfully when operator credentials are unavailable, but it now emits an explicit machine-readable non-proving skip disposition instead of implying live-provider proof


### PR DESCRIPTION
Closes #5044

## Summary
Implemented and proved a repeatable Fable 5 UTS acceptance path through the ADL hosted Anthropic provider adapter. The issue adds a reusable ADL provider-adapter output-token-budget wrapper, a Fable 5 UTS runner, focused wrapper tests, Anthropic refusal-shape normalization, focused Rust regressions, documentation, and a tracked proof packet.

Live proof used the operator-approved `$HOME/keys/claude2.key` source mapped command-locally to `ANTHROPIC_API_KEY`. The final accepted run used route `hosted:adl-anthropic:claude-fable-5`, model id `claude-fable-5`, and `max_output_tokens: 1024`. Fable 5 was invokable, had zero provider failures after Anthropic refusal normalization, scored `10/11` on the regular lane, and scored `11/11` on the UTS-only lane. The single regular-lane semantic failure was `update_inventory_basic`, where the model refused an ordinary mutation-shaped tool prompt; the same task passed in UTS-only because the UTS proposal carries `dry_run_requested: true`.

## Artifacts
- Tracked implementation artifacts:
  - `adl/src/provider/http_family.rs`
  - `adl/src/provider/http_family/tests.rs`
  - `adl/src/provider_adapter.rs`
  - `adl/tools/adl_provider_adapter_with_budget.py`
  - `adl/tools/run_fable5_uts_acceptance.sh`
  - `adl/tools/test_fable5_uts_acceptance.sh`
  - `docs/tooling/PROVIDER_SETUP.md`
  - `docs/milestones/v0.91.7/review/provider/FABLE5_UTS_ACCEPTANCE_5044.md`
- Local ignored proof artifacts:
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_selector.txt`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_self_check.json`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_probe_results.json`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_probe_results_summary.md`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results.json`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_summary.md`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_provider_status.json`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_details.md`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_run.jsonl`
  - `.adl/local-artifacts/provider-fable5-5044-normalized/fable5_uts_results_self_check.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Verified Rust formatting for touched code.`
  - `bash adl/tools/test_fable5_uts_acceptance.sh`
    `Verified non-live wrapper contract for selector generation and budget injection.`
  - `cargo test --manifest-path adl/Cargo.toml anthropic_provider_complete_normalizes_empty_refusal_response -- --nocapture`
    `Verified native Anthropic provider refusal-shape normalization.`
  - `cargo test --manifest-path adl/Cargo.toml claude_hosted_adapter_normalizes_empty_refusal_response -- --nocapture`
    `Verified provider adapter Anthropic refusal-shape normalization.`
  - `cargo test --manifest-path adl/Cargo.toml optional_output_token_budget_maps_to_provider_native_fields -- --nocapture`
    `Verified portable max output budget mapping.`
  - `bash adl/tools/run_fable5_uts_acceptance.sh --artifact-dir .adl/local-artifacts/provider-fable5-5044-normalized --key-file $HOME/keys/claude2.key --max-output-tokens 1024 --run-id issue-5044-fable5-uts-normalized`
    `Verified Fable 5 through ADL provider adapter: availability probe listed_and_invokable; regular 10/11; UTS-only 11/11; provider failures 0.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
  - `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/local-artifacts/provider-fable5-5044-changed-files.txt`
    `Non-proving broad lane. Full nextest stopped at unrelated validation selector coverage drift: finish_validation_profile_classifies_bounded_cav_tokio_paths. Summary before fail-fast cancellation: 9993/20307 tests run, 9992 passed, 1 failed, 18 skipped, 10314 not run.`
- Results:
  - `PASS for focused provider proof and live Fable 5 UTS acceptance; BROAD_LANE_NON_PROVING for the opt-in full-nextest escalation.`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5044__v0-91-7-provider-anthropic-run-fable-5-uts-provider-acceptance-panel/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5044__v0-91-7-provider-anthropic-run-fable-5-uts-provider-acceptance-panel/sor.md
- Idempotency-Key: v0-91-7-provider-anthropic-run-fable-5-uts-provider-acceptance-panel-adl-src-provider-http-family-rs-adl-src-provider-http-family-tests-rs-adl-src-provider-adapter-rs-adl-tools-adl-provider-adapter-with-budget-py-adl-tools-run-fable5-uts-acceptance-sh-adl-tools-test-fable5-uts-acceptance-sh-docs-milestones-v0-91-7-review-provider-fable5-uts-acceptance-5044-md-docs-tooling-provider-setup-md-adl-v0-91-7-tasks-issue-5044-v0-91-7-provider-anthropic-run-fable-5-uts-provider-acceptance-panel-sip-md-adl-v0-91-7-tasks-issue-5044-v0-91-7-provider-anthropic-run-fable-5-uts-provider-acceptance-panel-sor-md