### PR TITLE
[v0.91.7][tools][validation] Require durable build-action logs for every build and validation action

### DIFF
--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -31,6 +31,7 @@ bash "$SCRIPT" --changed-files "$docs_only" --json >"$TMP/docs.json"
 python3 - <<'PY' "$TMP/docs.json"
 import json
 import sys
+from pathlib import Path
 
 profile = json.load(open(sys.argv[1]))
 assert profile["schema_version"] == "adl.validation_profile.v1"
@@ -63,6 +64,99 @@ assert recorded["selected_profile"] == "docs_diff_check_profile"
 assert recorded["status"] == "ready_to_run"
 assert recorded == stdout_profile
 PY
+
+docs_run_log_dir="$TMP/build-action-logs"
+bash "$SCRIPT" \
+  --changed-files "$docs_only" \
+  --json \
+  --run \
+  --build-action-log-dir "$docs_run_log_dir" \
+  >"$TMP/docs-run.json"
+python3 - <<'PY' "$TMP/docs-run.json" "$docs_run_log_dir"
+import json
+import sys
+from pathlib import Path
+
+profile = json.load(open(sys.argv[1]))
+log_dir = Path(sys.argv[2])
+assert profile["run_status"] == "passed"
+assert profile["build_action_logs"]["schema_version"] == "adl.build_action_log_manifest.v1"
+assert profile["build_action_logs"]["packet_count"] == 1
+packet_ref = profile["run"][0]["build_action_log"]
+packet_path = Path(packet_ref)
+if not packet_path.is_absolute():
+    packet_path = Path.cwd() / packet_path
+assert packet_path.is_file()
+packet = json.load(open(packet_path))
+assert packet["schema_version"] == "adl.build_action_log.v1"
+assert packet["runner"] == "validation_manager"
+assert packet["lane_id"] == "docs_diff_check"
+assert packet["command"] == "git diff --check"
+assert packet["cwd"] == "."
+assert packet["binary_path"] == "shell"
+assert packet["cache_posture"] == "local_target_or_repo_configured"
+assert packet["exit_code"] == 0
+assert packet["status"] == "passed"
+for key in ("stdout_ref", "stderr_ref", "packet_ref"):
+    ref = packet[key]
+    assert "/Users/" not in ref and "/private/tmp" not in ref
+stdout_ref = Path(packet["stdout_ref"])
+stderr_ref = Path(packet["stderr_ref"])
+if not stdout_ref.is_absolute():
+    stdout_ref = Path.cwd() / stdout_ref
+if not stderr_ref.is_absolute():
+    stderr_ref = Path.cwd() / stderr_ref
+assert stdout_ref.is_file()
+assert stderr_ref.is_file()
+manifest_path = log_dir / "manifest.json"
+assert manifest_path.is_file()
+manifest = json.load(open(manifest_path))
+assert manifest["schema_version"] == "adl.build_action_log_manifest.v1"
+assert manifest["packet_count"] == 1
+assert manifest["packets"] == [packet["packet_ref"]]
+PY
+
+noisy_manifest="$TMP/noisy-manifest.json"
+python3 - <<'PY' "$ROOT/adl/config/validation_lane_selector.v0.91.6.json" "$noisy_manifest"
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1]))
+for lane in manifest["lanes"]:
+    if lane["id"] == "docs_diff_check":
+        lane["command"] = "printf noisy-json-safe-stdout"
+        lane["run_command"] = "printf noisy-json-safe-stdout"
+json.dump(manifest, open(sys.argv[2], "w"), indent=2, sort_keys=True)
+PY
+noisy_log_dir="$TMP/noisy-build-action-logs"
+bash "$SCRIPT" \
+  --manifest "$noisy_manifest" \
+  --changed-files "$docs_only" \
+  --json \
+  --run \
+  --build-action-log-dir "$noisy_log_dir" \
+  >"$TMP/noisy-run.json" \
+  2>"$TMP/noisy-run.stderr"
+python3 - <<'PY' "$TMP/noisy-run.json"
+import json
+import sys
+from pathlib import Path
+
+profile = json.load(open(sys.argv[1]))
+assert profile["run_status"] == "passed"
+packet_ref = profile["run"][0]["build_action_log"]
+packet_path = Path(packet_ref)
+if not packet_path.is_absolute():
+    packet_path = Path.cwd() / packet_path
+packet = json.load(open(packet_path))
+stdout_ref = Path(packet["stdout_ref"])
+if not stdout_ref.is_absolute():
+    stdout_ref = Path.cwd() / stdout_ref
+stdout_text = open(stdout_ref).read()
+assert stdout_text == "noisy-json-safe-stdout"
+assert packet["command"] == "printf noisy-json-safe-stdout"
+PY
+assert_has "$TMP/noisy-run.stderr" "noisy-json-safe-stdout"
 
 tooling="$TMP/tooling.txt"
 printf 'M\tadl/tools/ci_path_policy.sh\n' >"$tooling"

