### PR TITLE
[v0.91.7][release][version] Update Cargo.toml version to 0.91.7

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.91.6"
+version = "0.91.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.91.6"
+version = "0.91.7"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #5062

## Summary
Updated ADL Rust package metadata from `0.91.6` to `0.91.7` in both the manifest and lockfile so Cargo metadata matches the active v0.91.7 milestone.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-5062__v0-91-7-release-version-update-cargo-toml-version-to-0-91-7/sor.md`
- Tracked implementation artifacts: `adl/Cargo.toml`; `adl/Cargo.lock`
- Additional proof artifacts: `not_applicable; focused validation output is command-recorded below`

## Validation
- Validation commands and their purpose:
  - `python3 - <<'PY' ...`
  - `cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1`
  - `git diff --check`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5062__v0-91-7-release-version-update-cargo-toml-version-to-0-91-7/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5062__v0-91-7-release-version-update-cargo-toml-version-to-0-91-7/sor.md
- Idempotency-Key: v0-91-7-release-version-update-cargo-toml-version-to-0-91-7-adl-cargo-toml-adl-cargo-lock-adl-v0-91-7-tasks-issue-5062-v0-91-7-release-version-update-cargo-toml-version-to-0-91-7-sip-md-adl-v0-91-7-tasks-issue-5062-v0-91-7-release-version-update-cargo-toml-version-to-0-91-7-sor-md