### PR TITLE
[v0.91.7][tools][worktree] Separate open and dirty closed worktrees in prune reports

### DIFF
--- a/adl/tools/test_worktree_prune.sh
+++ b/adl/tools/test_worktree_prune.sh
@@ -46,6 +46,16 @@ assert_path_missing() {
 
 managed_root="$(cd "$managed_root" && pwd -P)"
 report_path="$tmpdir/report.md"
+issue_states="$tmpdir/issue-states.json"
+cat >"$issue_states" <<'JSON'
+[
+  {"number": 900, "state": "closed"},
+  {"number": 901, "state": "closed"},
+  {"number": 902, "state": "OPEN"},
+  {"number": 903, "state": "closed"},
+  {"number": 904, "state": "OPEN"}
+]
+JSON
 
 (
   cd "$repo"
@@ -53,25 +63,62 @@ report_path="$tmpdir/report.md"
   git worktree add -q "$managed_root/adl-wp-900" codex/900-merged
   git branch codex/901-merged >/dev/null 2>&1 || true
   git worktree add -q "$managed_root/adl-wp-901" codex/901-merged
+  git branch codex/902-merged >/dev/null 2>&1 || true
+  git worktree add -q "$managed_root/adl-wp-902" codex/902-merged
+  git branch codex/903-merged >/dev/null 2>&1 || true
+  git worktree add -q "$managed_root/adl-wp-903" codex/903-merged
+  echo "dirty" > "$managed_root/adl-wp-903/dirty.txt"
+  git branch codex/904-active >/dev/null 2>&1 || true
+  git worktree add -q "$managed_root/adl-wp-904" codex/904-active
+  (
+    cd "$managed_root/adl-wp-904"
+    echo "active" > active.txt
+    git add active.txt
+    git commit -q -m "active change"
+    echo "dirty" > open-dirty.txt
+  )
 
-  dry_limited="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1)"
+  dry_limited="$(ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE="$issue_states" "$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1)"
   assert_contains "Registered clean merged worktrees removable: 1" "$dry_limited" "limit constrains selected registered removals"
+  assert_contains "Open issue worktrees not pruned: 2" "$dry_limited" "open issue worktrees separated"
+  assert_contains "Closed dirty worktrees needing disposition: 1" "$dry_limited" "closed dirty worktree separated"
+  assert_contains "$managed_root/adl-wp-902 (#902 open; open_issue_not_pruned)" "$dry_limited" "open issue warning"
+  assert_contains "$managed_root/adl-wp-904 (#904 open; open_issue_not_pruned)" "$dry_limited" "open dirty issue warning"
+  assert_contains "$managed_root/adl-wp-903 (#903 closed; dirty_class=meaningful_unpublished_edits;dirty_paths=?? dirty.txt)" "$dry_limited" "closed dirty summary"
 
-  out="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1 --report "$report_path" --apply)"
+  out="$(ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE="$issue_states" "$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1 --report "$report_path" --apply)"
   assert_contains "Registered clean merged worktrees removable: 1" "$out" "empty remove_dirs apply run"
   assert_contains "Directory removals eligible: 0" "$out" "empty remove_dirs apply run"
   assert_contains "Applying cleanup" "$out" "empty remove_dirs apply run"
   assert_contains "Report: $report_path" "$out" "report path printed"
   assert_path_missing "$managed_root/adl-wp-900" "registered worktree removed"
   assert_contains "# Worktree Cleanup Report" "$(cat "$report_path")" "report written"
+  assert_contains "## Open Issue Worktrees (Not Pruned)" "$(cat "$report_path")" "report has open issue section"
+  assert_contains "$managed_root/adl-wp-902 (issue: #902; state: open" "$(cat "$report_path")" "report lists open issue"
+  assert_contains "$managed_root/adl-wp-904 (issue: #904; state: open" "$(cat "$report_path")" "report lists open dirty issue"
+  assert_contains "## Closed Clean Prune Candidates" "$(cat "$report_path")" "report has closed clean section"
   assert_contains "$managed_root/adl-wp-900" "$(cat "$report_path")" "report lists selected removal"
+  assert_contains "## Closed Dirty Worktrees (Manual Disposition Required)" "$(cat "$report_path")" "report has closed dirty section"
+  assert_contains "$managed_root/adl-wp-903 (issue: #903; state: closed" "$(cat "$report_path")" "report lists closed dirty issue"
   [[ -d "$managed_root/adl-wp-901" ]] || {
     echo "assertion failed (limit retained second merged worktree): expected path to remain: $managed_root/adl-wp-901" >&2
     exit 1
   }
