### PR TITLE
[v0.91.7][provider][proof] Run Z.ai and Bedrock provider acceptance smoke tests

### DIFF
--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -200,7 +200,7 @@ Usage:\n\
   adl-runtime identity <init|show|now|foundation|...> ...\n\
   adl-runtime instrument <graph|replay|replay-bundle|diff-plan|diff-trace|trace-schema|validate-trace-v1|provider-substrate|provider-substrate-schema> ...\n\
   adl-runtime learn export --format <jsonl|bundle-v1|trace-bundle-v2> ...\n\
-  adl-runtime provider setup <family> [--out <dir>] [--force]\n\
+  adl-runtime provider setup <family> [--model <provider_model_id>] [--out <dir>] [--force]\n\
   adl-runtime keygen --out-dir <dir>\n\
   adl-runtime sign <adl.yaml> --key <private_key_path> [--key-id <id>] [--out <signed_file>]\n\
   adl-runtime verify <adl.yaml> [--key <public_key_path>]\n\

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -220,6 +220,18 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
             endpoint_hint: None,
             notes: "Use this for the Rust-native AWS Bedrock provider path. ADL AWS work must use the Agent Logic business profile `agent-logic-admin`; set `ADL_AWS_REGION` or `AWS_REGION` when selecting a Bedrock region.",
         },
+        "z_ai" | "zai" | "zhipu" => &ProviderSetupTemplate {
+            family: "z_ai",
+            profile: None,
+            kind: Some("z_ai"),
+            env_var: "ZAI_API_KEY",
+            provider_id: "z_ai_primary",
+            agent_id: "z_ai_agent",
+            model_ref: "hosted:adl-z-ai:glm-5",
+            provider_model_id: "glm-5",
+            endpoint_hint: None,
+            notes: "Use this for the Rust-native Z.ai provider path. The default endpoint is Z.ai/Zhipu's OpenAI-compatible chat completions API; override config.endpoint only for tests or a trusted compatible endpoint. Z.ai capability support is model-specific, so record model-specific UTS/provider proof before routing production work.",
+        },
         "http" | "generic-http" => &ProviderSetupTemplate {
             family: "http",
             profile: Some("http:gpt-4.1-mini"),
@@ -234,7 +246,7 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
         },
         other => {
             return Err(anyhow!(
-                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, openrouter, bedrock, http)"
+                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, openrouter, bedrock, z_ai, http)"
             ))
         }
     };
@@ -594,6 +606,7 @@ mod tests {
             ),
             ("deepseek", "type: \"deepseek\"", "DEEPSEEK_API_KEY"),
             ("openrouter", "type: \"openrouter\"", "OPENROUTER_API_KEY"),
