### PR TITLE
[v0.91.7][WP-10][curiosity] Implement Runtime v2 curiosity engine core

### DIFF
--- a/adl/src/cli/runtime_v2_cmd/commands.rs
+++ b/adl/src/cli/runtime_v2_cmd/commands.rs
@@ -13,8 +13,8 @@ use ::adl::{
         runtime_v2_aee_obsmem_pvf_trace_handoff_contract,
         runtime_v2_cognitive_being_flagship_demo_contract,
         runtime_v2_contract_market_demo_contract, runtime_v2_csm_integrated_run_contract,
-        runtime_v2_feature_proof_coverage_contract, runtime_v2_foundation_demo_contract,
-        runtime_v2_godel_agent_runtime_contract_for,
+        runtime_v2_curiosity_engine_contract, runtime_v2_feature_proof_coverage_contract,
+        runtime_v2_foundation_demo_contract, runtime_v2_godel_agent_runtime_contract_for,
         runtime_v2_governed_tools_flagship_demo_contract, runtime_v2_loop_runtime_contract,
         runtime_v2_minimal_integrated_runtime_path_contract,
         runtime_v2_observatory_flagship_contract, runtime_v2_operator_control_report_contract,
@@ -636,6 +636,42 @@ pub(crate) fn real_runtime_v2_reasoning_graph(repo_root: &Path, args: &[String])
     Ok(())
 }
 
+pub(crate) fn real_runtime_v2_curiosity_engine(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!("runtime-v2 curiosity-engine requires --out <path>"));
+                };
+                out_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for runtime-v2 curiosity-engine: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let packet = runtime_v2_curiosity_engine_contract()?;
+    let Some(out_path) = out_path else {
+        println!("{}", to_string_pretty(&packet.canonicalized()?)?);
+        return Ok(());
+    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "curiosity-engine")?;
+    packet.write_to_path(&resolved)?;
+    println!("{}", curiosity_engine_stdout_line(&out_path));
+    Ok(())
+}
+
 pub(crate) fn real_runtime_v2_loop_runtime(repo_root: &Path, args: &[String]) -> Result<()> {
     let mut out_path: Option<PathBuf> = None;
     let mut i = 0usize;
@@ -843,6 +879,10 @@ pub(crate) fn feature_proof_coverage_stdout_line(out_path: &Path) -> String {
 
 pub(crate) fn reasoning_graph_stdout_line(out_path: &Path) -> String {
     format!("RUNTIME_V2_REASONING_GRAPH_PATH={}", out_path.display())
+}
+
+pub(crate) fn curiosity_engine_stdout_line(out_path: &Path) -> String {
+    format!("RUNTIME_V2_CURIOSITY_ENGINE_PATH={}", out_path.display())
 }
 
 pub(crate) fn loop_runtime_stdout_line(out_path: &Path) -> String {

--- a/adl/src/cli/runtime_v2_cmd/helpers.rs
+++ b/adl/src/cli/runtime_v2_cmd/helpers.rs
@@ -71,7 +71,7 @@ pub(crate) fn resolve_relative_output_path(
 pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime"
+            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime"
         ));
     };
 
@@ -102,6 +102,7 @@ pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Resu
             commands::real_runtime_v2_feature_proof_coverage(repo_root, &args[1..])
         }
         "reasoning-graph" => commands::real_runtime_v2_reasoning_graph(repo_root, &args[1..]),
+        "curiosity-engine" => commands::real_runtime_v2_curiosity_engine(repo_root, &args[1..]),
         "loop-runtime" => commands::real_runtime_v2_loop_runtime(repo_root, &args[1..]),
         "godel-agent-runtime" => {
             commands::real_runtime_v2_godel_agent_runtime(repo_root, &args[1..])
@@ -111,7 +112,7 @@ pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Resu
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime)"
+            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime)"
         )),
     }
 }

--- a/adl/src/cli/runtime_v2_cmd/tests.rs
+++ b/adl/src/cli/runtime_v2_cmd/tests.rs
@@ -1,9 +1,9 @@
 use crate::cli::runtime_v2_cmd::{
     commands::{
         cognitive_being_flagship_demo_stdout_line, contract_market_demo_stdout_line,
-        feature_proof_coverage_stdout_line, godel_agent_runtime_stdout_line,
-        governed_tools_flagship_demo_stdout_line, loop_runtime_stdout_line,
-        reasoning_graph_stdout_line,
+        curiosity_engine_stdout_line, feature_proof_coverage_stdout_line,
+        godel_agent_runtime_stdout_line, governed_tools_flagship_demo_stdout_line,
+        loop_runtime_stdout_line, reasoning_graph_stdout_line,
     },
     helpers::{real_runtime_v2, real_runtime_v2_in_repo},
 };