+  [[ -d "$managed_root/adl-wp-902" ]] || {
+    echo "assertion failed (open issue worktree retained): expected path to remain: $managed_root/adl-wp-902" >&2
+    exit 1
+  }
+  [[ -f "$managed_root/adl-wp-903/dirty.txt" ]] || {
+    echo "assertion failed (closed dirty worktree retained): expected dirty file to remain" >&2
+    exit 1
+  }
+  [[ -f "$managed_root/adl-wp-904/open-dirty.txt" ]] || {
+    echo "assertion failed (open dirty worktree retained): expected dirty file to remain" >&2
+    exit 1
+  }
 
   mkdir -p "$managed_root/rogue-clean"
-  out2="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
+  out2="$(ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE="$issue_states" "$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
   assert_contains "Registered clean merged worktrees removable: 1" "$out2" "remaining merged worktree still removable"
   assert_contains "Directory removals eligible: 0" "$out2" "non-empty remove_dirs apply run"
   assert_contains "Applying cleanup" "$out2" "non-empty remove_dirs apply run"
@@ -80,7 +127,7 @@ report_path="$tmpdir/report.md"
     exit 1
   }
 
-  out3="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --include-scratch --apply)"
+  out3="$(ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE="$issue_states" "$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --include-scratch --apply)"
   assert_contains "Directory removals eligible: 1" "$out3" "explicit scratch inclusion"
   assert_path_missing "$managed_root/rogue-clean" "managed scratch removed when explicitly included"
 )

--- a/adl/tools/worktree_prune.sh
+++ b/adl/tools/worktree_prune.sh
@@ -60,13 +60,137 @@ while IFS= read -r line; do
   rows+=("$line")
 done < <("$doctor" "${args[@]}")
 
