### PR TITLE
[v0.91.7][WP-11][godel-ghb] Integrate GHB as Runtime v2 agent runtime

### DIFF
--- a/adl/src/cli/runtime_v2_cmd/commands.rs
+++ b/adl/src/cli/runtime_v2_cmd/commands.rs
@@ -14,6 +14,7 @@ use ::adl::{
         runtime_v2_cognitive_being_flagship_demo_contract,
         runtime_v2_contract_market_demo_contract, runtime_v2_csm_integrated_run_contract,
         runtime_v2_feature_proof_coverage_contract, runtime_v2_foundation_demo_contract,
+        runtime_v2_godel_agent_runtime_contract_for,
         runtime_v2_governed_tools_flagship_demo_contract, runtime_v2_loop_runtime_contract,
         runtime_v2_minimal_integrated_runtime_path_contract,
         runtime_v2_observatory_flagship_contract, runtime_v2_operator_control_report_contract,
@@ -667,6 +668,62 @@ pub(crate) fn real_runtime_v2_loop_runtime(repo_root: &Path, args: &[String]) ->
     Ok(())
 }
 
+pub(crate) fn real_runtime_v2_godel_agent_runtime(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+    let mut agent_count: usize = 10;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 godel-agent-runtime requires --out <path>"
+                    ));
+                };
+                out_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--agents" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 godel-agent-runtime requires --agents <count>"
+                    ));
+                };
+                agent_count = value.parse::<usize>().with_context(|| {
+                    format!("parse runtime-v2 godel-agent-runtime --agents value '{value}'")
+                })?;
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for runtime-v2 godel-agent-runtime: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let graph = runtime_v2_reasoning_graph_contract()?;
+    let loop_runtime = runtime_v2_loop_runtime_contract()?;
+    let packet = runtime_v2_godel_agent_runtime_contract_for(
+        agent_count,
+        &graph.graph_id,
+        &loop_runtime.runtime_id,
+    )?;
+    let Some(out_path) = out_path else {
+        println!("{}", to_string_pretty(&packet.canonicalized()?)?);
+        return Ok(());
+    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "godel-agent-runtime")?;
+    packet.write_to_path(&resolved)?;
+    println!("{}", godel_agent_runtime_stdout_line(&out_path));
+    Ok(())
+}
+
 pub(crate) fn real_runtime_v2_contract_market_demo(
     repo_root: &Path,
     args: &[String],
@@ -790,6 +847,10 @@ pub(crate) fn reasoning_graph_stdout_line(out_path: &Path) -> String {
 
 pub(crate) fn loop_runtime_stdout_line(out_path: &Path) -> String {
     format!("RUNTIME_V2_LOOP_RUNTIME_PATH={}", out_path.display())
+}
+
+pub(crate) fn godel_agent_runtime_stdout_line(out_path: &Path) -> String {
+    format!("RUNTIME_V2_GODEL_AGENT_RUNTIME_PATH={}", out_path.display())
 }
 
 pub(crate) fn cognitive_being_flagship_demo_stdout_line(out_path: &Path) -> String {

--- a/adl/src/cli/runtime_v2_cmd/helpers.rs
+++ b/adl/src/cli/runtime_v2_cmd/helpers.rs
@@ -71,7 +71,7 @@ pub(crate) fn resolve_relative_output_path(
 pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, or loop-runtime"
+            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime"
         ));
     };
 
@@ -103,12 +103,15 @@ pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Resu
         }
         "reasoning-graph" => commands::real_runtime_v2_reasoning_graph(repo_root, &args[1..]),
         "loop-runtime" => commands::real_runtime_v2_loop_runtime(repo_root, &args[1..]),
+        "godel-agent-runtime" => {
+            commands::real_runtime_v2_godel_agent_runtime(repo_root, &args[1..])
+        }
         "--help" | "-h" | "help" => {
             println!("{}", usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, or loop-runtime)"
+            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime)"
         )),
     }
 }

--- a/adl/src/cli/runtime_v2_cmd/tests.rs
+++ b/adl/src/cli/runtime_v2_cmd/tests.rs
@@ -1,8 +1,9 @@
 use crate::cli::runtime_v2_cmd::{
     commands::{
         cognitive_being_flagship_demo_stdout_line, contract_market_demo_stdout_line,
-        feature_proof_coverage_stdout_line, governed_tools_flagship_demo_stdout_line,
-        loop_runtime_stdout_line, reasoning_graph_stdout_line,
+        feature_proof_coverage_stdout_line, godel_agent_runtime_stdout_line,
+        governed_tools_flagship_demo_stdout_line, loop_runtime_stdout_line,
+        reasoning_graph_stdout_line,
     },
     helpers::{real_runtime_v2, real_runtime_v2_in_repo},
 };
