### PR TITLE
[v0.91.7][tools][coverage] Repair adl-coverage PR-fast late failures

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -175,6 +175,7 @@
         "adl/tools/ci_path_policy.sh",
         "adl/tools/run_v0913_proof_validation_lane.sh",
         "adl/tools/run_pr_fast_coverage_lane.sh",
+        "adl/tools/test_run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh",
         "adl/tools/run_nessus_remote_validation.sh",
         "adl/tools/run_validation_manager_nessus_lane.sh",
@@ -204,6 +205,7 @@
         "adl/tools/ci_path_policy.sh",
         "adl/tools/run_v0913_proof_validation_lane.sh",
         "adl/tools/run_pr_fast_coverage_lane.sh",
+        "adl/tools/test_run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh",
         "adl/tools/run_nessus_remote_validation.sh",
         "adl/tools/run_validation_manager_nessus_lane.sh",
@@ -946,6 +948,7 @@
         "adl/tools/rust_validation_warm_cache.sh",
         "adl/tools/test_rust_validation_warm_cache.sh",
         "adl/tools/run_authoritative_coverage_lane.sh",
+        "adl/tools/test_run_pr_fast_coverage_lane.sh",
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh"
@@ -956,6 +959,7 @@
         "adl/tools/rust_validation_warm_cache.sh",
         "adl/tools/test_rust_validation_warm_cache.sh",
         "adl/tools/run_authoritative_coverage_lane.sh",
+        "adl/tools/test_run_pr_fast_coverage_lane.sh",
         "adl/tools/run_owner_validation_lane.sh",
         "adl/tools/run_pr_fast_coverage_lane.sh",
         "adl/tools/run_pr_fast_test_lane.sh"

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -218,6 +218,18 @@ candidate_filter_for_path() {
     adl/src/cli/tooling_cmd/github_release.rs)
       printf 'github_release_'
       ;;
