### PR TITLE
[v0.91.7][WP-07][csm] Add loopback browser access policy for CSM runtime API

### DIFF
--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -17,6 +17,7 @@ pub const CSM_RUNTIME_API_HEALTH_SCHEMA: &str = "adl.csm.runtime_api.health.v1";
 pub const CSM_RUNTIME_API_READY_SCHEMA: &str = "adl.csm.runtime_api.ready.v1";
 pub const CSM_RUNTIME_API_METRICS_SCHEMA: &str = "adl.csm.runtime_api.metrics.v1";
 pub const CSM_RUNTIME_API_EVENTS_SCHEMA: &str = "adl.csm.runtime_api.events.v1";
+const CSM_RUNTIME_API_BROWSER_DEMO_PORT: &str = "8765";
 
 #[derive(Debug, Clone)]
 pub struct CsmRuntimeApiOptions {
@@ -73,9 +74,9 @@ pub fn serve_runtime_api(options: CsmRuntimeApiOptions) -> Result<CsmRuntimeApiS
                     stream
                         .set_read_timeout(Some(Duration::from_secs(5)))
                         .context("set CSM runtime API read timeout")?;
-                    let request = read_request_path(&mut stream)?;
-                    let response = runtime_api_response(&options, &request)?;
-                    write_http_json(&mut stream, &response)?;
+                    let request = read_runtime_api_request(&mut stream)?;
+                    let response = runtime_api_http_response(&options, &request)?;
+                    write_http_response(&mut stream, &response)?;
                     served += 1;
                     last_activity = Instant::now();
                 }
@@ -94,9 +95,9 @@ pub fn serve_runtime_api(options: CsmRuntimeApiOptions) -> Result<CsmRuntimeApiS
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .context("set CSM runtime API read timeout")?;
-            let request = read_request_path(&mut stream)?;
-            let response = runtime_api_response(&options, &request)?;
-            write_http_json(&mut stream, &response)?;
+            let request = read_runtime_api_request(&mut stream)?;
+            let response = runtime_api_http_response(&options, &request)?;
+            write_http_response(&mut stream, &response)?;
             served += 1;
             if options
                 .test_max_requests
@@ -669,7 +670,21 @@ fn validate_loopback_bind(addr: &SocketAddr) -> Result<()> {
     Ok(())
 }
 
