### PR TITLE
[v0.91.7][tools][cards] VPP bootstrap references missing PVF lane registry path

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -27,6 +27,9 @@ use ::adl::control_plane::{
     card_validation_plan_path, resolve_cards_root, IssueRef,
 };
 
+const VPP_LANE_REGISTRY_PATH: &str = "docs/validation/pvf_lanes.json";
+const VPP_LANE_REGISTRY_TEMPLATE_SET: &str = "vpp.lane.v1";
+
 pub(crate) fn ensure_task_bundle_stp(
     root: &Path,
     issue_ref: &IssueRef,
@@ -1799,11 +1802,11 @@ fn render_bootstrap_validation_plan_card(
             ("<spp_card>", spp_rel),
             ("<initial_pvf_lane>", initial_pvf_lane),
             ("<planned_pvf_lane>", planned_pvf_lane.clone()),
+            ("<lane_registry_path>", VPP_LANE_REGISTRY_PATH.to_string()),
             (
-                "<lane_registry_path>",
-                "docs/validation/pvf_lanes.json".to_string(),
+                "<lane_registry_template_set>",
+                VPP_LANE_REGISTRY_TEMPLATE_SET.to_string(),
             ),
-            ("<lane_registry_template_set>", "vpp.lane.v1".to_string()),
             (
                 "<validation_runtime_class>",
                 generated_vpp.validation_runtime_class,
@@ -2423,5 +2426,36 @@ mod tests {
         assert!(plan
             .notes_risks_inline
             .contains("escalation remains explicit"));
+    }
+
+    #[test]
+    fn generated_vpp_lane_registry_path_points_to_tracked_registry() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("cargo manifest dir should be under repo root");
+        let registry_path = repo_root.join(VPP_LANE_REGISTRY_PATH);
+        assert!(
+            registry_path.is_file(),
+            "generated VPP lane registry path must point to a tracked file: {}",
+            VPP_LANE_REGISTRY_PATH
+        );
+
+        let registry_text = fs::read_to_string(&registry_path)
+            .expect("generated VPP lane registry should be readable");
+        let registry: Value =
+            serde_json::from_str(&registry_text).expect("generated VPP lane registry is JSON");
+        assert_eq!(
+            registry.get("contract_version").and_then(Value::as_str),
+            Some(VPP_LANE_REGISTRY_TEMPLATE_SET)
+        );
+        let lane_ids: BTreeSet<_> = registry
+            .get("lanes")
+            .and_then(Value::as_array)
+            .expect("registry should contain lanes")
+            .iter()
+            .filter_map(|lane| lane.get("id").and_then(Value::as_str))
+            .collect();
+        assert!(lane_ids.contains("prompt_template"));
+        assert!(lane_ids.contains("needs_planning_lane_assignment"));
     }
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
@@ -1108,7 +1108,7 @@ fn real_pr_finish_promotes_green_unchanged_existing_pr_ready() {
     let server = tiny_http::Server::from_listener(listener, None).expect("validation server");
     let validation_handle = std::thread::spawn(move || {
         while let Some(mut request) = server
-            .recv_timeout(std::time::Duration::from_secs(5))
+            .recv_timeout(std::time::Duration::from_secs(60))
             .expect("validation server receive")
         {
             let mut body = String::new();

--- a/docs/milestones/v0.91.7/review/ISSUE_4987_SLOW_PR_CMD_E2E_DISPOSITION.yml
+++ b/docs/milestones/v0.91.7/review/ISSUE_4987_SLOW_PR_CMD_E2E_DISPOSITION.yml
@@ -1,0 +1,13 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 4987
+disposition: approved_with_focused_slow_lane_proof
+changed_release_gate_surfaces:
+  - adl/src/cli/pr_cmd_cards/cards.rs
+  - adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs
+reviewer_or_review_mode: bounded pre-PR review plus focused slow PR-command E2E proof
+focused_validation_run: cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_finish_promotes_green_unchanged_existing_pr_ready -- --nocapture
+residual_ci_proof_required_before_merge: required
+notes:
+  - The changed slow surface is a test-only mock timeout repair for an existing finish publication-flow test.
+  - The focused proof passed locally after rebasing on origin/main.
+  - GitHub CI remains required before merge.

--- a/docs/validation/pvf_lanes.json
+++ b/docs/validation/pvf_lanes.json
@@ -1,0 +1,50 @@
+{
+  "schema": "adl.pvf_lanes.v1",
+  "contract_version": "vpp.lane.v1",
+  "description": "Canonical lane-registry reference used by generated VPP cards. Detailed executable lane selection remains in adl/config/validation_lane_selector.v0.91.6.json.",
+  "source_registry": "adl/config/validation_lane_selector.v0.91.6.json",
+  "lanes": [
+    {
+      "id": "prompt_template",
+      "owner": "csdlc",
+      "proof_role": "prompt_template_contract",
+      "default_validation": "bash adl/tools/test_prompt_template_workflow_integration.sh"
+    },
+    {
+      "id": "tooling",
+      "owner": "tools",
+      "proof_role": "tooling_regression",
+      "default_validation": "bash adl/tools/run_owner_validation_lane.sh csdlc"
+    },
+    {
+      "id": "docs_only",
+      "owner": "docs",
+      "proof_role": "diff_hygiene",
+      "default_validation": "git diff --check"
+    },
+    {
+      "id": "owner_binary",
+      "owner": "tools",
+      "proof_role": "owner_binary_contract",
+      "default_validation": "bash adl/tools/test_owner_binary_install.sh"
+    },
+    {
+      "id": "runtime",
+      "owner": "runtime",
+      "proof_role": "runtime_regression",
+      "default_validation": "bash adl/tools/run_owner_validation_lane.sh runtime"
+    },
+    {
+      "id": "provider",
+      "owner": "provider",
+      "proof_role": "provider_regression",
+      "default_validation": "provider-specific acceptance proof"
+    },
+    {
+      "id": "needs_planning_lane_assignment",
+      "owner": "unassigned",
+      "proof_role": "fail_closed_planning_required",
+      "default_validation": "select a concrete validation lane before execution"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #4987

## Summary
Implemented the narrow VPP registry truth fix: generated VPP cards may keep referencing `docs/validation/pvf_lanes.json` because that path now exists as a tracked registry contract. The Rust VPP bootstrap renderer now uses a shared constant for the registry path/template-set pair, and a focused regression test fails if that generated path stops pointing at a readable registry.

## Artifacts
- Tracked implementation artifact: `docs/validation/pvf_lanes.json`
- Tracked implementation artifact: `adl/src/cli/pr_cmd_cards/cards.rs`
- Tracked validation-blocker repair: `adl/src/cli/tests/pr_cmd_inline/finish/publication/flow.rs`
- Tracked explicit slow-lane disposition: `docs/milestones/v0.91.7/review/ISSUE_4987_SLOW_PR_CMD_E2E_DISPOSITION.yml`
- Local output-card update: `.adl/v0.91.7/tasks/issue-4987__v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path/sor.md`
- Additional proof artifact: focused Rust regression `generated_vpp_lane_registry_path_points_to_tracked_registry`

## Validation
- Validation commands and their purpose:
  - `python3 -m json.tool docs/validation/pvf_lanes.json >/dev/null`
    `Verified the new registry is parseable JSON.`
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    `Verified Rust formatting.`
  - `cargo test --manifest-path adl/Cargo.toml generated_vpp_lane_registry_path_points_to_tracked_registry -- --nocapture`
    `Verified the generated VPP registry path points at a real registry and carries contract_version vpp.lane.v1.`
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`
    `Verified active prompt-template render/edit/import/schema workflow.`
  - `python3 adl/tools/test_prompt_template_structure_schemas.py --template-set 1.0.3`
    `Verified structure schema artifacts are Python-readable.`
  - `bash adl/tools/validate_structured_prompt.sh --type vpp --input .adl/v0.91.7/tasks/issue-4987__v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path/vpp.md`
    `Verified issue VPP structure.`
  - `git diff --check`
    `Verified whitespace hygiene.`
  - `git diff --cached --check`
    `Verified staged whitespace hygiene.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_finish_promotes_green_unchanged_existing_pr_ready -- --nocapture`
    `Verified the finish publication-flow mock timeout repair.`
- Results:
  - `python3 -m json.tool docs/validation/pvf_lanes.json >/dev/null`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --check`: PASS
  - `cargo test --manifest-path adl/Cargo.toml generated_vpp_lane_registry_path_points_to_tracked_registry -- --nocapture`: PASS
  - `bash adl/tools/test_prompt_template_workflow_integration.sh`: PASS
  - `python3 adl/tools/test_prompt_template_structure_schemas.py --template-set 1.0.3`: PASS
  - `bash adl/tools/validate_structured_prompt.sh --type vpp --input .adl/v0.91.7/tasks/issue-4987__v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path/vpp.md`: PASS
  - `git diff --check`: PASS
  - `git diff --cached --check`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --bin adl real_pr_finish_promotes_green_unchanged_existing_pr_ready -- --nocapture`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4987__v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4987__v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path/sor.md
- Idempotency-Key: v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path-adl-src-cli-pr-cmd-cards-cards-rs-adl-src-cli-tests-pr-cmd-inline-finish-publication-flow-rs-docs-milestones-v0-91-7-review-issue-4987-slow-pr-cmd-e2e-disposition-yml-docs-validation-pvf-lanes-json-adl-v0-91-7-tasks-issue-4987-v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path-sip-md-adl-v0-91-7-tasks-issue-4987-v0-91-7-tools-cards-vpp-bootstrap-references-missing-pvf-lane-registry-path-sor-md