### PR TITLE
[v0.91.7][WP-07][runtime] Implement CSM component supervision policy matrix

### DIFF
--- a/adl-runtime/Cargo.lock
+++ b/adl-runtime/Cargo.lock
@@ -6,10 +6,13 @@ version = 4
 name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
+ "fs2",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -20,6 +23,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -57,6 +66,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +144,12 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -174,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +255,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -201,6 +309,28 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zmij"

--- a/adl-runtime/Cargo.toml
+++ b/adl-runtime/Cargo.toml
@@ -10,7 +10,10 @@ name = "adl_runtime"
 path = "src/lib.rs"
 
 [dependencies]
+fs2 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 serde_jcs = "0.2"
+tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/adl-runtime/src/determinism.rs
+++ b/adl-runtime/src/determinism.rs
@@ -774,8 +774,9 @@ mod tests {
             DeterministicCoreComponent::AeeGovernedExecution,
             vec![CoreDecisionInput::captured(&event)],
         );
-        let decision = evaluate_core_decision(request.clone(), &[event.clone()]).unwrap();
-        replay_core_decision(request.clone(), &[event.clone()], &decision).unwrap();
+        let decision =
+            evaluate_core_decision(request.clone(), std::slice::from_ref(&event)).unwrap();
+        replay_core_decision(request.clone(), std::slice::from_ref(&event), &decision).unwrap();
 
         let mut tampered_event = event;
         tampered_event.payload = serde_json::json!({"publishable": false, "region": "configured"});
