### PR TITLE
[v0.91.7][tools][cli] Expose canonical csdlc control-plane binary

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -19,6 +19,10 @@ name = "adl-csdlc"
 path = "src/bin/adl_csdlc.rs"
 
 [[bin]]
+name = "csdlc"
+path = "src/bin/csdlc.rs"
+
+[[bin]]
 name = "adl-runtime"
 path = "src/bin/adl_runtime.rs"
 

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -325,8 +325,8 @@
       "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
       "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
     },
-    {
-      "id": "csdlc_owner_lane",
+        {
+            "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",
       "owner": "csdlc",
@@ -347,12 +347,15 @@
         "adl/tools/install_owner_binaries.sh",
         "adl/tools/build_v0917_execution_outlier_analysis.py",
         "adl/tools/build_v0916_workflow_metric_backfill_inventory.py",
+        "adl/tools/validation_inventory.py",
+        "adl/tools/validation_inventory.sh",
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
         "adl/tools/test_owner_binary_install.sh",
         "adl/tools/test_owner_validation_lane.sh",
         "adl/tools/test_readiness_prep_metrics_non_terminal.sh",
+        "adl/tools/test_validation_inventory.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "path_hints": [
@@ -368,12 +371,15 @@
         "adl/tools/install_owner_binaries.sh",
         "adl/tools/build_v0917_execution_outlier_analysis.py",
         "adl/tools/build_v0916_workflow_metric_backfill_inventory.py",
+        "adl/tools/validation_inventory.py",
+        "adl/tools/validation_inventory.sh",
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/test_control_plane_observability.sh",
         "adl/tools/test_five_command_regression_suite.sh",
         "adl/tools/test_owner_binary_install.sh",
         "adl/tools/test_owner_validation_lane.sh",
         "adl/tools/test_readiness_prep_metrics_non_terminal.sh",
+        "adl/tools/test_validation_inventory.sh",
         "adl/tools/test_pr_*.sh"
       ],
       "command": "bash adl/tools/run_owner_validation_lane.sh csdlc --print-plan",

--- a/adl/src/bin/adl_csdlc.rs
+++ b/adl/src/bin/adl_csdlc.rs
@@ -6,12 +6,12 @@ mod cli;
 
 #[cfg(not(test))]
 fn main() {
-    cli::run_csdlc_main();
+    cli::run_csdlc_main_named("adl-csdlc");
 }
 
 #[cfg(test)]
 fn binary_help_probe() -> String {
-    cli::csdlc_usage().to_string()
+    cli::csdlc_usage_for("adl-csdlc").to_string()
 }
 
 #[cfg(test)]

--- a/adl/src/bin/csdlc.rs
+++ b/adl/src/bin/csdlc.rs
@@ -1,0 +1,28 @@
+extern crate adl;
+
+#[allow(dead_code)]
+#[path = "../cli/mod.rs"]
+mod cli;
+
+#[cfg(not(test))]
+fn main() {
+    cli::run_csdlc_main_named("csdlc");
+}
+
+#[cfg(test)]
+fn binary_help_probe() -> String {
+    cli::csdlc_usage_for("csdlc")
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn csdlc_cli_binary_links_to_canonical_csdlc_dispatch_surface() {
+        let output = super::binary_help_probe();
+
+        assert!(output.contains("csdlc - ADL C-SDLC workflow control-plane binary"));
+        assert!(output.contains("csdlc issue run <issue>"));
+        assert!(output.contains("adl-csdlc remains a compatibility alias"));
+        assert!(output.contains("adl/tools/pr.sh remains the canonical"));
+    }
+}

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -104,7 +104,13 @@ pub fn run_review_main() {
 #[allow(dead_code)]
 #[cfg(not(test))]
 pub fn run_csdlc_main() {
-    if let Err(err) = real_csdlc_main() {
+    run_csdlc_main_named("adl-csdlc");
+}
+
+#[allow(dead_code)]
+#[cfg(not(test))]
+pub fn run_csdlc_main_named(binary_name: &'static str) {
+    if let Err(err) = real_csdlc_main(binary_name) {
         print_error_chain(&err);
         std::process::exit(1);
     }
@@ -135,9 +141,9 @@ fn real_review_main() -> Result<()> {
 
 #[allow(dead_code)]
 #[cfg(not(test))]
-fn real_csdlc_main() -> Result<()> {
+fn real_csdlc_main(binary_name: &'static str) -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    dispatch_csdlc_args(&args)
+    dispatch_csdlc_args_for(binary_name, &args)
 }
 
 fn dispatch_args(args: &[String]) -> Result<()> {
@@ -401,28 +407,46 @@ fn looks_like_issue_ref(value: &str) -> bool {
 }
 
 #[allow(dead_code)]
-pub(crate) fn csdlc_usage() -> &'static str {
-    "adl-csdlc - ADL C-SDLC compatibility binary\n\n\
+pub(crate) fn csdlc_usage_for(binary_name: &str) -> String {
+    let title = if binary_name == "csdlc" {
+        "csdlc - ADL C-SDLC workflow control-plane binary"
+    } else {
+        "adl-csdlc - ADL C-SDLC compatibility binary"
+    };
+    format!(
+        "{title}\n\n\
 Usage:\n\
-  adl-csdlc pr <create|init|start|doctor|ready|preflight|finish|closeout> ...\n\
-  adl-csdlc issue <create|init|run|doctor|finish|closeout> ...\n\
-  adl-csdlc issue run <issue> [--slug <slug>] [--version <v>]\n\
-  adl-csdlc tooling <card-prompt|csdlc-prompt-editor|generate-wp-issue-wave|lint-prompt-spec|prompt-template|srp-sor-update|validate-structured-prompt|...> ...\n\
-  adl-csdlc --help\n\
-  adl-csdlc --version\n\n\
+  {binary_name} pr <create|init|start|doctor|ready|preflight|finish|closeout> ...\n\
+  {binary_name} issue <create|init|run|doctor|finish|closeout> ...\n\
+  {binary_name} issue run <issue> [--slug <slug>] [--version <v>]\n\
+  {binary_name} tooling <card-prompt|csdlc-prompt-editor|generate-wp-issue-wave|lint-prompt-spec|prompt-template|srp-sor-update|validate-structured-prompt|...> ...\n\
+  {binary_name} --help\n\
+  {binary_name} --version\n\n\
 Notes:\n\
   adl/tools/pr.sh remains the canonical agent-facing issue wrapper during migration.\n\
+  csdlc is the canonical C-SDLC binary; adl-csdlc remains a compatibility alias.\n\
   GitHub issue/PR metadata interpretation is owned by the shared pr control-plane client layer.\n\
-  adl-csdlc issue run expects a numeric issue id. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
+  {binary_name} issue run expects a numeric issue id. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
+    )
+}
+
+#[allow(dead_code)]
+pub(crate) fn csdlc_usage() -> String {
+    csdlc_usage_for("adl-csdlc")
 }
 
 #[allow(dead_code)]
 fn dispatch_csdlc_args(args: &[String]) -> Result<()> {
+    dispatch_csdlc_args_for("adl-csdlc", args)
+}
+
+#[allow(dead_code)]
+fn dispatch_csdlc_args_for(binary_name: &'static str, args: &[String]) -> Result<()> {
     if matches!(
         args.first().map(|s| s.as_str()),
         Some("--help" | "-h" | "help")
     ) {
-        println!("{}", csdlc_usage());
+        println!("{}", csdlc_usage_for(binary_name));
         return Ok(());
     }
 
@@ -432,7 +456,7 @@ fn dispatch_csdlc_args(args: &[String]) -> Result<()> {
     }
 
     observability::emit_event(
-        "adl-csdlc",
+        binary_name,
         "dispatch",
         "started",
         &[("subcommand", args.first().map(String::as_str).unwrap_or(""))],
@@ -440,46 +464,51 @@ fn dispatch_csdlc_args(args: &[String]) -> Result<()> {
 
     match args.first().map(|s| s.as_str()) {
         Some("pr") => {
-            reject_csdlc_runtime_run("adl-csdlc pr", &args[1..])?;
+            reject_csdlc_runtime_run(&format!("{binary_name} pr"), &args[1..])?;
             real_pr(&args[1..])
         }
-        Some("issue") => real_csdlc_issue(&args[1..]),
+        Some("issue") => real_csdlc_issue(binary_name, &args[1..]),
         Some("tooling") => real_tooling(&args[1..]),
         Some("run") => Err(anyhow::anyhow!(
-            "adl-csdlc does not run ADL workflow YAML. Use adl-runtime run <adl.yaml> for runtime workflows or adl-csdlc issue run <issue> for C-SDLC issue execution."
+            "{binary_name} does not run ADL workflow YAML. Use adl-runtime run <adl.yaml> for runtime workflows or {binary_name} issue run <issue> for C-SDLC issue execution."
         )),
         Some(other) => Err(anyhow::anyhow!(
-            "unknown adl-csdlc command '{other}'. Expected pr, issue, tooling, help, or --version."
+            "unknown {binary_name} command '{other}'. Expected pr, issue, tooling, help, or --version."
         )),
         None => Err(anyhow::anyhow!(
-            "adl-csdlc requires a command. Run `adl-csdlc --help` for usage."
+            "{binary_name} requires a command. Run `{binary_name} --help` for usage."
         )),
     }
 }
 
 #[allow(dead_code)]
-fn real_csdlc_issue(args: &[String]) -> Result<()> {
-    let pr_args = csdlc_issue_to_pr_args(args)?;
+fn real_csdlc_issue(binary_name: &'static str, args: &[String]) -> Result<()> {
+    let pr_args = csdlc_issue_to_pr_args_for(binary_name, args)?;
     real_pr(&pr_args)
 }
 
 #[allow(dead_code)]
 fn csdlc_issue_to_pr_args(args: &[String]) -> Result<Vec<String>> {
-    reject_csdlc_runtime_run("adl-csdlc issue", args)?;
+    csdlc_issue_to_pr_args_for("adl-csdlc", args)
+}
+
+#[allow(dead_code)]
+fn csdlc_issue_to_pr_args_for(binary_name: &'static str, args: &[String]) -> Result<Vec<String>> {
+    reject_csdlc_runtime_run(&format!("{binary_name} issue"), args)?;
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         return Err(anyhow::anyhow!(
-            "adl-csdlc issue requires a pr-compatible subcommand such as run, doctor, finish, or closeout."
+            "{binary_name} issue requires a pr-compatible subcommand such as run, doctor, finish, or closeout."
         ));
     };
     if subcommand == "run" {
         let Some(issue) = args.get(1) else {
             return Err(anyhow::anyhow!(
-                "adl-csdlc issue run requires a numeric issue id."
+                "{binary_name} issue run requires a numeric issue id."
             ));
         };
         if !issue.chars().all(|ch| ch.is_ascii_digit()) {
             return Err(anyhow::anyhow!(
-                "adl-csdlc issue run expects a numeric issue id, got '{issue}'. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
+                "{binary_name} issue run expects a numeric issue id, got '{issue}'. Runtime workflow YAML belongs to adl-runtime run <adl.yaml>."
             ));
         }
         let mut mapped = Vec::with_capacity(args.len());

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -20,10 +20,11 @@ use super::run_artifacts::{
     AEE_DECISION_VERSION, PAUSE_STATE_SCHEMA_VERSION,
 };
 use super::{
-    csdlc_issue_to_pr_args, csdlc_usage, dispatch_args, dispatch_csdlc_args, dispatch_review_args,
-    dispatch_runtime_args, looks_like_adl_workflow_path, looks_like_issue_ref, real_instrument,
-    real_keygen, real_learn, real_sign, real_verify, reject_csdlc_runtime_run,
-    review_to_tooling_args, review_usage, runtime_usage, usage, version_text,
+    csdlc_issue_to_pr_args, csdlc_usage, csdlc_usage_for, dispatch_args, dispatch_csdlc_args,
+    dispatch_csdlc_args_for, dispatch_review_args, dispatch_runtime_args,
+    looks_like_adl_workflow_path, looks_like_issue_ref, real_instrument, real_keygen, real_learn,
+    real_sign, real_verify, reject_csdlc_runtime_run, review_to_tooling_args, review_usage,
+    runtime_usage, usage, version_text,
 };
 use ::adl::godel::cross_workflow::{
     DownstreamWorkflowDecision, PersistedCrossWorkflowArtifact, CROSS_WORKFLOW_ARTIFACT_VERSION,
@@ -193,6 +194,26 @@ fn csdlc_dispatch_exposes_help_and_version_without_runtime_dispatch() {
     assert!(usage.contains("adl/tools/pr.sh remains the canonical agent-facing issue wrapper"));
     assert!(usage.contains("shared pr control-plane client layer"));
     assert!(usage.contains("adl-runtime run <adl.yaml>"));
+}
+
+#[test]
+fn canonical_csdlc_dispatch_uses_canonical_command_name_in_help_and_errors() {
+    dispatch_csdlc_args_for("csdlc", &["--help".to_string()])
+        .expect("canonical csdlc help should succeed");
+    dispatch_csdlc_args_for("csdlc", &["--version".to_string()])
+        .expect("canonical csdlc version should succeed");
+
+    let usage = csdlc_usage_for("csdlc");
+    assert!(usage.contains("csdlc - ADL C-SDLC workflow control-plane binary"));
+    assert!(usage.contains("csdlc issue run <issue>"));
+    assert!(usage.contains("adl-csdlc remains a compatibility alias"));
+
+    let err = dispatch_csdlc_args_for("csdlc", &["run".to_string()])
+        .expect_err("canonical csdlc run should reject runtime YAML execution");
+    assert!(err
+        .to_string()
+        .contains("csdlc does not run ADL workflow YAML"));
+    assert!(err.to_string().contains("csdlc issue run <issue>"));
 }
 
 #[test]

--- a/adl/tests/cli_smoke.rs
+++ b/adl/tests/cli_smoke.rs
@@ -38,6 +38,13 @@ fn run_adl_csdlc(args: &[&str]) -> std::process::Output {
         .expect("run adl-csdlc binary")
 }
 
+fn run_csdlc(args: &[&str]) -> std::process::Output {
+    Command::new(resolve_csdlc_exe())
+        .args(args)
+        .output()
+        .expect("run csdlc binary")
+}
+
 fn run_adl_runtime(args: &[&str]) -> std::process::Output {
     Command::new(resolve_adl_runtime_exe())
         .args(args)
@@ -108,6 +115,17 @@ fn resolve_adl_csdlc_exe() -> PathBuf {
     }
 }
 
+fn resolve_csdlc_exe() -> PathBuf {
+    let raw = std::env::var("CARGO_BIN_EXE_csdlc")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_csdlc").to_string());
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+    }
+}
+
 fn resolve_adl_runtime_exe() -> PathBuf {
     let raw = std::env::var("CARGO_BIN_EXE_adl-runtime")
         .unwrap_or_else(|_| env!("CARGO_BIN_EXE_adl-runtime").to_string());
@@ -166,6 +184,33 @@ fn adl_csdlc_cli_binary_help_and_version_smoke() {
     assert!(help_stdout.contains("adl-csdlc issue run <issue>"));
 
     let version = run_adl_csdlc(&["--version"]);
+    assert!(
+        version.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&version.stdout),
+        String::from_utf8_lossy(&version.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn csdlc_cli_binary_help_and_version_smoke() {
+    let help = run_csdlc(&["--help"]);
+    assert!(
+        help.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&help.stdout),
+        String::from_utf8_lossy(&help.stderr)
+    );
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(help_stdout.contains("csdlc - ADL C-SDLC workflow control-plane binary"));
+    assert!(help_stdout.contains("csdlc issue run <issue>"));
+    assert!(help_stdout.contains("adl-csdlc remains a compatibility alias"));
+
+    let version = run_csdlc(&["--version"]);
     assert!(
         version.status.success(),
         "stdout:\n{}\nstderr:\n{}",

--- a/adl/tools/install_owner_binaries.sh
+++ b/adl/tools/install_owner_binaries.sh
@@ -54,7 +54,7 @@ done
 
 if [[ "${#BINS[@]}" -eq 0 ]]; then
   BINS=(
-    adl adl-csdlc adl-runtime adl-review
+    adl csdlc adl-csdlc adl-runtime adl-review
     adl-pr-create adl-pr-init adl-pr-repair-issue-body
     adl-pr-run adl-pr-doctor adl-pr-ready adl-pr-preflight
     adl-pr-finish adl-pr-validation adl-pr-inventory

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -82,7 +82,7 @@ build_owner_bins() {
   [[ "$BUILD" == "1" ]] || return 0
   run_command "cargo build owner binaries" \
     cargo build --quiet --manifest-path "$MANIFEST" \
-      --bin adl --bin adl-csdlc --bin adl-runtime --bin adl-review \
+      --bin adl --bin csdlc --bin adl-csdlc --bin adl-runtime --bin adl-review \
       --bin adl-pr-create --bin adl-pr-init --bin adl-pr-repair-issue-body \
       --bin adl-pr-run --bin adl-pr-doctor --bin adl-pr-ready \
       --bin adl-pr-preflight --bin adl-pr-finish --bin adl-pr-validation \
@@ -97,7 +97,8 @@ build_owner_bins() {
   run_command "install stable owner binaries" \
     bash adl/tools/install_owner_binaries.sh --no-build
   export ADL_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/adl"
-  export ADL_CSDLC_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/adl-csdlc"
+  export ADL_CSDLC_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/csdlc"
+  export ADL_CSDLC_COMPAT_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/adl-csdlc"
   export ADL_RUNTIME_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/adl-runtime"
   export ADL_REVIEW_BIN="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}/adl-review"
   export ADL_PACKAGE_VERSION

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -261,7 +261,9 @@ filter_token_for_path() {
       return 0
       ;;
     adl/src/cli/mod.rs)
-      if [ "$saw_scheduler_related_surface" = true ]; then
+      if [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
+        printf 'csdlc_binary_dispatch'
+      elif [ "$saw_scheduler_related_surface" = true ]; then
         printf 'scheduler_cli'
       elif [ "$saw_tokio_bootstrap_related_surface" = true ]; then
         printf 'tokio_bootstrap'
@@ -273,7 +275,9 @@ filter_token_for_path() {
       return 0
       ;;
     adl/src/cli/tests.rs)
-      if [ "$saw_scheduler_related_surface" = true ]; then
+      if [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
+        printf 'csdlc_binary_dispatch'
+      elif [ "$saw_scheduler_related_surface" = true ]; then
         printf 'scheduler_cli'
       else
         printf 'cli_dispatch'
@@ -367,6 +371,10 @@ filter_token_for_path() {
     adl/src/cli/tests/pr_cmd_inline/*/*|adl/src/cli/tests/pr_cmd_inline/*)
       return 1
       ;;
+    adl/src/bin/csdlc.rs|adl/src/bin/adl_csdlc.rs)
+      printf 'csdlc_binary'
+      return 0
+      ;;
     adl/src/cli/pr_cmd_cards.rs|adl/src/cli/pr_cmd_cards/*.rs)
       printf 'pr_cmd'
       return 0
@@ -383,7 +391,14 @@ filter_token_for_path() {
       printf 'pr_cmd'
       return 0
       ;;
-    docs/default_workflow.md|docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
+    docs/default_workflow.md)
+      if [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
+        return 1
+      fi
+      printf 'pr_cmd'
+      return 0
+      ;;
+    docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
       printf 'pr_cmd'
       return 0
       ;;
@@ -392,6 +407,10 @@ filter_token_for_path() {
       return 0
       ;;
     adl/tests/cli_smoke.rs|adl/tests/cli_smoke/*.rs)
+      if [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
+        printf 'csdlc_binary_smoke'
+        return 0
+      fi
       printf 'process_status'
       return 0
       ;;
@@ -509,6 +528,9 @@ TOKEN_MAP = {
     "agent_cli_smoke": 'binary_id(adl::cli_smoke) and test(/^agent::/)',
     "agent_cmd": 'test(/^cli::agent_cmd::/)',
     "process_status": 'binary_id(adl::cli_smoke) and test(/^process_status::/)',
+    "csdlc_binary": 'binary_id(adl::bin/csdlc) and test(/^tests::/) or binary_id(adl::bin/adl-csdlc) and test(/^tests::/)',
+    "csdlc_binary_dispatch": 'test(/^cli::tests::csdlc_/)',
+    "csdlc_binary_smoke": 'binary_id(adl::cli_smoke) and test(/^(csdlc_cli_binary_help_and_version_smoke|adl_csdlc_cli_binary_help_and_version_smoke)$/)',
     "scheduler_cli": 'test(/^cli::scheduler_cmd::tests::/) or test(/^cli::tests::runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch$/) or test(/^cli::tests::open_usage::usage_mentions_v0_4_and_legacy_examples$/)',
     "scheduler_economics": 'test(/^scheduler::tests::/) or test(/^provider::tests::provider_mod_/) or binary_id(adl::provider_tests) and test(/^profiles::/)',
     "demo_adl_gws_context_mirror": 'binary_id(adl::bin/demo-adl-gws-context-mirror) and test(/^tests::/)',
@@ -573,6 +595,7 @@ saw_slow_proof_contract_surface=false
 saw_tokio_bootstrap_related_surface=false
 saw_process_status_related_surface=false
 saw_scheduler_related_surface=false
+saw_csdlc_binary_taxonomy_surface=false
 
 declare -a tokens=()
 declare -a family_tokens=()
@@ -604,6 +627,10 @@ while IFS= read -r path; do
     adl/src/bin/run_v0916_integrated_runtime_soak.rs)
       saw_scheduler_related_surface=true
       ;;
+    adl/src/bin/csdlc.rs|\
+    adl/src/bin/adl_csdlc.rs)
+      saw_csdlc_binary_taxonomy_surface=true
+      ;;
   esac
 done <<EOF
 $(changed_rows \
@@ -614,6 +641,9 @@ EOF
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   if ! is_relevant_fast_lane_surface "$path"; then
+    continue
+  fi
+  if [ "$path" = "docs/default_workflow.md" ] && [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
     continue
   fi
   if is_structural_companion_surface "$path"; then
@@ -633,7 +663,9 @@ while IFS= read -r path; do
     family_tokens=()
     break
   fi
-  if is_broad_rust_surface "$path"; then
+  if [ "$path" = "adl/src/cli/tests.rs" ] && [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
+    :
+  elif is_broad_rust_surface "$path"; then
     mode="full"
     reason="broad_rust_surface_requires_full_nextest"
     classification_locked=true

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -184,16 +184,17 @@ For new or fully re-rendered prompt cards, prefer the Rust-owned values
 renderer and structure-schema validator before editing Markdown directly:
 
 ```bash
-adl-csdlc tooling prompt-template validate-values --kind <kind> --values <kind>.values.yaml
-adl-csdlc tooling prompt-template render --kind <kind> --values <kind>.values.yaml --out <kind>.md
-adl-csdlc tooling prompt-template validate-structure --kind <kind> --input <kind>.md
-adl-csdlc tooling prompt-template validate-schemas
+csdlc tooling prompt-template validate-values --kind <kind> --values <kind>.values.yaml
+csdlc tooling prompt-template render --kind <kind> --values <kind>.values.yaml --out <kind>.md
+csdlc tooling prompt-template validate-structure --kind <kind> --input <kind>.md
+csdlc tooling prompt-template validate-schemas
 python3 adl/tools/test_prompt_template_structure_schemas.py
 ```
 
-If `adl-csdlc` is not already on `PATH`, run the same owner-binary commands
-through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`
-from a fresh checkout.
+If `csdlc` is not already on `PATH`, use the repo-owned binary at
+`adl/target/debug/csdlc` when present. Rebuild it only when working on the
+binary surface itself or when no trusted repo binary exists. `adl-csdlc`
+remains a compatibility alias, not the preferred new command spelling.
 
 For docs-only, milestone-truth, or workflow-doc issues, prefer the
 `docs-bounded` fast path described later in this guide instead of reflexively

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -17,6 +17,17 @@ assert_has() {
   fi
 }
 
+assert_not_has() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fqx "$needle" <<<"$haystack"; then
+    echo "expected runner output not to contain: $needle" >&2
+    echo "actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
 focused_runtime="$TMP/focused_runtime.txt"
 printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$focused_runtime"
 focused_runtime_output="$(bash "$SCRIPT" --changed-files "$focused_runtime" --print-plan)"
@@ -198,6 +209,23 @@ assert_has "$owner_binary_decomposition_output" "mode=family"
 assert_has "$owner_binary_decomposition_output" "reason=bounded_rust_surface_runs_family_nextest"
 assert_has "$owner_binary_decomposition_output" "filter_tokens=pr_control_plane,cli"
 assert_has "$owner_binary_decomposition_output" "filter_expression=test(/^cli::pr_cmd::/) or test(/^cli::/) or binary_id(adl::bin/adl-process) or binary_id(adl::bin/adl-session)"
+
+csdlc_binary_taxonomy="$TMP/csdlc_binary_taxonomy.txt"
+cat >"$csdlc_binary_taxonomy" <<'EOF'
+M	adl/Cargo.toml
+M	adl/src/bin/adl_csdlc.rs
+A	adl/src/bin/csdlc.rs
+M	adl/src/cli/mod.rs
+M	adl/src/cli/tests.rs
+M	adl/tests/cli_smoke.rs
+M	docs/default_workflow.md
+EOF
+csdlc_binary_taxonomy_output="$(bash "$SCRIPT" --changed-files "$csdlc_binary_taxonomy" --print-plan)"
+assert_has "$csdlc_binary_taxonomy_output" "mode=focused"
+assert_has "$csdlc_binary_taxonomy_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$csdlc_binary_taxonomy_output" "filter_tokens=manifest_support,csdlc_binary,csdlc_binary_dispatch,csdlc_binary_smoke"
+assert_has "$csdlc_binary_taxonomy_output" "filter_expression=test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/) or binary_id(adl::bin/csdlc) and test(/^tests::/) or binary_id(adl::bin/adl-csdlc) and test(/^tests::/) or test(/^cli::tests::csdlc_/) or binary_id(adl::cli_smoke) and test(/^(csdlc_cli_binary_help_and_version_smoke|adl_csdlc_cli_binary_help_and_version_smoke)$/)"
+assert_not_has "$csdlc_binary_taxonomy_output" "pr_cmd"
 
 scheduler_cli_wave="$TMP/scheduler_cli_wave.txt"
 cat >"$scheduler_cli_wave" <<'EOF'

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -83,6 +83,16 @@ assert_has "$TMP/metric-backfill-tool.out" "aggregate_status=selected"
 assert_has "$TMP/metric-backfill-tool.out" "csdlc_owner_lane status=selected"
 assert_not_has "$TMP/metric-backfill-tool.out" "unmapped_change_surface"
 
+validation_inventory_tool="$TMP/validation-inventory-tool.txt"
+cat >"$validation_inventory_tool" <<'EOF'
+M	adl/tools/validation_inventory.py
+M	adl/tools/test_validation_inventory.sh
+EOF
+bash "$SCRIPT" --changed-files "$validation_inventory_tool" >"$TMP/validation-inventory-tool.out"
+assert_has "$TMP/validation-inventory-tool.out" "aggregate_status=selected"
+assert_has "$TMP/validation-inventory-tool.out" "csdlc_owner_lane status=selected"
+assert_not_has "$TMP/validation-inventory-tool.out" "unmapped_change_surface"
+
 remote_validation_tool="$TMP/remote-validation-tool.txt"
 printf 'M\tadl/tools/run_nessus_remote_validation.sh\n' >"$remote_validation_tool"
 bash "$SCRIPT" --changed-files "$remote_validation_tool" >"$TMP/remote-validation-tool.out"

--- a/adl/tools/test_validation_inventory.sh
+++ b/adl/tools/test_validation_inventory.sh
@@ -67,6 +67,11 @@ csdlc_records = [
     if record["path"] == "adl/src/bin/adl_csdlc.rs"
 ]
 assert any(record["owner"] == "csdlc" for record in csdlc_records)
+canonical_csdlc_records = [
+    record for record in inventory["all_surface_records"]
+    if record["path"] == "adl/src/bin/csdlc.rs"
+]
+assert any(record["owner"] == "csdlc" for record in canonical_csdlc_records)
 
 demo_paths = {record["path"] for record in inventory["demo_proof_surfaces"]}
 assert "adl/tools/demo_smoke_v07_story.sh" in demo_paths

--- a/adl/tools/validation_inventory.py
+++ b/adl/tools/validation_inventory.py
@@ -112,6 +112,7 @@ def classify_owner(path: str) -> str | None:
     if path.startswith("adl/src/bin/adl_pr_"):
         return "csdlc"
     if path in {
+        "adl/src/bin/csdlc.rs",
         "adl/src/bin/adl_csdlc.rs",
         "adl/src/bin/adl_prompt_template.rs",
         "adl/src/bin/adl_validate_structured_prompt.rs",

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -26,12 +26,20 @@ stubs early, but new issue work should follow this semantic order only.
 
 The active control-plane surface is:
 
+- `csdlc issue`
+- `csdlc tooling`
 - `pr issue`
 - `pr init`
 - `pr doctor`
 - `pr run`
 - `pr finish`
 - `adl-pr-shepherd`
+
+`csdlc` is the canonical C-SDLC owner binary for direct command use. The
+`adl-csdlc` binary remains a compatibility alias during migration. Agent issue
+work should still use `bash adl/tools/pr.sh ...` when lifecycle policy,
+session-ledger ownership, queue checks, worktree binding, and finish/closeout
+rules matter.
 
 Lifecycle synthesis and PR-tail waiting-state classification now have a
 dedicated owner binary:
@@ -373,7 +381,7 @@ the code side is already covered by an explicit focused lane.
 Not every focused C-SDLC path uses the same Rust selector. Finish-validation
 planner changes such as `adl/src/cli/pr_cmd/finish_support.rs` and
 `adl/src/cli/tests/pr_cmd_inline/finish/*` are proved by formatter checks plus
-narrow `adl-csdlc` filtered tests for finish validation planning and focused
+narrow `csdlc` filtered tests for finish validation planning and focused
 runner dispatch. Broader lifecycle surfaces such as `doctor`, `git_support`,
 `github`, and `lifecycle` still use the broader `cli::pr_cmd` filtered test
 until they have their own narrower proof lane.
@@ -381,9 +389,10 @@ until they have their own narrower proof lane.
 Public prompt packet tooling is also a focused lane: changes to
 `adl/src/cli/tooling_cmd/public_prompt_packet.rs` or its paired
 `public_prompt_packet` tests are proved by formatter checks and the
-`adl-csdlc public_prompt_packet` filtered test, while merge-context CI remains
-required before merge. Other actual changed paths still escalate to full local
-validation until more focused lanes are explicitly implemented and tested.
+`csdlc tooling public-prompt-packet` filtered test, while merge-context CI
+remains required before merge. Other actual changed paths still escalate to
+full local validation until more focused lanes are explicitly implemented and
+tested.
 
 Use full local validation for runtime, schema, security, release, broad tooling,
 or ambiguous changes.

--- a/docs/templates/prompts/README.md
+++ b/docs/templates/prompts/README.md
@@ -81,7 +81,7 @@ Use the Rust tool to regenerate schemas only when template structure changes
 intentionally:
 
 ```sh
-adl-csdlc tooling prompt-template \
+csdlc tooling prompt-template \
   write-structure-schemas \
   --template-set 1.0.3 \
   --out-dir docs/templates/prompts/1.0.3/schemas
@@ -90,13 +90,13 @@ adl-csdlc tooling prompt-template \
 Then run both Rust and Python-readable schema checks:
 
 ```sh
-adl-csdlc tooling prompt-template validate-schemas --template-set 1.0.3
+csdlc tooling prompt-template validate-schemas --template-set 1.0.3
 python3 adl/tools/test_prompt_template_structure_schemas.py --template-set 1.0.3
 ```
 
-If `adl-csdlc` is not already on `PATH`, run the same owner-binary commands
-through `cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- ...`
-from a fresh checkout.
+If `csdlc` is not already on `PATH`, use the repo-owned binary at
+`adl/target/debug/csdlc` when present. Rebuild it only when working on the
+binary surface itself or when no trusted repo binary exists.
 
 `current.json` should not move to a new active template set until every card
 kind in that set has renderer fixtures, values validation, and compatibility
@@ -110,7 +110,7 @@ The local human editor for this template set lives at
 generated from Rust with:
 
 ```sh
-cargo run --manifest-path adl/Cargo.toml --bin adl-csdlc -- tooling csdlc-prompt-editor \
+cargo run --manifest-path adl/Cargo.toml --bin csdlc -- tooling csdlc-prompt-editor \
   --emit-model-js docs/tooling/csdlc-prompt-editor/editor_model.js
 ```
 

--- a/docs/tooling/ADL_PLATFORM_CLI_BINARY_TAXONOMY.md
+++ b/docs/tooling/ADL_PLATFORM_CLI_BINARY_TAXONOMY.md
@@ -1,0 +1,63 @@
+# ADL Platform CLI Binary Taxonomy
+
+ADL uses owned command binaries so command families do not all share one
+validation and operational blast radius.
+
+## Canonical Binaries
+
+| Binary | Owner surface | Current status |
+|---|---|---|
+| `adl` | ADL language/compiler/manager entrypoint | canonical |
+| `csdlc` | C-SDLC workflow control plane: issue lifecycle, cards, PR lifecycle, validation planning, review, and closeout | canonical as of v0.91.7 |
+| `csm` | Cognitive Spacetime runtime execution surface | canonical |
+| `csmctl` | CSM runtime administration and operator control | planned; do not place C-SDLC commands here |
+| `adl-csdlc` | Compatibility alias for C-SDLC commands | retained during migration |
+| `adl-runtime` | Runtime compatibility alias | retained during migration |
+| `adl-review` | Review tooling compatibility surface | retained during migration |
+
+## C-SDLC Usage
+
+Use `csdlc` for direct C-SDLC control-plane commands:
+
+```bash
+csdlc --help
+csdlc issue run <issue>
+csdlc tooling prompt-template validate-structure --kind sor --input <path>
+```
+
+Agent issue execution should still prefer the repo wrapper while it owns
+session-ledger, worktree, queue, and finish policy:
+
+```bash
+bash adl/tools/pr.sh run <issue>
+bash adl/tools/pr.sh finish <issue> --title "<title>" --paths "<paths>"
+```
+
+`adl-csdlc` remains available for compatibility and should produce the same
+C-SDLC dispatch behavior, but new docs and scripts should prefer `csdlc` when
+they need the owner binary directly.
+
+## Validation Boundary
+
+Changes to one binary family should not automatically require broad validation
+for all binaries. For C-SDLC binary-surface changes, prefer:
+
+```bash
+cargo fmt --manifest-path adl/Cargo.toml --all -- --check
+cargo check --manifest-path adl/Cargo.toml --bin csdlc --bin adl-csdlc
+cargo test --manifest-path adl/Cargo.toml --test cli_smoke csdlc_cli_binary_help_and_version_smoke -- --exact
+git diff --check
+```
+
+Broader owner-lane validation is still available when the touched surface
+changes delegation policy:
+
+```bash
+bash adl/tools/run_owner_validation_lane.sh csdlc --build
+```
+
+## Non-Claims
+
+- This document does not remove compatibility binaries.
+- This document does not make `csmctl` ready; it reserves the boundary.
+- This document does not move every C-SDLC helper out of `adl` in one step.


### PR DESCRIPTION
Closes #4995

## Summary
Implemented the first ADL Platform CLI binary taxonomy slice for C-SDLC. The issue worktree now exposes `csdlc` as the canonical C-SDLC workflow control-plane binary, keeps `adl-csdlc` as a compatibility alias, updates direct-command docs and operational skill guidance to prefer `csdlc`, and teaches focused validation inventory/fast-lane tooling about the bounded `csdlc` binary surface.

## Artifacts
- `adl/src/bin/csdlc.rs`: new canonical C-SDLC binary entrypoint.
- `adl/src/bin/adl_csdlc.rs`: compatibility alias entrypoint now dispatches through the named C-SDLC surface.
- `adl/src/cli/mod.rs`: C-SDLC usage, dispatch, observability command name, and error text now support canonical `csdlc` and compatibility `adl-csdlc`.
- `adl/src/cli/tests.rs` and `adl/tests/cli_smoke.rs`: focused tests for canonical and compatibility binary behavior.
- `adl/tools/run_owner_validation_lane.sh`: owner binary build exports canonical `csdlc` and retains compatibility alias.
- `adl/tools/run_pr_fast_test_lane.sh`, `adl/tools/test_run_pr_fast_test_lane.sh`, `adl/tools/validation_inventory.py`, and `adl/tools/test_validation_inventory.sh`: focused validation classification for the C-SDLC binary taxonomy surface.
- `adl/config/validation_lane_selector.v0.91.6.json` and `adl/tools/test_select_validation_lanes.sh`: validation-lane selector coverage that routes validation-inventory surfaces through the publishable C-SDLC owner lane.
- `docs/tooling/ADL_PLATFORM_CLI_BINARY_TAXONOMY.md`: operator-facing taxonomy document.
- `docs/default_workflow.md`, `docs/templates/prompts/README.md`, and `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`: direct-command docs updated to prefer `csdlc` while preserving `pr.sh` as the agent lifecycle wrapper.
- Additional proof artifacts: command outputs from local validation runs in this session; no durable external proof bundle was created before PR publication.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    `Verified Rust formatting for the touched crate surfaces.`
  - `cargo check --manifest-path adl/Cargo.toml --bin csdlc --bin adl-csdlc`
    `Verified both C-SDLC binaries compile.`
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    `Verified the fast test lane remains focused for the C-SDLC binary taxonomy diff.`
  - `bash adl/tools/test_validation_inventory.sh`
    `Verified the validation inventory assigns canonical and compatibility C-SDLC binaries to the C-SDLC owner.`
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`
    `Verified selector manifest JSON syntax.`
  - `bash adl/tools/test_select_validation_lanes.sh`
    `Verified selector contract coverage, including validation-inventory surfaces.`
  - `bash adl/tools/select_validation_lanes.sh --changed-files <validation-inventory fixture>`
    `Verified validation-inventory paths map to `csdlc_owner_lane` and remain publication-sufficient.`
  - `git diff --check --cached`
    `Verified staged changes are free of whitespace errors.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke adl_csdlc_cli_binary_help_and_version_smoke -- --exact`
    `Verified compatibility alias help/version behavior.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csdlc_cli_binary_help_and_version_smoke -- --exact`
    `Verified canonical binary help/version behavior.`
  - `adl/target/debug/csdlc --help` and `adl/target/debug/adl-csdlc --help`
    `Verified direct command output for canonical and compatibility help text.`
  - `cargo test --manifest-path adl/Cargo.toml 'cli::tests::csdlc_'`
    `Verified C-SDLC dispatch tests covering issue-run mapping, runtime-run rejection, help/version dispatch, and tooling/pr routing.`
  - `bash adl/tools/run_owner_validation_lane.sh csdlc --build`
    `Verified the C-SDLC owner validation lane after the canonical binary split.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4995__v0-91-7-tools-cli-implement-adl-platform-cli-binary-taxonomy/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4995__v0-91-7-tools-cli-implement-adl-platform-cli-binary-taxonomy/sor.md
- Idempotency-Key: v0-91-7-tools-cli-expose-canonical-csdlc-control-plane-binary-adl-cargo-toml-adl-config-validation-lane-selector-v0-91-6-json-adl-src-bin-adl-csdlc-rs-adl-src-bin-csdlc-rs-adl-src-cli-mod-rs-adl-src-cli-tests-rs-adl-tests-cli-smoke-rs-adl-tools-run-owner-validation-lane-sh-adl-tools-run-pr-fast-test-lane-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-run-pr-fast-test-lane-sh-adl-tools-test-select-validation-lanes-sh-adl-tools-test-validation-inventory-sh-adl-tools-validation-inventory-py-docs-default-workflow-md-docs-templates-prompts-readme-md-docs-tooling-adl-platform-cli-binary-taxonomy-md-adl-v0-91-7-tasks-issue-4995-v0-91-7-tools-cli-implement-adl-platform-cli-binary-taxonomy-sip-md-adl-v0-91-7-tasks-issue-4995-v0-91-7-tools-cli-implement-adl-platform-cli-binary-taxonomy-sor-md