### PR TITLE
[v0.91.7][WP-10][constructability] Implement constructability anchor validator

### DIFF
--- a/adl/src/cli/runtime_v2_cmd/commands.rs
+++ b/adl/src/cli/runtime_v2_cmd/commands.rs
@@ -5,13 +5,16 @@ use serde_json::{json, to_string_pretty};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::helpers::{resolve_relative_output_path, write_runtime_v2_governed_trace_demo};
+use super::helpers::{
+    resolve_relative_input_path, resolve_relative_output_path, write_runtime_v2_governed_trace_demo,
+};
 use crate::cli::usage;
 use ::adl::{
     long_lived_agent::{self, RunOptions},
     runtime_v2::{
         runtime_v2_aee_obsmem_pvf_trace_handoff_contract,
         runtime_v2_cognitive_being_flagship_demo_contract,
+        runtime_v2_constructability_anchor_validator_contract,
         runtime_v2_contract_market_demo_contract, runtime_v2_csm_integrated_run_contract,
         runtime_v2_curiosity_engine_contract, runtime_v2_feature_proof_coverage_contract,
         runtime_v2_foundation_demo_contract, runtime_v2_godel_agent_runtime_contract_for,
@@ -19,6 +22,7 @@ use ::adl::{
         runtime_v2_minimal_integrated_runtime_path_contract,
         runtime_v2_observatory_flagship_contract, runtime_v2_operator_control_report_contract,
         runtime_v2_reasoning_graph_contract, runtime_v2_security_boundary_proof_contract,
+        RuntimeV2ConstructabilityAnchorValidatorPacket,
     },
 };
 
@@ -672,6 +676,113 @@ pub(crate) fn real_runtime_v2_curiosity_engine(repo_root: &Path, args: &[String]
     Ok(())
 }
 
+pub(crate) fn real_runtime_v2_constructability_anchor_validator(
+    repo_root: &Path,
+    args: &[String],
+) -> Result<()> {
+    let mut input_path: Option<PathBuf> = None;
+    let mut out_path: Option<PathBuf> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--input" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 constructability-anchor-validator requires --input <packet.json>"
+                    ));
+                };
+                input_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 constructability-anchor-validator requires --out <path>"
+                    ));
+                };
+                out_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for runtime-v2 constructability-anchor-validator: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let resolved_out = out_path
+        .as_ref()
+        .map(|out_path| {
+            resolve_relative_output_path(repo_root, out_path, "constructability-anchor-validator")
+        })
+        .transpose()?;
+    let packet = if let Some(input_path) = input_path {
+        let resolved = resolve_relative_input_path(
+            repo_root,
+            &input_path,
+            "constructability-anchor-validator",
+        )?;
+        if resolved_out
+            .as_ref()
+            .is_some_and(|resolved_out| resolved_out == &resolved)
+        {
+            return Err(anyhow!(
+                "runtime-v2 constructability-anchor-validator --input and --out must be different paths"
+            ));
+        }
+        let bytes = fs::read(&resolved).with_context(|| {
+            format!(
+                "read Runtime v2 Constructability Anchor Validator input {}",
+                input_path.display()
+            )
+        })?;
+        if let Some(resolved_out) = &resolved_out {
+            match fs::remove_file(resolved_out) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "remove stale Runtime v2 Constructability Anchor Validator output {}",
+                            out_path
+                                .as_ref()
+                                .expect("resolved output has requested path")
+                                .display()
+                        )
+                    })
+                }
+            }
+        }
+        let packet: RuntimeV2ConstructabilityAnchorValidatorPacket = serde_json::from_slice(&bytes)
+            .with_context(|| {
+                format!(
+                    "parse Runtime v2 Constructability Anchor Validator input {}",
+                    input_path.display()
+                )
+            })?;
+        packet.canonicalized()?
+    } else {
+        runtime_v2_constructability_anchor_validator_contract()?
+    };
+    let Some(out_path) = out_path else {
+        println!("{}", to_string_pretty(&packet)?);
+        return Ok(());
+    };
+    let resolved = resolved_out.expect("output path was resolved above");
+    packet.write_to_path(&resolved)?;
+    println!(
+        "{}",
+        constructability_anchor_validator_stdout_line(&out_path)
+    );
+    Ok(())
+}
+
 pub(crate) fn real_runtime_v2_loop_runtime(repo_root: &Path, args: &[String]) -> Result<()> {
     let mut out_path: Option<PathBuf> = None;
     let mut i = 0usize;
@@ -883,6 +994,13 @@ pub(crate) fn reasoning_graph_stdout_line(out_path: &Path) -> String {
 
 pub(crate) fn curiosity_engine_stdout_line(out_path: &Path) -> String {
     format!("RUNTIME_V2_CURIOSITY_ENGINE_PATH={}", out_path.display())
+}
+
+pub(crate) fn constructability_anchor_validator_stdout_line(out_path: &Path) -> String {
+    format!(
+        "RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH={}",
+        out_path.display()
+    )
 }
 
 pub(crate) fn loop_runtime_stdout_line(out_path: &Path) -> String {

--- a/adl/src/cli/runtime_v2_cmd/helpers.rs
+++ b/adl/src/cli/runtime_v2_cmd/helpers.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use std::{
-    env,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -65,13 +65,87 @@ pub(crate) fn resolve_relative_output_path(
             }
         }
     }
-    Ok(repo_root.join(out_path))
+    let canonical_root = fs::canonicalize(repo_root)
+        .with_context(|| format!("canonicalize repository root {}", repo_root.display()))?;
+    reject_symlink_components(&canonical_root, out_path, command, "--out")?;
+    Ok(canonical_root.join(out_path))
+}
+
+pub(crate) fn resolve_relative_input_path(
+    repo_root: &Path,
+    input_path: &PathBuf,
+    command: &str,
+) -> Result<PathBuf> {
+    if input_path.is_absolute() {
+        return Err(anyhow!(
+            "runtime-v2 {command} --input path must be repository-relative"
+        ));
+    }
+    for component in input_path.components() {
+        match component {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            _ => {
+                return Err(anyhow!(
+                    "runtime-v2 {command} --input path must stay within the repository"
+                ))
+            }
+        }
+    }
+    let canonical_root = fs::canonicalize(repo_root)
+        .with_context(|| format!("canonicalize repository root {}", repo_root.display()))?;
+    reject_symlink_components(&canonical_root, input_path, command, "--input")?;
+    let resolved = fs::canonicalize(canonical_root.join(input_path)).with_context(|| {
+        format!(
+            "runtime-v2 {command} failed to resolve repository-relative --input path {}",
+            input_path.display()
+        )
+    })?;
+    if !resolved.starts_with(&canonical_root) {
+        return Err(anyhow!(
+            "runtime-v2 {command} --input path must stay within the repository"
+        ));
+    }
+    Ok(resolved)
+}
+
+fn reject_symlink_components(
+    canonical_root: &Path,
+    relative_path: &Path,
+    command: &str,
+    flag: &str,
+) -> Result<()> {
+    let mut candidate = canonical_root.to_path_buf();
+    for component in relative_path.components() {
+        match component {
+            std::path::Component::Normal(component) => candidate.push(component),
+            std::path::Component::CurDir => continue,
+            _ => continue,
+        }
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(anyhow!(
+                    "runtime-v2 {command} {flag} path must not traverse symbolic links"
+                ))
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "inspect runtime-v2 {command} {flag} path component {}",
+                        candidate.display()
+                    )
+                })
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime"
+            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, constructability-anchor-validator, loop-runtime, or godel-agent-runtime"
         ));
     };
 
@@ -103,6 +177,9 @@ pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Resu
         }
         "reasoning-graph" => commands::real_runtime_v2_reasoning_graph(repo_root, &args[1..]),
         "curiosity-engine" => commands::real_runtime_v2_curiosity_engine(repo_root, &args[1..]),
+        "constructability-anchor-validator" => {
+            commands::real_runtime_v2_constructability_anchor_validator(repo_root, &args[1..])
+        }
         "loop-runtime" => commands::real_runtime_v2_loop_runtime(repo_root, &args[1..]),
         "godel-agent-runtime" => {
             commands::real_runtime_v2_godel_agent_runtime(repo_root, &args[1..])
@@ -112,7 +189,7 @@ pub(crate) fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Resu
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime)"
+            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, constructability-anchor-validator, loop-runtime, or godel-agent-runtime)"
         )),
     }
 }

--- a/adl/src/cli/runtime_v2_cmd/tests.rs
+++ b/adl/src/cli/runtime_v2_cmd/tests.rs
@@ -1,13 +1,17 @@
 use crate::cli::runtime_v2_cmd::{
     commands::{
-        cognitive_being_flagship_demo_stdout_line, contract_market_demo_stdout_line,
-        curiosity_engine_stdout_line, feature_proof_coverage_stdout_line,
-        godel_agent_runtime_stdout_line, governed_tools_flagship_demo_stdout_line,
-        loop_runtime_stdout_line, reasoning_graph_stdout_line,
+        cognitive_being_flagship_demo_stdout_line, constructability_anchor_validator_stdout_line,
+        contract_market_demo_stdout_line, curiosity_engine_stdout_line,
+        feature_proof_coverage_stdout_line, godel_agent_runtime_stdout_line,
+        governed_tools_flagship_demo_stdout_line, loop_runtime_stdout_line,
+        reasoning_graph_stdout_line,
     },
     helpers::{real_runtime_v2, real_runtime_v2_in_repo},
 };
