### PR TITLE
[v0.91.7][tools][validation] Classify scheduler JSON fixture repairs into a runnable focused proof lane

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -1027,6 +1027,37 @@
       "reason": "provider_benchmark_helper_surface_requires_python_syntax_check"
     },
     {
+      "id": "scheduler_fixture_validation",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "tools",
+      "proof_role": "scheduler_fixture_contract",
+      "requirement_ids": [
+        "scheduler_fixture_validation"
+      ],
+      "path_selectors": [
+        "adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json",
+        "docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json"
+      ],
+      "path_hints": [
+        "adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json",
+        "docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json"
+      ],
+      "command": "cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics",
+      "run_command": "cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics",
+      "reason": "scheduler_fixture_and_retained_artifact_surface_requires_scheduler_contract_tests",
+      "vpp_record": {
+        "contract_version": "vpp.lane.v1",
+        "artifacts": [
+          "scheduler_fixture_contract_tests"
+        ],
+        "expected_runtime_class": "medium",
+        "parallel_group": "scheduler_validation",
+        "cache_equivalence_group": "cargo_scheduler_tests",
+        "failure_semantics": "fail_closed"
+      }
+    },
+    {
       "id": "docs_diff_check",
       "lane_class": "docs",
       "default_surface": "docs",

--- a/adl/tools/select_validation_lanes.py
+++ b/adl/tools/select_validation_lanes.py
@@ -355,6 +355,7 @@ def select_lanes(
         if matches(path, selectors_for(rust_entry))
         and not path.endswith("/README.md")
         and not path.endswith(".md")
+        and path != "adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json"
     ]
     if rust_paths:
         fast_plan = pr_fast_plan(changed_files, base, head)

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -100,6 +100,18 @@ assert_has "$TMP/remote-validation-tool.out" "aggregate_status=selected"
 assert_has "$TMP/remote-validation-tool.out" "ci_path_policy_contracts status=selected"
 assert_not_has "$TMP/remote-validation-tool.out" "unmapped_change_surface"
 
+scheduler_fixture_repair="$TMP/scheduler-fixture-repair.txt"
+cat >"$scheduler_fixture_repair" <<'EOF'
+M	adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json
+M	docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json
+EOF
+bash "$SCRIPT" --changed-files "$scheduler_fixture_repair" >"$TMP/scheduler-fixture-repair.out"
+assert_has "$TMP/scheduler-fixture-repair.out" "aggregate_status=selected"
+assert_has "$TMP/scheduler-fixture-repair.out" "scheduler_fixture_validation status=selected"
+assert_has "$TMP/scheduler-fixture-repair.out" "command=cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics"
+assert_not_has "$TMP/scheduler-fixture-repair.out" "rust_pr_fast"
+assert_not_has "$TMP/scheduler-fixture-repair.out" "no_rust_surface_detected_for_fast_lane"
+
 aws_remote_validation_tool="$TMP/aws-remote-validation-tool.txt"
 printf 'A\ttools/aws_remote_validation/src/aws_remote_validation.rs\n' >"$aws_remote_validation_tool"
 bash "$SCRIPT" --changed-files "$aws_remote_validation_tool" >"$TMP/aws-remote-validation-tool.out"
@@ -275,6 +287,28 @@ assert release_gate_lane["resource_class"] == "high"
 assert release_gate_lane["escalation_rule"] == "require_release_gate_disposition"
 assert ci_policy_lane["proof_role"] == "ci_contract"
 assert ci_policy_lane["default_surface"] == "ci_policy"
+PY
+
+bash "$SCRIPT" --changed-files "$scheduler_fixture_repair" --json >"$TMP/scheduler-fixture-repair.json"
+python3 - <<'PY' "$TMP/scheduler-fixture-repair.json"
+import json
+import sys
+
+plan = json.load(open(sys.argv[1]))
+assert plan["schema_version"] == "adl.validation_lane_plan.v1"
+assert plan["aggregate_status"] == "selected"
+assert plan["pr_publication_sufficient"] is True
+assert set(plan["lanes"]) == {"scheduler_fixture_validation"}
+lane = plan["lanes"]["scheduler_fixture_validation"]
+assert lane["status"] == "selected"
+assert lane["owner"] == "tools"
+assert lane["proof_role"] == "scheduler_fixture_contract"
+assert lane["matched_paths"] == [
+    "adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json",
+    "docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json",
+]
+assert lane["vpp_record"]["parallel_group"] == "scheduler_validation"
+assert "rust_pr_fast" not in plan["lanes"]
 PY
 
 report="$TMP/report.json"

--- a/adl/tools/test_validation_manager.sh
+++ b/adl/tools/test_validation_manager.sh
@@ -197,6 +197,43 @@ assert "adl/tools/rust_cache_env.sh" in surface["matched_paths"]
 assert "adl/tools/test_rust_cache_env.sh" in surface["matched_paths"]
 PY
 
+scheduler_fixture_repair="$TMP/scheduler-fixture-repair.txt"
+cat >"$scheduler_fixture_repair" <<'EOF'
+M	adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json
+M	docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json
+EOF
+bash "$SCRIPT" --changed-files "$scheduler_fixture_repair" --json >"$TMP/scheduler-fixture-repair.json"
+python3 - <<'PY' "$TMP/scheduler-fixture-repair.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_profile.v1"
+assert profile["selected_profile"] == "scheduler_fixture_validation_profile"
+assert profile["status"] == "ready_to_run"
+assert profile["pr_publication_sufficient"] is True
+assert [item["lane_id"] for item in profile["run"]] == ["scheduler_fixture_validation"]
+assert profile["run"][0]["command"] == "cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics"
+assert profile["run"][0]["matched_paths"] == [
+    "adl/tests/fixtures/scheduler/local_agent_delegation_readiness_inputs_v1.json",
+    "docs/milestones/v0.91.7/review/provider/artifacts/local_agent_delegation_readiness_plan_4675.json",
+]
+surface = profile["behavior_surfaces"][0]
+assert surface["id"] == "scheduler_fixture_contract_scheduler_fixture_validation"
+assert surface["owner"] == "tools"
+assert surface["proof_role"] == "scheduler_fixture_contract"
+assert profile["validation_dag"]["nodes"][0]["status"] == "runnable"
+assert profile["validation_dag"]["nodes"][0]["proof_role"] == "scheduler_fixture_contract"
+assert profile["escalation"]["required"] is False
+assert profile["escalation"]["reasons"] == []
+assert profile["diagnostics"] == []
+assert not any(
+    reason.get("reason") == "no_rust_surface_detected_for_fast_lane"
+    for reason in profile["escalation"]["reasons"]
+)
+assert "rust_pr_fast" not in profile["selector_plan"]["lanes"]
+PY
+
 unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
 M	demos/v0.91.6/unity-observatory/Assets/Resources/observatory_contract.json


### PR DESCRIPTION
Closes #4938

## Summary
Implemented the bounded scheduler fixture validation-lane classification fix for #4938. The local-agent delegation readiness scheduler fixture and its retained provider proof artifact now map to a runnable `scheduler_fixture_validation` profile using the existing finish-compatible scheduler-economics proof command, instead of splitting into `docs_diff_check` plus an escalated `rust_pr_fast` lane with `no_rust_surface_detected_for_fast_lane`.

## Artifacts
- Tracked implementation artifact: `adl/config/validation_lane_selector.v0.91.6.json`
- Tracked implementation artifact: `adl/tools/select_validation_lanes.py`
- Tracked regression coverage: `adl/tools/test_select_validation_lanes.sh`
- Tracked regression coverage: `adl/tools/test_validation_manager.sh`
- Local output-card update: `.adl/v0.91.7/tasks/issue-4938__v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validation_manager.sh --changed-files <temporary changed-files manifest> --json`
    Verified the exact #4938 fixture/artifact path set selects `scheduler_fixture_validation_profile` and is PR-publication sufficient.
  - `bash adl/tools/test_select_validation_lanes.sh`
    Verified selector contract coverage.
  - `bash adl/tools/test_validation_manager.sh`
    Verified validation-manager contract coverage.
  - `cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics`
    Verified the selected scheduler economics proof lane.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_accepts_scheduler_provider_policy_slice -- --nocapture`
    Verified no regression to existing scheduler/provider finish planning.
  - `cargo test --manifest-path adl/Cargo.toml scheduler -- --nocapture`
    Verified broader scheduler-filtered Rust tests and finish arg-render scheduler tests.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - `bash adl/tools/validation_manager.sh --changed-files <temporary changed-files manifest> --json`: PASS
  - `bash adl/tools/test_select_validation_lanes.sh`: PASS
  - `bash adl/tools/test_validation_manager.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --lib scheduler_economics`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --bin adl finish_validation_profile_accepts_scheduler_provider_policy_slice -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml scheduler -- --nocapture`: PASS
  - `git diff --check`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4938__v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4938__v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane/sor.md
- Idempotency-Key: v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-select-validation-lanes-py-adl-tools-test-select-validation-lanes-sh-adl-tools-test-validation-manager-sh-adl-v0-91-7-tasks-issue-4938-v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane-sip-md-adl-v0-91-7-tasks-issue-4938-v0-91-7-tools-validation-classify-scheduler-json-fixture-repairs-into-a-runnable-focused-proof-lane-sor-md