### PR TITLE
[v0.91.7][tools][validation] Map HTML Observatory demo paths to a runnable proof lane

### DIFF
--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -331,8 +331,31 @@
       "run_command": "bash -n adl/tools/test_v0916_unity_observatory_unity65_smoke.sh && bash adl/tools/test_v0916_unity_observatory_baseline.sh && bash adl/tools/test_v0916_unity_observatory_contract.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption_unit.sh && bash adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh && bash adl/tools/test_v0916_unity_observatory_soak_integration.sh && cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_observatory_cli_writes_unity_contract_bundle_and_matches_seeded_resource -- --nocapture",
       "reason": "unity_observatory_surface_requires_contract_and_csm_smoke"
     },
-        {
-            "id": "csdlc_owner_lane",
+    {
+      "id": "html_observatory_v0917_runtime_surface",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "demo_contract",
+      "requirement_ids": [
+        "html_observatory_v0917_runtime_surface"
+      ],
+      "path_selectors": [
+        "adl/tools/test_v0917_html_observatory_integrated_proof.sh",
+        "adl/tools/validate_v0917_html_observatory.py",
+        "demos/v0.91.7/html-observatory/**"
+      ],
+      "path_hints": [
+        "adl/tools/test_v0917_html_observatory_integrated_proof.sh",
+        "adl/tools/validate_v0917_html_observatory.py",
+        "demos/v0.91.7/html-observatory/"
+      ],
+      "command": "bash adl/tools/test_v0917_html_observatory_integrated_proof.sh",
+      "run_command": "bash adl/tools/test_v0917_html_observatory_integrated_proof.sh",
+      "reason": "v0917_html_observatory_surface_requires_integrated_runtime_demo_proof"
+    },
+    {
+      "id": "csdlc_owner_lane",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",
       "owner": "csdlc",

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -639,6 +639,40 @@ assert lane["proof_role"] == "demo_contract"
 assert lane["owner"] == "review"
 PY
 
+html_observatory_v0917="$TMP/html-observatory-v0917.txt"
+cat >"$html_observatory_v0917" <<'EOF'
+A	adl/tools/test_v0917_html_observatory_integrated_proof.sh
+A	adl/tools/validate_v0917_html_observatory.py
+A	demos/v0.91.7/html-observatory/README.md
+A	demos/v0.91.7/html-observatory/app.js
+A	demos/v0.91.7/html-observatory/index.html
+A	demos/v0.91.7/html-observatory/styles.css
+EOF
+bash "$SCRIPT" --changed-files "$html_observatory_v0917" --json >"$TMP/html-observatory-v0917.json"
+python3 - <<'PY' "$TMP/html-observatory-v0917.json"
+import json
+import sys
+
+profile = json.load(open(sys.argv[1]))
+assert profile["schema_version"] == "adl.validation_lane_plan.v1"
+assert profile["aggregate_status"] == "selected"
+assert profile["pr_publication_sufficient"] is True
+assert set(profile["lanes"].keys()) == {"html_observatory_v0917_runtime_surface"}
+lane = profile["lanes"]["html_observatory_v0917_runtime_surface"]
+assert lane["status"] == "selected"
+assert lane["proof_role"] == "demo_contract"
+assert lane["owner"] == "review"
+assert lane["run_command"] == "bash adl/tools/test_v0917_html_observatory_integrated_proof.sh"
+assert set(lane["matched_paths"]) == {
+    "adl/tools/test_v0917_html_observatory_integrated_proof.sh",
+    "adl/tools/validate_v0917_html_observatory.py",
+    "demos/v0.91.7/html-observatory/README.md",
+    "demos/v0.91.7/html-observatory/app.js",
+    "demos/v0.91.7/html-observatory/index.html",
+    "demos/v0.91.7/html-observatory/styles.css",
+}
+PY
+
 unity_observatory="$TMP/unity-observatory.txt"
 cat >"$unity_observatory" <<'EOF'
 M	adl/tools/test_v0916_unity_observatory_local_runtime_consumption.sh


### PR DESCRIPTION
Closes #4990

## Summary
Mapped the v0.91.7 HTML Observatory demo and proof-script paths from #4690 to a dedicated runnable validation lane. The selector now returns `html_observatory_v0917_runtime_surface` with `bash adl/tools/test_v0917_html_observatory_integrated_proof.sh` as the run command for the exact #4690 changed-path set, instead of falling through to docs-only or `unmapped_change_surface` routing.

## Artifacts
- `adl/config/validation_lane_selector.v0.91.6.json`
- `adl/tools/test_select_validation_lanes.sh`
- Local ignored output-card update at `.adl/v0.91.7/tasks/issue-4990__v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_select_validation_lanes.sh`
    `Verified the selector manifest, including the new #4990 v0.91.7 HTML Observatory path fixture.`
  - `bash adl/tools/test_ci_path_policy.sh`
    `Verified CI path-policy contract behavior after the selector change.`
  - `bash adl/tools/test_validation_manager.sh`
    `Verified validation manager contract behavior after the selector change.`
  - `bash adl/tools/validation_manager.sh --changed-files TMP_FIXTURE --json`
    `Verified the #4690 HTML Observatory changed-path set maps to the runnable `html_observatory_v0917_runtime_surface` profile.`
  - `git diff --check`
    `Verified whitespace hygiene.`
- Results:
  - `PASS`
- Not run:
  - `bash adl/tools/test_v0917_html_observatory_integrated_proof.sh`
    `The proof script is added by #4690 and is not present on the #4990 base worktree; this issue verifies selector mapping for that path, not the demo implementation itself.`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4990__v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4990__v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane/sor.md
- Idempotency-Key: v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane-adl-config-validation-lane-selector-v0-91-6-json-adl-tools-test-select-validation-lanes-sh-adl-v0-91-7-tasks-issue-4990-v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane-sip-md-adl-v0-91-7-tasks-issue-4990-v0-91-7-tools-validation-map-html-observatory-demo-paths-to-a-runnable-proof-lane-sor-md