### PR TITLE
Fix canonical remote builder nextest image

### DIFF
--- a/adl/tools/setup_adl_builder_image.sh
+++ b/adl/tools/setup_adl_builder_image.sh
@@ -11,7 +11,7 @@ Usage:
 Options:
   --image-uri <uri>          Explicit image URI. Required for --write-env unless --ecr-repository is used.
   --ecr-repository <name>    ECR repository name. Defaults to adl-builder.
-  --tag <tag>                Image tag. Defaults to v0.91.7.
+  --tag <tag>                Image tag. Defaults to v0.91.7-fixed.
   --region <region>          AWS region. Defaults to us-west-2.
   --aws-profile <profile>    AWS profile. Defaults to agent-logic-admin.
   --docker-bin <path>        Docker-compatible CLI. Defaults to docker.
@@ -40,7 +40,7 @@ EOF
 
 IMAGE_URI="${ADL_BUILDER_IMAGE:-}"
 ECR_REPOSITORY="${ADL_BUILDER_ECR_REPOSITORY:-adl-builder}"
-TAG="${ADL_BUILDER_IMAGE_TAG:-v0.91.7}"
+TAG="${ADL_BUILDER_IMAGE_TAG:-v0.91.7-fixed}"
 REGION="${ADL_AWS_REGION:-us-west-2}"
 AWS_PROFILE_VALUE="${AWS_PROFILE:-agent-logic-admin}"
 DOCKER_BIN="${DOCKER_BIN:-docker}"

--- a/adl/tools/setup_aws_codefriend_build_resources.sh
+++ b/adl/tools/setup_aws_codefriend_build_resources.sh
@@ -16,7 +16,7 @@ Options:
   --source-location <url>         CodeBuild GitHub source URL.
   --compute-type <type>           CodeBuild compute type. Default: BUILD_GENERAL1_LARGE.
   --image-uri <uri>               CodeBuild environment image. Default: ADL_AWS_CODEFRIEND_IMAGE,
-                                  then aws/codebuild/standard:7.0.
+                                  then adl-builder:v0.91.7-fixed.
   --cache-bucket <bucket>         S3 cache bucket. Default: adl-codefriend-build-cache.
   --cache-prefix <prefix>         S3 cache prefix. Default: codebuild/cache.
   --github-role-name <name>       OIDC role for GitHub Actions.
@@ -43,7 +43,7 @@ PROJECT_NAME="${ADL_AWS_CODEFRIEND_CODEBUILD_PROJECT:-adl-codefriend-build}"
 REPO="danielbaustin/agent-design-language"
 SOURCE_LOCATION="https://github.com/danielbaustin/agent-design-language.git"
 COMPUTE_TYPE="${ADL_AWS_CODEFRIEND_COMPUTE_TYPE:-BUILD_GENERAL1_LARGE}"
-IMAGE_URI="${ADL_AWS_CODEFRIEND_IMAGE:-aws/codebuild/standard:7.0}"
+IMAGE_URI="${ADL_AWS_CODEFRIEND_IMAGE:-adl-builder:v0.91.7-fixed}"
 CACHE_BUCKET="${ADL_AWS_CODEFRIEND_CACHE_BUCKET:-adl-codefriend-build-cache}"
 CACHE_PREFIX="${ADL_AWS_CODEFRIEND_CACHE_PREFIX:-codebuild/cache}"
 GITHUB_ROLE_NAME="adl-codefriend-github-actions-build-role"

--- a/adl/tools/test_adl_builder_image.sh
+++ b/adl/tools/test_adl_builder_image.sh
@@ -39,6 +39,10 @@ assert_has "$config" "docker_config=.adl/local/docker-config"
 assert_has "$config" "platform=linux/amd64"
 assert_has "$config" "aws_profile=agent-logic-admin"
 
+default_config="$TMP/default-config.txt"
+bash "$SCRIPT" --print-config >"$default_config"
+assert_has "$default_config" "builder_image=adl-builder:v0.91.7-fixed"
+
 env_file="$TMP/builder.env"
 bash "$SCRIPT" --image-uri "example.invalid/adl-builder:test" --write-env "$env_file"
 assert_has "$env_file" "ADL_BUILDER_IMAGE=example.invalid/adl-builder:test"