--- a/adl/tools/validation_manager.py
+++ b/adl/tools/validation_manager.py
@@ -4,10 +4,15 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
+import platform
 import shlex
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +26,8 @@ AWS_SPOT_REMOTE_RUNNER = "bash adl/tools/run_aws_spot_remote_validation_lane.sh"
 AWS_CODEFRIEND_BUILD_RUNNER = "bash adl/tools/run_aws_codefriend_build_lane.sh"
 AWS_CODEFRIEND_BUILD_RUNNER_PATH = ROOT / "adl/tools/run_aws_codefriend_build_lane.sh"
 VALIDATION_PLATFORMS = ("auto", "local", "nessus", "aws_spot", "codebuild", "wuji")
+BUILD_ACTION_LOG_SCHEMA = "adl.build_action_log.v1"
+BUILD_ACTION_LOG_MANIFEST_SCHEMA = "adl.build_action_log_manifest.v1"
 
 
 def fail(message: str) -> None:
@@ -1104,7 +1111,115 @@ def write_report(path: Path, profile: dict[str, Any]) -> None:
     path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
 
 
-def run_profile(profile: dict[str, Any]) -> int:
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def repo_relative(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def default_build_action_log_dir() -> Path:
+    run_id = f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{os.getpid()}"
+    return ROOT / ".adl/logs/build-actions/validation-manager" / run_id
+
+
+def safe_packet_stem(lane_id: str, index: int) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in lane_id)
+    safe = safe.strip("-_") or "lane"
+    return f"{index:02d}-{safe}"
+
+
+def build_action_log_root(args: argparse.Namespace) -> Path:
+    configured = args.build_action_log_dir or os.environ.get("ADL_BUILD_ACTION_LOG_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return default_build_action_log_dir()
+
+
+def write_build_action_manifest(log_root: Path, packets: list[dict[str, Any]]) -> Path:
+    manifest_path = log_root / "manifest.json"
+    manifest = {
+        "schema_version": BUILD_ACTION_LOG_MANIFEST_SCHEMA,
+        "runner": "validation_manager",
+        "packet_count": len(packets),
+        "packets": [packet["packet_ref"] for packet in packets],
+        "created_at": utc_now_iso(),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest_path
+
+
+def run_validation_action_with_log(
+    item: dict[str, Any],
+    *,
+    log_root: Path,
+    index: int,
+    json_mode: bool,
+) -> tuple[int, dict[str, Any]]:
+    log_root.mkdir(parents=True, exist_ok=True)
+    stem = safe_packet_stem(str(item.get("lane_id", "lane")), index)
+    stdout_path = log_root / f"{stem}.stdout.log"
+    stderr_path = log_root / f"{stem}.stderr.log"
+    packet_path = log_root / f"{stem}.build-action-log.json"
+    command = str(item["command"])
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    with stdout_path.open("w") as stdout_file, stderr_path.open("w") as stderr_file:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            shell=True,
+            text=True,
+            stdout=stdout_file,
+            stderr=stderr_file,
+        )
+    ended_at = utc_now_iso()
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    stdout_text = stdout_path.read_text(errors="replace")
+    stderr_text = stderr_path.read_text(errors="replace")
+    if stdout_text:
+        stdout_stream = sys.stderr if json_mode else sys.stdout
+        print(stdout_text, end="", file=stdout_stream)
+    if stderr_text:
+        print(stderr_text, end="", file=sys.stderr)
+
+    packet = {
+        "schema_version": BUILD_ACTION_LOG_SCHEMA,
+        "runner": "validation_manager",
+        "lane_id": item.get("lane_id"),
+        "reason": item.get("reason"),
+        "command": command,
+        "command_sha256": hashlib.sha256(command.encode("utf-8")).hexdigest(),
+        "cwd": ".",
+        "binary_path": "shell",
+        "cache_posture": "local_target_or_repo_configured",
+        "platform": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "elapsed_ms": elapsed_ms,
+        "exit_code": result.returncode,
+        "status": "passed" if result.returncode == 0 else "failed",
+        "stdout_ref": repo_relative(stdout_path),
+        "stderr_ref": repo_relative(stderr_path),
+        "packet_ref": repo_relative(packet_path),
+        "redaction_status": "not_redacted_local_private_log",
+        "retention": "local_workflow_evidence",
+    }
+    packet_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+    return result.returncode, packet
+
+
+def run_profile(profile: dict[str, Any], args: argparse.Namespace) -> int:
     platform_routing = profile.get("platform_routing")
     if platform_routing:
         selected_platform = platform_routing.get("selected_platform")
@@ -1126,12 +1241,23 @@ def run_profile(profile: dict[str, Any]) -> int:
         print("validation_manager: refusing --run for non-runnable profile", file=sys.stderr)
         return 1
     failed = False
-    for item in profile["run"]:
+    packets: list[dict[str, Any]] = []
+    log_root = build_action_log_root(args)
+    for index, item in enumerate(profile["run"], start=1):
         print(f"==> {item['lane_id']}: {item['command']}", file=sys.stderr)
-        result = subprocess.run(item["command"], cwd=ROOT, shell=True)
-        item["run_status"] = "passed" if result.returncode == 0 else "failed"
-        if result.returncode != 0:
+        returncode, packet = run_validation_action_with_log(item, log_root=log_root, index=index, json_mode=args.json)
+        packets.append(packet)
+        item["run_status"] = packet["status"]
+        item["build_action_log"] = packet["packet_ref"]
+        if returncode != 0:
             failed = True
+    manifest_path = write_build_action_manifest(log_root, packets)
+    profile["build_action_logs"] = {
+        "schema_version": BUILD_ACTION_LOG_MANIFEST_SCHEMA,
+        "manifest_ref": repo_relative(manifest_path),
+        "packet_count": len(packets),
+        "packets": [packet["packet_ref"] for packet in packets],
+    }
     profile["run_status"] = "failed" if failed else "passed"
     return 1 if failed else 0
 
@@ -1148,6 +1274,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--report-out", type=Path)
     parser.add_argument("--run", action="store_true")
+    parser.add_argument("--build-action-log-dir", type=Path)
     parser.add_argument("--remote-runner", choices=["nessus"])
     parser.add_argument("--remote-command")
     parser.add_argument("--remote-artifact-dir", type=Path)
@@ -1181,7 +1308,7 @@ def main(argv: list[str]) -> int:
             ]
     exit_code = 0
     if args.run:
-        exit_code = run_profile(profile)
+        exit_code = run_profile(profile, args)
     if args.report_out:
         write_report(args.report_out, profile)
     if args.json:

--- a/docs/tooling/BUILD_ACTION_LOGS.md
+++ b/docs/tooling/BUILD_ACTION_LOGS.md
@@ -1,0 +1,47 @@
+# Build Action Logs
+
+ADL build and validation commands that participate in workflow truth can emit
+durable build-action packets. The initial integrated producer is
+`adl/tools/validation_manager.py --run`.
+
+## Schema
+
+Each packet uses `schema_version: adl.build_action_log.v1` and records:
+
+- `runner`: command surface that created the packet, such as
+  `validation_manager`
+- `lane_id` and `reason`: validation-lane identity and selection reason
+- `command` and `command_sha256`: command text plus a stable digest
+- `cwd`, `binary_path`, and `cache_posture`: execution context
+- `started_at`, `ended_at`, `elapsed_ms`, `exit_code`, and `status`
+- `stdout_ref`, `stderr_ref`, and `packet_ref`: durable evidence refs
+- `redaction_status` and `retention`: truth about publication posture
+
+The manifest uses `schema_version: adl.build_action_log_manifest.v1` and lists
+the packet refs emitted by one validation-manager run.
+
+## Validation Manager
+
+`validation_manager.py --run` writes build-action logs by default under:
+
+```text
+.adl/logs/build-actions/validation-manager/<timestamp>/
+```
+
+The default run directory includes a UTC timestamp and process id to avoid
+overwriting packets from another validation-manager run started in the same
+second. Use `--build-action-log-dir <path>` or
+`ADL_BUILD_ACTION_LOG_DIR=<path>` for a bounded proof directory. When the
+directory is inside the repository, refs are repo-relative. Explicit external
+directories may produce absolute local refs and should stay out of tracked
+artifacts.
+
+The command replays captured stdout/stderr after each lane exits so existing
+human-facing behavior remains available while durable logs are retained.
+
+## Boundaries
+
+This surface records private workflow evidence. It does not redact raw command
+logs, upload logs, or claim hosted observability. CI log archive manifests remain
+the CI raw-log evidence surface; build-action packets may cite or complement
+those manifests as workflow consumers are wired in.

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -119,6 +119,7 @@ Important repo-local tooling surfaces include:
 - `adl tooling validate-structured-prompt` — structured prompt contract validation
 - `bash adl/tools/run_aws_codefriend_build_lane.sh` — manual GitHub Actions plus AWS CodeBuild lane wrapper for CodeFriend build orchestration; see [AWS CodeFriend Build Lane](AWS_CODEFRIEND_BUILD_LANE.md)
 - `adl tooling ci-log-archive summarize` — summarize extracted CI logs and optionally upload raw logs plus the generated manifest to private S3 evidence storage; see [CI Log Archive To S3](CI_LOG_ARCHIVE_S3.md)