+            ("z_ai", "type: \"z_ai\"", "ZAI_API_KEY"),
             (
                 "generic-http",
                 "profile: \"http:gpt-4.1-mini\"",

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -139,6 +139,7 @@ Examples:
   adl provider setup claude
   adl provider setup openrouter
   adl provider setup bedrock
+  adl provider setup z_ai
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic
   adl godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary \"step failed with deterministic parse error\" --evidence-ref runs/run-745-a/run_status.json
   adl godel inspect --run-id run-745-a --runs-dir .adl/runs

--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -1,6 +1,6 @@
 //! HTTP-based provider implementations and request transport helpers.
 //!
-//! Supports OpenAI, Anthropic, DeepSeek, OpenRouter, generic HTTP, and Ollama-HTTP style backends.
+//! Supports OpenAI, Anthropic, DeepSeek, OpenRouter, Z.ai, generic HTTP, and Ollama-HTTP style backends.
 use super::*;
 use aws_config::{meta::region::RegionProviderChain, BehaviorVersion};
 use aws_sdk_bedrockruntime as bedrockruntime;
@@ -862,6 +862,79 @@ fn sha256_hex(value: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+#[derive(Debug, Clone)]
+/// Z.ai native provider using the OpenAI-compatible chat completions API format.
+pub struct ZAiProvider {
+    endpoint: String,
+    auth_env: String,
+    model: String,
+    max_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl ZAiProvider {
+    /// Build a Z.ai provider from normalized invocation target.
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        let endpoint = vendor_endpoint(spec, target, Z_AI_CHAT_COMPLETIONS_ENDPOINT, "z_ai")?;
+        let auth_env = auth_env_for(spec, "ZAI_API_KEY")?;
+        validate_vendor_credential_endpoint(
+            spec,
+            "z_ai",
+            &endpoint,
+            &auth_env,
+            "ZAI_API_KEY",
+            &["open.bigmodel.cn", "api.z.ai"],
+        )?;
+        Ok(Self {
+            endpoint,
+            auth_env,
+            model: target.provider_model_id.clone(),
+            max_tokens: cfg_u64(&spec.config, "max_tokens")
+                .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
+                .unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for ZAiProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let token = env::var(&self.auth_env).map_err(|_| {
+            invalid_config(
+                "z_ai",
+                format!("missing required auth env var '{}'", self.auth_env),
+            )
+        })?;
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build Z.ai client")
+            .map_err(|err| runtime_error("z_ai", err.to_string()))?;
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": self.max_tokens,
+                "stream": false,
+            }));
+        let (json, http_status) = provider_http_json("z_ai", req)?;
+        let output = extract_deepseek_output_text(&json).ok_or_else(|| {
+            runtime_error_non_retryable("z_ai", "response missing message content")
+        })?;
+        write_native_invocation_record("z_ai", &self.model, prompt, &output, http_status)?;
+        Ok(output)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -911,6 +911,119 @@ fn openrouter_provider_rejects_missing_credentials_and_bad_response_shape() {
 }
 
 #[test]
+fn zai_provider_sends_chat_completion_request_and_records_sanitized_artifact() {
+    let _guard = env_lock();
+    let Some((endpoint, captured, handle)) = spawn_json_server(
+        200,
+        r#"{"model":"glm-5","choices":[{"message":{"content":"zai ok"}}]}"#,
+    ) else {
+        return;
+    };
+    let artifact = std::env::temp_dir().join(format!(
+        "adl-zai-provider-artifact-{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&artifact);
+    let prev_artifact = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH");
+    let prev_key = env::var_os("ZAI_API_KEY");
+    env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", &artifact);
+    env::set_var("ZAI_API_KEY", "test-zai-token");
+
+    let spec = provider_spec(
+        "z_ai",
+        &format!("{endpoint}/api/paas/v4/chat/completions"),
+        None,
+        &[],
+    );
+    let target = provider_target(
+        "z_ai",
+        format!("{endpoint}/api/paas/v4/chat/completions"),
+        "glm-5",
+    );
+    let provider = ZAiProvider::from_target(&spec, &target).expect("provider");
+
+    let output = provider.complete("hello zai").expect("completion");
+    assert_eq!(output, "zai ok");
+
+    let captured = captured.lock().expect("capture").clone().expect("request");
+    assert_eq!(captured.url, "/api/paas/v4/chat/completions");
+    assert!(captured.body.contains(r#""model":"glm-5""#));
+    assert!(captured.body.contains(r#""content":"hello zai""#));
+    assert!(captured.body.contains(r#""stream":false"#));
+    assert!(captured
+        .headers
+        .iter()
+        .any(|(k, v)| k.eq_ignore_ascii_case("authorization") && v == "Bearer test-zai-token"));
+
+    let payload = std::fs::read_to_string(&artifact).expect("artifact");
+    assert!(!payload.contains("test-zai-token"));
+    let json: serde_json::Value = serde_json::from_str(&payload).expect("json artifact");
+    assert_eq!(json["invocations"][0]["family"], "z_ai");
+    assert_eq!(json["invocations"][0]["model"], "glm-5");
+    assert_eq!(json["invocations"][0]["output_chars"], 6);
+
+    match prev_artifact {
+        Some(v) => env::set_var("ADL_PROVIDER_INVOCATIONS_PATH", v),
+        None => env::remove_var("ADL_PROVIDER_INVOCATIONS_PATH"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("ZAI_API_KEY", v),
+        None => env::remove_var("ZAI_API_KEY"),
+    }
+
+    let _ = handle.join();
+}
+
+#[test]
+fn zai_provider_rejects_missing_credentials_and_bad_response_shape() {
+    let _guard = env_lock();
+    let prev_key = env::var_os("ZAI_API_KEY");
+    env::remove_var("ZAI_API_KEY");
+
+    let spec = provider_spec(
+        "z_ai",
+        Z_AI_CHAT_COMPLETIONS_ENDPOINT,
+        Some("ZAI_API_KEY"),
+        &[],
+    );
+    let target = provider_target("z_ai", Z_AI_CHAT_COMPLETIONS_ENDPOINT.to_string(), "glm-5");
+    let provider = ZAiProvider::from_target(&spec, &target).expect("provider");
+    let missing_key = provider
+        .complete("hello")
+        .expect_err("missing credential should fail");
+    assert!(missing_key
+        .to_string()
+        .contains("missing required auth env var 'ZAI_API_KEY'"));
+
+    env::set_var("ZAI_API_KEY", "test-zai-token");
+    let Some((endpoint, _captured, handle)) = spawn_json_server(200, r#"{"choices":[]}"#) else {
+        restore_env_var("ZAI_API_KEY", prev_key);
+        return;
+    };
+    let bad_spec = provider_spec(
+        "z_ai",
+        &format!("{endpoint}/api/paas/v4/chat/completions"),
+        Some("ZAI_API_KEY"),
+        &[],
+    );
+    let bad_target = provider_target(
+        "z_ai",
+        format!("{endpoint}/api/paas/v4/chat/completions"),
+        "glm-5",
+    );
+    let bad_provider = ZAiProvider::from_target(&bad_spec, &bad_target).expect("provider");
+    let bad_shape = bad_provider
+        .complete("hello")
+        .expect_err("missing message content should fail");
+    assert!(bad_shape
+        .to_string()
+        .contains("response missing message content"));
+
+    restore_env_var("ZAI_API_KEY", prev_key);
+    let _ = handle.join();
+}
+
+#[test]
 fn deepseek_provider_rejects_missing_credentials_and_bad_response_shape() {
     let _guard = env_lock();
     let prev_key = env::var_os("DEEPSEEK_API_KEY");

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -25,6 +25,7 @@ mod profiles;
 
 pub use http_family::{
     AnthropicProvider, AwsBedrockProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider,
+    ZAiProvider,
 };
 pub use http_family::{DeepSeekProvider, OpenRouterProvider};
 pub use local::{MockProvider, OllamaProvider};
@@ -33,7 +34,7 @@ pub use profiles::{expand_provider_profiles, provider_profile_names};
 pub(crate) use profiles::{
     is_allowed_ollama_endpoint, is_allowed_remote_endpoint, ANTHROPIC_MESSAGES_ENDPOINT,
     ANTHROPIC_VERSION, DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT, OPENAI_RESPONSES_ENDPOINT,
-    OPENROUTER_CHAT_COMPLETIONS_ENDPOINT,
+    OPENROUTER_CHAT_COMPLETIONS_ENDPOINT, Z_AI_CHAT_COMPLETIONS_ENDPOINT,
 };
 
 /// A minimal blocking provider abstraction used by runtime execution paths.
@@ -73,8 +74,8 @@ impl ProviderError {
             kind: ProviderErrorKind::UnknownKind,
             provider: None,
             message: format!(
-                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock). \
-Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock. The remote provider surfaces are HTTPS-only."
+                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock, z_ai). \
+Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic, deepseek, openrouter, bedrock, aws_bedrock, z_ai. The remote provider surfaces are HTTPS-only."
             ),
         }
     }
@@ -239,7 +240,7 @@ pub fn build_provider_for_id(
 ) -> Result<Box<dyn Provider>> {
     match spec.kind.trim() {
         "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic"
-        | "deepseek" | "openrouter" | "bedrock" | "aws_bedrock" => {}
+        | "deepseek" | "openrouter" | "bedrock" | "aws_bedrock" | "z_ai" | "zai" | "zhipu" => {}
         other => return Err(unknown_kind(other)),
     }
 
@@ -257,6 +258,7 @@ pub fn build_provider_for_id(
             "bedrock" | "aws_bedrock" => {
                 Ok(Box::new(AwsBedrockProvider::from_target(spec, &target)?))
             }
+            "z_ai" | "zai" | "zhipu" => Ok(Box::new(ZAiProvider::from_target(spec, &target)?)),
             other => Err(unknown_kind(other)),
         },
         provider_substrate::ProviderTransportV1::LocalCli

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -60,6 +60,8 @@ pub(crate) const DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT: &str =
     "https://api.deepseek.com/chat/completions";
 pub(crate) const OPENROUTER_CHAT_COMPLETIONS_ENDPOINT: &str =
     "https://openrouter.ai/api/v1/chat/completions";
+pub(crate) const Z_AI_CHAT_COMPLETIONS_ENDPOINT: &str =
+    "https://open.bigmodel.cn/api/paas/v4/chat/completions";
 /// Canonical Anthropic API version used by the HTTP adapter.
 pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";
 
@@ -121,8 +123,8 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         ),
         (
             "bedrock:nova-pro-v1",
-            "hosted:adl-bedrock:amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
+            "hosted:adl-bedrock:us.amazon.nova-pro-v1:0",
+            "us.amazon.nova-pro-v1:0",
         ),
     ] {
         m.insert(
@@ -135,6 +137,15 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
             },
         );
     }
+    m.insert(
+        "z_ai:glm-5",
+        ProviderProfilePreset {
+            kind: "z_ai",
+            default_model: Some("hosted:adl-z-ai:glm-5"),
+            provider_model_id: Some("glm-5"),
+            endpoint: Some(Z_AI_CHAT_COMPLETIONS_ENDPOINT),
+        },
+    );
     // HTTP presets (explicit fixed endpoint placeholders; no secrets)
     for (name, model) in [
         ("http:gpt-4o-mini", "gpt-4o-mini"),
@@ -248,7 +259,6 @@ pub fn expand_provider_profiles(doc: &adl::AdlDoc) -> Result<adl::AdlDoc> {
                 }
             }
         }
-
         expanded.providers.insert(
             provider_id,
             adl::ProviderSpec {

--- a/adl/src/provider_adapter.rs
+++ b/adl/src/provider_adapter.rs
@@ -30,6 +30,8 @@ const DEFAULT_ANTHROPIC_MESSAGES_URL: &str = "https://api.anthropic.com/v1/messa
 const DEFAULT_DEEPSEEK_CHAT_COMPLETIONS_URL: &str = "https://api.deepseek.com/chat/completions";
 const DEFAULT_OPENROUTER_CHAT_COMPLETIONS_URL: &str =
     "https://openrouter.ai/api/v1/chat/completions";
+const DEFAULT_ZAI_CHAT_COMPLETIONS_URL: &str =
+    "https://open.bigmodel.cn/api/paas/v4/chat/completions";
 const DEFAULT_OPENROUTER_MAX_TOKENS: u64 = 2048;
 const DEFAULT_BEDROCK_PROFILE: &str = "agent-logic-admin";
 const DEFAULT_BEDROCK_REGION: &str = "us-west-2";
@@ -615,6 +617,7 @@ fn execute_hosted(
         "deepseek" => execute_hosted_deepseek(request, policy),
         "openrouter" => execute_hosted_openrouter(request, policy),
         "bedrock" | "aws_bedrock" => execute_hosted_bedrock(request, policy),
+        "z_ai" | "zai" | "zhipu" => execute_hosted_zai(request, policy),
         "google" | "gemini" => execute_hosted_gemini(request, policy),
         _ => Err(ProviderFailureV1 {
             kind: ProviderFailureKindV1::ProviderError,
@@ -972,6 +975,43 @@ fn redact_aws_error_value(input: &str, marker: &str) -> String {
     }
     redacted.push_str(&input[cursor..]);
     redacted
+}
+
+fn execute_hosted_zai(
+    request: &ProviderInvocationRequestV1,
+    policy: &ProviderAttemptPolicyV1,
+) -> std::result::Result<ProviderTextResponse, ProviderFailureV1> {
+    let key = resolve_credential(request.route.credential_ref.as_deref(), "ZAI_API_KEY")?;
+    let url = request
+        .route
+        .endpoint_ref
+        .as_deref()
+        .filter(|endpoint| endpoint.starts_with("http://") || endpoint.starts_with("https://"))
+        .unwrap_or(DEFAULT_ZAI_CHAT_COMPLETIONS_URL);
+    let response = client(policy)?
+        .post(url)
+        .bearer_auth(key)
+        .json(&zai_request_body(request))
+        .send()
+        .map_err(map_reqwest_error)?;
+    decode_text_response(
+        response,
+        extract_chat_completion_output_text,
+        extract_chat_completion_model_id,
+        RuntimeSurfaceV1::HostedApi,
+    )
+}
+
+fn zai_request_body(request: &ProviderInvocationRequestV1) -> Value {
+    json!({
+        "model": request.route.provider_model_id,
+        "messages": [{
+            "role": "user",
+            "content": request.input_text.as_deref().unwrap_or_default(),
+        }],
+        "max_tokens": output_token_budget_or_default(request, 256),
+        "stream": false,
+    })
 }
 
 fn execute_hosted_gemini(
@@ -1632,6 +1672,7 @@ mod tests {
         assert_eq!(anthropic_request_body(&req)["max_tokens"], json!(1_024));
         assert_eq!(deepseek_request_body(&req)["max_tokens"], json!(1_024));
         assert_eq!(openrouter_request_body(&req)["max_tokens"], json!(1_024));
+        assert_eq!(zai_request_body(&req)["max_tokens"], json!(1_024));
         assert_eq!(
             bedrock_nova_request_body(&req).pointer("/inferenceConfig/maxTokens"),
             Some(&json!(1_024))
@@ -1664,6 +1705,7 @@ mod tests {
         assert!(openai_request_body(&req).get("max_output_tokens").is_none());
         assert_eq!(anthropic_request_body(&req)["max_tokens"], json!(256));
         assert_eq!(deepseek_request_body(&req)["max_tokens"], json!(256));
+        assert_eq!(zai_request_body(&req)["max_tokens"], json!(256));
         assert_eq!(
             openrouter_request_body(&req)["max_tokens"],
             json!(DEFAULT_OPENROUTER_MAX_TOKENS)
@@ -2619,6 +2661,76 @@ mod tests {
 
         let _ = fs::remove_file(path);
         env::remove_var("ADL_PROVIDER_ADAPTER_OPENROUTER_OBSERVED_KEY");
+    }
+
+    #[test]
+    fn zai_hosted_adapter_returns_output_observed_model_and_redacts_log() {
+        env::set_var("ADL_PROVIDER_ADAPTER_ZAI_SUCCESS_KEY", "test-zai-key");
+        let (endpoint, rx) = capture_one_request_server(
+            r#"{"model":"glm-5","choices":[{"message":{"content":"zai success"}}]}"#,
+            "200 OK",
+        );
+        let path = temp_log("zai");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, endpoint);
+        req.route.provider = "z_ai".to_string();
+        req.route.provider_model_id = "glm-5".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_ZAI_SUCCESS_KEY".to_string());
+        req.model_identity = hosted_model_identity(
+            "z_ai",
+            "glm-5",
+            "hosted:adl-z-ai:glm-5",
+            Some("test".to_string()),
+        );
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Ok);
+        assert_eq!(result.output_text.as_deref(), Some("zai success"));
+        assert_eq!(result.model_identity.provider_model_id, "glm-5");
+        let raw_request = rx.recv().expect("captured request");
+        assert!(raw_request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-zai-key"));
+        assert!(raw_request.contains(r#""model":"glm-5""#));
+        assert!(raw_request.contains(r#""content":"secret prompt should not enter logs""#));
+        assert!(raw_request.contains(r#""stream":false"#));
+        let log = fs::read_to_string(&path).expect("read log");
+        assert!(log.contains("attempt_success"));
+        assert!(!log.contains("test-zai-key"));
+        assert!(!log.contains("secret prompt"));
+        assert!(!log.contains("zai success"));
+        let _ = fs::remove_file(path);
+        env::remove_var("ADL_PROVIDER_ADAPTER_ZAI_SUCCESS_KEY");
+    }
+
+    #[test]
+    fn zai_hosted_adapter_rejects_missing_key_without_network_call() {
+        env::remove_var("ADL_PROVIDER_ADAPTER_ZAI_MISSING_KEY");
+        let (tx, rx) = mpsc::channel();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        thread::spawn(move || {
+            if listener.accept().is_ok() {
+                let _ = tx.send(());
+            }
+        });
+        let path = temp_log("zai-missing-key");
+        let mut logger = ProviderRunLoggerV1::create(&path, "run-test").expect("open logger");
+        let mut req = request(RuntimeSurfaceV1::HostedApi, format!("http://{addr}"));
+        req.route.provider = "z_ai".to_string();
+        req.route.credential_ref = Some("env:ADL_PROVIDER_ADAPTER_ZAI_MISSING_KEY".to_string());
+
+        let result = execute_provider_invocation(req, &mut logger);
+        drop(logger);
+
+        assert_eq!(result.final_status, ProviderInvocationFinalStatusV1::Failed);
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.kind.clone()),
+            Some(ProviderFailureKindV1::ProviderAuthMissing)
+        );
+        assert!(rx.try_recv().is_err());
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -127,6 +127,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
                 "claude" => return "anthropic".to_string(),
                 "bedrock" => return "aws_bedrock".to_string(),
                 "openrouter" => return "openrouter".to_string(),
+                "z_ai" | "zai" | "zhipu" => return "z_ai".to_string(),
                 "http" => return "generic_http".to_string(),
                 _ => {}
             }
@@ -160,6 +161,9 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         if lower.contains("bedrock-runtime") || lower.contains("bedrock") {
             return "aws_bedrock".to_string();
         }
+        if lower.contains("bigmodel.cn") || lower.contains("z.ai") || lower.contains("zhipu") {
+            return "z_ai".to_string();
+        }
         if lower.contains("ollama") || lower.contains("11434") {
             return "ollama".to_string();
         }
@@ -173,6 +177,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
         "deepseek" => "deepseek".to_string(),
         "bedrock" | "aws_bedrock" => "aws_bedrock".to_string(),
         "openrouter" => "openrouter".to_string(),
+        "z_ai" | "zai" | "zhipu" => "z_ai".to_string(),
         "http" | "http_remote" => "generic_http".to_string(),
         other if !other.is_empty() => other.to_lowercase(),
         _ => "unknown".to_string(),
@@ -189,7 +194,7 @@ fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
             }
         }
         "http" | "http_remote" | "openai" | "anthropic" | "deepseek" | "openrouter" | "bedrock"
-        | "aws_bedrock" => Ok(ProviderTransportV1::Http),
+        | "aws_bedrock" | "z_ai" | "zai" | "zhipu" => Ok(ProviderTransportV1::Http),
         "local_ollama" => Ok(ProviderTransportV1::LocalCli),
         "mock" => Ok(ProviderTransportV1::InProcess),
         other => Err(anyhow!(
@@ -278,7 +283,10 @@ fn infer_capability_defaults(
     }
 
     if matches!(transport, ProviderTransportV1::Http)
-        && (vendor == "deepseek" || vendor == "openrouter" || vendor == "aws_bedrock")
+        && (vendor == "deepseek"
+            || vendor == "openrouter"
+            || vendor == "aws_bedrock"
+            || vendor == "z_ai")
     {
         return ProviderCapabilitiesV1 {
             tool_calling: CapabilitySupportV1 {
@@ -550,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_substrate_accepts_native_openai_anthropic_deepseek_and_openrouter_kinds() {
+    fn provider_substrate_accepts_native_openai_anthropic_deepseek_openrouter_and_zai_kinds() {
         let mut openai = provider_spec("openai");
         openai.default_model = Some("gpt-test".to_string());
         let openai_substrate =
@@ -625,6 +633,50 @@ mod tests {
             "hosted:adl-bedrock:amazon.nova-lite-v1:0"
         );
         assert_eq!(bedrock_target.provider_model_id, "amazon.nova-lite-v1:0");
+
+        let mut z_ai = provider_spec("z_ai");
+        z_ai.default_model = Some("glm-5".to_string());
+        let z_ai_substrate = provider_substrate_v1("z_ai_primary", &z_ai).expect("z_ai substrate");
+        assert_eq!(z_ai_substrate.vendor, "z_ai");
+        assert_eq!(z_ai_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(z_ai_substrate.provider_kind, "z_ai");
+        assert!(!z_ai_substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            z_ai_substrate.capabilities.tool_calling.mode,
+            CapabilityModeV1::None
+        );
+        assert_eq!(
+            z_ai_substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
+    }
+
+    #[test]
+    fn provider_substrate_accepts_zai_profile_and_distinct_provider_model_id() {
+        let mut spec = provider_spec("z_ai");
+        spec.profile = Some("z_ai:glm-5".to_string());
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("https://open.bigmodel.cn/api/paas/v4/chat/completions"),
+        );
+        spec.default_model = Some("hosted:adl-z-ai:glm-5".to_string());
+        spec.config
+            .insert("provider_model_id".to_string(), json!("glm-5"));
+
+        let substrate = provider_substrate_v1("z_ai_primary", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "z_ai");
+        assert_eq!(substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(
+            substrate.provider_default_model_id.as_deref(),
+            Some("glm-5")
+        );
+
+        let target = provider_invocation_target_v1("z_ai_primary", &spec, None).expect("target");
+        assert_eq!(target.model_ref, "hosted:adl-z-ai:glm-5");
+        assert_eq!(target.provider_model_id, "glm-5");
+        assert_eq!(target.model_identity.provider_kind, "z_ai");
+        assert_eq!(target.model_identity.provider_model_id, "glm-5");
+        assert_eq!(target.model_identity.runtime_surface, "hosted_http");
     }
 
     #[test]

--- a/adl/tests/provider_tests/http_family.rs
+++ b/adl/tests/provider_tests/http_family.rs
@@ -154,6 +154,52 @@ config:
 }
 
 #[test]
+fn zai_provider_translates_native_response_through_build_provider() {
+    let server = match std::net::TcpListener::bind("127.0.0.1:0") {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(e) => panic!("failed to bind local test server: {e}"),
+    };
+    let addr = server.local_addr().unwrap();
+    let _env_guard = localhost_and_auth_env_guard("ADL_TEST_ZAI_KEY", "test-zai-token");
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = server.accept().unwrap();
+        let request = read_http_request(&mut stream);
+        assert!(request.to_ascii_lowercase().contains("authorization:"));
+        assert!(request.contains("Bearer test-zai-token"));
+        assert!(request.contains("\"model\":\"glm-5\""));
+        assert!(request.contains("\"content\":\"hello zai\""));
+        assert!(request.contains("\"stream\":false"));
+        let body = r#"{"model":"glm-5","choices":[{"message":{"content":"ZAI_NATIVE_OK"}}]}"#;
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(resp.as_bytes());
+    });
+
+    let spec = provider_spec_from_yaml(&format!(
+        r#"
+type: z_ai
+config:
+  endpoint: "http://{addr}/api/paas/v4/chat/completions"
+  provider_model_id: "glm-5"
+  auth:
+    type: bearer
+    env: ADL_TEST_ZAI_KEY
+"#
+    ));
+
+    let p = build_provider(&spec, None).expect("z_ai provider should build");
+    let out = p
+        .complete("hello zai")
+        .expect("z_ai provider should succeed");
+    assert_eq!(out, "ZAI_NATIVE_OK");
+}
+
+#[test]
 fn native_provider_missing_auth_env_is_sanitized() {
     let _env_guard = EnvVarGuard::unset("ADL_TEST_MISSING_OPENAI_KEY");
     let spec = provider_spec_from_yaml(

--- a/adl/tests/provider_tests/profiles.rs
+++ b/adl/tests/provider_tests/profiles.rs
@@ -127,6 +127,93 @@ run:
 }
 
 #[test]
+fn expand_provider_profiles_accepts_zai_glm5_profile() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  zai_primary:
+    profile: "z_ai:glm-5"
+agents:
+  a1:
+    provider: "zai_primary"
+    model: "hosted:adl-z-ai:glm-5"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let expanded = expand_provider_profiles(&doc).expect("expand z_ai profile");
+    let provider = &expanded.providers["zai_primary"];
+    assert_eq!(provider.kind, "z_ai");
+    assert_eq!(
+        provider.default_model.as_deref(),
+        Some("hosted:adl-z-ai:glm-5")
+    );
+    assert_eq!(
+        provider
+            .config
+            .get("provider_model_id")
+            .and_then(|value| value.as_str()),
+        Some("glm-5")
+    );
+    assert_eq!(
+        provider
+            .config
+            .get("endpoint")
+            .and_then(|value| value.as_str()),
+        Some("https://open.bigmodel.cn/api/paas/v4/chat/completions")
+    );
+}
+
+#[test]
+fn expand_provider_profiles_accepts_bedrock_nova_pro_inference_profile() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  bedrock_primary:
+    profile: "bedrock:nova-pro-v1"
+agents:
+  a1:
+    provider: "bedrock_primary"
+    model: "hosted:adl-bedrock:us.amazon.nova-pro-v1:0"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let expanded = expand_provider_profiles(&doc).expect("expand bedrock nova pro profile");
+    let provider = &expanded.providers["bedrock_primary"];
+    assert_eq!(provider.kind, "bedrock");
+    assert_eq!(
+        provider.default_model.as_deref(),
+        Some("hosted:adl-bedrock:us.amazon.nova-pro-v1:0")
+    );
+    assert_eq!(
+        provider
+            .config
+            .get("provider_model_id")
+            .and_then(|value| value.as_str()),
+        Some("us.amazon.nova-pro-v1:0")
+    );
+}
+
+#[test]
 fn expand_provider_profiles_rejects_http_profile_without_endpoint_override() {
     let doc = adl_doc_from_yaml(
         r#"

--- a/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
+++ b/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
@@ -78,7 +78,8 @@ ADL should model provider execution with four explicit layers:
 
 Key capabilities:
 - define first-class provider adapters for OpenAI, Anthropic, AWS Bedrock,
-  Gemini, Ollama, compatible HTTP, optional WebSocket, and mock
+  Gemini, DeepSeek, OpenRouter, Z.ai, Ollama, compatible HTTP, optional
+  WebSocket, and mock
 - isolate unstable provider model names behind stable ADL-facing references
 - provide a configuration surface that lets agents target vendors and models without brittle string coupling
 - integrate cleanly with declared, observed, and effective capability envelopes

--- a/docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md
+++ b/docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md
@@ -9,7 +9,7 @@ Date: 2026-07-07
 - Added Rust-native AWS Bedrock provider support through the provider family path.
 - Added provider profile presets for:
   - `bedrock:nova-lite-v1` -> `amazon.nova-lite-v1:0`
-  - `bedrock:nova-pro-v1` -> `amazon.nova-pro-v1:0`
+  - `bedrock:nova-pro-v1` -> `us.amazon.nova-pro-v1:0`
 - Integrated `bedrock` / `aws_bedrock` into provider substrate inference, provider construction, hosted adapter routing, and `adl provider setup bedrock`.
 - Added profile/region guardrails:
   - default AWS profile: `agent-logic-admin`
@@ -65,6 +65,11 @@ Model discovery:
 - `amazon.nova-lite-v1:0` was visible in both regions.
 - `us-east-1` returned a live daily-token throttle for the tiny smoke call: `Too many tokens per day, please wait before trying again.`
 - `us-west-2` successfully invoked the same Nova Lite model, so `us-west-2` is the default Bedrock region in this implementation.
+- Follow-up live Nova Pro proof in #5026 showed that `amazon.nova-pro-v1:0`
+  is rejected for on-demand throughput in this account/region. The accepted
+  Nova Pro route is the active system inference profile
+  `us.amazon.nova-pro-v1:0`, and the `bedrock:nova-pro-v1` profile now maps to
+  that id.
 
 ## Live Adapter Smoke
 

--- a/docs/milestones/v0.91.7/review/provider/BEDROCK_NOVA_PRO_ACCEPTANCE_5026.md
+++ b/docs/milestones/v0.91.7/review/provider/BEDROCK_NOVA_PRO_ACCEPTANCE_5026.md
@@ -1,0 +1,106 @@
+# Bedrock Nova Pro Provider Acceptance Proof
+
+Issue: #5026
+Milestone: v0.91.7
+Date: 2026-07-09
+Provider: AWS Bedrock
+AWS profile: `agent-logic-admin`
+Region: `us-west-2`
+Model target: `us.amazon.nova-pro-v1:0`
+
+## Summary
+
+Bedrock Nova Pro worked through the ADL provider-adapter path when invoked by
+the system inference profile `us.amazon.nova-pro-v1:0`.
+
+Direct on-demand invocation with `amazon.nova-pro-v1:0` failed with a Bedrock
+validation error because Nova Pro does not support on-demand throughput in this
+account/region. Bedrock inference-profile discovery returned an active system
+profile named `US Nova Pro` with id `us.amazon.nova-pro-v1:0`; using that id as
+the Bedrock `modelId` produced a successful live adapter smoke and UTS benchmark
+run. The built-in `bedrock:nova-pro-v1` profile was aligned to that accepted
+inference-profile route during conflict repair so profile expansion does not
+select the rejected on-demand id.
+
+## Results
+
+| Surface | Result | Evidence |
+| --- | --- | --- |
+| AWS profile verification | PASS | Sanitized STS proof recorded only account/user digests and ARN shape. |
+| Direct Nova Pro model id | EXPECTED_BLOCKED | `amazon.nova-pro-v1:0` rejected on-demand invocation; use inference profile. |
+| Nova Pro inference profile discovery | PASS | `us.amazon.nova-pro-v1:0` was active in `us-west-2`. |
+| Built-in Nova Pro profile route | PASS | `bedrock:nova-pro-v1` expands to the accepted `us.amazon.nova-pro-v1:0` inference-profile id. |
+| Live adapter smoke | PASS | `final_status: ok`, one attempt, HTTP 200, output text `bedrock nova pro ok`. |
+| UTS regular lane | PASS | `11/11`, full support true, zero provider failures. |
+| UTS-only lane | PASS | `11/11`, full support true, zero provider failures. |
+| UTS+ACC governed lane | NOT_RUN | Runner requires `--include-governed`; #5026 required regular and UTS-only provider acceptance. |
+
+## Timing Snapshot
+
+| Measurement | Value |
+| --- | --- |
+| UTS wall clock | ~40 seconds (`2026-07-09T18:24:54Z` to `2026-07-09T18:25:34Z`) |
+| Regular lane summed provider duration | 20.852 seconds |
+| UTS-only lane summed provider duration | 19.172 seconds |
+| Slowest regular task | `search_contacts_basic`, 3.165 seconds |
+| Slowest UTS-only task | `batch_weather_lookup_basic`, 2.495 seconds |
+
+## Local Evidence
+
+Raw run artifacts are local ignored files under:
+
+- `.adl/local-artifacts/provider-acceptance-5026/aws/sts_agent_logic_admin_sanitized.json`
+- `.adl/local-artifacts/provider-acceptance-5026/aws/bedrock_nova_inference_profiles_us_west_2.json`
+- `.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_result.json`
+- `.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_log.jsonl`
+- `.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_issue5026_results.json`
+- `.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_issue5026_results_run.log.jsonl`
+- `.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_issue5026_results_adapter_evidence/`
+
+## Commands Run
+
+```bash
+AWS_PROFILE=agent-logic-admin AWS_REGION=us-west-2 \
+  aws bedrock list-inference-profiles --region us-west-2 --output json
+```
+
+```bash
+env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION \
+  ADL_AWS_PROFILE=agent-logic-admin \
+  AWS_PROFILE=agent-logic-admin \
+  <ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter \
+  --request .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_inference_profile_request.json \
+  --out .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_result.json \
+  --log .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_log.jsonl
+```
+
+```bash
+env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION \
+  ADL_HOME=<ADL_5026_WORKTREE> \
+  ADL_PROVIDER_ADAPTER_BIN=<ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter \
+  ADL_AWS_PROFILE=agent-logic-admin \
+  AWS_PROFILE=agent-logic-admin \
+  python3 <ADL_5026_WORKTREE>/adl/tools/uts_benchmark_runner.py \
+  --panel-file <ADL_5026_WORKTREE>/.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_model_panel.json \
+  hosted \
+  <ADL_5026_WORKTREE>/.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_selector.txt \
+  <ADL_5026_WORKTREE>/.adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_issue5026_results.json
+```
+
+## Redaction Notes
+
+- No AWS credentials, authorization headers, raw account id, or secret values are
+  recorded in this tracked packet.
+- The STS record stores SHA-256 digests only.
+- UTS result records use redacted response excerpts and retained adapter
+  evidence paths.
+- The successful Nova Pro route is the inference profile id
+  `us.amazon.nova-pro-v1:0`, not the on-demand model id.
+
+## Non-Claims
+
+- This packet does not claim Nova Pro on-demand support.
+- This packet does not claim the governed UTS+ACC lane was run.
+- This packet does not claim byte-stable live provider output.
+- Z.ai live proof is recorded separately in
+  `docs/milestones/v0.91.7/review/provider/Z_AI_ACCEPTANCE_5026.md`.

--- a/docs/milestones/v0.91.7/review/provider/PROVIDER_ACCEPTANCE_MATRIX_5026.md
+++ b/docs/milestones/v0.91.7/review/provider/PROVIDER_ACCEPTANCE_MATRIX_5026.md
@@ -1,0 +1,62 @@
+# Provider Acceptance Matrix - Issue #5026
+
+Issue: `#5026 [v0.91.7][provider][proof] Run Z.ai and Bedrock provider acceptance smoke tests`
+
+Date: 2026-07-09
+
+## Summary
+
+This packet is the #5026 shared acceptance matrix for the provider mini-sprint.
+It rolls up the provider/model rows that #5026 depends on without overstating
+rows owned by separate issues.
+
+Z.ai GLM-5 and AWS Bedrock Nova Pro are accepted live provider paths through
+the #5026-local ADL provider adapter. Fable 5 is accepted as an ad-hoc ADL
+provider-adapter UTS target through #5044, with one ordinary regular-lane
+semantic refusal recorded. DSpark is not accepted as an acceleration/provider
+path yet: #4653 produced a conservative candidate evaluation and #4654 failed
+closed before EC2 launch because the Agent Logic account had zero P-family
+quota and no exact single-node 2xH100 shape was available.
+
+## Matrix
+
+| Row | Provider route | Provider model id | Status | Proof | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Z.ai GLM-5 | `hosted:adl-z-ai:glm-5` | `glm-5` | `implemented_and_integrated` | `Z_AI_ACCEPTANCE_5026.md` | Live smoke PASS; UTS regular `11/11`; UTS-only `11/11`; provider failures `0`; slow provider latency recorded. |
+| AWS Bedrock Nova Pro | `hosted:adl-bedrock:us.amazon.nova-pro-v1:0` | `us.amazon.nova-pro-v1:0` | `implemented_and_integrated` | `BEDROCK_NOVA_PRO_ACCEPTANCE_5026.md` | Live smoke PASS through the `US Nova Pro` system inference profile; UTS regular `11/11`; UTS-only `11/11`; direct on-demand id `amazon.nova-pro-v1:0` rejected as expected. |
+| Fable 5 | `hosted:adl-anthropic:claude-fable-5` | `claude-fable-5` | `accepted_model_path_with_recorded_semantic_caveat` | `FABLE5_UTS_ACCEPTANCE_5044.md` | Live provider route listed and invokable; UTS regular `10/11`; UTS-only `11/11`; provider failures `0`; one ordinary mutation-shaped regular task produced a refusal. |
+| DSpark Qwen/Gemma candidates | not accepted as a provider route | not applicable | `candidate_only_not_accepted_model_path` | `DSPARK_SPECULATIVE_DECODING_EVALUATION_4653.md` | Same-family Qwen/Gemma rows remain candidates blocked on a real DSpark backend; cross-family rows are rejected as non-proving. |
+| DeepSeek V4 Flash DSpark GPU smoke | not launched | `deepseek-ai/DeepSeek-V4-Flash-DSpark` | `blocked_external_capacity` | `dspark_gpu_smoke_4654/README.md` | Live preflight found public model metadata, but EC2 P-family On-Demand and Spot quotas were `0` vCPUs and quota requests were pending; no EC2 GPU resource was launched. |
+
+## Selection And Runtime Boundary
+
+- Z.ai and Bedrock are selected through provider profile/registry expansion and
+  invoked through the ADL provider-adapter boundary, not bespoke one-off HTTP
+  scripts.
+- Bedrock Nova Pro profile expansion now maps `bedrock:nova-pro-v1` to the
+  accepted inference-profile id `us.amazon.nova-pro-v1:0`.
+- Z.ai profile expansion maps `z_ai:glm-5` to the canonical model ref
+  `hosted:adl-z-ai:glm-5` and provider model id `glm-5`.
+- Fable 5 is recorded as an ad-hoc ADL provider-adapter UTS target rather than
+  a canonical provider profile.
+- DSpark remains outside scheduler-accepted provider routing until a real
+  backend proves draft/target behavior and live capacity constraints are
+  cleared.
+
+## Negative Cases
+
+| Case | Disposition |
+| --- | --- |
+| Bedrock direct Nova Pro on-demand id | `EXPECTED_BLOCKED`; `amazon.nova-pro-v1:0` was rejected for on-demand throughput, so the accepted path is `us.amazon.nova-pro-v1:0`. |
+| Bedrock profile/account guardrail | Covered by the native Bedrock provider proof and #5026 AWS profile use; AWS work used `agent-logic-admin`. |
+| Z.ai credential handling | Key contents and exact filename are not recorded; proof commands map an operator-approved key file under `$HOME/keys/` command-locally to `ZAI_API_KEY`. |
+| Fable 5 mutation-shaped ordinary task | Recorded semantic caveat: `update_inventory_basic` refused in the regular lane while passing in the UTS-only dry-run lane. |
+| DSpark AWS GPU capacity | `BLOCKED`; #4654 failed closed before launch because quota/shape gates were not satisfied. |
+
+## Non-Claims
+
+- This packet does not claim governed UTS+ACC lanes were run for #5026.
+- This packet does not claim DSpark acceleration is proven.
+- This packet does not claim Fable 5 has broad quality superiority or unrestricted
+  autonomous repository-mutation suitability.
+- This packet does not claim byte-stable live provider output.

--- a/docs/milestones/v0.91.7/review/provider/PROVIDER_ACCEPTANCE_RELEASE_GATE_DISPOSITION_5026.yaml
+++ b/docs/milestones/v0.91.7/review/provider/PROVIDER_ACCEPTANCE_RELEASE_GATE_DISPOSITION_5026.yaml
@@ -1,0 +1,31 @@
+issue: 5026
+disposition: publish_with_runtime_owner_lane_proof
+reviewer_or_review_mode: pre_pr_bounded_provider_acceptance_review
+focused_validation_run: "bash adl/tools/run_owner_validation_lane.sh runtime --build"
+residual_ci_proof_required_before_merge: "GitHub adl-ci and adl-coverage must complete green on the published PR head before merge."
+changed_release_gate_surfaces:
+  - adl/src/cli/mod.rs
+  - adl/src/cli/provider_cmd.rs
+  - adl/src/cli/usage.rs
+  - adl/src/provider/http_family.rs
+  - adl/src/provider/http_family/tests.rs
+  - adl/src/provider/mod.rs
+  - adl/src/provider/profiles.rs
+  - adl/src/provider_adapter.rs
+  - adl/src/provider_substrate.rs
+  - adl/tests/provider_tests/http_family.rs
+  - adl/tests/provider_tests/profiles.rs
+validation_truth:
+  provider_acceptance_matrix: pass
+  z_ai_live_smoke: pass
+  z_ai_uts_panel: pass_11_of_11_regular_and_11_of_11_uts_only
+  bedrock_nova_pro_live_smoke: pass
+  bedrock_nova_pro_uts_panel: pass_11_of_11_regular_and_11_of_11_uts_only
+  runtime_owner_lane: pass
+  full_nextest_attempt: failed_outside_provider_surface
+residual_risks:
+  - "The explicit full-nextest attempt compiled and started 20450 tests, then failed on two CSM local-service smoke tests that passed in focused rerun. That indicates a full-lane service-test isolation concern outside this provider acceptance change."
+  - "The provider PR must still rely on GitHub CI for integrated PR-head proof before merge."
+non_claims:
+  - "This disposition does not claim the full-nextest attempt passed."
+  - "This disposition does not close the CSM local-service full-lane isolation concern."

--- a/docs/milestones/v0.91.7/review/provider/Z_AI_ACCEPTANCE_5026.md
+++ b/docs/milestones/v0.91.7/review/provider/Z_AI_ACCEPTANCE_5026.md
@@ -1,0 +1,98 @@
+# Z.ai Provider Acceptance Proof
+
+Issue: #5026
+Milestone: v0.91.7
+Date: 2026-07-09
+Provider: Z.ai
+Model target: `glm-5`
+ADL route: `hosted:adl-z-ai:glm-5`
+Credential source: operator-approved key file under `$HOME/keys/`, mapped
+command-locally to `ZAI_API_KEY`
+
+## Summary
+
+Z.ai live proof reached the native ADL Z.ai provider-adapter path with an
+approved key file mapped command-locally to `ZAI_API_KEY`. After the operator
+repaired the account balance/resource package, the live adapter smoke passed and
+the UTS benchmark passed both requested provider acceptance lanes.
+
+The final accepted live smoke returned HTTP 200 with `final_status: ok`, one
+attempt, and exact output text `ADL Z.ai provider adapter smoke ok`. The UTS
+run evaluated the canonical `hosted:adl-z-ai:glm-5` route through the ADL
+provider adapter with
+regular `11/11`, UTS-only `11/11`, and zero provider failures. The governed
+UTS+ACC lane was not run because #5026 required the regular and UTS-only
+provider acceptance lanes.
+
+## Results
+
+| Surface | Result | Evidence |
+| --- | --- | --- |
+| Approved key-file presence | PASS | Operator-approved key file under `$HOME/keys/` existed and was non-empty. |
+| Native adapter route | PASS | Request used provider `z_ai`, model `glm-5`, canonical ADL model ref `hosted:adl-z-ai:glm-5`; the retained UTS selector id used the historical `hosted:adl-z_ai:glm-5` alias. |
+| Live adapter smoke | PASS | `final_status: ok`, one attempt, HTTP 200, exact output text `ADL Z.ai provider adapter smoke ok`. |
+| UTS regular lane | PASS | `11/11`, full support true, zero provider failures. |
+| UTS-only lane | PASS | `11/11`, full support true, zero provider failures. |
+| UTS+ACC governed lane | NOT_RUN | Runner requires `--include-governed`; #5026 required regular and UTS-only provider acceptance. |
+
+## Timing Snapshot
+
+| Measurement | Value |
+| --- | --- |
+| UTS wall clock | ~6 minutes 49 seconds (`2026-07-09T18:24:18Z` to `2026-07-09T18:31:07Z`) |
+| Regular lane summed provider duration | 120.484 seconds |
+| UTS-only lane summed provider duration | 288.489 seconds |
+| Slowest regular task | `get_weather_basic`, 37.746 seconds |
+| Slowest UTS-only task | `update_inventory_basic`, 85.835 seconds |
+
+## Local Evidence
+
+Raw run artifacts are local ignored files under:
+
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_request.json`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_result.json`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_log.jsonl`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_selector.txt`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_model_panel.json`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_issue5026_results.json`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_issue5026_results_run.log.jsonl`
+- `.adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_issue5026_results_adapter_evidence/`
+
+## Commands Run
+
+```bash
+test -s "<operator-approved-z-ai-key-file-under-$HOME/keys>"
+```
+
+```bash
+ZAI_API_KEY="redacted" \
+  <ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter \
+  --request .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_request.json \
+  --out .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_result.json \
+  --log .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_log.jsonl
+```
+
+```bash
+ZAI_API_KEY="redacted" \
+  ADL_HOME=<ADL_5026_WORKTREE> \
+  ADL_PROVIDER_ADAPTER_BIN=<ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter \
+  python3 <ADL_5026_WORKTREE>/adl/tools/uts_benchmark_runner.py \
+  --panel-file .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_model_panel.json \
+  hosted \
+  .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_selector.txt \
+  .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_issue5026_results.json
+```
+
+## Redaction Notes
+
+- The tracked packet records only that an operator-approved key file under
+  `$HOME/keys/` was used; it does not record the key filename or contents.
+- The live command mapped the key file into `ZAI_API_KEY` only for the adapter
+  process.
+- The retained provider log redacts provider diagnostic fields.
+- No authorization headers or raw secret values are recorded here.
+
+## Non-Claims
+
+- This packet does not claim the governed UTS+ACC lane was run.
+- This packet does not claim byte-stable live provider output.

--- a/docs/milestones/v0.91.7/review/provider/Z_AI_NATIVE_PROVIDER_PROOF_5025.md
+++ b/docs/milestones/v0.91.7/review/provider/Z_AI_NATIVE_PROVIDER_PROOF_5025.md
@@ -1,0 +1,117 @@
+# Z.ai Native Provider Proof - Issue #5025
+
+Date: 2026-07-07
+
+Issue: #5025 `[v0.91.7][provider][z-ai] Implement native Z.ai provider adapter and tests`
+
+## Scope
+
+This issue adds a first-class Z.ai hosted provider path for ADL runtime provider execution:
+
+- Provider kind: `z_ai`
+- Accepted aliases: `zai`, `zhipu`
+- Default endpoint: `https://open.bigmodel.cn/api/paas/v4/chat/completions`
+- Default credential environment variable: `ZAI_API_KEY`
+- Provider profile selector: `z_ai:glm-5`
+- Stable model reference: `hosted:adl-z-ai:glm-5`
+- Provider model id: `glm-5`
+
+The implementation routes Z.ai through the hosted HTTP provider family, provider profiles, provider substrate identity/capability inference, provider setup CLI, and provider adapter runtime path.
+
+## Local Validation
+
+The following focused validation passed in the issue worktree:
+
+```bash
+cargo fmt --manifest-path adl/Cargo.toml
+cargo test --manifest-path adl/Cargo.toml zai -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_substrate -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture
+cargo test --manifest-path adl/Cargo.toml provider_adapter -- --nocapture
+git diff --check
+```
+
+The repo PR-fast lane classified the touched Rust/provider surface as requiring
+full nextest escalation. The escalation lane also passed:
+
+```bash
+ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 \
+bash adl/tools/run_pr_fast_test_lane.sh \
+  --changed-files .adl/local-artifacts/provider-zai-5025/changed-files-5025.txt
+```
+
+Result: nextest completed with exit code 0; 20,312 tests passed, 2 leaky tests
+reported, and 18 tests skipped in 470.816 seconds.
+
+The repo binary setup surface also passed against a repo-relative local artifact directory:
+
+```bash
+adl/target/debug/adl provider setup z_ai \
+  --out .adl/local-artifacts/provider-zai-5025/setup-smoke/z_ai \
+  --force
+```
+
+Covered surfaces include:
+
+- Z.ai HTTP-family request translation, credential failure behavior, response extraction, and redacted invocation records.
+- Provider adapter runtime execution for mocked Z.ai hosted calls.
+- Provider registry construction through `build_provider_for_id`.
+- Provider profile expansion for `z_ai:glm-5`.
+- Provider setup CLI family coverage for `z_ai`.
+- Provider substrate vendor, transport, and model identity inference.
+
+## UTS Harness Result
+
+The UTS deterministic self-check passed:
+
+```bash
+python3 tools/benchmark/deterministic_self_check.py
+```
+
+The hosted UTS runner was then invoked from the sibling `universal-tool-schema` checkout with the issue worktree as `ADL_HOME`:
+
+```bash
+ADL_HOME=<issue-worktree> \
+python3 tools/uts_benchmark_runner.py hosted \
+  <issue-worktree>/.adl/local-artifacts/provider-zai-5025/uts/zai_selector.txt \
+  <issue-worktree>/.adl/local-artifacts/provider-zai-5025/uts/zai_uts_result.json \
+  --lanes regular,uts_only \
+  --run-id issue-5025-zai-uts \
+  --overwrite
+```
+
+Result:
+
+- UTS runner completed and wrote the result artifact.
+- Deterministic self-check inside the runner passed.
+- The ADL hosted provider adapter resolved provider identity as `z_ai` and provider model id `glm-5`.
+- Both `regular` and `uts_only` lanes stopped with `provider_failed` because `ZAI_API_KEY` was not available.
+- No semantic UTS score is claimed for Z.ai in this issue.
+
+Local artifact summary:
+
+- `.adl/local-artifacts/provider-zai-5025/uts/zai_uts_result.json`
+- `.adl/local-artifacts/provider-zai-5025/uts/zai_uts_result_summary.md`
+- `.adl/local-artifacts/provider-zai-5025/uts/zai_uts_result_details.md`
+
+## Live Provider Credential State
+
+The live smoke was prepared but not executed because no approved Z.ai credential source was present:
+
+- `$HOME/keys/zai.key`: not readable/present
+- `$HOME/keys/z_ai.key`: not readable/present
+- `$HOME/keys/zhipu.key`: not readable/present
+- `ZAI_API_KEY`: absent in the command environment
+
+Prepared local smoke request:
+
+- `.adl/local-artifacts/provider-zai-5025/zai_live_smoke_request.json`
+
+No credential contents were printed, copied, committed, or scanned.
+
+## Non-Claims
+
+- This issue does not claim a successful live Z.ai API call.
+- This issue does not claim Z.ai UTS semantic support.
+- This issue does not add a canonical UTS panel member; the UTS invocation used an ad-hoc hosted selector to verify the ADL provider adapter path.
+- Follow-on live proof requires an approved Z.ai API key mapped to `ZAI_API_KEY`.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -11,6 +11,8 @@ Current supported families:
 - `gemini`
 - `deepseek`
 - `bedrock`
+- `openrouter`
+- `z_ai`
 - `http`
 
 Related shared proof-surface docs:
@@ -31,12 +33,13 @@ The generated bundle is intentionally local-only:
 - users are expected to copy/fill a local env file and source it before running ADL
 
 Important transport note:
-- `openai`, `anthropic`, `deepseek`, `openrouter`, and `bedrock` now use Rust-native provider adapters by default:
+- `openai`, `anthropic`, `deepseek`, `openrouter`, `bedrock`, and `z_ai` now use Rust-native provider adapters by default:
   - `type: "openai"` targets the OpenAI Responses API unless `config.endpoint` is explicitly overridden
   - `type: "anthropic"` targets the Anthropic Messages API unless `config.endpoint` is explicitly overridden
   - `type: "deepseek"` targets the DeepSeek chat completions API unless `config.endpoint` is explicitly overridden
   - `type: "openrouter"` targets the OpenRouter chat completions API unless `config.endpoint` is explicitly overridden
   - `type: "bedrock"` targets AWS Bedrock Runtime through the AWS SDK and defaults to `ADL_AWS_PROFILE=agent-logic-admin`
+  - `type: "z_ai"` targets the Z.ai/Zhipu OpenAI-compatible chat completions API unless `config.endpoint` is explicitly overridden
 - ADL's bounded HTTP provider expects a completion-style contract:
   - request JSON with `{"prompt": "..."}`
   - response JSON with `{"output": "..."}`
@@ -54,6 +57,7 @@ adl provider setup claude
 adl provider setup openai --out ./.adl/provider-setup/openai
 adl provider setup deepseek
 adl provider setup bedrock
+adl provider setup z_ai
 ```
 
 AWS Bedrock native note:
@@ -64,6 +68,10 @@ AWS Bedrock native note:
 DeepSeek native note:
 - `adl provider setup deepseek` emits `type: "deepseek"`, reads `DEEPSEEK_API_KEY`, and uses `https://api.deepseek.com/chat/completions` by default
 - the older `http:deepseek-chat` profile remains a compatibility surface for ADL-style completion gateways; it is not the native DeepSeek API path
+
+Z.ai native note:
+- `adl provider setup z_ai` emits `type: "z_ai"`, reads `ZAI_API_KEY`, and uses `https://open.bigmodel.cn/api/paas/v4/chat/completions` by default
+- the first built-in Z.ai profile is `z_ai:glm-5`, which maps to provider model id `glm-5` for the provider mini-sprint UTS route `hosted:adl-z-ai:glm-5`
 
 Loopback demo note:
 - the `v0.87.1` bounded HTTP family demo uses `http://127.0.0.1:8787/complete` with a dummy bearer token as a local proof path for the ADL completion contract


### PR DESCRIPTION
Closes #5026

## Summary
Provider acceptance proof execution is complete. Bedrock Nova Pro is now proven
through the ADL provider-adapter path using the Agent Logic AWS profile
`agent-logic-admin` and the `us-west-2` system inference profile
`us.amazon.nova-pro-v1:0`.

Nova Pro live adapter smoke passed with `final_status: ok`, one attempt, HTTP
200, and output text `bedrock nova pro ok`. Nova Pro UTS benchmark proof also
passed through the ADL provider adapter: regular lane `11/11`, UTS-only lane
`11/11`, zero provider failures in evaluated cases. The governed UTS+ACC lane
was not run because this provider proof used the runner's default regular and
UTS-only provider acceptance lanes.

Z.ai live proof reached the native ADL Z.ai provider-adapter path with an
operator-approved key file under `$HOME/keys/` mapped command-locally to
`ZAI_API_KEY`. After the operator repaired the account balance/resource package,
the final live smoke passed with `final_status: ok`, one attempt, HTTP 200, and
exact output text `ADL Z.ai provider adapter smoke ok`. Z.ai UTS benchmark
proof also passed through the #5026-local ADL provider adapter: regular lane
`11/11`, UTS-only lane `11/11`, zero provider failures in evaluated cases. The
governed UTS+ACC lane was not run because this provider proof used the runner's
default regular and UTS-only provider acceptance lanes.

Timing truth: Nova Pro completed both UTS lanes in about 40 seconds wall clock.
Z.ai completed both lanes in about 6 minutes 49 seconds wall clock. The Z.ai
run was successful but materially slower, with summed provider durations of
120.484 seconds for the regular lane and 288.489 seconds for the UTS-only lane.

Shared matrix truth: Z.ai and Bedrock rows are accepted as implemented provider
paths in #5026. Fable 5 is rolled up from #5044 as an accepted ad-hoc ADL
provider-adapter UTS target with one ordinary regular-lane semantic caveat.
DSpark is explicitly not accepted as a provider/acceleration path yet; #4653
records candidate-only evaluation truth and #4654 records live AWS GPU smoke
blocked by external capacity/quota gates.

## Artifacts
- Local ignored provider evidence under `.adl/local-artifacts/provider-acceptance-5026/`
- Tracked proof artifacts:
  - `docs/milestones/v0.91.7/review/provider/AWS_BEDROCK_NATIVE_PROVIDER_PROOF_5024.md`
  - `docs/milestones/v0.91.7/review/provider/BEDROCK_NOVA_PRO_ACCEPTANCE_5026.md`
  - `docs/milestones/v0.91.7/review/provider/PROVIDER_ACCEPTANCE_MATRIX_5026.md`
  - `docs/milestones/v0.91.7/review/provider/Z_AI_ACCEPTANCE_5026.md`
- Additional proof artifacts: local ignored Nova Pro adapter smoke, inference-profile discovery, UTS result, summary, details, retained adapter evidence files, Z.ai live smoke artifacts, and Z.ai UTS artifacts

## Validation
- Validation commands and their purpose:
  - `AWS_PROFILE=agent-logic-admin AWS_REGION=us-west-2 aws bedrock list-inference-profiles --region us-west-2 --output json`
    `Discovered active Nova inference profiles and confirmed Nova Pro should be invoked through us.amazon.nova-pro-v1:0 rather than the direct on-demand model id.`
  - `env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION ADL_AWS_PROFILE=agent-logic-admin AWS_PROFILE=agent-logic-admin <ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter --request .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_inference_profile_request.json --out .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_result.json --log .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/live/bedrock_nova_pro_issue5026_log.jsonl`
    `Verified live Nova Pro adapter smoke through Bedrock inference profile us.amazon.nova-pro-v1:0.`
  - `env -u ADL_AWS_REGION -u AWS_REGION -u AWS_DEFAULT_REGION ADL_HOME=<ADL_5026_WORKTREE> ADL_PROVIDER_ADAPTER_BIN=<ADL_5026_WORKTREE>/adl/target/debug/adl-provider-adapter ADL_AWS_PROFILE=agent-logic-admin AWS_PROFILE=agent-logic-admin python3 adl/tools/uts_benchmark_runner.py --panel-file .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_model_panel.json hosted .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_selector.txt .adl/local-artifacts/provider-acceptance-5026/bedrock-nova-pro/uts/bedrock_nova_pro_issue5026_results.json`
    `Verified Nova Pro UTS regular and UTS-only benchmark lanes through the ADL provider adapter.`
  - `test -s "<operator-approved-z-ai-key-file-under-$HOME/keys>"`
    `Verified the operator-provided Z.ai key file exists without printing key contents or recording the key filename.`
  - `run #5026-local Z.ai provider adapter with approved key-file value mapped command-locally to ZAI_API_KEY, request .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_request.json, out .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_result.json, log .adl/local-artifacts/provider-acceptance-5026/z-ai/live/zai_live_smoke_issue5026_zai_impl_log.jsonl`
    `Verified Z.ai adapter route, credential mapping, and provider reachability; after account balance repair, the final accepted run returned final_status ok, HTTP 200, and exact output text ADL Z.ai provider adapter smoke ok.`
  - `run #5026-local UTS benchmark runner with approved key-file value mapped command-locally to ZAI_API_KEY, panel .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_model_panel.json, selector .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_selector.txt, out .adl/local-artifacts/provider-acceptance-5026/z-ai/uts/zai_issue5026_results.json`
    `Verified Z.ai UTS regular and UTS-only benchmark lanes through the ADL provider adapter.`
  - `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=<ADL_5026_WORKTREE>/adl/target cargo test --manifest-path adl/Cargo.toml expand_provider_profiles_accepts_bedrock_nova_pro_inference_profile -- --nocapture`
    `Verified the built-in Bedrock Nova Pro profile expands to the live-proven inference-profile id.`
  - `git diff --check`
    `Verified tracked whitespace cleanliness.`
- Results:
  - `PASS` for live Nova Pro adapter smoke using inference profile `us.amazon.nova-pro-v1:0`.
  - `PASS` for Nova Pro UTS regular lane: `11/11`.
  - `PASS` for Nova Pro UTS-only lane: `11/11`.
  - `NOT_RUN` for governed UTS+ACC lane.
  - `PASS` for live Z.ai adapter smoke using `glm-5`.
  - `PASS` for Z.ai UTS regular lane: `11/11`.
  - `PASS` for Z.ai UTS-only lane: `11/11`.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5026__v0-91-7-provider-proof-run-z-ai-and-bedrock-provider-acceptance-smoke-tests/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5026__v0-91-7-provider-proof-run-z-ai-and-bedrock-provider-acceptance-smoke-tests/sor.md
- Idempotency-Key: v0-91-7-provider-proof-run-z-ai-and-bedrock-provider-acceptance-smoke-tests-adl-src-adl-tests-docs-architecture-provider-capability-and-transport-architecture-md-docs-milestones-v0-91-7-review-provider-docs-tooling-provider-setup-md-adl-v0-91-7-tasks-issue-5026-v0-91-7-provider-proof-run-z-ai-and-bedrock-provider-acceptance-smoke-tests-sip-md-adl-v0-91-7-tasks-issue-5026-v0-91-7-provider-proof-run-z-ai-and-bedrock-provider-acceptance-smoke-tests-sor-md