-use adl::runtime_v2::runtime_v2_csm_integrated_run_contract;
+use adl::runtime_v2::{
+    runtime_v2_constructability_anchor_validator_contract, runtime_v2_csm_integrated_run_contract,
+    RuntimeV2ConstructabilityOutcome,
+};
 use std::{
     fs,
     path::PathBuf,
@@ -39,6 +43,9 @@ const RUNTIME_V2_CLI_REGRESSION_SMOKES: &[&str] = &[
     "reasoning-graph:arg-validation",
     "curiosity-engine:write-json",
     "curiosity-engine:arg-validation",
+    "constructability-anchor-validator:write-json",
+    "constructability-anchor-validator:input-validation",
+    "constructability-anchor-validator:arg-validation",
     "loop-runtime:write-json",
     "loop-runtime:arg-validation",
     "godel-agent-runtime:write-json",
@@ -54,10 +61,12 @@ fn temp_repo(label: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("time went backwards")
         .as_nanos();
-    std::env::temp_dir().join(format!(
+    let repo = std::env::temp_dir().join(format!(
         "adl-runtime-v2-cli-{label}-{}-{nanos}",
         std::process::id()
-    ))
+    ));
+    fs::create_dir_all(&repo).expect("create temporary repository root");
+    repo
 }
 
 #[test]
@@ -121,7 +130,7 @@ fn trace_runtime_v2_dispatch_covers_help_and_subcommand_errors() {
     let err = real_runtime_v2_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, loop-runtime, or godel-agent-runtime"));
+        .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, minimal-integrated-runtime-path, aee-obsmem-pvf-handoff, observatory-flagship-demo, cognitive-being-flagship-demo, contract-market-demo, governed-tools-flagship-demo, feature-proof-coverage, reasoning-graph, curiosity-engine, constructability-anchor-validator, loop-runtime, or godel-agent-runtime"));
 
     let err = real_runtime_v2_in_repo(&["bogus".to_string()], &repo)
         .expect_err("unknown subcommand should fail");
@@ -1068,6 +1077,278 @@ fn trace_runtime_v2_curiosity_engine_validates_stdout_help_and_output_path_rules
 }
 
 #[test]
+fn trace_runtime_v2_constructability_anchor_validator_writes_packet_json() {
+    let repo = temp_repo("constructability-anchor-validator");
+    let out_path = repo.join("out/constructability-anchor-validator.json");
+
+    real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--out".to_string(),
+            "out/constructability-anchor-validator.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("constructability anchor validator");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("constructability packet should exist"))
+            .expect("valid json");
+    assert_eq!(
+        json["schema_version"],
+        "runtime_v2.constructability_anchor_validator.v1"
+    );
+    assert_eq!(json["milestone"], "v0.91.7");
+    assert_eq!(json["wp"], "WP-10");
+    assert_eq!(
+        json["construction_events"]
+            .as_array()
+            .expect("construction events")
+            .len(),
+        2
+    );
+    assert_eq!(json["decisions"].as_array().expect("decisions").len(), 2);
+    assert_eq!(
+        json["shared_reality_boundary"]["promotion_requires_anchor"],
+        true
+    );
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
+fn trace_runtime_v2_constructability_anchor_validator_validates_caller_input_fail_closed() {
+    let repo = temp_repo("constructability-anchor-validator-input");
+    fs::create_dir_all(repo.join("input")).expect("create input directory");
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.construction_events.reverse();
+    packet.decisions.reverse();
+    fs::write(
+        repo.join("input/candidate.json"),
+        serde_json::to_vec_pretty(&packet).expect("serialize candidate"),
+    )
+    .expect("write candidate packet");
+
+    real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "input/candidate.json".to_string(),
+            "--out".to_string(),
+            "out/validated.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("validate caller-supplied packet");
+    let validated: serde_json::Value = serde_json::from_slice(
+        &fs::read(repo.join("out/validated.json")).expect("validated output"),
+    )
+    .expect("validated json");
+    assert_eq!(
+        validated["construction_events"][0]["event_id"],
+        "event-curiosity-proposal-admission"
+    );
+
+    let decision = packet
+        .decisions
+        .iter_mut()
+        .find(|decision| decision.event_id == "event-unanchored-promotion-attempt")
+        .expect("unanchored decision");
+    decision.outcome = RuntimeV2ConstructabilityOutcome::Pass;
+    fs::write(
+        repo.join("input/invalid.json"),
+        serde_json::to_vec_pretty(&packet).expect("serialize invalid candidate"),
+    )
+    .expect("write invalid packet");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "input/invalid.json".to_string(),
+            "--out".to_string(),
+            "out/must-not-exist.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("invalid caller input must fail closed");
+    assert!(err.to_string().contains("must fail closed"));
+    assert!(!repo.join("out/must-not-exist.json").exists());
+
+    fs::write(repo.join("out/stale.json"), b"stale").expect("write stale output");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "input/invalid.json".to_string(),
+            "--out".to_string(),
+            "out/stale.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("invalid caller input must remove stale output");
+    assert!(err.to_string().contains("must fail closed"));
+    assert!(!repo.join("out/stale.json").exists());
+
+    let same_path = repo.join("input/invalid.json");
+    let before = fs::read(&same_path).expect("read same-path input before rejection");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "input/invalid.json".to_string(),
+            "--out".to_string(),
+            "input/invalid.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("input and output paths must differ");
+    assert!(err
+        .to_string()
+        .contains("--input and --out must be different paths"));
+    assert_eq!(
+        fs::read(&same_path).expect("same-path input must survive rejection"),
+        before
+    );
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[test]
+fn trace_runtime_v2_constructability_anchor_validator_validates_stdout_help_and_output_path_rules()
+{
+    let repo = temp_repo("constructability-anchor-validator-branches");
+
+    real_runtime_v2_in_repo(&["constructability-anchor-validator".to_string()], &repo)
+        .expect("stdout constructability packet");
+    real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--help".to_string(),
+        ],
+        &repo,
+    )
+    .expect("constructability help");
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--out".to_string(),
+            repo.join("absolute/constructability-anchor-validator.json")
+                .to_string_lossy()
+                .to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("absolute output path should fail");
+    assert!(err.to_string().contains(
+        "runtime-v2 constructability-anchor-validator --out path must be repository-relative"
+    ));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--bogus".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for runtime-v2 constructability-anchor-validator: --bogus"));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--out".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("missing out value should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 constructability-anchor-validator requires --out <path>"));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            repo.join("absolute/candidate.json")
+                .to_string_lossy()
+                .to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("absolute input path should fail");
+    assert!(err.to_string().contains(
+        "runtime-v2 constructability-anchor-validator --input path must be repository-relative"
+    ));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "../candidate.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("parent traversal input should fail");
+    assert!(err.to_string().contains(
+        "runtime-v2 constructability-anchor-validator --input path must stay within the repository"
+    ));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("missing input value should fail");
+    assert!(err
+        .to_string()
+        .contains("runtime-v2 constructability-anchor-validator requires --input <packet.json>"));
+
+    fs::remove_dir_all(repo).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_runtime_v2_constructability_anchor_validator_rejects_symlink_path_escape() {
+    use std::os::unix::fs::symlink;
+
+    let repo = temp_repo("constructability-anchor-validator-symlink");
+    let outside = temp_repo("constructability-anchor-validator-outside");
+    fs::write(outside.join("candidate.json"), b"{}").expect("outside candidate");
+    symlink(&outside, repo.join("escape")).expect("create escape symlink");
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--input".to_string(),
+            "escape/candidate.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("input symlink escape must fail");
+    assert!(err.to_string().contains("must not traverse symbolic links"));
+
+    let err = real_runtime_v2_in_repo(
+        &[
+            "constructability-anchor-validator".to_string(),
+            "--out".to_string(),
+            "escape/output.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("output symlink escape must fail");
+    assert!(err.to_string().contains("must not traverse symbolic links"));
+    assert!(!outside.join("output.json").exists());
+
+    fs::remove_dir_all(repo).ok();
+    fs::remove_dir_all(outside).ok();
+}
+
+#[test]
 fn trace_runtime_v2_loop_runtime_writes_packet_json() {
     let repo = temp_repo("loop-runtime");
     let out_path = repo.join("out/loop-runtime.json");
@@ -1260,6 +1541,9 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
         trace_runtime_v2_reasoning_graph_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_curiosity_engine_writes_packet_json,
         trace_runtime_v2_curiosity_engine_validates_stdout_help_and_output_path_rules,
+        trace_runtime_v2_constructability_anchor_validator_writes_packet_json,
+        trace_runtime_v2_constructability_anchor_validator_validates_caller_input_fail_closed,
+        trace_runtime_v2_constructability_anchor_validator_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_loop_runtime_writes_packet_json,
         trace_runtime_v2_loop_runtime_validates_stdout_help_and_output_path_rules,
         trace_runtime_v2_godel_agent_runtime_writes_packet_json,
@@ -1294,6 +1578,9 @@ fn trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_r
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("curiosity-engine:")));
+    assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
+        .iter()
+        .any(|smoke| smoke.starts_with("constructability-anchor-validator:")));
     assert!(RUNTIME_V2_CLI_REGRESSION_SMOKES
         .iter()
         .any(|smoke| smoke.starts_with("loop-runtime:")));
@@ -1524,6 +1811,21 @@ fn trace_runtime_v2_demo_stdout_lines_preserve_requested_relative_paths() {
     assert!(
         !curiosity_engine_stdout.contains(&cwd),
         "curiosity engine stdout should not expose absolute repo root:\n{curiosity_engine_stdout}"
+    );
+
+    let constructability_file = rel_root.join("constructability-anchor-validator.json");
+    let constructability_stdout =
+        constructability_anchor_validator_stdout_line(&constructability_file);
+    assert_eq!(
+        constructability_stdout,
+        format!(
+            "RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH={}",
+            constructability_file.display()
+        )
+    );
+    assert!(
+        !constructability_stdout.contains(&cwd),
+        "constructability stdout should not expose absolute repo root:\n{constructability_stdout}"
     );
 
     let loop_runtime_file = rel_root.join("loop-runtime.json");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -52,6 +52,7 @@ pub fn usage() -> &'static str {
   adl runtime-v2 feature-proof-coverage [--out <path>]
   adl runtime-v2 reasoning-graph [--out <path>]
   adl runtime-v2 curiosity-engine [--out <path>]
+  adl runtime-v2 constructability-anchor-validator [--input <packet.json>] [--out <path>]
   adl runtime-v2 loop-runtime [--out <path>]
   adl runtime-v2 godel-agent-runtime [--agents <count>] [--out <path>]
   adl scheduler plan --input <bundle.json> [--out <path>] [--json]
@@ -142,6 +143,7 @@ Examples:
   adl runtime-v2 feature-proof-coverage --out artifacts/v0904/feature-proof-coverage.json
   adl runtime-v2 reasoning-graph --out artifacts/v0917/reasoning-graph.json
   adl runtime-v2 curiosity-engine --out artifacts/v0917/curiosity-engine.json
+  adl runtime-v2 constructability-anchor-validator --input artifacts/v0917/constructability-candidate.json --out artifacts/v0917/constructability-decision.json
   adl runtime-v2 loop-runtime --out artifacts/v0917/loop-runtime.json
   adl runtime-v2 godel-agent-runtime --agents 10 --out artifacts/v0917/godel-agent-runtime.json
   adl scheduler plan --input adl/tests/fixtures/scheduler/economics_inputs_v1.json --out artifacts/examples/scheduler-plan.json

--- a/adl/src/runtime_v2/constructability_anchor_validator.rs
+++ b/adl/src/runtime_v2/constructability_anchor_validator.rs
@@ -1,0 +1,791 @@
+//! Runtime-v2 Constructability Anchor Validator contract for v0.91.7 WP-10.
+//!
+//! This module owns the deterministic boundary that separates provisional
+//! cognition from shared-reality publication. It validates that construction
+//! events cite admissible anchors, retain validator decisions, and fail closed
+//! when promotion is attempted without evidence.
+
+use super::*;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+pub const RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_SCHEMA: &str =
+    "runtime_v2.constructability_anchor_validator.v1";
+pub const RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH: &str =
+    "runtime_v2/constructability/anchor-validator.json";
+pub const RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_FEATURE_DOC: &str =
+    "docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md";
+pub const RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_TEST_MARKER: &str =
+    "runtime_v2_constructability_anchor_validator";
+pub const RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF: &str =
+    "validator-constructability-anchor-v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ConstructabilityAnchorValidatorPacket {
+    pub schema_version: String,
+    pub validator_id: String,
+    pub milestone: String,
+    pub wp: String,
+    pub artifact_path: String,
+    pub source_feature_doc: String,
+    pub runtime_module_ref: String,
+    pub construction_events: Vec<RuntimeV2ConstructionEvent>,
+    pub admissible_anchors: Vec<RuntimeV2ConstructabilityAnchor>,
+    pub decisions: Vec<RuntimeV2ConstructabilityDecision>,
+    pub shared_reality_boundary: RuntimeV2SharedRealityBoundary,
+    pub failure_modes: Vec<RuntimeV2ConstructabilityFailureMode>,
+    pub validation_commands: Vec<String>,
+    pub claim_boundary: String,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ConstructionEvent {
+    pub event_id: String,
+    pub source_ref: String,
+    pub provisional_claim: String,
+    pub requested_publication: RuntimeV2ConstructabilityPublicationScope,
+    pub anchor_refs: Vec<String>,
+    pub validator_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2ConstructabilityPublicationScope {
+    InternalTraceOnly,
+    ReviewPacket,
+    SharedReality,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ConstructabilityAnchor {
+    pub anchor_id: String,
+    pub anchor_kind: RuntimeV2ConstructabilityAnchorKind,
+    pub source_ref: String,
+    pub admissibility: RuntimeV2ConstructabilityAdmissibility,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2ConstructabilityAnchorKind {
+    RetainedArtifact,
+    RuntimeTrace,
+    OperatorApproval,
+    ExternalRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2ConstructabilityAdmissibility {
+    Admissible,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ConstructabilityDecision {
+    pub decision_id: String,
+    pub event_id: String,
+    pub outcome: RuntimeV2ConstructabilityOutcome,
+    pub blocking_reasons: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub reviewer_notes: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeV2ConstructabilityOutcome {
+    Pass,
+    FailClosed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2SharedRealityBoundary {
+    pub promotion_requires_anchor: bool,
+    pub promotion_requires_validator_pass: bool,
+    pub promotion_requires_operator_review: bool,
+    pub provisional_storage_path: String,
+    pub shared_reality_publication_path: String,
+    pub prohibited_promotions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ConstructabilityFailureMode {
+    pub failure_id: String,
+    pub rejected_event_id: String,
+    pub expected_error: String,
+    pub blocks_shared_reality: bool,
+}
+
+impl RuntimeV2ConstructabilityAnchorValidatorPacket {
+    pub fn prototype() -> Result<Self> {
+        let packet = Self {
+            schema_version: RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_SCHEMA.to_string(),
+            validator_id: RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF.to_string(),
+            milestone: "v0.91.7".to_string(),
+            wp: "WP-10".to_string(),
+            artifact_path: RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH.to_string(),
+            source_feature_doc: RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_FEATURE_DOC
+                .to_string(),
+            runtime_module_ref: "adl/src/runtime_v2/constructability_anchor_validator.rs"
+                .to_string(),
+            construction_events: prototype_construction_events(),
+            admissible_anchors: prototype_anchors(),
+            decisions: prototype_decisions(),
+            shared_reality_boundary: RuntimeV2SharedRealityBoundary {
+                promotion_requires_anchor: true,
+                promotion_requires_validator_pass: true,
+                promotion_requires_operator_review: true,
+                provisional_storage_path:
+                    "runtime_v2/constructability/provisional-claims.jsonl".to_string(),
+                shared_reality_publication_path:
+                    "runtime_v2/constructability/shared-reality-publications.jsonl".to_string(),
+                prohibited_promotions: vec![
+                    "unanchored_claim".to_string(),
+                    "validator_failed_claim".to_string(),
+                    "operator_unreviewed_external_claim".to_string(),
+                    "private_reasoning_as_public_truth".to_string(),
+                ],
+            },
+            failure_modes: vec![RuntimeV2ConstructabilityFailureMode {
+                failure_id: "failure-unanchored-shared-reality".to_string(),
+                rejected_event_id: "event-unanchored-promotion-attempt".to_string(),
+                expected_error:
+                    "shared-reality promotion requires at least one admissible anchor"
+                        .to_string(),
+                blocks_shared_reality: true,
+            }],
+            validation_commands: vec![
+                format!("cargo test --manifest-path adl/Cargo.toml {RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_TEST_MARKER} -- --nocapture"),
+                "cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_constructability_anchor_validator -- --nocapture".to_string(),
+                "adl/target/debug/adl runtime-v2 constructability-anchor-validator --input .adl/local-artifacts/wp10-constructability/anchor-validator.json --out .adl/local-artifacts/wp10-constructability/validated-anchor-decision.json".to_string(),
+                "git diff --check".to_string(),
+            ],
+            claim_boundary:
+                "WP-10 #4693 proves a bounded Runtime v2 constructability anchor validator for construction-event admissibility and shared-reality promotion gating. It is ready for later CSM runtime-component hosting, but does not claim universal truth adjudication, autonomous publication, or WP-07A supervisor integration."
+                    .to_string(),
+            non_claims: vec![
+                "does not adjudicate universal truth".to_string(),
+                "does not publish shared reality without admissible anchors".to_string(),
+                "does not bypass Freedom Gate, CAV, or operator review".to_string(),
+                "does not claim WP-07A CSM component supervisor integration".to_string(),
+                "does not replace human review".to_string(),
+            ],
+        };
+        packet.validate()?;
+        Ok(packet)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        require_exact(
+            &self.schema_version,
+            RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_SCHEMA,
+            "constructability.schema_version",
+        )?;
+        require_exact(
+            &self.validator_id,
+            RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF,
+            "constructability.validator_id",
+        )?;
+        require_exact(&self.milestone, "v0.91.7", "constructability.milestone")?;
+        require_exact(&self.wp, "WP-10", "constructability.wp")?;
+        require_exact(
+            &self.artifact_path,
+            RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH,
+            "constructability.artifact_path",
+        )?;
+        require_exact(
+            &self.source_feature_doc,
+            RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_FEATURE_DOC,
+            "constructability.source_feature_doc",
+        )?;
+        validate_relative_path(&self.artifact_path, "constructability.artifact_path")?;
+        validate_relative_path(
+            &self.source_feature_doc,
+            "constructability.source_feature_doc",
+        )?;
+        validate_relative_path(
+            &self.runtime_module_ref,
+            "constructability.runtime_module_ref",
+        )?;
+        validate_anchors(&self.admissible_anchors)?;
+        validate_events(&self.construction_events, &self.admissible_anchors)?;
+        validate_decisions(
+            &self.decisions,
+            &self.construction_events,
+            &self.admissible_anchors,
+        )?;
+        validate_shared_reality_boundary(&self.shared_reality_boundary)?;
+        validate_failure_modes(
+            &self.failure_modes,
+            &self.construction_events,
+            &self.decisions,
+        )?;
+        validate_command_list(&self.validation_commands)?;
+        ensure_contains_in_list(
+            &self.non_claims,
+            "does not claim WP-07A CSM component supervisor integration",
+            "constructability non-claims must preserve WP-07A boundary",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "bounded Runtime v2 constructability anchor validator",
+            "constructability claim boundary must stay bounded to this validator",
+        )?;
+        ensure_contains(
+            &self.claim_boundary,
+            "later CSM runtime-component hosting",
+            "constructability claim boundary must name future CSM hosting",
+        )
+    }
+
+    pub fn canonicalized(&self) -> Result<Self> {
+        self.validate()?;
+        let mut canonical = self.clone();
+        canonical
+            .construction_events
+            .sort_by(|a, b| a.event_id.cmp(&b.event_id));
+        for event in &mut canonical.construction_events {
+            event.anchor_refs.sort();
+            event.validator_refs.sort();
+        }
+        canonical
+            .admissible_anchors
+            .sort_by(|a, b| a.anchor_id.cmp(&b.anchor_id));
+        canonical
+            .decisions
+            .sort_by(|a, b| a.decision_id.cmp(&b.decision_id));
+        for decision in &mut canonical.decisions {
+            decision.blocking_reasons.sort();
+            decision.blocking_reasons.dedup();
+            decision.evidence_refs.sort();
+        }
+        canonical
+            .failure_modes
+            .sort_by(|a, b| a.failure_id.cmp(&b.failure_id));
+        canonical
+            .shared_reality_boundary
+            .prohibited_promotions
+            .sort();
+        canonical
+            .shared_reality_boundary
+            .prohibited_promotions
+            .dedup();
+        canonical.validation_commands.sort();
+        canonical.validation_commands.dedup();
+        canonical.non_claims.sort();
+        canonical.non_claims.dedup();
+        canonical.validate()?;
+        Ok(canonical)
+    }
+
+    pub fn pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(&self.canonicalized()?)
+            .context("serialize Runtime v2 Constructability Anchor Validator packet")
+    }
+
+    pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "create Runtime v2 Constructability output directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(path, self.pretty_json_bytes()?).with_context(|| {
+            format!(
+                "write Runtime v2 Constructability Anchor Validator packet to {}",
+                path.display()
+            )
+        })
+    }
+}
+
+pub fn runtime_v2_constructability_anchor_validator_contract(
+) -> Result<RuntimeV2ConstructabilityAnchorValidatorPacket> {
+    RuntimeV2ConstructabilityAnchorValidatorPacket::prototype()?.canonicalized()
+}
+
+fn prototype_construction_events() -> Vec<RuntimeV2ConstructionEvent> {
+    vec![
+        RuntimeV2ConstructionEvent {
+            event_id: "event-curiosity-proposal-admission".to_string(),
+            source_ref: "runtime_v2/curiosity_engine/curiosity_engine.json".to_string(),
+            provisional_claim:
+                "A bounded curiosity proposal may enter shared review when anchored to retained Runtime v2 evidence."
+                    .to_string(),
+            requested_publication: RuntimeV2ConstructabilityPublicationScope::ReviewPacket,
+            anchor_refs: vec![
+                "anchor-curiosity-engine-packet".to_string(),
+                "anchor-operator-review-boundary".to_string(),
+            ],
+            validator_refs: vec![RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF.to_string()],
+        },
+        RuntimeV2ConstructionEvent {
+            event_id: "event-unanchored-promotion-attempt".to_string(),
+            source_ref: "runtime_v2/constructability/provisional-claims.jsonl".to_string(),
+            provisional_claim:
+                "A provisional internal hypothesis can be promoted directly to shared reality."
+                    .to_string(),
+            requested_publication: RuntimeV2ConstructabilityPublicationScope::SharedReality,
+            anchor_refs: vec![],
+            validator_refs: vec![RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF.to_string()],
+        },
+    ]
+}
+
+fn prototype_anchors() -> Vec<RuntimeV2ConstructabilityAnchor> {
+    vec![
+        RuntimeV2ConstructabilityAnchor {
+            anchor_id: "anchor-curiosity-engine-packet".to_string(),
+            anchor_kind: RuntimeV2ConstructabilityAnchorKind::RetainedArtifact,
+            source_ref: "runtime_v2/curiosity_engine/curiosity_engine.json".to_string(),
+            admissibility: RuntimeV2ConstructabilityAdmissibility::Admissible,
+            summary:
+                "Retained Runtime v2 curiosity packet records proposal, gates, and non-claims."
+                    .to_string(),
+        },
+        RuntimeV2ConstructabilityAnchor {
+            anchor_id: "anchor-operator-review-boundary".to_string(),
+            anchor_kind: RuntimeV2ConstructabilityAnchorKind::OperatorApproval,
+            source_ref: RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_FEATURE_DOC.to_string(),
+            admissibility: RuntimeV2ConstructabilityAdmissibility::Admissible,
+            summary:
+                "Feature boundary requires operator or reviewer approval before shared-reality publication."
+                    .to_string(),
+        },
+    ]
+}
+
+fn prototype_decisions() -> Vec<RuntimeV2ConstructabilityDecision> {
+    vec![
+        RuntimeV2ConstructabilityDecision {
+            decision_id: "decision-curiosity-proposal-admitted".to_string(),
+            event_id: "event-curiosity-proposal-admission".to_string(),
+            outcome: RuntimeV2ConstructabilityOutcome::Pass,
+            blocking_reasons: vec![],
+            evidence_refs: vec![
+                "anchor-curiosity-engine-packet".to_string(),
+                "anchor-operator-review-boundary".to_string(),
+            ],
+            reviewer_notes:
+                "Review-packet publication is allowed because all cited anchors are admissible and no shared-reality publication is attempted."
+                    .to_string(),
+        },
+        RuntimeV2ConstructabilityDecision {
+            decision_id: "decision-unanchored-promotion-rejected".to_string(),
+            event_id: "event-unanchored-promotion-attempt".to_string(),
+            outcome: RuntimeV2ConstructabilityOutcome::FailClosed,
+            blocking_reasons: vec![
+                "shared-reality promotion requires at least one admissible anchor".to_string(),
+                "operator review is required before external/shared publication".to_string(),
+            ],
+            evidence_refs: vec![],
+            reviewer_notes:
+                "The validator rejects direct promotion of a provisional internal hypothesis into shared reality."
+                    .to_string(),
+        },
+    ]
+}
+
+fn validate_events(
+    events: &[RuntimeV2ConstructionEvent],
+    anchors: &[RuntimeV2ConstructabilityAnchor],
+) -> Result<()> {
+    if events.is_empty() {
+        return Err(anyhow!(
+            "constructability construction_events must not be empty"
+        ));
+    }
+    let anchor_ids: BTreeSet<_> = anchors
+        .iter()
+        .map(|anchor| anchor.anchor_id.as_str())
+        .collect();
+    let mut seen = BTreeSet::new();
+    for event in events {
+        normalize_id(event.event_id.clone(), "constructability.event_id")?;
+        if !seen.insert(event.event_id.clone()) {
+            return Err(anyhow!(
+                "duplicate constructability event '{}'",
+                event.event_id
+            ));
+        }
+        validate_relative_path(&event.source_ref, "constructability.event.source_ref")?;
+        validate_nonempty_text(
+            &event.provisional_claim,
+            "constructability.event.provisional_claim",
+        )?;
+        let mut seen_anchor_refs = BTreeSet::new();
+        for anchor_ref in &event.anchor_refs {
+            normalize_id(anchor_ref.clone(), "constructability.event.anchor_refs")?;
+            if !seen_anchor_refs.insert(anchor_ref.as_str()) {
+                return Err(anyhow!(
+                    "constructability event '{}' repeats anchor ref '{}'",
+                    event.event_id,
+                    anchor_ref
+                ));
+            }
+            if !anchor_ids.contains(anchor_ref.as_str()) {
+                return Err(anyhow!(
+                    "constructability event '{}' cites missing anchor '{}'",
+                    event.event_id,
+                    anchor_ref
+                ));
+            }
+        }
+        if event.validator_refs.is_empty() {
+            return Err(anyhow!(
+                "constructability event '{}' must name a validator",
+                event.event_id
+            ));
+        }
+        for validator_ref in &event.validator_refs {
+            normalize_id(
+                validator_ref.clone(),
+                "constructability.event.validator_refs",
+            )?;
+        }
+        if event.validator_refs != [RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF.to_string()] {
+            return Err(anyhow!(
+                "constructability event '{}' must cite exactly canonical validator '{}'",
+                event.event_id,
+                RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_REF
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_anchors(anchors: &[RuntimeV2ConstructabilityAnchor]) -> Result<()> {
+    if anchors.is_empty() {
+        return Err(anyhow!(
+            "constructability admissible_anchors must not be empty"
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    for anchor in anchors {
+        normalize_id(anchor.anchor_id.clone(), "constructability.anchor_id")?;
+        if !seen.insert(anchor.anchor_id.clone()) {
+            return Err(anyhow!(
+                "duplicate constructability anchor '{}'",
+                anchor.anchor_id
+            ));
+        }
+        validate_relative_path(&anchor.source_ref, "constructability.anchor.source_ref")?;
+        validate_nonempty_text(&anchor.summary, "constructability.anchor.summary")?;
+    }
+    Ok(())
+}
+
+fn validate_decisions(
+    decisions: &[RuntimeV2ConstructabilityDecision],
+    events: &[RuntimeV2ConstructionEvent],
+    anchors: &[RuntimeV2ConstructabilityAnchor],
+) -> Result<()> {
+    if decisions.is_empty() {
+        return Err(anyhow!("constructability decisions must not be empty"));
+    }
+    let event_ids: BTreeSet<_> = events.iter().map(|event| event.event_id.as_str()).collect();
+    let admissible_anchor_ids: BTreeSet<_> = anchors
+        .iter()
+        .filter(|anchor| anchor.admissibility == RuntimeV2ConstructabilityAdmissibility::Admissible)
+        .map(|anchor| anchor.anchor_id.as_str())
+        .collect();
+    let mut seen = BTreeSet::new();
+    let mut decisions_by_event = BTreeSet::new();
+
+    for decision in decisions {
+        normalize_id(decision.decision_id.clone(), "constructability.decision_id")?;
+        if !seen.insert(decision.decision_id.clone()) {
+            return Err(anyhow!(
+                "duplicate constructability decision '{}'",
+                decision.decision_id
+            ));
+        }
+        if !event_ids.contains(decision.event_id.as_str()) {
+            return Err(anyhow!(
+                "constructability decision '{}' cites missing event '{}'",
+                decision.decision_id,
+                decision.event_id
+            ));
+        }
+        if !decisions_by_event.insert(decision.event_id.as_str()) {
+            return Err(anyhow!(
+                "constructability event '{}' has multiple validator decisions",
+                decision.event_id
+            ));
+        }
+        validate_nonempty_text(
+            &decision.reviewer_notes,
+            "constructability.decision.reviewer_notes",
+        )?;
+        let event = events
+            .iter()
+            .find(|event| event.event_id == decision.event_id)
+            .expect("decision event was validated above");
+        if event.requested_publication == RuntimeV2ConstructabilityPublicationScope::SharedReality
+            && event.anchor_refs.is_empty()
+            && decision.outcome != RuntimeV2ConstructabilityOutcome::FailClosed
+        {
+            return Err(anyhow!(
+                "unanchored shared-reality event '{}' must fail closed",
+                event.event_id
+            ));
+        }
+        match decision.outcome {
+            RuntimeV2ConstructabilityOutcome::Pass => {
+                if decision.evidence_refs.is_empty() {
+                    return Err(anyhow!(
+                        "constructability pass decision '{}' must cite evidence refs",
+                        decision.decision_id
+                    ));
+                }
+                let mut seen_evidence_refs = BTreeSet::new();
+                for evidence_ref in &decision.evidence_refs {
+                    if !seen_evidence_refs.insert(evidence_ref.as_str()) {
+                        return Err(anyhow!(
+                            "constructability pass decision '{}' repeats evidence ref '{}'",
+                            decision.decision_id,
+                            evidence_ref
+                        ));
+                    }
+                    if !admissible_anchor_ids.contains(evidence_ref.as_str()) {
+                        return Err(anyhow!(
+                            "constructability pass decision '{}' cites non-admissible anchor '{}'",
+                            decision.decision_id,
+                            evidence_ref
+                        ));
+                    }
+                    if !event.anchor_refs.contains(evidence_ref) {
+                        return Err(anyhow!(
+                            "constructability pass decision '{}' cites anchor '{}' not declared by event '{}'",
+                            decision.decision_id,
+                            evidence_ref,
+                            decision.event_id
+                        ));
+                    }
+                }
+                let declared_anchors: BTreeSet<_> =
+                    event.anchor_refs.iter().map(String::as_str).collect();
+                let decision_evidence: BTreeSet<_> =
+                    decision.evidence_refs.iter().map(String::as_str).collect();
+                if declared_anchors != decision_evidence {
+                    return Err(anyhow!(
+                        "constructability pass decision '{}' must retain every declared event anchor exactly once",
+                        decision.decision_id
+                    ));
+                }
+                if event.requested_publication
+                    == RuntimeV2ConstructabilityPublicationScope::SharedReality
+                    && !decision.evidence_refs.iter().any(|evidence_ref| {
+                        anchors.iter().any(|anchor| {
+                            anchor.anchor_id == *evidence_ref
+                                && anchor.anchor_kind
+                                    == RuntimeV2ConstructabilityAnchorKind::OperatorApproval
+                                && anchor.admissibility
+                                    == RuntimeV2ConstructabilityAdmissibility::Admissible
+                        })
+                    })
+                {
+                    return Err(anyhow!(
+                        "constructability shared-reality pass decision '{}' requires an admissible operator-approval anchor",
+                        decision.decision_id
+                    ));
+                }
+                if !decision.blocking_reasons.is_empty() {
+                    return Err(anyhow!(
+                        "constructability pass decision '{}' must not include blocking reasons",
+                        decision.decision_id
+                    ));
+                }
+            }
+            RuntimeV2ConstructabilityOutcome::FailClosed => {
+                if decision.blocking_reasons.is_empty() {
+                    return Err(anyhow!(
+                        "constructability fail-closed decision '{}' must name blocking reasons",
+                        decision.decision_id
+                    ));
+                }
+            }
+        }
+    }
+
+    for event in events {
+        if !decisions_by_event.contains(event.event_id.as_str()) {
+            return Err(anyhow!(
+                "constructability event '{}' has no validator decision",
+                event.event_id
+            ));
+        }
+        if event.requested_publication == RuntimeV2ConstructabilityPublicationScope::SharedReality
+            && event.anchor_refs.is_empty()
+        {
+            let decision = decisions
+                .iter()
+                .find(|decision| decision.event_id == event.event_id)
+                .expect("decision exists for event");
+            if decision.outcome != RuntimeV2ConstructabilityOutcome::FailClosed {
+                return Err(anyhow!(
+                    "unanchored shared-reality event '{}' must fail closed",
+                    event.event_id
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_shared_reality_boundary(boundary: &RuntimeV2SharedRealityBoundary) -> Result<()> {
+    if !boundary.promotion_requires_anchor {
+        return Err(anyhow!(
+            "constructability boundary must require an admissible anchor"
+        ));
+    }
+    if !boundary.promotion_requires_validator_pass {
+        return Err(anyhow!(
+            "constructability boundary must require validator pass"
+        ));
+    }
+    if !boundary.promotion_requires_operator_review {
+        return Err(anyhow!(
+            "constructability boundary must require operator review"
+        ));
+    }
+    validate_relative_path(
+        &boundary.provisional_storage_path,
+        "constructability.boundary.provisional_storage_path",
+    )?;
+    validate_relative_path(
+        &boundary.shared_reality_publication_path,
+        "constructability.boundary.shared_reality_publication_path",
+    )?;
+    ensure_contains_in_list(
+        &boundary.prohibited_promotions,
+        "unanchored_claim",
+        "constructability boundary must prohibit unanchored claims",
+    )?;
+    ensure_contains_in_list(
+        &boundary.prohibited_promotions,
+        "private_reasoning_as_public_truth",
+        "constructability boundary must prohibit private reasoning as public truth",
+    )
+}
+
+fn validate_failure_modes(
+    failure_modes: &[RuntimeV2ConstructabilityFailureMode],
+    events: &[RuntimeV2ConstructionEvent],
+    decisions: &[RuntimeV2ConstructabilityDecision],
+) -> Result<()> {
+    if failure_modes.is_empty() {
+        return Err(anyhow!("constructability failure_modes must not be empty"));
+    }
+    let event_ids: BTreeSet<_> = events.iter().map(|event| event.event_id.as_str()).collect();
+    let mut seen = BTreeSet::new();
+    for failure in failure_modes {
+        normalize_id(
+            failure.failure_id.clone(),
+            "constructability.failure.failure_id",
+        )?;
+        if !seen.insert(failure.failure_id.as_str()) {
+            return Err(anyhow!(
+                "duplicate constructability failure mode '{}'",
+                failure.failure_id
+            ));
+        }
+        if !event_ids.contains(failure.rejected_event_id.as_str()) {
+            return Err(anyhow!(
+                "constructability failure '{}' cites missing rejected event '{}'",
+                failure.failure_id,
+                failure.rejected_event_id
+            ));
+        }
+        validate_nonempty_text(
+            &failure.expected_error,
+            "constructability.failure.expected_error",
+        )?;
+        if !failure.blocks_shared_reality {
+            return Err(anyhow!(
+                "constructability failure '{}' must block shared reality",
+                failure.failure_id
+            ));
+        }
+        let decision = decisions
+            .iter()
+            .find(|decision| decision.event_id == failure.rejected_event_id)
+            .ok_or_else(|| {
+                anyhow!(
+                    "constructability failure '{}' has no validator decision for rejected event '{}'",
+                    failure.failure_id,
+                    failure.rejected_event_id
+                )
+            })?;
+        if decision.outcome != RuntimeV2ConstructabilityOutcome::FailClosed {
+            return Err(anyhow!(
+                "constructability failure '{}' must map to a fail-closed decision",
+                failure.failure_id
+            ));
+        }
+        if !decision
+            .blocking_reasons
+            .iter()
+            .any(|reason| reason == &failure.expected_error)
+        {
+            return Err(anyhow!(
+                "constructability failure '{}' expected error is not retained in its decision",
+                failure.failure_id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_command_list(commands: &[String]) -> Result<()> {
+    if commands.is_empty() {
+        return Err(anyhow!(
+            "constructability validation_commands must not be empty"
+        ));
+    }
+    ensure_contains_in_list(
+        commands,
+        RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_TEST_MARKER,
+        "constructability validation commands must include focused Rust test marker",
+    )?;
+    ensure_contains_in_list(
+        commands,
+        "trace_runtime_v2_constructability_anchor_validator",
+        "constructability validation commands must include CLI proof marker",
+    )?;
+    ensure_contains_in_list(
+        commands,
+        "git diff --check",
+        "constructability validation commands must include whitespace/path hygiene",
+    )
+}
+
+fn ensure_contains_in_list(values: &[String], needle: &str, message: &str) -> Result<()> {
+    if values.iter().any(|value| value.contains(needle)) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn ensure_contains(value: &str, needle: &str, message: &str) -> Result<()> {
+    if value.contains(needle) {
+        Ok(())
+    } else {
+        Err(anyhow!("{message}"))
+    }
+}
+
+fn require_exact(actual: &str, expected: &str, field: &str) -> Result<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(anyhow!("{field} must be '{expected}', got '{actual}'"))
+    }
+}

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -17,6 +17,7 @@ mod challenge;
 mod citizen;
 mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
+mod constructability_anchor_validator;
 mod contract_lifecycle_state;
 mod contract_market_demo;
 mod contract_schema;
@@ -105,6 +106,8 @@ pub use citizen::*;
 pub use citizen_state_substrate::*;
 #[allow(unused_imports)]
 pub use cognitive_being_flagship_demo::*;
+#[allow(unused_imports)]
+pub use constructability_anchor_validator::*;
 #[allow(unused_imports)]
 pub use contract_lifecycle_state::*;
 #[allow(unused_imports)]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -19,6 +19,7 @@ mod citizen_lifecycle;
 mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
 mod common;
+mod constructability_anchor_validator;
 mod contract_lifecycle_state;
 mod contract_market_demo;
 #[cfg(any(feature = "slow-proof-tests", feature = "slow-proof-runtime"))]

--- a/adl/src/runtime_v2/tests/constructability_anchor_validator.rs
+++ b/adl/src/runtime_v2/tests/constructability_anchor_validator.rs
@@ -1,0 +1,229 @@
+use super::*;
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_contract_is_stable() {
+    let packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet
+        .validate()
+        .expect("valid constructability anchor validator packet");
+
+    assert_eq!(
+        packet.schema_version,
+        RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_SCHEMA
+    );
+    assert_eq!(packet.milestone, "v0.91.7");
+    assert_eq!(packet.wp, "WP-10");
+    assert_eq!(packet.construction_events.len(), 2);
+    assert_eq!(packet.admissible_anchors.len(), 2);
+    assert!(packet.shared_reality_boundary.promotion_requires_anchor);
+    assert!(packet
+        .validation_commands
+        .iter()
+        .any(|command| command.contains(RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_TEST_MARKER)));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_canonical_json_is_deterministic() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    let expected = packet
+        .pretty_json_bytes()
+        .expect("baseline canonical constructability json");
+    packet.construction_events.reverse();
+    for event in &mut packet.construction_events {
+        event.anchor_refs.reverse();
+        event.validator_refs.reverse();
+    }
+    packet.admissible_anchors.reverse();
+    packet.decisions.reverse();
+    for decision in &mut packet.decisions {
+        decision.blocking_reasons.reverse();
+        decision.evidence_refs.reverse();
+    }
+    packet.validation_commands.reverse();
+
+    let json = String::from_utf8(packet.pretty_json_bytes().expect("constructability json"))
+        .expect("utf8 constructability json");
+    assert_eq!(json.as_bytes(), expected);
+    let reparsed: RuntimeV2ConstructabilityAnchorValidatorPacket =
+        serde_json::from_str(&json).expect("reparse constructability json");
+
+    assert_eq!(
+        reparsed.construction_events[0].event_id,
+        "event-curiosity-proposal-admission"
+    );
+    assert_eq!(
+        reparsed.decisions[0].decision_id,
+        "decision-curiosity-proposal-admitted"
+    );
+    reparsed
+        .validate()
+        .expect("canonical constructability packet remains valid");
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_unanchored_promotion_pass() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    let decision = packet
+        .decisions
+        .iter_mut()
+        .find(|decision| decision.event_id == "event-unanchored-promotion-attempt")
+        .expect("unanchored decision");
+    decision.outcome = RuntimeV2ConstructabilityOutcome::Pass;
+    decision.blocking_reasons.clear();
+    decision
+        .evidence_refs
+        .push("anchor-curiosity-engine-packet".to_string());
+
+    assert!(packet
+        .validate()
+        .expect_err("unanchored shared-reality promotion must fail closed")
+        .to_string()
+        .contains("must fail closed"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_non_admissible_evidence() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.admissible_anchors[0].admissibility = RuntimeV2ConstructabilityAdmissibility::Rejected;
+
+    assert!(packet
+        .validate()
+        .expect_err("pass decision must cite admissible anchors")
+        .to_string()
+        .contains("non-admissible anchor"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_disabled_boundary() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.shared_reality_boundary.promotion_requires_anchor = false;
+
+    assert!(packet
+        .validate()
+        .expect_err("boundary must require anchors")
+        .to_string()
+        .contains("admissible anchor"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_missing_event_anchor() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.construction_events[0]
+        .anchor_refs
+        .push("anchor-does-not-exist".to_string());
+
+    assert!(packet
+        .validate()
+        .expect_err("event anchor refs must resolve")
+        .to_string()
+        .contains("cites missing anchor"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_duplicate_event_decision() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    let mut duplicate = packet.decisions[0].clone();
+    duplicate.decision_id = "decision-duplicate-for-event".to_string();
+    packet.decisions.push(duplicate);
+
+    assert!(packet
+        .validate()
+        .expect_err("one event must have exactly one decision")
+        .to_string()
+        .contains("multiple validator decisions"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_unretained_failure_reason() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.failure_modes[0].expected_error = "different failure reason".to_string();
+
+    assert!(packet
+        .validate()
+        .expect_err("failure reason must be retained in the decision")
+        .to_string()
+        .contains("expected error is not retained"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_unknown_validator_ref() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.construction_events[0].validator_refs = vec!["validator-unknown".to_string()];
+
+    assert!(packet
+        .validate()
+        .expect_err("events must cite the canonical validator")
+        .to_string()
+        .contains("must cite exactly canonical validator"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_additional_validator_ref() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.construction_events[0]
+        .validator_refs
+        .push("validator-unknown".to_string());
+
+    assert!(packet
+        .validate()
+        .expect_err("events must not cite additional validators")
+        .to_string()
+        .contains("must cite exactly canonical validator"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_partial_pass_evidence() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.decisions[0].evidence_refs.pop();
+
+    assert!(packet
+        .validate()
+        .expect_err("pass evidence must retain all declared anchors")
+        .to_string()
+        .contains("must retain every declared event anchor"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_duplicate_pass_evidence() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    let duplicate = packet.decisions[0].evidence_refs[0].clone();
+    packet.decisions[0].evidence_refs.push(duplicate);
+
+    assert!(packet
+        .validate()
+        .expect_err("pass evidence refs must be unique")
+        .to_string()
+        .contains("repeats evidence ref"));
+}
+
+#[test]
+fn runtime_v2_constructability_anchor_validator_rejects_shared_reality_without_operator_approval() {
+    let mut packet = runtime_v2_constructability_anchor_validator_contract()
+        .expect("constructability anchor validator packet");
+    packet.construction_events[0].requested_publication =
+        RuntimeV2ConstructabilityPublicationScope::SharedReality;
+    packet.construction_events[0]
+        .anchor_refs
+        .retain(|anchor_ref| anchor_ref != "anchor-operator-review-boundary");
+    packet.decisions[0]
+        .evidence_refs
+        .retain(|anchor_ref| anchor_ref != "anchor-operator-review-boundary");
+
+    assert!(packet
+        .validate()
+        .expect_err("shared-reality pass requires operator approval")
+        .to_string()
+        .contains("requires an admissible operator-approval anchor"));
+}

--- a/adl/tests/cli_smoke.rs
+++ b/adl/tests/cli_smoke.rs
@@ -428,6 +428,100 @@ fn adl_runtime_run_fails_closed_for_issue_ids() {
     );
 }
 
+#[test]
+fn runtime_v2_constructability_anchor_validator_processes_input_and_preserves_channels() {
+    let repo = unique_test_temp_dir("constructability-validator-process");
+    fs::create_dir_all(&repo).expect("create temporary repository root");
+
+    let fixture = Command::new(resolve_adl_exe())
+        .current_dir(&repo)
+        .args([
+            "runtime-v2",
+            "constructability-anchor-validator",
+            "--out",
+            "candidate.json",
+        ])
+        .output()
+        .expect("emit constructability fixture");
+    assert!(
+        fixture.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&fixture.stdout),
+        String::from_utf8_lossy(&fixture.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&fixture.stdout),
+        "RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH=candidate.json\n"
+    );
+    assert!(String::from_utf8_lossy(&fixture.stderr).contains("adl_event"));
+
+    let validated = Command::new(resolve_adl_exe())
+        .current_dir(&repo)
+        .args([
+            "runtime-v2",
+            "constructability-anchor-validator",
+            "--input",
+            "candidate.json",
+            "--out",
+            "validated.json",
+        ])
+        .output()
+        .expect("validate constructability input");
+    assert!(
+        validated.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&validated.stdout),
+        String::from_utf8_lossy(&validated.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&validated.stdout),
+        "RUNTIME_V2_CONSTRUCTABILITY_ANCHOR_VALIDATOR_PATH=validated.json\n"
+    );
+    assert!(String::from_utf8_lossy(&validated.stderr).contains("adl_event"));
+    assert_eq!(
+        fs::read(repo.join("candidate.json")).expect("candidate packet"),
+        fs::read(repo.join("validated.json")).expect("validated packet")
+    );
+
+    let mut invalid: serde_json::Value = serde_json::from_slice(
+        &fs::read(repo.join("candidate.json")).expect("read candidate packet"),
+    )
+    .expect("parse candidate packet");
+    invalid["decisions"]
+        .as_array_mut()
+        .expect("decision array")
+        .iter_mut()
+        .find(|decision| decision["event_id"] == "event-unanchored-promotion-attempt")
+        .expect("unanchored decision")["outcome"] = serde_json::json!("pass");
+    fs::write(
+        repo.join("invalid.json"),
+        serde_json::to_vec_pretty(&invalid).expect("serialize invalid packet"),
+    )
+    .expect("write invalid packet");
+
+    let rejected = Command::new(resolve_adl_exe())
+        .current_dir(&repo)
+        .args([
+            "runtime-v2",
+            "constructability-anchor-validator",
+            "--input",
+            "invalid.json",
+            "--out",
+            "validated.json",
+        ])
+        .output()
+        .expect("reject invalid constructability input");
+    assert!(!rejected.status.success());
+    assert!(rejected.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&rejected.stderr).contains("must fail closed"));
+    assert!(
+        !repo.join("validated.json").exists(),
+        "failed validation must remove a stale output from the prior successful run"
+    );
+
+    fs::remove_dir_all(repo).ok();
+}
+
 #[path = "cli_smoke/agent.rs"]
 mod agent;
 #[path = "cli_smoke/basics.rs"]

--- a/adl/tools/run_owner_validation_lane.sh
+++ b/adl/tools/run_owner_validation_lane.sh
@@ -87,11 +87,13 @@ build_owner_bins() {
       --bin adl-pr-create --bin adl-pr-init --bin adl-pr-repair-issue-body \
       --bin adl-pr-run --bin adl-pr-doctor --bin adl-pr-ready \
       --bin adl-pr-preflight --bin adl-pr-finish --bin adl-pr-validation \
-      --bin adl-pr-inventory --bin adl-pr-closing-linkage \
+      --bin adl-pr-inventory --bin adl-pr-shepherd --bin adl-pr-closing-linkage \
       --bin adl-issue \
       --bin adl-pr-closeout \
       --bin adl-session --bin adl-process \
-      --bin adl-prompt-template --bin adl-validate-structured-prompt
+      --bin adl-prompt-template --bin adl-validate-structured-prompt \
+      --bin adl-lint-prompt-spec --bin adl-remote \
+      --bin adl-aws-remote-validation --bin adl-provider-adapter
   if [[ "$PRINT_PLAN" == "1" ]]; then
     return 0
   fi

--- a/adl/tools/test_owner_validation_lane.sh
+++ b/adl/tools/test_owner_validation_lane.sh
@@ -9,7 +9,10 @@ for expected in \
   "cargo build owner binaries" \
   "--bin csm" \
   "--bin adl-pr-inventory" \
+  "--bin adl-pr-shepherd" \
   "--bin adl-session --bin adl-process" \
+  "--bin adl-lint-prompt-spec --bin adl-remote" \
+  "--bin adl-aws-remote-validation --bin adl-provider-adapter" \
   "C-SDLC wrapper migration contract" \
   "C-SDLC run ambiguity policy" \
   "C-SDLC control-plane observability contract" \

--- a/adl/tools/test_owner_validation_lane.sh
+++ b/adl/tools/test_owner_validation_lane.sh
@@ -3,16 +3,33 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNNER="$ROOT_DIR/adl/tools/run_owner_validation_lane.sh"
+INSTALLER="$ROOT_DIR/adl/tools/install_owner_binaries.sh"
 
 plan_output="$(bash "$RUNNER" all --build --print-plan)"
+installer_bins="$(
+  awk '
+    /^  BINS=\($/ { capture = 1; next }
+    capture && /^  \)$/ { exit }
+    capture { print }
+  ' "$INSTALLER" |
+    tr -d '\\' |
+    xargs -n1 |
+    LC_ALL=C sort
+)"
+runner_bins="$(
+  grep -o -- '--bin [[:alnum:]-]*' <<<"$plan_output" |
+    awk '{ print $2 }' |
+    LC_ALL=C sort
+)"
+if ! diff -u \
+  <(printf '%s\n' "$installer_bins") \
+  <(printf '%s\n' "$runner_bins"); then
+  echo "owner validation build set does not match installer defaults" >&2
+  exit 1
+fi
+
 for expected in \
   "cargo build owner binaries" \
-  "--bin csm" \
-  "--bin adl-pr-inventory" \
-  "--bin adl-pr-shepherd" \
-  "--bin adl-session --bin adl-process" \
-  "--bin adl-lint-prompt-spec --bin adl-remote" \
-  "--bin adl-aws-remote-validation --bin adl-provider-adapter" \
   "C-SDLC wrapper migration contract" \
   "C-SDLC run ambiguity policy" \
   "C-SDLC control-plane observability contract" \

--- a/adl/tools/test_prompt_template_wrappers_no_implicit_cargo.sh
+++ b/adl/tools/test_prompt_template_wrappers_no_implicit_cargo.sh
@@ -33,6 +33,7 @@ set +e
   cd "$fake_root"
   env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
     -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    -u ADL_PRIMARY_CHECKOUT_ROOT -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_TARGET_DIR \
     PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$prompt_cargo_args" \
     ADL_PROMPT_TEMPLATE_DISABLE_PATH_LOOKUP=1 \
@@ -70,6 +71,7 @@ legacy_args="$tmpdir/legacy.args"
   cd "$fake_root"
   env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
     -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    -u ADL_PRIMARY_CHECKOUT_ROOT -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_TARGET_DIR \
     PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$prompt_cargo_args" \
     ADL_TEST_LEGACY_ARGS="$legacy_args" \
@@ -95,6 +97,7 @@ set +e
   cd "$fake_root"
   env -u ADL_STRUCTURED_PROMPT_VALIDATOR_BIN -u ADL_TOOLING_RUST_BIN \
     -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    -u ADL_PRIMARY_CHECKOUT_ROOT -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_TARGET_DIR \
     PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$validator_cargo_args" \
     ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
@@ -134,6 +137,7 @@ validator_args="$tmpdir/validator.args"
   cd "$fake_root"
   env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
     -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    -u ADL_PRIMARY_CHECKOUT_ROOT -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_TARGET_DIR \
     PATH="$mockbin:$PATH" \
     ADL_TEST_PROMPT_ARGS="$prompt_args" \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \
@@ -149,6 +153,7 @@ grep -Fqx "prompt:validate-schemas --repo-root $fake_root" "$prompt_args" || {
   cd "$fake_root"
   env -u ADL_STRUCTURED_PROMPT_VALIDATOR_BIN -u ADL_TOOLING_RUST_BIN \
     -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    -u ADL_PRIMARY_CHECKOUT_ROOT -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_TARGET_DIR \
     PATH="$mockbin:$PATH" \
     ADL_TEST_VALIDATOR_ARGS="$validator_args" \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \

--- a/adl/tools/test_prompt_template_wrappers_no_implicit_cargo.sh
+++ b/adl/tools/test_prompt_template_wrappers_no_implicit_cargo.sh
@@ -31,7 +31,9 @@ validator_cargo_args="$tmpdir/validator-cargo.args"
 set +e
 (
   cd "$fake_root"
-  PATH="$mockbin:$PATH" \
+  env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
+    -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$prompt_cargo_args" \
     ADL_PROMPT_TEMPLATE_DISABLE_PATH_LOOKUP=1 \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \
@@ -66,7 +68,9 @@ legacy_args="$tmpdir/legacy.args"
 : >"$prompt_cargo_args"
 (
   cd "$fake_root"
-  PATH="$mockbin:$PATH" \
+  env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
+    -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$prompt_cargo_args" \
     ADL_TEST_LEGACY_ARGS="$legacy_args" \
     ADL_PROMPT_TEMPLATE_DISABLE_PATH_LOOKUP=1 \
@@ -89,7 +93,9 @@ grep -Fqx "legacy:tooling prompt-template validate-schemas --repo-root $fake_roo
 set +e
 (
   cd "$fake_root"
-  PATH="$mockbin:$PATH" \
+  env -u ADL_STRUCTURED_PROMPT_VALIDATOR_BIN -u ADL_TOOLING_RUST_BIN \
+    -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    PATH="$mockbin:$PATH" \
     ADL_TEST_CARGO_ARGS="$validator_cargo_args" \
     ADL_STRUCTURED_PROMPT_VALIDATOR_DISABLE_PATH_LOOKUP=1 \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \
@@ -126,7 +132,9 @@ prompt_args="$tmpdir/prompt.args"
 validator_args="$tmpdir/validator.args"
 (
   cd "$fake_root"
-  PATH="$mockbin:$PATH" \
+  env -u ADL_PROMPT_TEMPLATE_BIN -u ADL_TOOLING_RUST_BIN \
+    -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    PATH="$mockbin:$PATH" \
     ADL_TEST_PROMPT_ARGS="$prompt_args" \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \
     "$fake_root/adl/tools/prompt_template.sh" validate-schemas --repo-root "$fake_root" >/dev/null
@@ -139,7 +147,9 @@ grep -Fqx "prompt:validate-schemas --repo-root $fake_root" "$prompt_args" || {
 
 (
   cd "$fake_root"
-  PATH="$mockbin:$PATH" \
+  env -u ADL_STRUCTURED_PROMPT_VALIDATOR_BIN -u ADL_TOOLING_RUST_BIN \
+    -u ADL_PR_RUST_BIN -u ADL_OWNER_BIN_DIR \
+    PATH="$mockbin:$PATH" \
     ADL_TEST_VALIDATOR_ARGS="$validator_args" \
     ADL_TOOLING_MANIFEST_ROOT="$fake_root" \
     "$fake_root/adl/tools/validate_structured_prompt.sh" --type sip --input example.md >/dev/null

--- a/docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md
+++ b/docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Constructability Gate
 - Milestone Target: `v0.91.7`
-- Status: planned
+- Status: bounded Runtime v2 validator implemented
 - Owner: ADL maintainers
 - Doc Role: primary
 - Feature Types: architecture, policy, schema
@@ -12,8 +12,8 @@
 
 ## Purpose
 
-Define the gate that separates provisional cognition from authoritative shared
-reality.
+Define and implement the gate that separates provisional cognition from
+authoritative shared reality.
 
 ## Scope
 
@@ -28,15 +28,37 @@ In scope:
 Out of scope:
 
 - universal truth adjudication;
-- runtime implementation;
+- CSM supervisor hosting, which remains a WP-07A runtime-component concern;
 - replacing human/operator review.
+
+## Runtime Status
+
+ADL Runtime v2 exposes the bounded validator through:
+
+```text
+adl runtime-v2 constructability-anchor-validator --input <packet.json> --out <decision.json>
+```
+
+The command accepts a caller-supplied
+`runtime_v2.constructability_anchor_validator.v1` packet, validates it
+fail-closed, and emits canonical validated output at the caller-selected
+repository-relative path. Omitting `--input` emits the built-in bounded proof
+fixture for inspection. The packet records construction events, admissible
+anchors, one validator decision per event, shared-reality promotion
+requirements, retained fail-closed cases, validation commands, and explicit
+non-claims.
+
+The implementation lives in
+`adl/src/runtime_v2/constructability_anchor_validator.rs`. It is host-agnostic
+Runtime v2 core logic: this issue does not claim that the validator is already
+hosted by the WP-07A CSM component supervisor.
 
 ## Required Decisions
 
-- Which internal events may become construction events?
-- Which external anchors are admissible?
-- Which validator failures block shared-reality publication?
-- Which constructability proofs are required before `v0.92`?
+- Which additional runtime event families may become construction events?
+- Which additional external anchor kinds are admissible?
+- Which WP-07A CSM component should host the validator?
+- Which additional constructability proofs are required before `v0.92`?
 
 ## Dependencies
 
@@ -50,6 +72,14 @@ Out of scope:
 - Validate that provisional claims cannot become public truth without anchors.
 - Require implemented proof or evidence-backed blocker status for missing validators.
 
+Focused proof commands:
+
+```text
+cargo test --manifest-path adl/Cargo.toml runtime_v2_constructability_anchor_validator -- --nocapture
+cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_constructability_anchor_validator -- --nocapture
+adl/target/debug/adl runtime-v2 constructability-anchor-validator --input .adl/local-artifacts/wp10-constructability/anchor-validator.json --out .adl/local-artifacts/wp10-constructability/validated-anchor-decision.json
+```
+
 ## v0.92 Consumption
 
 `v0.92` may consume Constructability only as a reviewed boundary and proven or
@@ -58,6 +88,6 @@ reality.
 
 ## Non-Goals
 
-- No runtime gate implementation.
+- No WP-07A CSM supervisor-hosting claim.
 - No universal epistemic authority claim.
 - No public truth claim without anchors.

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
@@ -16,6 +16,7 @@ changed_release_gate_surfaces:
   - adl/tests/cli_smoke.rs
   - adl/tools/run_owner_validation_lane.sh
   - adl/tools/test_owner_validation_lane.sh
+  - adl/tools/test_prompt_template_wrappers_no_implicit_cargo.sh
   - docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md
 evidence:
   - "Focused constructability validator contract, command, and compiled CLI smoke tests passed locally."
@@ -23,6 +24,7 @@ evidence:
   - "Bounded pre-PR review passed after all actionable findings were fixed and retested."
   - "Exact runtime owner lane passed on CodeBuild XLARGE at commit 1015f6e95: bash adl/tools/run_owner_validation_lane.sh runtime --build completed successfully in 297.3 seconds."
   - "The owner-lane contract test passed locally and now requires exact normalized parity between all 28 installer-default binaries and the build plan."
+  - "The prompt-template wrapper isolation test passed with finish-time owner-binary overrides present after the fixture explicitly cleared inherited resolver variables."
   - "The explicit full-nextest diagnostic was stopped after unrelated Ollama, CSM OTLP loopback, and live GitHub publication tests failed; its retained log demonstrates that the local full profile is not hermetic for this issue."
   - "The exact containerized Nessus owner-lane rerun at commit 1015f6e95 failed after 673 seconds with no space left on device while building the ADL library archive; it is retained as negative platform evidence and is not used as validation proof."
 non_claims:

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
@@ -21,8 +21,12 @@ evidence:
   - "Focused constructability validator contract, command, and compiled CLI smoke tests passed locally."
   - "Clippy passed for the ADL library and binary with warnings denied."
   - "Bounded pre-PR review passed after all actionable findings were fixed and retested."
+  - "Exact runtime owner lane passed on CodeBuild XLARGE at commit 1015f6e95: bash adl/tools/run_owner_validation_lane.sh runtime --build completed successfully in 297.3 seconds."
+  - "The owner-lane contract test passed locally and now requires exact normalized parity between all 28 installer-default binaries and the build plan."
   - "The explicit full-nextest diagnostic was stopped after unrelated Ollama, CSM OTLP loopback, and live GitHub publication tests failed; its retained log demonstrates that the local full profile is not hermetic for this issue."
+  - "The exact containerized Nessus owner-lane rerun at commit 1015f6e95 failed after 673 seconds with no space left on device while building the ADL library archive; it is retained as negative platform evidence and is not used as validation proof."
 non_claims:
   - "This disposition does not claim that the mixed live full-nextest profile passed locally."
+  - "This disposition does not claim that the Nessus owner-lane run passed."
   - "This disposition does not claim that post-push GitHub checks have completed."
   - "This disposition does not claim that issue #4693 is merged or closed."

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
@@ -1,0 +1,26 @@
+schema_version: adl.release_gate_disposition.v1
+issue: 4693
+disposition: approved_with_runtime_owner_lane_proof
+reviewer_or_review_mode: bounded runtime owner-lane review after broad runtime-surface escalation
+focused_validation_run: bash adl/tools/run_owner_validation_lane.sh runtime --build
+residual_ci_proof_required_before_merge: required
+changed_release_gate_surfaces:
+  - adl/src/cli/runtime_v2_cmd/commands.rs
+  - adl/src/cli/runtime_v2_cmd/helpers.rs
+  - adl/src/cli/runtime_v2_cmd/tests.rs
+  - adl/src/cli/usage.rs
+  - adl/src/runtime_v2/constructability_anchor_validator.rs
+  - adl/src/runtime_v2/mod.rs
+  - adl/src/runtime_v2/tests.rs
+  - adl/src/runtime_v2/tests/constructability_anchor_validator.rs
+  - adl/tests/cli_smoke.rs
+  - docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md
+evidence:
+  - "Focused constructability validator contract, command, and compiled CLI smoke tests passed locally."
+  - "Clippy passed for the ADL library and binary with warnings denied."
+  - "Bounded pre-PR review passed after all actionable findings were fixed and retested."
+  - "The explicit full-nextest diagnostic was stopped after unrelated Ollama, CSM OTLP loopback, and live GitHub publication tests failed; its retained log demonstrates that the local full profile is not hermetic for this issue."
+non_claims:
+  - "This disposition does not claim that the mixed live full-nextest profile passed locally."
+  - "This disposition does not claim that post-push GitHub checks have completed."
+  - "This disposition does not claim that issue #4693 is merged or closed."

--- a/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
+++ b/docs/milestones/v0.91.7/review/pr_finish_release_gate_disposition/ISSUE_4693_CONSTRUCTABILITY_ANCHOR_VALIDATOR_RUNTIME_OWNER_LANE_DISPOSITION.yaml
@@ -14,6 +14,8 @@ changed_release_gate_surfaces:
   - adl/src/runtime_v2/tests.rs
   - adl/src/runtime_v2/tests/constructability_anchor_validator.rs
   - adl/tests/cli_smoke.rs
+  - adl/tools/run_owner_validation_lane.sh
+  - adl/tools/test_owner_validation_lane.sh
   - docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md
 evidence:
   - "Focused constructability validator contract, command, and compiled CLI smoke tests passed locally."


### PR DESCRIPTION
Closes #4693

## Summary
Implemented a deterministic Runtime v2 constructability anchor validator and
exposed it through `adl runtime-v2 constructability-anchor-validator`. The
validator retains admissible-anchor pass evidence, rejects unanchored
shared-reality promotion fail-closed, enforces one decision per event, and
emits a canonical repository-relative JSON proof packet.

## Artifacts
- Runtime contract: `adl/src/runtime_v2/constructability_anchor_validator.rs`
- Focused contract tests: `adl/src/runtime_v2/tests/constructability_anchor_validator.rs`
- Runtime and CLI module wiring under `adl/src/runtime_v2/` and `adl/src/cli/runtime_v2_cmd/`
- Feature contract: `docs/milestones/v0.91.7/features/CONSTRUCTABILITY_GATE_v0.91.7.md`
- Local retained packets: `.adl/local-artifacts/wp10-constructability/anchor-validator.json` and `.adl/local-artifacts/wp10-constructability/channel-proof.json`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_constructability_anchor_validator -- --nocapture` - prove deterministic packet construction, admissible-anchor pass behavior, explicit fail-closed promotion behavior, caller-input validation, CLI path rejection, and compiled-process channel separation
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_dispatch_covers_help_and_subcommand_errors -- --nocapture` - prove Runtime v2 dispatch and error text include the constructability subcommand
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_registry -- --nocapture` - prove the constructability CLI tests are retained in the Runtime v2 regression registry
  - `cargo build --manifest-path adl/Cargo.toml --bin adl` - build the integrated ADL binary containing the Runtime v2 subcommand
  - `cargo clippy --manifest-path adl/Cargo.toml --lib --bin adl -- -D warnings` - reject warnings and lint defects across the touched library and ADL binary integration surfaces
  - `adl/target/debug/adl runtime-v2 constructability-anchor-validator --input .adl/local-artifacts/wp10-constructability/anchor-validator.json --out .adl/local-artifacts/wp10-constructability/validated-anchor-decision.json` - validate caller-supplied packet input and emit retained canonical output through the compiled CLI
  - `cmp -s .adl/local-artifacts/wp10-constructability/anchor-validator.json .adl/local-artifacts/wp10-constructability/channel-proof.json` - prove repeated CLI executions emit byte-identical canonical JSON
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check` - verify Rust formatting
  - `git diff --check` - verify whitespace and patch hygiene
  - `bash adl/tools/test_owner_validation_lane.sh` - prove the owner validation build plan exactly matches all installer-default binaries and preserve the owner compatibility contracts
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build` - prove the broad runtime owner lane on CodeBuild XLARGE using the fixed builder image and retained target/S3 cache posture
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build` - record containerized Nessus negative platform evidence after cleanup and rerun
- Results:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_constructability_anchor_validator -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_dispatch_covers_help_and_subcommand_errors -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_feature_proof_coverage_validates_runtime_v2_cli_regression_registry -- --nocapture`: PASS
  - `cargo build --manifest-path adl/Cargo.toml --bin adl`: PASS
  - `cargo clippy --manifest-path adl/Cargo.toml --lib --bin adl -- -D warnings`: PASS
  - `adl/target/debug/adl runtime-v2 constructability-anchor-validator --input .adl/local-artifacts/wp10-constructability/anchor-validator.json --out .adl/local-artifacts/wp10-constructability/validated-anchor-decision.json`: PASS
  - `cmp -s .adl/local-artifacts/wp10-constructability/anchor-validator.json .adl/local-artifacts/wp10-constructability/channel-proof.json`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`: PASS
  - `git diff --check`: PASS
  - `bash adl/tools/test_owner_validation_lane.sh`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build`: PASS
  - `bash adl/tools/run_owner_validation_lane.sh runtime --build`: FAIL: no space left on device after 673 seconds; not validation proof

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-4693__v0-91-7-wp-10-constructability-implement-constructability-anchor-validator/sip.md
- Output card: .adl/v0.91.7/tasks/issue-4693__v0-91-7-wp-10-constructability-implement-constructability-anchor-validator/sor.md
- Idempotency-Key: v0-91-7-wp-10-constructability-implement-constructability-anchor-validator-adl-src-cli-runtime-v2-cmd-commands-rs-adl-src-cli-runtime-v2-cmd-helpers-rs-adl-src-cli-runtime-v2-cmd-tests-rs-adl-src-cli-usage-rs-adl-src-runtime-v2-constructability-anchor-validator-rs-adl-src-runtime-v2-mod-rs-adl-src-runtime-v2-tests-rs-adl-src-runtime-v2-tests-constructability-anchor-validator-rs-adl-tests-cli-smoke-rs-adl-tools-run-owner-validation-lane-sh-adl-tools-test-owner-validation-lane-sh-adl-tools-test-prompt-template-wrappers-no-implicit-cargo-sh-docs-milestones-v0-91-7-features-constructability-gate-v0-91-7-md-docs-milestones-v0-91-7-review-pr-finish-release-gate-disposition-issue-4693-constructability-anchor-validator-runtime-owner-lane-disposition-yaml-adl-v0-91-7-tasks-issue-4693-v0-91-7-wp-10-constructability-implement-constructability-anchor-validator-sip-md-adl-v0-91-7-tasks-issue-4693-v0-91-7-wp-10-constructability-implement-constructability-anchor-validator-sor-md