### PR TITLE
[v0.91.7][WP-07A][runtime][provider] Make CSM resident agents use provider substrate

### DIFF
--- a/adl-runtime/src/lib.rs
+++ b/adl-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod backpressure;
 pub mod networking;
+pub mod resident_agent;
 pub mod runtime_api;
 pub mod supervision;
 pub mod topology;

--- a/adl-runtime/src/resident_agent.rs
+++ b/adl-runtime/src/resident_agent.rs
@@ -1,0 +1,252 @@
+//! CSM resident-agent admission contracts.
+//!
+//! These contracts live in the runtime crate so model-backed agents enter CSM
+//! through one runtime-owned shape rather than bespoke component policies.
+
+use serde::{Deserialize, Serialize};
+
+pub const CSM_RESIDENT_AGENT_SCHEMA: &str = "adl.csm.resident_agent.v1";
+pub const CSM_RESIDENT_AGENT_SET_SCHEMA: &str = "adl.csm.resident_agent_set.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CsmResidentAgentAuthority {
+    Ordinary,
+    ShepherdOperator,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CsmResidentAgentLifecycleState {
+    Admitted,
+    Ready,
+    Running,
+    Degraded,
+    Quarantined,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmResidentAgentProviderBinding {
+    pub provider_id: String,
+    pub provider_kind: String,
+    pub vendor: String,
+    pub transport: String,
+    pub runtime_surface: String,
+    pub model_ref: String,
+    pub provider_model_id: String,
+    pub tool_calling_mode: String,
+    pub structured_json_mode: String,
+    pub binding_status: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmResidentAgentChannels {
+    pub lifecycle: String,
+    pub provider_request: String,
+    pub provider_response: String,
+    pub checkpoint: String,
+    pub observability: String,
+    pub lifelog: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmResidentAgentPolicyGates {
+    pub freedom_gate_required: bool,
+    pub cav_required: bool,
+    pub constitutional_policy_required: bool,
+    pub model_output_advisory_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmResidentAgentSpec {
+    pub schema: String,
+    pub agent_instance_id: String,
+    pub display_name: String,
+    pub agent_role: String,
+    pub authority: CsmResidentAgentAuthority,
+    pub lifecycle_state: CsmResidentAgentLifecycleState,
+    pub provider_binding: CsmResidentAgentProviderBinding,
+    pub channels: CsmResidentAgentChannels,
+    pub policy_gates: CsmResidentAgentPolicyGates,
+    pub checkpoint_policy: String,
+    pub lifelog_policy: String,
+    pub observability_policy: String,
+    pub privilege_reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmResidentAgentSet {
+    pub schema: String,
+    pub runtime_owner: String,
+    pub admission_model: String,
+    pub provider_entrypoint: String,
+    pub agents: Vec<CsmResidentAgentSpec>,
+}
+
+impl CsmResidentAgentSpec {
+    pub fn validate(&self) -> Result<(), String> {
+        require_exact(&self.schema, CSM_RESIDENT_AGENT_SCHEMA, "schema")?;
+        require_non_empty(&self.agent_instance_id, "agent_instance_id")?;
+        require_non_empty(&self.agent_role, "agent_role")?;
+        require_non_empty(
+            &self.provider_binding.provider_id,
+            "provider_binding.provider_id",
+        )?;
+        require_non_empty(
+            &self.provider_binding.model_ref,
+            "provider_binding.model_ref",
+        )?;
+        require_non_empty(
+            &self.provider_binding.provider_model_id,
+            "provider_binding.provider_model_id",
+        )?;
+        require_non_empty(
+            &self.provider_binding.runtime_surface,
+            "provider_binding.runtime_surface",
+        )?;
+        require_exact(
+            &self.provider_binding.binding_status,
+            "provider_target_resolved",
+            "provider_binding.binding_status",
+        )?;
+        if self.authority == CsmResidentAgentAuthority::ShepherdOperator {
+            if !self.policy_gates.freedom_gate_required
+                || !self.policy_gates.cav_required
+                || !self.policy_gates.constitutional_policy_required
+                || !self.policy_gates.model_output_advisory_only
+            {
+                return Err(
+                    "shepherd resident agent must be gated by Freedom Gate, CAV, constitutional policy, and advisory output authority"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CsmResidentAgentSet {
+    pub fn validate(&self) -> Result<(), String> {
+        require_exact(&self.schema, CSM_RESIDENT_AGENT_SET_SCHEMA, "schema")?;
+        require_exact(&self.runtime_owner, "csm", "runtime_owner")?;
+        require_exact(
+            &self.provider_entrypoint,
+            "provider_substrate",
+            "provider_entrypoint",
+        )?;
+        if self.agents.len() < 3 {
+            return Err("resident agent set must contain at least three agents".to_string());
+        }
+        let shepherd_count = self
+            .agents
+            .iter()
+            .filter(|agent| agent.authority == CsmResidentAgentAuthority::ShepherdOperator)
+            .count();
+        if shepherd_count != 1 {
+            return Err(
+                "resident agent set must contain exactly one Shepherd operator".to_string(),
+            );
+        }
+        for agent in &self.agents {
+            agent.validate()?;
+        }
+        Ok(())
+    }
+}
+
+fn require_non_empty(value: &str, field: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(())
+}
+
+fn require_exact(value: &str, expected: &str, field: &str) -> Result<(), String> {
+    if value != expected {
+        return Err(format!("{field} must be {expected}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(provider_id: &str, model_ref: &str) -> CsmResidentAgentProviderBinding {
+        CsmResidentAgentProviderBinding {
+            provider_id: provider_id.to_string(),
+            provider_kind: "ollama".to_string(),
+            vendor: "ollama".to_string(),
+            transport: "http".to_string(),
+            runtime_surface: "ollama_http".to_string(),
+            model_ref: model_ref.to_string(),
+            provider_model_id: model_ref.to_string(),
+            tool_calling_mode: "native".to_string(),
+            structured_json_mode: "prompt_based".to_string(),
+            binding_status: "provider_target_resolved".to_string(),
+            source: "provider_substrate".to_string(),
+        }
+    }
+
+    fn channels(id: &str) -> CsmResidentAgentChannels {
+        CsmResidentAgentChannels {
+            lifecycle: format!("csm.lifecycle.{id}"),
+            provider_request: format!("csm.provider_requests.{id}"),
+            provider_response: format!("csm.provider_responses.{id}"),
+            checkpoint: format!("csm.checkpoint.{id}"),
+            observability: format!("csm.observability.{id}"),
+            lifelog: format!("csm.lifelog.{id}"),
+        }
+    }
+
+    fn gates() -> CsmResidentAgentPolicyGates {
+        CsmResidentAgentPolicyGates {
+            freedom_gate_required: true,
+            cav_required: true,
+            constitutional_policy_required: true,
+            model_output_advisory_only: true,
+        }
+    }
+
+    fn agent(id: &str, authority: CsmResidentAgentAuthority) -> CsmResidentAgentSpec {
+        CsmResidentAgentSpec {
+            schema: CSM_RESIDENT_AGENT_SCHEMA.to_string(),
+            agent_instance_id: id.to_string(),
+            display_name: id.to_string(),
+            agent_role: "runtime_worker".to_string(),
+            authority,
+            lifecycle_state: CsmResidentAgentLifecycleState::Admitted,
+            provider_binding: binding("local_ollama", "gemma4:12b-mlx"),
+            channels: channels(id),
+            policy_gates: gates(),
+            checkpoint_policy: "periodic_and_agent_requested".to_string(),
+            lifelog_policy: "append_lifecycle_provider_events".to_string(),
+            observability_policy: "emit_provider_lifecycle_metrics_traces_logs".to_string(),
+            privilege_reason: "ordinary_runtime_agent".to_string(),
+        }
+    }
+
+    #[test]
+    fn resident_agent_set_requires_one_shepherd_and_provider_bindings() {
+        let set = CsmResidentAgentSet {
+            schema: CSM_RESIDENT_AGENT_SET_SCHEMA.to_string(),
+            runtime_owner: "csm".to_string(),
+            admission_model: "provider_bound_resident_agents".to_string(),
+            provider_entrypoint: "provider_substrate".to_string(),
+            agents: vec![
+                agent("shepherd", CsmResidentAgentAuthority::ShepherdOperator),
+                agent("codex", CsmResidentAgentAuthority::Ordinary),
+                agent("ollama-worker", CsmResidentAgentAuthority::Ordinary),
+            ],
+        };
+        assert!(set.validate().is_ok());
+    }
+
+    #[test]
+    fn shepherd_cannot_bypass_runtime_policy_gates() {
+        let mut shepherd = agent("shepherd", CsmResidentAgentAuthority::ShepherdOperator);
+        shepherd.policy_gates.cav_required = false;
+        assert!(shepherd.validate().is_err());
+    }
+}

--- a/adl-runtime/src/topology.rs
+++ b/adl-runtime/src/topology.rs
@@ -39,6 +39,11 @@ pub fn runtime_components() -> Vec<RuntimeComponent> {
             role: "reasoning graphs, loops, and adaptive DAG execution",
         },
         RuntimeComponent {
+            id: "resident_agents",
+            plane: "cognition",
+            role: "provider-backed resident agents admitted through CSM lifecycle",
+        },
+        RuntimeComponent {
             id: "freedom_gate",
             plane: "security",
             role: "lawful execution and commitment mediation gate",
@@ -109,6 +114,12 @@ pub fn runtime_stack_json() -> Value {
             "role": "collect_transform_redact_route_logs_metrics_and_otel",
             "runtime_topology": "csm_managed_observability_component",
             "csm_role": "emit_canonical_runtime_events_and_otel_shaped_summaries"
+        },
+        "resident_agent_entrypoint": {
+            "schema": crate::resident_agent::CSM_RESIDENT_AGENT_SET_SCHEMA,
+            "provider_entrypoint": "provider_substrate",
+            "lifecycle": "same_csm_supervision_checkpoint_lifelog_observability_path_for_privileged_and_ordinary_agents",
+            "shepherd_model": "privileged_resident_agent_not_bespoke_model_path"
         }
     })
 }
@@ -127,6 +138,7 @@ mod tests {
         assert!(ids.contains(&"chronosense"));
         assert!(ids.contains(&"scheduler"));
         assert!(ids.contains(&"reasoning_runtime"));
+        assert!(ids.contains(&"resident_agents"));
         assert!(ids.contains(&"observability"));
         assert!(ids.contains(&"cloud_bridge"));
     }

--- a/adl/src/csm_resident_agents.rs
+++ b/adl/src/csm_resident_agents.rs
@@ -1,0 +1,298 @@
+//! Provider-backed CSM resident-agent bridge.
+//!
+//! The runtime crate owns the resident-agent contract. This module adapts ADL's
+//! existing provider substrate into that contract so privileged and ordinary
+//! CSM agents share one admission path.
+
+use adl_runtime::resident_agent::{
+    CsmResidentAgentAuthority, CsmResidentAgentChannels, CsmResidentAgentLifecycleState,
+    CsmResidentAgentPolicyGates, CsmResidentAgentProviderBinding, CsmResidentAgentSet,
+    CsmResidentAgentSpec, CSM_RESIDENT_AGENT_SCHEMA, CSM_RESIDENT_AGENT_SET_SCHEMA,
+};
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+use crate::adl;
+use crate::provider_substrate::{
+    provider_invocation_target_v1, CapabilityModeV1, ProviderInvocationTargetV1,
+    ProviderTransportV1,
+};
+
+pub const CSM_RESIDENT_AGENTS_STATUS_REF: &str = "csm_resident_agents_status.json";
+
+pub fn resident_agent_set(agent_instance_id: &str) -> Result<CsmResidentAgentSet> {
+    let set = CsmResidentAgentSet {
+        schema: CSM_RESIDENT_AGENT_SET_SCHEMA.to_string(),
+        runtime_owner: "csm".to_string(),
+        admission_model: "provider_bound_resident_agents".to_string(),
+        provider_entrypoint: "provider_substrate".to_string(),
+        agents: vec![
+            shepherd_resident_agent(agent_instance_id)?,
+            codex_resident_agent(agent_instance_id)?,
+            ollama_worker_resident_agent(agent_instance_id)?,
+        ],
+    };
+    set.validate().map_err(|err| anyhow!(err))?;
+    Ok(set)
+}
+
+pub fn resident_agent_set_status(agent_instance_id: &str) -> Value {
+    match resident_agent_set(agent_instance_id) {
+        Ok(set) => json!({
+            "status": "available",
+            "ref": CSM_RESIDENT_AGENTS_STATUS_REF,
+            "value": set,
+            "proof": {
+                "resident_agent_count": 3,
+                "privileged_agent": "polis_shepherd_agent",
+                "ordinary_agents": ["codex_chatgpt_resident", "local_ollama_resident"],
+                "provider_entrypoint": "provider_substrate",
+                "no_shepherd_bespoke_provider_path": true
+            }
+        }),
+        Err(err) => json!({
+            "status": "invalid",
+            "ref": CSM_RESIDENT_AGENTS_STATUS_REF,
+            "error": err.to_string()
+        }),
+    }
+}
+
+pub fn shepherd_resident_agent_value(agent_instance_id: &str) -> Value {
+    match shepherd_resident_agent(agent_instance_id) {
+        Ok(agent) => json!(agent),
+        Err(err) => json!({
+            "schema": CSM_RESIDENT_AGENT_SCHEMA,
+            "agent_instance_id": format!("{agent_instance_id}:polis_shepherd_agent"),
+            "status": "invalid",
+            "error": err.to_string()
+        }),
+    }
+}
+
+pub fn shepherd_resident_agent(agent_instance_id: &str) -> Result<CsmResidentAgentSpec> {
+    let target = provider_invocation_target_v1(
+        "local_ollama",
+        &provider_spec(
+            "ollama",
+            Some("ollama:gemma4"),
+            Some("gemma4:12b-mlx"),
+            Some("gemma4:12b-mlx"),
+            Some("http://127.0.0.1:11434"),
+        ),
+        Some("gemma4:12b-mlx"),
+    )?;
+    resident_agent(
+        agent_instance_id,
+        "polis_shepherd_agent",
+        "Polis Shepherd Agent",
+        "privileged_polis_operator",
+        CsmResidentAgentAuthority::ShepherdOperator,
+        "elevated_operator_agent_for_runtime_preservation_and_recovery_requests",
+        target,
+    )
+}
+
+pub fn codex_resident_agent(agent_instance_id: &str) -> Result<CsmResidentAgentSpec> {
+    let target = provider_invocation_target_v1(
+        "chatgpt_codex",
+        &provider_spec(
+            "openai",
+            Some("chatgpt:codex"),
+            Some("hosted:chatgpt/codex-agent"),
+            Some("gpt-5-codex"),
+            None,
+        ),
+        Some("hosted:chatgpt/codex-agent"),
+    )?;
+    resident_agent(
+        agent_instance_id,
+        "codex_chatgpt_resident",
+        "Codex/ChatGPT Resident Agent",
+        "ordinary_runtime_agent",
+        CsmResidentAgentAuthority::Ordinary,
+        "ordinary_provider_backed_agent_occupying_csm_for_operator_proof",
+        target,
+    )
+}
+
+pub fn ollama_worker_resident_agent(agent_instance_id: &str) -> Result<CsmResidentAgentSpec> {
+    let target = provider_invocation_target_v1(
+        "local_ollama_qwen",
+        &provider_spec(
+            "ollama",
+            Some("ollama:qwen"),
+            Some("qwen3.5:9b"),
+            Some("qwen3.5:9b"),
+            Some("http://127.0.0.1:11434"),
+        ),
+        Some("qwen3.5:9b"),
+    )?;
+    resident_agent(
+        agent_instance_id,
+        "local_ollama_resident",
+        "Local Ollama Resident Agent",
+        "ordinary_runtime_agent",
+        CsmResidentAgentAuthority::Ordinary,
+        "ordinary_local_provider_agent_for_resident_runtime_proof",
+        target,
+    )
+}
+
+fn resident_agent(
+    polis_id: &str,
+    local_agent_id: &str,
+    display_name: &str,
+    agent_role: &str,
+    authority: CsmResidentAgentAuthority,
+    privilege_reason: &str,
+    target: ProviderInvocationTargetV1,
+) -> Result<CsmResidentAgentSpec> {
+    let agent_instance_id = format!("{polis_id}:{local_agent_id}");
+    let agent = CsmResidentAgentSpec {
+        schema: CSM_RESIDENT_AGENT_SCHEMA.to_string(),
+        agent_instance_id: agent_instance_id.clone(),
+        display_name: display_name.to_string(),
+        agent_role: agent_role.to_string(),
+        authority,
+        lifecycle_state: CsmResidentAgentLifecycleState::Admitted,
+        provider_binding: provider_binding_from_target(target),
+        channels: channels(&agent_instance_id),
+        policy_gates: policy_gates(),
+        checkpoint_policy: "periodic_and_agent_requested_with_runtime_min_interval".to_string(),
+        lifelog_policy:
+            "append_admission_lifecycle_provider_invocation_refusal_and_recovery_events".to_string(),
+        observability_policy:
+            "emit_resident_agent_provider_lifecycle_metrics_traces_logs_and_runtime_events"
+                .to_string(),
+        privilege_reason: privilege_reason.to_string(),
+    };
+    agent.validate().map_err(|err| anyhow!(err))?;
+    Ok(agent)
+}
+
+fn provider_binding_from_target(
+    target: ProviderInvocationTargetV1,
+) -> CsmResidentAgentProviderBinding {
+    CsmResidentAgentProviderBinding {
+        provider_id: target.provider_id,
+        provider_kind: target.provider_kind,
+        vendor: target.vendor,
+        transport: transport_label(&target.transport).to_string(),
+        runtime_surface: target.model_identity.runtime_surface,
+        model_ref: target.model_ref,
+        provider_model_id: target.provider_model_id,
+        tool_calling_mode: capability_mode_label(&target.capabilities.tool_calling.mode)
+            .to_string(),
+        structured_json_mode: capability_mode_label(&target.capabilities.structured_json.mode)
+            .to_string(),
+        binding_status: "provider_target_resolved".to_string(),
+        source: "provider_substrate".to_string(),
+    }
+}
+
+fn provider_spec(
+    kind: &str,
+    profile: Option<&str>,
+    default_model: Option<&str>,
+    provider_model_id: Option<&str>,
+    base_url: Option<&str>,
+) -> adl::ProviderSpec {
+    let mut config = HashMap::new();
+    if let Some(provider_model_id) = provider_model_id {
+        config.insert(
+            "provider_model_id".to_string(),
+            Value::String(provider_model_id.to_string()),
+        );
+    }
+    adl::ProviderSpec {
+        id: None,
+        profile: profile.map(ToString::to_string),
+        kind: kind.to_string(),
+        base_url: base_url.map(ToString::to_string),
+        default_model: default_model.map(ToString::to_string),
+        config,
+    }
+}
+
+fn channels(agent_instance_id: &str) -> CsmResidentAgentChannels {
+    let channel_id = agent_instance_id.replace(':', ".");
+    CsmResidentAgentChannels {
+        lifecycle: format!("csm.lifecycle.{channel_id}"),
+        provider_request: format!("csm.provider_requests.{channel_id}"),
+        provider_response: format!("csm.provider_responses.{channel_id}"),
+        checkpoint: format!("csm.checkpoint.{channel_id}"),
+        observability: format!("csm.observability.{channel_id}"),
+        lifelog: format!("csm.lifelog.{channel_id}"),
+    }
+}
+
+fn policy_gates() -> CsmResidentAgentPolicyGates {
+    CsmResidentAgentPolicyGates {
+        freedom_gate_required: true,
+        cav_required: true,
+        constitutional_policy_required: true,
+        model_output_advisory_only: true,
+    }
+}
+
+fn transport_label(transport: &ProviderTransportV1) -> &'static str {
+    match transport {
+        ProviderTransportV1::Http => "http",
+        ProviderTransportV1::LocalCli => "local_cli",
+        ProviderTransportV1::InProcess => "in_process",
+    }
+}
+
+fn capability_mode_label(mode: &CapabilityModeV1) -> &'static str {
+    match mode {
+        CapabilityModeV1::Native => "native",
+        CapabilityModeV1::PromptBased => "prompt_based",
+        CapabilityModeV1::SemanticFallback => "semantic_fallback",
+        CapabilityModeV1::None => "none",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn csm_resident_agent_set_admits_shepherd_codex_and_ollama_through_provider_substrate() {
+        let set = resident_agent_set("polis-test").expect("resident set");
+        assert_eq!(set.agents.len(), 3);
+        assert_eq!(set.provider_entrypoint, "provider_substrate");
+        let shepherd = set
+            .agents
+            .iter()
+            .find(|agent| agent.agent_role == "privileged_polis_operator")
+            .expect("shepherd");
+        assert_eq!(shepherd.provider_binding.provider_id, "local_ollama");
+        assert_eq!(shepherd.provider_binding.model_ref, "gemma4:12b-mlx");
+        assert_eq!(
+            shepherd.provider_binding.binding_status,
+            "provider_target_resolved"
+        );
+        assert!(set
+            .agents
+            .iter()
+            .any(|agent| agent.provider_binding.provider_id == "chatgpt_codex"));
+        assert!(set
+            .agents
+            .iter()
+            .any(|agent| agent.provider_binding.provider_id == "local_ollama_qwen"));
+    }
+
+    #[test]
+    fn csm_shepherd_is_privileged_by_role_not_by_provider_bypass() {
+        let shepherd = shepherd_resident_agent("polis-test").expect("shepherd");
+        assert_eq!(
+            shepherd.authority,
+            CsmResidentAgentAuthority::ShepherdOperator
+        );
+        assert_eq!(shepherd.provider_binding.source, "provider_substrate");
+        assert!(shepherd.policy_gates.freedom_gate_required);
+        assert!(shepherd.policy_gates.cav_required);
+    }
+}

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -28,6 +28,7 @@ use crate::csm_networking::{
     csm_connection_pooling_plan, csm_listener_registry_json, csm_runtime_connection_pool_status,
     resolve_main_runtime_api_listener, CSM_POOLING_PLAN_SCHEMA,
 };
+use crate::csm_resident_agents;
 use crate::csm_shepherd_agent::{self, CSM_SHEPHERD_STATUS_REF};
 use crate::long_lived_agent::{load_spec, AgentStatusState, LoadedAgentSpec, StatusRecord};
 
@@ -299,6 +300,7 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
         &backpressure_state,
         &runtime_capabilities,
     );
+    let resident_agents = resident_agents_status(loaded);
     let response = json!({
         "schema": CSM_RUNTIME_API_STATUS_SCHEMA,
         "runtime_owner": "csm",
@@ -325,6 +327,7 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
         "chronosense": runtime_capabilities.get("chronosense").cloned().unwrap_or_else(|| json!({"status": "missing"})),
         "aee_resilience": runtime_capabilities.get("aee").cloned().unwrap_or_else(|| json!({"status": "missing"})),
         "resilience_middleware": runtime_capabilities.get("resilience_middleware").cloned().unwrap_or_else(|| json!({"status": "missing"})),
+        "resident_agents": resident_agents,
         "polis_shepherd_agent": shepherd,
         "checkpoint": checkpoint_freshness,
         "continuity": {
@@ -661,6 +664,48 @@ fn read_json_artifact(path: &Path) -> Value {
         },
         Err(err) => json!({"status": "unreadable", "reason": err.to_string()}),
     }
+}
+
+fn resident_agents_status(loaded: &LoadedAgentSpec) -> Value {
+    let artifact = read_json_artifact(&artifact_path(
+        loaded,
+        csm_resident_agents::CSM_RESIDENT_AGENTS_STATUS_REF,
+    ));
+    if artifact.get("status").and_then(Value::as_str) == Some("serialized") {
+        let mut retained = artifact
+            .get("value")
+            .cloned()
+            .unwrap_or_else(|| json!({"status": "unreadable"}));
+        if let Some(map) = retained.as_object_mut() {
+            map.insert("evidence_source".to_string(), json!("retained_artifact"));
+            map.insert(
+                "artifact_status".to_string(),
+                artifact
+                    .get("status")
+                    .cloned()
+                    .unwrap_or_else(|| json!("unknown")),
+            );
+        }
+        return retained;
+    }
+
+    let mut fallback =
+        csm_resident_agents::resident_agent_set_status(&loaded.spec.agent_instance_id);
+    if let Some(map) = fallback.as_object_mut() {
+        map.insert("evidence_source".to_string(), json!("computed_fallback"));
+        map.insert(
+            "retained_artifact_status".to_string(),
+            artifact
+                .get("status")
+                .cloned()
+                .unwrap_or_else(|| json!("unknown")),
+        );
+        map.insert(
+            "retained_artifact_ref".to_string(),
+            json!(csm_resident_agents::CSM_RESIDENT_AGENTS_STATUS_REF),
+        );
+    }
+    fallback
 }
 
 fn read_jsonl_tail(path: &Path, limit: usize) -> Value {
@@ -1532,6 +1577,14 @@ memory: {}
             .unwrap(),
         )
         .unwrap();
+        fs::write(
+            state.join(csm_resident_agents::CSM_RESIDENT_AGENTS_STATUS_REF),
+            serde_json::to_string_pretty(&csm_resident_agents::resident_agent_set_status(
+                "api-agent",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
         let options = CsmRuntimeApiOptions {
             spec_path: spec,
             bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
@@ -1554,10 +1607,36 @@ memory: {}
             status["polis_shepherd_agent"]["decision"]["authority"],
             "advisory"
         );
+        assert_eq!(status["resident_agents"]["status"], "available");
+        assert_eq!(
+            status["resident_agents"]["value"]["provider_entrypoint"],
+            "provider_substrate"
+        );
+        assert_eq!(
+            status["resident_agents"]["evidence_source"],
+            "retained_artifact"
+        );
+        let agents = status["resident_agents"]["value"]["agents"]
+            .as_array()
+            .expect("resident agents");
+        assert_eq!(agents.len(), 3);
+        assert!(agents.iter().any(|agent| {
+            agent["provider_binding"]["provider_id"] == "chatgpt_codex"
+                && agent["provider_binding"]["binding_status"] == "provider_target_resolved"
+        }));
+        assert!(agents.iter().any(|agent| {
+            agent["authority"] == "shepherd_operator"
+                && agent["provider_binding"]["provider_id"] == "local_ollama"
+                && agent["provider_binding"]["source"] == "provider_substrate"
+        }));
 
         let shepherd = runtime_api_response(&options, "/shepherd").unwrap();
         assert_eq!(shepherd["schema"], CSM_RUNTIME_API_SHEPHERD_SCHEMA);
         assert_eq!(shepherd["component"]["component"], "polis_shepherd_agent");
+        assert_eq!(
+            shepherd["component"]["resident_agent"]["provider_binding"]["provider_id"],
+            "local_ollama"
+        );
         assert_eq!(
             shepherd["component"]["policy_gates"]["freedom_gate_required"],
             true

--- a/adl/src/csm_shepherd_agent.rs
+++ b/adl/src/csm_shepherd_agent.rs
@@ -9,6 +9,10 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::Path;
 
+use adl_runtime::resident_agent::CSM_RESIDENT_AGENT_SCHEMA;
+
+use crate::csm_resident_agents;
+
 pub const CSM_SHEPHERD_AGENT_STATUS_SCHEMA: &str = "adl.csm.shepherd_agent.status.v1";
 pub const CSM_SHEPHERD_AGENT_DECISION_SCHEMA: &str = "adl.csm.shepherd_agent.decision.v1";
 pub const CSM_SHEPHERD_MODEL_POLICY_SCHEMA: &str = "adl.csm.shepherd_agent.model_policy.v1";
@@ -33,6 +37,12 @@ pub fn runtime_capability() -> Value {
         ],
         "decision_schema": CSM_SHEPHERD_AGENT_DECISION_SCHEMA,
         "decision_actions": shepherd_decision_actions(),
+        "resident_agent_contract": {
+            "schema": CSM_RESIDENT_AGENT_SCHEMA,
+            "authority": "shepherd_operator",
+            "provider_entrypoint": "provider_substrate",
+            "same_lifecycle_as_ordinary_agents": true
+        },
         "checkpoint_authority": {
             "can_request_urgent_checkpoint": true,
             "request_limit": "policy_governed_min_interval",
@@ -45,7 +55,9 @@ pub fn runtime_capability() -> Value {
             "cannot_blind_restart_corrupted_state": true
         },
         "retained_status_ref": CSM_SHEPHERD_STATUS_REF,
-        "model_policy": shepherd_model_policy()
+        "model_policy": shepherd_model_policy(),
+        "provider_entrypoint": "provider_substrate",
+        "no_bespoke_provider_path": true
     })
 }
 
@@ -120,6 +132,7 @@ pub fn build_status_snapshot(
         "component": "polis_shepherd_agent",
         "agent_instance_id": agent_instance_id,
         "status": "monitoring",
+        "resident_agent": csm_resident_agents::shepherd_resident_agent_value(agent_instance_id),
         "model_policy": shepherd_model_policy(),
         "decision": decision,
         "observed_inputs": {
@@ -195,6 +208,7 @@ pub fn api_status(
         "component": "polis_shepherd_agent",
         "capability": runtime_capability,
         "decision": value.get("decision").cloned().unwrap_or_else(|| fallback["decision"].clone()),
+        "resident_agent": value.get("resident_agent").cloned().unwrap_or_else(|| csm_resident_agents::shepherd_resident_agent_value(agent_instance_id)),
         "model_policy": value.get("model_policy").cloned().unwrap_or_else(shepherd_model_policy),
         "observed_inputs": value.get("observed_inputs").cloned().unwrap_or_else(|| fallback["observed_inputs"].clone()),
         "policy_gates": value.get("policy_gates").cloned().unwrap_or_else(|| fallback["policy_gates"].clone())

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -36,6 +36,7 @@ pub mod csm_godel_snapshot;
 pub mod csm_networking;
 pub mod csm_observatory;
 pub mod csm_polis_storage;
+pub mod csm_resident_agents;
 pub mod csm_runtime_api;
 pub mod csm_shepherd_agent;
 pub mod dangerous_negative_suite;

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -15,6 +15,7 @@ use crate::chronosense::{
     ChronosenseRuntimeServiceConfig,
 };
 use crate::csm_godel_snapshot::{validate_recovery_read, write_checkpoint_snapshot_diff};
+use crate::csm_resident_agents;
 use crate::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 use crate::csm_shepherd_agent;
 use crate::runtime_aws_signal::publish_csm_governed_notice_signal;
@@ -2107,7 +2108,7 @@ fn record_safe_fail_bundle(
             "trace_id": daemon_trace_id(loaded),
             "span_id": daemon_span_id("safe_fail_serialization", record.restart_count),
             "parent_span_id": daemon_parent_span_id(loaded),
-            "runtime_capabilities": csm_runtime_capabilities(runtime_context),
+            "runtime_capabilities": csm_runtime_capabilities(runtime_context, &loaded.spec.agent_instance_id),
             "chronosense_clock_stack": csm_chronosense_clock_stack(runtime_context)
         },
         "recovery_hints": safe_fail_recovery_hints(record.status),
@@ -2261,7 +2262,7 @@ fn record_governed_runtime_notice(
             "trace_id": daemon_trace_id(loaded),
             "span_id": daemon_span_id("governed_runtime_notice", input.restart_count),
             "parent_span_id": daemon_parent_span_id(loaded),
-            "runtime_capabilities": csm_runtime_capabilities(runtime_context),
+            "runtime_capabilities": csm_runtime_capabilities(runtime_context, &loaded.spec.agent_instance_id),
             "chronosense_clock_stack": csm_chronosense_clock_stack(runtime_context)
         },
         "delivery_policy": {
@@ -2780,10 +2781,15 @@ fn write_daemon_status(
     } else {
         input.last_event
     };
+    let resident_agents_status =
+        csm_resident_agents::resident_agent_set_status(&loaded.spec.agent_instance_id);
     let status = DaemonStatusRecord {
         schema: DAEMON_STATUS_SCHEMA.to_string(),
         agent_instance_id: loaded.spec.agent_instance_id.clone(),
-        runtime_capabilities: csm_runtime_capabilities(runtime_context),
+        runtime_capabilities: csm_runtime_capabilities_with_resident_agents(
+            runtime_context,
+            resident_agents_status.clone(),
+        ),
         state: effective_state.to_string(),
         supervisor_pid: std::process::id(),
         restart_policy: daemon_restart_policy().to_string(),
@@ -2828,6 +2834,25 @@ fn write_daemon_status(
                 "status": "degraded_nonfatal",
                 "reason": err.to_string(),
                 "recovery_policy": "continue_runtime_and_surface_missing_or_degraded_shepherd_status"
+            }),
+        );
+    }
+    if let Err(err) = write_json_pretty(
+        &loaded
+            .state_root
+            .join(csm_resident_agents::CSM_RESIDENT_AGENTS_STATUS_REF),
+        &resident_agents_status,
+    ) {
+        let _ = append_operator_event(
+            loaded,
+            "csm_resident_agents_status_write_failed",
+            json!({
+                "schema": "adl.csm.resident_agents.write_failure.v1",
+                "runtime_owner": "csm",
+                "component": "resident_agents",
+                "status": "degraded_nonfatal",
+                "reason": err.to_string(),
+                "recovery_policy": "continue_runtime_and_surface_computed_resident_agent_status"
             }),
         );
     }
@@ -3013,7 +3038,7 @@ fn emit_daemon_event(
             "service_name": "csm-runtime-daemon",
             "event_name": event
         },
-        "runtime_capabilities": csm_runtime_capabilities(runtime_context),
+        "runtime_capabilities": csm_runtime_capabilities(runtime_context, &loaded.spec.agent_instance_id),
         "chronosense_clock_stack": csm_chronosense_clock_stack(runtime_context),
         "details": details
     });
@@ -3049,7 +3074,17 @@ fn emit_daemon_event(
     Ok(())
 }
 
-fn csm_runtime_capabilities(runtime_context: &CsmRuntimeContext) -> Value {
+fn csm_runtime_capabilities(runtime_context: &CsmRuntimeContext, agent_instance_id: &str) -> Value {
+    csm_runtime_capabilities_with_resident_agents(
+        runtime_context,
+        csm_resident_agents::resident_agent_set_status(agent_instance_id),
+    )
+}
+
+fn csm_runtime_capabilities_with_resident_agents(
+    runtime_context: &CsmRuntimeContext,
+    resident_agents_status: Value,
+) -> Value {
     json!({
         "schema": "adl.csm.runtime_capabilities.v1",
         "runtime_owner": "csm",
@@ -3097,6 +3132,7 @@ fn csm_runtime_capabilities(runtime_context: &CsmRuntimeContext) -> Value {
             "partial_checkpoints": "daemon_partial_checkpoint",
             "safe_fail_serialization": "integrated_safe_fail_bundle"
         },
+        "resident_agents": resident_agents_status,
         "polis_shepherd_agent": csm_shepherd_agent::runtime_capability(),
         "observability": {
             "status": "integrated",


### PR DESCRIPTION
Closes #5150

## Summary
Implemented the first provider-backed CSM resident-agent admission surface. The runtime crate now owns a resident-agent contract, the ADL runtime bridges that contract through the existing provider substrate, the CSM status/API surfaces expose resident agents, and daemon status writes retained resident-agent evidence. Bounded subagent review found one retained-evidence issue, which was repaired before publication; this output record is ready for PR publication.

## Artifacts
- Issue-local SOR/SRP fact packet at `.adl/v0.91.7/tasks/issue-5150__v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-the-runtime-provider-substrate/artifacts/review/srp_sor_facts.yaml`
- Tracked implementation artifacts:
  - `adl-runtime/src/resident_agent.rs`
  - `adl/src/csm_resident_agents.rs`
  - runtime API/status integration updates listed in the integration section
- Additional proof artifacts: focused validation commands recorded below

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` - verify Rust formatting for workspace code touched by the resident-agent provider integration
  - `cargo test --manifest-path adl-runtime/Cargo.toml resident_agent -- --nocapture` - exercise the runtime-owned resident-agent contract and policy-gate validation
  - `cargo test --manifest-path adl/Cargo.toml csm_resident_agents -- --nocapture` - exercise the ADL provider-substrate bridge for Shepherd, Codex/ChatGPT, and local Ollama resident agents
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_surfaces_shepherd_agent_component_and_model_policy -- --nocapture` - verify the CSM runtime API surfaces resident agents and Shepherd provider-binding evidence
  - `git diff --check` - verify the issue diff has no whitespace errors
  - `bash adl/tools/run_owner_validation_lane.sh runtime` - run the repo-native runtime owner lane after the resident-agent retained-evidence repair
- Results:
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: PASS
  - `cargo test --manifest-path adl-runtime/Cargo.toml resident_agent -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml csm_resident_agents -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_surfaces_shepherd_agent_component_and_model_policy -- --nocapture`: PASS
  - `git diff --check`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh runtime`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5150__v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-the-runtime-provider-substrate/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5150__v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-the-runtime-provider-substrate/sor.md
- Idempotency-Key: v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-provider-substrate-adl-runtime-src-lib-rs-adl-runtime-src-resident-agent-rs-adl-runtime-src-topology-rs-adl-src-csm-resident-agents-rs-adl-src-csm-runtime-api-rs-adl-src-csm-shepherd-agent-rs-adl-src-lib-rs-adl-src-long-lived-agent-rs-adl-v0-91-7-tasks-issue-5150-v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-the-runtime-provider-substrate-sip-md-adl-v0-91-7-tasks-issue-5150-v0-91-7-wp-07a-runtime-provider-make-csm-resident-agents-use-the-runtime-provider-substrate-sor-md