### PR TITLE
[v0.91.7][WP-07][runtime][chronosense] Make CSM own embedded SNTP time observation

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rsntp",
  "rustls 0.23.36",
  "schemars",
  "serde",
@@ -3424,6 +3425,16 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsntp"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc507d0efdc8ce91a17455b1efe9ada6a21e2414470b3f1d84aefc7ebcf247bd"
+dependencies = [
+ "chrono",
+ "tokio",
 ]
 
 [[package]]

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -221,6 +221,7 @@ sha2 = "0.10"
 zeroize = "1"
 deadpool = { version = "0.13.0", default-features = false, features = ["unmanaged"] }
 ntp-daemon = "0.3.7"
+rsntp = "4.1.2"
 
 [dev-dependencies]
 loom = "0.7"

--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -69,9 +69,9 @@ pub use retrieval::{
     TemporalQueryPrimitiveSet, TemporalQueryRetrievalContract, TemporalRetrievalSemantics,
 };
 pub use service::{
-    capture_ntpd_rs_time_sync_status, chronosense_time_sync_status_from_ntp_ctl_output,
-    ChronosenseClockStack, ChronosenseRuntimeService, ChronosenseRuntimeServiceConfig,
-    ChronosenseTimeSyncStatus,
+    capture_runtime_time_sync_status, chronosense_time_sync_status_from_ntp_ctl_output,
+    start_runtime_time_observation, ChronosenseClockStack, ChronosenseRuntimeService,
+    ChronosenseRuntimeServiceConfig, ChronosenseTimeSyncStatus,
 };
 pub use temporal_schema::{
     CostVectorSchema, ExecutionPolicySchema, ExecutionRealizationSchema, SubjectiveTimeSchema,

--- a/adl/src/chronosense/service.rs
+++ b/adl/src/chronosense/service.rs
@@ -8,23 +8,23 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::{TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::io;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use super::{
     ChronosenseFoundation, IdentityProfile, TemporalContext, CHRONOSENSE_CLOCK_STACK_SCHEMA,
     CHRONOSENSE_RUNTIME_SERVICE_SCHEMA, CHRONOSENSE_TIME_SYNC_STATUS_SCHEMA,
 };
 
+const SNTP_STATUS_ENV: &str = "ADL_CSM_SNTP_STATUS";
+const SNTP_PEERS_ENV: &str = "ADL_CSM_SNTP_PEERS";
 const NTPD_RS_STATUS_ENV: &str = "ADL_CSM_NTPD_RS_STATUS";
-const NTPD_RS_OBSERVE_SOCKET_ENV: &str = "ADL_CSM_NTPD_RS_OBSERVE_SOCKET";
-const NTPD_RS_CTL_COMPAT_ENV: &str = "ADL_CSM_NTPD_RS_CTL_COMPAT";
-const NTPD_RS_CTL_ENV: &str = "ADL_CSM_NTPD_RS_CTL";
-const NTPD_RS_CTL_TIMEOUT: Duration = Duration::from_millis(500);
-const NTPD_RS_OBSERVE_TIMEOUT: Duration = Duration::from_millis(500);
+const NTPD_RS_PEERS_ENV: &str = "ADL_CSM_NTPD_RS_PEERS";
+const NTP_SAMPLER_TIMEOUT: Duration = Duration::from_secs(2);
+const SNTP_DEFAULT_PEERS: &str = "time.cloudflare.com,time.google.com,pool.ntp.org";
+#[cfg(test)]
+const SNTP_EMBEDDED_TEST_PEER_ENV: &str = "ADL_CSM_SNTP_TEST_PEERS";
+#[cfg(test)]
+const NTPD_RS_EMBEDDED_TEST_PEER_ENV: &str = "ADL_CSM_NTPD_RS_EMBEDDED_TEST_PEERS";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChronosenseRuntimeServiceConfig {
@@ -150,160 +150,143 @@ impl ChronosenseRuntimeService {
     }
 }
 
-pub fn capture_ntpd_rs_time_sync_status() -> ChronosenseTimeSyncStatus {
+pub fn capture_runtime_time_sync_status() -> ChronosenseTimeSyncStatus {
+    if std::env::var(SNTP_STATUS_ENV).ok().as_deref() == Some("0") {
+        return ChronosenseTimeSyncStatus::unavailable(
+            "runtime_sntp_probe_disabled",
+            format!("{SNTP_STATUS_ENV}=0"),
+            None,
+        );
+    }
     if std::env::var(NTPD_RS_STATUS_ENV).ok().as_deref() == Some("0") {
         return ChronosenseTimeSyncStatus::unavailable(
-            "ntpd_rs_probe_disabled",
+            "runtime_sntp_probe_disabled",
             format!("{NTPD_RS_STATUS_ENV}=0"),
             None,
         );
     }
-    match capture_ntpd_rs_observable_state() {
-        Ok(status) => return status,
-        Err(observe_error) => {
-            if std::env::var(NTPD_RS_CTL_COMPAT_ENV).ok().as_deref() != Some("1") {
-                return ChronosenseTimeSyncStatus::unavailable(
-                    observe_error.failure_state,
-                    observe_error.command,
-                    observe_error.summary,
-                );
+    capture_runtime_sntp_status()
+}
+
+pub fn start_runtime_time_observation() -> ChronosenseTimeSyncStatus {
+    capture_runtime_time_sync_status()
+}
+
+fn embedded_ntpd_rs_peers() -> Vec<String> {
+    #[cfg(test)]
+    if let Ok(peers) = std::env::var(SNTP_EMBEDDED_TEST_PEER_ENV) {
+        return peers
+            .split(',')
+            .map(str::trim)
+            .filter(|peer| !peer.is_empty())
+            .map(ToString::to_string)
+            .collect();
+    }
+    #[cfg(test)]
+    if let Ok(peers) = std::env::var(NTPD_RS_EMBEDDED_TEST_PEER_ENV) {
+        return peers
+            .split(',')
+            .map(str::trim)
+            .filter(|peer| !peer.is_empty())
+            .map(ToString::to_string)
+            .collect();
+    }
+    std::env::var(SNTP_PEERS_ENV)
+        .or_else(|_| std::env::var(NTPD_RS_PEERS_ENV))
+        .unwrap_or_else(|_| SNTP_DEFAULT_PEERS.to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|peer| !peer.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn capture_runtime_sntp_status() -> ChronosenseTimeSyncStatus {
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+    {
+        Ok(runtime) => runtime.block_on(capture_runtime_sntp_status_async()),
+        Err(err) => ChronosenseTimeSyncStatus::unavailable(
+            "runtime_sntp_sampler_unavailable",
+            "rsntp::AsyncSntpClient",
+            Some(sanitize_probe_summary(&err.to_string())),
+        ),
+    }
+}
+
+async fn capture_runtime_sntp_status_async() -> ChronosenseTimeSyncStatus {
+    let peers = embedded_ntpd_rs_peers();
+    let client =
+        rsntp::AsyncSntpClient::with_config(rsntp::Config::default().timeout(NTP_SAMPLER_TIMEOUT));
+    let mut summaries = Vec::new();
+    for peer in peers {
+        match client.synchronize(peer.as_str()).await {
+            Ok(result) => {
+                let offset = result.clock_offset().as_secs_f64();
+                let uncertainty = result.round_trip_delay().as_secs_f64().abs() / 2.0;
+                return chronosense_time_sync_status_from_sntp_sample(&peer, offset, uncertainty);
             }
+            Err(err) => summaries.push(format!(
+                "{}={}",
+                sanitize_probe_summary(&peer),
+                sanitize_probe_summary(&err.to_string())
+            )),
         }
     }
-    let command = std::env::var(NTPD_RS_CTL_ENV).unwrap_or_else(|_| "ntp-ctl".to_string());
-    let command_label = ntpd_rs_command_label(&command);
-    match ntpd_rs_status_output(&command) {
-        Ok(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            chronosense_time_sync_status_from_ntp_ctl_output(&stdout, &command_label)
-        }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            ChronosenseTimeSyncStatus::unavailable(
-                "ntpd_rs_status_command_failed",
-                command_label,
-                first_non_empty_line(&stderr).map(|line| sanitize_probe_summary(&line)),
-            )
-        }
-        Err(err) => {
-            let failure_state = if err.kind() == std::io::ErrorKind::TimedOut {
-                "ntpd_rs_status_command_timeout"
-            } else {
-                "ntpd_rs_status_command_unavailable"
-            };
-            ChronosenseTimeSyncStatus::unavailable(
-                failure_state,
-                command_label,
-                Some(err.kind().to_string()),
-            )
-        }
-    }
+    ChronosenseTimeSyncStatus::unavailable(
+        "runtime_sntp_sample_unavailable",
+        "rsntp::AsyncSntpClient",
+        Some(sanitize_probe_summary(&summaries.join("; "))),
+    )
 }
 
-struct NtpdRsObserveError {
-    failure_state: &'static str,
-    command: String,
-    summary: Option<String>,
-}
-
-fn capture_ntpd_rs_observable_state() -> Result<ChronosenseTimeSyncStatus, NtpdRsObserveError> {
-    let socket = std::env::var(NTPD_RS_OBSERVE_SOCKET_ENV)
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/run/ntpd-rs/observe"));
-    let command = format!("ntp_daemon::ObservableState:{}", socket.display());
-    let command_label = ntpd_rs_command_label(&command);
-    match ntpd_rs_observable_state_value(&socket) {
-        Ok(value) => Ok(chronosense_time_sync_status_from_ntpd_rs_observable_value(
-            &value,
-            &command_label,
-        )),
-        Err(err) => Err(NtpdRsObserveError {
-            failure_state: ntpd_rs_observe_failure_state(&err),
-            command: command_label,
-            summary: Some(sanitize_probe_summary(&err.to_string())),
-        }),
-    }
-}
-
-fn ntpd_rs_observe_failure_state(err: &io::Error) -> &'static str {
-    match err.kind() {
-        io::ErrorKind::NotFound => "ntpd_rs_observation_socket_missing",
-        io::ErrorKind::TimedOut => "ntpd_rs_observation_socket_timeout",
-        io::ErrorKind::ConnectionRefused => "ntpd_rs_observation_socket_refused",
-        _ => "ntpd_rs_observation_socket_unavailable",
-    }
-}
-
-pub fn chronosense_time_sync_status_from_ntpd_rs_observable_value(
-    value: &Value,
-    command: &str,
+pub fn chronosense_time_sync_status_from_sntp_sample(
+    peer: &str,
+    offset_seconds: f64,
+    uncertainty_seconds: f64,
 ) -> ChronosenseTimeSyncStatus {
-    let peer_count = value
-        .get("peers")
-        .and_then(Value::as_array)
-        .map(|peers| {
-            peers
-                .iter()
-                .filter(|peer| !matches!(peer, Value::String(label) if label == "Nothing"))
-                .count()
-        })
-        .unwrap_or(0);
-    let offset = first_numeric_field(value, &["offset", "offset_seconds", "last_offset"]);
-    let uncertainty = first_numeric_field(
-        value,
-        &["uncertainty", "uncertainty_seconds", "root_dispersion"],
-    );
-    let (health, confidence, drift_status, failure_state, reason) = if peer_count == 0 {
-        (
-            "unavailable",
-            "none",
-            "unknown",
-            Some("ntpd_rs_observable_state_has_no_peers"),
-            "ntpd_rs_observable_state_reports_no_peers",
-        )
-    } else if matches!(offset, Some(value) if value.abs() <= 0.5) {
+    let healthy = offset_seconds.is_finite()
+        && uncertainty_seconds.is_finite()
+        && offset_seconds.abs() <= 0.5
+        && uncertainty_seconds <= 1.0;
+    let (health, confidence, drift_status, failure_state, reason) = if healthy {
         (
             "synced",
             "high",
-            "within_ntpd_rs_reported_bounds",
+            "within_sntp_reported_bounds",
             None,
-            "ntpd_rs_observable_state_reports_active_sources",
-        )
-    } else if offset.is_some() {
-        (
-            "degraded",
-            "medium",
-            "offset_or_missing_polls_observed",
-            Some("ntpd_rs_observable_state_degraded"),
-            "ntpd_rs_observable_state_reports_degraded_sources",
+            "runtime_sntp_client_reports_active_source",
         )
     } else {
         (
-            "unknown",
-            "low",
-            "unknown",
-            Some("ntpd_rs_observable_state_offset_unavailable"),
-            "ntpd_rs_observable_state_missing_parseable_offset",
+            "degraded",
+            "medium",
+            "outside_sntp_reported_bounds",
+            Some("runtime_sntp_sample_degraded"),
+            "runtime_sntp_client_reports_degraded_source",
         )
     };
 
     ChronosenseTimeSyncStatus {
         schema_version: CHRONOSENSE_TIME_SYNC_STATUS_SCHEMA.to_string(),
-        substrate: "ntpd-rs".to_string(),
-        source: "ntp-daemon::ObservableState observation socket".to_string(),
-        mode: "csm_in_process_ntpd_rs_observable_state".to_string(),
+        substrate: "SNTP".to_string(),
+        source: "rsntp::AsyncSntpClient in-process runtime sampler".to_string(),
+        mode: "csm_in_process_async_sntp_client".to_string(),
         health: health.to_string(),
         confidence: confidence.to_string(),
         drift_status: drift_status.to_string(),
         failure_state: failure_state.map(ToString::to_string),
         reason: reason.to_string(),
         observed_at_rfc3339: Utc::now().to_rfc3339(),
-        poll_command: command.to_string(),
-        port_policy: "csm_in_process_ntpd_rs_component_no_separate_binary_no_csm_udp_123_listener"
-            .to_string(),
-        parsed_offset_seconds: offset,
-        parsed_uncertainty_seconds: uncertainty,
-        raw_summary: Some(format!("observable_peer_count={peer_count}")),
+        poll_command: "rsntp::AsyncSntpClient".to_string(),
+        port_policy:
+            "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout"
+                .to_string(),
+        parsed_offset_seconds: Some(offset_seconds),
+        parsed_uncertainty_seconds: Some(uncertainty_seconds),
+        raw_summary: Some(format!("peer={}", sanitize_probe_summary(peer))),
     }
 }
 
@@ -392,16 +375,21 @@ impl ChronosenseTimeSyncStatus {
     ) -> Self {
         let reason = reason.into();
         let command = command.into();
-        let observation_socket_source = command.starts_with("ntp_daemon_observable_state")
-            || reason == "ntpd_rs_probe_disabled";
-        let (source, mode, port_policy) = if observation_socket_source {
+        let runtime_sntp_source = command == "rsntp::AsyncSntpClient"
+            || reason == "runtime_sntp_probe_disabled"
+            || reason == "ntpd_rs_probe_disabled"
+            || command.starts_with("ADL_CSM_SNTP_")
+            || command.starts_with("ADL_CSM_NTPD_RS_");
+        let (substrate, source, mode, port_policy) = if runtime_sntp_source {
             (
-                "ntp-daemon::ObservableState observation socket",
-                "csm_ntpd_rs_observable_state",
-                "csm_ntpd_rs_component_observation_no_separate_csm_time_binary_no_csm_udp_123_listener",
+                "SNTP",
+                "rsntp::AsyncSntpClient in-process runtime sampler",
+                "csm_in_process_async_sntp_client",
+                "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout",
             )
         } else {
             (
+                "ntpd-rs",
                 "ntp-ctl status --format prometheus",
                 "external_status_projection",
                 "observes_ntpd_rs_status_only_no_csm_listener_on_udp_123",
@@ -409,14 +397,19 @@ impl ChronosenseTimeSyncStatus {
         };
         Self {
             schema_version: CHRONOSENSE_TIME_SYNC_STATUS_SCHEMA.to_string(),
-            substrate: "ntpd-rs".to_string(),
+            substrate: substrate.to_string(),
             source: source.to_string(),
             mode: mode.to_string(),
             health: "unavailable".to_string(),
             confidence: "none".to_string(),
             drift_status: "unknown".to_string(),
             failure_state: Some(reason),
-            reason: "ntpd_rs_status_unavailable_without_csm_failure".to_string(),
+            reason: if runtime_sntp_source {
+                "runtime_sntp_status_unavailable_without_csm_failure"
+            } else {
+                "ntpd_rs_status_unavailable_without_csm_failure"
+            }
+            .to_string(),
             observed_at_rfc3339: Utc::now().to_rfc3339(),
             poll_command: command,
             port_policy: port_policy.to_string(),
@@ -427,94 +420,12 @@ impl ChronosenseTimeSyncStatus {
     }
 }
 
-#[cfg(unix)]
-fn ntpd_rs_observable_state_value(socket: &Path) -> io::Result<Value> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .map_err(|err| io::Error::other(format!("create ntpd-rs observation runtime: {err}")))?;
-    runtime.block_on(async move {
-        let mut stream = tokio::time::timeout(
-            NTPD_RS_OBSERVE_TIMEOUT,
-            tokio::net::UnixStream::connect(socket),
-        )
-        .await
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "connect ntpd-rs observe socket"))??;
-        let mut message = Vec::with_capacity(16 * 1024);
-        let observable = tokio::time::timeout(
-            NTPD_RS_OBSERVE_TIMEOUT,
-            ntp_daemon::sockets::read_json::<ntp_daemon::ObservableState>(
-                &mut stream,
-                &mut message,
-            ),
-        )
-        .await
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "read ntpd-rs observable state"))??;
-        serde_json::to_value(observable)
-            .map_err(|err| io::Error::other(format!("serialize ntpd-rs observable state: {err}")))
-    })
-}
-
-#[cfg(not(unix))]
-fn ntpd_rs_observable_state_value(_socket: &Path) -> io::Result<Value> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "ntpd-rs observation sockets require unix domain socket support",
-    ))
-}
-
-fn first_numeric_field(value: &Value, names: &[&str]) -> Option<f64> {
-    match value {
-        Value::Object(map) => {
-            for (key, candidate) in map {
-                let normalized = key.replace('-', "_").to_ascii_lowercase();
-                if names.iter().any(|name| normalized.contains(name)) {
-                    if let Some(number) = candidate.as_f64() {
-                        return Some(number);
-                    }
-                }
-            }
-            map.values()
-                .find_map(|candidate| first_numeric_field(candidate, names))
-        }
-        Value::Array(values) => values
-            .iter()
-            .find_map(|candidate| first_numeric_field(candidate, names)),
-        _ => None,
-    }
-}
-
-fn ntpd_rs_status_output(command: &str) -> std::io::Result<Output> {
-    let mut child = Command::new(command)
-        .arg("status")
-        .arg("--format")
-        .arg("prometheus")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    let deadline = Instant::now() + NTPD_RS_CTL_TIMEOUT;
-    loop {
-        if child.try_wait()?.is_some() {
-            return child.wait_with_output();
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "ntpd-rs status probe timed out",
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
-
+#[cfg(test)]
 pub(super) fn ntpd_rs_command_label(command: &str) -> String {
     if command.starts_with("ntp_daemon::ObservableState:") {
         "ntp_daemon_observable_state".to_string()
     } else if command == "ntp-ctl"
-        || Path::new(command)
+        || std::path::Path::new(command)
             .file_name()
             .and_then(|name| name.to_str())
             == Some("ntp-ctl")
@@ -523,13 +434,6 @@ pub(super) fn ntpd_rs_command_label(command: &str) -> String {
     } else {
         "custom_ntp_ctl".to_string()
     }
-}
-
-fn first_non_empty_line(raw: &str) -> Option<String> {
-    raw.lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(ToString::to_string)
 }
 
 pub(super) fn sanitize_probe_summary(raw: &str) -> String {

--- a/adl/src/chronosense/tests.rs
+++ b/adl/src/chronosense/tests.rs
@@ -337,41 +337,26 @@ Servers:
 }
 
 #[test]
-fn ntpd_rs_observable_state_projects_in_process_runtime_health() {
-    let status = super::service::chronosense_time_sync_status_from_ntpd_rs_observable_value(
-        &serde_json::json!({
-            "system": {
-                "time_snapshot": {
-                    "offset": 0.000031,
-                    "uncertainty": 0.000142
-                }
-            },
-            "peers": [
-                {
-                    "Observable": {
-                        "address": "time.example.invalid:123",
-                        "reachability": 255,
-                        "offset": 0.000031
-                    }
-                }
-            ],
-            "servers": []
-        }),
-        "ntp_daemon_observable_state",
+fn runtime_sntp_sample_projects_in_process_time_health_without_socket_or_shell() {
+    let status = super::service::chronosense_time_sync_status_from_sntp_sample(
+        "time.example.invalid",
+        0.000031,
+        0.000142,
     );
 
     assert_eq!(status.schema_version, CHRONOSENSE_TIME_SYNC_STATUS_SCHEMA);
-    assert_eq!(status.substrate, "ntpd-rs");
+    assert_eq!(status.substrate, "SNTP");
     assert_eq!(
         status.source,
-        "ntp-daemon::ObservableState observation socket"
+        "rsntp::AsyncSntpClient in-process runtime sampler"
     );
-    assert_eq!(status.mode, "csm_in_process_ntpd_rs_observable_state");
+    assert_eq!(status.mode, "csm_in_process_async_sntp_client");
     assert_eq!(status.health, "synced");
     assert_eq!(status.confidence, "high");
+    assert_eq!(status.poll_command, "rsntp::AsyncSntpClient");
     assert_eq!(
         status.port_policy,
-        "csm_in_process_ntpd_rs_component_no_separate_binary_no_csm_udp_123_listener"
+        "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout"
     );
     assert_eq!(status.parsed_offset_seconds, Some(0.000031));
     assert_eq!(status.parsed_uncertainty_seconds, Some(0.000142));
@@ -406,35 +391,36 @@ fn ntpd_rs_status_projection_sanitizes_probe_command_and_summary() {
         "custom_ntp_ctl"
     );
     assert_eq!(
-        super::service::ntpd_rs_command_label("ntp_daemon::ObservableState:/run/ntpd-rs/observe"),
-        "ntp_daemon_observable_state"
-    );
-    assert_eq!(
         super::service::sanitize_probe_summary("failed opening /Users/daniel/.config/secret"),
         "[redacted]"
     );
 }
 
 #[test]
-fn disabled_ntpd_rs_probe_reports_runtime_observable_contract() {
+fn disabled_sntp_probe_reports_runtime_sntp_contract() {
     let status = super::service::ChronosenseTimeSyncStatus::unavailable(
-        "ntpd_rs_probe_disabled",
-        "ADL_CSM_NTPD_RS_STATUS=0",
+        "runtime_sntp_probe_disabled",
+        "ADL_CSM_SNTP_STATUS=0",
         None,
     );
 
+    assert_eq!(status.substrate, "SNTP");
     assert_eq!(
         status.source,
-        "ntp-daemon::ObservableState observation socket"
+        "rsntp::AsyncSntpClient in-process runtime sampler"
     );
-    assert_eq!(status.mode, "csm_ntpd_rs_observable_state");
+    assert_eq!(status.mode, "csm_in_process_async_sntp_client");
     assert_eq!(
         status.port_policy,
-        "csm_ntpd_rs_component_observation_no_separate_csm_time_binary_no_csm_udp_123_listener"
+        "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout"
     );
     assert_eq!(
         status.failure_state.as_deref(),
-        Some("ntpd_rs_probe_disabled")
+        Some("runtime_sntp_probe_disabled")
+    );
+    assert_eq!(
+        status.reason,
+        "runtime_sntp_status_unavailable_without_csm_failure"
     );
 }
 

--- a/adl/src/csm_networking.rs
+++ b/adl/src/csm_networking.rs
@@ -24,7 +24,6 @@ pub const CSM_POOL_STATUS_SCHEMA: &str = "adl.csm.connection_pool_status.v1";
 pub enum CsmListenerRole {
     MainRuntimeApi,
     ApiGatewayBridge,
-    ChronosenseNtp,
     OTelCollector,
     LocalTestHarness,
     FutureServiceListener,
@@ -35,7 +34,6 @@ impl CsmListenerRole {
         match self {
             Self::MainRuntimeApi => "main_runtime_api",
             Self::ApiGatewayBridge => "api_gateway_bridge",
-            Self::ChronosenseNtp => "chronosense_ntp",
             Self::OTelCollector => "otel_collector",
             Self::LocalTestHarness => "local_test_harness",
             Self::FutureServiceListener => "future_service_listener",
@@ -294,13 +292,6 @@ pub fn csm_listener_registry_json() -> Value {
                 "temporary_allocation_allowed": false
             },
             {
-                "role": CsmListenerRole::ChronosenseNtp.as_str(),
-                "default_bind": "123/udp boundary owned by 5041",
-                "ownership": "chronosense_boundary",
-                "consumers": ["time_sync"],
-                "temporary_allocation_allowed": false
-            },
-            {
                 "role": CsmListenerRole::OTelCollector.as_str(),
                 "default_bind": "collector_configured_endpoint",
                 "ownership": "observability_pipeline",
@@ -320,7 +311,12 @@ pub fn csm_listener_registry_json() -> Value {
             {"port": 8443, "role": "future_local_tls_dev_gateway", "owner": "unimplemented_future_listener"},
             {"port": 22, "role": "ssh_admin", "owner": "host_or_cloud_provider"},
             {"port": 2222, "role": "alternate_ssh_dev", "owner": "host_or_cloud_provider"},
-            {"port": 123, "role": "ntp", "owner": "chronosense_boundary"},
+            {
+                "port": 123,
+                "role": "external_ntp_servers",
+                "owner": "external_time_sources",
+                "csm_policy": "chronosense_uses_rsntp_async_sntp_client_with_ephemeral_outbound_udp_no_csm_listener"
+            },
             {"port": Value::Null, "role": "eventbridge_sns_sqs", "owner": "aws_control_plane_no_local_listener"}
         ]
     })
@@ -444,6 +440,26 @@ mod tests {
             .to_string()
             .contains("reserved for the CSM main runtime API"));
         assert!(reject_temp_allocation_port(20001).is_ok());
+    }
+
+    #[test]
+    fn networking_registry_does_not_advertise_chronosense_udp_listener() {
+        let registry = csm_listener_registry_json();
+        let listeners = registry["listeners"].as_array().expect("listeners");
+        assert!(!listeners
+            .iter()
+            .any(|listener| listener["role"] == "chronosense_ntp"));
+        let ntp_boundary = registry["external_boundaries"]
+            .as_array()
+            .expect("external boundaries")
+            .iter()
+            .find(|boundary| boundary["port"] == 123)
+            .expect("external NTP boundary");
+        assert_eq!(ntp_boundary["role"], "external_ntp_servers");
+        assert_eq!(
+            ntp_boundary["csm_policy"],
+            "chronosense_uses_rsntp_async_sntp_client_with_ephemeral_outbound_udp_no_csm_listener"
+        );
     }
 
     #[test]

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -278,15 +278,15 @@ fn chronosense_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions
     let time_sync = chronosense.get("time_sync").cloned().unwrap_or_else(|| {
         json!({
             "schema_version": "chronosense_time_sync_status.v1",
-            "substrate": "ntpd-rs",
-            "source": "ntp-daemon::ObservableState observation socket",
-            "mode": "csm_ntpd_rs_observable_state",
+            "substrate": "SNTP",
+            "source": "rsntp::AsyncSntpClient in-process runtime sampler",
+            "mode": "csm_in_process_async_sntp_client",
             "health": "unknown",
             "confidence": "none",
             "drift_status": "unknown",
             "failure_state": "chronosense_time_sync_missing",
             "reason": "daemon_status_missing_chronosense_time_sync",
-            "port_policy": "csm_ntpd_rs_component_observation_no_separate_csm_time_binary_no_csm_udp_123_listener"
+            "port_policy": "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout"
         })
     });
     let response = json!({
@@ -914,12 +914,7 @@ fn time_sync_blocks_ready(health: &str, failure_state: &Value) -> bool {
     }
     !matches!(
         failure_state.as_str(),
-        Some(
-            "ntpd_rs_probe_disabled"
-                | "ntpd_rs_observation_socket_missing"
-                | "ntpd_rs_observation_socket_refused"
-                | "ntpd_rs_observation_socket_unavailable"
-        )
+        Some("ntpd_rs_probe_disabled" | "runtime_sntp_probe_disabled")
     )
 }
 
@@ -1449,10 +1444,10 @@ memory: {}
                         "status": "integrated",
                         "time_sync": {
                             "schema_version": "chronosense_time_sync_status.v1",
-                            "substrate": "ntpd-rs",
+                            "substrate": "SNTP",
                             "health": "unavailable",
-                            "failure_state": "ntpd_rs_probe_disabled",
-                            "reason": "ntpd_rs_status_unavailable_without_csm_failure"
+                            "failure_state": "runtime_sntp_probe_disabled",
+                            "reason": "runtime_sntp_status_unavailable_without_csm_failure"
                         }
                     }
                 }
@@ -1816,7 +1811,7 @@ memory: {}
     }
 
     #[test]
-    fn runtime_api_exposes_chronosense_ntpd_rs_observable_state_projection() {
+    fn runtime_api_exposes_chronosense_async_sntp_projection() {
         let root = temp_root("chronosense");
         let spec = write_spec(&root);
         let state = root.join("state");
@@ -1837,20 +1832,20 @@ memory: {}
                         "clock_stack_capture": "daemon_event_time",
                         "time_sync": {
                             "schema_version": "chronosense_time_sync_status.v1",
-                            "substrate": "ntpd-rs",
-                            "source": "ntp-daemon::ObservableState observation socket",
-                            "mode": "csm_in_process_ntpd_rs_observable_state",
+                            "substrate": "SNTP",
+                            "source": "rsntp::AsyncSntpClient in-process runtime sampler",
+                            "mode": "csm_in_process_async_sntp_client",
                             "health": "synced",
                             "confidence": "high",
-                            "drift_status": "within_ntpd_rs_reported_bounds",
+                            "drift_status": "within_sntp_reported_bounds",
                             "failure_state": null,
-                            "reason": "ntpd_rs_observable_state_reports_active_sources",
+                            "reason": "runtime_sntp_client_reports_active_source",
                             "observed_at_rfc3339": Utc::now(),
-                            "poll_command": "ntp_daemon_observable_state",
-                            "port_policy": "csm_in_process_ntpd_rs_component_no_separate_binary_no_csm_udp_123_listener",
+                            "poll_command": "rsntp::AsyncSntpClient",
+                            "port_policy": "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout",
                             "parsed_offset_seconds": 0.000024,
                             "parsed_uncertainty_seconds": 0.000137,
-                            "raw_summary": "observable_peer_count=1"
+                            "raw_summary": "peer=time.example.invalid"
                         }
                     }
                 }
@@ -1878,19 +1873,19 @@ memory: {}
         let response = runtime_api_response(&options, "/chronosense").unwrap();
 
         assert_eq!(response["schema"], CSM_RUNTIME_API_CHRONOSENSE_SCHEMA);
-        assert_eq!(response["time_sync"]["substrate"], "ntpd-rs");
+        assert_eq!(response["time_sync"]["substrate"], "SNTP");
         assert_eq!(
             response["time_sync"]["source"],
-            "ntp-daemon::ObservableState observation socket"
+            "rsntp::AsyncSntpClient in-process runtime sampler"
         );
         assert_eq!(
             response["time_sync"]["mode"],
-            "csm_in_process_ntpd_rs_observable_state"
+            "csm_in_process_async_sntp_client"
         );
         assert_eq!(response["time_sync"]["health"], "synced");
         assert_eq!(
             response["time_sync"]["port_policy"],
-            "csm_in_process_ntpd_rs_component_no_separate_binary_no_csm_udp_123_listener"
+            "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout"
         );
         assert_eq!(response["ready"], "ready");
     }
@@ -1914,10 +1909,10 @@ memory: {}
                         "status": "integrated",
                         "time_sync": {
                             "schema_version": "chronosense_time_sync_status.v1",
-                            "substrate": "ntpd-rs",
+                            "substrate": "SNTP",
                             "health": "degraded",
-                            "failure_state": "ntpd_rs_observable_state_degraded",
-                            "reason": "ntpd_rs_observable_state_reports_degraded_sources"
+                            "failure_state": "runtime_sntp_sample_degraded",
+                            "reason": "runtime_sntp_client_reports_degraded_source"
                         }
                     }
                 }
@@ -2001,7 +1996,7 @@ memory: {}
     }
 
     #[test]
-    fn runtime_api_ready_does_not_block_absent_ntpd_rs_observation_socket() {
+    fn runtime_api_ready_blocks_absent_legacy_ntpd_rs_observation_socket() {
         let root = temp_root("chronosense-socket-missing");
         let spec = write_spec(&root);
         let state = root.join("state");
@@ -2049,8 +2044,8 @@ memory: {}
 
         let response = runtime_api_response(&options, "/ready").unwrap();
 
-        assert_eq!(response["ready"], "ready");
-        assert!(!response["blocking_reasons"]
+        assert_eq!(response["ready"], "not_ready");
+        assert!(response["blocking_reasons"]
             .as_array()
             .unwrap()
             .contains(&json!("chronosense_time_sync_unavailable")));

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -11,7 +11,8 @@ use std::thread;
 use std::time::Duration;
 
 use crate::chronosense::{
-    capture_ntpd_rs_time_sync_status, ChronosenseRuntimeService, ChronosenseRuntimeServiceConfig,
+    capture_runtime_time_sync_status, start_runtime_time_observation, ChronosenseRuntimeService,
+    ChronosenseRuntimeServiceConfig,
 };
 use crate::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 use crate::runtime_aws_signal::publish_csm_governed_notice_signal;
@@ -2692,11 +2693,12 @@ impl CsmRuntimeContext {
             started_at_epoch_ms,
         ))
         .context("failed initializing CSM Chronosense runtime service")?;
+        let _initial_time_sync = start_runtime_time_observation();
         Ok(Self { chronosense })
     }
 
     fn time_sync_status(&self) -> crate::chronosense::ChronosenseTimeSyncStatus {
-        capture_ntpd_rs_time_sync_status()
+        capture_runtime_time_sync_status()
     }
 }
 
@@ -2975,10 +2977,10 @@ fn csm_runtime_capabilities(runtime_context: &CsmRuntimeContext) -> Value {
             "service_schema": runtime_context.chronosense.config().schema_version,
             "clock_stack_schema": crate::chronosense::CHRONOSENSE_CLOCK_STACK_SCHEMA,
             "clock_stack_capture": "daemon_event_time",
-            "ntp_substrate": "ntpd-rs",
-            "ntp_process_model": "csm_in_process_component_no_separate_binary",
-            "ntp_primary_status_source": "ntp_daemon::ObservableState",
-            "ntp_compatibility_fallback": "ntp-ctl only when ADL_CSM_NTPD_RS_CTL_COMPAT=1",
+            "time_substrate": "SNTP",
+            "time_process_model": "csm_in_process_component_no_separate_binary",
+            "time_primary_status_source": "rsntp::AsyncSntpClient",
+            "time_compatibility_fallback": "none_in_runtime_path",
             "time_sync": runtime_context.time_sync_status()
         },
         "aee": {

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5098_CHRONOSENSE_RUNTIME_SNTP_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_5098_CHRONOSENSE_RUNTIME_SNTP_OWNER_LANE_DISPOSITION.yaml
@@ -1,0 +1,19 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 5098
+disposition: approved_with_runtime_owner_lane_proof
+changed_release_gate_surfaces:
+  - adl/Cargo.toml
+  - adl/src/chronosense.rs
+  - adl/src/chronosense/service.rs
+  - adl/src/chronosense/tests.rs
+  - adl/src/csm_networking.rs
+  - adl/src/csm_runtime_api.rs
+  - adl/src/long_lived_agent.rs
+reviewer_or_review_mode: bounded runtime owner-lane review
+focused_validation_run: bash adl/tools/run_owner_validation_lane.sh runtime
+residual_ci_proof_required_before_merge: required
+notes:
+  - "Validation manager escalated #5098 because the CSM Chronosense runtime change spans multiple shared Rust runtime surfaces."
+  - "Local owner proof passed: bash adl/tools/run_owner_validation_lane.sh runtime."
+  - "Focused proof also covered Chronosense tests, CSM networking registry, csm/adl binary build, live 127.0.0.1:19997 runtime API readiness, and /chronosense synced SNTP status."
+  - "GitHub PR checks remain required before merge."

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/README.md
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/README.md
@@ -1,0 +1,27 @@
+# Issue 5098 Chronosense Runtime Proof
+
+This packet retains the issue-local CSM runtime proof for the in-process
+Chronosense time observation path.
+
+- `service_status.json`: repo-native `csm service status` showing the CSM-owned
+  local supervisor and canonical runtime API listener on `127.0.0.1:19997`.
+- `process_pid.json`: permission-safe pid-file liveness probe for the CSM
+  service.
+- `process_port_19997.json`: permission-safe exact loopback port probe for the
+  embedded runtime API.
+- `status.json`: `/status` response from the running CSM API.
+- `ready.json`: `/ready` response from the running CSM API.
+- `chronosense.json`: `/chronosense` response showing SNTP health from
+  `rsntp::AsyncSntpClient` without a missing observation socket or shellout.
+- `disk.txt`: local disk snapshot retained because prior WP-07 runtime runs hit
+  ENOSPC.
+
+Observed proof highlights:
+
+- CSM runtime API is bound on the canonical local port `127.0.0.1:19997`.
+- Chronosense reports `substrate=SNTP`, `mode=csm_in_process_async_sntp_client`,
+  and `health=synced`.
+- CSM does not advertise a Chronosense UDP/123 listener; UDP/123 is recorded
+  only as an external NTP server boundary used by outbound SNTP sampling.
+- The sampled peer was `time.cloudflare.com`.
+- `/ready` reports `ready` with no blocking reasons.

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/chronosense.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/chronosense.json
@@ -1,0 +1,61 @@
+{
+  "agent_instance_id": "issue-5098-csm-runtime",
+  "clock_stack": "chronosense_clock_stack.v1",
+  "monotonic_runtime": {
+    "clock_stack_capture": "daemon_event_time",
+    "reference_frames": [
+      "utc_epoch_millis",
+      "local_civil_time",
+      "runtime_lifetime",
+      "runtime_monotonic_elapsed"
+    ]
+  },
+  "ready": "ready",
+  "runtime_owner": "csm",
+  "schema": "adl.csm.runtime_api.chronosense.v1",
+  "service": {
+    "clock_stack_capture": "daemon_event_time",
+    "clock_stack_schema": "chronosense_clock_stack.v1",
+    "service_schema": "chronosense_runtime_service.v1",
+    "status": "integrated",
+    "time_compatibility_fallback": "none_in_runtime_path",
+    "time_primary_status_source": "rsntp::AsyncSntpClient",
+    "time_process_model": "csm_in_process_component_no_separate_binary",
+    "time_substrate": "SNTP",
+    "time_sync": {
+      "confidence": "high",
+      "drift_status": "within_sntp_reported_bounds",
+      "failure_state": null,
+      "health": "synced",
+      "mode": "csm_in_process_async_sntp_client",
+      "observed_at_rfc3339": "2026-07-10T08:55:59.620038+00:00",
+      "parsed_offset_seconds": 0.03319374565035105,
+      "parsed_uncertainty_seconds": 0.010599727975204589,
+      "poll_command": "rsntp::AsyncSntpClient",
+      "port_policy": "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout",
+      "raw_summary": "peer=time.cloudflare.com",
+      "reason": "runtime_sntp_client_reports_active_source",
+      "schema_version": "chronosense_time_sync_status.v1",
+      "source": "rsntp::AsyncSntpClient in-process runtime sampler",
+      "substrate": "SNTP"
+    }
+  },
+  "status": "healthy",
+  "time_sync": {
+    "confidence": "high",
+    "drift_status": "within_sntp_reported_bounds",
+    "failure_state": null,
+    "health": "synced",
+    "mode": "csm_in_process_async_sntp_client",
+    "observed_at_rfc3339": "2026-07-10T08:55:59.620038+00:00",
+    "parsed_offset_seconds": 0.03319374565035105,
+    "parsed_uncertainty_seconds": 0.010599727975204589,
+    "poll_command": "rsntp::AsyncSntpClient",
+    "port_policy": "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout",
+    "raw_summary": "peer=time.cloudflare.com",
+    "reason": "runtime_sntp_client_reports_active_source",
+    "schema_version": "chronosense_time_sync_status.v1",
+    "source": "rsntp::AsyncSntpClient in-process runtime sampler",
+    "substrate": "SNTP"
+  }
+}

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/disk.txt
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/disk.txt
@@ -1,0 +1,2 @@
+Filesystem      Size    Used   Avail Capacity iused ifree %iused  Mounted on
+/dev/disk3s5   926Gi   766Gi   101Gi    89%     11M  1.1G    1%   /System/Volumes/Data

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_pid.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_pid.json
@@ -1,0 +1,12 @@
+{
+  "schema": "adl.process_status.v1",
+  "check": "pid_file",
+  "status": "live_pid",
+  "pid": 31953,
+  "host": null,
+  "port": null,
+  "safe_order": "metadata_or_exact_target_first",
+  "broad_process_scan": false,
+  "uses_ps": false,
+  "note": "known pid responded to a bounded liveness probe"
+}

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_port_19997.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_port_19997.json
@@ -1,0 +1,12 @@
+{
+  "schema": "adl.process_status.v1",
+  "check": "port",
+  "status": "bound_port",
+  "pid": null,
+  "host": "127.0.0.1",
+  "port": 19997,
+  "safe_order": "metadata_or_exact_target_first",
+  "broad_process_scan": false,
+  "uses_ps": false,
+  "note": "exact TCP connect probe reached a loopback service"
+}

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/ready.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/ready.json
@@ -1,0 +1,7 @@
+{
+  "agent_instance_id": "issue-5098-csm-runtime",
+  "blocking_reasons": [],
+  "ready": "ready",
+  "runtime_owner": "csm",
+  "schema": "adl.csm.runtime_api.ready.v1"
+}

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/service_status.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/service_status.json
@@ -1,0 +1,261 @@
+{
+  "schema": "adl.csm.service_status.v1",
+  "label": "com.agentlogic.csm.issue5098",
+  "manager": "local",
+  "runtime_owner": "csm",
+  "restart_policy": "always",
+  "service_mode": "rust_supervisor",
+  "service_state": "observed",
+  "pid": 31953,
+  "pid_liveness": "live_pid",
+  "broad_process_scan": false,
+  "uses_ps": false,
+  "manifest_ref": "service_manifest.json",
+  "plist_ref": "csm.launchd.plist",
+  "daemon_status_ref": "../state/daemon_status.json",
+  "continuity_checkpoint_ref": "../state/continuity_checkpoint.json",
+  "observability_log_ref": "logs/observability.log",
+  "otel_log_ref": "logs/otel.jsonl",
+  "otel_status_ref": "logs/otel_status.json",
+  "startup_ledger_ref": "logs/startup_ledger.jsonl",
+  "network_registry": {
+    "active_listener": {
+      "bind_addr": "127.0.0.1:19997",
+      "canonical": true,
+      "configured_by": "explicit_override",
+      "listener_role": "main_runtime_api",
+      "remediation_hint": "free 127.0.0.1:19997 or pass an explicit reserved CSM port override",
+      "reserved_range": "19950-19999",
+      "schema": "adl.csm.networking.v1",
+      "test_ephemeral_reason": null
+    },
+    "registry": {
+      "external_boundaries": [
+        {
+          "owner": "external_or_gateway",
+          "port": 443,
+          "role": "public_tls_or_aws_api_gateway"
+        },
+        {
+          "owner": "unimplemented_future_listener",
+          "port": 8443,
+          "role": "future_local_tls_dev_gateway"
+        },
+        {
+          "owner": "host_or_cloud_provider",
+          "port": 22,
+          "role": "ssh_admin"
+        },
+        {
+          "owner": "host_or_cloud_provider",
+          "port": 2222,
+          "role": "alternate_ssh_dev"
+        },
+        {
+          "csm_policy": "chronosense_uses_rsntp_async_sntp_client_with_ephemeral_outbound_udp_no_csm_listener",
+          "owner": "external_time_sources",
+          "port": 123,
+          "role": "external_ntp_servers"
+        },
+        {
+          "owner": "aws_control_plane_no_local_listener",
+          "port": null,
+          "role": "eventbridge_sns_sqs"
+        }
+      ],
+      "listeners": [
+        {
+          "consumers": [
+            "local_operator",
+            "api_gateway_bridge"
+          ],
+          "default_bind": "127.0.0.1:19997",
+          "ownership": "csm",
+          "role": "main_runtime_api",
+          "temporary_allocation_allowed": false
+        },
+        {
+          "consumers": [
+            "aws_api_gateway_bridge"
+          ],
+          "default_bind": "not_bound_by_5040",
+          "ownership": "csm_runtime_side_contract_for_5039",
+          "role": "api_gateway_bridge",
+          "temporary_allocation_allowed": false
+        },
+        {
+          "consumers": [
+            "otel_export"
+          ],
+          "default_bind": "collector_configured_endpoint",
+          "ownership": "observability_pipeline",
+          "role": "otel_collector",
+          "temporary_allocation_allowed": false
+        },
+        {
+          "consumers": [
+            "unit_tests",
+            "cli_smoke"
+          ],
+          "default_bind": "127.0.0.1:0 only with explicit test flags",
+          "ownership": "bounded_test_infrastructure",
+          "role": "local_test_harness",
+          "temporary_allocation_allowed": true
+        }
+      ],
+      "loopback_host": "127.0.0.1",
+      "reserved_local_range": "19950-19999",
+      "schema": "adl.csm.networking.v1"
+    }
+  },
+  "connection_pooling_plan": {
+    "decision_summary": "CSM runtime pooling uses the deadpool crate for governed bounded resource-slot mechanics; protocol-specific clients may still perform native reuse inside checked-out deadpool slots.",
+    "default_capacity": 4,
+    "default_status": {
+      "available": 4,
+      "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+      "max_size": 4,
+      "pool_backend": "deadpool::unmanaged",
+      "pool_crate": "deadpool",
+      "role": "database_or_lifelog_connections",
+      "schema": "adl.csm.connection_pool_status.v1",
+      "size": 4,
+      "waiting": 0
+    },
+    "pool_backend": "deadpool::unmanaged",
+    "pool_crate": "deadpool",
+    "pool_event_contract": {
+      "events": [
+        "pool_configured",
+        "pool_exhausted",
+        "pool_recovered",
+        "client_reused"
+      ],
+      "required_fields": [
+        "role",
+        "event",
+        "capacity_or_limit",
+        "remediation_hint"
+      ]
+    },
+    "roles": [
+      {
+        "decision": "use_deadpool_for_governed_client_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with http_clients role and retry/backpressure context",
+        "role": "http_clients",
+        "strategy": "deadpool-bounded runtime owner slots hold reusable reqwest/hyper clients; protocol-native HTTP reuse remains inside each checked-out slot"
+      },
+      {
+        "decision": "use_deadpool_for_governed_aws_client_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with aws_sdk_clients role and throttle/remediation context",
+        "role": "aws_sdk_clients",
+        "strategy": "deadpool-bounded runtime owner slots hold reusable AWS SDK clients/config per account/profile/region"
+      },
+      {
+        "decision": "use_deadpool_bounded_pool_for_connection_slots",
+        "exhaustion_signal": "emit pool_exhausted with role and remediation hint",
+        "role": "database_or_lifelog_connections",
+        "strategy": "deadpool::unmanaged bounded pool owns concrete database/lifelog connection slots"
+      },
+      {
+        "decision": "use_deadpool_for_export_sink_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with otel_export_sinks role",
+        "role": "otel_export_sinks",
+        "strategy": "deadpool-bounded exporter slots feed bounded batch/export queues with explicit timeout"
+      },
+      {
+        "decision": "use_deadpool_for_internal_channel_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with channel_backpressure and safe_fail_action",
+        "role": "internal_citizen_polis_channels",
+        "strategy": "deadpool-bounded channel endpoint slots with named capacity and safe-fail policy"
+      }
+    ],
+    "schema": "adl.csm.pooling_plan.v1"
+  },
+  "connection_pool_status": {
+    "event_contract": {
+      "configured": "pool_configured",
+      "exhausted": "pool_exhausted",
+      "recovered": "pool_recovered"
+    },
+    "pool_backend": "deadpool::unmanaged",
+    "pool_crate": "deadpool",
+    "roles": [
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "http_clients",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "aws_sdk_clients",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "database_or_lifelog_connections",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "otel_export_sinks",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "internal_citizen_polis_channels",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      }
+    ],
+    "runtime_owner": "csm",
+    "schema": "adl.csm.connection_pool_status.v1",
+    "status": "configured"
+  },
+  "startup_classification": "startup_runtime_ready",
+  "first_daemon_record_observed": true,
+  "continuity_checkpoint_observed": true,
+  "cycle_ledger_observed": true,
+  "runtime_api_observed": true,
+  "otlp_exporter_configured": false,
+  "otlp_endpoint_ref": null,
+  "last_action": "status",
+  "last_error": null,
+  "unsupported_permanence_claims": [
+    "host_reboot_survival_not_proven",
+    "kill_9_recovery_not_proven",
+    "disk_full_recovery_not_proven",
+    "resource_exhaustion_recovery_not_proven",
+    "cloud_orchestration_not_claimed"
+  ],
+  "updated_at": "2026-07-10T08:56:02.697390+00:00"
+}

--- a/docs/milestones/v0.91.7/review/runtime/chronosense_5098/status.json
+++ b/docs/milestones/v0.91.7/review/runtime/chronosense_5098/status.json
@@ -1,0 +1,369 @@
+{
+  "adl_role": "tooling_control_plane",
+  "aee_resilience": {
+    "failure_recovery": "permanent_restart_loop_with_checkpoint_restore",
+    "recoverable_states": [
+      "idle",
+      "completed",
+      "failed",
+      "stopped",
+      "leased"
+    ],
+    "status": "integrated"
+  },
+  "agent_instance_id": "issue-5098-csm-runtime",
+  "agent_status": {
+    "completed_cycle_count": 206,
+    "consecutive_failure_count": 0,
+    "last_cycle_id": "cycle-000206",
+    "last_cycle_status": "success",
+    "state": "idle",
+    "stop_requested": false,
+    "updated_at": "2026-07-10T08:55:59.533058Z"
+  },
+  "api_gateway_bridge": {
+    "artifact_owned_by": "csm_runtime_api",
+    "ingress_model": "one_api_gateway_api_per_polis",
+    "polis_id_hash": null,
+    "ref": "api_gateway_bridge_summary.json",
+    "runtime_api_path": "/api-gateway-bridge",
+    "runtime_identity_verified": null,
+    "runtime_owner": "csm",
+    "schema": null,
+    "status": "missing"
+  },
+  "backpressure": {
+    "ref": "csm_backpressure_state.json",
+    "safe_fail_action": null,
+    "schema": null,
+    "status": "missing",
+    "storage_pressure": null,
+    "summary": null
+  },
+  "checkpoint": {
+    "age_secs": 2,
+    "checkpoint_ref": "continuity_checkpoint.json",
+    "last_checkpoint_at": "2026-07-10T08:55:59.597054Z",
+    "status": "fresh"
+  },
+  "chronosense": {
+    "clock_stack_capture": "daemon_event_time",
+    "clock_stack_schema": "chronosense_clock_stack.v1",
+    "service_schema": "chronosense_runtime_service.v1",
+    "status": "integrated",
+    "time_compatibility_fallback": "none_in_runtime_path",
+    "time_primary_status_source": "rsntp::AsyncSntpClient",
+    "time_process_model": "csm_in_process_component_no_separate_binary",
+    "time_substrate": "SNTP",
+    "time_sync": {
+      "confidence": "high",
+      "drift_status": "within_sntp_reported_bounds",
+      "failure_state": null,
+      "health": "synced",
+      "mode": "csm_in_process_async_sntp_client",
+      "observed_at_rfc3339": "2026-07-10T08:55:59.620038+00:00",
+      "parsed_offset_seconds": 0.03319374565035105,
+      "parsed_uncertainty_seconds": 0.010599727975204589,
+      "poll_command": "rsntp::AsyncSntpClient",
+      "port_policy": "csm_in_process_async_sntp_client_ephemeral_udp_no_csm_udp_123_listener_no_shellout",
+      "raw_summary": "peer=time.cloudflare.com",
+      "reason": "runtime_sntp_client_reports_active_source",
+      "schema_version": "chronosense_time_sync_status.v1",
+      "source": "rsntp::AsyncSntpClient in-process runtime sampler",
+      "substrate": "SNTP"
+    }
+  },
+  "connection_pool_status": {
+    "event_contract": {
+      "configured": "pool_configured",
+      "exhausted": "pool_exhausted",
+      "recovered": "pool_recovered"
+    },
+    "pool_backend": "deadpool::unmanaged",
+    "pool_crate": "deadpool",
+    "roles": [
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "http_clients",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "aws_sdk_clients",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "database_or_lifelog_connections",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "otel_export_sinks",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      },
+      {
+        "available": 4,
+        "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+        "max_size": 4,
+        "pool_backend": "deadpool::unmanaged",
+        "pool_crate": "deadpool",
+        "role": "internal_citizen_polis_channels",
+        "schema": "adl.csm.connection_pool_status.v1",
+        "size": 4,
+        "waiting": 0
+      }
+    ],
+    "runtime_owner": "csm",
+    "schema": "adl.csm.connection_pool_status.v1",
+    "status": "configured"
+  },
+  "continuity": {
+    "checkpoint": {
+      "ref": "continuity_checkpoint.json",
+      "safe_fail_action": null,
+      "schema": "adl.long_lived_agent_continuity_checkpoint.v1",
+      "status": "serialized",
+      "storage_pressure": null,
+      "summary": null
+    },
+    "replay_manifest": {
+      "ref": "continuity_replay_manifest.json",
+      "safe_fail_action": null,
+      "schema": "adl.long_lived_agent_continuity_replay_manifest.v1",
+      "status": "serialized",
+      "storage_pressure": null,
+      "summary": null
+    },
+    "safe_fail_bundle": {
+      "ref": "safe_fail_bundle.json",
+      "safe_fail_action": null,
+      "schema": "adl.csm.safe_fail_bundle.v1",
+      "status": "serialized",
+      "storage_pressure": null,
+      "summary": null
+    }
+  },
+  "daemon_liveness": {
+    "last_event": "child_exit",
+    "state": "running",
+    "status": "observed",
+    "supervisor_pid_liveness": "live_pid",
+    "updated_at": "2026-07-10T08:55:59.597054Z"
+  },
+  "events": {
+    "bytes": 3756422,
+    "ref": "operator_events.jsonl",
+    "status": "retained"
+  },
+  "networking": {
+    "external_boundaries": [
+      {
+        "owner": "external_or_gateway",
+        "port": 443,
+        "role": "public_tls_or_aws_api_gateway"
+      },
+      {
+        "owner": "unimplemented_future_listener",
+        "port": 8443,
+        "role": "future_local_tls_dev_gateway"
+      },
+      {
+        "owner": "host_or_cloud_provider",
+        "port": 22,
+        "role": "ssh_admin"
+      },
+      {
+        "owner": "host_or_cloud_provider",
+        "port": 2222,
+        "role": "alternate_ssh_dev"
+      },
+      {
+        "csm_policy": "chronosense_uses_rsntp_async_sntp_client_with_ephemeral_outbound_udp_no_csm_listener",
+        "owner": "external_time_sources",
+        "port": 123,
+        "role": "external_ntp_servers"
+      },
+      {
+        "owner": "aws_control_plane_no_local_listener",
+        "port": null,
+        "role": "eventbridge_sns_sqs"
+      }
+    ],
+    "listeners": [
+      {
+        "consumers": [
+          "local_operator",
+          "api_gateway_bridge"
+        ],
+        "default_bind": "127.0.0.1:19997",
+        "ownership": "csm",
+        "role": "main_runtime_api",
+        "temporary_allocation_allowed": false
+      },
+      {
+        "consumers": [
+          "aws_api_gateway_bridge"
+        ],
+        "default_bind": "not_bound_by_5040",
+        "ownership": "csm_runtime_side_contract_for_5039",
+        "role": "api_gateway_bridge",
+        "temporary_allocation_allowed": false
+      },
+      {
+        "consumers": [
+          "otel_export"
+        ],
+        "default_bind": "collector_configured_endpoint",
+        "ownership": "observability_pipeline",
+        "role": "otel_collector",
+        "temporary_allocation_allowed": false
+      },
+      {
+        "consumers": [
+          "unit_tests",
+          "cli_smoke"
+        ],
+        "default_bind": "127.0.0.1:0 only with explicit test flags",
+        "ownership": "bounded_test_infrastructure",
+        "role": "local_test_harness",
+        "temporary_allocation_allowed": true
+      }
+    ],
+    "loopback_host": "127.0.0.1",
+    "reserved_local_range": "19950-19999",
+    "schema": "adl.csm.networking.v1"
+  },
+  "otel": {
+    "log": {
+      "bytes": 1056754,
+      "ref": "ADL_OTEL_LOG",
+      "status": "retained"
+    },
+    "status": {
+      "ref": "ADL_OTEL_STATUS",
+      "safe_fail_action": null,
+      "schema": "adl.otel.monitor_status.v1",
+      "status": "serialized",
+      "storage_pressure": null,
+      "summary": null
+    }
+  },
+  "pooling_plan": {
+    "decision_summary": "CSM runtime pooling uses the deadpool crate for governed bounded resource-slot mechanics; protocol-specific clients may still perform native reuse inside checked-out deadpool slots.",
+    "default_capacity": 4,
+    "default_status": {
+      "available": 4,
+      "exhaustion_signal": "emit pool_exhausted with role, capacity, available, waiting, and remediation hint",
+      "max_size": 4,
+      "pool_backend": "deadpool::unmanaged",
+      "pool_crate": "deadpool",
+      "role": "database_or_lifelog_connections",
+      "schema": "adl.csm.connection_pool_status.v1",
+      "size": 4,
+      "waiting": 0
+    },
+    "pool_backend": "deadpool::unmanaged",
+    "pool_crate": "deadpool",
+    "pool_event_contract": {
+      "events": [
+        "pool_configured",
+        "pool_exhausted",
+        "pool_recovered",
+        "client_reused"
+      ],
+      "required_fields": [
+        "role",
+        "event",
+        "capacity_or_limit",
+        "remediation_hint"
+      ]
+    },
+    "roles": [
+      {
+        "decision": "use_deadpool_for_governed_client_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with http_clients role and retry/backpressure context",
+        "role": "http_clients",
+        "strategy": "deadpool-bounded runtime owner slots hold reusable reqwest/hyper clients; protocol-native HTTP reuse remains inside each checked-out slot"
+      },
+      {
+        "decision": "use_deadpool_for_governed_aws_client_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with aws_sdk_clients role and throttle/remediation context",
+        "role": "aws_sdk_clients",
+        "strategy": "deadpool-bounded runtime owner slots hold reusable AWS SDK clients/config per account/profile/region"
+      },
+      {
+        "decision": "use_deadpool_bounded_pool_for_connection_slots",
+        "exhaustion_signal": "emit pool_exhausted with role and remediation hint",
+        "role": "database_or_lifelog_connections",
+        "strategy": "deadpool::unmanaged bounded pool owns concrete database/lifelog connection slots"
+      },
+      {
+        "decision": "use_deadpool_for_export_sink_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with otel_export_sinks role",
+        "role": "otel_export_sinks",
+        "strategy": "deadpool-bounded exporter slots feed bounded batch/export queues with explicit timeout"
+      },
+      {
+        "decision": "use_deadpool_for_internal_channel_slot_capacity",
+        "exhaustion_signal": "emit pool_exhausted with channel_backpressure and safe_fail_action",
+        "role": "internal_citizen_polis_channels",
+        "strategy": "deadpool-bounded channel endpoint slots with named capacity and safe-fail policy"
+      }
+    ],
+    "schema": "adl.csm.pooling_plan.v1"
+  },
+  "ready": "ready",
+  "redaction": {
+    "absolute_host_paths": "not_returned",
+    "cloud_account_identifiers": "not_returned",
+    "secret_material": "not_returned"
+  },
+  "resilience_middleware": {
+    "lease_policy": "active_stale_recoverable_blocked",
+    "partial_checkpoints": "daemon_partial_checkpoint",
+    "restart_backoff": "bounded_exponential",
+    "safe_fail_serialization": "integrated_safe_fail_bundle",
+    "status": "integrated"
+  },
+  "runtime_owner": "csm",
+  "scheduler": {
+    "cadence_source": "heartbeat.interval_secs_or_daemon_default",
+    "partial_checkpoint_interval": "checkpoint_interval_secs",
+    "status": "integrated",
+    "stop_observation": "stop_json_checked_between_cycles_and_sleep_slices"
+  },
+  "schema": "adl.csm.runtime_api.status.v1",
+  "status": "healthy",
+  "uptime": {
+    "source": "daemon_status.started_at",
+    "started_at": "2026-07-10T08:39:57.535687Z",
+    "status": "observed",
+    "updated_at": "2026-07-10T08:55:59.597054Z",
+    "uptime_secs": 965
+  }
+}


### PR DESCRIPTION
Closes #5098

## Summary
Implemented the runtime-owned Chronosense time-observation path in CSM. The original ntp-daemon embedding attempt was rejected by live proof because it attempted host clock control and failed without clock-set privileges; the final runtime path uses `rsntp::AsyncSntpClient` as an in-process async SNTP sampler. CSM starts the time observation during runtime context initialization, exposes the result through `/status` and `/chronosense`, blocks `/ready` on missing/degraded time sync, and records UDP/123 as an external NTP server boundary rather than a CSM listener.

## Artifacts
- Tracked implementation artifacts:
  - `adl/Cargo.toml`
  - `adl/Cargo.lock`
  - `adl/src/chronosense.rs`
  - `adl/src/chronosense/service.rs`
  - `adl/src/chronosense/tests.rs`
  - `adl/src/csm_networking.rs`
  - `adl/src/csm_runtime_api.rs`
  - `adl/src/long_lived_agent.rs`
- Additional proof artifacts:
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/README.md`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/status.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/chronosense.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/ready.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/service_status.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_pid.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/process_port_19997.json`
  - `docs/milestones/v0.91.7/review/runtime/chronosense_5098/disk.txt`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Formatted Rust sources after implementation and review-finding repairs.`
  - `cargo test --manifest-path adl/Cargo.toml chronosense -- --nocapture`
    `Ran the focused Chronosense/runtime API test slice; result PASS with 56 matching tests.`
  - `cargo test --manifest-path adl/Cargo.toml csm_networking::tests::networking_registry_does_not_advertise_chronosense_udp_listener -- --nocapture`
    `Ran the focused networking-registry regression; result PASS.`
  - `cargo build --manifest-path adl/Cargo.toml --bin csm --bin adl`
    `Built the actual binaries used for the issue-local live runtime proof; result PASS.`
  - `./adl/target/debug/csm service start --service-root .adl/runtime/issue-5098-csm/service --json`
    `Verified the issue-local service reaches startup_runtime_ready.`
  - `./adl/target/debug/adl process status --port 19997 --host 127.0.0.1 --json`
    `Verified exact canonical port liveness; result bound_port.`
  - `curl -sS http://127.0.0.1:19997/chronosense`
    `Verified live SNTP status; result health=synced, source=rsntp::AsyncSntpClient, peer=time.cloudflare.com.`
  - `git diff --check`
    `Verified patch whitespace cleanliness.`
  - `bash adl/tools/run_owner_validation_lane.sh runtime`
    `Ran the runtime owner validation lane required by the validation manager; result PASS.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5098__v0-91-7-wp-07-runtime-chronosense-make-csm-own-embedded-ntpd-rs-time-observation/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5098__v0-91-7-wp-07-runtime-chronosense-make-csm-own-embedded-ntpd-rs-time-observation/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-chronosense-make-csm-own-embedded-sntp-time-observation-adl-v0-91-7-tasks-issue-5098-v0-91-7-wp-07-runtime-chronosense-make-csm-own-embedded-ntpd-rs-time-observation-sip-md-adl-v0-91-7-tasks-issue-5098-v0-91-7-wp-07-runtime-chronosense-make-csm-own-embedded-ntpd-rs-time-observation-sor-md