+    adl/src/cli/tooling_cmd/structured_prompt.rs)
+      printf 'structured_prompt'
+      ;;
+    adl/src/cli/tooling_cmd/markdown.rs)
+      printf 'markdown'
+      ;;
+    adl/src/trace_schema_v1.rs)
+      printf 'trace_schema_v1'
+      ;;
+    adl/src/pr_dispatch_support.rs)
+      printf 'pr_dispatch_support'
+      ;;
     adl/src/runtime_v2/cultivating_intelligence.rs|adl/src/runtime_v2/cultivating_intelligence_parts/*.rs)
       printf 'cultivating_intelligence'
       ;;
@@ -236,6 +248,12 @@ candidate_filter_for_path() {
     adl/src/bin/adl_lint_prompt_spec.rs|adl/src/bin/adl_prompt_template.rs|adl/src/bin/adl_validate_structured_prompt.rs)
       printf 'tooling_cmd'
       ;;
+    adl/src/bin/demo_adl_gws_context_mirror.rs)
+      printf 'demo_adl_gws_context_mirror'
+      ;;
+    adl/src/bin/demo_adl_gws_native_drive_sync.rs)
+      printf 'demo_adl_gws_native_drive_sync'
+      ;;
     adl/src/bin/adl_aws_remote_validation.rs)
       printf 'adl_aws_remote_validation_bin'
       ;;
@@ -246,7 +264,7 @@ candidate_filter_for_path() {
       printf 'run_state'
       ;;
     *)
-      basename "$path" .rs
+      return 1
       ;;
   esac
 }
@@ -277,6 +295,18 @@ nextest_expression_for_filter() {
       ;;
     github_release_)
       printf 'test(/^cli::tooling_cmd::github_release::/)'
+      ;;
+    structured_prompt)
+      printf 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::tests::structured_prompt::/)'
+      ;;
+    markdown)
+      printf 'binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::tests::markdown/)'
+      ;;
+    trace_schema_v1)
+      printf 'test(trace_schema_v1)'
+      ;;
+    pr_dispatch_support)
+      printf 'test(pr_dispatch_support)'
       ;;
     finish)
       printf 'binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::tests::finish::arg_render::/) or binary_id(adl::bin/adl-pr-finish) and test(/^cli::pr_cmd::finish_support::tests::/)'
@@ -354,11 +384,44 @@ print_next_actions_for_path() {
   local path="$1"
   local context="$2"
   local filter
-  filter="$(candidate_filter_for_path "$path")"
+  if ! filter="$(candidate_filter_for_path "$path")"; then
+    echo "    candidate filter: unmapped"
+    echo "    ${context}: add an explicit coverage-impact mapping for ${path} before running PR-fast coverage"
+    echo "    fail-closed reason: unmapped production Rust source must not fall back to a broad basename nextest filter"
+    return
+  fi
   echo "    candidate filter: ${filter}"
   echo "    ${context}: $(focused_summary_command_for_filter "$filter")"
   extra_guidance_for_path "$path"
   echo "    rerun preflight: $(rerun_preflight_command)"
+}
+
+print_candidate_filters_fail_closed() {
+  local filters=""
+  local errors=""
+  local status path filter
+
+  while IFS=$'\t' read -r status path; do
+    [ -n "$path" ] || continue
+    if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
+      continue
+    fi
+    if ! filter="$(candidate_filter_for_path "$path")"; then
+      errors="${errors}coverage-impact: unmapped changed Rust source requires an explicit PR-fast coverage mapping before cargo llvm-cov nextest can run: ${path}"$'\n'
+      continue
+    fi
+    filters="${filters}${filter}"$'\n'
+  done <<EOF
+$changed_source_rows
+EOF
+
+  if [ -n "$errors" ]; then
+    printf '%s' "$errors" >&2
+    echo "coverage-impact: refusing broad fallback; add a narrow mapping or select an explicit full/slow coverage lane." >&2
+    return 1
+  fi
+
+  printf '%s' "$filters" | awk 'NF && !seen[$0]++'
 }
 
 file_is_structural_module_barrel() {
@@ -514,31 +577,13 @@ EOF
 fi
 
 if [ "$PRINT_RISK_FILTERS" = true ]; then
-  printf '%s\n' "$changed_source_rows" \
-    | while IFS=$'\t' read -r _status path; do
-        [ -n "$path" ] || continue
-        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
-          continue
-        fi
-        candidate_filter_for_path "$path"
-        printf '\n'
-      done \
-    | awk 'NF && !seen[$0]++'
+  print_candidate_filters_fail_closed
   exit 0
 fi
 
 if [ "$PRINT_RISK_NEXTEST_EXPRESSION" = true ]; then
-  if ! printf '%s\n' "$changed_source_rows" \
-    | while IFS=$'\t' read -r _status path; do
-        [ -n "$path" ] || continue
-        if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
-          continue
-        fi
-        candidate_filter_for_path "$path"
-        printf '\n'
-      done \
-    | awk 'NF && !seen[$0]++' \
-    | combined_nextest_expression_from_filters; then
+  candidate_filters="$(print_candidate_filters_fail_closed)" || exit 1
+  if ! printf '%s\n' "$candidate_filters" | combined_nextest_expression_from_filters; then
     exit 0
   fi
   printf '\n'

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -47,8 +47,19 @@ grep -F "no changed production adl/src Rust files" /tmp/coverage-impact-test-onl
 changed="$TMP/changed.txt"
 printf 'A\tadl/src/runtime_v2/new_large_surface.rs\n' >"$changed"
 risk_filters="$TMP/risk-filters.txt"
-bash "$SCRIPT" --changed-files "$changed" --print-risk-filters >"$risk_filters"
-grep -Fx "new_large_surface" "$risk_filters" >/dev/null
+if bash "$SCRIPT" --changed-files "$changed" --print-risk-filters >"$risk_filters" 2>/tmp/coverage-impact-unmapped-filter.out; then
+  echo "expected unmapped changed source to fail closed before printing risk filters" >&2
+  exit 1
+fi
+[ ! -s "$risk_filters" ]
+grep -F "unmapped changed Rust source requires an explicit PR-fast coverage mapping" /tmp/coverage-impact-unmapped-filter.out >/dev/null
+grep -F "adl/src/runtime_v2/new_large_surface.rs" /tmp/coverage-impact-unmapped-filter.out >/dev/null
+if bash "$SCRIPT" --changed-files "$changed" --print-risk-nextest-expression >/tmp/coverage-impact-unmapped-expression.out 2>/tmp/coverage-impact-unmapped-expression.err; then
+  echo "expected unmapped changed source to fail closed before printing nextest expression" >&2
+  exit 1
+fi
+[ ! -s /tmp/coverage-impact-unmapped-expression.out ]
+grep -F "refusing broad fallback" /tmp/coverage-impact-unmapped-expression.err >/dev/null
 
 control_plane_changed="$TMP/control-plane-changed.txt"
 printf 'A\tadl/src/cli/pr_cmd/doctor.rs\n' >"$control_plane_changed"
@@ -208,8 +219,9 @@ if bash "$SCRIPT" --changed-files "$changed" --require-summary-for-risk >/tmp/co
 fi
 grep -F "Coverage-impact preflight needs coverage evidence" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
-grep -F "candidate filter: new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "candidate filter: unmapped" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "generate focused summary: add an explicit coverage-impact mapping for adl/src/runtime_v2/new_large_surface.rs before running PR-fast coverage" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "fail-closed reason: unmapped production Rust source must not fall back to a broad basename nextest filter" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base origin/main --changed-files $changed --summary adl/target/coverage-impact-summary.json --require-summary-for-risk" /tmp/coverage-impact-missing.out >/dev/null
 
 if bash "$SCRIPT" --changed-files "$finish_helper_changed" --require-summary-for-risk >/tmp/coverage-impact-finish-helper-missing.out 2>&1; then
@@ -298,7 +310,7 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$low_summary" >/tmp/cove
 fi
 grep -F "77.00% < 80%" /tmp/coverage-impact-low.out >/dev/null
 grep -F "Actionable next steps:" /tmp/coverage-impact-low.out >/dev/null
-grep -F "refresh focused summary after adding or expanding tests: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-low.out >/dev/null
+grep -F "refresh focused summary after adding or expanding tests: add an explicit coverage-impact mapping for adl/src/runtime_v2/new_large_surface.rs before running PR-fast coverage" /tmp/coverage-impact-low.out >/dev/null
 grep -F "Common failure modes:" /tmp/coverage-impact-low.out >/dev/null
 
 cli_dispatch_companion_changed="$TMP/cli-dispatch-companion-changed.txt"
@@ -351,7 +363,7 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$missing_summary" >/tmp/
   exit 1
 fi
 grep -F "no coverage row" /tmp/coverage-impact-missing-row.out >/dev/null
-grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E 'test(new_large_surface)' && cargo llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" /tmp/coverage-impact-missing-row.out >/dev/null
+grep -F "generate focused summary: add an explicit coverage-impact mapping for adl/src/runtime_v2/new_large_surface.rs before running PR-fast coverage" /tmp/coverage-impact-missing-row.out >/dev/null
 
 live_runtime_boundary_summary="$TMP/live-runtime-boundary-summary.json"
 make_summary "adl/src/aws_remote_validation.rs" 1610 2559 "$live_runtime_boundary_summary"

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -510,3 +510,5 @@ for step_name in (
 
 print("PASS test_ci_runtime_contracts")
 PY
+
+bash "$ROOT_DIR/adl/tools/test_run_pr_fast_coverage_lane.sh"

--- a/adl/tools/test_run_pr_fast_coverage_lane.sh
+++ b/adl/tools/test_run_pr_fast_coverage_lane.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh"
+
+if bash "$SCRIPT" >/tmp/pr-fast-coverage-missing-args.out 2>&1; then
+  echo "expected run_pr_fast_coverage_lane to require --filter-expression" >&2
+  exit 1
+fi
+grep -F "run_pr_fast_coverage_lane: --filter-expression is required" /tmp/pr-fast-coverage-missing-args.out >/dev/null
+
+temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"; rm -f "$ROOT_DIR/adl/pr-fast-coverage-warm-cache.json"' EXIT
+
+bin_dir="$temp_root/bin"
+mkdir -p "$bin_dir"
+cargo_log="$temp_root/cargo.log"
+cat >"$bin_dir/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'cmd=%s\n' "$*" >> "$PR_FAST_COVERAGE_CARGO_LOG"
+printf 'target=%s\n' "${CARGO_TARGET_DIR:-}" >> "$PR_FAST_COVERAGE_CARGO_LOG"
+printf 'llvm_cov_target=%s\n' "${CARGO_LLVM_COV_TARGET_DIR:-}" >> "$PR_FAST_COVERAGE_CARGO_LOG"
+exit 0
+EOF
+chmod +x "$bin_dir/cargo"
+
+scratch_root="$temp_root/pr-fast-target"
+expression='binary_id(adl::bin/adl) and test(/^cli::tooling_cmd::tests::structured_prompt::/)'
+PATH="$bin_dir:$PATH" \
+PR_FAST_COVERAGE_CARGO_LOG="$cargo_log" \
+ADL_RUST_WARM_CACHE=0 \
+ADL_PR_FAST_COVERAGE_BUILD_ROOT="$scratch_root" \
+  bash "$SCRIPT" --filter-expression "$expression" >/tmp/pr-fast-coverage-run.out
+
+grep -F "PR-fast coverage expression: $expression" /tmp/pr-fast-coverage-run.out >/dev/null
+grep -F "PR-fast coverage target: $scratch_root" /tmp/pr-fast-coverage-run.out >/dev/null
+
+for required in \
+  "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E $expression" \
+  "cmd=llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" \
+  "target=$scratch_root" \
+  "llvm_cov_target=$scratch_root/llvm-cov-target"
+do
+  if ! grep -F "$required" "$cargo_log" >/dev/null 2>&1; then
+    echo "missing PR-fast coverage execution token: $required" >&2
+    cat "$cargo_log" >&2
+    exit 1
+  fi
+done
+
+echo "PASS test_run_pr_fast_coverage_lane"


### PR DESCRIPTION
Closes #5083

## Summary
Implemented the `#5083` coverage control-plane repair. PR-fast coverage no longer falls back from unmapped production Rust source paths to broad basename nextest filters. Instead, `check_coverage_impact.sh` fails closed before emitting risk filters or a PR-fast nextest expression, with diagnostics that require an explicit mapping or a broader/full lane route. Added explicit mappings for current known surfaces that had been relying on fallback behavior, added a PR-fast coverage runner contract test, and wired that test into focused validation selector lanes.

## Artifacts
- Updated coverage-impact mapper: `adl/tools/check_coverage_impact.sh`
- Updated coverage-impact contracts: `adl/tools/test_check_coverage_impact.sh`
- Added PR-fast coverage runner contract: `adl/tools/test_run_pr_fast_coverage_lane.sh`
- Updated CI runtime contract to run the PR-fast coverage runner contract: `adl/tools/test_ci_runtime_contracts.sh`
- Updated validation selector wiring: `adl/config/validation_lane_selector.v0.91.6.json`
- Updated issue review truth: `.adl/v0.91.7/tasks/issue-5083__v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures/srp.md`
- Updated issue output truth: `.adl/v0.91.7/tasks/issue-5083__v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/check_coverage_impact.sh adl/tools/run_pr_fast_coverage_lane.sh adl/tools/run_authoritative_coverage_lane.sh adl/tools/test_run_pr_fast_coverage_lane.sh`
    `Verified shell syntax for touched coverage scripts and the new contract test.`
  - `bash adl/tools/test_check_coverage_impact.sh`
    `Verified coverage-impact mapping, fail-closed unmapped-source behavior, and focused summary guidance.`
  - `bash adl/tools/test_run_pr_fast_coverage_lane.sh`
    `Verified PR-fast coverage runner command construction without invoking real cargo coverage.`
  - `bash adl/tools/test_run_authoritative_coverage_lane.sh`
    `Verified authoritative coverage runner contract remains intact.`
  - `bash adl/tools/test_select_validation_lanes.sh`
    `Verified selector configuration parses and focused lanes remain selectable.`
  - `bash adl/tools/test_ci_path_policy.sh`
    `Verified CI path-policy and PR-fast/full-coverage workflow contracts.`
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    `Verified workflow runtime contract for coverage runner integration.`
  - `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`
    `Verified edited selector JSON parses.`
  - `git diff --check`
    `Verified whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5083__v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5083__v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures/sor.md
- Idempotency-Key: v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures-adl-tools-check-coverage-impact-sh-adl-tools-test-check-coverage-impact-sh-adl-tools-test-run-pr-fast-coverage-lane-sh-adl-tools-test-ci-runtime-contracts-sh-adl-config-validation-lane-selector-v0-91-6-json-adl-v0-91-7-tasks-issue-5083-v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures-sip-md-adl-v0-91-7-tasks-issue-5083-v0-91-7-tools-coverage-repair-adl-coverage-pr-fast-late-failures-sor-md