### PR TITLE
[v0.91.7][tools][subagents] Record terminal review status

### DIFF
--- a/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+++ b/adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
@@ -652,7 +652,14 @@ fn normalized_review_value(value: Option<&str>) -> Option<String> {
 fn matches_final_findings_status(value: Option<&str>) -> bool {
     matches!(
         normalized_review_value(value).as_deref(),
-        Some("no_findings" | "findings_present")
+        Some(
+            "no_findings"
+                | "findings_present"
+                | "review_unavailable"
+                | "review_timeout"
+                | "review_cancelled"
+                | "review_failed"
+        )
     )
 }
 

--- a/adl/src/cli/pr_cmd/doctor/tests.rs
+++ b/adl/src/cli/pr_cmd/doctor/tests.rs
@@ -957,6 +957,28 @@ fn card_lifecycle_blocks_completed_srp_without_review_results() {
 }
 
 #[test]
+fn card_lifecycle_accepts_terminal_review_timeout_results() {
+    let repo = lifecycle_temp_repo("completed-srp-review-timeout-results");
+    let paths = write_lifecycle_fixture(
+        &repo,
+        LifecycleFixture {
+            sip: "Card Status: ready\nBranch: codex/3065-test\n",
+            stp: "---\ncard_status: \"ready\"\n---\n\n## Summary\n\nfixture summary\n\n## Goal\n\nfixture goal\n\n## Required Outcome\n\nready\n\n## Deliverables\n\n- fixture deliverable\n\n## Acceptance Criteria\n\n- pass\n\n## Repo Inputs\n\n- fixture\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- none\n\n## Issue-Graph Notes\n\n- fixture note\n\n## Notes\n\nfixture notes\n\n## Tooling Notes\n\n- fixture tooling note\n",
+            spp: reviewed_ready_spp_frontmatter("codex/3065-test"),
+            srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\ncard_status: \"completed\"\nstatus: \"approved\"\nreview_results:\n  findings_status: \"review_timeout\"\n  recommended_outcome: \"block\"\n---\n\n# Structured Review Prompt\n\n## Review Results\n\n- The bounded review subagent timed out; no review completion is claimed.\n",
+            sor: "# output\n\nBranch: codex/3065-test\nCard Status: ready\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
+        },
+    );
+
+    let lifecycle = build_doctor_card_lifecycle(
+        &repo, &paths.sip, &paths.stp, &paths.spp, &paths.vpp, &paths.srp, &paths.sor,
+    );
+
+    assert_eq!(lifecycle.pr_finish_readiness, "ready");
+    assert_stage(&lifecycle, "SRP", "final", true, true);
+}
+
+#[test]
 fn card_lifecycle_blocks_completed_sor_before_terminal_closeout() {
     let repo = lifecycle_temp_repo("completed-sor-before-closeout");
     let paths = write_lifecycle_fixture(

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -641,7 +641,7 @@ fn recovery_candidate_is_usable(path: &Path, relative: &str) -> Result<bool> {
     }
 }
 
-fn srp_has_final_review_results_text(text: &str) -> Result<bool> {
+pub(super) fn srp_has_final_review_results_text(text: &str) -> Result<bool> {
     let Some(front_matter) = markdown_front_matter_local(text) else {
         return Ok(false);
     };
@@ -662,7 +662,14 @@ fn srp_has_final_review_results_text(text: &str) -> Result<bool> {
     let recommended_outcome = yaml_mapping_string_local(review_results, "recommended_outcome");
     Ok(matches!(
         findings_status.as_deref(),
-        Some("no_findings" | "findings_present")
+        Some(
+            "no_findings"
+                | "findings_present"
+                | "review_unavailable"
+                | "review_timeout"
+                | "review_cancelled"
+                | "review_failed"
+        )
     ) && matches!(
         recommended_outcome.as_deref(),
         Some("pass" | "block" | "needs_followup")

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -4,6 +4,7 @@ use crate::cli::pr_cmd::lifecycle::cleanup::{
     record_worktree_prune_result, replace_worktree_only_paths_remaining,
     scrub_noncanonical_issue_bundle_residue,
 };
+use crate::cli::pr_cmd::lifecycle::reconciliation::srp_has_final_review_results_text;
 use crate::cli::pr_cmd::{card_output_path, resolve_cards_root};
 use crate::cli::pr_cmd_cards::{ensure_pre_run_bootstrap_cards, ensure_task_bundle_stp};
 use crate::cli::tests::env_lock;
@@ -590,6 +591,31 @@ fn ensure_closed_completed_issue_bundle_truth_rejects_stale_fields() {
     assert!(rendered.contains(
         "SRP review_results must record final findings_status/recommended_outcome truth for closed issues"
     ));
+}
+
+#[test]
+fn srp_final_review_results_accept_terminal_review_failure_statuses() {
+    let srp = r#"---
+schema_version: "0.1"
+artifact_type: "structured_review_prompt"
+name: "fixture-review"
+status: "approved"
+review_results:
+  findings_status: "review_failed"
+  recommended_outcome: "block"
+---
+
+# Structured Review Prompt
+
+## Review Results
+
+- The bounded review subagent returned a terminal failure; no completed review is claimed.
+"#;
+
+    assert!(
+        srp_has_final_review_results_text(srp).expect("parse SRP review results"),
+        "terminal review failure status should be final SRP truth"
+    );
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1352,6 +1352,47 @@ review_results:
 }
 
 #[test]
+fn sor_emitted_facts_preserve_terminal_review_timeout_truth() {
+    let output = "## Verification Summary\n\n```yaml\nverification_summary:\n  validation:\n    status: PASS\n```\n";
+    let review = r#"---
+review_results:
+  findings_status: "review_timeout"
+  recommended_outcome: "block"
+---
+
+# Structured Review Prompt
+
+## Findings
+
+- Bounded review subagent timed out after repeated waits; no completed review is claimed.
+
+## Dispositions
+
+- Record terminal review timeout truth in SRP/SOR and block publication until follow-up review.
+"#;
+
+    let normalized = normalize_sor_emitted_facts_fixture(
+        output,
+        &["adl/src/cli/pr_cmd/finish_support.rs".to_string()],
+        &["git diff --check".to_string()],
+        review,
+        SorFactEmissionContext {
+            validation_status: "PASS",
+            pr_url: None,
+            integration_state: "worktree_only",
+            closing_linkage_repaired: false,
+            issue_watcher: None,
+        },
+    )
+    .expect("normalize terminal review timeout evidence");
+
+    assert!(normalized.contains("findings_status: review_timeout"));
+    assert!(normalized.contains("recommended_outcome: block"));
+    assert!(normalized.contains("Bounded review subagent timed out after repeated waits"));
+    assert!(normalized.contains("Record terminal review timeout truth in SRP/SOR"));
+}
+
+#[test]
 fn render_default_finish_validation_includes_profile_truth_and_sanitizes_changed_files() {
     let plan = FinishValidationPlan {
         mode: FinishValidationMode::SmallBinaryFocused,

--- a/adl/src/cli/tooling_cmd/srp_sor_update.rs
+++ b/adl/src/cli/tooling_cmd/srp_sor_update.rs
@@ -390,8 +390,19 @@ fn normalize_findings_status(value: &str) -> Result<String> {
         }
         "findings_present" | "findings-present" | "findings" | "open" | "unresolved"
         | "blocked" => Ok("findings_present".to_string()),
+        "review_unavailable" | "review-unavailable" | "unavailable" => {
+            Ok("review_unavailable".to_string())
+        }
+        "review_timeout" | "review-timeout" | "timeout" | "timed_out" | "timed-out" => {
+            Ok("review_timeout".to_string())
+        }
+        "review_cancelled" | "review-cancelled" | "cancelled" | "canceled" | "cancelled_review"
+        | "canceled_review" => Ok("review_cancelled".to_string()),
+        "review_failed" | "review-failed" | "failed" | "failure" | "error" => {
+            Ok("review_failed".to_string())
+        }
         other => bail!(
-            "unsupported review.findings_status '{other}' (expected no_findings or findings_present)"
+            "unsupported review.findings_status '{other}' (expected no_findings, findings_present, review_unavailable, review_timeout, review_cancelled, or review_failed)"
         ),
     }
 }

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -526,7 +526,17 @@ fn validate_completed_srp_card_status(fm: &serde_yaml::Mapping) -> Result<()> {
         .and_then(Value::as_mapping)
         .map(|mapping| {
             mapping_string(mapping, "findings_status")
-                .map(|v| matches!(v.as_str(), "no_findings" | "findings_present"))
+                .map(|v| {
+                    matches!(
+                        v.as_str(),
+                        "no_findings"
+                            | "findings_present"
+                            | "review_unavailable"
+                            | "review_timeout"
+                            | "review_cancelled"
+                            | "review_failed"
+                    )
+                })
                 .unwrap_or(false)
                 && mapping_string(mapping, "recommended_outcome")
                     .map(|v| matches!(v.as_str(), "pass" | "block" | "needs_followup"))

--- a/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/tests/structured_prompt.rs
@@ -139,6 +139,13 @@ fn structured_prompt_srp_completed_card_status_requires_final_review_truth() {
         "review_results:\n  findings_status: \"no_findings\"\n  recommended_outcome: \"pass\"\nnotes: \"test note\"",
     );
     validate_srp_text(&final_srp).expect("completed SRP with final review truth should pass");
+
+    let terminal_failure_srp = srp.replace(
+        "notes: \"test note\"",
+        "review_results:\n  findings_status: \"review_unavailable\"\n  recommended_outcome: \"block\"\nnotes: \"test note\"",
+    );
+    validate_srp_text(&terminal_failure_srp)
+        .expect("completed SRP with terminal review failure truth should pass");
 }
 
 #[test]

--- a/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+++ b/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
@@ -347,6 +347,42 @@ release_tail:
 }
 
 #[test]
+fn srp_sor_update_records_terminal_review_timeout_truth() {
+    let repo = TempRepo::new("srp-sor-update-review-timeout");
+    let facts = repo.write_rel(
+        "facts.yaml",
+        r#"review:
+  findings_status: timed_out
+  recommended_outcome: block
+validation:
+  status: PASS
+  commands:
+    - command: "cargo test --manifest-path adl/Cargo.toml terminal_review_timeout"
+      purpose: "terminal review timeout proof"
+      result: PASS
+"#,
+    );
+    let srp = repo.write_rel("srp.md", &valid_srp_text(4999));
+    let sor = repo.write_rel("sor.md", &valid_sor_text());
+
+    real_srp_sor_update(&[
+        "--facts".into(),
+        facts.display().to_string(),
+        "--srp".into(),
+        srp.display().to_string(),
+        "--sor".into(),
+        sor.display().to_string(),
+    ])
+    .expect("update SRP/SOR with terminal review timeout truth");
+
+    let srp_text = fs::read_to_string(&srp).expect("read srp");
+    assert!(srp_text.contains("findings_status: review_timeout"));
+    assert!(srp_text.contains("recommended_outcome: block"));
+    assert!(!srp_text.contains("review_results_exception"));
+    validate_srp_text(&srp_text).expect("terminal review timeout SRP validates");
+}
+
+#[test]
 fn srp_sor_update_projects_goal_metrics_summary_into_sor() {
     let repo = TempRepo::new("srp-sor-update-goal-summary");
     let summary = repo.write_rel(

--- a/adl/src/csdlc_prompt_editor.rs
+++ b/adl/src/csdlc_prompt_editor.rs
@@ -2762,7 +2762,15 @@ fn form_fields(kind: PromptCardKind) -> Vec<PromptField> {
                 "Findings Status",
                 true,
                 "Machine-readable final review findings status.",
-                &["not_run", "findings_present", "no_findings"],
+                &[
+                    "not_run",
+                    "findings_present",
+                    "no_findings",
+                    "review_unavailable",
+                    "review_timeout",
+                    "review_cancelled",
+                    "review_failed",
+                ],
             ));
             fields.push(select(
                 "recommended_outcome",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -980,6 +980,14 @@ manager_profile_is_release_gate_pr_fast_escalation() {
   [ "$validation_profile_escalation_lanes" = "release_gate_review,rust_pr_fast" ]
 }
 
+manager_profile_is_csdlc_owner_pr_fast_escalation() {
+  [ "$validation_profile_status" = "escalation_required" ] || return 1
+  [ "$validation_profile_escalation_required" = true ] || return 1
+  [ "$validation_profile_escalation_lanes" = "rust_pr_fast" ] || return 1
+  validation_profile_includes_lane "csdlc_owner_lane" || return 1
+  return 0
+}
+
 validation_profile_includes_lane() {
   local lane="$1"
   case ",$validation_profile_run_lanes," in
@@ -1217,6 +1225,11 @@ apply_validation_manager_routing() {
     if manager_profile_is_release_gate_pr_fast_escalation; then
       mark_pr_fast_rust_validation
       reason="validation_manager_release_gate_pr_fast_escalation_runs_focused_validation"
+      return 0
+    fi
+    if manager_profile_is_csdlc_owner_pr_fast_escalation; then
+      mark_pr_fast_rust_validation
+      reason="validation_manager_csdlc_owner_pr_fast_escalation_runs_focused_validation"
       return 0
     fi
     fail_closed=true

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -1229,6 +1229,7 @@ apply_validation_manager_routing() {
     fi
     if manager_profile_is_csdlc_owner_pr_fast_escalation; then
       mark_pr_fast_rust_validation
+      demo_smoke_required=false
       reason="validation_manager_csdlc_owner_pr_fast_escalation_runs_focused_validation"
       return 0
     fi

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -657,6 +657,56 @@ EOF
   assert_has "$finish_control_plane_plus_runtime_output" "validation_profile_escalation_required=true"
   assert_has "$finish_control_plane_plus_runtime_output" "validation_profile_escalation_lanes=rust_pr_fast"
 
+  git checkout -q -b csdlc-owner-pr-fast-escalation "$base_sha"
+  mkdir -p adl/src/cli/pr_cmd/doctor \
+    adl/src/cli/pr_cmd/lifecycle \
+    adl/src/cli/tests/pr_cmd_inline/finish \
+    adl/src/cli/tooling_cmd/tests \
+    docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition \
+    docs/templates/prompts/1.0.3
+  printf 'pub fn lifecycle_srp_status() -> bool { true }\n' > adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+  printf 'use super::*;\n#[test]\nfn srp_status_accepts_terminal_review_failure() {}\n' > adl/src/cli/pr_cmd/doctor/tests.rs
+  printf 'pub fn srp_review_results_text() -> bool { true }\n' > adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+  printf 'use super::*;\n#[test]\nfn reconciliation_accepts_terminal_review_failure() {}\n' > adl/src/cli/pr_cmd/lifecycle/tests.rs
+  printf 'use super::*;\n#[test]\nfn finish_path_records_terminal_review_failure() {}\n' > adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+  printf 'pub fn srp_sor_update() -> bool { true }\n' > adl/src/cli/tooling_cmd/srp_sor_update.rs
+  printf 'pub fn structured_prompt() -> bool { true }\n' > adl/src/cli/tooling_cmd/structured_prompt.rs
+  printf 'use super::*;\n#[test]\nfn structured_prompt_accepts_terminal_review_failure() {}\n' > adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+  printf 'use super::*;\n#[test]\nfn tooling_dispatch_accepts_terminal_review_failure() {}\n' > adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+  printf 'pub fn prompt_editor() -> bool { true }\n' > adl/src/csdlc_prompt_editor.rs
+  printf 'status: reviewed\n' > docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4999_TERMINAL_REVIEW_STATUS_BROAD_OWNER_LANE_DISPOSITION.yaml
+  printf '# SRP\n\nreview_results: review_failed\n' > docs/templates/prompts/1.0.3/srp.md
+  git add adl/src/cli/pr_cmd/doctor/card_lifecycle.rs \
+    adl/src/cli/pr_cmd/doctor/tests.rs \
+    adl/src/cli/pr_cmd/lifecycle/reconciliation.rs \
+    adl/src/cli/pr_cmd/lifecycle/tests.rs \
+    adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs \
+    adl/src/cli/tooling_cmd/srp_sor_update.rs \
+    adl/src/cli/tooling_cmd/structured_prompt.rs \
+    adl/src/cli/tooling_cmd/tests/structured_prompt.rs \
+    adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs \
+    adl/src/csdlc_prompt_editor.rs \
+    docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4999_TERMINAL_REVIEW_STATUS_BROAD_OWNER_LANE_DISPOSITION.yaml \
+    docs/templates/prompts/1.0.3/srp.md
+  git commit -q -m csdlc-owner-pr-fast-escalation
+  csdlc_owner_pr_fast_head="$(git rev-parse HEAD)"
+
+  csdlc_owner_pr_fast_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$csdlc_owner_pr_fast_head" --ref "refs/pull/1/merge")"
+  assert_has "$csdlc_owner_pr_fast_output" "rust_required=true"
+  assert_has "$csdlc_owner_pr_fast_output" "coverage_required=false"
+  assert_has "$csdlc_owner_pr_fast_output" "full_coverage_required=false"
+  assert_has "$csdlc_owner_pr_fast_output" "demo_smoke_required=true"
+  assert_has "$csdlc_owner_pr_fast_output" "ci_contracts_required=true"
+  assert_has "$csdlc_owner_pr_fast_output" "validation_profile_contract_lanes_selected=true"
+  assert_has "$csdlc_owner_pr_fast_output" "fail_closed=false"
+  assert_has "$csdlc_owner_pr_fast_output" "coverage_lane=deferred_pr_fast"
+  assert_has "$csdlc_owner_pr_fast_output" "coverage_authority=focused_nextest_pr_fast"
+  assert_has "$csdlc_owner_pr_fast_output" "reason=validation_manager_csdlc_owner_pr_fast_escalation_runs_focused_validation"
+  assert_has "$csdlc_owner_pr_fast_output" "validation_profile_status=escalation_required"
+  assert_has "$csdlc_owner_pr_fast_output" "validation_profile_escalation_required=true"
+  assert_has "$csdlc_owner_pr_fast_output" "validation_profile_run_lanes=csdlc_owner_lane,docs_diff_check,prompt_template_contracts"
+  assert_has "$csdlc_owner_pr_fast_output" "validation_profile_escalation_lanes=rust_pr_fast"
+
   git checkout -q -b policy-surface-change "$base_sha"
   mkdir -p adl/tools
   printf '#!/usr/bin/env bash\nprintf policy\n' > adl/tools/enforce_coverage_gates.sh

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -695,7 +695,7 @@ EOF
   assert_has "$csdlc_owner_pr_fast_output" "rust_required=true"
   assert_has "$csdlc_owner_pr_fast_output" "coverage_required=false"
   assert_has "$csdlc_owner_pr_fast_output" "full_coverage_required=false"
-  assert_has "$csdlc_owner_pr_fast_output" "demo_smoke_required=true"
+  assert_has "$csdlc_owner_pr_fast_output" "demo_smoke_required=false"
   assert_has "$csdlc_owner_pr_fast_output" "ci_contracts_required=true"
   assert_has "$csdlc_owner_pr_fast_output" "validation_profile_contract_lanes_selected=true"
   assert_has "$csdlc_owner_pr_fast_output" "fail_closed=false"

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4999_TERMINAL_REVIEW_STATUS_BROAD_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4999_TERMINAL_REVIEW_STATUS_BROAD_OWNER_LANE_DISPOSITION.yaml
@@ -1,0 +1,21 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 4999
+disposition: approved_with_runtime_owner_lane_proof
+changed_release_gate_surfaces:
+  - adl/src/cli/pr_cmd/doctor/card_lifecycle.rs
+  - adl/src/cli/pr_cmd/doctor/tests.rs
+  - adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+  - adl/src/cli/pr_cmd/lifecycle/tests.rs
+  - adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+  - adl/src/cli/tooling_cmd/srp_sor_update.rs
+  - adl/src/cli/tooling_cmd/structured_prompt.rs
+  - adl/src/cli/tooling_cmd/tests/structured_prompt.rs
+  - adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+  - adl/src/csdlc_prompt_editor.rs
+reviewer_or_review_mode: bounded runtime owner-lane review
+focused_validation_run: bash adl/tools/run_owner_validation_lane.sh runtime --build
+residual_ci_proof_required_before_merge: required
+notes:
+  - "Validation manager escalated #4999 because the Rust/tooling surface required broad owner-lane proof before PR publication."
+  - "Local proof passed: bash adl/tools/run_owner_validation_lane.sh runtime --build."
+  - "Pre-PR independent review remains recorded as review_unavailable/block in the issue SRP because subagent spawning is gated to explicit user delegation."

--- a/docs/templates/prompts/1.0.3/srp.md
+++ b/docs/templates/prompts/1.0.3/srp.md
@@ -117,7 +117,7 @@ When finalizing review, record the machine-readable review result in frontmatter
 
 ```yaml
 review_results:
-  findings_status: "no_findings | findings_present"
+  findings_status: "no_findings | findings_present | review_unavailable | review_timeout | review_cancelled | review_failed"
   recommended_outcome: "pass | block | needs_followup"
 ```
 


### PR DESCRIPTION
Closes #4999

## Summary
Implemented terminal pre-PR review-status handling so stalled, unavailable, cancelled, timeout, and failed review paths can be recorded as final SRP/SOR truth without claiming a completed review. Focused Rust regressions and whitespace validation passed. PR publication remains blocked until an explicit review route is available.

## Artifacts
- Updated Rust tooling sources and focused regression tests for terminal review-status truth.
- Updated active SRP template guidance for terminal review failure statuses.
- Issue-local fact packet at `.adl/v0.91.7/tasks/issue-4999__v0-91-7-tooling-subagents-review-agent-can-hang-without-terminal-status-during-adl-pre-pr-review/review-terminal-status-facts.yaml`.
- Updated SRP/SOR/VPP issue records for actual proof and review availability truth.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml review_timeout -- --nocapture` - Proves terminal review timeout truth is accepted by doctor readiness, SRP/SOR update, and finish/SOR fact emission paths.
  - `cargo test --manifest-path adl/Cargo.toml srp_final_review_results_accept_terminal_review_failure_statuses -- --nocapture` - Proves closeout reconciliation accepts terminal review_failed SRP truth as final recordable review status.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_srp_completed_card_status_requires_final_review_truth -- --nocapture` - Proves structured prompt validation accepts terminal review failure truth on completed SRP cards.
  - `git diff --check` - Checks changed files for whitespace errors before publication.
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build` - Satisfies validation-manager broad owner-lane proof after finish escalated #4999 with too_many_focused_filters_require_full_nextest.
- Results:
  - `cargo test --manifest-path adl/Cargo.toml review_timeout -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml srp_final_review_results_accept_terminal_review_failure_statuses -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_srp_completed_card_status_requires_final_review_truth -- --nocapture`: PASS
  - `git diff --check`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4999__v0-91-7-tooling-subagents-review-agent-can-hang-without-terminal-status-during-adl-pre-pr-review/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4999__v0-91-7-tooling-subagents-review-agent-can-hang-without-terminal-status-during-adl-pre-pr-review/sor.md
- Idempotency-Key: v0-91-7-tools-subagents-record-terminal-review-status-adl-v0-91-7-tasks-issue-4999-v0-91-7-tooling-subagents-review-agent-can-hang-without-terminal-status-during-adl-pre-pr-review-sip-md-adl-v0-91-7-tasks-issue-4999-v0-91-7-tooling-subagents-review-agent-can-hang-without-terminal-status-during-adl-pre-pr-review-sor-md