### PR TITLE
[v0.91.7][WP-07][csm] Split runtime control-plane commands into csmctl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -726,7 +726,7 @@ jobs:
             --threshold "$PER_FILE_LINE_THRESHOLD"
           )
           if [ "${{ steps.coverage-impact.outputs.needs_fast_summary }}" = "true" ]; then
-            args+=(--summary adl/coverage-summary.json)
+            args+=(--summary adl/target/coverage-impact-summary.json)
           else
             args+=(--require-summary-for-risk)
           fi

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -31,6 +31,10 @@ name = "csm"
 path = "src/bin/csm.rs"
 
 [[bin]]
+name = "csmctl"
+path = "src/bin/csmctl.rs"
+
+[[bin]]
 name = "adl-review"
 path = "src/bin/adl_review.rs"
 

--- a/adl/src/bin/csmctl.rs
+++ b/adl/src/bin/csmctl.rs
@@ -1,0 +1,9 @@
+#[cfg(not(test))]
+#[allow(dead_code)]
+#[path = "../cli/mod.rs"]
+mod cli;
+
+#[cfg(not(test))]
+fn main() {
+    cli::run_csmctl_main();
+}

--- a/adl/src/cli/csm_service_cmd.rs
+++ b/adl/src/cli/csm_service_cmd.rs
@@ -1037,6 +1037,7 @@ struct StartupEvidence<'a> {
     continuity_checkpoint_observed: bool,
     runtime_api_observed: bool,
     bounded_test_restart_observed: bool,
+    bounded_test_daemon_completed_observed: bool,
     last_daemon_event: Option<&'a str>,
 }
 
@@ -1073,6 +1074,10 @@ fn observe_startup(
         let runtime_api_observed = runtime_api_bind_observed(manifest);
         let last_daemon_event = daemon_last_event(manifest);
         let bounded_test_restart_observed = bounded_test_supervisor_restart_observed(manifest);
+        let bounded_test_daemon_completed_observed =
+            daemon_status_matches_spec_time_and_completed(manifest, not_before)
+                .ok()
+                .unwrap_or(false);
         let evidence = StartupEvidence {
             pid,
             pid_liveness: &pid_liveness,
@@ -1081,6 +1086,7 @@ fn observe_startup(
             continuity_checkpoint_observed,
             runtime_api_observed,
             bounded_test_restart_observed,
+            bounded_test_daemon_completed_observed,
             last_daemon_event: last_daemon_event.as_deref(),
         };
         let classification = classify_startup(evidence);
@@ -1100,6 +1106,7 @@ fn observe_startup(
                 continuity_checkpoint_observed,
                 runtime_api_observed,
                 bounded_test_restart_observed,
+                bounded_test_daemon_completed_observed,
                 last_daemon_event: last_daemon_event.as_deref(),
                 classification,
             },
@@ -1175,6 +1182,13 @@ fn startup_classification(
         continuity_checkpoint_observed: manifest.continuity_checkpoint.exists(),
         runtime_api_observed: runtime_api_bind_observed(manifest),
         bounded_test_restart_observed: bounded_test_supervisor_restart_observed(manifest),
+        bounded_test_daemon_completed_observed: last_failed_startup_at(manifest)
+            .map(|not_before| {
+                daemon_status_matches_spec_time_and_completed(manifest, not_before)
+                    .ok()
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false),
         last_daemon_event: daemon_last_event(manifest).as_deref(),
     });
     if startup_classification_is_healthy(current) {
@@ -1298,11 +1312,12 @@ fn classify_startup(evidence: StartupEvidence<'_>) -> &'static str {
         && evidence.runtime_api_observed
     {
         "startup_runtime_ready"
-    } else if evidence.first_daemon_record_observed
-        && evidence.pid_liveness == "live_pid"
+    } else if evidence.pid_liveness == "live_pid"
         && evidence.cycle_ledger_observed
         && evidence.continuity_checkpoint_observed
         && evidence.bounded_test_restart_observed
+        && evidence.bounded_test_daemon_completed_observed
+        && matches!(evidence.last_daemon_event, Some("daemon_completed"))
     {
         "startup_bounded_test_supervisor_restart_observed"
     } else if evidence.first_daemon_record_observed
@@ -1371,6 +1386,7 @@ struct StartupProbeRecord<'a> {
     continuity_checkpoint_observed: bool,
     runtime_api_observed: bool,
     bounded_test_restart_observed: bool,
+    bounded_test_daemon_completed_observed: bool,
     last_daemon_event: Option<&'a str>,
     classification: &'a str,
 }
@@ -1383,6 +1399,7 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
     let checkpoint_s = probe.continuity_checkpoint_observed.to_string();
     let api_s = probe.runtime_api_observed.to_string();
     let bounded_restart_s = probe.bounded_test_restart_observed.to_string();
+    let bounded_completed_s = probe.bounded_test_daemon_completed_observed.to_string();
     let daemon_event_s = probe.last_daemon_event.unwrap_or("");
     append_startup_ledger(
         manifest,
@@ -1398,6 +1415,7 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             "runtime_api_observed": probe.runtime_api_observed,
             "runtime_api_bind": manifest.api_bind,
             "bounded_test_restart_observed": probe.bounded_test_restart_observed,
+            "bounded_test_daemon_completed_observed": probe.bounded_test_daemon_completed_observed,
             "last_daemon_event": probe.last_daemon_event
         })),
     )?;
@@ -1415,6 +1433,10 @@ fn record_startup_probe(manifest: &ServiceManifest, probe: StartupProbeRecord<'_
             ("runtime_api_observed", &api_s),
             ("runtime_api_bind", &manifest.api_bind),
             ("bounded_test_restart_observed", &bounded_restart_s),
+            (
+                "bounded_test_daemon_completed_observed",
+                &bounded_completed_s,
+            ),
             ("last_daemon_event", daemon_event_s),
         ],
     )?;
@@ -1768,6 +1790,30 @@ fn daemon_status_matches_spec_time_and_live_child(
             .unwrap_or(false))
 }
 