--- a/adl/tools/test_run_aws_codefriend_build_lane.sh
+++ b/adl/tools/test_run_aws_codefriend_build_lane.sh
@@ -203,7 +203,7 @@ assert_has "$SETUP_SCRIPT" "--compute-type <type>"
 assert_has "$SETUP_SCRIPT" "--image-uri <uri>"
 assert_has "$SETUP_SCRIPT" "--cache-bucket <bucket>"
 assert_has "$SETUP_SCRIPT" 'CACHE_BUCKET="${ADL_AWS_CODEFRIEND_CACHE_BUCKET:-adl-codefriend-build-cache}"'
-assert_has "$SETUP_SCRIPT" 'IMAGE_URI="${ADL_AWS_CODEFRIEND_IMAGE:-aws/codebuild/standard:7.0}"'
+assert_has "$SETUP_SCRIPT" 'IMAGE_URI="${ADL_AWS_CODEFRIEND_IMAGE:-adl-builder:v0.91.7-fixed}"'
 assert_has "$SETUP_SCRIPT" 'COMPUTE_TYPE="${ADL_AWS_CODEFRIEND_COMPUTE_TYPE:-BUILD_GENERAL1_LARGE}"'
 assert_has "$SETUP_SCRIPT" '"computeType": compute_type'
 assert_has "$SETUP_SCRIPT" '"image": image_uri'
@@ -277,7 +277,7 @@ bash "$SETUP_SCRIPT" \
   --region us-west-2 \
   --project-name adl-codefriend-build \
   --compute-type BUILD_GENERAL1_XLARGE \
-  --image-uri example.invalid/adl-builder:v0.91.7 \
+  --image-uri example.invalid/adl-builder:v0.91.7-fixed \
   --cache-bucket adl-codefriend-build-cache \
   --cache-prefix codebuild/cache \
   --artifact-dir "$TMP/setup-artifacts" >"$TMP/setup.out"
@@ -292,7 +292,7 @@ from pathlib import Path
 project = json.loads(Path(sys.argv[1]).read_text())
 buildspec = project["source"]["buildspec"]
 assert project["environment"]["computeType"] == "BUILD_GENERAL1_XLARGE"
-assert project["environment"]["image"] == "example.invalid/adl-builder:v0.91.7"
+assert project["environment"]["image"] == "example.invalid/adl-builder:v0.91.7-fixed"
 assert project["environment"]["imagePullCredentialsType"] == "CODEBUILD"
 assert project["cache"]["type"] == "LOCAL"
 assert project["cache"]["modes"] == ["LOCAL_SOURCE_CACHE", "LOCAL_CUSTOM_CACHE"]
@@ -336,7 +336,7 @@ bash "$SETUP_SCRIPT" \
   --region us-west-2 \
   --project-name adl-codefriend-build \
   --compute-type BUILD_GENERAL1_XLARGE \
-  --image-uri 000000000000.dkr.ecr.us-west-2.amazonaws.com/adl-builder:v0.91.7 \
+  --image-uri 000000000000.dkr.ecr.us-west-2.amazonaws.com/adl-builder:v0.91.7-fixed \
   --cache-bucket adl-codefriend-build-cache \
   --cache-prefix codebuild/cache \
   --artifact-dir "$TMP/setup-ecr-artifacts" >"$TMP/setup-ecr.out"
@@ -349,7 +349,7 @@ from pathlib import Path
 
 project = json.loads(Path(sys.argv[1]).read_text())
 policy = json.loads(Path(sys.argv[2]).read_text())
