### PR TITLE
[v0.91.7][tools][watch] Align pr watch and doctor SOR readiness reporting

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -920,7 +920,7 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
         .clone()
         .or_else(|| local_identity.as_ref().map(|(_, slug)| slug.clone()))
         .unwrap_or_else(|| sanitize_slug(&issue_record.title));
-    let issue_ref = IssueRef::new(issue, version, slug)?;
+    let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
     let linked_pr = if let Some(pr) = direct_pr {
         let validation = github::pr_validation_report(&repo, &pr.number.to_string())?;
         Some((pr, validation))
@@ -951,6 +951,7 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
         &issue_ref,
         &issue_ref.branch_name("codex"),
     );
+    let local_readiness_command = doctor_ready_command(&issue_ref);
     let (ready_lifecycle_state, pr_finish_readiness, local_readiness) = match ready {
         Ok(ready) => (
             ready.lifecycle_state,
@@ -959,6 +960,8 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
                 status: "ready".to_string(),
                 pr_run_readiness: ready.card_lifecycle.pr_run_readiness.to_string(),
                 reason: "doctor_ready_pass".to_string(),
+                check: "doctor_ready".to_string(),
+                command: local_readiness_command.clone(),
             },
         ),
         Err(err) => (
@@ -968,6 +971,8 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
                 status: "failed".to_string(),
                 pr_run_readiness: "unknown".to_string(),
                 reason: err.to_string(),
+                check: "doctor_ready".to_string(),
+                command: local_readiness_command,
             },
         ),
     };
@@ -998,6 +1003,15 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
         ready_lifecycle_state,
         pr_finish_readiness,
     })
+}
+
+fn doctor_ready_command(issue_ref: &IssueRef) -> String {
+    format!(
+        "adl pr doctor {} --version {} --slug {} --mode ready --json",
+        issue_ref.issue_number(),
+        issue_ref.scope(),
+        issue_ref.slug()
+    )
 }
 
 fn parse_issue_ref_number(command: &str, issue_ref: &str) -> Result<u32> {
@@ -2325,7 +2339,7 @@ fn bootstrap_ready_status_label(status: &str) -> &str {
 
 #[cfg(test)]
 mod bootstrap_output_tests {
-    use super::{bootstrap_ready_status_label, read_issue_goal_metric_refs};
+    use super::{bootstrap_ready_status_label, doctor_ready_command, read_issue_goal_metric_refs};
     use ::adl::control_plane::IssueRef;
     use std::fs;
 
@@ -2336,6 +2350,17 @@ mod bootstrap_output_tests {
             "BLOCKED_PENDING_CARD_REVIEW"
         );
         assert_eq!(bootstrap_ready_status_label("PASS"), "PASS");
+    }
+
+    #[test]
+    fn doctor_ready_command_reports_normalized_issue_ref_slug() {
+        let issue_ref =
+            IssueRef::new(5002, "v0.91.7", "Watch Target With Spaces").expect("issue ref");
+
+        assert_eq!(
+            doctor_ready_command(&issue_ref),
+            "adl pr doctor 5002 --version v0.91.7 --slug watch-target-with-spaces --mode ready --json"
+        );
     }
 
     #[test]

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -189,6 +189,8 @@ pub(crate) struct IssueWatchLocalReadinessReport {
     pub(crate) status: String,
     pub(crate) pr_run_readiness: String,
     pub(crate) reason: String,
+    pub(crate) check: String,
+    pub(crate) command: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/adl/src/cli/pr_cmd/github/tests/watch.rs
+++ b/adl/src/cli/pr_cmd/github/tests/watch.rs
@@ -5,6 +5,9 @@ fn readiness_ready() -> IssueWatchLocalReadinessReport {
         status: "ready".to_string(),
         pr_run_readiness: "ready".to_string(),
         reason: "doctor_ready_pass".to_string(),
+        check: "doctor_ready".to_string(),
+        command: "adl pr doctor 4397 --version v0.91.7 --slug watch-target --mode ready --json"
+            .to_string(),
     }
 }
 
@@ -13,6 +16,9 @@ fn readiness_failed() -> IssueWatchLocalReadinessReport {
         status: "failed".to_string(),
         pr_run_readiness: "unknown".to_string(),
         reason: "doctor: sor failed validation".to_string(),
+        check: "doctor_ready".to_string(),
+        command: "adl pr doctor 4397 --version v0.91.7 --slug watch-target --mode ready --json"
+            .to_string(),
     }
 }
 
@@ -637,6 +643,19 @@ fn issue_watch_routes_failed_local_readiness_without_pr_to_blocked() {
         report.local_readiness.reason,
         "doctor: sor failed validation"
     );
+    assert_eq!(report.local_readiness.check, "doctor_ready");
+    assert!(report
+        .local_readiness
+        .command
+        .contains("adl pr doctor 4397"));
+    assert!(report.local_readiness.command.contains("--mode ready"));
+
+    let value = serde_json::to_value(&report).expect("watch report serializes");
+    assert_eq!(value["local_readiness"]["check"], "doctor_ready");
+    assert!(value["local_readiness"]["command"]
+        .as_str()
+        .expect("command is a string")
+        .contains("--json"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #5002

## Summary
Implemented the issue #5002 watch/doctor readiness alignment fix. `pr watch` local readiness JSON now records the shared doctor-ready check name and a concrete repo-native doctor command, preserving existing readiness/SOR validation semantics and routing behavior.

## Artifacts
- Updated SOR at `.adl/v0.91.7/tasks/issue-5002__v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting/sor.md`
- Updated SRP at `.adl/v0.91.7/tasks/issue-5002__v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting/srp.md`
- Tracked implementation artifacts:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/github.rs`
  - `adl/src/cli/pr_cmd/github/tests/watch.rs`
- Additional proof artifacts: focused Cargo test output and `pr watch --json` command-path output captured in terminal session.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::github::tests::watch:: -- --nocapture`
    `Verified the complete pr watch unit-test module, including failed local readiness routing and shepherd state preservation.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl cli::pr_cmd::bootstrap_output_tests::doctor_ready_command_reports_normalized_issue_ref_slug -- --nocapture`
    `Verified the concrete doctor-ready command reports the normalized IssueRef slug.`
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr watch 5002 --version v0.91.7 --slug v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting --json`
    `Verified live command-path JSON includes local_readiness.check and local_readiness.command.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5002__v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5002__v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting/sor.md
- Idempotency-Key: v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-github-rs-adl-src-cli-pr-cmd-github-tests-watch-rs-adl-v0-91-7-tasks-issue-5002-v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting-sip-md-adl-v0-91-7-tasks-issue-5002-v0-91-7-tools-watch-align-pr-watch-and-doctor-sor-readiness-reporting-sor-md