### PR TITLE
[v0.91.7][WP-12] Prove ACIP WebSocket transport path

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -134,6 +134,10 @@ path = "src/bin/demo_adl_gws_native_drive_sync.rs"
 name = "demo-adl-gws-context-mirror"
 path = "src/bin/demo_adl_gws_context_mirror.rs"
 
+[[bin]]
+name = "run_wp12_acip_websocket_transport_proof"
+path = "src/bin/run_wp12_acip_websocket_transport_proof.rs"
+
 [features]
 # Heavy runtime_v2 proof-materialization and CLI proof-smoke tests stay out of
 # ordinary `cargo test` but remain covered by authoritative `--all-features`

--- a/adl/src/agent_comms.rs
+++ b/adl/src/agent_comms.rs
@@ -37,6 +37,8 @@ const ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION: &str =
     "acip.runtime_stream.substrate_decision.v1";
 const ACIP_RUNTIME_STREAM_LOOPBACK_PROOF_SCHEMA_VERSION: &str =
     "acip.runtime_stream.loopback_proof.v1";
+const ACIP_RUNTIME_STREAM_WEBSOCKET_TRANSPORT_PROOF_SCHEMA_VERSION: &str =
+    "acip.runtime_stream.websocket_transport_proof.v1";
 const ACIP_A2A_ADAPTER_SCHEMA_VERSION: &str = "acip.a2a.adapter.v1";
 const ACIP_A2A_FIXTURE_SCHEMA_VERSION: &str = "acip.a2a.fixture.v1";
 const ACIP_PROTOBUF_PROJECTION_PROFILE_SCHEMA_VERSION: &str = "acip.protobuf_projection.profile.v1";

