### PR TITLE
[v0.91.7][tools][closeout] Repair merged PR closeout when watcher attachment packet is missing

### DIFF
--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1800,6 +1800,18 @@ fn pr_number_from_url(pr_url: &str) -> Option<u32> {
         .and_then(|value| value.parse::<u32>().ok())
 }
 
+fn repo_from_pr_url(pr_url: &str) -> Option<String> {
+    let marker = "github.com/";
+    let (_, tail) = pr_url.split_once(marker)?;
+    let mut parts = tail.trim_matches('/').split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    match parts.next()? {
+        "pull" if !owner.is_empty() && !repo.is_empty() => Some(format!("{owner}/{repo}")),
+        _ => None,
+    }
+}
+
 pub(crate) fn issue_watcher_attachment_record_path(
     repo_root: &Path,
     issue: u32,
@@ -1927,6 +1939,7 @@ pub(crate) fn ensure_issue_watcher_terminal_disposition(
     issue: u32,
     pr_url: Option<&str>,
     fallback_disposition: &str,
+    branch: Option<&str>,
 ) -> Result<()> {
     let Some(pr_url) = pr_url.filter(|value| !value.trim().is_empty()) else {
         let artifact_root = issue_watcher_artifact_root(repo_root, issue);
@@ -1968,13 +1981,61 @@ pub(crate) fn ensure_issue_watcher_terminal_disposition(
     };
 
     let (packet_path, mut record) =
-        read_issue_watcher_attachment_record(repo_root, issue, pr_url)?.ok_or_else(|| {
-            anyhow!(
-                "closeout: issue-bound PR '{}' for issue #{} has no watcher attachment packet; rerun pr finish or pr watch/shepherd before closeout",
-                pr_url,
-                issue
-            )
-        })?;
+        match read_issue_watcher_attachment_record(repo_root, issue, pr_url)? {
+            Some(record) => record,
+            None => {
+                let packet_path = issue_watcher_attachment_record_path(repo_root, issue, pr_url);
+                if let Some(parent) = packet_path.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!(
+                            "closeout: failed to create issue watcher artifact root '{}'",
+                            parent.display()
+                        )
+                    })?;
+                }
+                let repo = repo_from_pr_url(pr_url).unwrap_or_else(|| "unknown".to_string());
+                let expected_pr_state = if fallback_disposition == "green_merged" {
+                    "merged"
+                } else {
+                    "closed"
+                };
+                let record = IssueWatcherAttachmentRecord {
+                    schema: "adl.issue_watcher.attachment.v1".to_string(),
+                    issue,
+                    repo,
+                    branch: branch
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    pr_url: pr_url.to_string(),
+                    pr_number: pr_number_from_url(pr_url),
+                    expected_pr_state: expected_pr_state.to_string(),
+                    classification: fallback_disposition.to_string(),
+                    tail_owner: "pr-closeout".to_string(),
+                    shepherd_state: "terminal_closeout".to_string(),
+                    status: "terminal".to_string(),
+                    packet_path: issue_watcher_repo_relative_path(repo_root, &packet_path),
+                    input_path: String::new(),
+                    prompt_path: String::new(),
+                    log_path: String::new(),
+                    pid_path: String::new(),
+                    pid: None,
+                    terminal_disposition: Some(fallback_disposition.to_string()),
+                    terminal_recorded_at: Some(
+                        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    ),
+                };
+                let json = serde_json::to_string_pretty(&record)?;
+                fs::write(&packet_path, format!("{json}\n")).with_context(|| {
+                    format!(
+                        "closeout: failed to write watcher terminal packet '{}'",
+                        packet_path.display()
+                    )
+                })?;
+                return Ok(());
+            }
+        };
     if record.terminal_disposition.is_none() {
         record.status = "terminal".to_string();
         record.terminal_disposition = Some(fallback_disposition.to_string());

--- a/adl/src/cli/pr_cmd/github/tests/helpers.rs
+++ b/adl/src/cli/pr_cmd/github/tests/helpers.rs
@@ -401,6 +401,7 @@ fn issue_watcher_attachment_is_required_and_records_terminal_packet() {
         1153,
         Some("https://github.com/owner/repo/pull/1159"),
         "green_merged",
+        Some("codex/1153-fixture"),
     )
     .expect("terminal watcher disposition should update attached packet");
     let terminal = issue_pr_watcher_status_for_inventory(
@@ -414,16 +415,29 @@ fn issue_watcher_attachment_is_required_and_records_terminal_packet() {
         Some("green_merged")
     );
 
-    let missing_terminal = ensure_issue_watcher_terminal_disposition(
+    ensure_issue_watcher_terminal_disposition(
         &repo,
         1154,
         Some("https://github.com/owner/repo/pull/1160"),
         "closed_without_merge",
+        Some("codex/1154-fixture"),
     )
-    .expect_err("PR-backed closeout without watcher packet must fail");
-    assert!(missing_terminal
-        .to_string()
-        .contains("has no watcher attachment packet"));
+    .expect("terminal closeout should create missing PR-backed watcher packet");
+    let created_terminal = issue_pr_watcher_status_for_inventory(
+        &repo,
+        Some(1154),
+        "https://github.com/owner/repo/pull/1160",
+    );
+    assert_eq!(created_terminal.status, "terminal");
+    assert_eq!(
+        created_terminal.terminal_disposition.as_deref(),
+        Some("closed_without_merge")
+    );
+    let created_packet =
+        fs::read_to_string(repo.join(".adl/logs/issue-watcher/issue-1154/pr-1160-attachment.json"))
+            .expect("created terminal packet");
+    assert!(created_packet.contains("\"repo\": \"owner/repo\""));
+    assert!(created_packet.contains("\"branch\": \"codex/1154-fixture\""));
 
     restore_env("ADL_ISSUE_WATCHER_DISABLE", old_disable);
     restore_env("ADL_ISSUE_WATCHER_CMD", old_cmd);

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -179,6 +179,7 @@ fn ensure_terminal_watcher_for_closeout(
         )
     })?;
     let pr_url = closeout_sor_pr_url(&sor_text);
+    let branch = line_value_after_prefix(&sor_text, "Branch:");
     let terminal_disposition =
         match line_value_after_prefix(&sor_text, "- Integration state:").as_deref() {
             Some("merged") => "green_merged",
@@ -189,6 +190,7 @@ fn ensure_terminal_watcher_for_closeout(
         issue_ref.issue_number(),
         pr_url.as_deref(),
         terminal_disposition,
+        branch.as_deref(),
     )
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
@@ -125,6 +125,11 @@ fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
         &sor_path,
         "codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure",
     );
+    let mut sor_text = fs::read_to_string(&sor_path).expect("read completed sor");
+    sor_text.push_str(
+        "\n## Machine-readable closeout facts\n\n```yaml\npr_url: https://github.com/owner/repo/pull/1600\n```\n",
+    );
+    fs::write(&sor_path, sor_text).expect("write completed sor with pr url");
 
     let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
@@ -171,6 +176,17 @@ fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
     assert!(canonical_text.contains("- Verification scope: main_repo"));
     assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
     assert!(canonical_text.contains("- Worktree prune result: pruned: adl-wp-1596"));
+    let watcher_packet = repo.join(".adl/logs/issue-watcher/issue-1596/pr-1600-attachment.json");
+    assert!(
+        watcher_packet.is_file(),
+        "closeout should create terminal watcher packet"
+    );
+    let watcher_text = fs::read_to_string(&watcher_packet).expect("read watcher packet");
+    assert!(watcher_text.contains("\"repo\": \"owner/repo\""));
+    assert!(watcher_text.contains(
+        "\"branch\": \"codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure\""
+    ));
+    assert!(watcher_text.contains("\"terminal_disposition\": \"green_merged\""));
     assert!(!worktree.exists());
 }
 


