### PR TITLE
[v0.91.7][WP-07][tools][remote-build] Repair AWS Spot interruption serialization and resume handling

### DIFF
--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -357,6 +357,52 @@ set +e
 runner_status="$?"
 set -e
 
+wrapper_summary="$ARTIFACT_DIR/wrapper-final-summary.json"
+python3 - <<'PY' "$runner_status" "$OUT_PATH" "$ARTIFACT_DIR/resume-state.json" "$wrapper_summary"
+import json
+import sys
+from pathlib import Path
+
+runner_status, summary_path, resume_state_path, wrapper_summary_path = sys.argv[1:5]
+summary = {}
+resume_state = {}
+summary_file = Path(summary_path)
+resume_file = Path(resume_state_path)
+if summary_file.exists():
+    try:
+        summary = json.loads(summary_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        summary = {"status": "unparseable_summary"}
+if resume_file.exists():
+    try:
+        resume_state = json.loads(resume_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        resume_state = {"attempts": [], "final_status": "unparseable_resume_state"}
+
+status = summary.get("status") or resume_state.get("final_status")
+if not status:
+    status = "passed" if runner_status == "0" else "failed"
+attempts = resume_state.get("attempts")
+if not isinstance(attempts, list):
+    attempts = []
+interrupted_attempts = [
+    attempt for attempt in attempts
+    if str(attempt.get("status", "")).lower() in {"interrupted_by_aws", "interrupted"}
+]
+payload = {
+    "schema": "adl.aws_spot_remote_validation_wrapper_summary.v1",
+    "status": status,
+    "runner_exit_code": int(runner_status),
+    "summary_ref": Path(summary_path).name,
+    "resume_state_ref": "resume-state.json" if resume_file.exists() else None,
+    "attempt_count": len(attempts),
+    "interrupted_attempt_count": len(interrupted_attempts),
+    "resumed_after_interruption": status == "resumed_after_interruption",
+    "next_action": resume_state.get("next_action"),
+}
+Path(wrapper_summary_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
 python3 - <<'PY' "$runner_stdout"
 import json
 import re
@@ -389,4 +435,5 @@ print(json.dumps(payload, indent=2, sort_keys=False))
 PY
 
 cat "$runner_stderr" >&2
+printf 'aws_spot_remote_validation_wrapper_summary=%s\n' "$wrapper_summary" >&2
 exit "$runner_status"

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -66,9 +66,64 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 mkdir -p "$(dirname "$out")" "$artifact_dir"
-cat >"$out" <<'JSON'
-{"schema":"adl.aws_remote_validation_run.v1","status":"passed"}
+status="${ADL_FAKE_AWS_REMOTE_STATUS:-passed}"
+cat >"$out" <<JSON
+{"schema":"adl.aws_remote_validation_run.v1","status":"$status"}
 JSON
+if [[ "$status" == "resumed_after_interruption" ]]; then
+  cat >"$artifact_dir/resume-state.json" <<'JSON'
+{
+  "schema_version": "adl.aws_remote_validation_resume_state.v1",
+  "issue": 4974,
+  "run_id": "fixture-run-resumed",
+  "repo_url": "https://github.com/danielbaustin/agent-design-language.git",
+  "git_ref": "origin/main",
+  "command": "cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture",
+  "output_summary_ref": "summary.json",
+  "artifact_root_ref": ".",
+  "started_at": "2026-07-09T00:00:00Z",
+  "updated_at": "2026-07-09T00:01:00Z",
+  "max_spot_retries": 2,
+  "interrupted_attempts": 1,
+  "next_action": "complete",
+  "final_status": "resumed_after_interruption",
+  "attempts": [
+    {
+      "attempt_index": 0,
+      "started_at": "2026-07-09T00:00:00Z",
+      "finished_at": "2026-07-09T00:00:30Z",
+      "summary_path": "attempt-0/summary.json",
+      "artifact_dir": "attempt-0",
+      "status": "interrupted_by_aws",
+      "failure_reason": "AWS Spot interruption notice received",
+      "launch_purchase_option": "spot",
+      "launch_instance_type": "m7a.2xlarge",
+      "launch_initial_state": "pending",
+      "launch_instance_id_sha256": "0123456789abcdef",
+      "provider_interruption_confirmed": true,
+      "retryable": true,
+      "next_action": "retry_after_interruption_1"
+    },
+    {
+      "attempt_index": 1,
+      "started_at": "2026-07-09T00:00:31Z",
+      "finished_at": "2026-07-09T00:01:00Z",
+      "summary_path": "attempt-1/summary.json",
+      "artifact_dir": "attempt-1",
+      "status": "passed",
+      "failure_reason": null,
+      "launch_purchase_option": "spot",
+      "launch_instance_type": "m7a.2xlarge",
+      "launch_initial_state": "pending",
+      "launch_instance_id_sha256": "fedcba9876543210",
+      "provider_interruption_confirmed": false,
+      "retryable": false,
+      "next_action": "finalize"
+    }
+  ]
+}
+JSON
+fi
 cat >"$artifact_dir/events.jsonl" <<'JSONL'
 {"event":"fixture"}
 JSONL
@@ -144,6 +199,49 @@ grep -Fx -- "ec2-user" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--json" "$TMP/args.txt" >/dev/null
 test -f "$TMP/summary.json"
 test -f "$TMP/artifacts/events.jsonl"
+test -f "$TMP/artifacts/wrapper-final-summary.json"
+python3 - "$TMP/artifacts/wrapper-final-summary.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["schema"] == "adl.aws_spot_remote_validation_wrapper_summary.v1"
+assert payload["status"] == "passed"
+assert payload["runner_exit_code"] == 0
+assert payload["resumed_after_interruption"] is False
+PY
+
+ADL_FAKE_AWS_REMOTE_STATUS=resumed_after_interruption \
+ADL_FAKE_AWS_REMOTE_ARGS="$TMP/resume-args.txt" \
+ADL_AWS_CLI="$fake_bin/aws" \
+bash "$SCRIPT" \
+  --run \
+  --expected-proof "$proof" \
+  --bin "$fake_bin/adl-aws-remote-validation" \
+  --run-id fixture-run-resumed \
+  --command "cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture" \
+  --git-ref origin/main \
+  --out "$TMP/resumed-summary.json" \
+  --artifact-dir "$TMP/resumed-artifacts" \
+  --instance-type m7a.2xlarge \
+  --json >"$TMP/resumed-run.out" 2>"$TMP/resumed-run.err"
+
+python3 - "$TMP/resumed-artifacts/wrapper-final-summary.json" "$TMP/resumed-artifacts/resume-state.json" <<'PY'
+import json
+import sys
+wrapper = json.load(open(sys.argv[1], encoding="utf-8"))
+resume = json.load(open(sys.argv[2], encoding="utf-8"))
+assert wrapper["status"] == "resumed_after_interruption"
+assert wrapper["runner_exit_code"] == 0
+assert wrapper["attempt_count"] == 2
+assert wrapper["interrupted_attempt_count"] == 1
+assert wrapper["resumed_after_interruption"] is True
+assert resume["attempts"][0]["status"] == "interrupted_by_aws"
+assert "launch_instance_id" not in resume["attempts"][0]
+assert resume["attempts"][0]["summary_path"] == "attempt-0/summary.json"
+text = json.dumps(resume)
+assert "123456789012" not in text
+assert "arn:aws:" not in text
+PY
 
 if bash "$SCRIPT" --extra-arg --profile >"$TMP/extra.out" 2>"$TMP/extra.err"; then
   echo "expected --extra-arg to be rejected" >&2

--- a/docs/milestones/v0.91.7/review/runtime/csm_backpressure_4921/README.md
+++ b/docs/milestones/v0.91.7/review/runtime/csm_backpressure_4921/README.md
@@ -84,7 +84,11 @@ AWS Spot note: the post-publication Spot run launched and began validation, then
 the instance was interrupted while the validation command was still running. The
 local wrapper did not return a final failed summary after cleanup began, and
 `resume-state.json` still showed no recorded attempts. This is a remote-build
-tooling problem to fix before relying on Spot for sprint throughput.
+tooling problem to fix before relying on Spot for sprint throughput. Issue
+`#4974` owns that tooling repair: interrupted attempts must now be retained in
+`resume-state.json`, the local wrapper must retain
+`wrapper-final-summary.json`, and a successful retry must be reported as
+`resumed_after_interruption` rather than a plain pass.
 
 CodeBuild note: the post-publication CodeBuild run succeeded, but the inner
 benchmark was slower than wuji for this lane.

--- a/docs/tooling/AWS_SPOT_REMOTE_VALIDATION_LANE.md
+++ b/docs/tooling/AWS_SPOT_REMOTE_VALIDATION_LANE.md
@@ -15,6 +15,8 @@ It wraps the lower-level `adl-aws-remote-validation` binary from
 - reuse the retained warm EBS cache volume by default
 - enable live SSH tail logging by default when the retained debug key is present
 - retain the AWS runner's summary JSON and artifact directory
+- retain `resume-state.json` and `wrapper-final-summary.json` for interrupted
+  and resumed attempts
 
 ## Account Check
 
@@ -92,6 +94,27 @@ warm EBS cache is the default cache posture, not evidence of image execution.
 The underlying AWS runner still owns launch-surface preparation, Spot-first
 selection, on-demand fallback for classified Spot capacity failures, SSM command
 dispatch, retained logs, interruption classification, and cleanup truth.
+
+## Interruption And Resume Artifacts
+
+Spot interruption is an expected recoverable lane outcome, not an implicit
+validation failure or success. The runner records each attempt in
+`<artifact-dir>/resume-state.json` before deciding whether to retry. Attempt
+records include the issue, run id, repo URL, git ref, command, artifact-relative
+summary paths, attempt timing, lifecycle state, retry disposition, and hashed
+instance identity only. They must not retain raw AWS account ids, ARNs, instance
+ids, credentials, or host-local absolute paths.
+
+The wrapper also writes `<artifact-dir>/wrapper-final-summary.json` after every
+live run attempt. That summary is the bounded local wrapper result and records
+`passed`, `failed`, `interrupted_by_aws`, or `resumed_after_interruption` from
+the retained runner summary/resume state plus the wrapper exit code.
+
+When a Spot interruption is confirmed and retries remain, the next attempt is a
+fresh remote attempt using the original issue, run id, git ref, repo URL, and
+command context. If that retry passes, the final AWS summary status is
+`resumed_after_interruption` so review records do not hide the interrupted
+attempt behind a plain success.
 
 ## GitHub Actions Trigger
 
@@ -190,6 +213,7 @@ The wrapper fails closed when:
 - the runner binary is unavailable or not executable
 - the underlying AWS runner reports launch, SSM, validation, interruption, or
   cleanup failure
+- a final wrapper summary cannot be written under the artifact directory
 
 Fresh live AWS execution may incur AWS charges. Keep commands focused, use an
 advertised remote ref, and retain summary plus artifact paths in the issue SOR.

--- a/docs/tooling/REMOTE_BUILD_HOW_TO.md
+++ b/docs/tooling/REMOTE_BUILD_HOW_TO.md
@@ -149,10 +149,18 @@ Record:
 - retained EBS cache attached
 - benchmark line
 - cleanup/termination completed
+- `resume-state.json` with interrupted attempts when Spot is reclaimed
+- `wrapper-final-summary.json` with `passed`, `failed`, `interrupted_by_aws`,
+  or `resumed_after_interruption`
 - redacted logs/artifacts
 
 Do not call a Spot row warm unless the retained EBS cache is attached in the
 AWS-side summary.
+
+If Spot is interrupted, keep the retained artifact directory and rerun from the
+same issue/ref/command context. A successful retry must be recorded as
+`resumed_after_interruption`, with the previous interrupted attempt visible in
+`resume-state.json`; do not rewrite it as an ordinary `passed` run.
 
 ## 5. CodeBuild / CodeFriend
 
@@ -248,6 +256,8 @@ Every reported remote-build result should include:
 - Wrong AWS account: rerun the wrapper with `--check-account --profile agent-logic-admin`.
 - CodeBuild too slow: verify fixed ECR image, stable `/codebuild` paths,
   local target cache, and S3 `sccache` hit rate.
+- Spot interrupted: inspect `resume-state.json` and
+  `wrapper-final-summary.json`, then rerun the same issue/ref/command context.
 - Spot too slow: verify retained EBS cache attachment and cleanup status.
 - Nessus SSH asks for a password/passphrase: fix the operator SSH key before
   treating the lane as operational.

--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -82,6 +82,7 @@ pub enum RemoteRunStatus {
     Passed,
     Failed,
     InterruptedByAws,
+    ResumedAfterInterruption,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -537,7 +538,10 @@ fn classify_aws_remote_failure(
             "cleanup did not reach a complete terminated state; resource state is recorded for review"
                 .to_string(),
         )
-    } else if matches!(status, RemoteRunStatus::Passed) {
+    } else if matches!(
+        status,
+        RemoteRunStatus::Passed | RemoteRunStatus::ResumedAfterInterruption
+    ) {
         (
             AwsRemoteResilienceFaultClass::None,
             AwsRemoteResilienceDisposition::Succeeded,

--- a/tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs
@@ -28,11 +28,19 @@ struct ParsedArgs {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ResumeAttemptRecord {
     attempt_index: u32,
+    started_at: String,
+    finished_at: String,
     summary_path: String,
+    artifact_dir: String,
     status: String,
     failure_reason: Option<String>,
-    launch_instance_id: Option<String>,
+    launch_purchase_option: Option<String>,
+    launch_instance_type: Option<String>,
+    launch_initial_state: Option<String>,
+    launch_instance_id_sha256: Option<String>,
     provider_interruption_confirmed: bool,
+    retryable: bool,
+    next_action: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,8 +48,16 @@ struct ResumeState {
     schema_version: String,
     issue: Option<u32>,
     run_id: String,
+    repo_url: String,
+    git_ref: String,
+    command: String,
+    output_summary_ref: String,
+    artifact_root_ref: String,
+    started_at: String,
+    updated_at: String,
     max_spot_retries: u32,
     attempts: Vec<ResumeAttemptRecord>,
+    interrupted_attempts: u32,
     next_action: String,
     final_status: Option<String>,
 }
@@ -60,6 +76,31 @@ fn should_retry_remote_validation(
             && provider_interruption_confirmed;
     }
     true
+}
+
+fn artifact_ref(path: &Path, artifact_root: &Path) -> String {
+    path.strip_prefix(artifact_root)
+        .ok()
+        .and_then(|relative| {
+            let value = relative.display().to_string();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        })
+        .or_else(|| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn remote_status_label(status: &RemoteRunStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{status:?}"))
 }
 
 struct EnvVarGuard {
@@ -570,12 +611,24 @@ fn main() -> Result<()> {
         effective_config.instance_profile_name = prepared.record.instance_profile_name.clone();
         fs::create_dir_all(&effective_config.artifact_dir).await?;
         let resume_state_path = effective_config.artifact_dir.join("resume-state.json");
+        let run_started_at = Utc::now().to_rfc3339();
         let mut resume_state = ResumeState {
             schema_version: "adl.aws_remote_validation_resume_state.v1".to_string(),
             issue: effective_config.issue,
             run_id: effective_config.run_id.clone(),
+            repo_url: effective_config.repo_url.clone(),
+            git_ref: effective_config.git_ref.clone(),
+            command: effective_config.command.clone(),
+            output_summary_ref: artifact_ref(
+                &effective_config.out_path,
+                &effective_config.artifact_dir,
+            ),
+            artifact_root_ref: ".".to_string(),
+            started_at: run_started_at.clone(),
+            updated_at: run_started_at,
             max_spot_retries,
             attempts: Vec::new(),
+            interrupted_attempts: 0,
             next_action: "start_attempt_0".to_string(),
             final_status: None,
         };
@@ -602,6 +655,7 @@ fn main() -> Result<()> {
             );
             let issue_string = effective_config.issue.unwrap_or_default().to_string();
             let attempt_string = attempt_index.to_string();
+            let attempt_started_at = Utc::now().to_rfc3339();
             let heartbeat = ProgressHeartbeat::start(
                 "adl-aws-remote-validation",
                 "attempt",
@@ -612,6 +666,7 @@ fn main() -> Result<()> {
                 ],
             );
             resume_state.next_action = format!("run_attempt_{}", attempt_index);
+            resume_state.updated_at = Utc::now().to_rfc3339();
             write_resume_state(&resume_state_path, &resume_state).await?;
             let attempt_result = run_aws_remote_validation(&adapter, &attempt_config).await;
             let (mut summary, events) = match attempt_result {
@@ -637,28 +692,62 @@ fn main() -> Result<()> {
                 .as_ref()
                 .map(|evidence| evidence.provider_interruption_confirmed)
                 .unwrap_or(false);
-            resume_state.attempts.push(ResumeAttemptRecord {
-                attempt_index,
-                summary_path: attempt_out.display().to_string(),
-                status: format!("{:?}", summary.status),
-                failure_reason: summary.failure_reason.clone(),
-                launch_instance_id: summary
-                    .launch
-                    .as_ref()
-                    .map(|launch| launch.instance_id.clone()),
-                provider_interruption_confirmed,
-            });
             let should_retry = should_retry_remote_validation(
                 &summary,
                 provider_interruption_confirmed,
                 attempt_index,
                 max_spot_retries,
             );
+            let interrupted = matches!(summary.status, RemoteRunStatus::InterruptedByAws);
+            if interrupted {
+                resume_state.interrupted_attempts =
+                    resume_state.interrupted_attempts.saturating_add(1);
+            }
+            let next_action = if should_retry {
+                format!("retry_after_interruption_{}", attempt_index + 1)
+            } else if interrupted {
+                "interrupted_no_retry_remaining".to_string()
+            } else {
+                "finalize".to_string()
+            };
+            resume_state.attempts.push(ResumeAttemptRecord {
+                attempt_index,
+                started_at: attempt_started_at,
+                finished_at: Utc::now().to_rfc3339(),
+                summary_path: artifact_ref(&attempt_out, &effective_config.artifact_dir),
+                artifact_dir: artifact_ref(&attempt_dir, &effective_config.artifact_dir),
+                status: remote_status_label(&summary.status),
+                failure_reason: summary.failure_reason.clone(),
+                launch_purchase_option: summary
+                    .launch
+                    .as_ref()
+                    .map(|launch| launch.purchase_option.to_string()),
+                launch_instance_type: summary
+                    .launch
+                    .as_ref()
+                    .map(|launch| launch.instance_type.clone()),
+                launch_initial_state: summary
+                    .launch
+                    .as_ref()
+                    .map(|launch| launch.initial_state.clone()),
+                launch_instance_id_sha256: summary
+                    .launch
+                    .as_ref()
+                    .map(|launch| launch.instance_id_sha256.clone()),
+                provider_interruption_confirmed,
+                retryable: summary.resilience.retryable,
+                next_action: next_action.clone(),
+            });
             if should_retry {
-                resume_state.next_action =
-                    format!("retry_after_interruption_{}", attempt_index + 1);
+                resume_state.next_action = next_action;
+                resume_state.updated_at = Utc::now().to_rfc3339();
                 write_resume_state(&resume_state_path, &resume_state).await?;
                 continue;
+            }
+            if matches!(summary.status, RemoteRunStatus::Passed)
+                && resume_state.interrupted_attempts > 0
+            {
+                summary.status = RemoteRunStatus::ResumedAfterInterruption;
             }
             final_pair = Some((summary, events));
             break;
@@ -668,8 +757,9 @@ fn main() -> Result<()> {
             final_pair.ok_or_else(|| anyhow!("no attempt summary recorded"))?;
         summary.launch_surface = Some(prepared.record);
         summary.launch_surface_cleanup = Some(cleanup);
-        resume_state.final_status = Some(format!("{:?}", summary.status));
+        resume_state.final_status = Some(remote_status_label(&summary.status));
         resume_state.next_action = "complete".to_string();
+        resume_state.updated_at = Utc::now().to_rfc3339();
         write_resume_state(&resume_state_path, &resume_state).await?;
         write_summary_artifacts(
             &summary,
@@ -685,7 +775,10 @@ fn main() -> Result<()> {
     } else {
         println!("aws_remote_validation_summary={out_path_display}");
     }
-    if matches!(summary.status, RemoteRunStatus::Passed) {
+    if matches!(
+        summary.status,
+        RemoteRunStatus::Passed | RemoteRunStatus::ResumedAfterInterruption
+    ) {
         Ok(())
     } else {
         bail!(
@@ -802,6 +895,28 @@ mod tests {
             false,
         );
         assert!(!should_retry_remote_validation(&summary, false, 0, 2));
+    }
+
+    #[test]
+    fn resume_state_artifact_refs_are_relative_when_under_artifact_root() {
+        let root = PathBuf::from("/tmp/adl/aws-spot/artifacts");
+        assert_eq!(
+            artifact_ref(&root.join("attempt-0/summary.json"), &root),
+            "attempt-0/summary.json"
+        );
+        assert_eq!(artifact_ref(&root, &root), "artifacts");
+    }
+
+    #[test]
+    fn remote_status_label_uses_machine_status_values() {
+        assert_eq!(
+            remote_status_label(&RemoteRunStatus::InterruptedByAws),
+            "interrupted_by_aws"
+        );
+        assert_eq!(
+            remote_status_label(&RemoteRunStatus::ResumedAfterInterruption),
+            "resumed_after_interruption"
+        );
     }
 
     fn parse_ok(args: &[&str]) -> ParsedArgs {


### PR DESCRIPTION
Closes #4974

## Summary
Implemented the bounded #4974 Spot remote-build repair in the issue worktree. The AWS remote validation runner now records richer redacted resume-state context for interrupted attempts, promotes a successful retry after interruption to `resumed_after_interruption`, and the local wrapper writes a bounded `wrapper-final-summary.json` for every run. Operator docs now describe retained interruption/resume artifacts and the historical #4921 failure trigger.

## Artifacts
- Local output card updated at `.adl/v0.91.7/tasks/issue-4974__v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling/sor.md`
- Tracked implementation artifacts: `tools/aws_remote_validation/src/aws_remote_validation.rs`, `tools/aws_remote_validation/src/bin/adl_aws_remote_validation.rs`, `adl/tools/run_aws_spot_remote_validation_lane.sh`, `adl/tools/test_run_aws_spot_remote_validation_lane.sh`, `docs/tooling/AWS_SPOT_REMOTE_VALIDATION_LANE.md`, `docs/tooling/REMOTE_BUILD_HOW_TO.md`, `docs/milestones/v0.91.7/review/runtime/csm_backpressure_4921/README.md`
- Additional proof artifacts: simulated wrapper output created under temporary test directories during `bash adl/tools/test_run_aws_spot_remote_validation_lane.sh`; not retained in git.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path tools/aws_remote_validation/Cargo.toml`
    `Formatted the touched Rust crate.`
  - `bash adl/tools/test_run_aws_spot_remote_validation_lane.sh`
    `Verified wrapper argument forwarding, account redaction, wrapper-final-summary creation, and simulated resumed-after-interruption resume-state evidence.`
  - `bash -n adl/tools/run_aws_spot_remote_validation_lane.sh adl/tools/test_run_aws_spot_remote_validation_lane.sh tools/aws_remote_validation/scripts/remote_validation_runner.sh tools/aws_remote_validation/scripts/ssh_debug_control.sh`
    `Verified shell syntax for the touched wrapper/test scripts and adjacent remote validation scripts.`
  - `cargo test --manifest-path tools/aws_remote_validation/Cargo.toml --bin adl-aws-remote-validation -- --nocapture`
    `Repo-native finish validation completed successfully with 33 passed tests.`
  - `cargo check --manifest-path tools/aws_remote_validation/Cargo.toml --bin adl-aws-remote-validation`
    `Repo-native finish validation completed successfully.`
- Results:
  - `PASS`: `cargo fmt`, shell regression, shell syntax checks, cargo check, and focused Rust binary tests.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4974__v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4974__v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling/sor.md
- Idempotency-Key: v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling-adl-tools-run-aws-spot-remote-validation-lane-sh-adl-tools-test-run-aws-spot-remote-validation-lane-sh-docs-milestones-v0-91-7-review-runtime-csm-backpressure-4921-readme-md-docs-tooling-aws-spot-remote-validation-lane-md-docs-tooling-remote-build-how-to-md-tools-aws-remote-validation-src-aws-remote-validation-rs-tools-aws-remote-validation-src-bin-adl-aws-remote-validation-rs-adl-v0-91-7-tasks-issue-4974-v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling-sip-md-adl-v0-91-7-tasks-issue-4974-v0-91-7-wp-07-tools-remote-build-repair-aws-spot-interruption-serialization-and-resume-handling-sor-md