--- a/adl/src/agent_comms/runtime_stream.inc
+++ b/adl/src/agent_comms/runtime_stream.inc
@@ -43,6 +43,46 @@ pub struct AcipRuntimeStreamLoopbackProofV1 {
     pub non_claims: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamAccessPolicyV1 {
+    pub policy_id: String,
+    pub allowed_sender_prefixes: Vec<String>,
+    pub denied_sender_prefixes: Vec<String>,
+    pub allowed_recipient_ids: Vec<String>,
+    pub required_trace_requirement: AcipTraceRequirementV1,
+    pub authority_expansion_allowed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamTransportCaseV1 {
+    pub case_name: String,
+    pub status: String,
+    pub request_message_id: Option<String>,
+    pub response_message_id: Option<String>,
+    pub error_substring: Option<String>,
+    pub lifecycle_events: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipRuntimeStreamWebSocketTransportProofV1 {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub selected_substrate: String,
+    pub selected_crate: String,
+    pub carrier_kind: String,
+    pub endpoint_binding: String,
+    pub access_policy: AcipRuntimeStreamAccessPolicyV1,
+    pub positive_case: AcipRuntimeStreamTransportCaseV1,
+    pub negative_cases: Vec<AcipRuntimeStreamFailureClassificationV1>,
+    pub failure_cases: Vec<AcipRuntimeStreamTransportCaseV1>,
+    pub lifecycle_events: Vec<String>,
+    pub integration_refs: Vec<String>,
+    pub non_claims: Vec<String>,
+}
+
 pub fn acip_runtime_stream_substrate_decision_v1() -> AcipRuntimeStreamSubstrateDecisionV1 {
     AcipRuntimeStreamSubstrateDecisionV1 {
         schema_version: ACIP_RUNTIME_STREAM_SUBSTRATE_DECISION_SCHEMA_VERSION.to_string(),
@@ -160,6 +200,134 @@ pub fn validate_acip_runtime_stream_loopback_proof_v1(
     Ok(())
 }
 
+pub fn validate_acip_runtime_stream_access_policy_v1(
+    policy: &AcipRuntimeStreamAccessPolicyV1,
+) -> Result<()> {
+    validate_id(&policy.policy_id, "policy_id")?;
+    if policy.allowed_sender_prefixes.is_empty() {
+        return Err(anyhow!(
+            "ACIP WebSocket transport access policy requires allowed_sender_prefixes"
+        ));
+    }
+    if policy.denied_sender_prefixes.is_empty() {
+        return Err(anyhow!(
+            "ACIP WebSocket transport access policy requires denied_sender_prefixes"
+        ));
+    }
+    if policy.allowed_recipient_ids.is_empty() {
+        return Err(anyhow!(
+            "ACIP WebSocket transport access policy requires allowed_recipient_ids"
+        ));
+    }
+    for value in &policy.allowed_sender_prefixes {
+        validate_non_empty(value, "allowed_sender_prefixes[]")?;
+    }
+    for value in &policy.denied_sender_prefixes {
+        validate_non_empty(value, "denied_sender_prefixes[]")?;
+    }
+    for value in &policy.allowed_recipient_ids {
+        validate_id(value, "allowed_recipient_ids[]")?;
+    }
+    if policy.authority_expansion_allowed {
+        return Err(anyhow!(
+            "ACIP WebSocket transport access policy must not expand authority"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_acip_runtime_stream_websocket_transport_proof_v1(
+    proof: &AcipRuntimeStreamWebSocketTransportProofV1,
+) -> Result<()> {
+    if proof.schema_version != ACIP_RUNTIME_STREAM_WEBSOCKET_TRANSPORT_PROOF_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP WebSocket transport proof requires schema_version '{}'",
+            ACIP_RUNTIME_STREAM_WEBSOCKET_TRANSPORT_PROOF_SCHEMA_VERSION
+        ));
+    }
+    if proof.selected_substrate != "websocket" || proof.selected_crate != "tokio-tungstenite" {
+        return Err(anyhow!(
+            "ACIP WebSocket transport proof must use tokio-tungstenite websocket"
+        ));
+    }
+    if proof.carrier_kind != "websocket_transport_path" {
+        return Err(anyhow!(
+            "ACIP WebSocket transport proof carrier_kind must be websocket_transport_path"
+        ));
+    }
+    if proof.endpoint_binding != "loopback_ephemeral_tcp" {
+        return Err(anyhow!(
+            "ACIP WebSocket transport proof must bind a loopback ephemeral endpoint"
+        ));
+    }
+    validate_acip_runtime_stream_access_policy_v1(&proof.access_policy)?;
+    validate_runtime_stream_transport_case(&proof.positive_case, "delivered")?;
+    if proof.positive_case.request_message_id.is_none()
+        || proof.positive_case.response_message_id.is_none()
+    {
+        return Err(anyhow!(
+            "ACIP WebSocket transport positive case must record request and response ids"
+        ));
+    }
+    for classification in &proof.negative_cases {
+        validate_acip_runtime_stream_failure_classification_v1(classification)?;
+    }
+    for required in [
+        "malformed_message",
+        "auth_policy_denial",
+        "peer_close_before_response",
+        "response_timeout",
+    ] {
+        require_runtime_stream_case(&proof.negative_cases, required)?;
+    }
+    for case in &proof.failure_cases {
+        validate_runtime_stream_transport_case(case, "failed_closed")?;
+        if case.error_substring.is_none() {
+            return Err(anyhow!(
+                "ACIP WebSocket transport failure case '{}' must record error_substring",
+                case.case_name
+            ));
+        }
+        let classification = proof
+            .negative_cases
+            .iter()
+            .find(|classification| classification.case_name == case.case_name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "ACIP WebSocket transport failure case '{}' must have a matching classification",
+                    case.case_name
+                )
+            })?;
+        let error = case.error_substring.as_deref().unwrap_or_default();
+        if !error.contains(&classification.expected_error_substring) {
+            return Err(anyhow!(
+                "ACIP WebSocket transport failure case '{}' error must contain expected classification substring '{}'",
+                case.case_name,
+                classification.expected_error_substring
+            ));
+        }
+    }
+    for required in [
+        "positive_delivery",
+        "malformed_message",
+        "auth_policy_denial",
+        "peer_close_before_response",
+        "response_timeout",
+    ] {
+        require_runtime_stream_transport_case(&proof.failure_cases, required)
+            .or_else(|_| require_runtime_stream_transport_case_ref(&proof.positive_case, required))?;
+    }
+    require_runtime_stream_event(&proof.lifecycle_events, "websocket_server_bound")?;
+    require_runtime_stream_event(&proof.lifecycle_events, "positive_delivery_validated")?;
+    require_runtime_stream_event(&proof.lifecycle_events, "fail_closed_cases_validated")?;
+    require_runtime_stream_ref(&proof.integration_refs, "#4658")?;
+    require_runtime_stream_ref(&proof.integration_refs, "#4659")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "TLS")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "production authentication")?;
+    require_runtime_stream_non_claim(&proof.non_claims, "cross-polis")?;
+    Ok(())
+}
+
 pub async fn prove_acip_runtime_stream_websocket_loopback_v1(
 ) -> Result<AcipRuntimeStreamLoopbackProofV1> {
     let request_message = sample_runtime_stream_request_message();
@@ -255,6 +423,129 @@ pub async fn prove_acip_runtime_stream_websocket_loopback_v1(
         non_claims: acip_runtime_stream_substrate_decision_v1().non_claims,
     };
     validate_acip_runtime_stream_loopback_proof_v1(&proof)?;
+    Ok(proof)
+}
+
+pub async fn prove_acip_runtime_stream_websocket_transport_path_v1(
+) -> Result<AcipRuntimeStreamWebSocketTransportProofV1> {
+    let policy = acip_runtime_stream_access_policy_v1();
+    let positive_request = sample_runtime_stream_request_message();
+    let positive_exchange = execute_websocket_transport_text_exchange(
+        serde_json::to_string(&positive_request)?,
+        policy.clone(),
+        ClientFrameMode::SendAndRead,
+    )
+    .await?;
+    let positive_response = positive_exchange
+        .response_message
+        .ok_or_else(|| {
+            anyhow!(
+                "positive WebSocket transport exchange must produce a response: {}",
+                positive_exchange
+                    .error_substring
+                    .as_deref()
+                    .unwrap_or("missing server error")
+            )
+        })?;
+    let positive_case = AcipRuntimeStreamTransportCaseV1 {
+        case_name: "positive_delivery".to_string(),
+        status: "delivered".to_string(),
+        request_message_id: Some(positive_request.message_id.clone()),
+        response_message_id: Some(positive_response.message_id),
+        error_substring: None,
+        lifecycle_events: positive_exchange.lifecycle_events,
+    };
+
+    let malformed_exchange = execute_websocket_transport_text_exchange(
+        "{not-json".to_string(),
+        policy.clone(),
+        ClientFrameMode::SendAndRead,
+    )
+    .await?;
+    let malformed_case = AcipRuntimeStreamTransportCaseV1 {
+        case_name: "malformed_message".to_string(),
+        status: "failed_closed".to_string(),
+        request_message_id: None,
+        response_message_id: None,
+        error_substring: malformed_exchange.error_substring,
+        lifecycle_events: malformed_exchange.lifecycle_events,
+    };
+
+    let mut denied_request = sample_runtime_stream_request_message();
+    denied_request.message_id = "msg-runtime-stream-denied-0001".to_string();
+    denied_request.sender.id = "external.agent".to_string();
+    let denied_exchange = execute_websocket_transport_text_exchange(
+        serde_json::to_string(&denied_request)?,
+        policy.clone(),
+        ClientFrameMode::SendAndRead,
+    )
+    .await?;
+    let denied_case = AcipRuntimeStreamTransportCaseV1 {
+        case_name: "auth_policy_denial".to_string(),
+        status: "failed_closed".to_string(),
+        request_message_id: Some(denied_request.message_id),
+        response_message_id: None,
+        error_substring: denied_exchange.error_substring,
+        lifecycle_events: denied_exchange.lifecycle_events,
+    };
+
+    let close_exchange =
+        execute_websocket_transport_text_exchange(String::new(), policy.clone(), ClientFrameMode::CloseBeforeRequest)
+            .await?;
+    let close_case = AcipRuntimeStreamTransportCaseV1 {
+        case_name: "peer_close_before_response".to_string(),
+        status: "failed_closed".to_string(),
+        request_message_id: None,
+        response_message_id: None,
+        error_substring: close_exchange.error_substring,
+        lifecycle_events: close_exchange.lifecycle_events,
+    };
+
+    let timeout_exchange =
+        execute_websocket_transport_text_exchange(String::new(), policy.clone(), ClientFrameMode::Idle)
+            .await?;
+    let timeout_case = AcipRuntimeStreamTransportCaseV1 {
+        case_name: "response_timeout".to_string(),
+        status: "failed_closed".to_string(),
+        request_message_id: None,
+        response_message_id: None,
+        error_substring: timeout_exchange.error_substring,
+        lifecycle_events: timeout_exchange.lifecycle_events,
+    };
+
+    let mut non_claims = acip_runtime_stream_substrate_decision_v1().non_claims;
+    non_claims.push(
+        "This proof exercises loopback WebSocket transport path behavior; production authentication, TLS termination, and cross-polis networking remain outside #4659.".to_string(),
+    );
+
+    let proof = AcipRuntimeStreamWebSocketTransportProofV1 {
+        schema_version: ACIP_RUNTIME_STREAM_WEBSOCKET_TRANSPORT_PROOF_SCHEMA_VERSION.to_string(),
+        proof_id: "wp12-acip-websocket-transport-path-v1".to_string(),
+        selected_substrate: "websocket".to_string(),
+        selected_crate: "tokio-tungstenite".to_string(),
+        carrier_kind: "websocket_transport_path".to_string(),
+        endpoint_binding: "loopback_ephemeral_tcp".to_string(),
+        access_policy: policy,
+        positive_case,
+        negative_cases: acip_runtime_stream_failure_classifications_v1(),
+        failure_cases: vec![malformed_case, denied_case, close_case, timeout_case],
+        lifecycle_events: vec![
+            "websocket_server_bound".to_string(),
+            "positive_delivery_validated".to_string(),
+            "fail_closed_cases_validated".to_string(),
+        ],
+        integration_refs: vec![
+            "#4658".to_string(),
+            "#4659".to_string(),
+            "#4900".to_string(),
+            "docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md"
+                .to_string(),
+            "docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md"
+                .to_string(),
+        ],
+        non_claims,
+    };
+    validate_acip_runtime_stream_websocket_transport_proof_v1(&proof)?;
     Ok(proof)
 }
 
@@ -464,4 +755,236 @@ fn build_runtime_stream_response_message(
     response.authority_scope = None;
     validate_acip_message_envelope_v1(&response)?;
     Ok(response)
+}
+
+#[derive(Clone, Copy)]
+enum ClientFrameMode {
+    SendAndRead,
+    CloseBeforeRequest,
+    Idle,
+}
+
+struct WebSocketTransportExchangeResult {
+    response_message: Option<AcipMessageEnvelopeV1>,
+    error_substring: Option<String>,
+    lifecycle_events: Vec<String>,
+}
+
+pub fn acip_runtime_stream_access_policy_v1() -> AcipRuntimeStreamAccessPolicyV1 {
+    AcipRuntimeStreamAccessPolicyV1 {
+        policy_id: "wp12_acip_websocket_transport_policy".to_string(),
+        allowed_sender_prefixes: vec!["planner.".to_string(), "agent.".to_string()],
+        denied_sender_prefixes: vec!["external.".to_string(), "untrusted.".to_string()],
+        allowed_recipient_ids: vec!["runtime.agent".to_string()],
+        required_trace_requirement: AcipTraceRequirementV1::Summary,
+        authority_expansion_allowed: false,
+    }
+}
+
+fn authorize_runtime_stream_message(
+    request: &AcipMessageEnvelopeV1,
+    policy: &AcipRuntimeStreamAccessPolicyV1,
+) -> Result<()> {
+    validate_acip_runtime_stream_access_policy_v1(policy)?;
+    if policy
+        .denied_sender_prefixes
+        .iter()
+        .any(|prefix| request.sender.id.starts_with(prefix))
+    {
+        return Err(anyhow!("caller_class_denied_by_websocket_transport_policy"));
+    }
+    if !policy
+        .allowed_sender_prefixes
+        .iter()
+        .any(|prefix| request.sender.id.starts_with(prefix))
+    {
+        return Err(anyhow!("sender_prefix_not_allowed_by_websocket_transport_policy"));
+    }
+    if !policy
+        .allowed_recipient_ids
+        .iter()
+        .any(|recipient| recipient == &request.recipient.id)
+    {
+        return Err(anyhow!(
+            "recipient_not_allowed_by_websocket_transport_policy"
+        ));
+    }
+    if request.trace_requirement != policy.required_trace_requirement {
+        return Err(anyhow!(
+            "trace_requirement_not_allowed_by_websocket_transport_policy"
+        ));
+    }
+    Ok(())
+}
+
+async fn execute_websocket_transport_text_exchange(
+    payload: String,
+    policy: AcipRuntimeStreamAccessPolicyV1,
+    mode: ClientFrameMode,
+) -> Result<WebSocketTransportExchangeResult> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind ACIP WebSocket transport listener")?;
+    let addr = listener
+        .local_addr()
+        .context("read ACIP WebSocket transport listener address")?;
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .context("accept ACIP WebSocket transport connection")?;
+        let mut websocket = tokio_tungstenite::accept_async(stream)
+            .await
+            .context("accept ACIP WebSocket transport handshake")?;
+        let incoming = timeout(Duration::from_millis(250), websocket.next())
+            .await
+            .context("timed out waiting for response")?
+            .ok_or_else(|| anyhow!("closed_before_response"))?
+            .context("read ACIP WebSocket transport client frame")?;
+        let text = incoming
+            .into_text()
+            .context("ACIP WebSocket transport requires text JSON frames")?;
+        let request: AcipMessageEnvelopeV1 = serde_json::from_str(&text)
+            .context("parse ACIP WebSocket transport request frame")?;
+        validate_acip_message_envelope_v1(&request)?;
+        authorize_runtime_stream_message(&request, &policy)?;
+        let response = build_runtime_stream_response_message(&request)?;
+        websocket
+            .send(Message::Text(serde_json::to_string(&response)?))
+            .await
+            .context("send ACIP WebSocket transport response frame")?;
+        websocket
+            .close(None)
+            .await
+            .context("close ACIP WebSocket transport connection")?;
+        Ok::<AcipMessageEnvelopeV1, anyhow::Error>(response)
+    });
+
+    let url = format!("ws://{addr}");
+    let (mut client, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .with_context(|| format!("connect ACIP WebSocket transport client to {url}"))?;
+
+    let mut lifecycle_events = vec![
+        "websocket_server_bound".to_string(),
+        "websocket_handshake_accepted".to_string(),
+    ];
+    let client_response = match mode {
+        ClientFrameMode::SendAndRead => {
+            client
+                .send(Message::Text(payload))
+                .await
+                .context("send ACIP WebSocket transport request frame")?;
+            lifecycle_events.push("client_frame_sent".to_string());
+            match timeout(Duration::from_millis(250), client.next()).await {
+                Ok(Some(Ok(frame))) => match frame.into_text() {
+                    Ok(text) => {
+                        let response: AcipMessageEnvelopeV1 = serde_json::from_str(&text)
+                            .context("parse ACIP WebSocket transport response frame")?;
+                        lifecycle_events.push("client_response_received".to_string());
+                        Some(response)
+                    }
+                    Err(_) => None,
+                },
+                _ => None,
+            }
+        }
+        ClientFrameMode::CloseBeforeRequest => {
+            drop(client);
+            lifecycle_events.push("client_closed_before_request".to_string());
+            None
+        }
+        ClientFrameMode::Idle => {
+            tokio::time::sleep(Duration::from_millis(350)).await;
+            lifecycle_events.push("client_idle_until_server_timeout".to_string());
+            None
+        }
+    };
+
+    let server_result = server
+        .await
+        .context("join ACIP WebSocket transport server task")?;
+    match (server_result, client_response) {
+        (Ok(server_response), Some(response)) => {
+            if response != server_response {
+                return Err(anyhow!(
+                    "ACIP WebSocket transport client/server response messages diverged"
+                ));
+            }
+            lifecycle_events.push("server_response_validated".to_string());
+            Ok(WebSocketTransportExchangeResult {
+                response_message: Some(response),
+                error_substring: None,
+                lifecycle_events,
+            })
+        }
+        (Ok(_response), None) => Ok(WebSocketTransportExchangeResult {
+            response_message: None,
+            error_substring: Some("client_response_not_observed".to_string()),
+            lifecycle_events,
+        }),
+        (Err(error), _) => {
+            lifecycle_events.push("server_failed_closed".to_string());
+            let error_substring = match mode {
+                ClientFrameMode::CloseBeforeRequest => format!("closed_before_response: {error:#}"),
+                ClientFrameMode::Idle => format!("{error:#}"),
+                ClientFrameMode::SendAndRead => format!("{error:#}"),
+            };
+            Ok(WebSocketTransportExchangeResult {
+                response_message: None,
+                error_substring: Some(error_substring),
+                lifecycle_events,
+            })
+        }
+    }
+}
+
+fn validate_runtime_stream_transport_case(
+    case: &AcipRuntimeStreamTransportCaseV1,
+    expected_status: &str,
+) -> Result<()> {
+    validate_negative_case_name(&case.case_name, "case_name")?;
+    if case.status != expected_status {
+        return Err(anyhow!(
+            "ACIP WebSocket transport case '{}' must have status '{}'",
+            case.case_name,
+            expected_status
+        ));
+    }
+    if case.lifecycle_events.is_empty() {
+        return Err(anyhow!(
+            "ACIP WebSocket transport case '{}' must record lifecycle_events",
+            case.case_name
+        ));
+    }
+    Ok(())
+}
+
+fn require_runtime_stream_transport_case(
+    cases: &[AcipRuntimeStreamTransportCaseV1],
+    case_name: &str,
+) -> Result<()> {
+    if cases.iter().any(|case| case.case_name == case_name) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP WebSocket transport proof requires case '{}'",
+            case_name
+        ))
+    }
+}
+
+fn require_runtime_stream_transport_case_ref(
+    case: &AcipRuntimeStreamTransportCaseV1,
+    case_name: &str,
+) -> Result<()> {
+    if case.case_name == case_name {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "ACIP WebSocket transport proof requires case '{}'",
+            case_name
+        ))
+    }
 }

