### PR TITLE
[v0.91.7][WP-07][runtime] Define deterministic core and nondeterministic shell boundary

### DIFF
--- a/adl-runtime/Cargo.lock
+++ b/adl-runtime/Cargo.lock
@@ -7,7 +7,63 @@ name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
  "serde",
+ "serde_jcs",
  "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -15,6 +71,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
@@ -39,6 +101,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "serde"
@@ -71,6 +139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +160,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -95,10 +185,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "zmij"

--- a/adl-runtime/Cargo.toml
+++ b/adl-runtime/Cargo.toml
@@ -12,3 +12,5 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
+serde_jcs = "0.2"

--- a/adl-runtime/src/determinism.rs
+++ b/adl-runtime/src/determinism.rs
@@ -1,0 +1,827 @@
+//! Deterministic-core and nondeterministic-shell boundary contracts.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+pub const CSM_DETERMINISM_BOUNDARY_SCHEMA: &str = "adl.csm.determinism_boundary.v1";
+pub const CSM_SHELL_INPUT_EVENT_SCHEMA: &str = "adl.csm.shell_input_event.v2";
+pub const CSM_CORE_DECISION_REQUEST_SCHEMA: &str = "adl.csm.core_decision_request.v1";
+pub const CSM_CORE_DECISION_SCHEMA: &str = "adl.csm.core_decision.v1";
+pub const CSM_QUARANTINE_SCHEMA: &str = "adl.csm.nondeterminism_quarantine.v1";
+pub const CSM_CYCLE_BOUNDARY_RECORD_SCHEMA: &str = "adl.csm.cycle_determinism_boundary.v2";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeterministicCoreComponent {
+    SchedulerAdmission,
+    ReasoningRuntime,
+    AeeGovernedExecution,
+    CheckpointVersionTransition,
+    LifelogOrdering,
+}
+
+impl DeterministicCoreComponent {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SchedulerAdmission => "scheduler_admission",
+            Self::ReasoningRuntime => "reasoning_runtime",
+            Self::AeeGovernedExecution => "aee_governed_execution",
+            Self::CheckpointVersionTransition => "checkpoint_version_transition",
+            Self::LifelogOrdering => "lifelog_ordering",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeterministicCoreInputKind {
+    CycleId,
+    WorkflowId,
+    GraphId,
+    ActionId,
+    CheckpointVersion,
+    LifelogSequence,
+    PolicyDecision,
+}
+
+impl DeterministicCoreInputKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CycleId => "cycle_id",
+            Self::WorkflowId => "workflow_id",
+            Self::GraphId => "graph_id",
+            Self::ActionId => "action_id",
+            Self::CheckpointVersion => "checkpoint_version",
+            Self::LifelogSequence => "lifelog_sequence",
+            Self::PolicyDecision => "policy_decision",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NondeterministicShellClass {
+    ChronosenseNtp,
+    AwsCloud,
+    NetworkIo,
+    WallClock,
+    LocalProcessState,
+    ObservabilitySink,
+    ProviderModelIo,
+}
+
+impl NondeterministicShellClass {
+    pub const ALL: [Self; 7] = [
+        Self::ChronosenseNtp,
+        Self::AwsCloud,
+        Self::NetworkIo,
+        Self::WallClock,
+        Self::LocalProcessState,
+        Self::ObservabilitySink,
+        Self::ProviderModelIo,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ChronosenseNtp => "chronosense_ntp",
+            Self::AwsCloud => "aws_cloud",
+            Self::NetworkIo => "network_io",
+            Self::WallClock => "wall_clock",
+            Self::LocalProcessState => "local_process_state",
+            Self::ObservabilitySink => "observability_sink",
+            Self::ProviderModelIo => "provider_model_io",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationConfidence {
+    High,
+    Medium,
+    Low,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CsmDeterminismBoundaryContract {
+    pub schema: String,
+    pub deterministic_core: Vec<DeterministicCoreComponent>,
+    pub deterministic_input_kinds: Vec<DeterministicCoreInputKind>,
+    pub nondeterministic_shell: Vec<NondeterministicShellClass>,
+    pub boundary_rule: String,
+}
+
+impl Default for CsmDeterminismBoundaryContract {
+    fn default() -> Self {
+        Self {
+            schema: CSM_DETERMINISM_BOUNDARY_SCHEMA.to_string(),
+            deterministic_core: vec![
+                DeterministicCoreComponent::SchedulerAdmission,
+                DeterministicCoreComponent::ReasoningRuntime,
+                DeterministicCoreComponent::AeeGovernedExecution,
+                DeterministicCoreComponent::CheckpointVersionTransition,
+                DeterministicCoreComponent::LifelogOrdering,
+            ],
+            deterministic_input_kinds: vec![
+                DeterministicCoreInputKind::CycleId,
+                DeterministicCoreInputKind::WorkflowId,
+                DeterministicCoreInputKind::GraphId,
+                DeterministicCoreInputKind::ActionId,
+                DeterministicCoreInputKind::CheckpointVersion,
+                DeterministicCoreInputKind::LifelogSequence,
+                DeterministicCoreInputKind::PolicyDecision,
+            ],
+            nondeterministic_shell: NondeterministicShellClass::ALL.to_vec(),
+            boundary_rule: "nondeterministic shell values must be captured as retained typed input events before they influence deterministic core decisions".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CapturedShellInputEvent {
+    pub schema: String,
+    pub event_id: String,
+    pub shell_class: NondeterministicShellClass,
+    pub source: String,
+    pub observed_time: String,
+    pub confidence: ObservationConfidence,
+    pub retention_location: String,
+    pub value_fingerprint: String,
+    pub payload: Value,
+}
+
+impl CapturedShellInputEvent {
+    pub fn new(
+        event_id: impl Into<String>,
+        shell_class: NondeterministicShellClass,
+        source: impl Into<String>,
+        observed_time: impl Into<String>,
+        confidence: ObservationConfidence,
+        retention_location: impl Into<String>,
+        payload: Value,
+    ) -> Result<Self, DeterminismBoundaryError> {
+        let canonical = canonical_payload_bytes(&payload)?;
+        let payload: Value = serde_json::from_slice(&canonical).map_err(|error| {
+            DeterminismBoundaryError::Serialization(format!(
+                "failed normalizing retained shell payload: {error}"
+            ))
+        })?;
+        let value = canonical_payload_bytes(&payload)?;
+        let event = Self {
+            schema: CSM_SHELL_INPUT_EVENT_SCHEMA.to_string(),
+            event_id: event_id.into(),
+            shell_class,
+            source: source.into(),
+            observed_time: observed_time.into(),
+            confidence,
+            retention_location: retention_location.into(),
+            value_fingerprint: sha256_hex(&value),
+            payload,
+        };
+        event.validate()?;
+        Ok(event)
+    }
+
+    pub fn validate(&self) -> Result<(), DeterminismBoundaryError> {
+        require_non_empty("event_id", &self.event_id)?;
+        require_non_empty("source", &self.source)?;
+        require_non_empty("observed_time", &self.observed_time)?;
+        require_non_empty("retention_location", &self.retention_location)?;
+        if self.schema != CSM_SHELL_INPUT_EVENT_SCHEMA {
+            return Err(DeterminismBoundaryError::Invalid(format!(
+                "shell input event schema must be {CSM_SHELL_INPUT_EVENT_SCHEMA}"
+            )));
+        }
+        let expected_location = format!(
+            "determinism_boundary.json#captured_shell_events/{}",
+            self.event_id
+        );
+        if self.retention_location != expected_location {
+            return Err(DeterminismBoundaryError::Invalid(format!(
+                "shell input event {} has invalid retention location",
+                self.event_id
+            )));
+        }
+        validate_sha256("value_fingerprint", &self.value_fingerprint)
+            .and_then(|_| self.verify_payload())
+    }
+
+    pub fn verify_payload(&self) -> Result<(), DeterminismBoundaryError> {
+        let actual = sha256_hex(&canonical_payload_bytes(&self.payload)?);
+        if actual != self.value_fingerprint {
+            return Err(DeterminismBoundaryError::Invalid(format!(
+                "retained payload fingerprint mismatch for {}: expected {}, recomputed {}",
+                self.event_id, self.value_fingerprint, actual
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "input_domain", rename_all = "snake_case")]
+pub enum CoreDecisionInput {
+    Deterministic {
+        kind: DeterministicCoreInputKind,
+        value: String,
+    },
+    CapturedShell {
+        shell_class: NondeterministicShellClass,
+        event_id: String,
+        value_fingerprint: String,
+    },
+}
+
+impl CoreDecisionInput {
+    pub fn deterministic(kind: DeterministicCoreInputKind, value: impl Into<String>) -> Self {
+        Self::Deterministic {
+            kind,
+            value: value.into(),
+        }
+    }
+
+    pub fn captured(event: &CapturedShellInputEvent) -> Self {
+        Self::CapturedShell {
+            shell_class: event.shell_class,
+            event_id: event.event_id.clone(),
+            value_fingerprint: event.value_fingerprint.clone(),
+        }
+    }
+
+    fn sort_key(&self) -> String {
+        match self {
+            Self::Deterministic { kind, value } => {
+                format!("core\0{}\0{value}", kind.as_str())
+            }
+            Self::CapturedShell {
+                shell_class,
+                event_id,
+                value_fingerprint,
+            } => format!(
+                "shell\0{}\0{event_id}\0{value_fingerprint}",
+                shell_class.as_str()
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CoreDecisionRequest {
+    pub schema: String,
+    pub decision_id: String,
+    pub component: DeterministicCoreComponent,
+    pub inputs: Vec<CoreDecisionInput>,
+}
+
+impl CoreDecisionRequest {
+    pub fn new(
+        decision_id: impl Into<String>,
+        component: DeterministicCoreComponent,
+        inputs: Vec<CoreDecisionInput>,
+    ) -> Self {
+        Self {
+            schema: CSM_CORE_DECISION_REQUEST_SCHEMA.to_string(),
+            decision_id: decision_id.into(),
+            component,
+            inputs,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeterministicCoreDecision {
+    pub schema: String,
+    pub decision_id: String,
+    pub component: DeterministicCoreComponent,
+    pub cited_shell_events: Vec<String>,
+    pub deterministic_digest: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EventClassMismatch {
+    pub event_id: String,
+    pub requested_class: NondeterministicShellClass,
+    pub captured_class: NondeterministicShellClass,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NondeterminismQuarantine {
+    pub schema: String,
+    pub decision_id: String,
+    pub component: DeterministicCoreComponent,
+    pub reason: String,
+    pub missing_event_ids: Vec<String>,
+    pub class_mismatches: Vec<EventClassMismatch>,
+    pub fingerprint_mismatches: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CsmCycleDeterminismBoundaryRecord {
+    pub schema: String,
+    pub cycle_id: String,
+    pub boundary_contract: CsmDeterminismBoundaryContract,
+    pub captured_shell_events: Vec<CapturedShellInputEvent>,
+    pub decision_requests: Vec<CoreDecisionRequest>,
+    pub decisions: Vec<DeterministicCoreDecision>,
+}
+
+impl CsmCycleDeterminismBoundaryRecord {
+    pub fn new(
+        cycle_id: impl Into<String>,
+        captured_shell_events: Vec<CapturedShellInputEvent>,
+        decision_requests: Vec<CoreDecisionRequest>,
+        decisions: Vec<DeterministicCoreDecision>,
+    ) -> Self {
+        Self {
+            schema: CSM_CYCLE_BOUNDARY_RECORD_SCHEMA.to_string(),
+            cycle_id: cycle_id.into(),
+            boundary_contract: CsmDeterminismBoundaryContract::default(),
+            captured_shell_events,
+            decision_requests,
+            decisions,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), DeterminismBoundaryError> {
+        if self.schema != CSM_CYCLE_BOUNDARY_RECORD_SCHEMA {
+            return Err(DeterminismBoundaryError::Invalid(format!(
+                "cycle boundary schema must be {CSM_CYCLE_BOUNDARY_RECORD_SCHEMA}"
+            )));
+        }
+        require_non_empty("cycle_id", &self.cycle_id)?;
+        let shell_classes = self
+            .captured_shell_events
+            .iter()
+            .map(|event| event.shell_class)
+            .collect::<BTreeSet<_>>();
+        for shell_class in NondeterministicShellClass::ALL {
+            if !shell_classes.contains(&shell_class) {
+                return Err(DeterminismBoundaryError::Invalid(format!(
+                    "cycle boundary is missing {} shell evidence",
+                    shell_class.as_str()
+                )));
+            }
+        }
+        let components = self
+            .decisions
+            .iter()
+            .map(|decision| decision.component)
+            .collect::<BTreeSet<_>>();
+        for component in &self.boundary_contract.deterministic_core {
+            if !components.contains(component) {
+                return Err(DeterminismBoundaryError::Invalid(format!(
+                    "cycle boundary is missing {} core decision",
+                    component.as_str()
+                )));
+            }
+        }
+        if self.decision_requests.len() != self.decisions.len() {
+            return Err(DeterminismBoundaryError::Invalid(
+                "cycle boundary must retain one request per accepted decision".to_string(),
+            ));
+        }
+        self.replay()?;
+        Ok(())
+    }
+
+    pub fn replay(&self) -> Result<(), DeterminismBoundaryError> {
+        for request in &self.decision_requests {
+            let expected = self
+                .decisions
+                .iter()
+                .find(|decision| decision.decision_id == request.decision_id)
+                .ok_or_else(|| {
+                    DeterminismBoundaryError::Invalid(format!(
+                        "missing retained decision for request {}",
+                        request.decision_id
+                    ))
+                })?;
+            replay_core_decision(request.clone(), &self.captured_shell_events, expected)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn evaluate_core_decision(
+    request: CoreDecisionRequest,
+    captured_events: &[CapturedShellInputEvent],
+) -> Result<DeterministicCoreDecision, Box<NondeterminismQuarantine>> {
+    if request.schema != CSM_CORE_DECISION_REQUEST_SCHEMA || request.decision_id.trim().is_empty() {
+        return Err(quarantine(&request, "invalid core decision request"));
+    }
+    let captured_by_id = match validate_captured_events(captured_events) {
+        Ok(index) => index,
+        Err(error) => {
+            return Err(quarantine(
+                &request,
+                format!("invalid captured shell event ledger: {error}"),
+            ));
+        }
+    };
+
+    let mut missing_event_ids = BTreeSet::new();
+    let mut fingerprint_mismatches = BTreeSet::new();
+    let mut class_mismatches = Vec::new();
+    for input in &request.inputs {
+        if let CoreDecisionInput::CapturedShell {
+            shell_class,
+            event_id,
+            value_fingerprint,
+        } = input
+        {
+            match captured_by_id.get(event_id) {
+                None => {
+                    missing_event_ids.insert(event_id.clone());
+                }
+                Some(event) => {
+                    if event.shell_class != *shell_class {
+                        class_mismatches.push(EventClassMismatch {
+                            event_id: event_id.clone(),
+                            requested_class: *shell_class,
+                            captured_class: event.shell_class,
+                        });
+                    }
+                    if event.value_fingerprint != *value_fingerprint {
+                        fingerprint_mismatches.insert(event_id.clone());
+                    }
+                }
+            }
+        }
+    }
+    class_mismatches.sort_by(|left, right| left.event_id.cmp(&right.event_id));
+    if !missing_event_ids.is_empty()
+        || !class_mismatches.is_empty()
+        || !fingerprint_mismatches.is_empty()
+    {
+        return Err(Box::new(NondeterminismQuarantine {
+            schema: CSM_QUARANTINE_SCHEMA.to_string(),
+            decision_id: request.decision_id,
+            component: request.component,
+            reason: "core decision cited missing, reclassified, or mutated shell evidence"
+                .to_string(),
+            missing_event_ids: missing_event_ids.into_iter().collect(),
+            class_mismatches,
+            fingerprint_mismatches: fingerprint_mismatches.into_iter().collect(),
+        }));
+    }
+
+    Ok(DeterministicCoreDecision {
+        schema: CSM_CORE_DECISION_SCHEMA.to_string(),
+        decision_id: request.decision_id.clone(),
+        component: request.component,
+        cited_shell_events: cited_shell_events(&request),
+        deterministic_digest: decision_digest(&request, &captured_by_id),
+    })
+}
+
+pub fn replay_core_decision(
+    request: CoreDecisionRequest,
+    captured_events: &[CapturedShellInputEvent],
+    expected: &DeterministicCoreDecision,
+) -> Result<(), DeterminismBoundaryError> {
+    let actual = evaluate_core_decision(request, captured_events).map_err(|quarantine| {
+        DeterminismBoundaryError::Quarantined(format!(
+            "replay quarantined decision {}: {}",
+            quarantine.decision_id, quarantine.reason
+        ))
+    })?;
+    if &actual != expected {
+        return Err(DeterminismBoundaryError::Invalid(format!(
+            "deterministic replay mismatch for decision {}",
+            expected.decision_id
+        )));
+    }
+    Ok(())
+}
+
+pub fn cycle_record_fingerprint(
+    record: &CsmCycleDeterminismBoundaryRecord,
+) -> Result<String, DeterminismBoundaryError> {
+    let value = serde_json::to_value(record).map_err(|error| {
+        DeterminismBoundaryError::Serialization(format!(
+            "failed serializing cycle boundary record: {error}"
+        ))
+    })?;
+    Ok(sha256_hex(&canonical_payload_bytes(&value)?))
+}
+
+pub fn verify_retained_cycle_record(
+    record: &CsmCycleDeterminismBoundaryRecord,
+    expected_fingerprint: &str,
+) -> Result<(), DeterminismBoundaryError> {
+    validate_sha256("expected cycle boundary fingerprint", expected_fingerprint)?;
+    let actual = cycle_record_fingerprint(record)?;
+    if actual != expected_fingerprint {
+        return Err(DeterminismBoundaryError::Invalid(
+            "retained cycle boundary fingerprint mismatch".to_string(),
+        ));
+    }
+    record.validate()
+}
+
+fn validate_captured_events(
+    captured_events: &[CapturedShellInputEvent],
+) -> Result<BTreeMap<String, CapturedShellInputEvent>, DeterminismBoundaryError> {
+    let mut captured_by_id = BTreeMap::new();
+    for event in captured_events {
+        event.validate()?;
+        if captured_by_id
+            .insert(event.event_id.clone(), event.clone())
+            .is_some()
+        {
+            return Err(DeterminismBoundaryError::Invalid(format!(
+                "duplicate captured shell event id {}",
+                event.event_id
+            )));
+        }
+    }
+    Ok(captured_by_id)
+}
+
+fn canonical_payload_bytes(payload: &Value) -> Result<Vec<u8>, DeterminismBoundaryError> {
+    serde_jcs::to_vec(payload).map_err(|error| {
+        DeterminismBoundaryError::Serialization(format!(
+            "failed RFC 8785 canonicalization of retained shell payload: {error}"
+        ))
+    })
+}
+
+fn decision_digest(
+    request: &CoreDecisionRequest,
+    captured_by_id: &BTreeMap<String, CapturedShellInputEvent>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(request.schema.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(request.decision_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(request.component.as_str().as_bytes());
+    let mut inputs = request.inputs.clone();
+    inputs.sort_by_key(CoreDecisionInput::sort_key);
+    for input in inputs {
+        hasher.update(b"\0input\0");
+        hasher.update(input.sort_key().as_bytes());
+        if let CoreDecisionInput::CapturedShell { event_id, .. } = input {
+            if let Some(event) = captured_by_id.get(&event_id) {
+                hasher.update(b"\0source\0");
+                hasher.update(event.source.as_bytes());
+                hasher.update(b"\0observed\0");
+                hasher.update(event.observed_time.as_bytes());
+                hasher.update(b"\0retained\0");
+                hasher.update(event.retention_location.as_bytes());
+            }
+        }
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn cited_shell_events(request: &CoreDecisionRequest) -> Vec<String> {
+    let mut cited = BTreeSet::new();
+    for input in &request.inputs {
+        if let CoreDecisionInput::CapturedShell { event_id, .. } = input {
+            cited.insert(event_id.clone());
+        }
+    }
+    cited.into_iter().collect()
+}
+
+fn quarantine(
+    request: &CoreDecisionRequest,
+    reason: impl Into<String>,
+) -> Box<NondeterminismQuarantine> {
+    Box::new(NondeterminismQuarantine {
+        schema: CSM_QUARANTINE_SCHEMA.to_string(),
+        decision_id: request.decision_id.clone(),
+        component: request.component,
+        reason: reason.into(),
+        missing_event_ids: Vec::new(),
+        class_mismatches: Vec::new(),
+        fingerprint_mismatches: Vec::new(),
+    })
+}
+
+fn require_non_empty(name: &str, value: &str) -> Result<(), DeterminismBoundaryError> {
+    if value.trim().is_empty() {
+        return Err(DeterminismBoundaryError::Invalid(format!(
+            "{name} must be non-empty"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256(name: &str, value: &str) -> Result<(), DeterminismBoundaryError> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(DeterminismBoundaryError::Invalid(format!(
+            "{name} must use sha256:<hex> format"
+        )));
+    };
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(DeterminismBoundaryError::Invalid(format!(
+            "{name} must contain a 64-character sha256 hex digest"
+        )));
+    }
+    Ok(())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(value))
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DeterminismBoundaryError {
+    Invalid(String),
+    Io(String),
+    Serialization(String),
+    Quarantined(String),
+}
+
+impl Display for DeterminismBoundaryError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(message)
+            | Self::Io(message)
+            | Self::Serialization(message)
+            | Self::Quarantined(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl Error for DeterminismBoundaryError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn captured_event(
+        event_id: &str,
+        shell_class: NondeterministicShellClass,
+        value: &str,
+    ) -> CapturedShellInputEvent {
+        CapturedShellInputEvent::new(
+            event_id,
+            shell_class,
+            format!("fixture::{event_id}"),
+            "2026-07-11T00:00:00Z",
+            ObservationConfidence::High,
+            format!("determinism_boundary.json#captured_shell_events/{event_id}"),
+            Value::String(value.to_string()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn contract_uses_typed_core_and_shell_classifications() {
+        let contract = CsmDeterminismBoundaryContract::default();
+        assert_eq!(
+            contract.nondeterministic_shell,
+            NondeterministicShellClass::ALL
+        );
+        assert!(contract
+            .deterministic_input_kinds
+            .contains(&DeterministicCoreInputKind::PolicyDecision));
+        assert!(!contract.boundary_rule.contains("string key"));
+    }
+
+    #[test]
+    fn scheduler_decision_replays_from_retained_typed_inputs() {
+        let chronosense = captured_event(
+            "chronosense-1",
+            NondeterministicShellClass::ChronosenseNtp,
+            r#"{"offset_ms":2}"#,
+        );
+        let wall_clock = captured_event(
+            "wall-clock-1",
+            NondeterministicShellClass::WallClock,
+            "2026-07-11T00:00:00Z",
+        );
+        let events = vec![chronosense.clone(), wall_clock.clone()];
+        let request = CoreDecisionRequest::new(
+            "scheduler-admit-cycle-1",
+            DeterministicCoreComponent::SchedulerAdmission,
+            vec![
+                CoreDecisionInput::deterministic(DeterministicCoreInputKind::CycleId, "cycle-1"),
+                CoreDecisionInput::captured(&chronosense),
+                CoreDecisionInput::captured(&wall_clock),
+            ],
+        );
+        let decision = evaluate_core_decision(request.clone(), &events).unwrap();
+        replay_core_decision(request, &events, &decision).unwrap();
+    }
+
+    #[test]
+    fn event_class_relabeling_is_quarantined() {
+        let event = captured_event(
+            "network-1",
+            NondeterministicShellClass::NetworkIo,
+            r#"{"status":200}"#,
+        );
+        let request = CoreDecisionRequest::new(
+            "reasoning-1",
+            DeterministicCoreComponent::ReasoningRuntime,
+            vec![CoreDecisionInput::CapturedShell {
+                shell_class: NondeterministicShellClass::ProviderModelIo,
+                event_id: event.event_id.clone(),
+                value_fingerprint: event.value_fingerprint.clone(),
+            }],
+        );
+        let quarantine = evaluate_core_decision(request, &[event]).unwrap_err();
+        assert_eq!(quarantine.class_mismatches.len(), 1);
+        assert_eq!(
+            quarantine.class_mismatches[0].requested_class,
+            NondeterministicShellClass::ProviderModelIo
+        );
+    }
+
+    #[test]
+    fn event_fingerprint_mutation_is_quarantined() {
+        let event = captured_event(
+            "provider-1",
+            NondeterministicShellClass::ProviderModelIo,
+            r#"{"output":"a"}"#,
+        );
+        let request = CoreDecisionRequest::new(
+            "reasoning-1",
+            DeterministicCoreComponent::ReasoningRuntime,
+            vec![CoreDecisionInput::CapturedShell {
+                shell_class: event.shell_class,
+                event_id: event.event_id.clone(),
+                value_fingerprint: sha256_hex(b"mutated"),
+            }],
+        );
+        let quarantine = evaluate_core_decision(request, &[event]).unwrap_err();
+        assert_eq!(quarantine.fingerprint_mismatches, vec!["provider-1"]);
+    }
+
+    #[test]
+    fn retained_payload_is_replayable_and_tamper_evident() {
+        let event = CapturedShellInputEvent::new(
+            "aws-1",
+            NondeterministicShellClass::AwsCloud,
+            "eventbridge",
+            "2026-07-11T00:00:00Z",
+            ObservationConfidence::Medium,
+            "determinism_boundary.json#captured_shell_events/aws-1",
+            serde_json::json!({"publishable": true, "region": "configured"}),
+        )
+        .unwrap();
+        let request = CoreDecisionRequest::new(
+            "aee-1",
+            DeterministicCoreComponent::AeeGovernedExecution,
+            vec![CoreDecisionInput::captured(&event)],
+        );
+        let decision = evaluate_core_decision(request.clone(), &[event.clone()]).unwrap();
+        replay_core_decision(request.clone(), &[event.clone()], &decision).unwrap();
+
+        let mut tampered_event = event;
+        tampered_event.payload = serde_json::json!({"publishable": false, "region": "configured"});
+        let mut tampered_request = request;
+        if let CoreDecisionInput::CapturedShell {
+            value_fingerprint, ..
+        } = &mut tampered_request.inputs[0]
+        {
+            *value_fingerprint = tampered_event.value_fingerprint.clone();
+        }
+        let quarantine = evaluate_core_decision(tampered_request, &[tampered_event]).unwrap_err();
+        assert!(quarantine
+            .reason
+            .contains("invalid captured shell event ledger"));
+    }
+
+    #[test]
+    fn chronosense_payload_fingerprint_survives_json_roundtrip() {
+        let payload = serde_json::json!({
+            "offset_seconds": 0.000_125,
+            "dispersion_seconds": 1.75,
+            "nested": {
+                "stratum": 2,
+                "samples": [0.1, -0.25, 3.141592653589793]
+            },
+            "sources": [
+                {"host": "time-a", "reachable": true},
+                {"reachable": false, "host": "time-b"}
+            ]
+        });
+        let event = CapturedShellInputEvent::new(
+            "chronosense-1",
+            NondeterministicShellClass::ChronosenseNtp,
+            "chronosense_runtime_service",
+            "2026-07-11T00:00:00Z",
+            ObservationConfidence::High,
+            "determinism_boundary.json#captured_shell_events/chronosense-1",
+            payload,
+        )
+        .expect("capture Chronosense payload");
+        let retained = serde_json::to_vec_pretty(&event).expect("serialize event");
+        let reloaded: CapturedShellInputEvent =
+            serde_json::from_slice(&retained).expect("reload event");
+        reloaded
+            .verify_payload()
+            .expect("roundtrip preserves canonical payload fingerprint");
+        assert_eq!(event.value_fingerprint, reloaded.value_fingerprint);
+    }
+}

--- a/adl-runtime/src/lib.rs
+++ b/adl-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod backpressure;
 pub mod curiosity;
+pub mod determinism;
 pub mod networking;
 pub mod resident_agent;
 pub mod runtime_api;

--- a/adl-runtime/src/topology.rs
+++ b/adl-runtime/src/topology.rs
@@ -108,6 +108,12 @@ pub fn runtime_stack_json() -> Value {
             "status": "integrated",
             "source": "csm_connection_pool_status"
         },
+        "determinism_boundary": {
+            "schema": crate::determinism::CSM_DETERMINISM_BOUNDARY_SCHEMA,
+            "model": "typed_deterministic_core_and_nondeterministic_shell",
+            "capture_policy": "retain_before_governed_influence",
+            "failure_policy": "quarantine_missing_reclassified_or_mutated_shell_evidence"
+        },
         "time_sync": {
             "primary_crate": "rsntp",
             "status": "integrated",

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -71,7 +71,9 @@ name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
  "serde",
+ "serde_jcs",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -3632,6 +3634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,6 +3828,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1594,7 +1594,6 @@ impl CycleShellInputs {
 }
 
 fn capture_cycle_shell_input(
-    _cycle_dir: &Path,
     cycle_id: &str,
     shell_class: NondeterministicShellClass,
     source: &str,
@@ -1620,7 +1619,6 @@ fn capture_cycle_shell_input(
 
 fn capture_initial_cycle_shell_inputs(
     loaded: &LoadedAgentSpec,
-    cycle_dir: &Path,
     cycle_id: &str,
     observed_at: DateTime<Utc>,
     provider_binding: &Value,
@@ -1693,7 +1691,6 @@ fn capture_initial_cycle_shell_inputs(
     let mut retained = Vec::new();
     for (shell_class, source, confidence, value) in observations {
         let event = capture_cycle_shell_input(
-            cycle_dir,
             cycle_id,
             shell_class,
             source,
@@ -1744,13 +1741,8 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
     let previous_cycle_id = latest_cycle_id(loaded)?;
     let workflow_ref = workflow_ref(&loaded.spec.workflow);
     let provider_binding = provider_binding(loaded, cycle_id, started_at);
-    let mut shell_inputs = capture_initial_cycle_shell_inputs(
-        loaded,
-        &cycle_dir,
-        cycle_id,
-        started_at,
-        &provider_binding,
-    )?;
+    let mut shell_inputs =
+        capture_initial_cycle_shell_inputs(loaded, cycle_id, started_at, &provider_binding)?;
     let scheduler_request = CoreDecisionRequest::new(
         format!("{cycle_id}-scheduler-admission"),
         DeterministicCoreComponent::SchedulerAdmission,
@@ -1904,7 +1896,6 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
         ));
     }
     let provider_result_event = capture_cycle_shell_input(
-        &cycle_dir,
         cycle_id,
         NondeterministicShellClass::ProviderModelIo,
         "csm_provider_execution_result",
@@ -1917,7 +1908,6 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
 
     let completion_at = Utc::now();
     let completion_clock_event = capture_cycle_shell_input(
-        &cycle_dir,
         cycle_id,
         NondeterministicShellClass::WallClock,
         "chronosense_utc_clock",

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1,9 +1,16 @@
 //! Long-lived agent orchestration surfaces.
+use adl_runtime::determinism::{
+    cycle_record_fingerprint, evaluate_core_decision, CapturedShellInputEvent, CoreDecisionInput,
+    CoreDecisionRequest, CsmCycleDeterminismBoundaryRecord, DeterministicCoreComponent,
+    DeterministicCoreDecision, DeterministicCoreInputKind, NondeterministicShellClass,
+    ObservationConfidence,
+};
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -1568,6 +1575,167 @@ fn acquire_lease(
     Ok(lease)
 }
 
+struct CycleShellInputs {
+    by_class: BTreeMap<NondeterministicShellClass, CapturedShellInputEvent>,
+    retained: Vec<CapturedShellInputEvent>,
+}
+
+impl CycleShellInputs {
+    fn event(&self, shell_class: NondeterministicShellClass) -> Result<&CapturedShellInputEvent> {
+        self.by_class
+            .get(&shell_class)
+            .ok_or_else(|| anyhow!("missing retained {} shell input", shell_class.as_str()))
+    }
+
+    fn replace(&mut self, event: CapturedShellInputEvent) {
+        self.by_class.insert(event.shell_class, event.clone());
+        self.retained.push(event);
+    }
+}
+
+fn capture_cycle_shell_input(
+    _cycle_dir: &Path,
+    cycle_id: &str,
+    shell_class: NondeterministicShellClass,
+    source: &str,
+    observed_at: DateTime<Utc>,
+    confidence: ObservationConfidence,
+    value: &Value,
+    suffix: &str,
+) -> Result<CapturedShellInputEvent> {
+    let event_id = format!("{cycle_id}-{}-{suffix}", shell_class.as_str());
+    let retention_location = format!("determinism_boundary.json#captured_shell_events/{event_id}");
+    let event = CapturedShellInputEvent::new(
+        event_id,
+        shell_class,
+        source,
+        observed_at.to_rfc3339(),
+        confidence,
+        retention_location,
+        value.clone(),
+    )
+    .with_context(|| format!("capture {} shell observation", shell_class.as_str()))?;
+    Ok(event)
+}
+
+fn capture_initial_cycle_shell_inputs(
+    loaded: &LoadedAgentSpec,
+    cycle_dir: &Path,
+    cycle_id: &str,
+    observed_at: DateTime<Utc>,
+    provider_binding: &Value,
+) -> Result<CycleShellInputs> {
+    let chronosense = serde_json::to_value(capture_runtime_time_sync_status())
+        .context("serialize Chronosense time-sync observation")?;
+    let observations = [
+        (
+            NondeterministicShellClass::ChronosenseNtp,
+            "chronosense_runtime_service",
+            ObservationConfidence::Medium,
+            chronosense,
+        ),
+        (
+            NondeterministicShellClass::AwsCloud,
+            "runtime_aws_signal_configuration",
+            ObservationConfidence::Medium,
+            json!({
+                "region_configured": std::env::var_os("ADL_AWS_REGION").is_some(),
+                "event_bus_configured": std::env::var_os("ADL_CSM_NOTICE_EVENT_BUS").is_some(),
+                "profile_configured": std::env::var_os("ADL_AWS_PROFILE").is_some()
+                    || std::env::var_os("AWS_PROFILE").is_some()
+            }),
+        ),
+        (
+            NondeterministicShellClass::NetworkIo,
+            "csm_cycle_network_boundary",
+            ObservationConfidence::Medium,
+            json!({
+                "provider_transport_requested": provider_binding["binding_status"] == "available",
+                "runtime_api_contract": "embedded",
+                "external_side_effects_allowed": false
+            }),
+        ),
+        (
+            NondeterministicShellClass::WallClock,
+            "chronosense_utc_clock",
+            ObservationConfidence::High,
+            json!({"observed_at": observed_at}),
+        ),
+        (
+            NondeterministicShellClass::LocalProcessState,
+            "csm_process_runtime",
+            ObservationConfidence::High,
+            json!({
+                "process_id": std::process::id(),
+                "state_root_exists": loaded.state_root.exists(),
+                "agent_instance_id": loaded.spec.agent_instance_id
+            }),
+        ),
+        (
+            NondeterministicShellClass::ObservabilitySink,
+            "csm_observability_configuration",
+            ObservationConfidence::Medium,
+            json!({
+                "otel_status_configured": std::env::var_os("ADL_OTEL_STATUS_PATH").is_some(),
+                "otel_log_configured": std::env::var_os("ADL_OTEL_LOG_PATH").is_some(),
+                "local_event_retention": true
+            }),
+        ),
+        (
+            NondeterministicShellClass::ProviderModelIo,
+            "csm_provider_binding",
+            ObservationConfidence::Medium,
+            provider_binding.clone(),
+        ),
+    ];
+
+    let mut by_class = BTreeMap::new();
+    let mut retained = Vec::new();
+    for (shell_class, source, confidence, value) in observations {
+        let event = capture_cycle_shell_input(
+            cycle_dir,
+            cycle_id,
+            shell_class,
+            source,
+            observed_at,
+            confidence,
+            &value,
+            "initial",
+        )?;
+        by_class.insert(shell_class, event.clone());
+        retained.push(event);
+    }
+    Ok(CycleShellInputs { by_class, retained })
+}
+
+fn safe_provider_result_summary(value: &Value) -> Value {
+    json!({
+        "schema": "adl.csm.provider_result_summary.v1",
+        "status": value.get("status").cloned().unwrap_or(Value::Null),
+        "workflow_kind": value.get("workflow_kind").cloned().unwrap_or(Value::Null),
+        "trace_event_count": value
+            .pointer("/trace/events")
+            .and_then(Value::as_array)
+            .map(|events| events.len()),
+        "result_available": !value.is_null()
+    })
+}
+
+fn evaluate_core_decision_fail_closed(
+    _cycle_dir: &Path,
+    request: CoreDecisionRequest,
+    events: &[CapturedShellInputEvent],
+) -> Result<DeterministicCoreDecision> {
+    match evaluate_core_decision(request, events) {
+        Ok(decision) => Ok(decision),
+        Err(quarantine) => Err(anyhow!(
+            "nondeterministic shell boundary quarantined {}: {}",
+            quarantine.component.as_str(),
+            quarantine.reason
+        )),
+    }
+}
+
 fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()> {
     let cycle_dir = cycles_dir(loaded).join(cycle_id);
     fs::create_dir_all(&cycle_dir)
@@ -1576,6 +1744,38 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
     let previous_cycle_id = latest_cycle_id(loaded)?;
     let workflow_ref = workflow_ref(&loaded.spec.workflow);
     let provider_binding = provider_binding(loaded, cycle_id, started_at);
+    let mut shell_inputs = capture_initial_cycle_shell_inputs(
+        loaded,
+        &cycle_dir,
+        cycle_id,
+        started_at,
+        &provider_binding,
+    )?;
+    let scheduler_request = CoreDecisionRequest::new(
+        format!("{cycle_id}-scheduler-admission"),
+        DeterministicCoreComponent::SchedulerAdmission,
+        vec![
+            CoreDecisionInput::deterministic(DeterministicCoreInputKind::CycleId, cycle_id),
+            CoreDecisionInput::deterministic(
+                DeterministicCoreInputKind::WorkflowId,
+                workflow_ref.clone(),
+            ),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::ChronosenseNtp)?,
+            ),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::WallClock)?),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::LocalProcessState)?,
+            ),
+        ],
+    );
+    let scheduler_decision = evaluate_core_decision_fail_closed(
+        &cycle_dir,
+        scheduler_request.clone(),
+        &shell_inputs.retained,
+    )?;
+    let mut decision_requests = vec![scheduler_request];
+    let mut core_decisions = vec![scheduler_decision];
     let safety_policy = effective_safety_policy(loaded);
     let workflow_supported = workflow_kind_supported(&loaded.spec.workflow.kind);
     let broker_allowed = safety_bool_default(&loaded.spec.safety, "allow_broker", false);
@@ -1654,23 +1854,158 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
         dedup_strings(&mut rejected_actions);
     }
 
-    let max_runtime_not_exceeded =
-        Utc::now() <= started_at + ChronoDuration::seconds(max_cycle_runtime_secs(loaded) as i64);
-    if !max_runtime_not_exceeded {
-        rejected_actions.push("max_cycle_runtime_exceeded".to_string());
-        dedup_strings(&mut rejected_actions);
-    }
+    let admission_pass = workflow_supported && rejected_actions.is_empty() && sanitization.passed;
+    let aee_request = CoreDecisionRequest::new(
+        format!("{cycle_id}-aee-governed-execution"),
+        DeterministicCoreComponent::AeeGovernedExecution,
+        vec![
+            CoreDecisionInput::deterministic(
+                DeterministicCoreInputKind::ActionId,
+                "stage_and_record_cycle",
+            ),
+            CoreDecisionInput::deterministic(
+                DeterministicCoreInputKind::PolicyDecision,
+                if admission_pass { "admit" } else { "deny" },
+            ),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::ProviderModelIo)?,
+            ),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::NetworkIo)?),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::AwsCloud)?),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::ObservabilitySink)?,
+            ),
+        ],
+    );
+    let aee_decision = evaluate_core_decision_fail_closed(
+        &cycle_dir,
+        aee_request.clone(),
+        &shell_inputs.retained,
+    )?;
+    decision_requests.push(aee_request);
+    core_decisions.push(aee_decision);
 
-    let adl_run = if workflow_supported && loaded.spec.workflow.kind == "adl_workflow" {
+    let adl_run = if admission_pass && loaded.spec.workflow.kind == "adl_workflow" {
         Some(run_adl_workflow_cycle(loaded, cycle_id, &cycle_dir)?)
     } else {
         None
     };
 
-    let guardrail_pass = workflow_supported
-        && rejected_actions.is_empty()
-        && sanitization.passed
-        && max_runtime_not_exceeded;
+    let provider_result_raw = match &adl_run {
+        Some(_) => read_json_required(&cycle_dir.join("csm_adl_run_status.json"))?,
+        None => provider_binding.clone(),
+    };
+    let provider_result_value = safe_provider_result_summary(&provider_result_raw);
+    let provider_result_sanitization =
+        sanitize_public_artifacts(&[("provider_result_summary", &provider_result_value)])?;
+    if !provider_result_sanitization.passed {
+        return Err(anyhow!(
+            "provider result summary failed sanitization before deterministic retention"
+        ));
+    }
+    let provider_result_event = capture_cycle_shell_input(
+        &cycle_dir,
+        cycle_id,
+        NondeterministicShellClass::ProviderModelIo,
+        "csm_provider_execution_result",
+        Utc::now(),
+        ObservationConfidence::Medium,
+        &provider_result_value,
+        "result",
+    )?;
+    shell_inputs.replace(provider_result_event);
+
+    let completion_at = Utc::now();
+    let completion_clock_event = capture_cycle_shell_input(
+        &cycle_dir,
+        cycle_id,
+        NondeterministicShellClass::WallClock,
+        "chronosense_utc_clock",
+        completion_at,
+        ObservationConfidence::High,
+        &json!({"observed_at": completion_at, "phase": "completion"}),
+        "completion",
+    )?;
+    shell_inputs.replace(completion_clock_event);
+    let max_runtime_not_exceeded = completion_at
+        <= started_at + ChronoDuration::seconds(max_cycle_runtime_secs(loaded) as i64);
+    if !max_runtime_not_exceeded {
+        rejected_actions.push("max_cycle_runtime_exceeded".to_string());
+        dedup_strings(&mut rejected_actions);
+    }
+
+    let reasoning_request = CoreDecisionRequest::new(
+        format!("{cycle_id}-reasoning-runtime"),
+        DeterministicCoreComponent::ReasoningRuntime,
+        vec![
+            CoreDecisionInput::deterministic(
+                DeterministicCoreInputKind::GraphId,
+                workflow_ref.clone(),
+            ),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::ProviderModelIo)?,
+            ),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::NetworkIo)?),
+        ],
+    );
+    core_decisions.push(evaluate_core_decision_fail_closed(
+        &cycle_dir,
+        reasoning_request.clone(),
+        &shell_inputs.retained,
+    )?);
+    decision_requests.push(reasoning_request);
+    let checkpoint_request = CoreDecisionRequest::new(
+        format!("{cycle_id}-checkpoint-version-transition"),
+        DeterministicCoreComponent::CheckpointVersionTransition,
+        vec![
+            CoreDecisionInput::deterministic(
+                DeterministicCoreInputKind::CheckpointVersion,
+                "continuity_checkpoint.v1",
+            ),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::LocalProcessState)?,
+            ),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::WallClock)?),
+        ],
+    );
+    core_decisions.push(evaluate_core_decision_fail_closed(
+        &cycle_dir,
+        checkpoint_request.clone(),
+        &shell_inputs.retained,
+    )?);
+    decision_requests.push(checkpoint_request);
+    let lifelog_request = CoreDecisionRequest::new(
+        format!("{cycle_id}-lifelog-ordering"),
+        DeterministicCoreComponent::LifelogOrdering,
+        vec![
+            CoreDecisionInput::deterministic(DeterministicCoreInputKind::LifelogSequence, cycle_id),
+            CoreDecisionInput::captured(
+                shell_inputs.event(NondeterministicShellClass::ChronosenseNtp)?,
+            ),
+            CoreDecisionInput::captured(shell_inputs.event(NondeterministicShellClass::WallClock)?),
+        ],
+    );
+    core_decisions.push(evaluate_core_decision_fail_closed(
+        &cycle_dir,
+        lifelog_request.clone(),
+        &shell_inputs.retained,
+    )?);
+    decision_requests.push(lifelog_request);
+    let boundary_record = CsmCycleDeterminismBoundaryRecord::new(
+        cycle_id,
+        shell_inputs.retained.clone(),
+        decision_requests,
+        core_decisions.clone(),
+    );
+    boundary_record
+        .validate()
+        .context("validate assembled CSM cycle determinism boundary")?;
+    write_json_pretty(
+        &cycle_dir.join("determinism_boundary.json"),
+        &boundary_record,
+    )?;
+
+    let guardrail_pass = admission_pass && max_runtime_not_exceeded;
     let cycle_status = if guardrail_pass { "success" } else { "blocked" };
     let decision_status = if guardrail_pass {
         "accepted"
@@ -1689,7 +2024,11 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
     } else {
         json!({
             "action": "blocked",
-            "summary": "Cycle blocked before workflow execution because the configured contract failed required guardrails.",
+            "summary": if admission_pass {
+                "Workflow completed but a post-execution runtime guardrail failed."
+            } else {
+                "Cycle blocked before workflow execution because pre-execution admission failed."
+            },
             "workflow_ref": workflow_ref,
             "paper_only": true
         })
@@ -1847,10 +2186,24 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
     });
     write_json_pretty(&cycle_dir.join("guardrail_report.json"), &guardrail_report)?;
 
-    let completed_at = Utc::now();
+    let completed_at = completion_at;
+    let shell_event_fingerprints = boundary_record
+        .captured_shell_events
+        .iter()
+        .map(|event| {
+            json!({
+                "event_id": event.event_id,
+                "shell_class": event.shell_class,
+                "value_fingerprint": event.value_fingerprint,
+                "retention_location": event.retention_location
+            })
+        })
+        .collect::<Vec<_>>();
     let manifest_input = json!({
         "observations_ref": "observations.json",
         "decision_request_ref": "decision_request.json",
+        "determinism_boundary_ref": "determinism_boundary.json",
+        "shell_event_fingerprints": shell_event_fingerprints,
         "previous_cycle_id": previous_cycle_id,
         "workflow_kind": loaded.spec.workflow.kind.clone(),
         "workflow_ref": workflow_ref
@@ -1860,6 +2213,7 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
         "run_ref": "run_ref.json",
         "memory_writes_ref": "memory_writes.jsonl",
         "guardrail_report_ref": "guardrail_report.json",
+        "determinism_boundary_digest": cycle_record_fingerprint(&boundary_record)?,
         "status": cycle_status
     });
     let manifest = json!({
@@ -1873,6 +2227,7 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
         "workflow_ref": manifest_input["workflow_ref"].clone(),
         "input_hash": sha256_json(&manifest_input)?,
         "output_hash": sha256_json(&manifest_output)?,
+        "determinism_boundary_digest": manifest_output["determinism_boundary_digest"].clone(),
         "previous_cycle_id": manifest_input["previous_cycle_id"].clone(),
         "next_cycle_hint": "sleep_until_next_heartbeat",
         "csm_runtime": {
@@ -1881,7 +2236,8 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
             "aee": "integrated",
             "chronosense": "integrated",
             "scheduler_watcher": "integrated",
-            "resilience_middleware": "integrated"
+            "resilience_middleware": "integrated",
+            "determinism_boundary": "typed_capture_and_fail_closed_quarantine"
         },
         "artifacts": {
             "observations": "observations.json",
@@ -1890,6 +2246,7 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
             "run_ref": "run_ref.json",
             "memory_writes": "memory_writes.jsonl",
             "guardrail_report": "guardrail_report.json",
+            "determinism_boundary": "determinism_boundary.json",
             "cycle_summary": "cycle_summary.md",
             "csm_adl_run_status": adl_run.as_ref().map(|run| run.status_ref.as_str())
         },
@@ -1900,7 +2257,7 @@ fn write_cycle_artifacts(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()>
     fs::write(
         cycle_dir.join("cycle_summary.md"),
         format!(
-            "# Long-Lived Agent Cycle {cycle_id}\n\n- Agent: `{}`\n- Workflow kind: `{}`\n- Cycle status: `{cycle_status}`\n- Observations: `observations.json`\n- Decision request: `decision_request.json`\n- Decision result: `decision_result.json`\n- Guardrail result: `{guardrail_status}`\n- Memory writes: `memory_writes.jsonl`\n- Next-cycle note: `sleep_until_next_heartbeat`\n- Safety: paper-only; not financial advice; no broker execution\n",
+            "# Long-Lived Agent Cycle {cycle_id}\n\n- Agent: `{}`\n- Workflow kind: `{}`\n- Cycle status: `{cycle_status}`\n- Observations: `observations.json`\n- Replayable determinism ledger: `determinism_boundary.json`\n- Decision request: `decision_request.json`\n- Decision result: `decision_result.json`\n- Guardrail result: `{guardrail_status}`\n- Memory writes: `memory_writes.jsonl`\n- Next-cycle note: `sleep_until_next_heartbeat`\n- Safety: paper-only; not financial advice; no broker execution\n",
             loaded.spec.agent_instance_id, loaded.spec.workflow.kind
         ),
     )

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -2,6 +2,7 @@
 use super::*;
 use crate::observability::test_env_lock;
 use crate::runtime_aws_signal::mock_signal_artifact_path;
+use adl_runtime::determinism::verify_retained_cycle_record;
 use std::env;
 use std::ffi::OsString;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -109,6 +110,7 @@ fn required_cycle_files(root: &Path, cycle_id: &str) -> Vec<PathBuf> {
         "run_ref.json",
         "memory_writes.jsonl",
         "guardrail_report.json",
+        "determinism_boundary.json",
         "cycle_summary.md",
     ]
     .into_iter()
@@ -247,6 +249,83 @@ fn tick_creates_state_status_full_cycle_bundle_and_removes_lease() {
     assert_eq!(provider_entry["provider_id"], "local_ollama");
     assert_eq!(provider_entry["model"], "gemma4:latest");
     assert_eq!(provider_entry["binding_status"], "available");
+
+    let cycle_dir = root.join("state/cycles/cycle-000001");
+    let boundary: CsmCycleDeterminismBoundaryRecord = serde_json::from_str(
+        &fs::read_to_string(cycle_dir.join("determinism_boundary.json"))
+            .expect("read determinism boundary"),
+    )
+    .expect("parse determinism boundary");
+    assert_eq!(boundary.cycle_id, "cycle-000001");
+    assert_eq!(boundary.decisions.len(), 5);
+    assert_eq!(boundary.decision_requests.len(), 5);
+    boundary.replay().expect("replay retained cycle boundary");
+    let decision_components = boundary
+        .decisions
+        .iter()
+        .map(|decision| decision.component)
+        .collect::<Vec<_>>();
+    assert!(decision_components.contains(&DeterministicCoreComponent::SchedulerAdmission));
+    assert!(decision_components.contains(&DeterministicCoreComponent::ReasoningRuntime));
+    assert!(decision_components.contains(&DeterministicCoreComponent::AeeGovernedExecution));
+    assert!(decision_components.contains(&DeterministicCoreComponent::CheckpointVersionTransition));
+    assert!(decision_components.contains(&DeterministicCoreComponent::LifelogOrdering));
+    let aee_decision = boundary
+        .decisions
+        .iter()
+        .find(|decision| decision.component == DeterministicCoreComponent::AeeGovernedExecution)
+        .expect("AEE decision");
+    assert!(aee_decision
+        .cited_shell_events
+        .iter()
+        .any(|event_id| event_id.ends_with("provider_model_io-initial")));
+    let reasoning_decision = boundary
+        .decisions
+        .iter()
+        .find(|decision| decision.component == DeterministicCoreComponent::ReasoningRuntime)
+        .expect("reasoning decision");
+    assert!(reasoning_decision
+        .cited_shell_events
+        .iter()
+        .any(|event_id| event_id.ends_with("provider_model_io-result")));
+    for shell_class in NondeterministicShellClass::ALL {
+        assert!(
+            boundary
+                .captured_shell_events
+                .iter()
+                .any(|event| event.shell_class == shell_class),
+            "missing retained {} event",
+            shell_class.as_str()
+        );
+    }
+    assert!(boundary
+        .captured_shell_events
+        .iter()
+        .all(|event| !event.payload.is_null()));
+    assert!(boundary.captured_shell_events.iter().any(|event| {
+        event.shell_class == NondeterministicShellClass::WallClock
+            && event.payload["phase"] == "completion"
+    }));
+    assert!(!cycle_dir.join("shell_inputs").exists());
+    let determinism_artifacts = fs::read_dir(&cycle_dir)
+        .expect("read cycle directory")
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| {
+            name.contains("determinism")
+                || name.starts_with("core_decision_")
+                || name.starts_with("nondeterminism_quarantine_")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(determinism_artifacts, vec!["determinism_boundary.json"]);
+    assert_eq!(
+        manifest["artifacts"]["determinism_boundary"],
+        "determinism_boundary.json"
+    );
+    assert_eq!(
+        manifest["csm_runtime"]["determinism_boundary"],
+        "typed_capture_and_fail_closed_quarantine"
+    );
     let memory_index: Value =
         serde_json::from_str(&fs::read_to_string(root.join("state/memory_index.json")).unwrap())
             .expect("parse memory index");
@@ -256,6 +335,125 @@ fn tick_creates_state_status_full_cycle_bundle_and_removes_lease() {
         "cycles/cycle-000001/memory_writes.jsonl"
     );
     assert!(!root.join("state/lease.json").exists());
+}
+
+#[test]
+fn assembled_cycle_fail_closes_tampered_and_uncaptured_shell_influence() {
+    let root = temp_dir("determinism-boundary-quarantine");
+    let spec = write_spec(&root);
+    tick(&spec, TickOptions::default()).expect("tick creates retained shell evidence");
+
+    let cycle_dir = root.join("state/cycles/cycle-000001");
+    let boundary_path = cycle_dir.join("determinism_boundary.json");
+    let boundary_bytes = fs::read(&boundary_path).expect("read determinism boundary");
+    let boundary: CsmCycleDeterminismBoundaryRecord =
+        serde_json::from_slice(&boundary_bytes).expect("parse determinism boundary");
+    let expected_fingerprint = cycle_record_fingerprint(&boundary).expect("boundary fingerprint");
+    verify_retained_cycle_record(&boundary, &expected_fingerprint)
+        .expect("verify retained cycle boundary");
+
+    let provider_index = boundary
+        .captured_shell_events
+        .iter()
+        .rposition(|event| event.shell_class == NondeterministicShellClass::ProviderModelIo)
+        .expect("provider result event");
+
+    let mut payload_tampered = boundary.clone();
+    payload_tampered.captured_shell_events[provider_index].payload["status"] = json!("tampered");
+    assert!(payload_tampered.replay().is_err());
+
+    let old_event = &boundary.captured_shell_events[provider_index];
+    let replacement = CapturedShellInputEvent::new(
+        old_event.event_id.clone(),
+        old_event.shell_class,
+        old_event.source.clone(),
+        old_event.observed_time.clone(),
+        old_event.confidence,
+        old_event.retention_location.clone(),
+        json!({"schema": "adl.csm.provider_result_summary.v1", "status": "tampered"}),
+    )
+    .expect("create coordinated tamper event");
+    let mut coordinated_tamper = boundary.clone();
+    coordinated_tamper.captured_shell_events[provider_index] = replacement.clone();
+    for request in &mut coordinated_tamper.decision_requests {
+        for input in &mut request.inputs {
+            if let CoreDecisionInput::CapturedShell {
+                event_id,
+                value_fingerprint,
+                ..
+            } = input
+            {
+                if event_id == &replacement.event_id {
+                    *value_fingerprint = replacement.value_fingerprint.clone();
+                }
+            }
+        }
+    }
+    assert!(verify_retained_cycle_record(&coordinated_tamper, &expected_fingerprint).is_err());
+
+    let mut uncaptured = boundary.clone();
+    let aee_request = uncaptured
+        .decision_requests
+        .iter_mut()
+        .find(|request| request.component == DeterministicCoreComponent::AeeGovernedExecution)
+        .expect("AEE request");
+    aee_request.inputs.push(CoreDecisionInput::CapturedShell {
+        shell_class: NondeterministicShellClass::AwsCloud,
+        event_id: "cycle-000001-aws-cloud-not-retained".to_string(),
+        value_fingerprint: old_event.value_fingerprint.clone(),
+    });
+    assert!(uncaptured.replay().is_err());
+    assert_eq!(fs::read(&boundary_path).unwrap(), boundary_bytes);
+}
+
+#[test]
+fn pre_execution_admission_blocks_unsupported_workflow_before_provider_work() {
+    let root = temp_dir("determinism-pre-execution-admission");
+    let spec = write_spec_with_workflow_kind(&root, "unsupported_external_workflow");
+
+    let error = tick(&spec, TickOptions::default()).expect_err("unsupported workflow is blocked");
+    assert!(error.to_string().contains("cycle_blocked"));
+    let cycle_dir = root.join("state/cycles/cycle-000001");
+    assert!(!cycle_dir.join("csm_adl_run_status.json").exists());
+    let boundary: CsmCycleDeterminismBoundaryRecord = serde_json::from_slice(
+        &fs::read(cycle_dir.join("determinism_boundary.json")).expect("read boundary"),
+    )
+    .expect("parse boundary");
+    let aee_request = boundary
+        .decision_requests
+        .iter()
+        .find(|request| request.component == DeterministicCoreComponent::AeeGovernedExecution)
+        .expect("AEE request");
+    assert!(aee_request.inputs.iter().any(|input| matches!(
+        input,
+        CoreDecisionInput::Deterministic {
+            kind: DeterministicCoreInputKind::PolicyDecision,
+            value
+        } if value == "deny"
+    )));
+}
+
+#[test]
+fn provider_result_summary_does_not_retain_sensitive_fields() {
+    let raw = json!({
+        "status": "success",
+        "workflow_kind": "adl_workflow",
+        "secret": "do-not-retain",
+        "token": "token-do-not-retain",
+        "prompt": "prompt-do-not-retain",
+        "output": "output-do-not-retain",
+        "tool_output": {"authorization": "also-do-not-retain"},
+        "trace": {"events": [{"sensitive": "value"}]}
+    });
+    let summary = safe_provider_result_summary(&raw);
+    let retained = serde_json::to_string(&summary).expect("serialize summary");
+    assert_eq!(summary["status"], "success");
+    assert_eq!(summary["trace_event_count"], 1);
+    assert!(!retained.contains("do-not-retain"));
+    assert!(!retained.contains("token-do-not-retain"));
+    assert!(!retained.contains("prompt-do-not-retain"));
+    assert!(!retained.contains("output-do-not-retain"));
+    assert!(!retained.contains("authorization"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #5111

## Summary
#5111 implements a typed fail-closed deterministic-core/nondeterministic-shell boundary with pre-execution admission and one compact replayable per-cycle ledger containing safe canonical payloads, decision requests, accepted decisions, and a manifest-anchored fingerprint.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-5111__v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary/sor.md`
- Tracked implementation artifacts: `adl-runtime/src/determinism.rs; adl-runtime/src/lib.rs; adl-runtime/src/topology.rs; adl/src/long_lived_agent.rs; adl/src/long_lived_agent/tests.rs; Cargo manifests and locks.`
- Additional proof artifacts: `Kuhn first review findings fixed; Bernoulli second review no findings. serde_jcs 0.2.0 provenance: RFC 8785 JCS, MIT OR Apache-2.0, rust-version 1.85, compatible with repo Rust 1.92 and repository license. Residuals: cycle-local digest anchor, linear history growth, and broad live/fault-injection proof deferred.`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --all -- --check` - reproduce the CI formatting step in the adl workspace
  - `CARGO_TARGET_DIR=<temp-target> cargo clippy --all-targets -- -D warnings` - reproduce the exact adl-rust-fmt-clippy clippy step without using the disposable worktree target
  - `CARGO_TARGET_DIR=<temp-target> cargo test --manifest-path adl/Cargo.toml tick_creates_state_status_full_cycle_bundle_and_removes_lease` - verify the repaired shell-input capture call path still assembles the full cycle bundle
  - `CARGO_TARGET_DIR=<temp-target> cargo test --manifest-path adl/Cargo.toml assembled_cycle_fail_closes_tampered_and_uncaptured_shell_influence` - verify fail-closed determinism behavior remains intact after the mechanical parameter cleanup
- Results:
  - `cargo fmt --all -- --check`: PASS
  - `CARGO_TARGET_DIR=<temp-target> cargo clippy --all-targets -- -D warnings`: PASS
  - `CARGO_TARGET_DIR=<temp-target> cargo test --manifest-path adl/Cargo.toml tick_creates_state_status_full_cycle_bundle_and_removes_lease`: PASS
  - `CARGO_TARGET_DIR=<temp-target> cargo test --manifest-path adl/Cargo.toml assembled_cycle_fail_closes_tampered_and_uncaptured_shell_influence`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5111__v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary/stp.md
- Output card: .adl/v0.91.7/tasks/issue-5111__v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary-adl-v0-91-7-tasks-issue-5111-v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary-stp-md-adl-v0-91-7-tasks-issue-5111-v0-91-7-wp-07-runtime-define-deterministic-core-and-nondeterministic-shell-boundary-sor-md