@@ -799,7 +800,7 @@ mod tests {
             "dispersion_seconds": 1.75,
             "nested": {
                 "stratum": 2,
-                "samples": [0.1, -0.25, 3.141592653589793]
+                "samples": [0.1, -0.25, std::f64::consts::PI]
             },
             "sources": [
                 {"host": "time-a", "reachable": true},

--- a/adl-runtime/src/resident_agent.rs
+++ b/adl-runtime/src/resident_agent.rs
@@ -132,17 +132,16 @@ impl CsmResidentAgentSpec {
             "provider_target_resolved",
             "provider_binding.binding_status",
         )?;
-        if self.authority == CsmResidentAgentAuthority::ShepherdOperator {
-            if !self.policy_gates.freedom_gate_required
+        if self.authority == CsmResidentAgentAuthority::ShepherdOperator
+            && (!self.policy_gates.freedom_gate_required
                 || !self.policy_gates.cav_required
                 || !self.policy_gates.constitutional_policy_required
-                || !self.policy_gates.model_output_advisory_only
-            {
-                return Err(
-                    "shepherd resident agent must be gated by Freedom Gate, CAV, constitutional policy, and advisory output authority"
-                        .to_string(),
-                );
-            }
+                || !self.policy_gates.model_output_advisory_only)
+        {
+            return Err(
+                "shepherd resident agent must be gated by Freedom Gate, CAV, constitutional policy, and advisory output authority"
+                    .to_string(),
+            );
         }
         self.affect_model.validate()?;
         Ok(())

--- a/adl-runtime/src/supervision.rs
+++ b/adl-runtime/src/supervision.rs
@@ -1,86 +1,1394 @@
-//! CSM component supervision contracts.
+//! Typed supervision policies and the reusable CSM component supervisor.
 
-use serde::Serialize;
+use std::collections::VecDeque;
+use std::fs::{self, OpenOptions};
+use std::future::Future;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+
+pub const SUPERVISION_SCHEMA: &str = "adl.csm.supervision_policy.v1";
+pub const SUPERVISION_LIFECYCLE_SCHEMA: &str = "adl.csm.supervision_lifecycle_event.v1";
+pub const RECENT_LIFECYCLE_EVENT_LIMIT: usize = 256;
+const LIFECYCLE_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// CSM owns its process-wide panic reporting boundary and installs it at startup.
+pub fn install_csm_redacting_panic_hook() {
+    std::panic::set_hook(Box::new(|_| {
+        eprintln!(
+            "adl_event schema=adl.csm.supervision.panic.v1 result=panicked payload=<redacted>"
+        );
+    }));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentId {
+    RuntimeApi,
+    Chronosense,
+    Scheduler,
+    CuriosityEngine,
+    ReasoningRuntime,
+    Aee,
+    Checkpoint,
+    CloudBridge,
+    Lifelog,
+    Observability,
+}
+
+impl ComponentId {
+    pub const ALL: [ComponentId; 10] = [
+        ComponentId::RuntimeApi,
+        ComponentId::Chronosense,
+        ComponentId::Scheduler,
+        ComponentId::CuriosityEngine,
+        ComponentId::ReasoningRuntime,
+        ComponentId::Aee,
+        ComponentId::Checkpoint,
+        ComponentId::CloudBridge,
+        ComponentId::Lifelog,
+        ComponentId::Observability,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ComponentId::RuntimeApi => "runtime_api",
+            ComponentId::Chronosense => "chronosense",
+            ComponentId::Scheduler => "scheduler",
+            ComponentId::CuriosityEngine => "curiosity_engine",
+            ComponentId::ReasoningRuntime => "reasoning_runtime",
+            ComponentId::Aee => "aee",
+            ComponentId::Checkpoint => "checkpoint",
+            ComponentId::CloudBridge => "cloud_bridge",
+            ComponentId::Lifelog => "lifelog",
+            ComponentId::Observability => "observability",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComponentRestartPolicy {
     RestartWithBackoff,
     DegradeAndContinue,
-    EscalateToGovernedShutdown,
+    QuarantineOffendingWork,
+    EscalateFailClosed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentDecision {
+    ContinueHealthy,
+    RestartWithBackoff,
+    EscalateAndRestart,
+    DegradeAndContinue,
+    Quarantine,
+    EscalateFailClosed,
+    GovernedStop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentExit {
+    Healthy,
+    Failed,
+    Panicked,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentReadiness {
+    Ready,
+    Degraded,
+    NotReady,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleEventKind {
+    Start,
+    Healthy,
+    Degraded,
+    RestartScheduled,
+    Escalated,
+    Quarantined,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleRetention {
+    Retained,
+    NotRetained,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetainedLifecycleEvent {
+    pub schema: String,
+    pub sequence: u64,
+    pub component: ComponentId,
+    pub attempt: u32,
+    pub event: LifecycleEventKind,
+    pub readiness: ComponentReadiness,
+    pub retention: LifecycleRetention,
+    pub reason_code: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct ComponentSupervisionPolicy {
-    pub component: &'static str,
+    pub component: ComponentId,
     pub restart_policy: ComponentRestartPolicy,
+    pub backoff_base_ms: u64,
+    pub backoff_cap_ms: u64,
+    /// Emit an escalation every N consecutive failures without terminating CSM.
+    pub escalation_interval_failures: u32,
+    pub degradation_behavior: &'static str,
+    pub escalation_target: &'static str,
+    pub readiness_impact: &'static str,
     pub critical_for_continuity: bool,
     pub telemetry_can_degrade: bool,
 }
 
-pub const SUPERVISION_SCHEMA: &str = "adl.csm.supervision_policy.v1";
-
 pub fn default_component_supervision() -> Vec<ComponentSupervisionPolicy> {
     vec![
         ComponentSupervisionPolicy {
-            component: "runtime_api",
+            component: ComponentId::RuntimeApi,
             restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 100,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 3,
+            degradation_behavior: "readiness_false_while_api_unavailable",
+            escalation_target: "operator_and_runtime_observability",
+            readiness_impact: "ready_false_when_unavailable",
             critical_for_continuity: false,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "chronosense",
-            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
-            critical_for_continuity: true,
-            telemetry_can_degrade: false,
-        },
-        ComponentSupervisionPolicy {
-            component: "scheduler",
-            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
-            critical_for_continuity: true,
-            telemetry_can_degrade: false,
-        },
-        ComponentSupervisionPolicy {
-            component: "curiosity_engine",
+            component: ComponentId::Chronosense,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "continue_with_stale_time_confidence",
+            escalation_target: "block_time_sensitive_admission_below_confidence_floor",
+            readiness_impact: "ready_degraded_for_time_sensitive_work",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Scheduler,
+            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 2,
+            degradation_behavior: "quiesce_admission_until_schedule_state_recovers",
+            escalation_target: "operator_and_continuity_control",
+            readiness_impact: "ready_false_while_admission_quiesced",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::CuriosityEngine,
+            restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 500,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "disable_curiosity_admission_and_continue_core_runtime",
+            escalation_target: "operator_notice_if_curiosity_cannot_recover",
+            readiness_impact: "ready_degraded_for_curiosity_only",
             critical_for_continuity: false,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "checkpoint",
-            restart_policy: ComponentRestartPolicy::EscalateToGovernedShutdown,
+            component: ComponentId::ReasoningRuntime,
+            restart_policy: ComponentRestartPolicy::QuarantineOffendingWork,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "quarantine_offending_graph_and_preserve_input_evidence",
+            escalation_target: "recoverable_agent_state_with_quarantine_notice",
+            readiness_impact: "ready_true_when_unaffected_graphs_continue",
+            critical_for_continuity: false,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Aee,
+            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 2,
+            degradation_behavior: "close_execution_admission_until_aee_recovers",
+            escalation_target: "operator_and_execution_control",
+            readiness_impact: "ready_false_for_execution_admission",
             critical_for_continuity: true,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "observability",
+            component: ComponentId::Checkpoint,
+            restart_policy: ComponentRestartPolicy::EscalateFailClosed,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "block_admission_before_continuity_loss",
+            escalation_target: "emergency_safe_fail_serialization",
+            readiness_impact: "ready_false_until_checkpoint_persistence_recovers",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::CloudBridge,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 500,
+            backoff_cap_ms: 30_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "buffer_notices_without_advancing_publish_cursors",
+            escalation_target: "fail_closed_cloud_status_with_retained_notice_evidence",
+            readiness_impact: "ready_degraded_for_external_routes",
             critical_for_continuity: false,
             telemetry_can_degrade: true,
         },
         ComponentSupervisionPolicy {
-            component: "cloud_bridge",
+            component: ComponentId::Lifelog,
+            restart_policy: ComponentRestartPolicy::EscalateFailClosed,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "block_lifecycle_completion_when_append_fails",
+            escalation_target: "runtime_readiness_degraded_until_journal_persists",
+            readiness_impact: "ready_false_for_lifecycle_completion",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Observability,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "shed_low_priority_telemetry_but_retain_audit_events",
+            escalation_target: "operator_if_audit_events_cannot_be_retained_locally",
+            readiness_impact: "ready_degraded_for_metrics_only",
             critical_for_continuity: false,
             telemetry_can_degrade: true,
         },
     ]
 }
 
+pub fn policy_for(component: ComponentId) -> ComponentSupervisionPolicy {
+    default_component_supervision()
+        .into_iter()
+        .find(|policy| policy.component == component)
+        .expect("default supervision policy must cover every ComponentId")
+}
+
+pub fn backoff_for_failure(policy: &ComponentSupervisionPolicy, failures: u32) -> Duration {
+    let exponent = failures.saturating_sub(1).min(20);
+    let multiplier = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    Duration::from_millis(
+        policy
+            .backoff_base_ms
+            .saturating_mul(multiplier)
+            .min(policy.backoff_cap_ms),
+    )
+}
+
+pub fn decide_after_exit(
+    policy: &ComponentSupervisionPolicy,
+    exit: ComponentExit,
+    consecutive_failures: u32,
+) -> ComponentDecision {
+    match exit {
+        ComponentExit::Healthy => ComponentDecision::ContinueHealthy,
+        ComponentExit::Cancelled => ComponentDecision::GovernedStop,
+        ComponentExit::Failed | ComponentExit::Panicked => match policy.restart_policy {
+            ComponentRestartPolicy::RestartWithBackoff
+                if policy.escalation_interval_failures > 0
+                    && consecutive_failures > 0
+                    && consecutive_failures.is_multiple_of(policy.escalation_interval_failures) =>
+            {
+                ComponentDecision::EscalateAndRestart
+            }
+            ComponentRestartPolicy::RestartWithBackoff => ComponentDecision::RestartWithBackoff,
+            ComponentRestartPolicy::DegradeAndContinue => ComponentDecision::DegradeAndContinue,
+            ComponentRestartPolicy::QuarantineOffendingWork => ComponentDecision::Quarantine,
+            ComponentRestartPolicy::EscalateFailClosed => ComponentDecision::EscalateFailClosed,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentFailure {
+    Failed(&'static str),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleReplay {
+    pub events: Vec<RetainedLifecycleEvent>,
+    pub invalid_lines: usize,
+    pub read_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LifecycleSink {
+    sender: mpsc::Sender<JournalCommand>,
+    acknowledgement_timeout: Duration,
+}
+
+#[derive(Debug)]
+struct JournalCommand {
+    event: RetainedLifecycleEvent,
+    response: oneshot::Sender<JournalAppend>,
+}
+
+#[derive(Debug)]
+struct JournalAppend {
+    event: RetainedLifecycleEvent,
+    errors: Vec<String>,
+}
+
+impl LifecycleSink {
+    /// Starts the one writer that all component supervisors clone and share.
+    pub fn start(path: impl Into<PathBuf>) -> Self {
+        let (sender, receiver) = mpsc::channel(256);
+        let path = path.into();
+        let _ = std::thread::Builder::new()
+            .name("csm-lifecycle-writer".to_string())
+            .spawn(move || run_journal_writer(path, receiver));
+        Self {
+            sender,
+            acknowledgement_timeout: LIFECYCLE_ACK_TIMEOUT,
+        }
+    }
+
+    async fn append(&self, event: RetainedLifecycleEvent) -> JournalAppend {
+        let (response, receive) = oneshot::channel();
+        let mut fallback_event = event.clone();
+        if let Err(error) = self.sender.try_send(JournalCommand { event, response }) {
+            let (mut failed_event, reason) = match error {
+                mpsc::error::TrySendError::Full(command) => {
+                    (command.event, "lifecycle_writer_backpressure")
+                }
+                mpsc::error::TrySendError::Closed(command) => {
+                    (command.event, "lifecycle_writer_unavailable")
+                }
+            };
+            failed_event.retention = LifecycleRetention::NotRetained;
+            return JournalAppend {
+                event: failed_event,
+                errors: vec![reason.to_string()],
+            };
+        }
+        match tokio::time::timeout(self.acknowledgement_timeout, receive).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => {
+                fallback_event.retention = LifecycleRetention::Unknown;
+                JournalAppend {
+                    event: fallback_event,
+                    errors: vec!["lifecycle_writer_acknowledgement_lost".to_string()],
+                }
+            }
+            Err(_) => {
+                fallback_event.retention = LifecycleRetention::Unknown;
+                JournalAppend {
+                    event: fallback_event,
+                    errors: vec!["lifecycle_writer_acknowledgement_timeout".to_string()],
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LifecycleJournalWriter {
+    file: fs::File,
+    _writer_lock: fs::File,
+    next_sequence: u64,
+    startup_errors: Vec<String>,
+}
+
+impl LifecycleJournalWriter {
+    fn open(path: &Path) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("lifecycle_parent_create_failed:{error}"))?;
+        }
+        let writer_lock_path = lifecycle_writer_lock_path(path);
+        let writer_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&writer_lock_path)
+            .map_err(|error| format!("lifecycle_writer_lock_open_failed:{error}"))?;
+        FileExt::try_lock_exclusive(&writer_lock)
+            .map_err(|error| format!("lifecycle_writer_lock_failed:{error}"))?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .append(true)
+            .open(path)
+            .map_err(|error| format!("lifecycle_open_failed:{error}"))?;
+        FileExt::lock_exclusive(&file)
+            .map_err(|error| format!("lifecycle_data_lock_failed:{error}"))?;
+
+        file.seek(SeekFrom::Start(0))
+            .map_err(|error| format!("lifecycle_seek_failed:{error}"))?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|error| format!("lifecycle_read_failed:{error}"))?;
+        let mut startup_errors = Vec::new();
+        if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
+            file.seek(SeekFrom::End(0))
+                .map_err(|error| format!("lifecycle_seek_failed:{error}"))?;
+            file.write_all(b"\n")
+                .and_then(|_| file.flush())
+                .and_then(|_| file.sync_data())
+                .map_err(|error| format!("lifecycle_torn_tail_repair_failed:{error}"))?;
+            startup_errors.push("recovered_torn_final_line".to_string());
+        }
+
+        let replay = replay_lifecycle_bytes(&bytes);
+        if replay.invalid_lines > 0 {
+            startup_errors.push(format!("invalid_journal_lines:{}", replay.invalid_lines));
+        }
+        let next_sequence = replay
+            .events
+            .iter()
+            .map(|event| event.sequence)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        FileExt::unlock(&file).map_err(|error| format!("lifecycle_data_unlock_failed:{error}"))?;
+        Ok(Self {
+            file,
+            _writer_lock: writer_lock,
+            next_sequence,
+            startup_errors,
+        })
+    }
+
+    fn append(&mut self, mut event: RetainedLifecycleEvent) -> JournalAppend {
+        event.sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        event.retention = LifecycleRetention::Retained;
+        let result = FileExt::lock_exclusive(&self.file).and_then(|_| {
+            let write_result = serde_json::to_vec(&event)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+                .and_then(|mut bytes| {
+                    bytes.push(b'\n');
+                    self.file.write_all(&bytes)
+                })
+                .and_then(|_| self.file.flush())
+                .and_then(|_| self.file.sync_data());
+            let unlock_result = FileExt::unlock(&self.file);
+            write_result.and(unlock_result)
+        });
+        let mut errors = self.startup_errors.clone();
+        if let Err(error) = result {
+            event.retention = LifecycleRetention::NotRetained;
+            errors.push(format!("lifecycle_append_failed:{error}"));
+        }
+        JournalAppend { event, errors }
+    }
+}
+
+fn lifecycle_writer_lock_path(path: &Path) -> PathBuf {
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".writer.lock");
+    PathBuf::from(lock_path)
+}
+
+fn run_journal_writer(path: PathBuf, mut receiver: mpsc::Receiver<JournalCommand>) {
+    let mut writer = LifecycleJournalWriter::open(&path);
+    while let Some(command) = receiver.blocking_recv() {
+        let result = match writer.as_mut() {
+            Ok(writer) => writer.append(command.event),
+            Err(error) => {
+                let mut event = command.event;
+                event.retention = LifecycleRetention::NotRetained;
+                JournalAppend {
+                    event,
+                    errors: vec![error.clone()],
+                }
+            }
+        };
+        let _ = command.response.send(result);
+    }
+}
+
+pub fn replay_lifecycle_journal(path: &Path) -> LifecycleReplay {
+    let mut file = match OpenOptions::new().read(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return replay_lifecycle_bytes(&[]),
+        Err(error) => {
+            return LifecycleReplay {
+                events: Vec::new(),
+                invalid_lines: 0,
+                read_error: Some(format!("lifecycle_read_failed:{error}")),
+            };
+        }
+    };
+    if let Err(error) = FileExt::lock_shared(&file) {
+        return LifecycleReplay {
+            events: Vec::new(),
+            invalid_lines: 0,
+            read_error: Some(format!("lifecycle_read_lock_failed:{error}")),
+        };
+    }
+    let mut text = String::new();
+    let read_result = file.read_to_string(&mut text);
+    let unlock_result = FileExt::unlock(&file);
+    if let Err(error) = read_result.and(unlock_result) {
+        return LifecycleReplay {
+            events: Vec::new(),
+            invalid_lines: 0,
+            read_error: Some(format!("lifecycle_read_failed:{error}")),
+        };
+    }
+    let mut replay = replay_lifecycle_bytes(text.as_bytes());
+    replay.read_error = None;
+    replay
+}
+
+fn replay_lifecycle_bytes(bytes: &[u8]) -> LifecycleReplay {
+    let text = String::from_utf8_lossy(bytes);
+    let mut events = Vec::new();
+    let mut invalid_lines = 0;
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        match serde_json::from_str(line) {
+            Ok(event) => events.push(event),
+            Err(_) => invalid_lines += 1,
+        }
+    }
+    LifecycleReplay {
+        events,
+        invalid_lines,
+        read_error: None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupervisionOutcome {
+    pub component: ComponentId,
+    pub decision: ComponentDecision,
+    pub readiness: ComponentReadiness,
+    pub attempts: u32,
+    pub consecutive_failures: u32,
+    pub lifecycle_events: Vec<RetainedLifecycleEvent>,
+    pub dropped_in_memory_events: u64,
+    pub retention_errors: Vec<String>,
+}
+
+impl SupervisionOutcome {
+    pub fn retention_degraded(&self) -> bool {
+        !self.retention_errors.is_empty()
+            || self
+                .lifecycle_events
+                .iter()
+                .any(|event| event.retention != LifecycleRetention::Retained)
+    }
+}
+
+#[derive(Debug, Default)]
+struct LifecycleWindow {
+    recent: VecDeque<RetainedLifecycleEvent>,
+    dropped: u64,
+}
+
+impl LifecycleWindow {
+    fn push(&mut self, event: RetainedLifecycleEvent) {
+        if self.recent.len() == RECENT_LIFECYCLE_EVENT_LIMIT {
+            self.recent.pop_front();
+            self.dropped = self.dropped.saturating_add(1);
+        }
+        self.recent.push_back(event);
+    }
+}
+
+pub async fn supervise_component<F, Fut>(
+    component: ComponentId,
+    cancellation: CancellationToken,
+    lifecycle_sink: LifecycleSink,
+    mut run_component: F,
+) -> SupervisionOutcome
+where
+    F: FnMut(u32, CancellationToken) -> Fut,
+    Fut: Future<Output = Result<(), ComponentFailure>> + Send + 'static,
+{
+    let policy = policy_for(component);
+    let mut lifecycle_events = LifecycleWindow::default();
+    let mut retention_errors = Vec::new();
+    let mut attempt = 0_u32;
+    let mut consecutive_failures = 0_u32;
+
+    loop {
+        if cancellation.is_cancelled() {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Stopped,
+                    ComponentReadiness::Stopped,
+                    "governed_cancellation",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::GovernedStop,
+                ComponentReadiness::Stopped,
+                attempt,
+                consecutive_failures,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+
+        attempt = attempt.saturating_add(1);
+        retain_event(
+            &lifecycle_sink,
+            &mut lifecycle_events,
+            &mut retention_errors,
+            lifecycle_event(
+                component,
+                attempt,
+                LifecycleEventKind::Start,
+                ComponentReadiness::NotReady,
+                "component_attempt_started",
+            ),
+        )
+        .await;
+
+        let child_token = cancellation.child_token();
+        let constructed = catch_unwind(AssertUnwindSafe(|| {
+            run_component(attempt, child_token.clone())
+        }));
+        let exit = match constructed {
+            Err(_) => ComponentExit::Panicked,
+            Ok(future) => {
+                let mut join_set = JoinSet::new();
+                join_set.spawn(future);
+                tokio::select! {
+                    _ = cancellation.cancelled() => {
+                        child_token.cancel();
+                        join_set.abort_all();
+                        while join_set.join_next().await.is_some() {}
+                        ComponentExit::Cancelled
+                    }
+                    joined = join_set.join_next() => match joined {
+                        Some(Ok(Ok(()))) => ComponentExit::Healthy,
+                        Some(Ok(Err(ComponentFailure::Cancelled))) => ComponentExit::Cancelled,
+                        Some(Ok(Err(ComponentFailure::Failed(_)))) => ComponentExit::Failed,
+                        Some(Err(error)) if error.is_panic() => ComponentExit::Panicked,
+                        Some(Err(_)) | None => ComponentExit::Failed,
+                    }
+                }
+            }
+        };
+
+        if exit == ComponentExit::Healthy {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Healthy,
+                    ComponentReadiness::Ready,
+                    "component_healthy",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::ContinueHealthy,
+                ComponentReadiness::Ready,
+                attempt,
+                0,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+        if exit == ComponentExit::Cancelled {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Stopped,
+                    ComponentReadiness::Stopped,
+                    "governed_cancellation",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::GovernedStop,
+                ComponentReadiness::Stopped,
+                attempt,
+                consecutive_failures,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+
+        consecutive_failures = consecutive_failures.saturating_add(1);
+        let decision = decide_after_exit(&policy, exit, consecutive_failures);
+        let failure_code = if exit == ComponentExit::Panicked {
+            "component_task_panicked"
+        } else {
+            "component_task_failed"
+        };
+
+        match decision {
+            ComponentDecision::RestartWithBackoff | ComponentDecision::EscalateAndRestart => {
+                let kind = if decision == ComponentDecision::EscalateAndRestart {
+                    LifecycleEventKind::Escalated
+                } else {
+                    LifecycleEventKind::RestartScheduled
+                };
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        kind,
+                        ComponentReadiness::NotReady,
+                        failure_code,
+                    ),
+                )
+                .await;
+                let backoff = backoff_for_failure(&policy, consecutive_failures);
+                tokio::select! {
+                    _ = cancellation.cancelled() => {},
+                    _ = sleep(backoff) => continue,
+                }
+            }
+            ComponentDecision::DegradeAndContinue => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Degraded,
+                        ComponentReadiness::Degraded,
+                        policy.degradation_behavior,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::Degraded,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::Quarantine => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Quarantined,
+                        ComponentReadiness::Degraded,
+                        policy.degradation_behavior,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::Degraded,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::EscalateFailClosed => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Escalated,
+                        ComponentReadiness::NotReady,
+                        policy.escalation_target,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::NotReady,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::ContinueHealthy | ComponentDecision::GovernedStop => {
+                unreachable!("non-terminal failure cannot produce healthy or stopped decision")
+            }
+        }
+
+        retain_event(
+            &lifecycle_sink,
+            &mut lifecycle_events,
+            &mut retention_errors,
+            lifecycle_event(
+                component,
+                attempt,
+                LifecycleEventKind::Stopped,
+                ComponentReadiness::Stopped,
+                "governed_cancellation_during_backoff",
+            ),
+        )
+        .await;
+        return outcome(
+            &policy,
+            ComponentDecision::GovernedStop,
+            ComponentReadiness::Stopped,
+            attempt,
+            consecutive_failures,
+            lifecycle_events,
+            retention_errors,
+        );
+    }
+}
+
+fn lifecycle_event(
+    component: ComponentId,
+    attempt: u32,
+    event: LifecycleEventKind,
+    readiness: ComponentReadiness,
+    reason_code: impl Into<String>,
+) -> RetainedLifecycleEvent {
+    RetainedLifecycleEvent {
+        schema: SUPERVISION_LIFECYCLE_SCHEMA.to_string(),
+        sequence: 0,
+        component,
+        attempt,
+        event,
+        readiness,
+        retention: LifecycleRetention::NotRetained,
+        reason_code: reason_code.into(),
+    }
+}
+
+async fn retain_event(
+    sink: &LifecycleSink,
+    events: &mut LifecycleWindow,
+    retention_errors: &mut Vec<String>,
+    event: RetainedLifecycleEvent,
+) {
+    let appended = sink.append(event).await;
+    for error in appended.errors {
+        if !retention_errors.contains(&error) {
+            retention_errors.push(error);
+        }
+    }
+    events.push(appended.event);
+}
+
+fn outcome(
+    policy: &ComponentSupervisionPolicy,
+    mut decision: ComponentDecision,
+    mut readiness: ComponentReadiness,
+    attempts: u32,
+    consecutive_failures: u32,
+    lifecycle_events: LifecycleWindow,
+    retention_errors: Vec<String>,
+) -> SupervisionOutcome {
+    let LifecycleWindow {
+        recent: lifecycle_events,
+        dropped: dropped_in_memory_events,
+    } = lifecycle_events;
+    let lifecycle_events: Vec<_> = lifecycle_events.into_iter().collect();
+    let retention_degraded = !retention_errors.is_empty()
+        || lifecycle_events
+            .iter()
+            .any(|event| event.retention != LifecycleRetention::Retained);
+    if retention_degraded && readiness == ComponentReadiness::Ready {
+        if policy.telemetry_can_degrade {
+            decision = ComponentDecision::DegradeAndContinue;
+            readiness = ComponentReadiness::Degraded;
+        } else {
+            decision = ComponentDecision::EscalateFailClosed;
+            readiness = ComponentReadiness::NotReady;
+        }
+    }
+    SupervisionOutcome {
+        component: policy.component,
+        decision,
+        readiness,
+        attempts,
+        consecutive_failures,
+        lifecycle_events,
+        dropped_in_memory_events,
+        retention_errors,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestRoot(PathBuf);
+
+    impl TestRoot {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos();
+            Self(std::env::temp_dir().join(format!("adl-supervision-{name}-{unique}")))
+        }
+
+        fn journal(&self) -> PathBuf {
+            self.0.join("lifecycle.jsonl")
+        }
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
 
     #[test]
-    fn checkpoint_policy_is_continuity_critical() {
-        let checkpoint = default_component_supervision()
-            .into_iter()
-            .find(|policy| policy.component == "checkpoint")
-            .expect("checkpoint policy");
-        assert!(checkpoint.critical_for_continuity);
+    fn matrix_covers_every_runtime_component_with_explicit_policy() {
+        let policies = default_component_supervision();
+        assert_eq!(policies.len(), ComponentId::ALL.len());
+        for component in ComponentId::ALL {
+            let policy = policy_for(component);
+            assert_eq!(policy.component, component);
+            assert!(policy.backoff_cap_ms >= policy.backoff_base_ms);
+            assert!(policy.escalation_interval_failures > 0);
+            assert!(!policy.degradation_behavior.is_empty());
+            assert!(!policy.escalation_target.is_empty());
+            assert!(!policy.readiness_impact.is_empty());
+        }
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped_without_a_stop_budget() {
+        let policy = policy_for(ComponentId::RuntimeApi);
+        assert_eq!(backoff_for_failure(&policy, 1), Duration::from_millis(100));
+        assert_eq!(backoff_for_failure(&policy, 2), Duration::from_millis(200));
         assert_eq!(
-            checkpoint.restart_policy,
-            ComponentRestartPolicy::EscalateToGovernedShutdown
+            backoff_for_failure(&policy, 99),
+            Duration::from_millis(5_000)
         );
+        assert_eq!(
+            decide_after_exit(&policy, ComponentExit::Failed, 3),
+            ComponentDecision::EscalateAndRestart
+        );
+        assert_eq!(
+            decide_after_exit(&policy, ComponentExit::Failed, 4),
+            ComponentDecision::RestartWithBackoff
+        );
+    }
+
+    #[test]
+    fn in_memory_lifecycle_window_is_bounded_while_durable_history_remains_external() {
+        let mut window = LifecycleWindow::default();
+        for attempt in 1..=(RECENT_LIFECYCLE_EVENT_LIMIT as u32 + 10) {
+            window.push(lifecycle_event(
+                ComponentId::RuntimeApi,
+                attempt,
+                LifecycleEventKind::RestartScheduled,
+                ComponentReadiness::NotReady,
+                "component_task_failed",
+            ));
+        }
+        assert_eq!(window.recent.len(), RECENT_LIFECYCLE_EVENT_LIMIT);
+        assert_eq!(window.dropped, 10);
+        assert_eq!(window.recent.front().unwrap().attempt, 11);
+    }
+
+    #[tokio::test]
+    async fn restartable_component_recovers_and_replays_durable_lifecycle() {
+        let root = TestRoot::new("recover");
+        let attempts = Arc::new(AtomicU32::new(0));
+        let run_attempts = Arc::clone(&attempts);
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            move |_, _| {
+                let run_attempts = Arc::clone(&run_attempts);
+                async move {
+                    if run_attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                        Err(ComponentFailure::Failed("bind_failed"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.readiness, ComponentReadiness::Ready);
+        assert_eq!(outcome.attempts, 3);
+        assert!(!outcome.retention_degraded());
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events, outcome.lifecycle_events);
+        assert!(replay.events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.readiness == ComponentReadiness::NotReady
+        }));
+        assert_eq!(
+            replay.events.last().unwrap().event,
+            LifecycleEventKind::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_failure_escalates_but_never_exhausts_into_runtime_stop() {
+        let root = TestRoot::new("repeat");
+        let cancellation = CancellationToken::new();
+        let cancel_from_task = cancellation.clone();
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            cancellation,
+            LifecycleSink::start(root.journal()),
+            move |attempt, _| {
+                let cancel_from_task = cancel_from_task.clone();
+                async move {
+                    if attempt == 4 {
+                        cancel_from_task.cancel();
+                    }
+                    Err(ComponentFailure::Failed("bind_failed"))
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::GovernedStop);
+        assert_eq!(outcome.readiness, ComponentReadiness::Stopped);
+        assert_eq!(outcome.attempts, 4);
+        assert!(outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Escalated));
+        assert!(!outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Healthy));
+    }
+
+    #[tokio::test]
+    async fn component_panic_is_governed_and_then_restarted() {
+        install_csm_redacting_panic_hook();
+        let root = TestRoot::new("panic");
+        let outcome = supervise_component(
+            ComponentId::Scheduler,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |attempt, _| async move {
+                if attempt == 1 {
+                    panic!("test component panic");
+                }
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.attempts, 2);
+        assert!(outcome.lifecycle_events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.reason_code == "component_task_panicked"
+        }));
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_uncooperative_child_and_records_stop() {
+        let root = TestRoot::new("cancel");
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let outcome = supervise_component(
+            ComponentId::Aee,
+            cancellation,
+            LifecycleSink::start(root.journal()),
+            |_, _| async {
+                sleep(Duration::from_secs(60)).await;
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::GovernedStop);
+        assert_eq!(outcome.attempts, 0);
+        assert_eq!(outcome.lifecycle_events.len(), 1);
+        assert_eq!(
+            outcome.lifecycle_events[0].event,
+            LifecycleEventKind::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_failure_is_fail_closed_without_panicking_or_false_health() {
+        let root = TestRoot::new("checkpoint");
+        let outcome = supervise_component(
+            ComponentId::Checkpoint,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Err(ComponentFailure::Failed("storage_unavailable")) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::EscalateFailClosed);
+        assert_eq!(outcome.readiness, ComponentReadiness::NotReady);
+        assert_eq!(outcome.attempts, 1);
+        assert_eq!(
+            outcome.lifecycle_events.last().unwrap().reason_code,
+            "emergency_safe_fail_serialization"
+        );
+    }
+
+    #[tokio::test]
+    async fn chronosense_failure_degrades_truthfully() {
+        let root = TestRoot::new("chronosense");
+        let outcome = supervise_component(
+            ComponentId::Chronosense,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Err(ComponentFailure::Failed("time_source_unavailable")) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert_eq!(outcome.readiness, ComponentReadiness::Degraded);
+        assert!(!outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Healthy));
+    }
+
+    #[tokio::test]
+    async fn corrupt_prior_jsonl_does_not_stop_component_supervision() {
+        let root = TestRoot::new("corrupt");
+        fs::create_dir_all(&root.0).unwrap();
+        fs::write(root.journal(), b"not-json\n").unwrap();
+        let outcome = supervise_component(
+            ComponentId::Observability,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert_eq!(outcome.readiness, ComponentReadiness::Degraded);
+        assert!(outcome
+            .retention_errors
+            .iter()
+            .any(|error| error == "invalid_journal_lines:1"));
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 1);
+        assert_eq!(replay.events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn unwritable_lifecycle_target_degrades_retention_without_crashing_component() {
+        let root = TestRoot::new("unwritable");
+        fs::create_dir_all(root.journal()).unwrap();
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::EscalateFailClosed);
+        assert_eq!(outcome.readiness, ComponentReadiness::NotReady);
+        assert!(outcome.retention_degraded());
+        assert!(outcome
+            .lifecycle_events
+            .iter()
+            .all(|event| event.retention == LifecycleRetention::NotRetained));
+    }
+
+    #[tokio::test]
+    async fn torn_final_jsonl_record_is_preserved_and_separated_from_new_events() {
+        let root = TestRoot::new("torn");
+        fs::create_dir_all(&root.0).unwrap();
+        fs::write(root.journal(), b"torn-json").unwrap();
+        let outcome = supervise_component(
+            ComponentId::Observability,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert!(outcome
+            .retention_errors
+            .iter()
+            .any(|error| error == "recovered_torn_final_line"));
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 1);
+        assert_eq!(replay.events.len(), 2);
+        assert_eq!(replay.events[0].sequence, 1);
+        assert_eq!(replay.events[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn shared_lifecycle_sink_serializes_concurrent_component_events() {
+        let root = TestRoot::new("concurrent");
+        let sink = LifecycleSink::start(root.journal());
+        let (api, scheduler) = tokio::join!(
+            supervise_component(
+                ComponentId::RuntimeApi,
+                CancellationToken::new(),
+                sink.clone(),
+                |_, _| async { Ok(()) },
+            ),
+            supervise_component(
+                ComponentId::Scheduler,
+                CancellationToken::new(),
+                sink,
+                |_, _| async { Ok(()) },
+            )
+        );
+        assert_eq!(api.readiness, ComponentReadiness::Ready);
+        assert_eq!(scheduler.readiness, ComponentReadiness::Ready);
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events.len(), 4);
+        assert_eq!(
+            replay
+                .events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+    }
+
+    #[tokio::test]
+    async fn synchronous_future_construction_panic_is_governed_and_restarted() {
+        install_csm_redacting_panic_hook();
+        let root = TestRoot::new("construction-panic");
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |attempt, _| {
+                if attempt == 1 {
+                    panic!("future construction panic");
+                }
+                std::future::ready(Ok(()))
+            },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.attempts, 2);
+        assert!(outcome.lifecycle_events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.reason_code == "component_task_panicked"
+        }));
+    }
+
+    #[tokio::test]
+    async fn acknowledgement_timeout_reports_unknown_instead_of_false_retention() {
+        let (sender, mut receiver) = mpsc::channel::<JournalCommand>(1);
+        let writer = std::thread::spawn(move || {
+            let command = receiver.blocking_recv().unwrap();
+            std::thread::sleep(Duration::from_millis(100));
+            let mut event = command.event;
+            event.sequence = 7;
+            event.retention = LifecycleRetention::Retained;
+            let _ = command.response.send(JournalAppend {
+                event,
+                errors: Vec::new(),
+            });
+        });
+        let sink = LifecycleSink {
+            sender,
+            acknowledgement_timeout: Duration::from_millis(50),
+        };
+        let result = sink
+            .append(lifecycle_event(
+                ComponentId::RuntimeApi,
+                1,
+                LifecycleEventKind::Start,
+                ComponentReadiness::NotReady,
+                "component_attempt_started",
+            ))
+            .await;
+        assert_eq!(result.event.retention, LifecycleRetention::Unknown);
+        assert_eq!(result.event.sequence, 0);
+        assert_eq!(
+            result.errors,
+            vec!["lifecycle_writer_acknowledgement_timeout"]
+        );
+        writer.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn replay_waits_for_data_lock_and_never_reads_partial_record() {
+        let root = TestRoot::new("replay-lock");
+        fs::create_dir_all(&root.0).unwrap();
+        let mut event = lifecycle_event(
+            ComponentId::RuntimeApi,
+            1,
+            LifecycleEventKind::Healthy,
+            ComponentReadiness::Ready,
+            "component_healthy",
+        );
+        event.sequence = 1;
+        event.retention = LifecycleRetention::Retained;
+        fs::write(
+            root.journal(),
+            format!("{}\n", serde_json::to_string(&event).unwrap()),
+        )
+        .unwrap();
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(root.journal())
+            .unwrap();
+        FileExt::lock_exclusive(&lock_file).unwrap();
+        let path = root.journal();
+        let replay = tokio::task::spawn_blocking(move || replay_lifecycle_journal(&path));
+        sleep(Duration::from_millis(25)).await;
+        FileExt::unlock(&lock_file).unwrap();
+        let replay = replay.await.unwrap();
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events, vec![event]);
     }
 }

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -70,10 +70,13 @@ dependencies = [
 name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
+ "fs2",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1759,6 +1762,16 @@ checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4328,6 +4341,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -4726,6 +4740,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -89,6 +89,7 @@ pub fn run_runtime_main() {
 
 #[allow(dead_code)]
 pub fn run_csm_main() {
+    adl_runtime::supervision::install_csm_redacting_panic_hook();
     if let Err(err) = real_csm_main() {
         print_error_chain(&err);
         std::process::exit(1);


### PR DESCRIPTION
Closes #5112

## Summary
Implemented a typed CSM supervision policy matrix and reusable Tokio component supervisor. Restartable components retry indefinitely with capped exponential backoff and periodic escalation evidence rather than a process-ending retry budget. The supervisor governs task completion, panic, cancellation, degradation, quarantine, fail-closed escalation, readiness, and durable lifecycle retention.

## Artifacts
- Tracked implementation artifacts: `adl-runtime/Cargo.toml`, `adl-runtime/Cargo.lock`, `adl-runtime/src/supervision.rs`, `adl-runtime/src/determinism.rs`, `adl-runtime/src/resident_agent.rs`, `adl/Cargo.lock`, and `adl/src/cli/mod.rs`.
- Additional proof artifacts: focused tests embedded in `adl-runtime/src/supervision.rs`; final independent review truth in the issue SRP.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl-runtime/Cargo.toml supervision -- --nocapture` verified matrix coverage, permanent restart/escalation, panic/cancellation, fail-closed and degraded readiness, bounded history, durable replay, torn JSONL recovery, concurrent ordering, acknowledgement ambiguity, data locking, and retention failure behavior.
  - `cargo test --manifest-path adl-runtime/Cargo.toml` verified the complete runtime crate and compiler/C-SDLC independence contract; final result was 30 unit tests plus 1 independence test passing.
  - `cargo clippy --manifest-path adl-runtime/Cargo.toml --all-targets -- -D warnings` verified strict Clippy cleanliness after issue-local and inherited mechanical fixes.
  - `cargo check --manifest-path adl/Cargo.toml --bin csm` verified CSM compilation and runtime-owned panic-hook installation.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` and `git diff --check` verified formatting and patch hygiene.
  - `bash adl/tools/test_adl_runtime_compatibility.sh` with explicit stable owner binaries passed; an owner-lane invocation without `--build` was interrupted after Cargo fallback waited without progress and is not counted as proof.
  - `ADL_OWNER_BIN_DIR=$TMPDIR/adl-5112-owner-bin ADL_OWNER_VALIDATION_WARM_CACHE_OUTPUT=$TMPDIR/adl-5112-owner-warm-cache.json bash adl/tools/run_owner_validation_lane.sh runtime --build` built the issue branch owner binaries in temporary validation storage, proved stable CSM availability, and passed the runtime compatibility boundary.
- Results:
  - `PASS`: focused and full runtime tests.
  - `PASS`: strict runtime Clippy.
  - `PASS`: CSM compile integration.
  - `PASS`: formatting and diff hygiene.
  - `PASS`: `run_owner_validation_lane.sh runtime --build` branch-binary owner proof.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5112__v0-91-7-wp-07-runtime-implement-csm-component-supervision-policy-matrix/stp.md
- Output card: .adl/v0.91.7/tasks/issue-5112__v0-91-7-wp-07-runtime-implement-csm-component-supervision-policy-matrix/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-implement-csm-component-supervision-policy-matrix-adl-runtime-cargo-lock-adl-runtime-cargo-toml-adl-runtime-src-determinism-rs-adl-runtime-src-resident-agent-rs-adl-runtime-src-supervision-rs-adl-cargo-lock-adl-src-cli-mod-rs-adl-v0-91-7-tasks-issue-5112-v0-91-7-wp-07-runtime-implement-csm-component-supervision-policy-matrix-stp-md-adl-v0-91-7-tasks-issue-5112-v0-91-7-wp-07-runtime-implement-csm-component-supervision-policy-matrix-sor-md