@@ -37,6 +37,8 @@ const RUNTIME_V2_CLI_REGRESSION_SMOKES: &[&str] = &[
     "feature-proof-coverage:arg-validation",
     "reasoning-graph:write-json",
     "reasoning-graph:arg-validation",
+    "curiosity-engine:write-json",
+    "curiosity-engine:arg-validation",
     "loop-runtime:write-json",
     "loop-runtime:arg-validation",
     "godel-agent-runtime:write-json",
@@ -119,7 +121,7 @@ fn trace_runtime_v2_dispatch_covers_help_and_subcommand_errors() {
     let err = real_runtime_v2_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, loop-runtime, or godel-agent-runtime"));
+        .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime"));
 
     let err = real_runtime_v2_in_repo(&["bogus".to_string()], &repo)
         .expect_err("unknown subcommand should fail");
@@ -990,6 +992,82 @@ fn trace_runtime_v2_reasoning_graph_validates_stdout_help_and_output_path_rules(
 }
 
 #[test]
+fn trace_runtime_v2_curiosity_engine_writes_packet_json() {
+    let repo = temp_repo("curiosity-engine");
+    let out_path = repo.join("out/curiosity-engine.json");
+
+    real_runtime_v2_in_repo(
+        &[
+            "curiosity-engine".to_string(),
+            "--out".to_string(),
+            "out/curiosity-engine.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("curiosity engine");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("curiosity packet should exist"))
+            .expect("valid json");
+    assert_eq!(json["schema_version"], "runtime_v2.curiosity_engine.v1");
+    assert_eq!(json["milestone"], "v0.91.7");
+    assert_eq!(json["wp"], "WP-10");
+    assert_eq!(json["signals"].as_array().expect("signals").len(), 2);
+    assert_eq!(json["proposals"].as_array().expect("proposals").len(), 2);
+    assert_eq!(json["governance"]["freedom_gate_required"], true);
+    assert_eq!(json["governance"]["constructability_gate_required"], true);
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
+fn trace_runtime_v2_curiosity_engine_validates_stdout_help_and_output_path_rules() {
+    let repo = temp_repo("curiosity-engine-branches");
+
+    real_runtime_v2_in_repo(&["curiosity-engine".to_string()], &repo)
+        .expect("stdout curiosity packet");
+    real_runtime_v2_in_repo(
+        &["curiosity-engine".to_string(), "--help".to_string()],
+        &repo,
+    )
+    .expect("curiosity help");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "curiosity-engine".to_string(),
+            "--out".to_string(),
+            repo.join("absolute/curiosity-engine.json")
+                .to_string_lossy()
+                .to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("absolute output path should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 curiosity-engine --out path must be repository-relative"));
+
+    let err = real_runtime_v2_in_repo(
+        &["curiosity-engine".to_string(), "--bogus".to_string()],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for runtime-v2 curiosity-engine: --bogus"));
+
+    let err = real_runtime_v2_in_repo(
+        &["curiosity-engine".to_string(), "--out".to_string()],
+        &repo,
+    )
+    .expect_err("missing out value should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 curiosity-engine requires --out <path>"));
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
 fn trace_runtime_v2_loop_runtime_writes_packet_json() {
     let repo = temp_repo("loop-runtime");
     let out_path = repo.join("out/loop-runtime.json");
@@ -1180,6 +1258,8 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
         trace_runtime_v2_feature_proof_coverage_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_reasoning_graph_writes_packet_json,
         trace_runtime_v2_reasoning_graph_validates_stdout_help_and_output_path_rules,
+        trace_runtime_v2_curiosity_engine_writes_packet_json,
+        trace_runtime_v2_curiosity_engine_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_loop_runtime_writes_packet_json,
         trace_runtime_v2_loop_runtime_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_godel_agent_runtime_writes_packet_json,
@@ -1211,6 +1291,9 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("reasoning-graph:")));
+    assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
+        .iter()
+        .any(|smoke| smoke.starts_with("curiosity-engine:")));
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("loop-runtime:")));
@@ -1427,6 +1510,20 @@ fn trace_runtime_v2_demo_stdout_lines_preserve_requested_relative_paths() {
     assert!(
         !reasoning_graph_stdout.contains(&cwd),
         "reasoning graph stdout should not expose absolute repo root:\n{reasoning_graph_stdout}"
+    );
+
+    let curiosity_engine_file = rel_root.join("curiosity-engine.json");
+    let curiosity_engine_stdout = curiosity_engine_stdout_line(&curiosity_engine_file);
+    assert_eq!(
+        curiosity_engine_stdout,
+        format!(
+            "RUNTIME_V2_CURIOSITY_ENGINE_PATH={}",
+            curiosity_engine_file.display()
+        )
+    );
+    assert!(
+        !curiosity_engine_stdout.contains(&cwd),
+        "curiosity engine stdout should not expose absolute repo root:\n{curiosity_engine_stdout}"
     );
 
     let loop_runtime_file = rel_root.join("loop-runtime.json");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -51,6 +51,7 @@ pub fn usage() -> &'static str {
   adl runtime-v2 governed-tools-flagship-demo [--out <dir>]
   adl runtime-v2 feature-proof-coverage [--out <path>]
   adl runtime-v2 reasoning-graph [--out <path>]
+  adl runtime-v2 curiosity-engine [--out <path>]
   adl runtime-v2 loop-runtime [--out <path>]
   adl runtime-v2 godel-agent-runtime [--agents <count>] [--out <path>]
   adl scheduler plan --input <bundle.json> [--out <path>] [--json]
@@ -140,6 +141,7 @@ Examples:
   adl runtime-v2 governed-tools-flagship-demo --out artifacts/v0905/demo-d11-governed-tools-flagship
   adl runtime-v2 feature-proof-coverage --out artifacts/v0904/feature-proof-coverage.json
   adl runtime-v2 reasoning-graph --out artifacts/v0917/reasoning-graph.json
+  adl runtime-v2 curiosity-engine --out artifacts/v0917/curiosity-engine.json
   adl runtime-v2 loop-runtime --out artifacts/v0917/loop-runtime.json
   adl runtime-v2 godel-agent-runtime --agents 10 --out artifacts/v0917/godel-agent-runtime.json
   adl scheduler plan --input adl/tests/fixtures/scheduler/economics_inputs_v1.json --out artifacts/examples/scheduler-plan.json

--- a/adl/src/runtime_v2/curiosity_engine.rs
+++ b/adl/src/runtime_v2/curiosity_engine.rs
@@ -1,0 +1,617 @@
+//! Runtime-v2 Curiosity Engine contract for v0.91.7 WP-10.
+//!
+//! This module owns the governed curiosity core that later CSM runtime
+//! components can host. It produces bounded discovery proposals from explicit
+//! signals, routes them through governance handoffs, and rejects unbounded or
+//! ungated curiosity before activation.
+
+use super::*;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+pub const RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA: &str = "runtime_v2.curiosity_engine.v1";
+pub const RUNTIME_V2_CURIOSITY_ENGINE_PATH: &str =
+    "runtime_v2/curiosity_engine/curiosity_engine.json";
+pub const RUNTIME_V2_CURIOSITY_ENGINE_FEATURE_DOC: &str =
+    "docs/milestones/v0.91.7/features/CURIOSITY_ENGINE_DISCOVERY_SUBSTRATE_v0.91.7.md";
+pub const RUNTIME_V2_CURIOSITY_ENGINE_TEST_MARKER: &str = "runtime_v2_curiosity_engine";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriosityEnginePacket {
+    pub schema_version: String,
+    pub engine_id: String,
+    pub milestone: String,
+    pub wp: String,
+    pub artifact_path: String,
+    pub source_feature_doc: String,
+    pub runtime_module_ref: String,
+    pub future_component_refs: Vec<String>,
+    pub budget: RuntimeV2CuriosityBudget,
+    pub signals: Vec<RuntimeV2CuriositySignal>,
+    pub proposals: Vec<RuntimeV2CuriosityProposal>,
+    pub governance: RuntimeV2CuriosityGovernance,
+    pub handoff: RuntimeV2CuriosityHandoff,
+    pub validation_commands: Vec<String>,
+    pub claim_boundary: String,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriosityBudget {
+    pub max_open_questions: u32,
+    pub max_proposals_per_cycle: u32,
+    pub max_experiment_steps: u32,
+    pub max_external_actions: u32,
+    pub exhaustion_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriositySignal {
+    pub signal_id: String,
+    pub signal_kind: RuntimeV2CuriositySignalKind,
+    pub source_ref: String,
+    pub novelty_score: u8,
+    pub surprise_score: u8,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2CuriositySignalKind {
+    RuntimeAnomaly,
+    EvidenceGap,
+    CapabilityDelta,
+    OperatorQuestion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriosityProposal {
+    pub proposal_id: String,
+    pub source_signal_id: String,
+    pub question: String,
+    pub hypothesis: String,
+    pub experiment_plan: Vec<String>,
+    pub expected_artifacts: Vec<String>,
+    pub gated_by: Vec<String>,
+    pub status: RuntimeV2CuriosityProposalStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2CuriosityProposalStatus {
+    Proposed,
+    BlockedByBudget,
+    BlockedByGovernance,
+    ReadyForReview,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriosityGovernance {
+    pub freedom_gate_required: bool,
+    pub constructability_gate_required: bool,
+    pub cav_review_required: bool,
+    pub operator_review_required_for_external_action: bool,
+    pub allowed_runtime_actions: Vec<String>,
+    pub prohibited_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CuriosityHandoff {
+    pub reasoning_graph_refs: Vec<String>,
+    pub obsmem_refs: Vec<String>,
+    pub trace_refs: Vec<String>,
+    pub constructability_refs: Vec<String>,
+    pub csm_component_followups: Vec<String>,
+    pub replay_guarantees: Vec<String>,
+}
+
+impl RuntimeV2CuriosityEnginePacket {
+    pub fn prototype() -> Result<Self> {
+        let packet = Self {
+            schema_version: RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA.to_string(),
+            engine_id: "curiosity-engine-v0-91-7-wp-10".to_string(),
+            milestone: "v0.91.7".to_string(),
+            wp: "WP-10".to_string(),
+            artifact_path: RUNTIME_V2_CURIOSITY_ENGINE_PATH.to_string(),
+            source_feature_doc: RUNTIME_V2_CURIOSITY_ENGINE_FEATURE_DOC.to_string(),
+            runtime_module_ref: "adl/src/runtime_v2/curiosity_engine.rs".to_string(),
+            future_component_refs: vec![
+                "issue-5124-curiosity-engine-csm-runtime-component".to_string(),
+                "issue-5125-constructability-gate-csm-runtime-component".to_string(),
+            ],
+            budget: RuntimeV2CuriosityBudget {
+                max_open_questions: 4,
+                max_proposals_per_cycle: 2,
+                max_experiment_steps: 3,
+                max_external_actions: 0,
+                exhaustion_policy: "defer_new_questions_and_emit_budget_exhausted_event"
+                    .to_string(),
+            },
+            signals: prototype_signals(),
+            proposals: prototype_proposals(),
+            governance: RuntimeV2CuriosityGovernance {
+                freedom_gate_required: true,
+                constructability_gate_required: true,
+                cav_review_required: true,
+                operator_review_required_for_external_action: true,
+                allowed_runtime_actions: vec![
+                    "record_question".to_string(),
+                    "propose_bounded_experiment".to_string(),
+                    "write_reviewable_trace".to_string(),
+                    "handoff_to_reasoning_graph".to_string(),
+                ],
+                prohibited_actions: vec![
+                    "autonomous_external_execution".to_string(),
+                    "private_reasoning_disclosure".to_string(),
+                    "constructability_promotion_without_anchor".to_string(),
+                    "freedom_gate_bypass".to_string(),
+                ],
+            },
+            handoff: RuntimeV2CuriosityHandoff {
+                reasoning_graph_refs: vec![
+                    "runtime_v2/reasoning_graph/reasoning_graph.json".to_string(),
+                ],
+                obsmem_refs: vec!["obsmem/curiosity/curiosity-cycle-0001.json".to_string()],
+                trace_refs: vec![
+                    "trace://runtime_v2/curiosity/signal-gap-wp10".to_string(),
+                    "trace://runtime_v2/curiosity/proposal-bounded-proof".to_string(),
+                ],
+                constructability_refs: vec![
+                    "runtime_v2/constructability/anchor-validator.json".to_string(),
+                ],
+                csm_component_followups: vec![
+                    "issue-5124 consumes this curiosity core as a supervised CSM component"
+                        .to_string(),
+                    "issue-5125 hosts the constructability gate needed before promotion"
+                        .to_string(),
+                ],
+                replay_guarantees: vec![
+                    "signals and proposals are sorted deterministically before serialization"
+                        .to_string(),
+                    "every proposal must cite an existing signal".to_string(),
+                    "every executable proposal must be budget bounded".to_string(),
+                    "every proposal must retain Freedom Gate and Constructability gates"
+                        .to_string(),
+                ],
+            },
+            validation_commands: vec![
+                format!(
+                    "cargo test --manifest-path adl/Cargo.toml {RUNTIME_V2_CURIOSITY_ENGINE_TEST_MARKER} -- --nocapture"
+                ),
+                "cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_curiosity_engine -- --nocapture".to_string(),
+                "adl/target/debug/adl runtime-v2 curiosity-engine --out .adl/local-artifacts/wp10-curiosity/curiosity-engine.json".to_string(),
+                "git diff --check".to_string(),
+            ],
+            claim_boundary:
+                "WP-10 #4692 proves a bounded Runtime v2 Curiosity Engine core for governed discovery-cycle proposals. It is ready for later CSM runtime-component hosting, but does not claim autonomous exploration, live external action, or WP-07A supervisor integration."
+                    .to_string(),
+            non_claims: vec![
+                "does not perform autonomous external exploration".to_string(),
+                "does not bypass Freedom Gate, CAV, operator review, or Constructability"
+                    .to_string(),
+                "does not claim WP-07A CSM component supervisor integration".to_string(),
+                "does not promote hypotheses into shared reality without constructability anchors"
+                    .to_string(),
+                "does not expose private reasoning".to_string(),
+            ],
+        };
+        packet.validate()?;
+        Ok(packet)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        require_exact(
+            &self.schema_version,
+            RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA,
+            "curiosity.schema_version",
+        )?;
+        normalize_id(self.engine_id.clone(), "curiosity.engine_id")?;
+        require_exact(&self.milestone, "v0.91.7", "curiosity.milestone")?;
+        require_exact(&self.wp, "WP-10", "curiosity.wp")?;
+        require_exact(
+            &self.artifact_path,
+            RUNTIME_V2_CURIOSITY_ENGINE_PATH,
+            "curiosity.artifact_path",
+        )?;
+        require_exact(
+            &self.source_feature_doc,
+            RUNTIME_V2_CURIOSITY_ENGINE_FEATURE_DOC,
+            "curiosity.source_feature_doc",
+        )?;
+        validate_relative_path(&self.artifact_path, "curiosity.artifact_path")?;
+        validate_relative_path(&self.source_feature_doc, "curiosity.source_feature_doc")?;
+        validate_relative_path(&self.runtime_module_ref, "curiosity.runtime_module_ref")?;
+        validate_future_component_refs(&self.future_component_refs)?;
+        validate_budget(&self.budget)?;
+        validate_signals(&self.signals)?;
+        validate_proposals(&self.proposals, &self.signals, &self.budget)?;
+        validate_governance(&self.governance)?;
+        validate_handoff(&self.handoff)?;
+        validate_command_list(&self.validation_commands)?;
+        ensure_contains_in_list(
+            &self.non_claims,
+            "does not claim WP-07A CSM component supervisor integration",
+            "curiosity non-claims must preserve WP-07A boundary",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "bounded Runtime v2 Curiosity Engine core",
+            "curiosity claim boundary must stay bounded to this core",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "later CSM runtime-component hosting",
+            "curiosity claim boundary must name future CSM hosting",
+        )
+    }
+
+    pub fn canonicalized(&self) -> Result<Self> {
+        self.validate()?;
+        let mut canonical = self.clone();
+        canonical
+            .signals
+            .sort_by(|a, b| a.signal_id.cmp(&b.signal_id));
+        canonical
+            .proposals
+            .sort_by(|a, b| a.proposal_id.cmp(&b.proposal_id));
+        canonical.future_component_refs.sort();
+        canonical.governance.allowed_runtime_actions.sort();
+        canonical.governance.prohibited_actions.sort();
+        canonical.handoff.reasoning_graph_refs.sort();
+        canonical.handoff.obsmem_refs.sort();
+        canonical.handoff.trace_refs.sort();
+        canonical.handoff.constructability_refs.sort();
+        canonical.handoff.csm_component_followups.sort();
+        canonical.handoff.replay_guarantees.sort();
+        canonical.validation_commands.sort();
+        canonical.non_claims.sort();
+        canonical.validate()?;
+        Ok(canonical)
+    }
+
+    pub fn pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(&self.canonicalized()?)
+            .context("serialize Runtime v2 Curiosity Engine packet")
+    }
+
+    pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "create Runtime v2 Curiosity Engine output directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(path, self.pretty_json_bytes()?).with_context(|| {
+            format!(
+                "write Runtime v2 Curiosity Engine packet to {}",
+                path.display()
+            )
+        })
+    }
+}
+
+pub fn runtime_v2_curiosity_engine_contract() -> Result<RuntimeV2CuriosityEnginePacket> {
+    RuntimeV2CuriosityEnginePacket::prototype()?.canonicalized()
+}
+
+fn prototype_signals() -> Vec<RuntimeV2CuriositySignal> {
+    vec![
+        RuntimeV2CuriositySignal {
+            signal_id: "signal-capability-delta".to_string(),
+            signal_kind: RuntimeV2CuriositySignalKind::CapabilityDelta,
+            source_ref: "docs/milestones/v0.91.7/FEATURE_DOCS_v0.91.7.md".to_string(),
+            novelty_score: 4,
+            surprise_score: 3,
+            summary:
+                "v0.92 activation asks for curiosity behavior that was previously only documented."
+                    .to_string(),
+        },
+        RuntimeV2CuriositySignal {
+            signal_id: "signal-evidence-gap".to_string(),
+            signal_kind: RuntimeV2CuriositySignalKind::EvidenceGap,
+            source_ref: RUNTIME_V2_CURIOSITY_ENGINE_FEATURE_DOC.to_string(),
+            novelty_score: 3,
+            surprise_score: 4,
+            summary:
+                "The feature doc requires a governed discovery-cycle proof before consumption."
+                    .to_string(),
+        },
+    ]
+}
+
+fn prototype_proposals() -> Vec<RuntimeV2CuriosityProposal> {
+    vec![
+        RuntimeV2CuriosityProposal {
+            proposal_id: "proposal-bounded-discovery-proof".to_string(),
+            source_signal_id: "signal-evidence-gap".to_string(),
+            question: "Which bounded discovery cycle can prove curiosity without autonomous exploration?".to_string(),
+            hypothesis: "A deterministic proposal packet can prove curiosity admission, governance, handoff, and non-claims before CSM component hosting.".to_string(),
+            experiment_plan: vec![
+                "derive one reviewable question from an evidence gap".to_string(),
+                "bind the question to budget and governance gates".to_string(),
+                "emit trace, ObsMem, reasoning-graph, and Constructability handoff refs".to_string(),
+            ],
+            expected_artifacts: vec![
+                RUNTIME_V2_CURIOSITY_ENGINE_PATH.to_string(),
+                "runtime_v2/curiosity_engine/curiosity_trace.jsonl".to_string(),
+            ],
+            gated_by: vec![
+                "freedom_gate".to_string(),
+                "cav_review".to_string(),
+                "constructability_anchor".to_string(),
+                "operator_review_for_external_action".to_string(),
+            ],
+            status: RuntimeV2CuriosityProposalStatus::ReadyForReview,
+        },
+        RuntimeV2CuriosityProposal {
+            proposal_id: "proposal-csm-component-handoff".to_string(),
+            source_signal_id: "signal-capability-delta".to_string(),
+            question: "How should the curiosity core become a CSM runtime module later?".to_string(),
+            hypothesis: "Keep the core deterministic and host-agnostic now, then let WP-07A wrap it with supervision, channels, lifecycle, and provider access.".to_string(),
+            experiment_plan: vec![
+                "export a stable runtime_v2 contract function".to_string(),
+                "record WP-07A component follow-up refs".to_string(),
+            ],
+            expected_artifacts: vec![RUNTIME_V2_CURIOSITY_ENGINE_PATH.to_string()],
+            gated_by: vec![
+                "freedom_gate".to_string(),
+                "constructability_anchor".to_string(),
+            ],
+            status: RuntimeV2CuriosityProposalStatus::Proposed,
+        },
+    ]
+}
+
+fn validate_budget(budget: &RuntimeV2CuriosityBudget) -> Result<()> {
+    if budget.max_open_questions == 0 {
+        return Err(anyhow!(
+            "curiosity budget must allow at least one open question"
+        ));
+    }
+    if budget.max_proposals_per_cycle == 0 {
+        return Err(anyhow!("curiosity budget must allow at least one proposal"));
+    }
+    if budget.max_experiment_steps == 0 {
+        return Err(anyhow!(
+            "curiosity budget must allow at least one experiment step"
+        ));
+    }
+    if budget.max_external_actions != 0 {
+        return Err(anyhow!(
+            "WP-10 curiosity proof must not allow external actions before later CSM hosting"
+        ));
+    }
+    ensure_contains(
+        &budget.exhaustion_policy,
+        "defer",
+        "curiosity budget exhaustion must defer rather than silently continue",
+    )
+}
+
+fn validate_signals(signals: &[RuntimeV2CuriositySignal]) -> Result<()> {
+    if signals.is_empty() {
+        return Err(anyhow!("curiosity signals must not be empty"));
+    }
+    let mut seen = BTreeSet::new();
+    for signal in signals {
+        normalize_id(signal.signal_id.clone(), "curiosity.signal_id")?;
+        if !seen.insert(signal.signal_id.clone()) {
+            return Err(anyhow!("duplicate curiosity signal '{}'", signal.signal_id));
+        }
+        validate_relative_path(&signal.source_ref, "curiosity.signal.source_ref")?;
+        validate_score(signal.novelty_score, "curiosity.signal.novelty_score")?;
+        validate_score(signal.surprise_score, "curiosity.signal.surprise_score")?;
+        validate_nonempty_text(&signal.summary, "curiosity.signal.summary")?;
+    }
+    Ok(())
+}
+
+fn validate_proposals(
+    proposals: &[RuntimeV2CuriosityProposal],
+    signals: &[RuntimeV2CuriositySignal],
+    budget: &RuntimeV2CuriosityBudget,
+) -> Result<()> {
+    if proposals.is_empty() {
+        return Err(anyhow!("curiosity proposals must not be empty"));
+    }
+    if proposals.len() > budget.max_proposals_per_cycle as usize {
+        return Err(anyhow!(
+            "curiosity proposals exceed max_proposals_per_cycle budget"
+        ));
+    }
+    let signal_ids: BTreeSet<_> = signals
+        .iter()
+        .map(|signal| signal.signal_id.as_str())
+        .collect();
+    let mut seen = BTreeSet::new();
+    for proposal in proposals {
+        normalize_id(proposal.proposal_id.clone(), "curiosity.proposal_id")?;
+        if !seen.insert(proposal.proposal_id.clone()) {
+            return Err(anyhow!(
+                "duplicate curiosity proposal '{}'",
+                proposal.proposal_id
+            ));
+        }
+        if !signal_ids.contains(proposal.source_signal_id.as_str()) {
+            return Err(anyhow!(
+                "curiosity proposal '{}' cites missing source signal '{}'",
+                proposal.proposal_id,
+                proposal.source_signal_id
+            ));
+        }
+        validate_nonempty_text(&proposal.question, "curiosity.proposal.question")?;
+        validate_nonempty_text(&proposal.hypothesis, "curiosity.proposal.hypothesis")?;
+        if proposal.experiment_plan.is_empty()
+            || proposal.experiment_plan.len() > budget.max_experiment_steps as usize
+        {
+            return Err(anyhow!(
+                "curiosity proposal '{}' must stay within max_experiment_steps",
+                proposal.proposal_id
+            ));
+        }
+        for artifact in &proposal.expected_artifacts {
+            validate_relative_path(artifact, "curiosity.proposal.expected_artifacts")?;
+        }
+        require_gate(&proposal.gated_by, "freedom_gate")?;
+        require_gate(&proposal.gated_by, "constructability_anchor")?;
+    }
+    Ok(())
+}
+
+fn validate_governance(governance: &RuntimeV2CuriosityGovernance) -> Result<()> {
+    if !governance.freedom_gate_required {
+        return Err(anyhow!("curiosity governance must require Freedom Gate"));
+    }
+    if !governance.constructability_gate_required {
+        return Err(anyhow!(
+            "curiosity governance must require Constructability before promotion"
+        ));
+    }
+    if !governance.cav_review_required {
+        return Err(anyhow!("curiosity governance must require CAV review"));
+    }
+    if !governance.operator_review_required_for_external_action {
+        return Err(anyhow!(
+            "curiosity governance must require operator review for external action"
+        ));
+    }
+    ensure_contains_in_list(
+        &governance.allowed_runtime_actions,
+        "propose_bounded_experiment",
+        "curiosity governance must allow bounded proposal generation",
+    )?;
+    ensure_contains_in_list(
+        &governance.prohibited_actions,
+        "autonomous_external_execution",
+        "curiosity governance must prohibit autonomous external execution",
+    )?;
+    ensure_contains_in_list(
+        &governance.prohibited_actions,
+        "freedom_gate_bypass",
+        "curiosity governance must prohibit Freedom Gate bypass",
+    )
+}
+
+fn validate_handoff(handoff: &RuntimeV2CuriosityHandoff) -> Result<()> {
+    validate_path_list(
+        &handoff.reasoning_graph_refs,
+        "curiosity.handoff.reasoning_graph_refs",
+    )?;
+    validate_path_list(&handoff.obsmem_refs, "curiosity.handoff.obsmem_refs")?;
+    validate_trace_refs(&handoff.trace_refs)?;
+    validate_path_list(
+        &handoff.constructability_refs,
+        "curiosity.handoff.constructability_refs",
+    )?;
+    ensure_contains_in_list(
+        &handoff.csm_component_followups,
+        "issue-5124 consumes this curiosity core as a supervised CSM component",
+        "curiosity handoff must name the future CSM Curiosity component",
+    )?;
+    ensure_contains_in_list(
+        &handoff.csm_component_followups,
+        "issue-5125 hosts the constructability gate needed before promotion",
+        "curiosity handoff must name the Constructability component dependency",
+    )?;
+    ensure_contains_in_list(
+        &handoff.replay_guarantees,
+        "every proposal must cite an existing signal",
+        "curiosity replay guarantees must bind proposals to signals",
+    )
+}
+
+fn validate_future_component_refs(refs: &[String]) -> Result<()> {
+    ensure_contains_in_list(
+        refs,
+        "issue-5124-curiosity-engine-csm-runtime-component",
+        "curiosity future component refs must include #5124",
+    )?;
+    ensure_contains_in_list(
+        refs,
+        "issue-5125-constructability-gate-csm-runtime-component",
+        "curiosity future component refs must include #5125",
+    )
+}
+
+fn validate_path_list(values: &[String], field: &str) -> Result<()> {
+    if values.is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    for value in values {
+        validate_relative_path(value, field)?;
+    }
+    Ok(())
+}
+
+fn validate_trace_refs(values: &[String]) -> Result<()> {
+    if values.is_empty() {
+        return Err(anyhow!("curiosity trace refs must not be empty"));
+    }
+    for value in values {
+        if !value.starts_with("trace://") {
+            return Err(anyhow!("curiosity trace ref must start with trace://"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_score(value: u8, field: &str) -> Result<()> {
+    if value > 5 {
+        return Err(anyhow!("{field} must be in the range 0..=5"));
+    }
+    Ok(())
+}
+
+fn require_gate(gates: &[String], expected: &str) -> Result<()> {
+    if gates.iter().any(|gate| gate == expected) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "curiosity proposal missing required gate '{expected}'"
+        ))
+    }
+}
+
+fn validate_command_list(commands: &[String]) -> Result<()> {
+    if commands.is_empty() {
+        return Err(anyhow!("curiosity validation commands must not be empty"));
+    }
+    ensure_contains_in_list(
+        commands,
+        RUNTIME_V2_CURIOSITY_ENGINE_TEST_MARKER,
+        "curiosity validation commands must include the focused Rust test marker",
+    )?;
+    ensure_contains_in_list(
+        commands,
+        "git diff --check",
+        "curiosity validation commands must include whitespace/path hygiene",
+    )
+}
+
+fn ensure_contains_in_list(values: &[String], needle: &str, message: &str) -> Result<()> {
+    if values.iter().any(|value| value.contains(needle)) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn ensure_contains(value: &str, needle: &str, message: &str) -> Result<()> {
+    if value.contains(needle) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn require_exact(actual: &str, expected: &str, field: &str) -> Result<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(anyhow!("{field} must be '{expected}', got '{actual}'"))
+    }
+}

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -23,6 +23,7 @@ mod contract_schema;
 mod contracts;
 mod csm_run;
 mod cultivating_intelligence;
+mod curiosity_engine;
 mod delegation_subcontract;
 mod evaluation_selection;
 mod external_counterparty;
@@ -116,6 +117,8 @@ pub use contracts::*;
 pub use csm_run::*;
 #[allow(unused_imports)]
 pub use cultivating_intelligence::*;
+#[allow(unused_imports)]
+pub use curiosity_engine::*;
 #[allow(unused_imports)]
 pub use delegation_subcontract::*;
 #[allow(unused_imports)]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -26,6 +26,7 @@ mod contract_registry_accessors;
 mod contract_schema;
 mod csm_run_packet;
 mod cultivating_intelligence;
+mod curiosity_engine;
 #[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]
 mod delegation_subcontract;
 mod evaluation_selection;

--- a/adl/src/runtime_v2/tests/curiosity_engine.rs
+++ b/adl/src/runtime_v2/tests/curiosity_engine.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[test]
+fn runtime_v2_curiosity_engine_contract_is_stable() {
+    let packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.validate().expect("valid curiosity packet");
+
+    assert_eq!(packet.schema_version, RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA);
+    assert_eq!(packet.milestone, "v0.91.7");
+    assert_eq!(packet.wp, "WP-10");
+    assert_eq!(packet.signals.len(), 2);
+    assert_eq!(packet.proposals.len(), 2);
+    assert!(packet.governance.freedom_gate_required);
+    assert!(packet.governance.constructability_gate_required);
+    assert!(packet
+        .handoff
+        .csm_component_followups
+        .iter()
+        .any(|value| value.contains("issue-5124")));
+    assert!(packet
+        .validation_commands
+        .iter()
+        .any(|command| command.contains(RUNTIME_V2_CURIOSITY_ENGINE_TEST_MARKER)));
+}
+
+#[test]
+fn runtime_v2_curiosity_engine_canonical_json_is_deterministic() {
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.signals.reverse();
+    packet.proposals.reverse();
+    packet.validation_commands.reverse();
+
+    let json = String::from_utf8(packet.pretty_json_bytes().expect("curiosity json"))
+        .expect("utf8 curiosity json");
+    let reparsed: RuntimeV2CuriosityEnginePacket =
+        serde_json::from_str(&json).expect("reparse curiosity json");
+
+    assert_eq!(reparsed.signals[0].signal_id, "signal-capability-delta");
+    assert_eq!(
+        reparsed.proposals[0].proposal_id,
+        "proposal-bounded-discovery-proof"
+    );
+    reparsed
+        .validate()
+        .expect("canonical curiosity packet remains valid");
+}
+
+#[test]
+fn runtime_v2_curiosity_engine_rejects_ungated_governance() {
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.governance.freedom_gate_required = false;
+
+    assert!(packet
+        .validate()
+        .expect_err("Freedom Gate must be required")
+        .to_string()
+        .contains("Freedom Gate"));
+
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.proposals[0]
+        .gated_by
+        .retain(|gate| gate != "constructability_anchor");
+    assert!(packet
+        .validate()
+        .expect_err("Constructability gate must be required")
+        .to_string()
+        .contains("constructability_anchor"));
+}
+
+#[test]
+fn runtime_v2_curiosity_engine_rejects_unbounded_or_orphan_proposals() {
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.budget.max_external_actions = 1;
+    assert!(packet
+        .validate()
+        .expect_err("external actions are not allowed in WP-10 proof")
+        .to_string()
+        .contains("external actions"));
+
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.proposals[0].source_signal_id = "missing-signal".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("proposal must cite an existing signal")
+        .to_string()
+        .contains("missing source signal"));
+
+    let mut packet = runtime_v2_curiosity_engine_contract().expect("curiosity engine packet");
+    packet.proposals[0]
+        .experiment_plan
+        .push("extra step outside the budget".to_string());
+    assert!(packet
+        .validate()
+        .expect_err("proposal must stay within budget")
+        .to_string()
+        .contains("max_experiment_steps"));
+}

--- a/docs/milestones/v0.91.7/features/CURIOSITY_ENGINE_DISCOVERY_SUBSTRATE_v0.91.7.md
+++ b/docs/milestones/v0.91.7/features/CURIOSITY_ENGINE_DISCOVERY_SUBSTRATE_v0.91.7.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Curiosity Engine / Discovery Substrate
 - Milestone Target: `v0.91.7`
-- Status: planned
+- Status: bounded runtime core implemented
 - Owner: ADL maintainers
 - Doc Role: primary
 - Feature Types: architecture, policy, artifact
@@ -30,8 +30,32 @@ In scope:
 Out of scope:
 
 - broad autonomous exploration;
-- runtime implementation;
+- autonomous external action;
+- WP-07A CSM supervisor/component hosting;
 - public claims that curiosity is fully solved.
+
+## Runtime Status
+
+As of `v0.91.7`, WP-10 issue `#4692` implements a bounded Runtime v2
+Curiosity Engine core in `adl/src/runtime_v2/curiosity_engine.rs`.
+
+The runtime core emits a deterministic curiosity packet with:
+
+- explicit novelty/surprise signals;
+- budgeted discovery proposals;
+- Freedom Gate, CAV, operator-review, and Constructability gates;
+- reasoning-graph, ObsMem, trace, and constructability handoff references;
+- replay guarantees and non-claims.
+
+The packet is available through:
+
+```sh
+adl runtime-v2 curiosity-engine --out artifacts/v0917/curiosity-engine.json
+```
+
+This is the host-agnostic curiosity core. WP-07A issues `#5124` and `#5125`
+remain the CSM runtime-component hosting path for supervision, typed channels,
+lifecycle integration, and Constructability component placement.
 
 ## Required Decisions
 
@@ -49,14 +73,24 @@ Out of scope:
 ## Validation And Review
 
 - Review discovery-cycle artifacts and budget enforcement.
-- Require a bounded proof before `v0.92` consumes Curiosity.
+- Require the focused Runtime v2 proof command before `v0.92` consumes
+  Curiosity:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml runtime_v2_curiosity_engine -- --nocapture
+cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_curiosity_engine -- --nocapture
+adl/target/debug/adl runtime-v2 curiosity-engine --out .adl/local-artifacts/wp10-curiosity/curiosity-engine.json
+```
+
 - Block any curiosity claim that lacks governance with evidence and operator
   approval.
 
 ## v0.92 Consumption
 
-`v0.92` may consume Curiosity only if a governed discovery-cycle proof exists
-or the surface is explicitly blocked with evidence and operator approval.
+`v0.92` may consume Curiosity as a bounded governed-discovery core after
+`#4692` merges. It may not claim CSM runtime-component hosting until the
+WP-07A component path consumes this core and proves supervision/channel
+integration.
 
 ## Non-Goals
 


### PR DESCRIPTION
Closes #4692

## Summary
Implemented a bounded Runtime v2 Curiosity Engine core with deterministic packet generation, governance gates, proposal budgets, handoff references, CLI access, and focused Runtime v2 tests. The work is ready for repo-native PR publication from the bound issue branch. It does not claim WP-07A CSM component hosting, autonomous exploration, provider execution, or live external action.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-4692__v0-91-7-wp-10-curiosity-implement-curiosity-engine-in-full/sor.md`
- Tracked implementation artifacts:
  - `adl/src/runtime_v2/curiosity_engine.rs`
  - `adl/src/runtime_v2/tests/curiosity_engine.rs`
  - `adl/src/runtime_v2/mod.rs`
  - `adl/src/runtime_v2/tests.rs`
  - `adl/src/cli/runtime_v2_cmd/commands.rs`
  - `adl/src/cli/runtime_v2_cmd/helpers.rs`
  - `adl/src/cli/runtime_v2_cmd/tests.rs`
  - `adl/src/cli/usage.rs`
  - `docs/milestones/v0.91.7/features/CURIOSITY_ENGINE_DISCOVERY_SUBSTRATE_v0.91.7.md`
- Additional proof artifacts: `.adl/local-artifacts/wp10-curiosity/curiosity-engine.json` (ignored local CLI output)

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_curiosity_engine -- --nocapture`
    `Verified the Runtime v2 Curiosity Engine contract and negative cases.`
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_curiosity_engine -- --nocapture`
    `Verified the Runtime v2 CLI command contract.`
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_dispatch_covers_help_and_subcommand_errors -- --nocapture`
    `Verified runtime-v2 dispatcher coverage after adding curiosity-engine.`
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_registry -- --nocapture`
    `Verified runtime-v2 CLI regression registry coverage after adding curiosity-engine.`
  - `cargo build --manifest-path adl/Cargo.toml --bin adl`
    `Verified the adl binary builds with the new Runtime v2 module and CLI command.`
  - `adl/target/debug/adl runtime-v2 curiosity-engine --out .adl/local-artifacts/wp10-curiosity/curiosity-engine.json`
    `Verified the repo-built CLI writes the curiosity packet.`
  - `git diff --check`
    `Verified diff hygiene.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4692__v0-91-7-wp-10-curiosity-implement-curiosity-engine-in-full/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4692__v0-91-7-wp-10-curiosity-implement-curiosity-engine-in-full/sor.md
- Idempotency-Key: v0-91-7-wp-10-curiosity-implement-runtime-v2-curiosity-engine-core-adl-src-runtime-v2-curiosity-engine-rs-adl-src-runtime-v2-tests-curiosity-engine-rs-adl-src-runtime-v2-mod-rs-adl-src-runtime-v2-tests-rs-adl-src-cli-runtime-v2-cmd-commands-rs-adl-src-cli-runtime-v2-cmd-helpers-rs-adl-src-cli-runtime-v2-cmd-tests-rs-adl-src-cli-usage-rs-docs-milestones-v0-91-7-features-curiosity-engine-discovery-substrate-v0-91-7-md-adl-v0-91-7-tasks-issue-4692-v0-91-7-wp-10-curiosity-implement-curiosity-engine-in-full-sip-md-adl-v0-91-7-tasks-issue-4692-v0-91-7-wp-10-curiosity-implement-curiosity-engine-in-full-sor-md