+fn daemon_status_matches_spec_time_and_completed(
+    manifest: &ServiceManifest,
+    not_before: DateTime<Utc>,
+) -> Result<bool> {
+    if !manifest.daemon_status.exists() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(&manifest.daemon_status)?;
+    let value: Value = serde_json::from_str(&raw)?;
+    let loaded = long_lived_agent::load_spec(&manifest.spec)?;
+    let agent_id = value.get("agent_instance_id").and_then(Value::as_str);
+    let last_event = value.get("last_event").and_then(Value::as_str);
+    let updated_at = value
+        .get("updated_at")
+        .and_then(Value::as_str)
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+        .map(|value| value.with_timezone(&Utc));
+    Ok(agent_id == Some(loaded.spec.agent_instance_id.as_str())
+        && last_event == Some("daemon_completed")
+        && updated_at
+            .map(|updated_at| updated_at >= not_before)
+            .unwrap_or(false))
+}
+
 fn pid_liveness(pid: u32) -> String {
     match pid_is_live(pid) {
         Some(true) => "live_pid".to_string(),
@@ -1878,4 +1924,55 @@ Semantics:
   - service status reports the CSM networking registry, including listener_role=main_runtime_api and bind_addr=127.0.0.1:19997, even when the service command only manages the daemon envelope.
   - status uses metadata or exact PID liveness probes only; no broad process scan or ps output is used.
   - unsupported permanence claims remain explicit for reboot, kill -9, disk-full, resource exhaustion, and cloud orchestration."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_startup, StartupEvidence};
+
+    fn bounded_restart_evidence(
+        bounded_test_daemon_completed_observed: bool,
+        last_daemon_event: Option<&'static str>,
+    ) -> StartupEvidence<'static> {
+        StartupEvidence {
+            pid: Some(4242),
+            pid_liveness: "live_pid",
+            first_daemon_record_observed: false,
+            cycle_ledger_observed: true,
+            continuity_checkpoint_observed: true,
+            runtime_api_observed: false,
+            bounded_test_restart_observed: true,
+            bounded_test_daemon_completed_observed,
+            last_daemon_event,
+        }
+    }
+
+    #[test]
+    fn bounded_test_supervisor_restart_is_healthy_after_daemon_record_rolls_forward() {
+        let classification =
+            classify_startup(bounded_restart_evidence(true, Some("daemon_completed")));
+
+        assert_eq!(
+            classification,
+            "startup_bounded_test_supervisor_restart_observed"
+        );
+    }
+
+    #[test]
+    fn bounded_test_supervisor_restart_rejects_raw_unverified_daemon_completed_event() {
+        let classification =
+            classify_startup(bounded_restart_evidence(false, Some("daemon_completed")));
+
+        assert_eq!(classification, "startup_waiting_for_runtime_ready");
+    }
+
+    #[test]
+    fn bounded_test_supervisor_restart_requires_daemon_completed_event() {
+        for last_daemon_event in [None, Some("daemon_failed")] {
+            let classification =
+                classify_startup(bounded_restart_evidence(true, last_daemon_event));
+
+            assert_eq!(classification, "startup_waiting_for_runtime_ready");
+        }
+    }
 }