### PR DESCRIPTION
Closes #5034

## Summary
Implemented a bounded closeout repair for already-merged issue-bound PRs that
lack a watcher attachment packet. Terminal closeout now creates a terminal
issue-watcher packet from closeout evidence instead of failing solely because
the historical PR predates watcher attachment enforcement. Active/new PR
watcher attachment enforcement remains unchanged.

## Artifacts
- Tracked implementation artifacts: `adl/src/cli/pr_cmd/github.rs`, `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`
- Tracked regression test artifacts: `adl/src/cli/pr_cmd/github/tests/helpers.rs`, `adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs`
- Local output-card update: `.adl/v0.91.7/tasks/issue-5034__v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml issue_watcher_attachment_is_required_and_records_terminal_packet -- --nocapture`
    `Verified terminal watcher disposition behavior for both existing and missing watcher attachment packets.`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle -- --nocapture`
    `Verified closeout reconciliation succeeds for a completed issue bundle and synthesizes the terminal watcher packet from PR URL, branch, and disposition evidence.`
  - `bash adl/tools/pr.sh finish 5034 --title "[v0.91.7][tools][closeout] Repair merged PR closeout when watcher attachment packet is missing" --paths "adl/src/cli/pr_cmd/github.rs,adl/src/cli/pr_cmd/lifecycle/reconciliation.rs,adl/src/cli/pr_cmd/github/tests/helpers.rs,adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs" --output-card ".adl/v0.91.7/tasks/issue-5034__v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing/sor.md"`
    `Attempted normal repo-native finish; publication was blocked by validation-manager profile status escalation_required for slow PR command E2E surface selection before a PR was opened.`
- Results:
  - `PASS for focused Rust validation and pre-PR review; initial repo-native finish publication gate returned the known validation-selection escalation blocker before PR creation.`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5034__v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5034__v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing/sor.md
- Idempotency-Key: v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-lifecycle-reconciliation-rs-adl-src-cli-pr-cmd-github-tests-helpers-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-closeout-rs-adl-v0-91-7-tasks-issue-5034-v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing-sip-md-adl-v0-91-7-tasks-issue-5034-v0-91-7-tools-closeout-repair-merged-pr-closeout-when-watcher-attachment-packet-is-missing-sor-md