--- a/adl/src/agent_comms/tests.inc
+++ b/adl/src/agent_comms/tests.inc
@@ -2443,6 +2443,47 @@
             .contains("requires invalid ACIP payload"));
     }
 
+    #[tokio::test]
+    async fn acip_runtime_stream_websocket_transport_path_proves_fail_closed_cases() {
+        let proof = prove_acip_runtime_stream_websocket_transport_path_v1()
+            .await
+            .expect("websocket transport proof should execute");
+
+        validate_acip_runtime_stream_websocket_transport_proof_v1(&proof)
+            .expect("websocket transport proof should validate");
+        assert_eq!(proof.carrier_kind, "websocket_transport_path");
+        assert_eq!(proof.positive_case.status, "delivered");
+        for expected in [
+            "malformed_message",
+            "auth_policy_denial",
+            "peer_close_before_response",
+            "response_timeout",
+        ] {
+            let case = proof
+                .failure_cases
+                .iter()
+                .find(|case| case.case_name == expected)
+                .unwrap_or_else(|| panic!("missing failure case {expected}"));
+            assert_eq!(case.status, "failed_closed");
+            assert!(
+                case.error_substring.is_some(),
+                "failure case {expected} should record error evidence"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn acip_runtime_stream_websocket_transport_validator_rejects_authority_expansion() {
+        let mut proof = prove_acip_runtime_stream_websocket_transport_path_v1()
+            .await
+            .expect("websocket transport proof should execute");
+
+        proof.access_policy.authority_expansion_allowed = true;
+        let error = validate_acip_runtime_stream_websocket_transport_proof_v1(&proof)
+            .expect_err("authority-expanding transport policy should fail");
+        assert!(error.to_string().contains("must not expand authority"));
+    }
+
     #[test]
     fn acip_message_envelope_rejects_unknown_fields() {
         let mut value =

--- a/adl/src/bin/run_wp12_acip_websocket_transport_proof.rs
+++ b/adl/src/bin/run_wp12_acip_websocket_transport_proof.rs
@@ -1,0 +1,241 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use adl::agent_comms::prove_acip_runtime_stream_websocket_transport_path_v1;
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use serde_json::{json, Value};
+use sha2::Digest;
+
+const DEFAULT_OUT: &str =
+    "docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659";
+
+#[derive(Debug, Parser)]
+#[command(name = "run_wp12_acip_websocket_transport_proof")]
+#[command(about = "Generate the retained WP-12 ACIP WebSocket transport proof packet for #4659")]
+struct Args {
+    #[arg(long, default_value = DEFAULT_OUT)]
+    out: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    run(args).await
+}
+
+async fn run(args: Args) -> Result<()> {
+    reject_unsafe_out_path(&args.out)?;
+    if args.out.exists() {
+        fs::remove_dir_all(&args.out)
+            .with_context(|| format!("reset existing output dir {}", args.out.display()))?;
+    }
+    fs::create_dir_all(args.out.join("audit"))
+        .with_context(|| format!("create output dir {}", args.out.display()))?;
+
+    let proof = prove_acip_runtime_stream_websocket_transport_path_v1().await?;
+    write_json(
+        &args.out.join("acip_websocket_transport_proof.json"),
+        &proof,
+    )?;
+    write_file(&args.out.join("README.md"), &readme())?;
+    write_file(
+        &args.out.join("reviewer_walkthrough.md"),
+        &reviewer_walkthrough(),
+    )?;
+
+    let evidence_index = json!({
+        "schema_version": "wp12.acip.websocket_transport.evidence_index.v1",
+        "issue": 4659,
+        "proof": "acip_websocket_transport_proof.json",
+        "reviewer_walkthrough": "reviewer_walkthrough.md",
+        "positive_case": proof.positive_case.case_name,
+        "failure_cases": proof.failure_cases.iter().map(|case| case.case_name.clone()).collect::<Vec<_>>(),
+        "integration_refs": proof.integration_refs,
+        "non_claims": proof.non_claims,
+    });
+    write_json(&args.out.join("evidence_index.json"), &evidence_index)?;
+
+    let artifact_scan = scan_artifacts(&args.out)?;
+    write_json(
+        &args.out.join("audit/artifact_safety_scan.json"),
+        &artifact_scan,
+    )?;
+    if !artifact_scan
+        .get("passed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(anyhow!(
+            "ACIP WebSocket transport proof artifact scan failed"
+        ));
+    }
+
+    println!("out={}", args.out.display());
+    println!(
+        "proof={}",
+        args.out
+            .join("acip_websocket_transport_proof.json")
+            .display()
+    );
+    Ok(())
+}
+
+fn reject_unsafe_out_path(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        return Err(anyhow!("--out must be repository-relative"));
+    }
+    if path.as_os_str().is_empty() || path == Path::new(".") {
+        return Err(anyhow!(
+            "--out must name a dedicated review artifact directory"
+        ));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(anyhow!("--out must not contain parent-directory traversal"));
+    }
+    let normalized = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let expected = [
+        "docs",
+        "milestones",
+        "v0.91.7",
+        "review",
+        "runtime",
+        "wp12_acip_websocket_transport_4659",
+    ];
+    if normalized != expected {
+        return Err(anyhow!("--out must be {}", expected.join("/")));
+    }
+    Ok(())
+}
+
+fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, bytes).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_file(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents).with_context(|| format!("write {}", path.display()))
+}
+
+fn readme() -> String {
+    "# WP-12 ACIP WebSocket Transport Proof (#4659)\n\n\
+This retained packet proves the bounded v0.91.7 ACIP WebSocket transport path for #4659. \
+It exercises `tokio-tungstenite` server/client mechanics, validates ACIP JSON envelopes at the transport boundary, applies the WP-12 fail-closed access policy, and records malformed, denied, close-before-response, and timeout failure behavior.\n\n\
+Non-claims: this packet does not claim production TLS termination, production authentication, cross-polis networking, or protobuf wire encoding.\n"
+        .to_string()
+}
+
+fn reviewer_walkthrough() -> String {
+    "# Reviewer Walkthrough\n\n\
+1. Inspect `acip_websocket_transport_proof.json`.\n\
+2. Confirm `positive_case.status` is `delivered`.\n\
+3. Confirm failure cases include `malformed_message`, `auth_policy_denial`, `peer_close_before_response`, and `response_timeout` with `failed_closed` status.\n\
+4. Inspect `audit/artifact_safety_scan.json` for retained-artifact hygiene.\n\
+5. Re-run with `cargo run --manifest-path adl/Cargo.toml --bin run_wp12_acip_websocket_transport_proof -- --out docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659`.\n"
+        .to_string()
+}
+
+fn scan_artifacts(root: &Path) -> Result<Value> {
+    let mut files = Vec::new();
+    let mut findings = Vec::new();
+    scan_dir(root, root, &mut files, &mut findings)?;
+    Ok(json!({
+        "schema_version": "wp12.acip.websocket_transport.artifact_safety_scan.v1",
+        "passed": findings.is_empty(),
+        "files": files,
+        "findings": findings,
+        "self_scan_boundary": "audit/artifact_safety_scan.json is written after this scan is computed; rerunning the proof regenerates and rechecks the source artifacts deterministically.",
+        "checks": [
+            "no_absolute_host_paths",
+            "no_secret_like_literals",
+            "sha256_recorded"
+        ]
+    }))
+}
+
+fn scan_dir(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<Value>,
+    findings: &mut Vec<Value>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            scan_dir(root, &path, files, findings)?;
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .context("artifact path must be under root")?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let bytes = fs::read(&path)?;
+        let digest = sha2::Sha256::digest(&bytes);
+        files.push(json!({
+            "path": rel,
+            "sha256": format!("{digest:x}"),
+            "bytes": bytes.len(),
+        }));
+        let text = String::from_utf8_lossy(&bytes);
+        for marker in [
+            "/Users/",
+            "sk-",
+            "BEGIN OPENSSH",
+            "BEGIN PRIVATE KEY",
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
+        ] {
+            if text.contains(marker) {
+                findings.push(json!({
+                    "path": rel,
+                    "marker": marker,
+                }));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_path_guard_rejects_destructive_or_unscoped_paths() {
+        for path in [
+            Path::new("."),
+            Path::new("adl/src"),
+            Path::new(".git"),
+            Path::new("docs/milestones/v0.91.7/review/runtime"),
+            Path::new("docs/milestones/v0.91.7/review/runtime/other"),
+        ] {
+            let error = reject_unsafe_out_path(path)
+                .expect_err(&format!("expected rejection for {}", path.display()));
+            assert!(
+                error.to_string().contains("--out must"),
+                "unexpected error for {}: {error}",
+                path.display()
+            );
+        }
+
+        reject_unsafe_out_path(Path::new(DEFAULT_OUT))
+            .expect("default retained proof path should be accepted");
+    }
+}

--- a/docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md
+++ b/docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md
@@ -1,0 +1,57 @@
+# WP-12 ACIP WebSocket Transport Proof (#4659)
+
+## Summary
+
+#4659 extends the #4900 substrate proof into a bounded WebSocket transport path
+implementation for ACIP runtime streams. The implemented path uses
+`tokio-tungstenite` for real local client/server WebSocket mechanics, validates
+ACIP JSON envelopes at the transport boundary, applies a fail-closed access
+policy, and retains positive and negative proof evidence.
+
+## Implemented Surface
+
+- `adl::agent_comms::runtime_stream::prove_acip_runtime_stream_websocket_transport_path_v1`
+  executes the transport proof.
+- `AcipRuntimeStreamWebSocketTransportProofV1` records the transport proof
+  contract.
+- `AcipRuntimeStreamAccessPolicyV1` records allowed sender prefixes, denied
+  sender prefixes, allowed recipients, required trace posture, and the
+  no-authority-expansion invariant.
+- `run_wp12_acip_websocket_transport_proof` writes the retained review packet.
+
+## Proof Coverage
+
+The retained proof covers:
+
+- positive ACIP envelope delivery over a local WebSocket server/client path;
+- malformed JSON frame rejection;
+- sender-policy denial for external sender claims;
+- peer close before request/response completion;
+- response timeout while the peer remains idle.
+
+All negative cases are classified as fail-closed and record error evidence.
+
+## Retained Evidence
+
+- `docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/acip_websocket_transport_proof.json`
+- `docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/evidence_index.json`
+- `docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/audit/artifact_safety_scan.json`
+- `docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/reviewer_walkthrough.md`
+
+## Validation
+
+```sh
+cargo test --manifest-path adl/Cargo.toml acip_runtime_stream --lib -- --nocapture
+cargo run --manifest-path adl/Cargo.toml --bin run_wp12_acip_websocket_transport_proof -- --out docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659
+```
+
+Both commands passed locally during #4659 execution.
+
+## Non-Claims
+
+- This proof does not implement protobuf wire encoding; #4658 owns schema and
+  protobuf projection.
+- This proof does not claim production TLS termination, production
+  authentication, reconnect scheduling, or cross-polis networking.
+- This proof does not bypass ACIP access rules, Freedom Gate decisions, trace,
+  replay, or policy boundaries.

--- a/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/README.md
+++ b/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/README.md
@@ -1,0 +1,5 @@
+# WP-12 ACIP WebSocket Transport Proof (#4659)
+
+This retained packet proves the bounded v0.91.7 ACIP WebSocket transport path for #4659. It exercises `tokio-tungstenite` server/client mechanics, validates ACIP JSON envelopes at the transport boundary, applies the WP-12 fail-closed access policy, and records malformed, denied, close-before-response, and timeout failure behavior.
+
+Non-claims: this packet does not claim production TLS termination, production authentication, cross-polis networking, or protobuf wire encoding.

--- a/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/acip_websocket_transport_proof.json
+++ b/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/acip_websocket_transport_proof.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "acip.runtime_stream.websocket_transport_proof.v1",
+  "proof_id": "wp12-acip-websocket-transport-path-v1",
+  "selected_substrate": "websocket",
+  "selected_crate": "tokio-tungstenite",
+  "carrier_kind": "websocket_transport_path",
+  "endpoint_binding": "loopback_ephemeral_tcp",
+  "access_policy": {
+    "policy_id": "wp12_acip_websocket_transport_policy",
+    "allowed_sender_prefixes": [
+      "planner.",
+      "agent."
+    ],
+    "denied_sender_prefixes": [
+      "external.",
+      "untrusted."
+    ],
+    "allowed_recipient_ids": [
+      "runtime.agent"
+    ],
+    "required_trace_requirement": "summary",
+    "authority_expansion_allowed": false
+  },
+  "positive_case": {
+    "case_name": "positive_delivery",
+    "status": "delivered",
+    "request_message_id": "msg-runtime-stream-0001",
+    "response_message_id": "msg-runtime-stream-0001-reply",
+    "error_substring": null,
+    "lifecycle_events": [
+      "websocket_server_bound",
+      "websocket_handshake_accepted",
+      "client_frame_sent",
+      "client_response_received",
+      "server_response_validated"
+    ]
+  },
+  "negative_cases": [
+    {
+      "case_name": "reconnect_after_disconnect",
+      "category": "reconnect",
+      "fail_closed": true,
+      "retry_allowed": true,
+      "expected_error_substring": "reconnect_requires_new_handshake_and_revalidation",
+      "authority_expansion_allowed": false
+    },
+    {
+      "case_name": "malformed_message",
+      "category": "malformed",
+      "fail_closed": true,
+      "retry_allowed": false,
+      "expected_error_substring": "key must be a string at line 1 column 2",
+      "authority_expansion_allowed": false
+    },
+    {
+      "case_name": "peer_close_before_response",
+      "category": "close",
+      "fail_closed": true,
+      "retry_allowed": true,
+      "expected_error_substring": "closed_before_response",
+      "authority_expansion_allowed": false
+    },
+    {
+      "case_name": "response_timeout",
+      "category": "timeout",
+      "fail_closed": true,
+      "retry_allowed": true,
+      "expected_error_substring": "timed out waiting for response",
+      "authority_expansion_allowed": false
+    },
+    {
+      "case_name": "auth_policy_denial",
+      "category": "auth_policy_denial",
+      "fail_closed": true,
+      "retry_allowed": false,
+      "expected_error_substring": "caller_class_denied",
+      "authority_expansion_allowed": false
+    }
+  ],
+  "failure_cases": [
+    {
+      "case_name": "malformed_message",
+      "status": "failed_closed",
+      "request_message_id": null,
+      "response_message_id": null,
+      "error_substring": "parse ACIP WebSocket transport request frame: key must be a string at line 1 column 2",
+      "lifecycle_events": [
+        "websocket_server_bound",
+        "websocket_handshake_accepted",
+        "client_frame_sent",
+        "server_failed_closed"
+      ]
+    },
+    {
+      "case_name": "auth_policy_denial",
+      "status": "failed_closed",
+      "request_message_id": "msg-runtime-stream-denied-0001",
+      "response_message_id": null,
+      "error_substring": "caller_class_denied_by_websocket_transport_policy",
+      "lifecycle_events": [
+        "websocket_server_bound",
+        "websocket_handshake_accepted",
+        "client_frame_sent",
+        "server_failed_closed"
+      ]
+    },
+    {
+      "case_name": "peer_close_before_response",
+      "status": "failed_closed",
+      "request_message_id": null,
+      "response_message_id": null,
+      "error_substring": "closed_before_response: read ACIP WebSocket transport client frame: WebSocket protocol error: Connection reset without closing handshake: Connection reset without closing handshake",
+      "lifecycle_events": [
+        "websocket_server_bound",
+        "websocket_handshake_accepted",
+        "client_closed_before_request",
+        "server_failed_closed"
+      ]
+    },
+    {
+      "case_name": "response_timeout",
+      "status": "failed_closed",
+      "request_message_id": null,
+      "response_message_id": null,
+      "error_substring": "timed out waiting for response: deadline has elapsed",
+      "lifecycle_events": [
+        "websocket_server_bound",
+        "websocket_handshake_accepted",
+        "client_idle_until_server_timeout",
+        "server_failed_closed"
+      ]
+    }
+  ],
+  "lifecycle_events": [
+    "websocket_server_bound",
+    "positive_delivery_validated",
+    "fail_closed_cases_validated"
+  ],
+  "integration_refs": [
+    "#4658",
+    "#4659",
+    "#4900",
+    "docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md",
+    "docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md"
+  ],
+  "non_claims": [
+    "This decision does not implement protobuf wire encoding.",
+    "This decision does not prove production WebSocket authentication, TLS, reconnect scheduling, or cross-polis transport.",
+    "This decision does not bypass ACIP access rules, Freedom Gate decisions, trace, replay, or policy boundaries.",
+    "This proof exercises loopback WebSocket transport path behavior; production authentication, TLS termination, and cross-polis networking remain outside #4659."
+  ]
+}

--- a/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/audit/artifact_safety_scan.json
+++ b/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/audit/artifact_safety_scan.json
@@ -1,0 +1,33 @@
+{
+  "checks": [
+    "no_absolute_host_paths",
+    "no_secret_like_literals",
+    "sha256_recorded"
+  ],
+  "files": [
+    {
+      "bytes": 1096,
+      "path": "evidence_index.json",
+      "sha256": "922011bd3b10066a7ec50d231e4210169ac1976cfb5df12fc50c1f8f8a2c31ec"
+    },
+    {
+      "bytes": 546,
+      "path": "reviewer_walkthrough.md",
+      "sha256": "b199d7b4fec86e2c68ae08098c980ccb748293d052fbac03a9ec894dd4c10e8f"
+    },
+    {
+      "bytes": 527,
+      "path": "README.md",
+      "sha256": "cb8db253c8b20351396efde833aa85c924265ba476713b0aa94da277326609f2"
+    },
+    {
+      "bytes": 5150,
+      "path": "acip_websocket_transport_proof.json",
+      "sha256": "f67442ce1418715bc296d4efe5a3f247d3aac4b06ed347a1e9cc7b2c4dafa8bb"
+    }
+  ],
+  "findings": [],
+  "passed": true,
+  "schema_version": "wp12.acip.websocket_transport.artifact_safety_scan.v1",
+  "self_scan_boundary": "audit/artifact_safety_scan.json is written after this scan is computed; rerunning the proof regenerates and rechecks the source artifacts deterministically."
+}

--- a/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/evidence_index.json
+++ b/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/evidence_index.json
@@ -1,0 +1,26 @@
+{
+  "failure_cases": [
+    "malformed_message",
+    "auth_policy_denial",
+    "peer_close_before_response",
+    "response_timeout"
+  ],
+  "integration_refs": [
+    "#4658",
+    "#4659",
+    "#4900",
+    "docs/milestones/v0.91.7/review/runtime/ACIP_RUNTIME_STREAM_SUBSTRATE_4900.md",
+    "docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md"
+  ],
+  "issue": 4659,
+  "non_claims": [
+    "This decision does not implement protobuf wire encoding.",
+    "This decision does not prove production WebSocket authentication, TLS, reconnect scheduling, or cross-polis transport.",
+    "This decision does not bypass ACIP access rules, Freedom Gate decisions, trace, replay, or policy boundaries.",
+    "This proof exercises loopback WebSocket transport path behavior; production authentication, TLS termination, and cross-polis networking remain outside #4659."
+  ],
+  "positive_case": "positive_delivery",
+  "proof": "acip_websocket_transport_proof.json",
+  "reviewer_walkthrough": "reviewer_walkthrough.md",
+  "schema_version": "wp12.acip.websocket_transport.evidence_index.v1"
+}

--- a/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/reviewer_walkthrough.md
+++ b/docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/reviewer_walkthrough.md
@@ -1,0 +1,7 @@
+# Reviewer Walkthrough
+
+1. Inspect `acip_websocket_transport_proof.json`.
+2. Confirm `positive_case.status` is `delivered`.
+3. Confirm failure cases include `malformed_message`, `auth_policy_denial`, `peer_close_before_response`, and `response_timeout` with `failed_closed` status.
+4. Inspect `audit/artifact_safety_scan.json` for retained-artifact hygiene.
+5. Re-run with `cargo run --manifest-path adl/Cargo.toml --bin run_wp12_acip_websocket_transport_proof -- --out docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659`.

--- a/docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md
+++ b/docs/milestones/v0.92/features/ACIP_BINARY_SCHEMA_AND_WEBSOCKET_TRANSPORT_v0.92.md
@@ -161,6 +161,22 @@ and trace/audit requirements.
 v0.93 should harden transport security. v0.94 should close signed/queryable
 trace. v0.95 can consume the mature carrier if prior gates pass.
 
+## Backlog Capture: Runtime API Integration
+
+The v0.91.7 #4659 packet proves the bounded ACIP WebSocket transport path as a
+reusable runtime-stream proof, but it does not add a live WebSocket route to the
+CSM runtime API alongside HTTP. That runtime API integration is noncritical for
+v0.91.7/WP-12 closeout and should remain backlog-only until the operator
+explicitly promotes it; do not open a GitHub issue from this note.
+
+Backlog item:
+
+- Integrate the proven ACIP WebSocket runtime-stream path into the live runtime
+  API alongside HTTP, preserving existing HTTP routes, loopback binding policy,
+  fail-closed ACIP envelope validation, and non-claims around production
+  TLS/authentication, cross-polis networking, x402, and protobuf wire
+  activation.
+
 ## Notes
 
 WebSocket is a carrier proof, not an authority source.


### PR DESCRIPTION
Closes #4659

## Summary
#4659 implemented and proved the bounded WP-12 ACIP WebSocket transport path. The change extends `agent_comms::runtime_stream` beyond the #4900 loopback substrate proof by adding a `tokio-tungstenite` WebSocket transport proof with ACIP envelope validation, fail-closed access policy, positive client/server delivery, malformed-frame denial, sender-policy denial, peer-close classification, timeout classification, retained reviewer artifacts, and focused regression coverage.

## Artifacts
- `adl/src/agent_comms.rs`
- `adl/src/agent_comms/runtime_stream.inc`
- `adl/src/agent_comms/tests.inc`
- `adl/src/bin/run_wp12_acip_websocket_transport_proof.rs`
- `adl/Cargo.toml`
- `docs/milestones/v0.91.7/review/runtime/WP12_ACIP_WEBSOCKET_TRANSPORT_4659.md`
- `docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659/`

## Validation
- Validation commands and their purpose:
- `cargo test --manifest-path adl/Cargo.toml acip_runtime_stream --lib -- --nocapture`
  `Verified ACIP runtime-stream substrate and WebSocket transport proof tests.`
- `cargo test --manifest-path adl/Cargo.toml --bin run_wp12_acip_websocket_transport_proof output_path_guard -- --nocapture`
  `Verified proof-runner output path guardrails.`
- `cargo run --manifest-path adl/Cargo.toml --bin run_wp12_acip_websocket_transport_proof -- --out docs/milestones/v0.91.7/review/runtime/wp12_acip_websocket_transport_4659`
  `Generated retained proof artifacts.`
- `git diff --check`
  `Verified whitespace.`
- `bash adl/tools/validate_structured_prompt.sh --type spp --input .adl/v0.91.7/tasks/issue-4659__v0-91-7-wp-12-a2a-prove-websocket-transport-path/spp.md`
  `Verified SPP structure.`
- `bash adl/tools/validate_structured_prompt.sh --type vpp --input .adl/v0.91.7/tasks/issue-4659__v0-91-7-wp-12-a2a-prove-websocket-transport-path/vpp.md`
  `Verified VPP structure.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4659__v0-91-7-wp-12-a2a-prove-websocket-transport-path/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4659__v0-91-7-wp-12-a2a-prove-websocket-transport-path/sor.md
- Idempotency-Key: v0-91-7-wp-12-prove-acip-websocket-transport-path-adl-cargo-toml-adl-src-agent-comms-rs-adl-src-agent-comms-runtime-stream-inc-adl-src-agent-comms-tests-inc-adl-src-bin-run-wp12-acip-websocket-transport-proof-rs-docs-milestones-v0-91-7-review-runtime-wp12-acip-websocket-transport-4659-md-docs-milestones-v0-91-7-review-runtime-wp12-acip-websocket-transport-4659-adl-v0-91-7-tasks-issue-4659-v0-91-7-wp-12-a2a-prove-websocket-transport-path-sip-md-adl-v0-91-7-tasks-issue-4659-v0-91-7-wp-12-a2a-prove-websocket-transport-path-sor-md