### PR TITLE
[v0.91.7][tools][binaries] Repair owner binary installer defaults and no-build behavior

### DIFF
--- a/adl/tools/install_owner_binaries.sh
+++ b/adl/tools/install_owner_binaries.sh
@@ -6,6 +6,7 @@ MANIFEST="$ROOT_DIR/adl/Cargo.toml"
 STABLE_BIN_DIR="${ADL_OWNER_BIN_DIR:-$ROOT_DIR/.adl/bin}"
 SOURCE_BIN_DIR=""
 NO_BUILD=0
+EXPLICIT_BINS=0
 BINS=()
 
 usage() {
@@ -23,6 +24,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --bin)
       [[ $# -ge 2 ]] || { usage; exit 2; }
+      EXPLICIT_BINS=1
       BINS+=("$2")
       shift 2
       ;;
@@ -54,12 +56,14 @@ done
 
 if [[ "${#BINS[@]}" -eq 0 ]]; then
   BINS=(
-    adl csdlc adl-csdlc adl-runtime adl-review
+    adl csdlc adl-csdlc adl-runtime csm adl-review
+    adl-validate-structured-prompt adl-lint-prompt-spec adl-prompt-template
     adl-pr-create adl-pr-init adl-pr-repair-issue-body
     adl-pr-run adl-pr-doctor adl-pr-ready adl-pr-preflight
     adl-pr-finish adl-pr-validation adl-pr-inventory
-    adl-pr-closing-linkage adl-issue adl-pr-closeout
-    adl-session adl-process adl-prompt-template adl-validate-structured-prompt
+    adl-pr-shepherd adl-pr-closing-linkage adl-issue adl-pr-closeout
+    adl-session adl-process adl-remote adl-aws-remote-validation
+    adl-provider-adapter
   )
 fi
 
@@ -67,7 +71,7 @@ source_hash() {
   if git -C "$ROOT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
     (
       cd "$ROOT_DIR"
-      git ls-files --cached --others --exclude-standard -- adl/Cargo.toml adl/Cargo.lock adl/build.rs adl/src |
+      git ls-files --cached --others --exclude-standard -- adl/Cargo.toml adl/Cargo.lock adl/build.rs adl/src adl/tools/adl_provider_adapter.rs |
         grep -Ev '(^adl/src/cli/tests/|/tests\.rs$|/tests/)' |
         LC_ALL=C sort |
         while IFS= read -r path; do
@@ -81,7 +85,7 @@ source_hash() {
   fi
   (
     cd "$ROOT_DIR"
-    find adl -type f \( -path 'adl/src/*' -o -name Cargo.toml -o -name Cargo.lock -o -name build.rs \) -print 2>/dev/null |
+    find adl -type f \( -path 'adl/src/*' -o -path 'adl/tools/adl_provider_adapter.rs' -o -name Cargo.toml -o -name Cargo.lock -o -name build.rs \) -print 2>/dev/null |
       grep -Ev '(^adl/src/cli/tests/|/tests\.rs$|/tests/)' |
       LC_ALL=C sort |
       while IFS= read -r path; do
@@ -124,10 +128,16 @@ fi
 
 mkdir -p "$STABLE_BIN_DIR/.provenance"
 
+MISSING_BINS=()
 for bin in "${BUILD_BINS[@]}"; do
   src="$SOURCE_BIN_DIR/$bin"
   dest="$STABLE_BIN_DIR/$bin"
   [[ -x "$src" ]] || {
+    if [[ "$NO_BUILD" == "1" && "$EXPLICIT_BINS" != "1" ]]; then
+      echo "owner-binary source missing; skipped in default --no-build install: $src" >&2
+      MISSING_BINS+=("$bin")
+      continue
+    fi
     echo "install_owner_binaries: missing built source binary: $src" >&2
     exit 1
   }
@@ -141,3 +151,8 @@ for bin in "${BUILD_BINS[@]}"; do
 EOF
   echo "owner-binary installed: $bin -> $dest"
 done
+
+if [[ "${#MISSING_BINS[@]}" -gt 0 ]]; then
+  echo "install_owner_binaries: incomplete default --no-build install; missing source binaries: ${MISSING_BINS[*]}" >&2
+  exit 1
+fi

--- a/adl/tools/owner_binary_resolution.sh
+++ b/adl/tools/owner_binary_resolution.sh
@@ -57,7 +57,7 @@ adl_owner_source_hash() {
   if git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1; then
     (
       cd "$root"
-      git ls-files --cached --others --exclude-standard -- adl/Cargo.toml adl/Cargo.lock adl/build.rs adl/src |
+      git ls-files --cached --others --exclude-standard -- adl/Cargo.toml adl/Cargo.lock adl/build.rs adl/src adl/tools/adl_provider_adapter.rs |
         grep -Ev '(^adl/src/cli/tests/|/tests\.rs$|/tests/)' |
         LC_ALL=C sort |
         while IFS= read -r path; do
@@ -71,7 +71,7 @@ adl_owner_source_hash() {
   fi
   (
     cd "$root"
-    find adl -type f \( -path 'adl/src/*' -o -name Cargo.toml -o -name Cargo.lock -o -name build.rs \) -print 2>/dev/null |
+    find adl -type f \( -path 'adl/src/*' -o -path 'adl/tools/adl_provider_adapter.rs' -o -name Cargo.toml -o -name Cargo.lock -o -name build.rs \) -print 2>/dev/null |
       grep -Ev '(^adl/src/cli/tests/|/tests\.rs$|/tests/)' |
       LC_ALL=C sort |
       while IFS= read -r path; do

--- a/adl/tools/test_owner_binary_install.sh
+++ b/adl/tools/test_owner_binary_install.sh
@@ -30,6 +30,7 @@ version = "0.0.0"
 edition = "2021"
 EOF_CARGO
 printf 'pub fn seed() {}\n' >"$repo/adl/src/lib.rs"
+printf 'fn main() {}\n' >"$repo/adl/tools/adl_provider_adapter.rs"
 cat >"$source_bin_dir/adl-pr-closeout" <<'EOF_BIN'
 #!/usr/bin/env bash
 printf 'closeout-v1:%s\n' "$*"
@@ -41,7 +42,7 @@ chmod +x "$source_bin_dir/adl-pr-closeout"
   git init -q
   git config user.name "Test User"
   git config user.email "test@example.com"
-  git add adl/Cargo.toml adl/src/lib.rs adl/tools/install_owner_binaries.sh adl/tools/owner_binary_resolution.sh
+  git add adl/Cargo.toml adl/src/lib.rs adl/tools/adl_provider_adapter.rs adl/tools/install_owner_binaries.sh adl/tools/owner_binary_resolution.sh
   git commit -q -m "init"
 )
 
@@ -155,6 +156,24 @@ set -e
 }
 rm -f "$repo/adl/src/untracked_owner_input.rs"
 
+printf 'fn main() { let _provider_source_changed = true; }\n' >"$repo/adl/tools/adl_provider_adapter.rs"
+set +e
+provider_source_resolved="$(
+  cd "$repo"
+  # shellcheck source=/dev/null
+  source adl/tools/owner_binary_resolution.sh
+  root="$(adl_owner_manifest_root)"
+  primary="$(adl_owner_primary_root "$root")"
+  adl_owner_stable_binary_if_fresh adl-pr-closeout "$root" "$primary"
+)"
+provider_source_status=$?
+set -e
+[[ "$provider_source_status" -ne 0 && -z "$provider_source_resolved" ]] || {
+  echo "assertion failed: resolver accepted stale stable owner binary after provider adapter source changed" >&2
+  exit 1
+}
+git -C "$repo" checkout -- adl/tools/adl_provider_adapter.rs
+
 nogit="$tmpdir/nogit"
 mkdir -p "$nogit/adl/tools" "$nogit/adl/src" "$tmpdir/nogit-source-bins"
 cp "$INSTALL_SRC" "$nogit/adl/tools/install_owner_binaries.sh"
@@ -176,6 +195,81 @@ chmod +x "$tmpdir/nogit-source-bins/adl-pr-closeout"
 )
 "$nogit/.adl/bin/adl-pr-closeout" | grep -Fq 'closeout-nongit:' || {
   echo "assertion failed: non-git stable owner binary install did not produce runnable binary" >&2
+  exit 1
+}
+
+inventory_help="$("$BASH_BIN" "$INSTALL_SRC" --help 2>&1 || true)"
+[[ "$inventory_help" == *"install_owner_binaries.sh"* ]] || {
+  echo "assertion failed: installer help is not available" >&2
+  exit 1
+}
+
+default_repo="$tmpdir/default-repo"
+default_source_bins="$tmpdir/default-source-bins"
+mkdir -p "$default_repo/adl/tools" "$default_repo/adl/src" "$default_source_bins"
+cp "$INSTALL_SRC" "$default_repo/adl/tools/install_owner_binaries.sh"
+chmod +x "$default_repo/adl/tools/install_owner_binaries.sh"
+cp "$repo/adl/Cargo.toml" "$default_repo/adl/Cargo.toml"
+printf 'pub fn default_seed() {}\n' >"$default_repo/adl/src/lib.rs"
+for bin in adl adl-pr-validation adl-pr-shepherd csm adl-remote adl-aws-remote-validation adl-provider-adapter; do
+  cat >"$default_source_bins/$bin" <<EOF_BIN
+#!/usr/bin/env bash
+printf '$bin:%s\n' "\$*"
+EOF_BIN
+  chmod +x "$default_source_bins/$bin"
+done
+default_install_log="$tmpdir/default-install.log"
+set +e
+(
+  cd "$default_repo"
+  "$BASH_BIN" adl/tools/install_owner_binaries.sh \
+    --source-bin-dir "$default_source_bins" \
+    --no-build >"$default_install_log" 2>&1
+)
+default_install_status=$?
+set -e
+[[ "$default_install_status" -ne 0 ]] || {
+  echo "assertion failed: incomplete default no-build install should return nonzero" >&2
+  cat "$default_install_log" >&2
+  exit 1
+}
+for bin in adl adl-pr-validation adl-pr-shepherd csm adl-remote adl-aws-remote-validation adl-provider-adapter; do
+  [[ -x "$default_repo/.adl/bin/$bin" ]] || {
+    echo "assertion failed: default no-build install did not install current owner binary $bin" >&2
+    cat "$default_install_log" >&2
+    exit 1
+  }
+done
+grep -Fq "owner-binary source missing; skipped in default --no-build install" "$default_install_log" || {
+  echo "assertion failed: default no-build install should report skipped missing default binaries" >&2
+  cat "$default_install_log" >&2
+  exit 1
+}
+grep -Fq "install_owner_binaries: incomplete default --no-build install" "$default_install_log" || {
+  echo "assertion failed: default no-build install should report incomplete install summary" >&2
+  cat "$default_install_log" >&2
+  exit 1
+}
+
+explicit_missing_log="$tmpdir/explicit-missing.log"
+set +e
+(
+  cd "$default_repo"
+  "$BASH_BIN" adl/tools/install_owner_binaries.sh \
+    --bin definitely-missing-owner-binary \
+    --source-bin-dir "$default_source_bins" \
+    --no-build >"$explicit_missing_log" 2>&1
+)
+explicit_missing_status=$?
+set -e
+[[ "$explicit_missing_status" -ne 0 ]] || {
+  echo "assertion failed: explicit missing no-build binary should fail closed" >&2
+  cat "$explicit_missing_log" >&2
+  exit 1
+}
+grep -Fq "install_owner_binaries: missing built source binary" "$explicit_missing_log" || {
+  echo "assertion failed: explicit missing no-build binary should report missing source" >&2
+  cat "$explicit_missing_log" >&2
   exit 1
 }
 

--- a/docs/tooling/OWNER_BINARY_INSTALLATION.md
+++ b/docs/tooling/OWNER_BINARY_INSTALLATION.md
@@ -15,6 +15,19 @@ Use:
 bash adl/tools/install_owner_binaries.sh
 ```
 
+To populate the stable directory from already-built binaries without rebuilding,
+use:
+
+```sh
+bash adl/tools/install_owner_binaries.sh --source-bin-dir adl/target/debug --no-build
+```
+
+In default `--no-build` mode, binaries missing from the source directory are
+reported and skipped so an already-built subset can still be restored, but the
+command exits nonzero when the default install is incomplete. An explicit
+`--bin <name>` request still fails closed when the requested source binary is
+absent.
+
 The installer records per-binary provenance under `.adl/bin/.provenance/`.
 Re-running it is a no-op when the recorded source hash still matches the current
 owner-binary source inputs. This prevents unrelated issue merges or closeouts


### PR DESCRIPTION
Closes #5086

## Summary
Repaired the owner-binary installer so default installs include the current workflow/runtime owner binaries, shared stable-binary freshness hashes include the provider-adapter source, and default `--no-build` restores are detectable when incomplete. Restored root stable PR/core binaries operationally before the tracked fix, then implemented the durable installer/resolver fix in the #5086 worktree.

## Artifacts
- Updated installer: `adl/tools/install_owner_binaries.sh`
- Updated shared resolver: `adl/tools/owner_binary_resolution.sh`
- Updated focused installer test: `adl/tools/test_owner_binary_install.sh`
- Updated operator docs: `docs/tooling/OWNER_BINARY_INSTALLATION.md`
- Local ignored stable-binary smoke artifact: `.adl/bin/adl-pr-validation` in the issue worktree

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_owner_binary_install.sh`
    `Verified installer and resolver contract behavior for stable owner binaries.`
  - `bash -n adl/tools/install_owner_binaries.sh adl/tools/owner_binary_resolution.sh adl/tools/test_owner_binary_install.sh`
    `Verified edited shell syntax.`
  - `env -u ADL_PR_RUST_BIN ADL_PR_RUST_ALLOW_CARGO_FALLBACK=0 ADL_PRIMARY_CHECKOUT_ROOT=$ADL_PRIMARY_CHECKOUT_ROOT bash adl/tools/pr.sh validation 5085 --json`
    `Verified stable owner-binary delegate resolution without cargo fallback.`
  - `git diff --check`
    `Verified diff whitespace hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5086__v0-91-7-tools-binaries-repair-owner-binary-installer-defaults-and-no-build-behavior/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5086__v0-91-7-tools-binaries-repair-owner-binary-installer-defaults-and-no-build-behavior/sor.md
- Idempotency-Key: v0-91-7-tools-binaries-repair-owner-binary-installer-defaults-and-no-build-behavior-adl-tools-install-owner-binaries-sh-adl-tools-owner-binary-resolution-sh-adl-tools-test-owner-binary-install-sh-docs-tooling-owner-binary-installation-md-adl-v0-91-7-tasks-issue-5086-v0-91-7-tools-binaries-repair-owner-binary-installer-defaults-and-no-build-behavior-sip-md-adl-v0-91-7-tasks-issue-5086-v0-91-7-tools-binaries-repair-owner-binary-installer-defaults-and-no-build-behavior-sor-md