-fn read_request_path(stream: &mut TcpStream) -> Result<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeApiRequest {
+    method: String,
+    path: String,
+    origin: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeApiHttpResponse {
+    status: &'static str,
+    headers: Vec<(&'static str, String)>,
+    body: Option<Value>,
+}
+
+fn read_runtime_api_request(stream: &mut TcpStream) -> Result<RuntimeApiRequest> {
     let mut buf = Vec::new();
     let mut chunk = [0_u8; 256];
     loop {
@@ -687,27 +702,142 @@ fn read_request_path(stream: &mut TcpStream) -> Result<String> {
             break;
         }
     }
-    let request = String::from_utf8_lossy(&buf);
-    let first_line = request.lines().next().unwrap_or_default();
+    parse_runtime_api_request(&String::from_utf8_lossy(&buf))
+}
+
+fn parse_runtime_api_request(raw: &str) -> Result<RuntimeApiRequest> {
+    let mut lines = raw.lines();
+    let first_line = lines.next().unwrap_or_default();
     let mut parts = first_line.split_whitespace();
     let method = parts.next().unwrap_or_default();
     let path = parts.next().unwrap_or("/__bad_request");
-    if method != "GET" {
-        return Ok("/__method_not_allowed".to_string());
+    let mut origin = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("origin") {
+            origin = Some(value.trim().to_string());
+            break;
+        }
     }
-    Ok(path.to_string())
+    Ok(RuntimeApiRequest {
+        method: method.to_ascii_uppercase(),
+        path: path.to_string(),
+        origin,
+    })
 }
 
-fn write_http_json(stream: &mut TcpStream, body: &Value) -> Result<()> {
-    let status = if body.get("status").and_then(Value::as_str) == Some("not_found") {
-        "404 Not Found"
-    } else {
-        "200 OK"
+fn runtime_api_http_response(
+    options: &CsmRuntimeApiOptions,
+    request: &RuntimeApiRequest,
+) -> Result<RuntimeApiHttpResponse> {
+    let mut headers = loopback_browser_access_headers(request.origin.as_deref());
+    headers.push(("vary", "Origin".to_string()));
+    match request.method.as_str() {
+        "GET" => {
+            let body = runtime_api_response(options, &request.path)?;
+            let status = if body.get("status").and_then(Value::as_str) == Some("not_found") {
+                "404 Not Found"
+            } else {
+                "200 OK"
+            };
+            Ok(RuntimeApiHttpResponse {
+                status,
+                headers,
+                body: Some(body),
+            })
+        }
+        "OPTIONS" => Ok(RuntimeApiHttpResponse {
+            status: "204 No Content",
+            headers,
+            body: None,
+        }),
+        _ => Ok(RuntimeApiHttpResponse {
+            status: "405 Method Not Allowed",
+            headers,
+            body: Some(json!({
+                "schema": CSM_RUNTIME_API_SCHEMA,
+                "status": "method_not_allowed",
+                "allowed_methods": ["GET", "OPTIONS"]
+            })),
+        }),
+    }
+}
+
+fn loopback_browser_access_headers(origin: Option<&str>) -> Vec<(&'static str, String)> {
+    let Some(origin) = origin else {
+        return Vec::new();
     };
-    let raw = serde_json::to_vec_pretty(body)?;
+    if !is_approved_loopback_browser_origin(origin) {
+        return Vec::new();
+    }
+    vec![
+        ("access-control-allow-origin", origin.to_string()),
+        ("access-control-allow-methods", "GET, OPTIONS".to_string()),
+        (
+            "access-control-allow-headers",
+            "accept, content-type".to_string(),
+        ),
+        ("access-control-max-age", "600".to_string()),
+    ]
+}
+
+fn is_approved_loopback_browser_origin(origin: &str) -> bool {
+    let Some((scheme, rest)) = origin.split_once("://") else {
+        return false;
+    };
+    if scheme != "http" {
+        return false;
+    }
+    let host_port = rest
+        .split_once('/')
+        .map(|(host, _)| host)
+        .unwrap_or(rest)
+        .trim();
+    let (host, port) = if let Some(stripped) = host_port.strip_prefix('[') {
+        let Some((ipv6, suffix)) = stripped.split_once(']') else {
+            return false;
+        };
+        let port = if let Some(port) = suffix.strip_prefix(':') {
+            port
+        } else if suffix.is_empty() {
+            ""
+        } else {
+            return false;
+        };
+        (ipv6, port)
+    } else {
+        host_port.split_once(':').unwrap_or((host_port, ""))
+    };
+    if port != CSM_RUNTIME_API_BROWSER_DEMO_PORT {
+        return false;
+    }
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false)
+}
+
+fn write_http_response(stream: &mut TcpStream, response: &RuntimeApiHttpResponse) -> Result<()> {
+    let raw = response
+        .body
+        .as_ref()
+        .map(serde_json::to_vec_pretty)
+        .transpose()?
+        .unwrap_or_default();
+    write!(stream, "HTTP/1.1 {}\r\n", response.status)?;
+    if response.body.is_some() {
+        write!(stream, "content-type: application/json\r\n")?;
+    }
+    for (name, value) in &response.headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
     write!(
         stream,
-        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        "content-length: {}\r\nconnection: close\r\n\r\n",
         raw.len()
     )?;
     stream.write_all(&raw)?;
@@ -772,6 +902,113 @@ memory: {}
     fn test_api_bind(offset: u64) -> String {
         let port = 19950 + (offset % 47);
         format!("127.0.0.1:{port}")
+    }
+
+    fn test_options(root: &Path) -> CsmRuntimeApiOptions {
+        CsmRuntimeApiOptions {
+            spec_path: write_spec(root),
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        }
+    }
+
+    #[test]
+    fn runtime_api_parses_method_path_and_origin() {
+        let request = parse_runtime_api_request(
+            "OPTIONS /status HTTP/1.1\r\nHost: 127.0.0.1:19997\r\nOrigin: http://127.0.0.1:8765\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(
+            request,
+            RuntimeApiRequest {
+                method: "OPTIONS".to_string(),
+                path: "/status".to_string(),
+                origin: Some("http://127.0.0.1:8765".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_api_allows_explicit_loopback_browser_origins_only() {
+        assert!(is_approved_loopback_browser_origin("http://127.0.0.1:8765"));
+        assert!(is_approved_loopback_browser_origin("http://localhost:8765"));
+        assert!(is_approved_loopback_browser_origin("http://[::1]:8765"));
+        assert!(!is_approved_loopback_browser_origin(
+            "http://127.0.0.1:8766"
+        ));
+        assert!(!is_approved_loopback_browser_origin(
+            "https://127.0.0.1:8765"
+        ));
+        assert!(!is_approved_loopback_browser_origin(
+            "http://example.com:8765"
+        ));
+        assert!(!is_approved_loopback_browser_origin("null"));
+    }
+
+    #[test]
+    fn runtime_api_get_reflects_approved_loopback_origin_without_wildcard() {
+        let root = temp_root("cors-get");
+        let options = test_options(&root);
+        let request = RuntimeApiRequest {
+            method: "GET".to_string(),
+            path: "/ready".to_string(),
+            origin: Some("http://127.0.0.1:8765".to_string()),
+        };
+        let response = runtime_api_http_response(&options, &request).unwrap();
+        assert_eq!(response.status, "200 OK");
+        assert!(response.headers.contains(&(
+            "access-control-allow-origin",
+            "http://127.0.0.1:8765".to_string()
+        )));
+        assert!(!response
+            .headers
+            .contains(&("access-control-allow-origin", "*".to_string())));
+        assert_eq!(
+            response.body.as_ref().unwrap()["schema"],
+            CSM_RUNTIME_API_READY_SCHEMA
+        );
+    }
+
+    #[test]
+    fn runtime_api_preflight_succeeds_for_approved_loopback_origin() {
+        let root = temp_root("cors-options");
+        let options = test_options(&root);
+        let request = RuntimeApiRequest {
+            method: "OPTIONS".to_string(),
+            path: "/events".to_string(),
+            origin: Some("http://localhost:8765".to_string()),
+        };
+        let response = runtime_api_http_response(&options, &request).unwrap();
+        assert_eq!(response.status, "204 No Content");
+        assert!(response.body.is_none());
+        assert!(response.headers.contains(&(
+            "access-control-allow-origin",
+            "http://localhost:8765".to_string()
+        )));
+        assert!(response
+            .headers
+            .contains(&("access-control-allow-methods", "GET, OPTIONS".to_string())));
+    }
+
+    #[test]
+    fn runtime_api_does_not_grant_cors_to_non_loopback_origin() {
+        let root = temp_root("cors-deny");
+        let options = test_options(&root);
+        let request = RuntimeApiRequest {
+            method: "GET".to_string(),
+            path: "/status".to_string(),
+            origin: Some("http://example.com:8765".to_string()),
+        };
+        let response = runtime_api_http_response(&options, &request).unwrap();
+        assert_eq!(response.status, "200 OK");
+        assert!(!response
+            .headers
+            .iter()
+            .any(|(name, _)| *name == "access-control-allow-origin"));
+        assert!(response.headers.contains(&("vary", "Origin".to_string())));
     }
 
     #[test]


### PR DESCRIPTION
Closes #5003

## Summary
Implemented a bounded loopback browser access policy for the standalone CSM runtime API in `adl/src/csm_runtime_api.rs`.

The runtime API now parses HTTP method, path, and `Origin`; returns `GET` JSON responses with CORS headers only for explicit local HTML Observatory demo origins on port `8765`; returns `204 No Content` for approved `OPTIONS` preflight; returns `405 Method Not Allowed` for unsupported methods; and keeps disallowed origins from receiving `access-control-allow-origin`.

The current issue branch was fast-forwarded to `origin/main` before reapplying the #5003 change, so the implementation preserves the canonical CSM runtime API bind contract from #4980/#5040: `127.0.0.1:19997` remains the canonical local API port, and focused tests continue to use the reserved `19950-19999` CSM local runtime/dev/test band without allocating the canonical `19997` slot.

Independent pre-PR review now ran through `codex review --uncommitted` and reported no discrete correctness, security, or maintainability regressions. Full HTML Observatory browser UI live-poll proof remains unclaimed; runtime-side access policy proof passed.

## Artifacts
- Tracked implementation artifact: `adl/src/csm_runtime_api.rs`
- Issue-local proof artifact: `.adl/v0.91.7/tasks/issue-5003__v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api/artifacts/loopback_browser_access_proof.md`
- Local review artifact: `.adl/reviews/20260707-161800-issue-5003-local-repo-review.md`
- Independent Codex review artifact: `.adl/reviews/20260709-193353-issue-5003-codex-review.md`
- Repo-native review gate artifact: `.adl/reviews/issue-5003-adl-review-code-review/gate_result.json`
- Repo-native packet-only review gate artifact: `.adl/reviews/issue-5003-adl-review-code-review-packet-only/gate_result.json`
- PR artifact: `pending repo-native pr finish publication`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Formatted Rust code after implementation changes.`
  - `cargo test --manifest-path adl/Cargo.toml csm_runtime_api -- --nocapture`
    `Ran focused CSM runtime API unit and smoke tests; 10 csm_runtime_api unit tests and the existing agent::csm_runtime_api_serves_status_health_ready_metrics_and_events CLI smoke passed.`
  - `codex review --uncommitted`
    `Ran independent bounded pre-PR review over the uncommitted issue diff; no discrete correctness, security, or maintainability regressions were reported.`
  - `adl/target/debug/csm api serve --spec docs/milestones/v0.91.7/review/runtime/csm_liveness_4976/full/agent.yaml --bind 127.0.0.1:24645 --max-requests 10 --idle-timeout-ms 20000 --json`
    `Served the runtime API over loopback for manual HTTP proof.`
  - `curl -sS -i -H 'Origin: http://127.0.0.1:8765' http://127.0.0.1:24645/status`
    `Verified approved demo origin receives CORS headers on a JSON endpoint.`
  - `curl -sS -i -X OPTIONS -H 'Origin: http://127.0.0.1:8765' -H 'Access-Control-Request-Method: GET' http://127.0.0.1:24645/events`
    `Verified browser preflight succeeds for the approved demo origin.`
  - `curl -sS -i -H 'Origin: http://127.0.0.1:8766' http://127.0.0.1:24645/health`
    `Verified same-host alternate demo port receives no accidental CORS grant.`
  - `curl -sS http://127.0.0.1:24645/ready`, `curl -sS http://127.0.0.1:24645/metrics`, and `curl -sS http://127.0.0.1:24645/events`
    `Verified the remaining required runtime endpoints responded from the live loopback server.`
  - `adl/target/debug/adl-review verify-repo-contract --review .adl/reviews/20260707-161800-issue-5003-local-repo-review.md`
    `Verified the local review artifact uses the expected review-surface structure and avoids host-path leakage.`
- Results:
  - `PASS` for focused Rust tests.
  - `PASS` for independent Codex review with no findings.
  - `PASS` for live loopback HTTP smoke.
  - `NOT_CLAIMED` for full browser UI live-poll proof because browser automation timed out before reaching the runtime API.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5003__v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5003__v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api/sor.md
- Idempotency-Key: v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api-adl-src-csm-runtime-api-rs-adl-v0-91-7-tasks-issue-5003-v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api-sip-md-adl-v0-91-7-tasks-issue-5003-v0-91-7-wp-07-csm-add-loopback-browser-access-policy-for-csm-runtime-api-sor-md