### PR TITLE
[v0.91.7][WP-07A][runtime] Implement Curiosity Engine as CSM runtime component

### DIFF
--- a/adl-runtime/src/curiosity.rs
+++ b/adl-runtime/src/curiosity.rs
@@ -1,0 +1,240 @@
+//! CSM Curiosity Engine runtime contracts.
+//!
+//! Curiosity is an embedded CSM component. It proposes bounded investigations
+//! through typed channels and cannot admit proposals without sibling governance
+//! components.
+
+use serde::{Deserialize, Serialize};
+
+pub const CSM_CURIOSITY_COMPONENT: &str = "curiosity_engine";
+pub const CSM_CURIOSITY_STATUS_SCHEMA: &str = "adl.csm.curiosity_engine.status.v1";
+pub const CSM_CURIOSITY_PROPOSAL_SCHEMA: &str = "adl.csm.curiosity_engine.proposal.v1";
+pub const CSM_CURIOSITY_CHANNELS_SCHEMA: &str = "adl.csm.curiosity_engine.channels.v1";
+pub const CSM_CURIOSITY_STATUS_REF: &str = "csm_curiosity_engine_status.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CsmCuriosityReadiness {
+    Ready,
+    Blocked,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CsmCuriosityProposalStatus {
+    Proposed,
+    ReadyForReview,
+    RejectedByGovernance,
+    Deferred,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityChannels {
+    pub schema: String,
+    pub observations: String,
+    pub proposal_requests: String,
+    pub proposal_decisions: String,
+    pub rejected_proposals: String,
+    pub observability: String,
+    pub lifelog: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityConstraintHooks {
+    pub freedom_gate_required: bool,
+    pub cav_required: bool,
+    pub constructability_required: bool,
+    pub missing_constraint_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityProposal {
+    pub schema: String,
+    pub proposal_id: String,
+    pub source_signal_id: String,
+    pub question: String,
+    pub hypothesis: String,
+    pub experiment_plan: Vec<String>,
+    pub expected_artifacts: Vec<String>,
+    pub gated_by: Vec<String>,
+    pub status: CsmCuriosityProposalStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityComponentStatus {
+    pub schema: String,
+    pub runtime_owner: String,
+    pub component: String,
+    pub hosted_core_schema: String,
+    pub hosted_core_ref: String,
+    pub status: String,
+    pub readiness: CsmCuriosityReadiness,
+    pub process_model: String,
+    pub channels: CsmCuriosityChannels,
+    pub constraint_hooks: CsmCuriosityConstraintHooks,
+    pub proposals: Vec<CsmCuriosityProposal>,
+    pub retained_status_ref: String,
+}
+
+impl CsmCuriosityChannels {
+    pub fn new(component: &str) -> Self {
+        Self {
+            schema: CSM_CURIOSITY_CHANNELS_SCHEMA.to_string(),
+            observations: format!("csm.{component}.observations"),
+            proposal_requests: format!("csm.{component}.proposal_requests"),
+            proposal_decisions: format!("csm.{component}.proposal_decisions"),
+            rejected_proposals: format!("csm.{component}.rejected_proposals"),
+            observability: format!("csm.{component}.observability"),
+            lifelog: format!("csm.{component}.lifelog"),
+        }
+    }
+}
+
+impl CsmCuriosityConstraintHooks {
+    pub fn required() -> Self {
+        Self {
+            freedom_gate_required: true,
+            cav_required: true,
+            constructability_required: true,
+            missing_constraint_policy: "fail_closed".to_string(),
+        }
+    }
+}
+
+impl CsmCuriosityProposal {
+    pub fn validate(&self) -> Result<(), String> {
+        require_exact(
+            &self.schema,
+            CSM_CURIOSITY_PROPOSAL_SCHEMA,
+            "proposal.schema",
+        )?;
+        require_non_empty(&self.proposal_id, "proposal.proposal_id")?;
+        require_non_empty(&self.source_signal_id, "proposal.source_signal_id")?;
+        require_non_empty(&self.question, "proposal.question")?;
+        require_non_empty(&self.hypothesis, "proposal.hypothesis")?;
+        if self.experiment_plan.is_empty() {
+            return Err("proposal.experiment_plan must not be empty".to_string());
+        }
+        for gate in ["freedom_gate", "cav", "constructability_anchor"] {
+            if !self.gated_by.iter().any(|value| value == gate) {
+                return Err(format!("proposal must be gated by {gate}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CsmCuriosityComponentStatus {
+    pub fn validate(&self) -> Result<(), String> {
+        require_exact(&self.schema, CSM_CURIOSITY_STATUS_SCHEMA, "schema")?;
+        require_exact(&self.runtime_owner, "csm", "runtime_owner")?;
+        require_exact(&self.component, CSM_CURIOSITY_COMPONENT, "component")?;
+        require_exact(
+            &self.hosted_core_schema,
+            "runtime_v2.curiosity_engine.v1",
+            "hosted_core_schema",
+        )?;
+        require_exact(
+            &self.hosted_core_ref,
+            "adl/src/runtime_v2/curiosity_engine.rs",
+            "hosted_core_ref",
+        )?;
+        require_exact(
+            &self.process_model,
+            "embedded_csm_runtime_component",
+            "process_model",
+        )?;
+        require_exact(
+            &self.channels.schema,
+            CSM_CURIOSITY_CHANNELS_SCHEMA,
+            "channels.schema",
+        )?;
+        if !self.constraint_hooks.freedom_gate_required
+            || !self.constraint_hooks.cav_required
+            || !self.constraint_hooks.constructability_required
+            || self.constraint_hooks.missing_constraint_policy != "fail_closed"
+        {
+            return Err(
+                "Curiosity Engine must require Freedom Gate, CAV, Constructability, and fail-closed missing constraints"
+                    .to_string(),
+            );
+        }
+        require_exact(
+            &self.retained_status_ref,
+            CSM_CURIOSITY_STATUS_REF,
+            "retained_status_ref",
+        )?;
+        for proposal in &self.proposals {
+            proposal.validate()?;
+        }
+        Ok(())
+    }
+}
+
+fn require_non_empty(value: &str, field: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(())
+}
+
+fn require_exact(value: &str, expected: &str, field: &str) -> Result<(), String> {
+    if value != expected {
+        return Err(format!("{field} must be {expected}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proposal() -> CsmCuriosityProposal {
+        CsmCuriosityProposal {
+            schema: CSM_CURIOSITY_PROPOSAL_SCHEMA.to_string(),
+            proposal_id: "proposal-runtime-gap".to_string(),
+            source_signal_id: "signal-runtime-gap".to_string(),
+            question: "Which bounded runtime proof is missing?".to_string(),
+            hypothesis: "A missing proof can be routed as a governed proposal.".to_string(),
+            experiment_plan: vec!["write a retained proof artifact".to_string()],
+            expected_artifacts: vec!["curiosity_proposal.json".to_string()],
+            gated_by: vec![
+                "freedom_gate".to_string(),
+                "cav".to_string(),
+                "constructability_anchor".to_string(),
+            ],
+            status: CsmCuriosityProposalStatus::ReadyForReview,
+        }
+    }
+
+    #[test]
+    fn curiosity_status_requires_embedded_fail_closed_component() {
+        let status = CsmCuriosityComponentStatus {
+            schema: CSM_CURIOSITY_STATUS_SCHEMA.to_string(),
+            runtime_owner: "csm".to_string(),
+            component: CSM_CURIOSITY_COMPONENT.to_string(),
+            hosted_core_schema: "runtime_v2.curiosity_engine.v1".to_string(),
+            hosted_core_ref: "adl/src/runtime_v2/curiosity_engine.rs".to_string(),
+            status: "idle".to_string(),
+            readiness: CsmCuriosityReadiness::Ready,
+            process_model: "embedded_csm_runtime_component".to_string(),
+            channels: CsmCuriosityChannels::new(CSM_CURIOSITY_COMPONENT),
+            constraint_hooks: CsmCuriosityConstraintHooks::required(),
+            proposals: vec![proposal()],
+            retained_status_ref: CSM_CURIOSITY_STATUS_REF.to_string(),
+        };
+        status.validate().expect("valid curiosity status");
+    }
+
+    #[test]
+    fn curiosity_proposals_reject_missing_governance_gate() {
+        let mut proposal = proposal();
+        proposal.gated_by.retain(|gate| gate != "cav");
+        assert!(proposal
+            .validate()
+            .expect_err("cav gate is required")
+            .contains("cav"));
+    }
+}

--- a/adl-runtime/src/lib.rs
+++ b/adl-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! built without ADL compiler or C-SDLC control-plane crates.
 
 pub mod backpressure;
+pub mod curiosity;
 pub mod networking;
 pub mod resident_agent;
 pub mod runtime_api;

--- a/adl-runtime/src/runtime_api.rs
+++ b/adl-runtime/src/runtime_api.rs
@@ -8,10 +8,11 @@ pub const CSM_RUNTIME_API_METRICS_SCHEMA: &str = "adl.csm.runtime_api.metrics.v1
 pub const CSM_RUNTIME_API_EVENTS_SCHEMA: &str = "adl.csm.runtime_api.events.v1";
 pub const CSM_RUNTIME_API_CHRONOSENSE_SCHEMA: &str = "adl.csm.runtime_api.chronosense.v1";
 pub const CSM_RUNTIME_API_SHEPHERD_SCHEMA: &str = "adl.csm.runtime_api.shepherd.v1";
+pub const CSM_RUNTIME_API_CURIOSITY_SCHEMA: &str = "adl.csm.runtime_api.curiosity.v1";
 pub const CSM_RUNTIME_API_API_GATEWAY_BRIDGE_SCHEMA: &str =
     "adl.csm.runtime_api.api_gateway_bridge.v1";
 
-pub const CSM_RUNTIME_API_ENDPOINTS: [&str; 8] = [
+pub const CSM_RUNTIME_API_ENDPOINTS: [&str; 9] = [
     "/status",
     "/health",
     "/ready",
@@ -19,6 +20,7 @@ pub const CSM_RUNTIME_API_ENDPOINTS: [&str; 8] = [
     "/events",
     "/chronosense",
     "/shepherd",
+    "/curiosity",
     "/api-gateway-bridge",
 ];
 
@@ -31,6 +33,7 @@ mod tests {
         assert!(CSM_RUNTIME_API_ENDPOINTS.contains(&"/status"));
         assert!(CSM_RUNTIME_API_ENDPOINTS.contains(&"/chronosense"));
         assert!(CSM_RUNTIME_API_ENDPOINTS.contains(&"/shepherd"));
+        assert!(CSM_RUNTIME_API_ENDPOINTS.contains(&"/curiosity"));
         assert!(CSM_RUNTIME_API_ENDPOINTS.contains(&"/api-gateway-bridge"));
         assert_eq!(
             CSM_RUNTIME_API_STATUS_SCHEMA,

--- a/adl-runtime/src/supervision.rs
+++ b/adl-runtime/src/supervision.rs
@@ -41,6 +41,12 @@ pub fn default_component_supervision() -> Vec<ComponentSupervisionPolicy> {
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
+            component: "curiosity_engine",
+            restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            critical_for_continuity: false,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
             component: "checkpoint",
             restart_policy: ComponentRestartPolicy::EscalateToGovernedShutdown,
             critical_for_continuity: true,

--- a/adl-runtime/src/topology.rs
+++ b/adl-runtime/src/topology.rs
@@ -39,6 +39,11 @@ pub fn runtime_components() -> Vec<RuntimeComponent> {
             role: "reasoning graphs, loops, and adaptive DAG execution",
         },
         RuntimeComponent {
+            id: "curiosity_engine",
+            plane: "cognition",
+            role: "governed discovery and bounded hypothesis proposal routing",
+        },
+        RuntimeComponent {
             id: "resident_agents",
             plane: "cognition",
             role: "provider-backed resident agents admitted through CSM lifecycle",
@@ -120,6 +125,13 @@ pub fn runtime_stack_json() -> Value {
             "provider_entrypoint": "provider_substrate",
             "lifecycle": "same_csm_supervision_checkpoint_lifelog_observability_path_for_privileged_and_ordinary_agents",
             "shepherd_model": "privileged_resident_agent_not_bespoke_model_path"
+        },
+        "curiosity_engine": {
+            "schema": crate::curiosity::CSM_CURIOSITY_STATUS_SCHEMA,
+            "component": crate::curiosity::CSM_CURIOSITY_COMPONENT,
+            "process_model": "embedded_csm_runtime_component",
+            "retained_status_ref": crate::curiosity::CSM_CURIOSITY_STATUS_REF,
+            "governance": "freedom_gate_cav_constructability_fail_closed"
         }
     })
 }
@@ -138,6 +150,7 @@ mod tests {
         assert!(ids.contains(&"chronosense"));
         assert!(ids.contains(&"scheduler"));
         assert!(ids.contains(&"reasoning_runtime"));
+        assert!(ids.contains(&"curiosity_engine"));
         assert!(ids.contains(&"resident_agents"));
         assert!(ids.contains(&"observability"));
         assert!(ids.contains(&"cloud_bridge"));

--- a/adl/src/csm_api_gateway_bridge.rs
+++ b/adl/src/csm_api_gateway_bridge.rs
@@ -985,7 +985,7 @@ mod tests {
         let routes = if missing_routes {
             r#"{"Items":[{"RouteKey":"GET /status"}]}"#
         } else {
-            r#"{"Items":[{"RouteKey":"GET /status","Target":"integrations/int-1234567890"},{"RouteKey":"GET /health","Target":"integrations/int-1234567890"},{"RouteKey":"GET /ready","Target":"integrations/int-1234567890"},{"RouteKey":"GET /metrics","Target":"integrations/int-1234567890"},{"RouteKey":"GET /events","Target":"integrations/int-1234567890"},{"RouteKey":"GET /chronosense","Target":"integrations/int-1234567890"},{"RouteKey":"GET /shepherd","Target":"integrations/int-1234567890"},{"RouteKey":"GET /api-gateway-bridge","Target":"integrations/int-1234567890"}]}"#
+            r#"{"Items":[{"RouteKey":"GET /status","Target":"integrations/int-1234567890"},{"RouteKey":"GET /health","Target":"integrations/int-1234567890"},{"RouteKey":"GET /ready","Target":"integrations/int-1234567890"},{"RouteKey":"GET /metrics","Target":"integrations/int-1234567890"},{"RouteKey":"GET /events","Target":"integrations/int-1234567890"},{"RouteKey":"GET /chronosense","Target":"integrations/int-1234567890"},{"RouteKey":"GET /shepherd","Target":"integrations/int-1234567890"},{"RouteKey":"GET /curiosity","Target":"integrations/int-1234567890"},{"RouteKey":"GET /api-gateway-bridge","Target":"integrations/int-1234567890"}]}"#
         };
         fs::write(
             &path,

--- a/adl/src/csm_curiosity_engine.rs
+++ b/adl/src/csm_curiosity_engine.rs
@@ -1,0 +1,433 @@
+//! Curiosity Engine embedded CSM component surfaces.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::Path;
+
+use adl_runtime::curiosity::{
+    CsmCuriosityChannels, CsmCuriosityComponentStatus, CsmCuriosityConstraintHooks,
+    CsmCuriosityProposal, CsmCuriosityProposalStatus, CsmCuriosityReadiness,
+    CSM_CURIOSITY_COMPONENT, CSM_CURIOSITY_PROPOSAL_SCHEMA, CSM_CURIOSITY_STATUS_REF,
+    CSM_CURIOSITY_STATUS_SCHEMA,
+};
+
+use crate::runtime_v2::{
+    runtime_v2_curiosity_engine_contract, RuntimeV2CuriosityEnginePacket,
+    RuntimeV2CuriosityProposal, RuntimeV2CuriosityProposalStatus,
+    RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA,
+};
+
+pub const CSM_CURIOSITY_DECISION_SCHEMA: &str = "adl.csm.curiosity_engine.decision.v1";
+pub const CSM_CURIOSITY_OBSERVATION_SCHEMA: &str = "adl.csm.curiosity_engine.observation.v1";
+pub const CSM_CURIOSITY_HOSTED_CORE_REF: &str = "adl/src/runtime_v2/curiosity_engine.rs";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityObservation {
+    pub schema: String,
+    pub observation_id: String,
+    pub observation_kind: String,
+    pub summary: String,
+    pub novelty_score: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CsmCuriosityGovernanceDecision {
+    pub schema: String,
+    pub freedom_gate: String,
+    pub cav: String,
+    pub constructability: String,
+}
+
+pub fn runtime_capability() -> Value {
+    json!({
+        "status": "integrated",
+        "component": CSM_CURIOSITY_COMPONENT,
+        "component_class": "embedded_csm_runtime_component",
+        "process_model": "in_process_no_sidecar_no_separate_binary",
+        "hosted_core": {
+            "schema": RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA,
+            "module_ref": CSM_CURIOSITY_HOSTED_CORE_REF,
+            "source_wp": "WP-10",
+            "source_issue": "4692"
+        },
+        "proposal_schema": CSM_CURIOSITY_PROPOSAL_SCHEMA,
+        "decision_schema": CSM_CURIOSITY_DECISION_SCHEMA,
+        "observation_schema": CSM_CURIOSITY_OBSERVATION_SCHEMA,
+        "channels": CsmCuriosityChannels::new(CSM_CURIOSITY_COMPONENT),
+        "constraint_hooks": CsmCuriosityConstraintHooks::required(),
+        "retained_status_ref": CSM_CURIOSITY_STATUS_REF,
+        "governance": {
+            "freedom_gate_required": true,
+            "cav_required": true,
+            "constructability_required": true,
+            "missing_constraint_policy": "fail_closed",
+            "proposal_authority": "reviewable_proposal_only"
+        },
+        "non_claims": [
+            "does_not_execute_external_actions",
+            "does_not_bypass_sibling_governance",
+            "does_not_claim_autonomous_learning_success_without_retained_evidence"
+        ]
+    })
+}
+
+pub fn evaluate_observation(
+    observation: &CsmCuriosityObservation,
+    governance: &CsmCuriosityGovernanceDecision,
+) -> CsmCuriosityProposal {
+    let all_allowed = governance.freedom_gate == "allow"
+        && governance.cav == "allow"
+        && governance.constructability == "allow";
+    let status = if all_allowed {
+        CsmCuriosityProposalStatus::ReadyForReview
+    } else {
+        CsmCuriosityProposalStatus::RejectedByGovernance
+    };
+    CsmCuriosityProposal {
+        schema: CSM_CURIOSITY_PROPOSAL_SCHEMA.to_string(),
+        proposal_id: format!("proposal-{}", observation.observation_id),
+        source_signal_id: observation.observation_id.clone(),
+        question: format!(
+            "What bounded investigation follows from {}?",
+            observation.summary
+        ),
+        hypothesis: "A governed inquiry can reduce runtime uncertainty without bypassing policy."
+            .to_string(),
+        experiment_plan: vec!["retain a reviewable curiosity proposal".to_string()],
+        expected_artifacts: vec![
+            "curiosity_proposal.json".to_string(),
+            "operator_events.jsonl".to_string(),
+        ],
+        gated_by: vec![
+            "freedom_gate".to_string(),
+            "cav".to_string(),
+            "constructability_anchor".to_string(),
+        ],
+        status,
+    }
+}
+
+fn hosted_core_status(
+    upstream_constraints_available: bool,
+) -> Result<(Value, Vec<CsmCuriosityProposal>)> {
+    let packet = runtime_v2_curiosity_engine_contract()?;
+    let proposals = packet
+        .proposals
+        .iter()
+        .map(|proposal| hosted_core_proposal(proposal, upstream_constraints_available))
+        .collect();
+    Ok((serde_json::to_value(packet)?, proposals))
+}
+
+fn hosted_core_proposal(
+    proposal: &RuntimeV2CuriosityProposal,
+    upstream_constraints_available: bool,
+) -> CsmCuriosityProposal {
+    let status = if upstream_constraints_available {
+        match proposal.status {
+            RuntimeV2CuriosityProposalStatus::ReadyForReview => {
+                CsmCuriosityProposalStatus::ReadyForReview
+            }
+            RuntimeV2CuriosityProposalStatus::BlockedByBudget => {
+                CsmCuriosityProposalStatus::Deferred
+            }
+            RuntimeV2CuriosityProposalStatus::BlockedByGovernance => {
+                CsmCuriosityProposalStatus::RejectedByGovernance
+            }
+            RuntimeV2CuriosityProposalStatus::Proposed => CsmCuriosityProposalStatus::Proposed,
+        }
+    } else {
+        CsmCuriosityProposalStatus::RejectedByGovernance
+    };
+    let mut gated_by = proposal
+        .gated_by
+        .iter()
+        .map(|gate| {
+            if gate == "cav_review" {
+                "cav".to_string()
+            } else {
+                gate.clone()
+            }
+        })
+        .collect::<Vec<_>>();
+    if !gated_by.iter().any(|gate| gate == "cav") {
+        gated_by.push("cav".to_string());
+    }
+    CsmCuriosityProposal {
+        schema: CSM_CURIOSITY_PROPOSAL_SCHEMA.to_string(),
+        proposal_id: proposal.proposal_id.clone(),
+        source_signal_id: proposal.source_signal_id.clone(),
+        question: proposal.question.clone(),
+        hypothesis: proposal.hypothesis.clone(),
+        experiment_plan: proposal.experiment_plan.clone(),
+        expected_artifacts: proposal.expected_artifacts.clone(),
+        gated_by,
+        status,
+    }
+}
+
+pub fn build_status_snapshot(
+    agent_instance_id: &str,
+    daemon_state: &str,
+    agent_state: Option<&str>,
+    upstream_constraints_available: bool,
+) -> Value {
+    let readiness = if upstream_constraints_available {
+        CsmCuriosityReadiness::Ready
+    } else {
+        CsmCuriosityReadiness::Blocked
+    };
+    let status = if upstream_constraints_available {
+        "idle"
+    } else {
+        "blocked"
+    };
+    let (hosted_core, proposals) = hosted_core_status(upstream_constraints_available)
+        .unwrap_or_else(|err| {
+            (
+                json!({"status": "unavailable", "error": err.to_string()}),
+                vec![],
+            )
+        });
+    let component = CsmCuriosityComponentStatus {
+        schema: CSM_CURIOSITY_STATUS_SCHEMA.to_string(),
+        runtime_owner: "csm".to_string(),
+        component: CSM_CURIOSITY_COMPONENT.to_string(),
+        hosted_core_schema: RUNTIME_V2_CURIOSITY_ENGINE_SCHEMA.to_string(),
+        hosted_core_ref: CSM_CURIOSITY_HOSTED_CORE_REF.to_string(),
+        status: status.to_string(),
+        readiness,
+        process_model: "embedded_csm_runtime_component".to_string(),
+        channels: CsmCuriosityChannels::new(CSM_CURIOSITY_COMPONENT),
+        constraint_hooks: CsmCuriosityConstraintHooks::required(),
+        proposals,
+        retained_status_ref: CSM_CURIOSITY_STATUS_REF.to_string(),
+    };
+    let validation = component
+        .validate()
+        .map(|_| json!({"status": "passed"}))
+        .unwrap_or_else(|err| json!({"status": "fail_closed", "reason": err}));
+    json!({
+        "schema": CSM_CURIOSITY_STATUS_SCHEMA,
+        "runtime_owner": "csm",
+        "component": CSM_CURIOSITY_COMPONENT,
+        "agent_instance_id": agent_instance_id,
+        "hosted_core_schema": component.hosted_core_schema,
+        "hosted_core_ref": component.hosted_core_ref,
+        "hosted_core": hosted_core,
+        "status": component.status,
+        "readiness": component.readiness,
+        "process_model": component.process_model,
+        "channels": component.channels,
+        "constraint_hooks": component.constraint_hooks,
+        "proposals": component.proposals,
+        "observed_inputs": {
+            "daemon_state": daemon_state,
+            "agent_state": agent_state.unwrap_or("unknown"),
+            "upstream_constraints_available": upstream_constraints_available
+        },
+        "validation": validation,
+        "retention": {
+            "status_ref": CSM_CURIOSITY_STATUS_REF,
+            "lifelog_required": true,
+            "observability_required": true
+        },
+        "retained_status_ref": CSM_CURIOSITY_STATUS_REF,
+        "updated_at": Utc::now()
+    })
+}
+
+pub fn write_status_snapshot(
+    state_root: &Path,
+    agent_instance_id: &str,
+    daemon_state: &str,
+    agent_state: Option<&str>,
+    upstream_constraints_available: bool,
+) -> Result<Value> {
+    fs::create_dir_all(state_root)
+        .with_context(|| format!("create CSM Curiosity state root {}", state_root.display()))?;
+    let snapshot = build_status_snapshot(
+        agent_instance_id,
+        daemon_state,
+        agent_state,
+        upstream_constraints_available,
+    );
+    let path = state_root.join(CSM_CURIOSITY_STATUS_REF);
+    fs::write(&path, serde_json::to_vec_pretty(&snapshot)?)
+        .with_context(|| format!("write CSM Curiosity status {}", path.display()))?;
+    Ok(snapshot)
+}
+
+pub fn api_status(
+    agent_instance_id: &str,
+    artifact: &Value,
+    runtime_capability: Value,
+    daemon_state: &str,
+    agent_state: &str,
+) -> Value {
+    if artifact.get("status").and_then(Value::as_str) != Some("serialized") {
+        let mut fallback =
+            build_status_snapshot(agent_instance_id, daemon_state, Some(agent_state), false);
+        if let Some(map) = fallback.as_object_mut() {
+            map.insert("status".to_string(), json!("unavailable"));
+            map.insert("readiness".to_string(), json!("blocked"));
+            map.insert(
+                "validation".to_string(),
+                json!({
+                    "status": "fail_closed",
+                    "reason": "retained_curiosity_status_missing_or_unreadable"
+                }),
+            );
+        }
+        let validation = json!({
+            "status": "fail_closed",
+            "reason": "retained_curiosity_status_missing_or_unreadable"
+        });
+        return json!({
+            "status": artifact.get("status").cloned().unwrap_or_else(|| json!("missing")),
+            "ref": CSM_CURIOSITY_STATUS_REF,
+            "schema": CSM_CURIOSITY_STATUS_SCHEMA,
+            "runtime_owner": "csm",
+            "component": CSM_CURIOSITY_COMPONENT,
+            "capability": runtime_capability,
+            "value": fallback,
+            "validation": validation
+        });
+    }
+
+    let value = artifact.get("value").cloned().unwrap_or_else(|| {
+        build_status_snapshot(agent_instance_id, daemon_state, Some(agent_state), false)
+    });
+    let validation = validate_retained_status_for_agent(&value, agent_instance_id)
+        .map(|_| json!({"status": "passed"}))
+        .unwrap_or_else(|err| json!({"status": "fail_closed", "reason": err.to_string()}));
+    json!({
+        "status": artifact.get("status").cloned().unwrap_or_else(|| json!("missing")),
+        "ref": CSM_CURIOSITY_STATUS_REF,
+        "schema": value.get("schema").cloned().unwrap_or_else(|| json!(CSM_CURIOSITY_STATUS_SCHEMA)),
+        "runtime_owner": "csm",
+        "component": CSM_CURIOSITY_COMPONENT,
+        "capability": runtime_capability,
+        "value": value,
+        "validation": validation
+    })
+}
+
+pub fn validate_retained_status(value: &Value) -> Result<()> {
+    validate_retained_status_core(value)
+}
+
+pub fn validate_retained_status_for_agent(value: &Value, agent_instance_id: &str) -> Result<()> {
+    validate_retained_status_core(value)?;
+    let retained_agent = value
+        .get("agent_instance_id")
+        .and_then(Value::as_str)
+        .context("retained CSM Curiosity status missing agent_instance_id")?;
+    if retained_agent != agent_instance_id {
+        anyhow::bail!("retained CSM Curiosity status belongs to a different agent_instance_id");
+    }
+    Ok(())
+}
+
+fn validate_retained_status_core(value: &Value) -> Result<()> {
+    let status: CsmCuriosityComponentStatus =
+        serde_json::from_value(value.clone()).context("parse retained CSM Curiosity status")?;
+    status.validate().map_err(anyhow::Error::msg)?;
+    let hosted_core = value
+        .get("hosted_core")
+        .cloned()
+        .context("retained CSM Curiosity status missing hosted_core")?;
+    let hosted_packet: RuntimeV2CuriosityEnginePacket = serde_json::from_value(hosted_core)
+        .context("parse retained CSM Curiosity hosted_core packet")?;
+    hosted_packet
+        .validate()
+        .context("validate retained CSM Curiosity hosted_core packet")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn curiosity_rejects_proposals_when_governance_is_unavailable() {
+        let observation = CsmCuriosityObservation {
+            schema: CSM_CURIOSITY_OBSERVATION_SCHEMA.to_string(),
+            observation_id: "runtime-gap".to_string(),
+            observation_kind: "runtime_state".to_string(),
+            summary: "missing runtime evidence".to_string(),
+            novelty_score: 1,
+        };
+        let decision = CsmCuriosityGovernanceDecision {
+            schema: CSM_CURIOSITY_DECISION_SCHEMA.to_string(),
+            freedom_gate: "allow".to_string(),
+            cav: "deny".to_string(),
+            constructability: "allow".to_string(),
+        };
+        let proposal = evaluate_observation(&observation, &decision);
+        assert_eq!(
+            proposal.status,
+            CsmCuriosityProposalStatus::RejectedByGovernance
+        );
+        proposal.validate().expect("governed rejection is typed");
+    }
+
+    #[test]
+    fn missing_curiosity_artifact_fails_closed_for_api_status() {
+        let status = api_status(
+            "polis-alpha",
+            &json!({"status": "missing"}),
+            runtime_capability(),
+            "running",
+            "running",
+        );
+        assert_eq!(status["value"]["status"], "unavailable");
+        assert_eq!(status["value"]["readiness"], "blocked");
+        assert_eq!(status["value"]["validation"]["status"], "fail_closed");
+    }
+
+    #[test]
+    fn curiosity_snapshot_blocks_when_constraints_are_not_proven_available() {
+        let status = build_status_snapshot("polis-alpha", "running", Some("running"), false);
+        assert_eq!(status["status"], "blocked");
+        assert_eq!(status["readiness"], "blocked");
+        assert_eq!(
+            status["observed_inputs"]["upstream_constraints_available"],
+            false
+        );
+        assert_eq!(status["proposals"][0]["status"], "rejected_by_governance");
+    }
+
+    #[test]
+    fn retained_curiosity_status_must_belong_to_current_agent() {
+        let status = build_status_snapshot("polis-alpha", "running", Some("running"), true);
+        validate_retained_status_for_agent(&status, "polis-alpha")
+            .expect("matching agent status validates");
+        let err = validate_retained_status_for_agent(&status, "polis-beta")
+            .expect_err("cross-agent retained status must fail closed");
+        assert!(err.to_string().contains("different agent_instance_id"));
+    }
+
+    #[test]
+    fn retained_curiosity_status_must_validate_hosted_core_packet() {
+        let mut status = build_status_snapshot("polis-alpha", "running", Some("running"), true);
+        status
+            .as_object_mut()
+            .expect("snapshot is an object")
+            .remove("hosted_core");
+        let err = validate_retained_status_for_agent(&status, "polis-alpha")
+            .expect_err("missing hosted core must fail closed");
+        assert!(err.to_string().contains("missing hosted_core"));
+
+        let mut drifted = build_status_snapshot("polis-alpha", "running", Some("running"), true);
+        drifted["hosted_core"]["schema_version"] = json!("runtime_v2.curiosity_engine.drifted");
+        let err = validate_retained_status_for_agent(&drifted, "polis-alpha")
+            .expect_err("drifted hosted core must fail closed");
+        assert!(
+            err.to_string().contains("hosted_core packet"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Notify;
 use tower::ServiceBuilder;
 
+use crate::csm_curiosity_engine;
 use crate::csm_networking::{
     csm_connection_pooling_plan, csm_listener_registry_json, csm_runtime_connection_pool_status,
     resolve_main_runtime_api_listener, CSM_POOLING_PLAN_SCHEMA,
@@ -34,9 +35,9 @@ use crate::long_lived_agent::{load_spec, AgentStatusState, LoadedAgentSpec, Stat
 
 pub use adl_runtime::runtime_api::{
     CSM_RUNTIME_API_API_GATEWAY_BRIDGE_SCHEMA, CSM_RUNTIME_API_CHRONOSENSE_SCHEMA,
-    CSM_RUNTIME_API_ENDPOINTS, CSM_RUNTIME_API_EVENTS_SCHEMA, CSM_RUNTIME_API_HEALTH_SCHEMA,
-    CSM_RUNTIME_API_METRICS_SCHEMA, CSM_RUNTIME_API_READY_SCHEMA, CSM_RUNTIME_API_SCHEMA,
-    CSM_RUNTIME_API_SHEPHERD_SCHEMA, CSM_RUNTIME_API_STATUS_SCHEMA,
+    CSM_RUNTIME_API_CURIOSITY_SCHEMA, CSM_RUNTIME_API_ENDPOINTS, CSM_RUNTIME_API_EVENTS_SCHEMA,
+    CSM_RUNTIME_API_HEALTH_SCHEMA, CSM_RUNTIME_API_METRICS_SCHEMA, CSM_RUNTIME_API_READY_SCHEMA,
+    CSM_RUNTIME_API_SCHEMA, CSM_RUNTIME_API_SHEPHERD_SCHEMA, CSM_RUNTIME_API_STATUS_SCHEMA,
 };
 pub use api_gateway_bridge::{prove_api_gateway_bridge, ApiGatewayBridgeOptions};
 const CSM_RUNTIME_API_BROWSER_DEMO_PORT: &str = "8765";
@@ -238,6 +239,7 @@ pub fn runtime_api_response(options: &CsmRuntimeApiOptions, path: &str) -> Resul
         "/events" => events_response(&loaded),
         "/chronosense" => chronosense_response(&loaded, options),
         "/shepherd" => shepherd_response(&loaded, options),
+        "/curiosity" => curiosity_response(&loaded, options),
         "/api-gateway-bridge" => api_gateway_bridge_response(&loaded),
         other => Ok(json!({
             "schema": CSM_RUNTIME_API_SCHEMA,
@@ -300,8 +302,10 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
         &backpressure_state,
         &runtime_capabilities,
     );
+    let curiosity =
+        curiosity_api_status(loaded, &agent_status, &daemon_status, &runtime_capabilities);
     let resident_agents = resident_agents_status(loaded);
-    let response = json!({
+    let mut response = json!({
         "schema": CSM_RUNTIME_API_STATUS_SCHEMA,
         "runtime_owner": "csm",
         "adl_role": "tooling_control_plane",
@@ -329,6 +333,7 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
         "resilience_middleware": runtime_capabilities.get("resilience_middleware").cloned().unwrap_or_else(|| json!({"status": "missing"})),
         "resident_agents": resident_agents,
         "polis_shepherd_agent": shepherd,
+        "curiosity_engine": curiosity,
         "checkpoint": checkpoint_freshness,
         "continuity": {
             "checkpoint": compact_artifact_status(&continuity_checkpoint, "continuity_checkpoint.json"),
@@ -347,6 +352,22 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
             "secret_material": "not_returned",
             "cloud_account_identifiers": "not_returned"
         }
+    });
+    if !readiness_blockers(&response).is_empty() {
+        response["ready"] = json!("not_ready");
+    }
+    assert_api_response_redacted(&response)?;
+    Ok(response)
+}
+
+fn curiosity_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
+    let status = status_response(loaded, options)?;
+    let response = json!({
+        "schema": CSM_RUNTIME_API_CURIOSITY_SCHEMA,
+        "runtime_owner": "csm",
+        "agent_instance_id": loaded.spec.agent_instance_id,
+        "runtime_api_path": "/curiosity",
+        "component": status["curiosity_engine"]
     });
     assert_api_response_redacted(&response)?;
     Ok(response)
@@ -457,12 +478,18 @@ fn health_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
 
 fn ready_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> Result<Value> {
     let status = status_response(loaded, options)?;
+    let blocking_reasons = readiness_blockers(&status);
+    let ready = if blocking_reasons.is_empty() {
+        status["ready"].clone()
+    } else {
+        json!("not_ready")
+    };
     let response = json!({
         "schema": CSM_RUNTIME_API_READY_SCHEMA,
         "runtime_owner": "csm",
         "agent_instance_id": loaded.spec.agent_instance_id,
-        "ready": status["ready"],
-        "blocking_reasons": readiness_blockers(&status)
+        "ready": ready,
+        "blocking_reasons": blocking_reasons
     });
     assert_api_response_redacted(&response)?;
     Ok(response)
@@ -519,6 +546,37 @@ fn events_response(loaded: &LoadedAgentSpec) -> Result<Value> {
     });
     assert_api_response_redacted(&response)?;
     Ok(response)
+}
+
+fn curiosity_api_status(
+    loaded: &LoadedAgentSpec,
+    agent_status: &StatusRecord,
+    daemon_status: &Value,
+    runtime_capabilities: &Value,
+) -> Value {
+    let artifact = read_json_artifact(&artifact_path(
+        loaded,
+        adl_runtime::curiosity::CSM_CURIOSITY_STATUS_REF,
+    ));
+    let runtime_capability = runtime_capabilities
+        .get("curiosity_engine")
+        .cloned()
+        .unwrap_or_else(csm_curiosity_engine::runtime_capability);
+    let agent_state = serde_json::to_value(&agent_status.state)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+    let daemon_state = daemon_status
+        .pointer("/value/state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    csm_curiosity_engine::api_status(
+        &loaded.spec.agent_instance_id,
+        &artifact,
+        runtime_capability,
+        daemon_state,
+        &agent_state,
+    )
 }
 
 fn api_gateway_bridge_runtime_status(loaded: &LoadedAgentSpec) -> Value {
@@ -1050,6 +1108,20 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
         == Some("low_disk")
     {
         blockers.push("storage_low_disk".to_string());
+    }
+    if status
+        .pointer("/curiosity_engine/value/readiness")
+        .and_then(Value::as_str)
+        != Some("ready")
+    {
+        blockers.push("curiosity_engine_not_ready".to_string());
+    }
+    if status
+        .pointer("/curiosity_engine/validation/status")
+        .and_then(Value::as_str)
+        != Some("passed")
+    {
+        blockers.push("curiosity_engine_validation_failed".to_string());
     }
     blockers
 }
@@ -1644,6 +1716,102 @@ memory: {}
     }
 
     #[test]
+    fn runtime_api_surfaces_curiosity_engine_component_and_route() {
+        let root = temp_root("curiosity");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        fs::create_dir_all(&state).unwrap();
+        let curiosity = csm_curiosity_engine::build_status_snapshot(
+            "api-agent",
+            "running",
+            Some("running"),
+            true,
+        );
+        fs::write(
+            state.join(adl_runtime::curiosity::CSM_CURIOSITY_STATUS_REF),
+            serde_json::to_string_pretty(&curiosity).unwrap(),
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            shutdown_file: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let status = runtime_api_response(&options, "/status").unwrap();
+        assert_eq!(status["curiosity_engine"]["value"]["readiness"], "ready");
+        assert_eq!(
+            status["curiosity_engine"]["value"]["process_model"],
+            "embedded_csm_runtime_component"
+        );
+        assert_eq!(
+            status["curiosity_engine"]["value"]["constraint_hooks"]["missing_constraint_policy"],
+            "fail_closed"
+        );
+
+        let curiosity = runtime_api_response(&options, "/curiosity").unwrap();
+        assert_eq!(curiosity["schema"], CSM_RUNTIME_API_CURIOSITY_SCHEMA);
+        assert_eq!(curiosity["component"]["component"], "curiosity_engine");
+    }
+
+    #[test]
+    fn runtime_api_ready_blocks_missing_curiosity_status() {
+        let root = temp_root("curiosity-missing");
+        let spec = write_spec(&root);
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            shutdown_file: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let ready = runtime_api_response(&options, "/ready").unwrap();
+        assert!(ready["blocking_reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("curiosity_engine_not_ready")));
+    }
+
+    #[test]
+    fn runtime_api_ready_blocks_invalid_curiosity_status_even_when_ready_claimed() {
+        let root = temp_root("curiosity-invalid-ready");
+        let spec = write_spec(&root);
+        let state = root.join("state");
+        fs::create_dir_all(&state).unwrap();
+        let mut curiosity = csm_curiosity_engine::build_status_snapshot(
+            "api-agent",
+            "running",
+            Some("running"),
+            true,
+        );
+        curiosity["constraint_hooks"]["cav_required"] = json!(false);
+        fs::write(
+            state.join(adl_runtime::curiosity::CSM_CURIOSITY_STATUS_REF),
+            serde_json::to_string_pretty(&curiosity).unwrap(),
+        )
+        .unwrap();
+        let options = CsmRuntimeApiOptions {
+            spec_path: spec,
+            bind: test_api_bind(SEQ.load(Ordering::SeqCst)),
+            test_max_requests: Some(1),
+            idle_timeout_ms: None,
+            shutdown_file: None,
+            otel_status_path: None,
+            otel_log_path: None,
+        };
+        let ready = runtime_api_response(&options, "/ready").unwrap();
+        assert!(ready["blocking_reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("curiosity_engine_validation_failed")));
+    }
+
+    #[test]
     fn runtime_api_redacts_secret_and_host_path_event_payloads() {
         let root = temp_root("redaction");
         let spec = write_spec(&root);
@@ -1700,20 +1868,20 @@ memory: {}
         fs::write(
             state.join("daemon_status.json"),
             serde_json::to_string_pretty(&json!({
-                "schema": "adl.csm.daemon_status.v1",
-                "state": "running",
-                "last_event": "daemon_started",
-                "updated_at": Utc::now(),
-                "last_checkpoint_at": Utc::now(),
-                "runtime_capabilities": {
+            "schema": "adl.csm.daemon_status.v1",
+            "state": "running",
+            "last_event": "daemon_started",
+            "updated_at": Utc::now(),
+            "last_checkpoint_at": Utc::now(),
+            "runtime_capabilities": {
                     "chronosense": {
                         "status": "integrated",
                         "time_sync": {
                             "schema_version": "chronosense_time_sync_status.v1",
                             "substrate": "SNTP",
-                            "health": "unavailable",
-                            "failure_state": "runtime_sntp_probe_disabled",
-                            "reason": "runtime_sntp_status_unavailable_without_csm_failure"
+                                "health": "synced",
+                            "failure_state": null,
+                            "reason": null
                         }
                     }
                 }
@@ -1727,6 +1895,17 @@ memory: {}
                 "schema": "adl.csm.continuity_checkpoint.v1"
             }))
             .unwrap(),
+        )
+        .unwrap();
+        let curiosity = csm_curiosity_engine::build_status_snapshot(
+            "api-agent",
+            "running",
+            Some("running"),
+            true,
+        );
+        fs::write(
+            state.join(adl_runtime::curiosity::CSM_CURIOSITY_STATUS_REF),
+            serde_json::to_string_pretty(&curiosity).unwrap(),
         )
         .unwrap();
         let options = CsmRuntimeApiOptions {
@@ -2178,6 +2357,13 @@ memory: {}
                 "schema": "adl.long_lived_agent_continuity_checkpoint.v1"
             }))
             .unwrap(),
+        )
+        .unwrap();
+        let curiosity =
+            csm_curiosity_engine::build_status_snapshot("api-agent", "running", Some("idle"), true);
+        fs::write(
+            state.join(adl_runtime::curiosity::CSM_CURIOSITY_STATUS_REF),
+            serde_json::to_string_pretty(&curiosity).unwrap(),
         )
         .unwrap();
         let options = CsmRuntimeApiOptions {

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -33,6 +33,7 @@ pub mod csm_cav_red_blue;
 pub mod csm_cloud_control;
 pub mod csm_continuity_capsule;
 pub mod csm_credential_policy;
+pub mod csm_curiosity_engine;
 pub mod csm_godel_snapshot;
 pub mod csm_networking;
 pub mod csm_observatory;

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -14,6 +14,7 @@ use crate::chronosense::{
     capture_runtime_time_sync_status, start_runtime_time_observation, ChronosenseRuntimeService,
     ChronosenseRuntimeServiceConfig,
 };
+use crate::csm_curiosity_engine;
 use crate::csm_godel_snapshot::{validate_recovery_read, write_checkpoint_snapshot_diff};
 use crate::csm_resident_agents;
 use crate::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
@@ -2837,6 +2838,26 @@ fn write_daemon_status(
             }),
         );
     }
+    if let Err(err) = csm_curiosity_engine::write_status_snapshot(
+        &loaded.state_root,
+        &loaded.spec.agent_instance_id,
+        effective_state,
+        agent_state.as_deref(),
+        false,
+    ) {
+        let _ = append_operator_event(
+            loaded,
+            "csm_curiosity_engine_status_write_failed",
+            json!({
+                "schema": "adl.csm.curiosity_engine.write_failure.v1",
+                "runtime_owner": "csm",
+                "component": "curiosity_engine",
+                "status": "degraded_nonfatal",
+                "reason": err.to_string(),
+                "recovery_policy": "continue_runtime_and_surface_missing_or_fail_closed_curiosity_status"
+            }),
+        );
+    }
     if let Err(err) = write_json_pretty(
         &loaded
             .state_root
@@ -3134,6 +3155,7 @@ fn csm_runtime_capabilities_with_resident_agents(
         },
         "resident_agents": resident_agents_status,
         "polis_shepherd_agent": csm_shepherd_agent::runtime_capability(),
+        "curiosity_engine": csm_curiosity_engine::runtime_capability(),
         "observability": {
             "status": "integrated",
             "event_command": "csm",

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -1061,7 +1061,7 @@ memory:
 
     let mut status = http_get_json(&addr, "/status");
     let status_wait_started = std::time::Instant::now();
-    while status["daemon_liveness"]["state"] != "running" || status["ready"] != "ready" {
+    while status["daemon_liveness"]["state"] != "running" {
         if status_wait_started.elapsed() > std::time::Duration::from_secs(5) {
             panic!(
                 "embedded CSM API did not report ready running daemon state:\n{}",
@@ -1105,7 +1105,7 @@ memory:
     assert_eq!(status["runtime_owner"], "csm");
     assert_eq!(status["agent_instance_id"], "api-agent");
     assert_eq!(status["status"], "healthy");
-    assert_eq!(status["ready"], "ready");
+    assert_eq!(status["ready"], "not_ready");
     assert_eq!(status["daemon_liveness"]["state"], "running");
     assert_eq!(
         status["daemon_liveness"]["supervisor_pid_liveness"],
@@ -1142,11 +1142,11 @@ memory:
     assert_eq!(health["schema"], "adl.csm.runtime_api.health.v1");
     assert_eq!(health["status"], "healthy");
     assert_eq!(ready["schema"], "adl.csm.runtime_api.ready.v1");
-    assert_eq!(ready["ready"], "ready");
+    assert_eq!(ready["ready"], "not_ready");
     assert!(ready["blocking_reasons"]
         .as_array()
         .expect("ready blockers")
-        .is_empty());
+        .contains(&serde_json::json!("curiosity_engine_not_ready")));
     assert_eq!(metrics["schema"], "adl.csm.runtime_api.metrics.v1");
     assert_eq!(metrics["gauges"]["backpressure_queue_depth"], 12);
     assert_eq!(metrics["gauges"]["backpressure_lag_ms"], 3100);

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -3170,9 +3170,12 @@ memory:
             .as_array()
             .expect("not-ready response includes blockers");
         assert!(
-            blockers.iter().all(|blocker| blocker
-                .as_str()
-                .is_some_and(|value| value.starts_with("chronosense_time_sync_"))),
+            blockers.iter().all(|blocker| {
+                blocker.as_str().is_some_and(|value| {
+                    value.starts_with("chronosense_time_sync_")
+                        || value == "curiosity_engine_not_ready"
+                })
+            }),
             "unexpected runtime API readiness blockers: {blockers:?}"
         );
     }

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -227,6 +227,7 @@ candidate_filter_for_path() {
       printf 'csmctl'
       ;;
     adl/src/csm_api_gateway_bridge.rs|\
+    adl/src/csm_curiosity_engine.rs|\
     adl/src/csm_godel_snapshot.rs|\
     adl/src/csm_runtime_api.rs|\
     adl/src/csm_shepherd_agent.rs|\

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -134,6 +134,7 @@ grep -F "test(run_v0916_runtime_failure_injection)" <<<"$long_lived_agent_storag
 csm_runtime_agent_changed="$TMP/csm-runtime-agent-changed.txt"
 cat >"$csm_runtime_agent_changed" <<'EOF'
 M	adl/src/csm_api_gateway_bridge.rs
+M	adl/src/csm_curiosity_engine.rs
 M	adl/src/csm_godel_snapshot.rs
 M	adl/src/csm_runtime_api.rs
 M	adl/src/csm_shepherd_agent.rs

--- a/adl/tools/test_run_v0917_csm_api_gateway_bridge_proof.sh
+++ b/adl/tools/test_run_v0917_csm_api_gateway_bridge_proof.sh
@@ -23,7 +23,7 @@ case "$1 $2" in
     printf '%s\n' '{"Items":[{"StageName":"prod","AutoDeploy":true}]}'
     ;;
   "apigatewayv2 get-routes")
-    printf '%s\n' '{"Items":[{"RouteKey":"GET /status","Target":"integrations/int-1234567890"},{"RouteKey":"GET /health","Target":"integrations/int-1234567890"},{"RouteKey":"GET /ready","Target":"integrations/int-1234567890"},{"RouteKey":"GET /metrics","Target":"integrations/int-1234567890"},{"RouteKey":"GET /events","Target":"integrations/int-1234567890"},{"RouteKey":"GET /chronosense","Target":"integrations/int-1234567890"},{"RouteKey":"GET /shepherd","Target":"integrations/int-1234567890"},{"RouteKey":"GET /api-gateway-bridge","Target":"integrations/int-1234567890"}]}'
+    printf '%s\n' '{"Items":[{"RouteKey":"GET /status","Target":"integrations/int-1234567890"},{"RouteKey":"GET /health","Target":"integrations/int-1234567890"},{"RouteKey":"GET /ready","Target":"integrations/int-1234567890"},{"RouteKey":"GET /metrics","Target":"integrations/int-1234567890"},{"RouteKey":"GET /events","Target":"integrations/int-1234567890"},{"RouteKey":"GET /chronosense","Target":"integrations/int-1234567890"},{"RouteKey":"GET /shepherd","Target":"integrations/int-1234567890"},{"RouteKey":"GET /curiosity","Target":"integrations/int-1234567890"},{"RouteKey":"GET /api-gateway-bridge","Target":"integrations/int-1234567890"}]}'
     ;;
   "apigatewayv2 get-integrations")
     printf '%s\n' '{"Items":[{"IntegrationId":"int-1234567890","IntegrationType":"HTTP_PROXY","IntegrationUri":"https://loopback-proxy.invalid/csm"}]}'


### PR DESCRIPTION
Closes #5124

## Summary
Implemented Curiosity Engine as an embedded CSM runtime component in the issue worktree, with the CSM component hosting the WP-10 `runtime_v2.curiosity_engine.v1` core instead of creating a parallel Curiosity substrate. The slice adds crate-backed CSM Curiosity status/proposal contracts, restores the WP-10 runtime_v2 Curiosity module and CLI proof hook, adds CSM daemon retained status emission, registers runtime topology/supervision/API surfaces, makes API readiness fail closed when retained Curiosity status is missing or invalid, and updates API Gateway bridge proof coverage for the new `/curiosity` route. No separate binary, sidecar, listener, or external autonomous Curiosity agent was introduced.

## Artifacts
- Local output-card truth surface at `.adl/v0.91.7/tasks/issue-5124__v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component/sor.md`
- Tracked implementation artifacts:
  - `adl-runtime/src/curiosity.rs`
  - `adl-runtime/src/lib.rs`
  - `adl-runtime/src/runtime_api.rs`
  - `adl-runtime/src/supervision.rs`
  - `adl-runtime/src/topology.rs`
  - `adl/src/cli/runtime_v2_cmd/commands.rs`
  - `adl/src/cli/runtime_v2_cmd/helpers.rs`
  - `adl/src/cli/runtime_v2_cmd/tests.rs`
  - `adl/src/cli/usage.rs`
  - `adl/src/csm_curiosity_engine.rs`
  - `adl/src/csm_api_gateway_bridge.rs`
  - `adl/src/csm_runtime_api.rs`
  - `adl/src/lib.rs`
  - `adl/src/long_lived_agent.rs`
  - `adl/src/runtime_v2/curiosity_engine.rs`
  - `adl/src/runtime_v2/mod.rs`
  - `adl/src/runtime_v2/tests.rs`
  - `adl/src/runtime_v2/tests/curiosity_engine.rs`
  - `adl/tools/test_run_v0917_csm_api_gateway_bridge_proof.sh`
- Additional proof artifacts: `none beyond command output; bridge proof uses temporary redacted fixture output and validates it during execution`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.7/tasks/issue-5124__v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component/sor.md`
    `Verified the updated SOR execution-truth record after implementation.`
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Formatted the adl crate after runtime API and daemon edits.`
  - `cargo test --manifest-path adl-runtime/Cargo.toml curiosity -- --nocapture`
    `Verified Curiosity contract validation and proposal governance requirements.`
  - `cargo test --manifest-path adl/Cargo.toml csm_curiosity_engine -- --nocapture`
    `Verified CSM Curiosity API status fail-closed behavior, hosted WP-10 core projection, retained agent binding, retained hosted-core validation, governance rejection behavior, and blocked daemon-safe default when upstream constraints are not proven available.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_curiosity_engine -- --nocapture`
    `Verified restored WP-10 runtime_v2 Curiosity core contract and tests still pass in this worktree.`
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_curiosity_engine -- --nocapture`
    `Verified restored runtime-v2 CLI proof hook writes packet JSON and validates stdout/help/output-path rules.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_surfaces_curiosity_engine_component_and_route -- --nocapture`
    `Verified /status and /curiosity surface the embedded Curiosity component.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_reports_ready_during_active_agent_cycle -- --nocapture`
    `Verified an active ready fixture remains ready when valid Curiosity retained status is present.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_ready_blocks_missing_curiosity_status -- --nocapture`
    `Verified /ready blocks when Curiosity retained status is missing.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_api_ready_blocks_invalid_curiosity_status_even_when_ready_claimed -- --nocapture`
    `Verified /ready blocks invalid retained Curiosity status even when that artifact claims readiness.`
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture`
    `Verified the embedded API remains live while /status and /ready consistently report Curiosity as a fail-closed readiness blocker until its required governance components are available.`
  - `cargo test --manifest-path adl-runtime/Cargo.toml topology -- --nocapture`
    `Verified topology includes the Curiosity runtime component.`
  - `cargo test --manifest-path adl-runtime/Cargo.toml supervision -- --nocapture`
    `Verified runtime supervision tests still pass after adding Curiosity policy.`
  - `cargo test --manifest-path adl/Cargo.toml api_gateway_bridge_writes_redacted_summary_with_fake_aws_and_http -- --nocapture`
    `Verified API Gateway bridge unit proof with the updated route set.`
  - `bash adl/tools/test_run_v0917_csm_api_gateway_bridge_proof.sh`
    `Verified the bridge proof accepts the updated per-polis route set including GET /curiosity.`
- Results:
  - `PASS for focused runtime/API/bridge validation commands listed above and updated SOR structure validation`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5124__v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5124__v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component/sor.md
- Idempotency-Key: v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component-adl-tools-check-coverage-impact-sh-adl-tools-test-check-coverage-impact-sh-adl-v0-91-7-tasks-issue-5124-v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component-sip-md-adl-v0-91-7-tasks-issue-5124-v0-91-7-wp-07a-runtime-implement-curiosity-engine-as-csm-runtime-component-sor-md