+- `adl/tools/validation_manager.py --run` — emit durable `adl.build_action_log.v1` packets for local validation actions; see [Build Action Logs](BUILD_ACTION_LOGS.md)
 - `bash adl/tools/validate_structured_prompt.sh` — compatibility wrapper for the dedicated structured-prompt validator binary; see [binary resolution](structured-prompt-validator-binary-resolution.md)
 - `adl tooling generate-wp-issue-wave` — deterministic WBS/sprint-to-issue-wave planning generator
 - `adl tooling verify-review-output-provenance` — provenance verification for review-output artifacts


### PR DESCRIPTION
Closes #5032

## Summary
Implemented the first durable build-action log foundation for the local validation-manager execution path. `adl/tools/validation_manager.py --run` now captures each validation action's stdout, stderr, command identity, execution timing, exit status, and local evidence references into `adl.build_action_log.v1` packets plus an `adl.build_action_log_manifest.v1` manifest. Focused tests prove the docs lane emits the durable packet, keeps JSON stdout parse-safe for noisy validation commands, and keeps normal non-JSON command output behavior observable.

## Artifacts
- Updated implementation: `adl/tools/validation_manager.py`
- Updated regression proof: `adl/tools/test_validation_manager.sh`
- Updated tooling index: `docs/tooling/README.md`
- New build-action log contract doc: `docs/tooling/BUILD_ACTION_LOGS.md`
- Updated output card: `.adl/v0.91.7/tasks/issue-5032__v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action/sor.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/validation_manager.py`
    `Verified Python syntax for the changed validation-manager module.`
  - `bash adl/tools/test_validation_manager.sh`
    `Verified focused validation-manager behavior including durable build-action packet and manifest emission for a runnable docs validation lane.`
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    `Verified CI runtime contract tests still pass for the touched validation/tooling surface.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase bootstrap --input .adl/v0.91.7/tasks/issue-5032__v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action/srp.md`
    `Verified structured review prompt/result contract compliance after review.`
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.7/tasks/issue-5032__v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action/sor.md`
    `Verified output record contract compliance.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5032__v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5032__v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action/sor.md
- Idempotency-Key: v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action-adl-tools-validation-manager-py-adl-tools-test-validation-manager-sh-docs-tooling-build-action-logs-md-docs-tooling-readme-md-adl-v0-91-7-tasks-issue-5032-v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action-sip-md-adl-v0-91-7-tasks-issue-5032-v0-91-7-tools-validation-require-durable-build-action-logs-for-every-build-and-validation-action-sor-md