### PR TITLE
[v0.91.7][tools][coverage] Speed up PR-fast adl-coverage

### DIFF
--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -510,6 +510,7 @@ is_bounded_pr_fast_coverage_policy_surface() {
     adl/tools/test_check_coverage_impact.sh|\
     adl/tools/test_ci_path_policy.sh|\
     adl/tools/test_run_authoritative_coverage_lane.sh|\
+    adl/tools/test_run_pr_fast_coverage_lane.sh|\
     adl/tools/test_ci_runtime_contracts.sh)
       return 0
       ;;
@@ -545,7 +546,7 @@ is_bounded_pr_fast_coverage_policy_change() {
         fi
         ;;
       adl/tools/ci_path_policy.sh)
-        if git_pr_patch "$path" | grep -E 'is_pr_fast_coverage_workflow_change|is_bounded_pr_fast_coverage_policy_surface|is_bounded_pr_fast_coverage_policy_change|bounded_pr_fast_coverage_policy_change_keeps_pr_fast_rust_validation|manager_profile_is_release_gate_pr_fast_escalation|validation_manager_release_gate_pr_fast_escalation_runs_focused_validation|is_pvf_slow_proof_workflow_change|is_pvf_slow_proof_policy_change|slow_proof_contract_required|governed_learning_substrate|intelligence_metric_architecture|memory_identity_architecture|observatory_flagship' >/dev/null 2>&1; then
+        if git_pr_patch "$path" | grep -E 'is_pr_fast_coverage_workflow_change|is_bounded_pr_fast_coverage_policy_surface|is_bounded_pr_fast_coverage_policy_change|bounded_pr_fast_coverage_policy_change_keeps_pr_fast_rust_validation|manager_profile_is_release_gate_pr_fast_escalation|validation_manager_release_gate_pr_fast_escalation_runs_focused_validation|is_pvf_slow_proof_workflow_change|is_pvf_slow_proof_policy_change|slow_proof_contract_required|governed_learning_substrate|intelligence_metric_architecture|memory_identity_architecture|observatory_flagship|ADL_PR_FAST_COVERAGE_TEST_THREADS|PR-fast coverage test threads|nextest-default' >/dev/null 2>&1; then
           saw_bounded_marker=true
         else
           saw_other=true
@@ -566,7 +567,7 @@ is_bounded_pr_fast_coverage_policy_change() {
         fi
         ;;
       adl/tools/run_pr_fast_coverage_lane.sh)
-        if git_pr_patch "$path" | grep -E 'ADL_PR_FAST_COVERAGE_BUILD_ROOT|pr-fast-coverage|PR-fast coverage target' >/dev/null 2>&1; then
+        if git_pr_patch "$path" | grep -E 'ADL_PR_FAST_COVERAGE_BUILD_ROOT|ADL_PR_FAST_COVERAGE_TEST_THREADS|pr-fast-coverage|PR-fast coverage target|PR-fast coverage test threads|nextest-default' >/dev/null 2>&1; then
           saw_bounded_marker=true
         else
           saw_other=true
@@ -574,6 +575,13 @@ is_bounded_pr_fast_coverage_policy_change() {
         ;;
       adl/tools/test_run_authoritative_coverage_lane.sh)
         if git_pr_patch "$path" | grep -E 'build_jobs=1|link_accel=lld|ADL_AUTHORITATIVE_COVERAGE_BUILD_JOBS|RUST_LINK_ACCEL' >/dev/null 2>&1; then
+          saw_bounded_marker=true
+        else
+          saw_other=true
+        fi
+        ;;
+      adl/tools/test_run_pr_fast_coverage_lane.sh)
+        if git_pr_patch "$path" | grep -E 'ADL_PR_FAST_COVERAGE_TEST_THREADS|PR-fast coverage test threads|nextest-default|--test-threads' >/dev/null 2>&1; then
           saw_bounded_marker=true
         else
           saw_other=true
@@ -587,7 +595,7 @@ is_bounded_pr_fast_coverage_policy_change() {
         fi
         ;;
       adl/tools/test_ci_runtime_contracts.sh)
-        if git_pr_patch "$path" | grep -E 'coverage-summary.json|ADL_PR_FAST_COVERAGE_BUILD_ROOT|PR-fast coverage target|pr-fast-coverage|adl-slow-proof|slow_proof_contract_required|run_slow_proof_family|slow-proof lane fanned out|slow-proof family filter|broad slow-proof-tests' >/dev/null 2>&1; then
+        if git_pr_patch "$path" | grep -E 'coverage-summary.json|ADL_PR_FAST_COVERAGE_BUILD_ROOT|ADL_PR_FAST_COVERAGE_TEST_THREADS|PR-fast coverage target|PR-fast coverage test threads|nextest-default|pr-fast-coverage|adl-slow-proof|slow_proof_contract_required|run_slow_proof_family|slow-proof lane fanned out|slow-proof family filter|broad slow-proof-tests' >/dev/null 2>&1; then
           saw_bounded_marker=true
         else
           saw_other=true