+issue_states_file="$(mktemp)"
+trap 'rm -f "$issue_states_file"' EXIT
+
+extract_issue_number() {
+  local path="$1" branch="$2" base
+  base="$(basename "$path")"
+  if [[ "$base" =~ ^adl-wp-([0-9]+)([^0-9].*)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ "$branch" =~ ^codex/([0-9]+)- ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  echo ""
+}
+
+load_issue_states() {
+  local source_json="" issue_json_tmp issue_json_pid waited timeout_seconds
+  if [[ -n "${ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE:-}" ]]; then
+    source_json="$(cat "$ADL_WORKTREE_PRUNE_ISSUE_STATES_FILE")"
+  elif [[ -x "$repo/adl/tools/pr.sh" ]]; then
+    timeout_seconds="${ADL_WORKTREE_PRUNE_ISSUE_LIST_TIMEOUT_SECONDS:-15}"
+    issue_json_tmp="$(mktemp)"
+    bash "$repo/adl/tools/pr.sh" issue list --state all --limit 1000 --json >"$issue_json_tmp" 2>/dev/null &
+    issue_json_pid="$!"
+    waited=0
+    while kill -0 "$issue_json_pid" >/dev/null 2>&1; do
+      if (( waited >= timeout_seconds )); then
+        kill "$issue_json_pid" >/dev/null 2>&1 || true
+        wait "$issue_json_pid" >/dev/null 2>&1 || true
+        rm -f "$issue_json_tmp"
+        return 0
+      fi
+      sleep 1
+      waited=$((waited + 1))
+    done
+    wait "$issue_json_pid" >/dev/null 2>&1 || true
+    source_json="$(cat "$issue_json_tmp")"
+    rm -f "$issue_json_tmp"
+  fi
+  [[ -n "$source_json" ]] || return 0
+  ADL_WORKTREE_PRUNE_ISSUE_JSON="$source_json" python3 - "$issue_states_file" <<'PY'
+import json
+import os
+import re
+import sys
+
+out = sys.argv[1]
+raw = os.environ.get("ADL_WORKTREE_PRUNE_ISSUE_JSON", "")
+match = re.search(r"(\[\s*\{.*\}\s*\])", raw, flags=re.S)
+if not match:
+    raise SystemExit(0)
+try:
+    issues = json.loads(match.group(1))
+except json.JSONDecodeError:
+    raise SystemExit(0)
+with open(out, "w", encoding="utf-8") as handle:
+    for issue in issues:
+        number = issue.get("number")
+        state = issue.get("state")
+        if isinstance(state, str):
+            state = state.lower()
+        if number is None or state not in {"open", "closed"}:
+            continue
+        handle.write(f"{number}|{state}\n")
+PY
+}
+
+issue_state_for() {
+  local issue="$1"
+  [[ -n "$issue" ]] || {
+    echo "unknown"
+    return 0
+  }
+  awk -F'|' -v issue="$issue" '$1 == issue {print $2; found=1; exit} END {if (!found) print "unknown"}' "$issue_states_file"
+}
+
+dirty_summary() {
+  local path="$1" summary dirty_paths generated_count meaningful_count total_count dirty_path dirty_class
+  if [[ ! -d "$path" ]] || ! git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "dirty_class=unknown;dirty_paths=unavailable"
+    return 0
+  fi
+  dirty_paths="$(git -C "$path" status --short 2>/dev/null | sed 's/^...//')"
+  summary="$(git -C "$path" status --short 2>/dev/null | head -n 5 | sed 's/[[:space:]]\+/ /g' | paste -sd ';' -)"
+  if [[ -z "$summary" ]]; then
+    echo "dirty_class=unknown;dirty_paths=unavailable"
+  else
+    generated_count=0
+    meaningful_count=0
+    total_count=0
+    while IFS= read -r dirty_path; do
+      [[ -n "$dirty_path" ]] || continue
+      total_count=$((total_count + 1))
+      case "$dirty_path" in
+        .tmp/*|tmp/*|target/*|adl/target/*|Library/*|UserSettings/*|.adl/logs/*|.adl/runtime/*/logs/*|*.log|*.tmp)
+          generated_count=$((generated_count + 1))
+          ;;
+        *)
+          meaningful_count=$((meaningful_count + 1))
+          ;;
+      esac
+    done <<<"$dirty_paths"
+    if (( total_count == 0 )); then
+      dirty_class="unknown"
+    elif (( generated_count == total_count )); then
+      dirty_class="generated_disposable_residue"
+    elif (( meaningful_count == total_count )); then
+      dirty_class="meaningful_unpublished_edits"
+    else
+      dirty_class="mixed_generated_and_meaningful"
+    fi
+    echo "dirty_class=$dirty_class;dirty_paths=$summary"
+  fi
+}
+
 declare -a remove_registered remove_dirs
 prune_needed="no"
-declare -a selected_rows report_rows skipped_rows
+declare -a selected_rows report_rows skipped_rows open_issue_rows closed_clean_rows closed_dirty_rows
+
+load_issue_states
 
 for row in "${rows[@]}"; do
   IFS='|' read -r kind fate path branch clean merged prunable notes <<<"$row"
   report_rows+=("$row")
+  issue_number="$(extract_issue_number "$path" "$branch")"
+  issue_state="$(issue_state_for "$issue_number")"
+  if [[ "$issue_state" == "open" ]]; then
+    open_issue_rows+=("$row|$issue_number|$issue_state|open_issue_not_pruned")
+  fi
   case "$fate" in
     prune_now)
       prune_needed="yes"
@@ -74,10 +198,22 @@ for row in "${rows[@]}"; do
       ;;
     remove_merged_clean)
       if [[ "$kind" == "managed_registered" ]]; then
-        remove_registered+=("$path")
-        selected_rows+=("$row")
+        if [[ "$issue_state" == "open" ]]; then
+          skipped_rows+=("$row|open_issue_not_pruned")
+        else
+          remove_registered+=("$path")
+          selected_rows+=("$row")
+          if [[ "$issue_state" == "closed" ]]; then
+            closed_clean_rows+=("$row|$issue_number|$issue_state")
+          fi
+        fi
       else
         skipped_rows+=("$row|excluded_by_default")
+      fi
+      ;;
+    backup_then_remove|keep_dirty_active)
+      if [[ "$clean" == "dirty" && "$issue_state" == "closed" ]]; then
+        closed_dirty_rows+=("$row|$issue_number|$issue_state|$(dirty_summary "$path")")
       fi
       ;;
     remove_legacy_replaced|remove_scratch_clean)
@@ -167,6 +303,39 @@ write_report() {
     echo "- registered_removals_selected: $selected_registered_count"
     echo "- directory_removals_selected: $selected_dir_count"
     echo "- stale_registrations_present: $prune_needed"
+    echo "- open_issue_worktrees_not_pruned: ${#open_issue_rows[@]}"
+    echo "- closed_clean_prune_candidates: ${#closed_clean_rows[@]}"
+    echo "- closed_dirty_worktrees_needing_disposition: ${#closed_dirty_rows[@]}"
+    echo
+    echo "## Open Issue Worktrees (Not Pruned)"
+    if (( ${#open_issue_rows[@]} == 0 )); then
+      echo "- none"
+    else
+      for row in "${open_issue_rows[@]}"; do
+        IFS='|' read -r kind fate path branch clean merged prunable notes issue_number issue_state reason <<<"$row"
+        echo "- $path (issue: #$issue_number; state: $issue_state; clean: $clean; merged: $merged; reason: $reason)"
+      done
+    fi
+    echo
+    echo "## Closed Clean Prune Candidates"
+    if (( ${#closed_clean_rows[@]} == 0 )); then
+      echo "- none"
+    else
+      for row in "${closed_clean_rows[@]}"; do
+        IFS='|' read -r kind fate path branch clean merged prunable notes issue_number issue_state <<<"$row"
+        echo "- $path (issue: #$issue_number; state: $issue_state; fate: $fate)"
+      done
+    fi
+    echo
+    echo "## Closed Dirty Worktrees (Manual Disposition Required)"
+    if (( ${#closed_dirty_rows[@]} == 0 )); then
+      echo "- none"
+    else
+      for row in "${closed_dirty_rows[@]}"; do
+        IFS='|' read -r kind fate path branch clean merged prunable notes issue_number issue_state summary <<<"$row"
+        echo "- $path (issue: #$issue_number; state: $issue_state; fate: $fate; $summary)"
+      done
+    fi
     echo
     echo "## Selected Registered Removals"
     if (( selected_registered_count == 0 )); then
@@ -221,7 +390,28 @@ echo "Limit: ${limit:-all}"
 echo "Registered clean merged worktrees removable: $selected_registered_count"
 echo "Directory removals eligible: $selected_dir_count"
 echo "Stale/prunable registrations present: $prune_needed"
+echo "Open issue worktrees not pruned: ${#open_issue_rows[@]}"
+echo "Closed clean prune candidates: ${#closed_clean_rows[@]}"
+echo "Closed dirty worktrees needing disposition: ${#closed_dirty_rows[@]}"
 echo
+
+if (( ${#open_issue_rows[@]} > 0 )); then
+  echo "Open issue worktrees (not pruned):"
+  for row in "${open_issue_rows[@]}"; do
+    IFS='|' read -r kind fate path branch clean merged prunable notes issue_number issue_state reason <<<"$row"
+    printf '  %s (#%s %s; %s)\n' "$path" "$issue_number" "$issue_state" "$reason"
+  done
+  echo
+fi
+
+if (( ${#closed_dirty_rows[@]} > 0 )); then
+  echo "Closed dirty worktrees (manual disposition required):"
+  for row in "${closed_dirty_rows[@]}"; do
+    IFS='|' read -r kind fate path branch clean merged prunable notes issue_number issue_state summary <<<"$row"
+    printf '  %s (#%s %s; %s)\n' "$path" "$issue_number" "$issue_state" "$summary"
+  done
+  echo
+fi
 
 if (( selected_registered_count > 0 )); then
   echo "Registered removals:"


### PR DESCRIPTION
Closes #5031

## Summary
Implemented worktree prune report separation for open issue worktrees, closed clean prune candidates, and closed dirty worktrees. The prune helper now enriches report classification from repo-native issue-list JSON or a fixture file, preserves no-delete behavior for dirty worktrees, warns on open issue worktrees even when clean/merged, and records dirty-path summaries with conservative generated-vs-meaningful classification.

## Artifacts
- Updated implementation: `adl/tools/worktree_prune.sh`
- Updated focused regression proof: `adl/tools/test_worktree_prune.sh`
- Updated review record: `.adl/v0.91.7/tasks/issue-5031__v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports/srp.md`
- Updated output record: `.adl/v0.91.7/tasks/issue-5031__v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_worktree_prune.sh`
    `Verified focused prune-report fixture coverage for closed clean, open clean, open dirty, and closed dirty worktrees.`
  - `bash adl/tools/test_worktree_doctor.sh`
    `Verified existing worktree doctor/prune classification behavior.`
  - `bash -n adl/tools/worktree_prune.sh adl/tools/test_worktree_prune.sh`
    `Verified shell syntax.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5031__v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5031__v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports/sor.md
- Idempotency-Key: v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports-adl-tools-worktree-prune-sh-adl-tools-test-worktree-prune-sh-adl-v0-91-7-tasks-issue-5031-v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports-sip-md-adl-v0-91-7-tasks-issue-5031-v0-91-7-tools-worktree-separate-open-and-dirty-closed-worktrees-in-prune-reports-sor-md