-assert project["environment"]["image"] == "000000000000.dkr.ecr.us-west-2.amazonaws.com/adl-builder:v0.91.7"
+assert project["environment"]["image"] == "000000000000.dkr.ecr.us-west-2.amazonaws.com/adl-builder:v0.91.7-fixed"
 assert project["environment"]["imagePullCredentialsType"] == "SERVICE_ROLE"
 actions = {
     action

--- a/docs/tooling/ADL_BUILDER_IMAGE.md
+++ b/docs/tooling/ADL_BUILDER_IMAGE.md
@@ -31,7 +31,7 @@ For the Agent Logic AWS account, use the business profile:
 AWS_PROFILE=agent-logic-admin \
 adl/tools/setup_adl_builder_image.sh \
   --ecr-repository adl-builder \
-  --tag v0.91.7 \
+  --tag v0.91.7-fixed \
   --ensure-ecr \
   --push \
   --write-env .adl/local/adl-builder-image.env
@@ -51,14 +51,14 @@ If Docker's direct ECR push path is unreliable from the operator machine, use
 S3 as the transit layer:
 
 ```sh
-docker save <image-uri> -o .adl/local/builder-image/adl-builder-v0.91.7-amd64.tar
+docker save <image-uri> -o .adl/local/builder-image/adl-builder-v0.91.7-fixed-amd64.tar
 AWS_PROFILE=agent-logic-admin \
 aws s3 cp \
-  .adl/local/builder-image/adl-builder-v0.91.7-amd64.tar \
-  s3://adl-codefriend-build-cache/builder-images/adl-builder/v0.91.7/amd64/adl-builder-v0.91.7-amd64.tar
+  .adl/local/builder-image/adl-builder-v0.91.7-fixed-amd64.tar \
+  s3://adl-codefriend-build-cache/builder-images/adl-builder/v0.91.7-fixed/amd64/adl-builder-v0.91.7-fixed-amd64.tar
 AWS_PROFILE=agent-logic-admin \
 adl/tools/import_adl_builder_image_from_s3_to_ecr.sh \
-  --s3-uri s3://adl-codefriend-build-cache/builder-images/adl-builder/v0.91.7/amd64/adl-builder-v0.91.7-amd64.tar \
+  --s3-uri s3://adl-codefriend-build-cache/builder-images/adl-builder/v0.91.7-fixed/amd64/adl-builder-v0.91.7-fixed-amd64.tar \
   --image-uri <ecr-image-uri> \
   --ensure-role-policy \
   --create-project \
@@ -67,6 +67,13 @@ adl/tools/import_adl_builder_image_from_s3_to_ecr.sh \
 
 That importer uses a privileged, purpose-specific CodeBuild project to
 `docker load` the S3 tar and push it to ECR from inside AWS.
+
+The canonical ADL remote-build image tag for the repaired v0.91.7 toolchain is
+`v0.91.7-fixed`. Do not publish or select the stale `v0.91.7` tag for
+nextest-backed remote validation lanes; that tag does not carry the retained
+post-repair contract. Every canonical image build must prove
+`cargo nextest --version` inside the image before CodeBuild, Spot, Nessus, or
+local builder-image mode uses it.
 
 The importer project is `adl-builder-image-import`. It uses the existing
 CodeBuild service role, the existing `/aws/codebuild/adl-codefriend-build` log

--- a/docs/tooling/REMOTE_BUILD_HOW_TO.md
+++ b/docs/tooling/REMOTE_BUILD_HOW_TO.md
@@ -28,6 +28,9 @@ Rules:
   build job.
 - The ADL builder image must include `cargo-nextest`; PR-fast Rust lanes depend
   on it.
+- Use the canonical repaired tag, `adl-builder:v0.91.7-fixed`, or an ECR image
+  URI that points at that same image build. Do not route nextest-backed remote
+  validation through the stale `v0.91.7` builder tag.
 - Put scratch outputs under ignored `.adl/local-artifacts/`.
 - Record the platform, cache posture, benchmark line, and proof artifact path.
 


### PR DESCRIPTION
## Summary
- switch canonical ADL builder image defaults from stale `v0.91.7` / AWS standard fallback to `v0.91.7-fixed`
- make CodeBuild resource setup default to the fixed builder image when no override is supplied
- update builder image docs and remote-build how-to so nextest-backed lanes use the repaired image contract

## Review
- Bounded pre-PR review agent found the CodeBuild fallback still pointed at `aws/codebuild/standard:7.0`; fixed in this PR.

## Validation
- `bash adl/tools/test_adl_builder_image.sh`
- `bash adl/tools/test_run_aws_codefriend_build_lane.sh`
- `git diff --check`

Closes #5166