--- a/adl/tools/run_pr_fast_coverage_lane.sh
+++ b/adl/tools/run_pr_fast_coverage_lane.sh
@@ -12,6 +12,7 @@ USAGE
 }
 
 FILTER_EXPRESSION=""
+TEST_THREADS="${ADL_PR_FAST_COVERAGE_TEST_THREADS:-}"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --filter-expression)
@@ -49,13 +50,21 @@ ADL_RUST_WARM_CACHE_OUTPUT="${ADL_PR_FAST_COVERAGE_WARM_CACHE_OUTPUT:-$ADL_DIR/p
 
 printf 'PR-fast coverage expression: %s\n' "$FILTER_EXPRESSION"
 printf 'PR-fast coverage target: %s\n' "$CARGO_TARGET_DIR"
-CARGO_INCREMENTAL=0 cargo llvm-cov nextest \
-  --workspace \
-  --status-level all \
-  --final-status-level slow \
-  --test-threads 1 \
-  --no-report \
+coverage_args=(
+  llvm-cov nextest
+  --workspace
+  --status-level all
+  --final-status-level slow
+  --no-report
   -E "$FILTER_EXPRESSION"
+)
+if [ -n "$TEST_THREADS" ]; then
+  coverage_args+=(--test-threads "$TEST_THREADS")
+  printf 'PR-fast coverage test threads: %s\n' "$TEST_THREADS"
+else
+  printf 'PR-fast coverage test threads: nextest-default\n'
+fi
+CARGO_INCREMENTAL=0 cargo "${coverage_args[@]}"
 
 mkdir -p target
 cargo llvm-cov report \

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -1343,8 +1343,16 @@ coverage_test.write_text("#!/usr/bin/env bash\n# process_status\n")
 
 runtime_contract = Path("adl/tools/test_ci_runtime_contracts.sh")
 runtime_contract.write_text("if 'coverage-summary.json' not in fast_summary_step:\n    pass\n")
+
+runner_contract = Path("adl/tools/test_run_pr_fast_coverage_lane.sh")
+runner_contract.write_text(
+    "#!/usr/bin/env bash\n"
+    "# PR-fast coverage test threads: nextest-default\n"
+    "# ADL_PR_FAST_COVERAGE_TEST_THREADS\n"
+    "# --test-threads\n"
+)
 PY