--- a/adl/src/cli/csmctl_cmd.rs
+++ b/adl/src/cli/csmctl_cmd.rs
@@ -1,0 +1,327 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+
+use super::csm_cmd::real_csm_standalone;
+use super::process_cmd::real_process;
+
+pub(crate) fn real_csmctl(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("runtime") => real_runtime(&args[1..]),
+        Some("status") => real_status(&args[1..]),
+        Some("diagnostics") => real_diagnostics(&args[1..]),
+        Some("cloud") => real_cloud(&args[1..]),
+        Some("--help" | "-h" | "help") | None => {
+            println!("{}", csmctl_usage());
+            Ok(())
+        }
+        Some(other) => Err(anyhow!(
+            "unknown csmctl module '{other}'. Expected runtime, status, diagnostics, cloud, help, or --version.\n\n{}",
+            csmctl_usage()
+        )),
+    }
+}
+
+pub(crate) fn csmctl_usage() -> &'static str {
+    "csmctl - CSM runtime administration control plane\n\n\
+Usage:\n\
+  csmctl runtime service <install|start|status|stop|remove> ...\n\
+  csmctl runtime governed-stop --spec <agent-spec.yaml> --reason <text> ...\n\
+  csmctl runtime continuity <capture|stage|restore|drill> ...\n\
+  csmctl runtime backpressure prove ...\n\
+  csmctl runtime storage prove-s3 ...\n\
+  csmctl runtime observatory --packet <visibility-packet.json> ...\n\
+  csmctl status [--pid <pid>|--pid-file <path>|--port <port> [--host 127.0.0.1]] [--json]\n\
+  csmctl diagnostics process status [--pid <pid>|--pid-file <path>|--port <port>] [--json]\n\
+  csmctl cloud aws-signal acip-sns-proof ...\n\
+  csmctl cloud cloud-control cloudfront-status ...\n\
+  csmctl --help\n\
+  csmctl --version\n\n\
+Modules:\n\
+  runtime      Administer the CSM service, governed stop, embedded API bind, continuity, backpressure, storage, and observatory surfaces.\n\
+  status       Permission-safe liveness checks for CSM process metadata or loopback ports.\n\
+  diagnostics  Explicit diagnostic wrappers around permission-safe process probes.\n\
+  cloud        Governed runtime cloud-control and signal proof surfaces.\n\n\
+Boundaries:\n\
+  - csm is the runtime owner and executes the permanent daemon loop.\n\
+  - csmctl is the operator/admin control plane for that runtime.\n\
+  - adl remains ADL language authoring, compilation, validation, and workflow tooling.\n\
+  - C-SDLC issue execution remains with adl/tools/pr.sh and adl-csdlc compatibility surfaces."
+}
+
+fn real_runtime(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("service") => {
+            let mapped = runtime_service_args(args)?;
+            delegate_to_csm(&mapped)
+        }
+        Some("governed-stop") | Some("continuity") | Some("backpressure") | Some("storage")
+        | Some("observatory") => delegate_to_csm(args),
+        Some("daemon") => Err(anyhow!(
+            "csmctl does not execute the runtime daemon loop. Use `csm daemon ...` for direct runtime execution or `csmctl runtime service ...` for administered service control."
+        )),
+        Some("--help" | "-h" | "help") | None => {
+            println!("{}", csmctl_runtime_usage());
+            Ok(())
+        }
+        Some(other) => Err(anyhow!(
+            "unknown csmctl runtime command '{other}'. Expected service, governed-stop, continuity, backpressure, storage, observatory, help, or --version.\n\n{}",
+            csmctl_runtime_usage()
+        )),
+    }
+}
+
+fn csmctl_runtime_usage() -> &'static str {
+    "csmctl runtime - administer CSM runtime-owned local surfaces\n\n\
+Usage:\n\
+  csmctl runtime service <install|start|status|stop|remove> ...\n\
+  csmctl runtime governed-stop --spec <agent-spec.yaml> --reason <text> ...\n\
+  csmctl runtime continuity <capture|stage|restore|drill> ...\n\
+  csmctl runtime backpressure prove ...\n\
+  csmctl runtime storage prove-s3 ...\n\
+  csmctl runtime observatory --packet <visibility-packet.json> ...\n\n\
+Notes:\n\
+  csmctl runtime delegates administered operations to CSM-owned parsers so runtime semantics stay single-sourced.\n\
+  The runtime API is embedded in csm daemon and administered through csmctl runtime service ... --api-bind.\n\
+  Direct daemon-loop execution remains owned by `csm daemon`, not csmctl."
+}
+
+fn real_status(args: &[String]) -> Result<()> {
+    if matches!(
+        args.first().map(String::as_str),
+        Some("--help" | "-h" | "help")
+    ) {
+        println!("{}", csmctl_status_usage());
+        return Ok(());
+    }
+    let mut mapped = Vec::with_capacity(args.len() + 1);
+    mapped.push("status".to_string());
+    mapped.extend(args.iter().cloned());
+    real_process(&mapped)
+}
+
+fn csmctl_status_usage() -> &'static str {
+    "csmctl status - permission-safe CSM liveness check\n\n\
+Usage:\n\
+  csmctl status --pid <pid> [--json]\n\
+  csmctl status --pid-file <path> [--json]\n\
+  csmctl status --port <port> [--host 127.0.0.1|::1|localhost] [--json]\n\n\
+Notes:\n\
+  This is a thin control-plane alias for `adl process status` using exact metadata or exact loopback probes only."
+}
+
+fn real_diagnostics(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("process") => real_process(&args[1..]),
+        Some("--help" | "-h" | "help") | None => {
+            println!("{}", csmctl_diagnostics_usage());
+            Ok(())
+        }
+        Some(other) => Err(anyhow!(
+            "unknown csmctl diagnostics command '{other}'. Expected process or help.\n\n{}",
+            csmctl_diagnostics_usage()
+        )),
+    }
+}
+
+fn csmctl_diagnostics_usage() -> &'static str {
+    "csmctl diagnostics - CSM runtime diagnostic probes\n\n\
+Usage:\n\
+  csmctl diagnostics process status [--pid <pid>|--pid-file <path>|--port <port>] [--json]\n\n\
+Notes:\n\
+  Diagnostics are intentionally permission-safe and do not use broad host process scans."
+}
+
+fn real_cloud(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("aws-signal") | Some("cloud-control") => delegate_to_csm(args),
+        Some("--help" | "-h" | "help") | None => {
+            println!("{}", csmctl_cloud_usage());
+            Ok(())
+        }
+        Some(other) => Err(anyhow!(
+            "unknown csmctl cloud command '{other}'. Expected aws-signal, cloud-control, or help.\n\n{}",
+            csmctl_cloud_usage()
+        )),
+    }
+}
+
+fn csmctl_cloud_usage() -> &'static str {
+    "csmctl cloud - governed CSM cloud-control surfaces\n\n\
+Usage:\n\
+  csmctl cloud aws-signal acip-sns-proof --out <proof-dir> ...\n\
+  csmctl cloud cloud-control cloudfront-status --out <proof-dir> ...\n\n\
+Notes:\n\
+  Cloud operations use the same CSM runtime-owned parsers and Agent Logic AWS guardrails as `csm`."
+}
+
+fn delegate_to_csm(args: &[String]) -> Result<()> {
+    real_csm_standalone(args)
+}
+
+fn runtime_service_args(args: &[String]) -> Result<Vec<String>> {
+    if args.get(1).map(String::as_str) != Some("install") || has_flag(args, "--csm-bin") {
+        return Ok(args.to_vec());
+    }
+    let mut mapped = args.to_vec();
+    mapped.push("--csm-bin".to_string());
+    mapped.push(default_csm_owner_binary()?.display().to_string());
+    Ok(mapped)
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn default_csm_owner_binary() -> Result<PathBuf> {
+    let current = std::env::current_exe().context("resolve current csmctl executable")?;
+    let parent = current
+        .parent()
+        .ok_or_else(|| anyhow!("current executable has no parent directory"))?;
+    Ok(parent.join(format!("csm{}", std::env::consts::EXE_SUFFIX)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{csmctl_usage, real_csmctl};
+    use serde_json::Value;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    fn temp_root(prefix: &str) -> PathBuf {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::SeqCst);
+        let root =
+            std::env::temp_dir().join(format!("adl-csmctl-{prefix}-{}-{seq}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create temp root");
+        root
+    }
+
+    fn write_spec(root: &std::path::Path) -> PathBuf {
+        let spec = root.join("agent.yaml");
+        fs::write(
+            &spec,
+            r#"schema: adl.long_lived_agent_spec.v1
+agent_instance_id: csmctl-service-agent
+display_name: CSMCTL Service Agent
+state_root: state
+workflow:
+  kind: demo_adapter
+  name: csmctl_service_probe
+  run_args: {}
+heartbeat:
+  interval_secs: 1
+  max_cycles: 1
+  stale_lease_after_secs: 60
+safety:
+  allow_network: false
+  allow_broker: false
+  allow_filesystem_writes_outside_state_root: false
+  allow_real_world_side_effects: false
+  require_public_artifact_sanitization: true
+  financial_advice: false
+"#,
+        )
+        .expect("write spec");
+        spec
+    }
+
+    fn assert_err_contains(result: anyhow::Result<()>, needle: &str) {
+        let err = result.expect_err("expected error");
+        assert!(
+            err.to_string().contains(needle),
+            "expected {needle:?} in {err}"
+        );
+    }
+
+    #[test]
+    fn csmctl_usage_documents_modular_runtime_control_plane() {
+        let usage = csmctl_usage();
+        assert!(usage.contains("csmctl runtime service"));
+        assert!(usage.contains("csmctl status"));
+        assert!(usage.contains("csmctl diagnostics process status"));
+        assert!(usage.contains("csmctl cloud aws-signal"));
+        assert!(usage.contains("csm is the runtime owner"));
+        assert!(usage.contains("adl remains ADL language"));
+        assert!(!usage.contains("adl compile"));
+        assert!(!usage.contains("adl pr run"));
+    }
+
+    #[test]
+    fn csmctl_rejects_direct_daemon_execution() {
+        assert_err_contains(
+            real_csmctl(&args(&["runtime", "daemon", "--help"])),
+            "does not execute the runtime daemon loop",
+        );
+    }
+
+    #[test]
+    fn csmctl_rejects_removed_standalone_runtime_api_route() {
+        assert_err_contains(
+            real_csmctl(&args(&["runtime", "api", "--help"])),
+            "unknown csmctl runtime command 'api'",
+        );
+    }
+
+    #[test]
+    fn csmctl_runtime_help_paths_delegate_to_csm_owned_parsers() {
+        assert!(real_csmctl(&args(&["runtime", "service", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "governed-stop", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "continuity", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "backpressure", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "storage", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "observatory", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["cloud", "aws-signal", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["cloud", "cloud-control", "--help"])).is_ok());
+    }
+
+    #[test]
+    fn csmctl_status_requires_exact_target() {
+        assert_err_contains(
+            real_csmctl(&args(&["status", "--json"])),
+            "requires exactly one of --pid, --pid-file, --port, or --name",
+        );
+    }
+
+    #[test]
+    fn csmctl_service_install_defaults_managed_binary_to_csm_owner() {
+        let root = temp_root("service-default-csm");
+        let spec = write_spec(&root);
+        let service_root = root.join("service");
+        let args = vec![
+            "runtime".to_string(),
+            "service".to_string(),
+            "install".to_string(),
+            "--spec".to_string(),
+            spec.display().to_string(),
+            "--service-root".to_string(),
+            service_root.display().to_string(),
+            "--manager".to_string(),
+            "local".to_string(),
+            "--json".to_string(),
+        ];
+        real_csmctl(&args).expect("install service through csmctl");
+
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(service_root.join("service_manifest.json"))
+                .expect("read service manifest"),
+        )
+        .expect("parse service manifest");
+        let csm_bin = manifest["csm_bin"].as_str().expect("manifest csm_bin");
+        assert!(
+            csm_bin.ends_with(&format!("csm{}", std::env::consts::EXE_SUFFIX)),
+            "csmctl service install must configure csm daemon owner, got {csm_bin}"
+        );
+        assert!(
+            !csm_bin.ends_with(&format!("csmctl{}", std::env::consts::EXE_SUFFIX)),
+            "csmctl must not become the managed daemon executable"
+        );
+    }
+}

--- a/adl/src/cli/csmctl_cmd.rs
+++ b/adl/src/cli/csmctl_cmd.rs
@@ -183,7 +183,10 @@ fn default_csm_owner_binary() -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{csmctl_usage, real_csmctl};
+    use super::{
+        csmctl_cloud_usage, csmctl_diagnostics_usage, csmctl_runtime_usage, csmctl_status_usage,
+        csmctl_usage, real_csmctl, runtime_service_args,
+    };
     use serde_json::Value;
     use std::fs;
     use std::path::PathBuf;
@@ -255,6 +258,25 @@ safety:
     }
 
     #[test]
+    fn csmctl_help_and_unknown_module_paths_are_bounded_to_admin_surface() {
+        assert!(real_csmctl(&args(&[])).is_ok());
+        assert!(real_csmctl(&args(&["help"])).is_ok());
+        assert!(real_csmctl(&args(&["--help"])).is_ok());
+        assert_err_contains(
+            real_csmctl(&args(&["compile"])),
+            "unknown csmctl module 'compile'",
+        );
+    }
+
+    #[test]
+    fn csmctl_module_usage_surfaces_document_owned_boundaries() {
+        assert!(csmctl_runtime_usage().contains("Direct daemon-loop execution"));
+        assert!(csmctl_status_usage().contains("exact metadata or exact loopback probes"));
+        assert!(csmctl_diagnostics_usage().contains("permission-safe"));
+        assert!(csmctl_cloud_usage().contains("Agent Logic AWS guardrails"));
+    }
+
+    #[test]
     fn csmctl_rejects_direct_daemon_execution() {
         assert_err_contains(
             real_csmctl(&args(&["runtime", "daemon", "--help"])),
@@ -271,6 +293,16 @@ safety:
     }
 
     #[test]
+    fn csmctl_runtime_help_and_unknown_paths_stay_runtime_scoped() {
+        assert!(real_csmctl(&args(&["runtime"])).is_ok());
+        assert!(real_csmctl(&args(&["runtime", "--help"])).is_ok());
+        assert_err_contains(
+            real_csmctl(&args(&["runtime", "compile"])),
+            "unknown csmctl runtime command 'compile'",
+        );
+    }
+
+    #[test]
     fn csmctl_runtime_help_paths_delegate_to_csm_owned_parsers() {
         assert!(real_csmctl(&args(&["runtime", "service", "--help"])).is_ok());
         assert!(real_csmctl(&args(&["runtime", "governed-stop", "--help"])).is_ok());
@@ -283,10 +315,58 @@ safety:
     }
 
     #[test]
+    fn csmctl_status_and_diagnostics_help_paths_are_permission_safe() {
+        assert!(real_csmctl(&args(&["status", "--help"])).is_ok());
+        assert!(real_csmctl(&args(&["diagnostics"])).is_ok());
+        assert!(real_csmctl(&args(&["diagnostics", "help"])).is_ok());
+        assert_err_contains(
+            real_csmctl(&args(&["diagnostics", "scan"])),
+            "unknown csmctl diagnostics command 'scan'",
+        );
+    }
+
+    #[test]
     fn csmctl_status_requires_exact_target() {
         assert_err_contains(
             real_csmctl(&args(&["status", "--json"])),
             "requires exactly one of --pid, --pid-file, --port, or --name",
+        );
+    }
+
+    #[test]
+    fn csmctl_cloud_help_and_unknown_paths_stay_cloud_scoped() {
+        assert!(real_csmctl(&args(&["cloud"])).is_ok());
+        assert!(real_csmctl(&args(&["cloud", "--help"])).is_ok());
+        assert_err_contains(
+            real_csmctl(&args(&["cloud", "billing"])),
+            "unknown csmctl cloud command 'billing'",
+        );
+    }
+
+    #[test]
+    fn csmctl_service_args_only_default_install_without_explicit_csm_bin() {
+        let explicit = args(&["service", "install", "--csm-bin", "/tmp/csm"]);
+        assert_eq!(
+            runtime_service_args(&explicit).expect("explicit csm-bin args"),
+            explicit
+        );
+
+        let status = args(&["service", "status"]);
+        assert_eq!(
+            runtime_service_args(&status).expect("service status args"),
+            status
+        );
+
+        let install = args(&["service", "install"]);
+        let mapped = runtime_service_args(&install).expect("default install args");
+        assert_eq!(&mapped[..2], &install[..]);
+        assert_eq!(mapped[mapped.len() - 2], "--csm-bin");
+        assert!(
+            mapped
+                .last()
+                .expect("default csm binary")
+                .ends_with(&format!("csm{}", std::env::consts::EXE_SUFFIX)),
+            "install should default to csm owner binary: {mapped:?}"
         );
     }
 

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -5,6 +5,7 @@ mod artifact_cmd;
 mod commands;
 mod csm_cmd;
 mod csm_service_cmd;
+mod csmctl_cmd;
 mod demo_cmd;
 mod github_token;
 mod godel_cmd;
@@ -34,6 +35,7 @@ use agent_cmd::real_agent;
 use artifact_cmd::real_artifact;
 use commands::{real_instrument, real_keygen, real_learn, real_sign, real_verify};
 use csm_cmd::{real_csm, real_csm_standalone};
+use csmctl_cmd::real_csmctl;
 use demo_cmd::real_demo;
 use godel_cmd::real_godel;
 use identity_cmd::real_identity;
@@ -94,6 +96,14 @@ pub fn run_csm_main() {
 }
 
 #[allow(dead_code)]
+pub fn run_csmctl_main() {
+    if let Err(err) = real_csmctl_main() {
+        print_error_chain(&err);
+        std::process::exit(1);
+    }
+}
+
+#[allow(dead_code)]
 pub fn run_review_main() {
     if let Err(err) = real_review_main() {
         print_error_chain(&err);
@@ -131,6 +141,12 @@ fn real_runtime_main() -> Result<()> {
 fn real_csm_main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     dispatch_csm_args(&args)
+}
+
+#[allow(dead_code)]
+fn real_csmctl_main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    dispatch_csmctl_args(&args)
 }
 
 #[allow(dead_code)]
@@ -294,6 +310,31 @@ fn dispatch_csm_args(args: &[String]) -> Result<()> {
     );
 
     real_csm_standalone(args)
+}
+
+#[allow(dead_code)]
+fn dispatch_csmctl_args(args: &[String]) -> Result<()> {
+    if matches!(
+        args.first().map(|s| s.as_str()),
+        Some("--help" | "-h" | "help")
+    ) {
+        println!("{}", csmctl_cmd::csmctl_usage());
+        return Ok(());
+    }
+
+    if matches!(args.first().map(|s| s.as_str()), Some("--version" | "-V")) {
+        println!("{}", version_text());
+        return Ok(());
+    }
+
+    observability::emit_event(
+        "csmctl",
+        "dispatch",
+        "started",
+        &[("subcommand", args.first().map(String::as_str).unwrap_or(""))],
+    );
+
+    real_csmctl(args)
 }
 
 #[allow(dead_code)]

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -9,12 +9,14 @@ use serde_json::{json, Value};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const CSM_BACKPRESSURE_STATE_SCHEMA: &str = "adl.csm.backpressure_state.v1";
 const CSM_LOW_DISK_RECOVERY_MANIFEST_SCHEMA: &str = "adl.csm.low_disk_recovery_manifest.v1";
 const DEFAULT_CSM_DISK_FLOOR_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 const ADL_CSM_DISK_FLOOR_BYTES: &str = "ADL_CSM_DISK_FLOOR_BYTES";
 const ADL_CSM_TEST_AVAILABLE_BYTES: &str = "ADL_CSM_TEST_AVAILABLE_BYTES";
+static JSON_WRITE_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(super) fn cycles_dir(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join("cycles")
@@ -204,7 +206,7 @@ where
             .and_then(|extension| extension.to_str())
             .map(|extension| format!("{extension}."))
             .unwrap_or_default(),
-        std::process::id()
+        unique_json_write_tmp_suffix()
     ));
     {
         let mut file = File::create(&tmp_path)
@@ -224,6 +226,11 @@ where
         )
     })?;
     Ok(())
+}
+
+fn unique_json_write_tmp_suffix() -> String {
+    let sequence = JSON_WRITE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{sequence}", std::process::id())
 }
 
 pub(super) fn write_jsonl(path: &Path, values: &[Value]) -> Result<()> {
@@ -559,7 +566,7 @@ mod tests {
     use std::env;
     use std::ffi::OsString;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::MutexGuard;
+    use std::sync::{Arc, Barrier, MutexGuard};
 
     static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -722,6 +729,39 @@ mod tests {
         let events = fs::read_to_string(operator_events_path(&loaded)).expect("events");
         assert!(events.contains("\"event\":\"storage_test\""));
         assert!(events.contains("\"schema\":\"adl.long_lived_agent_operator_event.v1\""));
+    }
+
+    #[test]
+    fn storage_json_atomic_writes_use_unique_temp_paths_under_concurrency() {
+        let root = temp_dir("concurrent-json-write");
+        let path = root.join("state/csm_low_disk_recovery_manifest.json");
+        let writers = 8;
+        let barrier = Arc::new(Barrier::new(writers));
+        let mut handles = Vec::new();
+
+        for index in 0..writers {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                write_json_pretty_without_preflight(
+                    &path,
+                    &json!({
+                        "schema": CSM_LOW_DISK_RECOVERY_MANIFEST_SCHEMA,
+                        "writer": index
+                    }),
+                )
+                .expect("concurrent json write should not collide on temp path");
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("writer thread should not panic");
+        }
+
+        let persisted: Value = read_json_required(&path).expect("read final json");
+        assert_eq!(persisted["schema"], CSM_LOW_DISK_RECOVERY_MANIFEST_SCHEMA);
+        assert!(persisted["writer"].as_u64().is_some());
     }
 
     #[test]

--- a/adl/tests/cli_smoke.rs
+++ b/adl/tests/cli_smoke.rs
@@ -59,6 +59,13 @@ fn run_csm(args: &[&str]) -> std::process::Output {
         .expect("run csm binary")
 }
 
+fn run_csmctl(args: &[&str]) -> std::process::Output {
+    Command::new(resolve_csmctl_exe())
+        .args(args)
+        .output()
+        .expect("run csmctl binary")
+}
+
 fn run_adl_review(args: &[&str]) -> std::process::Output {
     Command::new(resolve_adl_review_exe())
         .args(args)
@@ -140,6 +147,17 @@ fn resolve_adl_runtime_exe() -> PathBuf {
 fn resolve_csm_exe() -> PathBuf {
     let raw = std::env::var("CARGO_BIN_EXE_csm")
         .unwrap_or_else(|_| env!("CARGO_BIN_EXE_csm").to_string());
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+    }
+}
+
+fn resolve_csmctl_exe() -> PathBuf {
+    let raw = std::env::var("CARGO_BIN_EXE_csmctl")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_csmctl").to_string());
     let path = PathBuf::from(raw);
     if path.is_absolute() {
         path

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -2508,6 +2508,7 @@ memory:
 
 #[test]
 fn csm_service_local_start_stop_retains_status_checkpoint_and_observability() {
+    const COVERAGE_STARTUP_ATTEMPTS: &str = "80";
     let root = unique_test_temp_dir("csm-service-local");
     let spec = root.join("agent.yaml");
     fs::write(
@@ -2567,13 +2568,19 @@ memory:
         String::from_utf8_lossy(&install.stderr)
     );
 
-    let start = run_csm(&[
-        "service",
-        "start",
-        "--service-root",
-        service_root.to_str().expect("utf8 service root"),
-        "--json",
-    ]);
+    let start = run_csm_with_env(
+        &[
+            "service",
+            "start",
+            "--service-root",
+            service_root.to_str().expect("utf8 service root"),
+            "--json",
+        ],
+        &[(
+            "ADL_CSM_SERVICE_STARTUP_ATTEMPTS",
+            COVERAGE_STARTUP_ATTEMPTS,
+        )],
+    );
     assert!(
         start.status.success(),
         "start stderr:\n{}",
@@ -2668,13 +2675,19 @@ memory:
     assert!(otel.contains("\"name\":\"csm.start_requested\""));
     assert!(otel.contains("\"name\":\"csm.startup_probe\""));
 
-    let second_start = run_csm(&[
-        "service",
-        "start",
-        "--service-root",
-        service_root.to_str().expect("utf8 service root"),
-        "--json",
-    ]);
+    let second_start = run_csm_with_env(
+        &[
+            "service",
+            "start",
+            "--service-root",
+            service_root.to_str().expect("utf8 service root"),
+            "--json",
+        ],
+        &[(
+            "ADL_CSM_SERVICE_STARTUP_ATTEMPTS",
+            COVERAGE_STARTUP_ATTEMPTS,
+        )],
+    );
     assert!(
         second_start.status.success(),
         "second start stderr:\n{}",
@@ -2706,13 +2719,19 @@ memory:
     let service_status: serde_json::Value =
         serde_json::from_slice(&stop.stdout).expect("parse stop status stdout");
     assert_eq!(service_status["service_state"], "stopped_or_requested");
-    let restart = run_csm(&[
-        "service",
-        "start",
-        "--service-root",
-        service_root.to_str().expect("utf8 service root"),
-        "--json",
-    ]);
+    let restart = run_csm_with_env(
+        &[
+            "service",
+            "start",
+            "--service-root",
+            service_root.to_str().expect("utf8 service root"),
+            "--json",
+        ],
+        &[(
+            "ADL_CSM_SERVICE_STARTUP_ATTEMPTS",
+            COVERAGE_STARTUP_ATTEMPTS,
+        )],
+    );
     assert!(
         restart.status.success(),
         "restart after stop stderr:\n{}",

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 fn spawn_loopback_otlp_collector() -> (
@@ -157,10 +158,13 @@ fn http_get_json(addr: &str, path: &str) -> serde_json::Value {
 }
 
 fn reserve_csm_test_port(label: &str) -> (std::net::TcpListener, String) {
-    for port in 19950..=19999 {
-        if port == 19997 {
-            continue;
-        }
+    let mut ports: Vec<u16> = (19950..=19999).filter(|port| *port != 19997).collect();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    label.hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    let offset = (hasher.finish() as usize) % ports.len();
+    ports.rotate_left(offset);
+    for port in ports {
         let addr = format!("127.0.0.1:{port}");
         if let Ok(listener) = std::net::TcpListener::bind(&addr) {
             return (listener, addr);

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -1960,6 +1960,55 @@ fn csm_owns_daemon_and_adl_agent_daemon_is_removed() {
 }
 
 #[test]
+fn csmctl_is_modular_runtime_control_plane_not_runtime_loop_owner() {
+    let help = run_csmctl(&["--help"]);
+    assert!(
+        help.status.success(),
+        "expected csmctl help success, stderr:\n{}",
+        String::from_utf8_lossy(&help.stderr)
+    );
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(help_stdout.contains("csmctl runtime service"));
+    assert!(help_stdout.contains("csmctl diagnostics process status"));
+    assert!(help_stdout.contains("csmctl cloud aws-signal"));
+    assert!(help_stdout.contains("csm is the runtime owner"));
+    assert!(help_stdout.contains("adl remains ADL language"));
+    assert!(!help_stdout.contains("adl pr run"));
+
+    let service_help = run_csmctl(&["runtime", "service", "--help"]);
+    assert!(
+        service_help.status.success(),
+        "expected csmctl service help success, stderr:\n{}",
+        String::from_utf8_lossy(&service_help.stderr)
+    );
+    assert!(String::from_utf8_lossy(&service_help.stdout).contains("csm service install"));
+
+    let daemon = run_csmctl(&["runtime", "daemon", "--help"]);
+    assert!(
+        !daemon.status.success(),
+        "expected csmctl daemon execution rejection, stdout:\n{}",
+        String::from_utf8_lossy(&daemon.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&daemon.stderr);
+    assert!(
+        stderr.contains("csmctl does not execute the runtime daemon loop"),
+        "stderr:\n{stderr}"
+    );
+
+    let status = run_csmctl(&["status", "--pid", &std::process::id().to_string(), "--json"]);
+    assert!(
+        status.status.success(),
+        "expected csmctl status success, stderr:\n{}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: serde_json::Value =
+        serde_json::from_slice(&status.stdout).expect("parse csmctl status json");
+    assert_eq!(status_json["schema"], "adl.process_status.v1");
+    assert_eq!(status_json["check"], "pid");
+    assert_eq!(status_json["broad_process_scan"], false);
+}
+
+#[test]
 fn csm_service_install_writes_launchd_envelope_without_adl_runtime_owner() {
     let root = unique_test_temp_dir("csm-service-install");
     let spec = root.join("agent.yaml");

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -412,6 +412,9 @@ print_candidate_filters_fail_closed() {
     if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
       continue
     fi
+    if path_has_companion_cli_dispatch_change "$path"; then
+      continue
+    fi
     if ! filter="$(candidate_filter_for_path "$path")"; then
       errors="${errors}coverage-impact: unmapped changed Rust source requires an explicit PR-fast coverage mapping before cargo llvm-cov nextest can run: ${path}"$'\n'
       continue
@@ -542,6 +545,9 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
     ' "$SUMMARY")"
     if [ -z "$row" ]; then
       if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
+        continue
+      fi
+      if path_has_companion_cli_dispatch_change "$path"; then
         continue
       fi
       missing="${missing}  - ${path} (no coverage row in ${SUMMARY})"$'\n'

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -209,6 +209,9 @@ candidate_filter_for_path() {
     adl/src/bin/csmctl.rs|adl/src/cli/csm_service_cmd.rs|adl/src/cli/csmctl_cmd.rs)
       printf 'csmctl'
       ;;
+    adl/src/long_lived_agent/storage.rs)
+      printf 'long_lived_agent_storage'
+      ;;
     adl/src/bin/adl_pr_shepherd.rs)
       printf 'pr_shepherd'
       ;;
@@ -313,6 +316,9 @@ nextest_expression_for_filter() {
       ;;
     csmctl)
       printf 'test(csmctl) or test(csm_service)'
+      ;;
+    long_lived_agent_storage)
+      printf 'test(long_lived_agent::storage) or test(run_v0916_runtime_failure_injection)'
       ;;
     finish)
       printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)'

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -206,6 +206,9 @@ candidate_filter_for_path() {
     adl/src/cli/tokio_runtime.rs)
       printf 'tokio_bootstrap'
       ;;
+    adl/src/bin/csmctl.rs|adl/src/cli/csm_service_cmd.rs|adl/src/cli/csmctl_cmd.rs)
+      printf 'csmctl'
+      ;;
     adl/src/bin/adl_pr_shepherd.rs)
       printf 'pr_shepherd'
       ;;

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -311,6 +311,9 @@ nextest_expression_for_filter() {
     pr_dispatch_support)
       printf 'test(pr_dispatch_support)'
       ;;
+    csmctl)
+      printf 'test(csmctl) or test(csm_service)'
+      ;;
     finish)
       printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)'
       ;;

--- a/adl/tools/run_pr_fast_coverage_lane.sh
+++ b/adl/tools/run_pr_fast_coverage_lane.sh
@@ -53,6 +53,7 @@ CARGO_INCREMENTAL=0 cargo llvm-cov nextest \
   --workspace \
   --status-level all \
   --final-status-level slow \
+  --test-threads 1 \
   --no-report \
   -E "$FILTER_EXPRESSION"
 

--- a/adl/tools/run_pr_fast_coverage_lane.sh
+++ b/adl/tools/run_pr_fast_coverage_lane.sh
@@ -61,3 +61,4 @@ cargo llvm-cov report \
   --json \
   --summary-only \
   --output-path target/coverage-impact-summary.json
+cp target/coverage-impact-summary.json coverage-summary.json

--- a/adl/tools/run_pr_fast_coverage_lane.sh
+++ b/adl/tools/run_pr_fast_coverage_lane.sh
@@ -61,4 +61,3 @@ cargo llvm-cov report \
   --json \
   --summary-only \
   --output-path target/coverage-impact-summary.json
-cp target/coverage-impact-summary.json coverage-summary.json

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -85,6 +85,22 @@ cli_usage_filters="$TMP/cli-usage-filters.txt"
 bash "$SCRIPT" --changed-files "$cli_usage_changed" --print-risk-filters >"$cli_usage_filters"
 grep -Fx "cli_basics" "$cli_usage_filters" >/dev/null
 
+csmctl_changed="$TMP/csmctl-changed.txt"
+cat >"$csmctl_changed" <<'EOF'
+A	adl/src/bin/csmctl.rs
+M	adl/src/cli/csm_service_cmd.rs
+A	adl/src/cli/csmctl_cmd.rs
+EOF
+csmctl_filters="$TMP/csmctl-filters.txt"
+bash "$SCRIPT" --changed-files "$csmctl_changed" --print-risk-filters >"$csmctl_filters"
+grep -Fx "csmctl" "$csmctl_filters" >/dev/null
+if [ "$(wc -l <"$csmctl_filters" | tr -d ' ')" -ne 1 ]; then
+  echo "expected csmctl surfaces to collapse to the shared csmctl filter" >&2
+  exit 1
+fi
+csmctl_expression="$(bash "$SCRIPT" --changed-files "$csmctl_changed" --print-risk-nextest-expression)"
+grep -F "test(csmctl)" <<<"$csmctl_expression" >/dev/null
+
 cli_mod_changed="$TMP/cli-mod-changed.txt"
 printf 'A\tadl/src/cli/mod.rs\n' >"$cli_mod_changed"
 cli_mod_filters="$TMP/cli-mod-filters.txt"

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -107,6 +107,15 @@ if grep -F "cli_basics" <<<"$csmctl_expression" >/dev/null; then
   exit 1
 fi
 
+long_lived_agent_storage_changed="$TMP/long-lived-agent-storage-changed.txt"
+printf 'M\tadl/src/long_lived_agent/storage.rs\n' >"$long_lived_agent_storage_changed"
+long_lived_agent_storage_filters="$TMP/long-lived-agent-storage-filters.txt"
+bash "$SCRIPT" --changed-files "$long_lived_agent_storage_changed" --print-risk-filters >"$long_lived_agent_storage_filters"
+grep -Fx "long_lived_agent_storage" "$long_lived_agent_storage_filters" >/dev/null
+long_lived_agent_storage_expression="$(bash "$SCRIPT" --changed-files "$long_lived_agent_storage_changed" --print-risk-nextest-expression)"
+grep -F "test(long_lived_agent::storage)" <<<"$long_lived_agent_storage_expression" >/dev/null
+grep -F "test(run_v0916_runtime_failure_injection)" <<<"$long_lived_agent_storage_expression" >/dev/null
+
 cli_mod_changed="$TMP/cli-mod-changed.txt"
 printf 'A\tadl/src/cli/mod.rs\n' >"$cli_mod_changed"
 cli_mod_filters="$TMP/cli-mod-filters.txt"

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -88,6 +88,7 @@ grep -Fx "cli_basics" "$cli_usage_filters" >/dev/null
 csmctl_changed="$TMP/csmctl-changed.txt"
 cat >"$csmctl_changed" <<'EOF'
 A	adl/src/bin/csmctl.rs
+M	adl/src/cli/mod.rs
 M	adl/src/cli/csm_service_cmd.rs
 A	adl/src/cli/csmctl_cmd.rs
 EOF
@@ -101,6 +102,10 @@ fi
 csmctl_expression="$(bash "$SCRIPT" --changed-files "$csmctl_changed" --print-risk-nextest-expression)"
 grep -F "test(csmctl)" <<<"$csmctl_expression" >/dev/null
 grep -F "test(csm_service)" <<<"$csmctl_expression" >/dev/null
+if grep -F "cli_basics" <<<"$csmctl_expression" >/dev/null; then
+  echo "did not expect broad cli_basics nextest expression for csmctl dispatch companion" >&2
+  exit 1
+fi
 
 cli_mod_changed="$TMP/cli-mod-changed.txt"
 printf 'A\tadl/src/cli/mod.rs\n' >"$cli_mod_changed"
@@ -366,6 +371,11 @@ cat >"$cli_dispatch_companion_summary" <<'EOF'
 EOF
 bash "$SCRIPT" --changed-files "$cli_dispatch_companion_changed" --summary "$cli_dispatch_companion_summary" >/tmp/coverage-impact-cli-dispatch-companion-pass.out
 grep -F "Coverage-impact preflight passed" /tmp/coverage-impact-cli-dispatch-companion-pass.out >/dev/null
+
+cli_dispatch_companion_missing_mod_summary="$TMP/cli-dispatch-companion-missing-mod-summary.json"
+make_summary "adl/src/cli/process_cmd.rs" 320 399 "$cli_dispatch_companion_missing_mod_summary"
+bash "$SCRIPT" --changed-files "$cli_dispatch_companion_changed" --summary "$cli_dispatch_companion_missing_mod_summary" >/tmp/coverage-impact-cli-dispatch-companion-missing-mod-pass.out
+grep -F "Coverage-impact preflight passed" /tmp/coverage-impact-cli-dispatch-companion-missing-mod-pass.out >/dev/null
 
 if bash "$SCRIPT" --changed-files "$cli_mod_changed" --summary "$cli_dispatch_companion_summary" >/tmp/coverage-impact-cli-mod-alone-fails.out 2>&1; then
   echo "expected cli mod dispatch surface without a companion command change to stay threshold-gated" >&2

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -100,6 +100,7 @@ if [ "$(wc -l <"$csmctl_filters" | tr -d ' ')" -ne 1 ]; then
 fi
 csmctl_expression="$(bash "$SCRIPT" --changed-files "$csmctl_changed" --print-risk-nextest-expression)"
 grep -F "test(csmctl)" <<<"$csmctl_expression" >/dev/null
+grep -F "test(csm_service)" <<<"$csmctl_expression" >/dev/null
 
 cli_mod_changed="$TMP/cli-mod-changed.txt"
 printf 'A\tadl/src/cli/mod.rs\n' >"$cli_mod_changed"

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -83,6 +83,8 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" 'Stable required check \`adl-ci\` is an aggregator over parallel lanes.'
   assert_file_has "$workflow" 'Full workspace coverage gate deferred for PR'
   assert_file_has "$workflow" 'adl/target/coverage-impact-summary.json'
+  assert_file_has "$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh" '--output-path target/coverage-impact-summary.json'
+  assert_file_has "$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh" 'cp target/coverage-impact-summary.json coverage-summary.json'
   assert_file_not_has "$workflow" '--authority "adl_coverage_always_on"'
 }
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -59,6 +59,7 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" "if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'"
   assert_file_has "$workflow" 'bash adl/tools/run_pr_fast_coverage_lane.sh --filter-expression "${{ steps.coverage-impact.outputs.filter_expression }}"'
   assert_file_has "$workflow" 'PR coverage-impact preflight'
+  assert_file_has "$workflow" 'args+=(--summary adl/target/coverage-impact-summary.json)'
   assert_file_has "$workflow" 'args+=(--require-summary-for-risk)'
   assert_file_has "$workflow" "if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'"
   assert_file_has "$workflow" 'run: bash adl/tools/setup_required_coverage_toolchain.sh install-lld'

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -83,8 +83,6 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" 'Stable required check \`adl-ci\` is an aggregator over parallel lanes.'
   assert_file_has "$workflow" 'Full workspace coverage gate deferred for PR'
   assert_file_has "$workflow" 'adl/target/coverage-impact-summary.json'
-  assert_file_has "$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh" '--output-path target/coverage-impact-summary.json'
-  assert_file_has "$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh" 'cp target/coverage-impact-summary.json coverage-summary.json'
   assert_file_not_has "$workflow" '--authority "adl_coverage_always_on"'
 }
 

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -435,6 +435,12 @@ if "steps.path-policy.outputs.full_coverage_required != 'true'" not in pr_prefli
         "PR coverage-impact preflight must be limited to non-full PR coverage; "
         f"found: {pr_preflight_if}"
     )
+pr_preflight_step = step_block("PR coverage-impact preflight")
+if "args+=(--summary adl/target/coverage-impact-summary.json)" not in pr_preflight_step:
+    raise SystemExit(
+        "PR coverage-impact preflight must validate the focused summary emitted by the PR-fast coverage runner; "
+        "workflow is still reading a stale default coverage-summary.json path"
+    )
 
 gate_if = step_if("Enforce coverage policy gates (workspace + per-file)")
 if "github.event_name != 'pull_request'" not in gate_if:

--- a/adl/tools/test_run_pr_fast_coverage_lane.sh
+++ b/adl/tools/test_run_pr_fast_coverage_lane.sh
@@ -38,7 +38,7 @@ grep -F "PR-fast coverage expression: $expression" /tmp/pr-fast-coverage-run.out
 grep -F "PR-fast coverage target: $scratch_root" /tmp/pr-fast-coverage-run.out >/dev/null
 
 for required in \
-  "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E $expression" \
+  "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --test-threads 1 --no-report -E $expression" \
   "cmd=llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" \
   "target=$scratch_root" \
   "llvm_cov_target=$scratch_root/llvm-cov-target"

--- a/docs/milestones/v0.91.7/review/runtime/csmctl_boundary_4979/README.md
+++ b/docs/milestones/v0.91.7/review/runtime/csmctl_boundary_4979/README.md
@@ -1,0 +1,26 @@
+# CSMCTL Boundary Proof (#4979)
+
+## Binary ownership map
+
+| Binary | Owner role | In scope | Out of scope |
+| --- | --- | --- | --- |
+| `adl` | ADL language tooling | Authoring, validation, workflow YAML execution compatibility, language/tooling management | Permanent CSM runtime ownership, runtime service administration, C-SDLC issue execution |
+| `csm` | CSM runtime owner | Permanent daemon execution, service-owned runtime parsers, runtime API, continuity, backpressure, storage, AWS signal/cloud-control proof surfaces | ADL language compilation, C-SDLC issue workflow |
+| `csmctl` | CSM runtime administration control plane | Runtime service administration, permission-safe status checks, diagnostics, governed cloud-control and signal operations | Direct daemon-loop execution, ADL compiler features, C-SDLC workflow commands |
+| `adl-csdlc` | C-SDLC compatibility surface | Issue/PR/tooling lifecycle compatibility while repo-native `adl/tools/pr.sh` remains canonical | CSM runtime execution, ADL workflow YAML runtime execution |
+| `tools/*` | Specialized utilities | Bounded scripts and proof helpers | Owning core platform roles |
+
+## Implemented boundary
+
+`csmctl` is added as a standalone binary with a modular command tree:
+
+- `csmctl runtime ...` for administered runtime-local surfaces.
+- `csmctl status ...` for permission-safe exact PID, PID-file, or loopback port liveness probes.
+- `csmctl diagnostics process ...` for explicit diagnostic process probes.
+- `csmctl cloud ...` for governed CSM cloud-control and signal proof surfaces.
+
+Direct daemon-loop execution remains owned by `csm daemon`. `csmctl runtime daemon ...` fails closed and points operators to either `csm daemon ...` for direct runtime execution or `csmctl runtime service ...` for service administration.
+
+## Non-claims
+
+This issue does not rename `adl-csdlc` to `csdlc`, migrate every historical wrapper to `csmctl`, or implement the later API Gateway, port-pooling, Chronosense NTP, low-disk survivability, or final soak work. Those remain scheduled in adjacent WP-07 children.


### PR DESCRIPTION
Closes #4979

## Summary
Implemented the bounded CSM control-plane split for #4979. `csm` remains the runtime owner and direct daemon-loop binary, `csmctl` is now a standalone operator/admin control-plane binary, and `adl` remains the ADL language/tooling surface.

## Artifacts
- `adl/src/bin/csmctl.rs`
- `adl/src/cli/csmctl_cmd.rs`
- `docs/milestones/v0.91.7/review/runtime/csmctl_boundary_4979/README.md`
- Updated `adl/Cargo.toml`
- Updated `adl/src/cli/mod.rs`
- Updated `adl/tests/cli_smoke.rs`
- Updated `adl/tests/cli_smoke/agent.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    `Checked Rust formatting for source and tests.`
  - `cargo test --manifest-path adl/Cargo.toml csmctl -- --nocapture`
    `Ran focused owner-binary/control-plane split tests. Result: 5 csmctl unit tests and 1 focused cli_smoke test passed; unrelated tests were filtered out.`
  - `git diff --check`
    `Checked diff whitespace.`
  - `./adl/target/debug/csmctl --help`
    `Confirmed csmctl exposes a modular admin command tree.`
  - `./adl/target/debug/csmctl runtime daemon --help`
    `Confirmed direct daemon-loop execution is rejected from csmctl.`
  - `./adl/target/debug/csmctl status --port 19997 --host 127.0.0.1 --json`
    `Confirmed the live main CSM runtime is observable on canonical port 19997 without broad process scans.`
- Results:
  - `PASS`

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4979__v0-91-7-wp-07-csm-split-runtime-control-plane-commands-from-adl-tooling-binary/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4979__v0-91-7-wp-07-csm-split-runtime-control-plane-commands-from-adl-tooling-binary/sor.md
- Idempotency-Key: v0-91-7-wp-07-csm-split-runtime-control-plane-commands-into-csmctl-adl-cargo-toml-adl-src-bin-csmctl-rs-adl-src-cli-mod-rs-adl-src-cli-csmctl-cmd-rs-adl-tests-cli-smoke-rs-adl-tests-cli-smoke-agent-rs-docs-milestones-v0-91-7-review-runtime-csmctl-boundary-4979-adl-v0-91-7-tasks-issue-4979-v0-91-7-wp-07-csm-split-runtime-control-plane-commands-from-adl-tooling-binary-sip-md-adl-v0-91-7-tasks-issue-4979-v0-91-7-wp-07-csm-split-runtime-control-plane-commands-from-adl-tooling-binary-sor-md