@@ -38,6 +39,8 @@ const RUNTIME_V2_CLI_REGRESSION_SMOKES: &[&str] = &[
     "reasoning-graph:arg-validation",
     "loop-runtime:write-json",
     "loop-runtime:arg-validation",
+    "godel-agent-runtime:write-json",
+    "godel-agent-runtime:arg-validation",
     "contract-market-demo:arg-validation",
     "governed-tools-flagship-demo:write-bundle",
     "governed-tools-flagship-demo:arg-validation",
@@ -115,8 +118,8 @@ fn trace_runtime_v2_dispatch_covers_help_and_subcommand_errors() {
 
     let err = real_runtime_v2_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
-            .to_string()
-            .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, or loop-runtime"));
+        .to_string()
+        .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime"));
 
     let err = real_runtime_v2_in_repo(&["bogus".to_string()], &repo)
         .expect_err("unknown subcommand should fail");
@@ -1056,6 +1059,103 @@ fn trace_runtime_v2_loop_runtime_validates_stdout_help_and_output_path_rules() {
 }
 
 #[test]
+fn trace_runtime_v2_godel_agent_runtime_writes_packet_json() {
+    let repo = temp_repo("godel-agent-runtime");
+    let out_path = repo.join("out/godel-agent-runtime.json");
+
+    real_runtime_v2_in_repo(
+        &[
+            "godel-agent-runtime".to_string(),
+            "--agents".to_string(),
+            "10".to_string(),
+            "--out".to_string(),
+            "out/godel-agent-runtime.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("Godel agent runtime");
+
+    let json: serde_json::Value = serde_json::from_slice(
+        &fs::read(&out_path).expect("Godel agent runtime packet should exist"),
+    )
+    .expect("valid json");
+    assert_eq!(json["schema_version"], "runtime_v2.godel_agent_runtime.v1");
+    assert_eq!(json["milestone"], "v0.91.7");
+    assert_eq!(json["wp"], "WP-11");
+    assert_eq!(json["agents"].as_array().expect("agents").len(), 10);
+    assert_eq!(json["scheduling"]["max_concurrent_agents"], 10);
+    assert_eq!(
+        json["provider_registry"]
+            .as_array()
+            .expect("provider registry")
+            .iter()
+            .filter(|provider| provider["runtime_surface"] == "hosted_http")
+            .count(),
+        3
+    );
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
+fn trace_runtime_v2_godel_agent_runtime_validates_stdout_help_and_output_path_rules() {
+    let repo = temp_repo("godel-agent-runtime-branches");
+
+    real_runtime_v2_in_repo(&["godel-agent-runtime".to_string()], &repo)
+        .expect("stdout Godel agent runtime packet");
+    real_runtime_v2_in_repo(
+        &["godel-agent-runtime".to_string(), "--help".to_string()],
+        &repo,
+    )
+    .expect("Godel agent runtime help");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "godel-agent-runtime".to_string(),
+            "--out".to_string(),
+            repo.join("absolute/godel-agent-runtime.json")
+                .to_string_lossy()
+                .to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("absolute output path should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 godel-agent-runtime --out path must be repository-relative"));
+
+    let err = real_runtime_v2_in_repo(
+        &["godel-agent-runtime".to_string(), "--bogus".to_string()],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for runtime-v2 godel-agent-runtime: --bogus"));
+
+    let err = real_runtime_v2_in_repo(
+        &["godel-agent-runtime".to_string(), "--out".to_string()],
+        &repo,
+    )
+    .expect_err("missing out value should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 godel-agent-runtime requires --out <path>"));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "godel-agent-runtime".to_string(),
+            "--agents".to_string(),
+            "9".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("less than ten agents should fail");
+    assert!(err.to_string().contains("agent count"));
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
 fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_registry() {
     let proof_surfaces: &[fn()] = &[
         trace_runtime_v2_operator_controls_writes_report_json,
@@ -1082,6 +1182,8 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
         trace_runtime_v2_reasoning_graph_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_loop_runtime_writes_packet_json,
         trace_runtime_v2_loop_runtime_validates_stdout_help_and_output_path_rules,
+        trace_runtime_v2_godel_agent_runtime_writes_packet_json,
+        trace_runtime_v2_godel_agent_runtime_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_contract_market_demo_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_governed_tools_flagship_demo_writes_proof_bundle,
         trace_runtime_v2_governed_tools_flagship_demo_validates_stdout_help_and_output_path_rules,
@@ -1112,6 +1214,9 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("loop-runtime:")));
+    assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
+        .iter()
+        .any(|smoke| smoke.starts_with("godel-agent-runtime:")));
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("contract-market-demo:")));
@@ -1336,6 +1441,20 @@ fn trace_runtime_v2_demo_stdout_lines_preserve_requested_relative_paths() {
     assert!(
         !loop_runtime_stdout.contains(&cwd),
         "loop runtime stdout should not expose absolute repo root:\n{loop_runtime_stdout}"
+    );
+
+    let godel_agent_runtime_file = rel_root.join("godel-agent-runtime.json");
+    let godel_agent_runtime_stdout = godel_agent_runtime_stdout_line(&godel_agent_runtime_file);
+    assert_eq!(
+        godel_agent_runtime_stdout,
+        format!(
+            "RUNTIME_V2_GODEL_AGENT_RUNTIME_PATH={}",
+            godel_agent_runtime_file.display()
+        )
+    );
+    assert!(
+        !godel_agent_runtime_stdout.contains(&cwd),
+        "Godel agent runtime stdout should not expose absolute repo root:\n{godel_agent_runtime_stdout}"
     );
 
     let d13_flagship_stdout = cognitive_being_flagship_demo_stdout_line(&rel_root);

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -52,6 +52,7 @@ pub fn usage() -> &'static str {
   adl runtime-v2 feature-proof-coverage [--out <path>]
   adl runtime-v2 reasoning-graph [--out <path>]
   adl runtime-v2 loop-runtime [--out <path>]
+  adl runtime-v2 godel-agent-runtime [--agents <count>] [--out <path>]
   adl scheduler plan --input <bundle.json> [--out <path>] [--json]
   adl provider setup <family> [--model <provider_model_id>] [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
@@ -140,6 +141,7 @@ Examples:
   adl runtime-v2 feature-proof-coverage --out artifacts/v0904/feature-proof-coverage.json
   adl runtime-v2 reasoning-graph --out artifacts/v0917/reasoning-graph.json
   adl runtime-v2 loop-runtime --out artifacts/v0917/loop-runtime.json
+  adl runtime-v2 godel-agent-runtime --agents 10 --out artifacts/v0917/godel-agent-runtime.json
   adl scheduler plan --input adl/tests/fixtures/scheduler/economics_inputs_v1.json --out artifacts/examples/scheduler-plan.json
   adl provider setup chatgpt
   adl provider setup claude

--- a/adl/src/godel/ghb_loop.rs
+++ b/adl/src/godel/ghb_loop.rs
@@ -811,6 +811,7 @@ fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 }
 
 fn prepare_proof_dir(out_dir: &Path) -> Result<()> {
+    validate_proof_dir_root(out_dir)?;
     fs::create_dir_all(out_dir)
         .with_context(|| format!("create GHB proof dir '{}'", out_dir.display()))?;
     for owned_child in ["ghb", "snapshot-proof", "local-runs", "remote-runs"] {
@@ -819,6 +820,23 @@ fn prepare_proof_dir(out_dir: &Path) -> Result<()> {
             fs::remove_dir_all(&path)
                 .with_context(|| format!("clean stale GHB proof child '{}'", path.display()))?;
         }
+    }
+    Ok(())
+}
+
+fn validate_proof_dir_root(out_dir: &Path) -> Result<()> {
+    if out_dir.as_os_str().is_empty() || out_dir == Path::new(".") {
+        return Err(anyhow!(
+            "GHB proof --out must name a dedicated proof directory, not the current directory"
+        ));
+    }
+    let has_named_component = out_dir
+        .components()
+        .any(|component| matches!(component, std::path::Component::Normal(_)));
+    if !has_named_component {
+        return Err(anyhow!(
+            "GHB proof --out must name a dedicated proof directory"
+        ));
     }
     Ok(())
 }
@@ -869,5 +887,18 @@ mod tests {
         assert!(err
             .to_string()
             .contains("remote provider route must start with hosted:"));
+    }
+
+    #[test]
+    fn ghb_loop_rejects_current_directory_as_proof_root() {
+        let err = prove_ghb_recursive_self_improvement(GhbProofOptions {
+            out_dir: PathBuf::from("."),
+            run_id: "ghb-proof-5096".to_string(),
+            admitted_task: "Improve a bounded review plan".to_string(),
+            local_provider_route: "local:ollama/qwen".to_string(),
+            remote_provider_route: "hosted:bedrock/nova-pro".to_string(),
+        })
+        .expect_err("current directory output should fail before cleanup");
+        assert!(err.to_string().contains("dedicated proof directory"));
     }
 }

--- a/adl/src/runtime_v2/godel_agent_runtime.rs
+++ b/adl/src/runtime_v2/godel_agent_runtime.rs
@@ -1,0 +1,759 @@
+//! Runtime-v2 Godel agent runtime contract.
+//!
+//! This surface binds the WP-11 GHB proof loop into Runtime v2 as executable
+//! runtime planning truth: independent agents, provider targets, scheduling
+//! bounds, and replay/proof artifact references.
+
+use super::*;
+use crate::{
+    adl,
+    provider_substrate::{
+        provider_invocation_target_v1, CapabilityModeV1, ProviderInvocationTargetV1,
+        ProviderTransportV1,
+    },
+};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+
+pub const RUNTIME_V2_GODEL_AGENT_RUNTIME_SCHEMA: &str = "runtime_v2.godel_agent_runtime.v1";
+pub const RUNTIME_V2_GODEL_AGENT_RUNTIME_PATH: &str =
+    "runtime_v2/godel_agent_runtime/godel_agent_runtime.json";
+pub const RUNTIME_V2_GODEL_AGENT_RUNTIME_TEST_MARKER: &str = "runtime_v2_godel_agent_runtime";
+const MIN_GODEL_AGENT_COUNT: usize = 10;
+const MAX_GODEL_AGENT_COUNT: usize = 64;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelAgentRuntimePacket {
+    pub schema_version: String,
+    pub runtime_id: String,
+    pub milestone: String,
+    pub wp: String,
+    pub artifact_path: String,
+    pub reasoning_graph_ref: String,
+    pub reasoning_graph_id: String,
+    pub loop_runtime_ref: String,
+    pub loop_runtime_id: String,
+    pub ghb_proof_command: String,
+    pub scheduling: RuntimeV2GodelSchedulingPolicy,
+    pub agents: Vec<RuntimeV2GodelAgentSpec>,
+    pub provider_registry: Vec<RuntimeV2GodelProviderBinding>,
+    pub runtime_channels: RuntimeV2GodelRuntimeChannels,
+    pub replay: RuntimeV2GodelRuntimeReplay,
+    pub validation_commands: Vec<String>,
+    pub claim_boundary: String,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelSchedulingPolicy {
+    pub min_independent_agents: u32,
+    pub max_independent_agents: u32,
+    pub max_concurrent_agents: u32,
+    pub backpressure_policy: String,
+    pub lifecycle_policy: String,
+    pub fairness_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelAgentSpec {
+    pub agent_instance_id: String,
+    pub agent_role: String,
+    pub provider_id: String,
+    pub model_ref: String,
+    pub loop_runtime_id: String,
+    pub reasoning_graph_id: String,
+    pub initial_state_id: String,
+    pub channel_id: String,
+    pub lifecycle_state: String,
+    pub evidence_root_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelProviderBinding {
+    pub provider_id: String,
+    pub provider_kind: String,
+    pub vendor: String,
+    pub transport: String,
+    pub model_ref: String,
+    pub provider_model_id: String,
+    pub runtime_surface: String,
+    pub tool_calling_mode: String,
+    pub structured_json_mode: String,
+    pub invocation_status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelRuntimeChannels {
+    pub channel_schema: String,
+    pub supervision_channel: String,
+    pub lifecycle_channel: String,
+    pub provider_request_channel: String,
+    pub provider_response_channel: String,
+    pub evidence_channel: String,
+    pub backpressure_signal: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2GodelRuntimeReplay {
+    pub replay_status: String,
+    pub scheduled_agent_count: u32,
+    pub provider_binding_count: u32,
+    pub independent_agent_ids: Vec<String>,
+    pub replay_guarantees: Vec<String>,
+}
+
+impl RuntimeV2GodelAgentRuntimePacket {
+    pub fn prototype(agent_count: usize) -> Result<Self> {
+        let graph = runtime_v2_reasoning_graph_contract()?;
+        let loop_runtime = runtime_v2_loop_runtime_contract()?;
+        runtime_v2_godel_agent_runtime_contract_for(
+            agent_count,
+            &graph.graph_id,
+            &loop_runtime.runtime_id,
+        )
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        require_exact(
+            &self.schema_version,
+            RUNTIME_V2_GODEL_AGENT_RUNTIME_SCHEMA,
+            "godel_agent_runtime.schema_version",
+        )?;
+        normalize_id(self.runtime_id.clone(), "godel_agent_runtime.runtime_id")?;
+        require_exact(&self.milestone, "v0.91.7", "godel_agent_runtime.milestone")?;
+        require_exact(&self.wp, "WP-11", "godel_agent_runtime.wp")?;
+        require_exact(
+            &self.artifact_path,
+            RUNTIME_V2_GODEL_AGENT_RUNTIME_PATH,
+            "godel_agent_runtime.artifact_path",
+        )?;
+        validate_relative_path(&self.artifact_path, "godel_agent_runtime.artifact_path")?;
+        validate_relative_path(
+            &self.reasoning_graph_ref,
+            "godel_agent_runtime.reasoning_graph_ref",
+        )?;
+        validate_relative_path(
+            &self.loop_runtime_ref,
+            "godel_agent_runtime.loop_runtime_ref",
+        )?;
+        normalize_id(
+            self.reasoning_graph_id.clone(),
+            "godel_agent_runtime.reasoning_graph_id",
+        )?;
+        normalize_id(
+            self.loop_runtime_id.clone(),
+            "godel_agent_runtime.loop_runtime_id",
+        )?;
+
+        let graph = runtime_v2_reasoning_graph_contract()?;
+        let loop_runtime = runtime_v2_loop_runtime_contract()?;
+        if self.reasoning_graph_id != graph.graph_id {
+            return Err(anyhow!(
+                "Godel runtime reasoning graph id must match Runtime v2 reasoning graph"
+            ));
+        }
+        if self.loop_runtime_id != loop_runtime.runtime_id {
+            return Err(anyhow!(
+                "Godel runtime loop runtime id must match Runtime v2 loop runtime"
+            ));
+        }
+        ensure_contains(
+            &self.ghb_proof_command,
+            "adl godel ghb-proof",
+            "Godel runtime must retain the GHB proof command bridge",
+        )?;
+        validate_scheduling(&self.scheduling)?;
+        validate_scheduling_against_agents(&self.scheduling, &self.agents)?;
+        validate_agents(
+            &self.agents,
+            &self.provider_registry,
+            &self.reasoning_graph_id,
+            &self.loop_runtime_id,
+        )?;
+        validate_provider_registry(&self.provider_registry)?;
+        validate_channels(&self.runtime_channels)?;
+        validate_replay(&self.replay, &self.agents, &self.provider_registry)?;
+        validate_command_list(&self.validation_commands)?;
+        ensure_contains_in_list(
+            &self.non_claims,
+            "live_hosted_provider_invocation",
+            "Godel runtime non-claims must preserve hosted invocation boundary",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "Runtime v2 Godel agent runtime",
+            "Godel runtime claim boundary must name Runtime v2 integration",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "10+ independent Godel agents",
+            "Godel runtime claim boundary must name multi-agent readiness",
+        )
+    }
+
+    pub fn canonicalized(&self) -> Result<Self> {
+        self.validate()?;
+        let mut canonical = self.clone();
+        canonical
+            .agents
+            .sort_by(|a, b| a.agent_instance_id.cmp(&b.agent_instance_id));
+        canonical
+            .provider_registry
+            .sort_by(|a, b| a.provider_id.cmp(&b.provider_id));
+        canonical.replay.independent_agent_ids.sort();
+        canonical.replay.replay_guarantees.sort();
+        canonical.validation_commands.sort();
+        canonical.non_claims.sort();
+        canonical.validate()?;
+        Ok(canonical)
+    }
+
+    pub fn pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(&self.canonicalized()?)
+            .context("serialize Runtime v2 Godel agent runtime packet")
+    }
+
+    pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "create Runtime v2 Godel agent runtime parent '{}'",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(path, self.pretty_json_bytes()?).with_context(|| {
+            format!(
+                "write Runtime v2 Godel agent runtime packet to '{}'",
+                path.display()
+            )
+        })
+    }
+}
+
+pub fn runtime_v2_godel_agent_runtime_contract() -> Result<RuntimeV2GodelAgentRuntimePacket> {
+    RuntimeV2GodelAgentRuntimePacket::prototype(MIN_GODEL_AGENT_COUNT)
+}
+
+pub fn runtime_v2_godel_agent_runtime_contract_for(
+    agent_count: usize,
+    reasoning_graph_id: &str,
+    loop_runtime_id: &str,
+) -> Result<RuntimeV2GodelAgentRuntimePacket> {
+    if !(MIN_GODEL_AGENT_COUNT..=MAX_GODEL_AGENT_COUNT).contains(&agent_count) {
+        return Err(anyhow!(
+            "Godel runtime agent count must be between {MIN_GODEL_AGENT_COUNT} and {MAX_GODEL_AGENT_COUNT}"
+        ));
+    }
+    let providers = prototype_provider_targets()?;
+    let mut agents = Vec::with_capacity(agent_count);
+    for idx in 0..agent_count {
+        let provider = &providers[idx % providers.len()];
+        let n = idx + 1;
+        agents.push(RuntimeV2GodelAgentSpec {
+            agent_instance_id: format!("godel-agent-{n:02}"),
+            agent_role: if idx == 0 {
+                "shepherd_candidate".to_string()
+            } else {
+                "independent_godel_worker".to_string()
+            },
+            provider_id: provider.provider_id.clone(),
+            model_ref: provider.model_ref.clone(),
+            loop_runtime_id: loop_runtime_id.to_string(),
+            reasoning_graph_id: reasoning_graph_id.to_string(),
+            initial_state_id: format!("godel-agent-{n:02}-state-0001"),
+            channel_id: format!("godel-agent-{n:02}-runtime-channel"),
+            lifecycle_state: "ready".to_string(),
+            evidence_root_ref: format!("runtime_v2/godel_agent_runtime/agents/godel-agent-{n:02}"),
+        });
+    }
+    let replay = RuntimeV2GodelRuntimeReplay {
+        replay_status: "deterministic_schedule_ready".to_string(),
+        scheduled_agent_count: agents.len() as u32,
+        provider_binding_count: providers.len() as u32,
+        independent_agent_ids: agents
+            .iter()
+            .map(|agent| agent.agent_instance_id.clone())
+            .collect(),
+        replay_guarantees: vec![
+            "agent ids are deterministic and unique".to_string(),
+            "provider bindings are resolved before agent admission".to_string(),
+            "scheduler bounds concurrent Godel agents before provider requests are admitted"
+                .to_string(),
+            "each Godel agent is bound to the Runtime v2 reasoning graph and loop runtime"
+                .to_string(),
+        ],
+    };
+    let packet = RuntimeV2GodelAgentRuntimePacket {
+        schema_version: RUNTIME_V2_GODEL_AGENT_RUNTIME_SCHEMA.to_string(),
+        runtime_id: "runtime-v2-godel-agent-runtime-v0-91-7-wp-11".to_string(),
+        milestone: "v0.91.7".to_string(),
+        wp: "WP-11".to_string(),
+        artifact_path: RUNTIME_V2_GODEL_AGENT_RUNTIME_PATH.to_string(),
+        reasoning_graph_ref: RUNTIME_V2_REASONING_GRAPH_PATH.to_string(),
+        reasoning_graph_id: reasoning_graph_id.to_string(),
+        loop_runtime_ref: RUNTIME_V2_LOOP_RUNTIME_PATH.to_string(),
+        loop_runtime_id: loop_runtime_id.to_string(),
+        ghb_proof_command: "adl godel ghb-proof --out <proof-dir> --json".to_string(),
+        scheduling: RuntimeV2GodelSchedulingPolicy {
+            min_independent_agents: MIN_GODEL_AGENT_COUNT as u32,
+            max_independent_agents: MAX_GODEL_AGENT_COUNT as u32,
+            max_concurrent_agents: 10,
+            backpressure_policy: "bounded_join_set_with_provider_request_backpressure".to_string(),
+            lifecycle_policy: "supervised_agent_runtime_start_run_checkpoint_stop".to_string(),
+            fairness_policy: "deterministic_round_robin_provider_target_assignment".to_string(),
+        },
+        agents,
+        provider_registry: providers,
+        runtime_channels: RuntimeV2GodelRuntimeChannels {
+            channel_schema: "runtime_v2.godel_agent_channels.v1".to_string(),
+            supervision_channel: "csm.supervision.godel_agents".to_string(),
+            lifecycle_channel: "csm.lifecycle.godel_agents".to_string(),
+            provider_request_channel: "csm.provider_requests.godel_agents".to_string(),
+            provider_response_channel: "csm.provider_responses.godel_agents".to_string(),
+            evidence_channel: "csm.evidence.godel_agents".to_string(),
+            backpressure_signal: "provider_request_queue_depth_and_agent_join_set_capacity"
+                .to_string(),
+        },
+        replay,
+        validation_commands: vec![
+            "cargo fmt --manifest-path adl/Cargo.toml --all -- --check".to_string(),
+            format!(
+                "cargo test --manifest-path adl/Cargo.toml {} -- --nocapture",
+                RUNTIME_V2_GODEL_AGENT_RUNTIME_TEST_MARKER
+            ),
+            "cargo test --manifest-path adl/Cargo.toml ghb_loop -- --nocapture".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_godel_agent_runtime -- --nocapture".to_string(),
+            "cargo run --manifest-path adl/Cargo.toml --bin adl -- runtime-v2 godel-agent-runtime --agents 10 --out <path>".to_string(),
+            "git diff --check".to_string(),
+        ],
+        claim_boundary: "WP-11 #5136 integrates GHB into Runtime v2 as a Runtime v2 Godel agent runtime plan for 10+ independent Godel agents with provider target binding, supervised lifecycle channels, bounded concurrency, and deterministic replay. It prepares the runtime/provider mechanism needed to run agents without claiming live hosted model calls until an explicit provider executor invokes them.".to_string(),
+        non_claims: vec![
+            "not_unbounded_recursive_self_improvement".to_string(),
+            "not_live_hosted_provider_invocation".to_string(),
+            "not_source_code_mutation_without_review".to_string(),
+            "not_credential_capture".to_string(),
+            "not_private_prompt_persistence".to_string(),
+            "not_v092_adaptive_learning_dag_completion".to_string(),
+        ],
+    };
+    packet.validate()?;
+    Ok(packet)
+}
+
+fn prototype_provider_targets() -> Result<Vec<RuntimeV2GodelProviderBinding>> {
+    let specs = vec![
+        (
+            "local_qwen",
+            adl_provider(
+                "ollama",
+                Some("ollama:qwen"),
+                Some("qwen2.5-coder:latest"),
+                None,
+            ),
+        ),
+        (
+            "local_gemma",
+            adl_provider("ollama", Some("ollama:gemma"), Some("gemma4:latest"), None),
+        ),
+        (
+            "bedrock_nova_pro",
+            adl_provider(
+                "bedrock",
+                Some("bedrock:nova-pro"),
+                Some("hosted:bedrock/nova-pro"),
+                Some("amazon.nova-pro-v1:0"),
+            ),
+        ),
+        (
+            "z_ai_glm",
+            adl_provider(
+                "z_ai",
+                Some("z_ai:glm"),
+                Some("hosted:z-ai/glm"),
+                Some("glm-5"),
+            ),
+        ),
+        (
+            "fable_5",
+            adl_provider(
+                "anthropic",
+                Some("claude:fable-5"),
+                Some("hosted:anthropic/fable-5"),
+                Some("fable-5"),
+            ),
+        ),
+    ];
+    specs
+        .into_iter()
+        .map(|(provider_id, spec)| {
+            provider_invocation_target_v1(provider_id, &spec, None)
+                .map(|target| provider_binding_from_target(provider_id, target))
+        })
+        .collect()
+}
+
+fn adl_provider(
+    kind: &str,
+    profile: Option<&str>,
+    default_model: Option<&str>,
+    provider_model_id: Option<&str>,
+) -> adl::ProviderSpec {
+    let mut config = HashMap::new();
+    if let Some(provider_model_id) = provider_model_id {
+        config.insert(
+            "provider_model_id".to_string(),
+            serde_json::Value::String(provider_model_id.to_string()),
+        );
+    }
+    adl::ProviderSpec {
+        id: None,
+        profile: profile.map(ToString::to_string),
+        kind: kind.to_string(),
+        base_url: None,
+        default_model: default_model.map(ToString::to_string),
+        config,
+    }
+}
+
+fn provider_binding_from_target(
+    provider_id: &str,
+    target: ProviderInvocationTargetV1,
+) -> RuntimeV2GodelProviderBinding {
+    RuntimeV2GodelProviderBinding {
+        provider_id: provider_id.to_string(),
+        provider_kind: target.provider_kind,
+        vendor: target.vendor,
+        transport: transport_label(&target.transport).to_string(),
+        model_ref: target.model_ref,
+        provider_model_id: target.provider_model_id,
+        runtime_surface: target.model_identity.runtime_surface,
+        tool_calling_mode: capability_mode_label(&target.capabilities.tool_calling.mode)
+            .to_string(),
+        structured_json_mode: capability_mode_label(&target.capabilities.structured_json.mode)
+            .to_string(),
+        invocation_status: "provider_target_resolved_not_invoked".to_string(),
+    }
+}
+
+fn transport_label(transport: &ProviderTransportV1) -> &'static str {
+    match transport {
+        ProviderTransportV1::Http => "http",
+        ProviderTransportV1::LocalCli => "local_cli",
+        ProviderTransportV1::InProcess => "in_process",
+    }
+}
+
+fn capability_mode_label(mode: &CapabilityModeV1) -> &'static str {
+    match mode {
+        CapabilityModeV1::Native => "native",
+        CapabilityModeV1::PromptBased => "prompt_based",
+        CapabilityModeV1::SemanticFallback => "semantic_fallback",
+        CapabilityModeV1::None => "none",
+    }
+}
+
+fn validate_scheduling(policy: &RuntimeV2GodelSchedulingPolicy) -> Result<()> {
+    if policy.min_independent_agents < MIN_GODEL_AGENT_COUNT as u32 {
+        return Err(anyhow!(
+            "Godel runtime must support at least {MIN_GODEL_AGENT_COUNT} independent agents"
+        ));
+    }
+    if policy.max_independent_agents < policy.min_independent_agents
+        || policy.max_independent_agents > MAX_GODEL_AGENT_COUNT as u32
+    {
+        return Err(anyhow!(
+            "Godel runtime max independent agents must be within supported bounds"
+        ));
+    }
+    if policy.max_concurrent_agents == 0
+        || policy.max_concurrent_agents > policy.max_independent_agents
+    {
+        return Err(anyhow!(
+            "Godel runtime max concurrent agents must be positive and bounded"
+        ));
+    }
+    validate_nonempty_text(
+        &policy.backpressure_policy,
+        "godel_agent_runtime.backpressure_policy",
+    )?;
+    validate_nonempty_text(
+        &policy.lifecycle_policy,
+        "godel_agent_runtime.lifecycle_policy",
+    )?;
+    validate_nonempty_text(
+        &policy.fairness_policy,
+        "godel_agent_runtime.fairness_policy",
+    )
+}
+
+fn validate_scheduling_against_agents(
+    policy: &RuntimeV2GodelSchedulingPolicy,
+    agents: &[RuntimeV2GodelAgentSpec],
+) -> Result<()> {
+    let agent_count = agents.len() as u32;
+    if agent_count < policy.min_independent_agents {
+        return Err(anyhow!(
+            "Godel runtime actual agent count is below scheduling minimum"
+        ));
+    }
+    if agent_count > policy.max_independent_agents {
+        return Err(anyhow!(
+            "Godel runtime actual agent count exceeds scheduling maximum"
+        ));
+    }
+    if policy.max_concurrent_agents > agent_count {
+        return Err(anyhow!(
+            "Godel runtime max concurrent agents cannot exceed actual agent count"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_agents(
+    agents: &[RuntimeV2GodelAgentSpec],
+    providers: &[RuntimeV2GodelProviderBinding],
+    reasoning_graph_id: &str,
+    loop_runtime_id: &str,
+) -> Result<()> {
+    if agents.len() < MIN_GODEL_AGENT_COUNT {
+        return Err(anyhow!(
+            "Godel runtime must include at least {MIN_GODEL_AGENT_COUNT} independent agents"
+        ));
+    }
+    let provider_ids: BTreeSet<&str> = providers
+        .iter()
+        .map(|provider| provider.provider_id.as_str())
+        .collect();
+    let provider_by_id: BTreeMap<&str, &RuntimeV2GodelProviderBinding> = providers
+        .iter()
+        .map(|provider| (provider.provider_id.as_str(), provider))
+        .collect();
+    let mut ids = BTreeSet::new();
+    let mut channel_ids = BTreeSet::new();
+    for agent in agents {
+        normalize_id(
+            agent.agent_instance_id.clone(),
+            "godel_agent_runtime.agent_instance_id",
+        )?;
+        if !ids.insert(agent.agent_instance_id.as_str()) {
+            return Err(anyhow!("Godel runtime agent ids must be unique"));
+        }
+        if !provider_ids.contains(agent.provider_id.as_str()) {
+            return Err(anyhow!(
+                "Godel runtime agent '{}' references unknown provider '{}'",
+                agent.agent_instance_id,
+                agent.provider_id
+            ));
+        }
+        let provider = provider_by_id
+            .get(agent.provider_id.as_str())
+            .expect("provider existence checked above");
+        if agent.model_ref != provider.model_ref {
+            return Err(anyhow!(
+                "Godel runtime agent '{}' model_ref must match provider '{}' target",
+                agent.agent_instance_id,
+                agent.provider_id
+            ));
+        }
+        if agent.reasoning_graph_id != reasoning_graph_id {
+            return Err(anyhow!(
+                "Godel runtime agent reasoning graph binding mismatch"
+            ));
+        }
+        if agent.loop_runtime_id != loop_runtime_id {
+            return Err(anyhow!("Godel runtime agent loop runtime binding mismatch"));
+        }
+        normalize_id(
+            agent.initial_state_id.clone(),
+            "godel_agent_runtime.initial_state_id",
+        )?;
+        if !channel_ids.insert(agent.channel_id.as_str()) {
+            return Err(anyhow!("Godel runtime agent channel ids must be unique"));
+        }
+        validate_nonempty_text(&agent.agent_role, "godel_agent_runtime.agent_role")?;
+        validate_nonempty_text(&agent.model_ref, "godel_agent_runtime.model_ref")?;
+        validate_nonempty_text(
+            &agent.lifecycle_state,
+            "godel_agent_runtime.lifecycle_state",
+        )?;
+        validate_relative_path(
+            &agent.evidence_root_ref,
+            "godel_agent_runtime.evidence_root_ref",
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_provider_registry(providers: &[RuntimeV2GodelProviderBinding]) -> Result<()> {
+    if providers.len() < 3 {
+        return Err(anyhow!(
+            "Godel runtime provider registry must include local and hosted provider choices"
+        ));
+    }
+    let mut ids = BTreeSet::new();
+    let mut vendors = BTreeSet::new();
+    for provider in providers {
+        normalize_id(
+            provider.provider_id.clone(),
+            "godel_agent_runtime.provider_id",
+        )?;
+        if !ids.insert(provider.provider_id.as_str()) {
+            return Err(anyhow!("Godel runtime provider ids must be unique"));
+        }
+        vendors.insert(provider.vendor.as_str());
+        validate_nonempty_text(&provider.provider_kind, "godel_agent_runtime.provider_kind")?;
+        validate_nonempty_text(&provider.vendor, "godel_agent_runtime.vendor")?;
+        validate_nonempty_text(&provider.transport, "godel_agent_runtime.transport")?;
+        validate_nonempty_text(&provider.model_ref, "godel_agent_runtime.model_ref")?;
+        validate_nonempty_text(
+            &provider.provider_model_id,
+            "godel_agent_runtime.provider_model_id",
+        )?;
+        validate_nonempty_text(
+            &provider.runtime_surface,
+            "godel_agent_runtime.runtime_surface",
+        )?;
+        require_exact(
+            &provider.invocation_status,
+            "provider_target_resolved_not_invoked",
+            "godel_agent_runtime.invocation_status",
+        )?;
+    }
+    for required in ["ollama", "aws_bedrock", "z_ai", "anthropic"] {
+        if !vendors.contains(required) {
+            return Err(anyhow!(
+                "Godel runtime provider registry must include vendor '{required}'"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_channels(channels: &RuntimeV2GodelRuntimeChannels) -> Result<()> {
+    validate_nonempty_text(
+        &channels.channel_schema,
+        "godel_agent_runtime.channel_schema",
+    )?;
+    validate_nonempty_text(
+        &channels.supervision_channel,
+        "godel_agent_runtime.supervision_channel",
+    )?;
+    validate_nonempty_text(
+        &channels.lifecycle_channel,
+        "godel_agent_runtime.lifecycle_channel",
+    )?;
+    validate_nonempty_text(
+        &channels.provider_request_channel,
+        "godel_agent_runtime.provider_request_channel",
+    )?;
+    validate_nonempty_text(
+        &channels.provider_response_channel,
+        "godel_agent_runtime.provider_response_channel",
+    )?;
+    validate_nonempty_text(
+        &channels.evidence_channel,
+        "godel_agent_runtime.evidence_channel",
+    )?;
+    validate_nonempty_text(
+        &channels.backpressure_signal,
+        "godel_agent_runtime.backpressure_signal",
+    )
+}
+
+fn validate_replay(
+    replay: &RuntimeV2GodelRuntimeReplay,
+    agents: &[RuntimeV2GodelAgentSpec],
+    providers: &[RuntimeV2GodelProviderBinding],
+) -> Result<()> {
+    require_exact(
+        &replay.replay_status,
+        "deterministic_schedule_ready",
+        "godel_agent_runtime.replay_status",
+    )?;
+    if replay.scheduled_agent_count != agents.len() as u32 {
+        return Err(anyhow!(
+            "Godel runtime replay scheduled agent count must match agents"
+        ));
+    }
+    if replay.provider_binding_count != providers.len() as u32 {
+        return Err(anyhow!(
+            "Godel runtime replay provider binding count must match registry"
+        ));
+    }
+    let expected: BTreeSet<&str> = agents
+        .iter()
+        .map(|agent| agent.agent_instance_id.as_str())
+        .collect();
+    let observed: BTreeSet<&str> = replay
+        .independent_agent_ids
+        .iter()
+        .map(String::as_str)
+        .collect();
+    if expected != observed {
+        return Err(anyhow!(
+            "Godel runtime replay independent agent ids must match agents"
+        ));
+    }
+    validate_requirement_list(
+        &replay.replay_guarantees,
+        "godel_agent_runtime.replay_guarantees",
+    )
+}
+
+fn validate_command_list(commands: &[String]) -> Result<()> {
+    if commands.is_empty() {
+        return Err(anyhow!(
+            "Godel runtime validation commands must not be empty"
+        ));
+    }
+    for command in commands {
+        validate_nonempty_text(command, "godel_agent_runtime.validation_commands")?;
+    }
+    Ok(())
+}
+
+fn validate_requirement_list(values: &[String], field: &str) -> Result<()> {
+    if values.is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    for value in values {
+        validate_nonempty_text(value, field)?;
+    }
+    Ok(())
+}
+
+fn ensure_contains_in_list(values: &[String], needle: &str, message: &str) -> Result<()> {
+    if values.iter().any(|value| value.contains(needle)) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn ensure_contains(value: &str, needle: &str, message: &str) -> Result<()> {
+    if value.contains(needle) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn require_exact(actual: &str, expected: &str, field: &str) -> Result<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(anyhow!("{field} must be '{expected}', got '{actual}'"))
+    }
+}
+
+pub fn runtime_v2_godel_provider_summary(
+    packet: &RuntimeV2GodelAgentRuntimePacket,
+) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for agent in &packet.agents {
+        *counts.entry(agent.provider_id.clone()).or_insert(0) += 1;
+    }
+    counts
+}

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -28,6 +28,7 @@ mod evaluation_selection;
 mod external_counterparty;
 mod feature_proof_coverage;
 mod foundation;
+mod godel_agent_runtime;
 mod governed_episode;
 mod governed_learning_substrate;
 mod governed_tools_flagship_demo;
@@ -125,6 +126,8 @@ pub use external_counterparty::*;
 pub use feature_proof_coverage::*;
 #[allow(unused_imports)]
 pub use foundation::*;
+#[allow(unused_imports)]
+pub use godel_agent_runtime::*;
 #[allow(unused_imports)]
 pub use governed_episode::*;
 #[allow(unused_imports)]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -32,6 +32,7 @@ mod evaluation_selection;
 mod external_counterparty;
 mod feature_proof_coverage;
 mod freedom_gate_mediation;
+mod godel_agent_runtime;
 mod governed_episode;
 #[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod governed_learning_substrate;

--- a/adl/src/runtime_v2/tests/godel_agent_runtime.rs
+++ b/adl/src/runtime_v2/tests/godel_agent_runtime.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+#[test]
+fn runtime_v2_godel_agent_runtime_supports_ten_independent_agents() {
+    let packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    packet.validate().expect("valid Godel agent runtime packet");
+
+    assert_eq!(packet.schema_version, RUNTIME_V2_GODEL_AGENT_RUNTIME_SCHEMA);
+    assert_eq!(packet.agents.len(), 10);
+    assert_eq!(packet.scheduling.max_concurrent_agents, 10);
+    assert!(packet
+        .validation_commands
+        .iter()
+        .any(|command| command.contains(RUNTIME_V2_GODEL_AGENT_RUNTIME_TEST_MARKER)));
+
+    let provider_counts = runtime_v2_godel_provider_summary(&packet);
+    assert_eq!(provider_counts.values().sum::<usize>(), 10);
+    assert!(provider_counts.contains_key("local_qwen"));
+    assert!(provider_counts.contains_key("bedrock_nova_pro"));
+    assert!(provider_counts.contains_key("z_ai_glm"));
+    assert!(provider_counts.contains_key("fable_5"));
+    assert!(packet
+        .provider_registry
+        .iter()
+        .any(|provider| provider.transport == "local_cli"));
+    assert!(packet
+        .provider_registry
+        .iter()
+        .any(|provider| provider.structured_json_mode == "prompt_based"));
+}
+
+#[test]
+fn runtime_v2_godel_agent_runtime_binds_agents_to_runtime_graph_and_loop() {
+    let packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    for agent in &packet.agents {
+        assert_eq!(agent.reasoning_graph_id, packet.reasoning_graph_id);
+        assert_eq!(agent.loop_runtime_id, packet.loop_runtime_id);
+        assert_eq!(agent.lifecycle_state, "ready");
+    }
+    assert_eq!(
+        packet.replay.scheduled_agent_count,
+        packet.agents.len() as u32
+    );
+}
+
+#[test]
+fn runtime_v2_godel_agent_runtime_rejects_underprovisioned_agent_sets() {
+    let graph = runtime_v2_reasoning_graph_contract().expect("reasoning graph");
+    let loop_runtime = runtime_v2_loop_runtime_contract().expect("loop runtime");
+    let err =
+        runtime_v2_godel_agent_runtime_contract_for(9, &graph.graph_id, &loop_runtime.runtime_id)
+            .expect_err("less than ten agents should fail");
+
+    assert!(err.to_string().contains("agent count"));
+}
+
+#[test]
+fn runtime_v2_godel_agent_runtime_rejects_provider_and_replay_mismatch() {
+    let mut packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    packet.agents[0].provider_id = "missing_provider".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("missing provider should fail")
+        .to_string()
+        .contains("unknown provider"));
+
+    let mut packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    packet.agents[0].model_ref = "hosted:bedrock/nova-pro".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("agent model ref must match provider target")
+        .to_string()
+        .contains("model_ref must match provider"));
+
+    let mut packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    packet.replay.independent_agent_ids.pop();
+    assert!(packet
+        .validate()
+        .expect_err("replay ids should match agents")
+        .to_string()
+        .contains("independent agent ids"));
+}
+
+#[test]
+fn runtime_v2_godel_agent_runtime_rejects_schedule_agent_count_mismatch() {
+    let mut packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    let mut extra_agent = packet.agents[0].clone();
+    extra_agent.agent_instance_id = "godel-agent-11".to_string();
+    extra_agent.initial_state_id = "godel-agent-11-state-0001".to_string();
+    extra_agent.channel_id = "godel-agent-11-runtime-channel".to_string();
+    extra_agent.evidence_root_ref =
+        "runtime_v2/godel_agent_runtime/agents/godel-agent-11".to_string();
+    packet.agents.push(extra_agent);
+    packet.replay.scheduled_agent_count = packet.agents.len() as u32;
+    packet
+        .replay
+        .independent_agent_ids
+        .push("godel-agent-11".to_string());
+    packet.scheduling.max_independent_agents = 10;
+    assert!(packet
+        .validate()
+        .expect_err("actual agents above scheduling maximum should fail")
+        .to_string()
+        .contains("exceeds scheduling maximum"));
+
+    let mut packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    packet.scheduling.max_concurrent_agents = 11;
+    assert!(packet
+        .validate()
+        .expect_err("concurrency above actual agents should fail")
+        .to_string()
+        .contains("cannot exceed actual agent count"));
+}
+
+#[test]
+fn runtime_v2_godel_agent_runtime_keeps_hosted_invocation_explicitly_bounded() {
+    let packet = runtime_v2_godel_agent_runtime_contract().expect("Godel agent runtime packet");
+    let hosted = packet
+        .provider_registry
+        .iter()
+        .filter(|provider| provider.runtime_surface == "hosted_http")
+        .collect::<Vec<_>>();
+
+    assert!(hosted.len() >= 3);
+    for provider in hosted {
+        assert_eq!(
+            provider.invocation_status,
+            "provider_target_resolved_not_invoked"
+        );
+    }
+    assert!(packet
+        .non_claims
+        .iter()
+        .any(|claim| claim == "not_live_hosted_provider_invocation"));
+}

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -12,6 +12,7 @@ LARGE_FILE_LINES="${COVERAGE_IMPACT_LARGE_FILE_LINES:-200}"
 LARGE_FILE_DELTA="${COVERAGE_IMPACT_LARGE_FILE_DELTA:-80}"
 AEE_COMPANION_DELTA_LIMIT="${COVERAGE_IMPACT_AEE_COMPANION_DELTA:-80}"
 LOOP_RUNTIME_COMPANION_DELTA_LIMIT="${COVERAGE_IMPACT_LOOP_RUNTIME_COMPANION_DELTA:-80}"
+GODEL_AGENT_RUNTIME_COMPANION_DELTA_LIMIT="${COVERAGE_IMPACT_GODEL_AGENT_RUNTIME_COMPANION_DELTA:-80}"
 REQUIRE_SUMMARY_FOR_RISK=false
 PRINT_RISK_FILTERS=false
 PRINT_RISK_NEXTEST_EXPRESSION=false
@@ -282,6 +283,9 @@ candidate_filter_for_path() {
     adl/src/runtime_v2/loop_runtime.rs)
       printf 'runtime_v2_loop_runtime'
       ;;
+    adl/src/runtime_v2/godel_agent_runtime.rs)
+      printf 'runtime_v2_godel_agent_runtime'
+      ;;
     adl/src/gws_live_capability_execution_surface.rs|adl/src/gws_live_content_card_roundtrip.rs|adl/src/gws_live_content_card_roundtrip/*.rs|adl/src/gws_live_safety_package.rs|adl/src/gws_live_test_support.rs)
       printf 'gws_live'
       ;;
@@ -460,6 +464,27 @@ file_is_loop_runtime_companion_surface() {
   esac
 }
 
+file_is_godel_agent_runtime_companion_surface() {
+  local path="$1"
+  grep -Fx "adl/src/runtime_v2/godel_agent_runtime.rs" \
+    <<<"$changed_source_paths" >/dev/null || return 1
+  local delta
+  delta="$(changed_line_delta_for_path "$path")"
+  if ! awk -v delta="$delta" -v limit="$GODEL_AGENT_RUNTIME_COMPANION_DELTA_LIMIT" \
+    'BEGIN { exit ((delta + 0) <= (limit + 0)) ? 0 : 1 }'; then
+    return 1
+  fi
+  case "$path" in
+    adl/src/cli/runtime_v2_cmd/commands.rs|\
+    adl/src/cli/runtime_v2_cmd/helpers.rs)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 focused_summary_command_for_filter() {
   local filter="$1"
   local expression
@@ -502,7 +527,7 @@ print_candidate_filters_fail_closed() {
 
   while IFS=$'\t' read -r status path; do
     [ -n "$path" ] || continue
-    if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_aee_obsmem_pvf_handoff_companion_surface "$path" || file_is_loop_runtime_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
+    if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_aee_obsmem_pvf_handoff_companion_surface "$path" || file_is_loop_runtime_companion_surface "$path" || file_is_godel_agent_runtime_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
       continue
     fi
     if path_has_companion_cli_dispatch_change "$path"; then
@@ -583,6 +608,9 @@ while IFS=$'\t' read -r status path; do
   if file_is_loop_runtime_companion_surface "$path"; then
     continue
   fi
+  if file_is_godel_agent_runtime_companion_surface "$path"; then
+    continue
+  fi
   lines="$(line_count_for_path "$path")"
   delta="$(changed_line_delta_for_path "$path")"
   reason=""
@@ -618,6 +646,9 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
     if file_is_loop_runtime_companion_surface "$path"; then
       continue
     fi
+    if file_is_godel_agent_runtime_companion_surface "$path"; then
+      continue
+    fi
     if file_is_live_runtime_boundary_surface "$path"; then
       continue
     fi
@@ -649,7 +680,7 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
         end
     ' "$SUMMARY")"
     if [ -z "$row" ]; then
-      if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_aee_obsmem_pvf_handoff_companion_surface "$path" || file_is_loop_runtime_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
+      if file_is_structural_module_barrel "$path" || file_has_no_executable_surface "$path" || file_is_tokio_bootstrap_companion_surface "$path" || file_is_aee_obsmem_pvf_handoff_companion_surface "$path" || file_is_loop_runtime_companion_surface "$path" || file_is_godel_agent_runtime_companion_surface "$path" || file_is_live_runtime_boundary_surface "$path"; then
         continue
       fi
       if path_has_companion_cli_dispatch_change "$path"; then

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -589,6 +589,74 @@ if bash "$SCRIPT" --changed-files "$loop_runtime_substantial_companion_changed" 
 fi
 grep -F "adl/src/cli/runtime_v2_cmd/commands.rs (0/609, 0.00% < 80%)" /tmp/coverage-impact-loop-runtime-substantial-companion-fails.out >/dev/null
 
+godel_agent_runtime_changed="$TMP/godel-agent-runtime-changed.txt"
+cat >"$godel_agent_runtime_changed" <<'EOF'
+M	adl/src/cli/runtime_v2_cmd/commands.rs	38
+M	adl/src/cli/runtime_v2_cmd/helpers.rs	5
+A	adl/src/runtime_v2/godel_agent_runtime.rs	710
+EOF
+godel_agent_runtime_filters="$TMP/godel-agent-runtime-filters.txt"
+bash "$SCRIPT" --changed-files "$godel_agent_runtime_changed" --print-risk-filters >"$godel_agent_runtime_filters"
+grep -Fx "runtime_v2_godel_agent_runtime" "$godel_agent_runtime_filters" >/dev/null
+if [ "$(wc -l <"$godel_agent_runtime_filters" | tr -d ' ')" -ne 1 ]; then
+  echo "expected Godel agent runtime surfaces to collapse to the shared runtime_v2_godel_agent_runtime filter" >&2
+  exit 1
+fi
+godel_agent_runtime_expression="$(bash "$SCRIPT" --changed-files "$godel_agent_runtime_changed" --print-risk-nextest-expression)"
+grep -F "test(runtime_v2_godel_agent_runtime)" <<<"$godel_agent_runtime_expression" >/dev/null
+
+godel_agent_runtime_summary="$TMP/godel-agent-runtime-summary.json"
+cat >"$godel_agent_runtime_summary" <<'EOF'
+{
+  "data": [
+    {
+      "files": [
+        {
+          "filename": "adl/src/cli/runtime_v2_cmd/commands.rs",
+          "summary": {
+            "lines": {
+              "covered": 0,
+              "count": 609
+            }
+          }
+        },
+        {
+          "filename": "adl/src/cli/runtime_v2_cmd/helpers.rs",
+          "summary": {
+            "lines": {
+              "covered": 0,
+              "count": 79
+            }
+          }
+        },
+        {
+          "filename": "adl/src/runtime_v2/godel_agent_runtime.rs",
+          "summary": {
+            "lines": {
+              "covered": 601,
+              "count": 710
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+EOF
+bash "$SCRIPT" --changed-files "$godel_agent_runtime_changed" --summary "$godel_agent_runtime_summary" >/tmp/coverage-impact-godel-agent-runtime-pass.out
+grep -F "Coverage-impact preflight passed" /tmp/coverage-impact-godel-agent-runtime-pass.out >/dev/null
+
+godel_agent_runtime_substantial_companion_changed="$TMP/godel-agent-runtime-substantial-companion-changed.txt"
+cat >"$godel_agent_runtime_substantial_companion_changed" <<'EOF'
+M	adl/src/cli/runtime_v2_cmd/commands.rs	120
+A	adl/src/runtime_v2/godel_agent_runtime.rs	710
+EOF
+if bash "$SCRIPT" --changed-files "$godel_agent_runtime_substantial_companion_changed" --summary "$godel_agent_runtime_summary" >/tmp/coverage-impact-godel-agent-runtime-substantial-companion-fails.out 2>&1; then
+  echo "expected substantial Godel agent runtime companion edits to stay threshold-gated" >&2
+  exit 1
+fi
+grep -F "adl/src/cli/runtime_v2_cmd/commands.rs (0/609, 0.00% < 80%)" /tmp/coverage-impact-godel-agent-runtime-substantial-companion-fails.out >/dev/null
+
 missing_summary="$TMP/missing-row-summary.json"
 make_summary "adl/src/runtime_v2/other.rs" 100 100 "$missing_summary"
 if bash "$SCRIPT" --changed-files "$changed" --summary "$missing_summary" >/tmp/coverage-impact-missing-row.out 2>&1; then


### PR DESCRIPTION
Closes #5136

## Summary
Implemented the #5136 follow-up to #5096/#5127 by integrating GHB into Runtime v2 as a first-class Godel agent runtime planning surface. The runtime packet supports 10+ independent Godel agents, binds each agent to Runtime v2 reasoning graph and loop-runtime ids, resolves local and hosted provider targets through the existing provider substrate, records supervised lifecycle/provider/evidence channels, and keeps hosted model invocation explicitly bounded as `provider_target_resolved_not_invoked`.

Also wired `adl runtime-v2 godel-agent-runtime` with optional agents-count and output-path arguments, added focused Runtime v2 contract and CLI tests, and hardened `adl godel ghb-proof --out DIR` so `--out .` is rejected instead of recursively deleting fixed proof child directories under a shared output root.

## Artifacts
- Updated output card at `.adl/v0.91.7/tasks/issue-5136__v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime/sor.md`
- Tracked implementation artifacts:
  - `adl/src/runtime_v2/godel_agent_runtime.rs`
  - `adl/src/runtime_v2/tests/godel_agent_runtime.rs`
  - `adl/src/runtime_v2/mod.rs`
  - `adl/src/runtime_v2/tests.rs`
  - `adl/src/cli/runtime_v2_cmd/commands.rs`
  - `adl/src/cli/runtime_v2_cmd/helpers.rs`
  - `adl/src/cli/runtime_v2_cmd/tests.rs`
  - `adl/src/cli/usage.rs`
  - `adl/src/godel/ghb_loop.rs`
- Additional proof artifacts:
  - `.adl/local-artifacts/issue-5136-godel-agent-runtime/godel-agent-runtime.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
    `Verified Rust formatting for the changed Runtime v2, CLI, and GHB source files.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_godel_agent_runtime -- --nocapture`
    `Verified the Runtime v2 Godel agent runtime packet supports 10 independent agents, binds agents to the reasoning graph and loop runtime, rejects underprovisioned schedules, rejects provider/model drift, rejects schedule/agent-count mismatch, and preserves hosted invocation as explicitly not invoked.`
  - `cargo test --manifest-path adl/Cargo.toml ghb_loop -- --nocapture`
    `Verified existing GHB proof behavior plus the new guard rejecting current-directory proof roots.`
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_godel_agent_runtime -- --nocapture`
    `Verified CLI write-json and argument-validation coverage for the godel-agent-runtime command.`
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- runtime-v2 godel-agent-runtime --agents 10 --out .adl/local-artifacts/issue-5136-godel-agent-runtime/godel-agent-runtime.json`
    `Verified the Runtime v2 CLI writes a 10-agent Godel runtime packet to the requested repository-relative output path.`
  - `git diff --check`
    `Verified staged diff whitespace hygiene.`
  - `ADL_PR_FAST_ALLOW_FULL_NEXTEST=1 bash adl/tools/run_pr_fast_test_lane.sh --changed-files issue-5136-changed-files.txt`
    `Attempted the validation-manager-required full PR-fast lane for the changed surface. The lane ran for approximately 3097 seconds and reported 6990 passed, 1 failed, 18 skipped, and 15320 not run due fail-fast. The single failure was a nextest double-spawn exec artifact for a missing adl-pr-closing-linkage test binary, not an assertion failure in the changed Runtime v2/GHB code.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-closing-linkage cli::pr_cmd::tests::basics::real_pr_create_generated_body_leaves_repairable_evidence_when_not_immediately_ready -- --exact --nocapture`
    `Reran the exact test named by the broad-lane artifact; Cargo rebuilt the missing binary and the test passed.`
- Results:
  - `PASS focused validation`
  - `PASS exact rerun of broad-lane artifact`
  - `BROAD_LANE_ATTEMPTED_WITH_UNRELATED_HARNESS_ARTIFACT`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5136__v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5136__v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime/sor.md
- Idempotency-Key: v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime-adl-src-cli-runtime-v2-cmd-commands-rs-adl-src-cli-runtime-v2-cmd-helpers-rs-adl-src-cli-runtime-v2-cmd-tests-rs-adl-src-cli-usage-rs-adl-src-godel-ghb-loop-rs-adl-src-runtime-v2-godel-agent-runtime-rs-adl-src-runtime-v2-mod-rs-adl-src-runtime-v2-tests-rs-adl-src-runtime-v2-tests-godel-agent-runtime-rs-adl-v0-91-7-tasks-issue-5136-v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime-sip-md-adl-v0-91-7-tasks-issue-5136-v0-91-7-wp-11-godel-ghb-integrate-ghb-as-runtime-v2-agent-runtime-sor-md