-  git add adl/src/cli/process_cmd.rs .github/workflows/ci.yaml adl/tools/check_coverage_impact.sh adl/tools/test_check_coverage_impact.sh adl/tools/test_ci_runtime_contracts.sh
+  git add adl/src/cli/process_cmd.rs .github/workflows/ci.yaml adl/tools/check_coverage_impact.sh adl/tools/test_check_coverage_impact.sh adl/tools/test_ci_runtime_contracts.sh adl/tools/test_run_pr_fast_coverage_lane.sh
   git commit -q -m runtime-bounded-pr-fast-coverage-policy-change
   runtime_bounded_pr_fast_head="$(git rev-parse HEAD)"
 

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -410,13 +410,18 @@ if "steps.path-policy.outputs.full_coverage_required != 'true'" in filter_if:
 pr_fast_runner_text = pr_fast_runner.read_text()
 for required_fragment in (
     'FILTER_EXPRESSION=""',
+    'TEST_THREADS="${ADL_PR_FAST_COVERAGE_TEST_THREADS:-}"',
     '--filter-expression',
-    'CARGO_INCREMENTAL=0 cargo llvm-cov nextest',
+    'coverage_args=(',
+    'llvm-cov nextest',
     '--workspace',
     '--status-level all',
     '--final-status-level slow',
     '--no-report',
     '-E "$FILTER_EXPRESSION"',
+    'coverage_args+=(--test-threads "$TEST_THREADS")',
+    'PR-fast coverage test threads: nextest-default',
+    'CARGO_INCREMENTAL=0 cargo "${coverage_args[@]}"',
     'cargo llvm-cov report',
     '--json',
     '--summary-only',
@@ -427,6 +432,8 @@ for required_fragment in (
             "PR-fast coverage runner must execute targeted nextest coverage and produce focused impact summary JSON; "
             f"missing fragment: {required_fragment}"
         )
+if "--test-threads 1" in pr_fast_runner_text:
+    raise SystemExit("PR-fast coverage runner must not force single-threaded nextest execution by default")
 for required_fragment in (
     "cargo llvm-cov nextest \\",
     "    --workspace \\",

--- a/adl/tools/test_run_pr_fast_coverage_lane.sh
+++ b/adl/tools/test_run_pr_fast_coverage_lane.sh
@@ -36,9 +36,10 @@ ADL_PR_FAST_COVERAGE_BUILD_ROOT="$scratch_root" \
 
 grep -F "PR-fast coverage expression: $expression" /tmp/pr-fast-coverage-run.out >/dev/null
 grep -F "PR-fast coverage target: $scratch_root" /tmp/pr-fast-coverage-run.out >/dev/null
+grep -F "PR-fast coverage test threads: nextest-default" /tmp/pr-fast-coverage-run.out >/dev/null
 
 for required in \
-  "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --test-threads 1 --no-report -E $expression" \
+  "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E $expression" \
   "cmd=llvm-cov report --json --summary-only --output-path target/coverage-impact-summary.json" \
   "target=$scratch_root" \
   "llvm_cov_target=$scratch_root/llvm-cov-target"
@@ -49,5 +50,16 @@ do
     exit 1
   fi
 done
+
+threads_cargo_log="$temp_root/cargo-threads.log"
+PATH="$bin_dir:$PATH" \
+PR_FAST_COVERAGE_CARGO_LOG="$threads_cargo_log" \
+ADL_RUST_WARM_CACHE=0 \
+ADL_PR_FAST_COVERAGE_BUILD_ROOT="$scratch_root-threads" \
+ADL_PR_FAST_COVERAGE_TEST_THREADS=2 \
+  bash "$SCRIPT" --filter-expression "$expression" >/tmp/pr-fast-coverage-threads-run.out
+
+grep -F "PR-fast coverage test threads: 2" /tmp/pr-fast-coverage-threads-run.out >/dev/null
+grep -F "cmd=llvm-cov nextest --workspace --status-level all --final-status-level slow --no-report -E $expression --test-threads 2" "$threads_cargo_log" >/dev/null
 
 echo "PASS test_run_pr_fast_coverage_lane"


### PR DESCRIPTION
Closes #5130

## Summary
Implemented a bounded PR-fast coverage speedup. `adl/tools/run_pr_fast_coverage_lane.sh` no longer forces `--test-threads 1`; it now uses nextest default parallelism unless `ADL_PR_FAST_COVERAGE_TEST_THREADS` is explicitly set for diagnostics. Path-policy tooling was updated so this runner/test change remains classified as bounded PR-fast coverage policy work instead of self-escalating to full authoritative coverage.

## Artifacts
- Local output card updated at `.adl/v0.91.7/tasks/issue-5130__v0-91-7-tools-coverage-speed-up-adl-coverage-by-separating-fast-and-long-coverage-work/sor.md`
- Tracked implementation artifacts:
  - `adl/tools/run_pr_fast_coverage_lane.sh`
  - `adl/tools/test_run_pr_fast_coverage_lane.sh`
  - `adl/tools/ci_path_policy.sh`
  - `adl/tools/test_ci_path_policy.sh`
  - `adl/tools/test_ci_runtime_contracts.sh`
- Additional proof artifacts: local command outputs recorded below; GitHub CI proof deferred to PR checks.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_pr_fast_coverage_lane.sh`
    `Verified PR-fast coverage command shape defaults to nextest parallelism and preserves the explicit test-thread override.`
  - `bash adl/tools/test_ci_path_policy.sh`
    `Verified bounded PR-fast/full-coverage path-policy contracts, including the review-finding fixture for the new runner-test surface.`
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    `Verified CI runtime contracts accept the new PR-fast coverage command construction and reject forced single-threaded default coverage.`
  - `bash adl/tools/test_check_coverage_impact.sh`
    `Verified coverage-impact mapping contracts still pass.`
  - `bash adl/tools/test_run_authoritative_coverage_lane.sh`
    `Verified authoritative coverage runner command shape remains unchanged.`
  - `bash -n adl/tools/*.sh`
    `Verified shell syntax for repo tooling scripts.`
  - `ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }; puts "PASS workflow yaml parse"' $(find .github/workflows -maxdepth 1 \( -name '*.yaml' -o -name '*.yml' \) -print)`
    `Verified workflow YAML parses with the available local Ruby parser.`
- Results:
  - `PASS`

Validation command/path rules:
- Repository-relative paths are used in recorded commands and artifact references.
- `absolute_path_leakage_detected: false`
- Local proof verifies command shape and policy contracts; hosted `adl-coverage` duration improvement must be observed on the PR.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5130__v0-91-7-tools-coverage-speed-up-adl-coverage-by-separating-fast-and-long-coverage-work/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5130__v0-91-7-tools-coverage-speed-up-adl-coverage-by-separating-fast-and-long-coverage-work/sor.md
- Idempotency-Key: v0-91-7-tools-coverage-speed-up-pr-fast-adl-coverage-adl-tools-run-pr-fast-coverage-lane-sh-adl-tools-test-run-pr-fast-coverage-lane-sh-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-tools-test-ci-runtime-contracts-sh-adl-v0-91-7-tasks-issue-5130-v0-91-7-tools-coverage-speed-up-adl-coverage-by-separating-fast-and-long-coverage-work-sip-md-adl-v0-91-7-tasks-issue-5130-v0-91-7-tools-coverage-speed-up-adl-coverage-by-separating-fast-and-long-coverage-work-sor-md