### PR TITLE
[v0.91.7][WP-07][runtime] Implement typed channel backpressure policy matrix

### DIFF
--- a/adl-runtime/Cargo.lock
+++ b/adl-runtime/Cargo.lock
@@ -7,13 +7,21 @@ name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
  "fs2",
+ "redb",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -64,6 +72,22 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fs2"
@@ -128,6 +152,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,10 +175,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -167,6 +214,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -258,6 +333,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +419,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/adl-runtime/Cargo.lock
+++ b/adl-runtime/Cargo.lock
@@ -6,10 +6,13 @@ version = 4
 name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
+ "fs2",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -20,6 +23,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -57,6 +66,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +144,12 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -174,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +255,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -201,6 +309,28 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zmij"

--- a/adl-runtime/Cargo.toml
+++ b/adl-runtime/Cargo.toml
@@ -10,7 +10,10 @@ name = "adl_runtime"
 path = "src/lib.rs"
 
 [dependencies]
+fs2 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 serde_jcs = "0.2"
+tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/adl-runtime/Cargo.toml
+++ b/adl-runtime/Cargo.toml
@@ -11,9 +11,13 @@ path = "src/lib.rs"
 
 [dependencies]
 fs2 = "0.4"
+redb = "4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 serde_jcs = "0.2"
-tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/adl-runtime/src/backpressure.rs
+++ b/adl-runtime/src/backpressure.rs
@@ -1,5 +1,21 @@
 //! CSM runtime backpressure contract.
 
+use redb::{Database, Durability, ReadableDatabase, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+const SPOOL_MESSAGES: TableDefinition<u64, &[u8]> = TableDefinition::new("messages");
+const SPOOL_META: TableDefinition<&str, u64> = TableDefinition::new("spool_meta");
+const PUBLISH_CURSOR: TableDefinition<&str, u64> = TableDefinition::new("publish_cursor");
+const PUBLISH_RECEIPTS: TableDefinition<u64, &[u8]> = TableDefinition::new("publish_receipts");
+
 pub const CSM_BACKPRESSURE_REPORT_SCHEMA: &str = "adl.csm.backpressure_report.v1";
 pub const CSM_BACKPRESSURE_STATE_SCHEMA: &str = "adl.csm.backpressure_state.v1";
 pub const CSM_BACKPRESSURE_COMMAND_RESULT_SCHEMA: &str = "adl.csm.backpressure_command_result.v1";
@@ -7,9 +23,1270 @@ pub const CSM_BACKPRESSURE_COMMAND_RESULT_SCHEMA: &str = "adl.csm.backpressure_c
 pub const REQUIRED_STATE_LOSS_POLICY: &str = "never_silent_drop";
 pub const NONCRITICAL_LOSS_POLICY: &str = "explicit_defer_or_shed";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeChannelId {
+    SchedulerToReasoningRuntime,
+    ReasoningRuntimeToAee,
+    AeeToCheckpoint,
+    ComponentsToLifelog,
+    ComponentsToObservability,
+    CloudBridgeToAwsRoutes,
+    RuntimeApiToControlPlane,
+}
+
+impl RuntimeChannelId {
+    pub const ALL: [Self; 7] = [
+        Self::SchedulerToReasoningRuntime,
+        Self::ReasoningRuntimeToAee,
+        Self::AeeToCheckpoint,
+        Self::ComponentsToLifelog,
+        Self::ComponentsToObservability,
+        Self::CloudBridgeToAwsRoutes,
+        Self::RuntimeApiToControlPlane,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SchedulerToReasoningRuntime => "scheduler_to_reasoning_runtime",
+            Self::ReasoningRuntimeToAee => "reasoning_runtime_to_aee",
+            Self::AeeToCheckpoint => "aee_to_checkpoint",
+            Self::ComponentsToLifelog => "components_to_lifelog",
+            Self::ComponentsToObservability => "components_to_observability",
+            Self::CloudBridgeToAwsRoutes => "cloud_bridge_to_aws_routes",
+            Self::RuntimeApiToControlPlane => "runtime_api_to_control_plane",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelPriority {
+    CriticalContinuity,
+    GovernedExecution,
+    Evidence,
+    Audit,
+    LowPriorityObservability,
+    ControlPlane,
+}
+
+impl ChannelPriority {
+    pub const fn is_required(self) -> bool {
+        !matches!(self, Self::LowPriorityObservability)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FullQueuePolicy {
+    BlockProducer,
+    ThrottleProducer,
+    DurableSpool,
+    ShedLowPriorityOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdmissionOutcome {
+    Accepted,
+    Blocked,
+    Throttled,
+    Spooled,
+    Shed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessState {
+    Ready,
+    Degraded,
+    Overloaded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorAdvancePolicy {
+    OnAccept,
+    AfterDurableSpool,
+    AfterPublishableAck,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RuntimeChannelPolicy {
+    pub id: RuntimeChannelId,
+    pub source: &'static str,
+    pub target: &'static str,
+    pub capacity: usize,
+    pub priority: ChannelPriority,
+    pub full_queue_policy: FullQueuePolicy,
+    pub loss_policy: &'static str,
+    pub cursor_advance_policy: CursorAdvancePolicy,
+    pub health_signal: &'static str,
+    pub readiness_projection: &'static str,
+}
+
+impl RuntimeChannelPolicy {
+    pub fn preserves_required_state(self) -> bool {
+        !self.priority.is_required()
+            || matches!(self.loss_policy, REQUIRED_STATE_LOSS_POLICY)
+            || matches!(self.full_queue_policy, FullQueuePolicy::ShedLowPriorityOnly)
+    }
+
+    pub fn allows_low_priority_shed(self) -> bool {
+        matches!(self.full_queue_policy, FullQueuePolicy::ShedLowPriorityOnly)
+            && matches!(self.loss_policy, NONCRITICAL_LOSS_POLICY)
+    }
+
+    pub fn decide(
+        self,
+        snapshot: ChannelQueueSnapshot,
+        priority: ChannelPriority,
+    ) -> AdmissionDecision {
+        if snapshot.depth < self.capacity {
+            return AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Accepted,
+                readiness: ReadinessState::Ready,
+                drop_accounted: false,
+                preserves_required_state: true,
+                cursor_may_advance: matches!(
+                    self.cursor_advance_policy,
+                    CursorAdvancePolicy::OnAccept
+                ),
+                health_signal: self.health_signal,
+                reason: "bounded_capacity_available",
+            };
+        }
+
+        match self.full_queue_policy {
+            FullQueuePolicy::BlockProducer => AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Blocked,
+                readiness: ReadinessState::Overloaded,
+                drop_accounted: false,
+                preserves_required_state: true,
+                cursor_may_advance: false,
+                health_signal: self.health_signal,
+                reason: "full_queue_blocks_required_state",
+            },
+            FullQueuePolicy::ThrottleProducer => AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Throttled,
+                readiness: ReadinessState::Degraded,
+                drop_accounted: false,
+                preserves_required_state: true,
+                cursor_may_advance: false,
+                health_signal: self.health_signal,
+                reason: "full_queue_throttles_control_plane",
+            },
+            FullQueuePolicy::DurableSpool => AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Spooled,
+                readiness: ReadinessState::Degraded,
+                drop_accounted: false,
+                preserves_required_state: true,
+                cursor_may_advance: matches!(
+                    self.cursor_advance_policy,
+                    CursorAdvancePolicy::AfterDurableSpool
+                ),
+                health_signal: self.health_signal,
+                reason: "full_queue_uses_durable_spool",
+            },
+            FullQueuePolicy::ShedLowPriorityOnly if priority.is_required() => AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Spooled,
+                readiness: ReadinessState::Degraded,
+                drop_accounted: false,
+                preserves_required_state: true,
+                cursor_may_advance: false,
+                health_signal: self.health_signal,
+                reason: "full_queue_spools_required_observability",
+            },
+            FullQueuePolicy::ShedLowPriorityOnly => AdmissionDecision {
+                channel: self.id,
+                outcome: AdmissionOutcome::Shed,
+                readiness: ReadinessState::Degraded,
+                drop_accounted: true,
+                preserves_required_state: true,
+                cursor_may_advance: false,
+                health_signal: self.health_signal,
+                reason: "full_queue_sheds_accounted_low_priority_observability",
+            },
+        }
+    }
+
+    pub fn to_json(self) -> Value {
+        json!({
+            "channel_id": self.id.as_str(),
+            "source": self.source,
+            "target": self.target,
+            "capacity": self.capacity,
+            "priority": self.priority,
+            "full_queue_policy": self.full_queue_policy,
+            "loss_policy": self.loss_policy,
+            "cursor_advance_policy": self.cursor_advance_policy,
+            "health_signal": self.health_signal,
+            "readiness_projection": self.readiness_projection,
+            "preserves_required_state": self.preserves_required_state(),
+            "allows_low_priority_shed": self.allows_low_priority_shed()
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelQueueSnapshot {
+    pub depth: usize,
+    pub dropped_count: u64,
+    pub deferred_count: u64,
+    pub throttled_count: u64,
+    pub durable_spool_depth: usize,
+}
+
+impl ChannelQueueSnapshot {
+    pub const fn empty() -> Self {
+        Self {
+            depth: 0,
+            dropped_count: 0,
+            deferred_count: 0,
+            throttled_count: 0,
+            durable_spool_depth: 0,
+        }
+    }
+
+    pub const fn full(capacity: usize) -> Self {
+        Self {
+            depth: capacity,
+            dropped_count: 0,
+            deferred_count: 0,
+            throttled_count: 0,
+            durable_spool_depth: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct AdmissionDecision {
+    pub channel: RuntimeChannelId,
+    pub outcome: AdmissionOutcome,
+    pub readiness: ReadinessState,
+    pub drop_accounted: bool,
+    pub preserves_required_state: bool,
+    pub cursor_may_advance: bool,
+    pub health_signal: &'static str,
+    pub reason: &'static str,
+}
+
+pub fn typed_channel_policy_matrix() -> Vec<RuntimeChannelPolicy> {
+    vec![
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::SchedulerToReasoningRuntime,
+            source: "scheduler",
+            target: "reasoning_runtime",
+            capacity: 64,
+            priority: ChannelPriority::GovernedExecution,
+            full_queue_policy: FullQueuePolicy::BlockProducer,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::OnAccept,
+            health_signal: "scheduler_reasoning_queue_overloaded",
+            readiness_projection: "/ready.scheduler_reasoning_admission",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::ReasoningRuntimeToAee,
+            source: "reasoning_runtime",
+            target: "aee",
+            capacity: 128,
+            priority: ChannelPriority::GovernedExecution,
+            full_queue_policy: FullQueuePolicy::BlockProducer,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::OnAccept,
+            health_signal: "reasoning_aee_queue_overloaded",
+            readiness_projection: "/ready.governed_execution_admission",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::AeeToCheckpoint,
+            source: "aee",
+            target: "checkpoint",
+            capacity: 32,
+            priority: ChannelPriority::CriticalContinuity,
+            full_queue_policy: FullQueuePolicy::DurableSpool,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::AfterDurableSpool,
+            health_signal: "checkpoint_spool_lag",
+            readiness_projection: "/ready.continuity_checkpoint_lag",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::ComponentsToLifelog,
+            source: "components",
+            target: "lifelog",
+            capacity: 256,
+            priority: ChannelPriority::Evidence,
+            full_queue_policy: FullQueuePolicy::DurableSpool,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::AfterDurableSpool,
+            health_signal: "lifelog_spool_lag",
+            readiness_projection: "/ready.lifecycle_evidence_lag",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::ComponentsToObservability,
+            source: "components",
+            target: "observability",
+            capacity: 1024,
+            priority: ChannelPriority::Audit,
+            full_queue_policy: FullQueuePolicy::ShedLowPriorityOnly,
+            loss_policy: NONCRITICAL_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::AfterDurableSpool,
+            health_signal: "observability_backpressure",
+            readiness_projection: "/ready.observability_degraded",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::CloudBridgeToAwsRoutes,
+            source: "cloud_bridge",
+            target: "aws_routes",
+            capacity: 64,
+            priority: ChannelPriority::Evidence,
+            full_queue_policy: FullQueuePolicy::DurableSpool,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::AfterPublishableAck,
+            health_signal: "cloud_publish_spool_lag",
+            readiness_projection: "/ready.cloud_publishability",
+        },
+        RuntimeChannelPolicy {
+            id: RuntimeChannelId::RuntimeApiToControlPlane,
+            source: "runtime_api",
+            target: "control_plane",
+            capacity: 32,
+            priority: ChannelPriority::ControlPlane,
+            full_queue_policy: FullQueuePolicy::ThrottleProducer,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::OnAccept,
+            health_signal: "runtime_api_control_plane_overload",
+            readiness_projection: "/ready.control_plane_overload",
+        },
+    ]
+}
+
+pub fn runtime_channel_policy(id: RuntimeChannelId) -> RuntimeChannelPolicy {
+    typed_channel_policy_matrix()
+        .into_iter()
+        .find(|policy| policy.id == id)
+        .expect("runtime channel policy matrix covers every typed channel")
+}
+
+pub fn typed_channel_policy_matrix_json() -> Value {
+    json!({
+        "schema": "adl.csm.typed_channel_backpressure_policy_matrix.v1",
+        "runtime_owner": "csm",
+        "channels": typed_channel_policy_matrix()
+            .into_iter()
+            .map(RuntimeChannelPolicy::to_json)
+            .collect::<Vec<_>>()
+    })
+}
+
+pub fn typed_channel_full_queue_readiness_projection_json() -> Value {
+    let mut decisions = typed_channel_policy_matrix()
+        .into_iter()
+        .map(|policy| policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority))
+        .collect::<Vec<_>>();
+    let observability = runtime_channel_policy(RuntimeChannelId::ComponentsToObservability);
+    decisions.push(observability.decide(
+        ChannelQueueSnapshot::full(observability.capacity),
+        ChannelPriority::LowPriorityObservability,
+    ));
+    readiness_projection(&decisions)
+}
+
+pub fn readiness_projection(decisions: &[AdmissionDecision]) -> Value {
+    let overloaded = decisions
+        .iter()
+        .filter(|decision| decision.readiness == ReadinessState::Overloaded)
+        .count();
+    let degraded = decisions
+        .iter()
+        .filter(|decision| decision.readiness == ReadinessState::Degraded)
+        .count();
+    let accounted_drops: u64 = decisions
+        .iter()
+        .filter(|decision| decision.drop_accounted)
+        .count() as u64;
+    let required_state_silently_dropped = decisions
+        .iter()
+        .any(|decision| !decision.preserves_required_state);
+    let state = if overloaded > 0 {
+        "overloaded"
+    } else if degraded > 0 {
+        "degraded"
+    } else {
+        "ready"
+    };
+
+    json!({
+        "schema": "adl.csm.typed_channel_backpressure_readiness.v1",
+        "state": state,
+        "overloaded_channel_count": overloaded,
+        "degraded_channel_count": degraded,
+        "accounted_drop_count": accounted_drops,
+        "required_state_silently_dropped": required_state_silently_dropped,
+        "decisions": decisions
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeMessage {
+    pub id: String,
+    pub priority: ChannelPriority,
+    pub payload: Value,
+}
+
+impl RuntimeMessage {
+    pub fn new(id: impl Into<String>, priority: ChannelPriority, payload: Value) -> Self {
+        Self {
+            id: id.into(),
+            priority,
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct RuntimeEnvelope {
+    message: RuntimeMessage,
+    spool_sequence: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeDelivery {
+    pub message: RuntimeMessage,
+    pub spool_sequence: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TransportPublishReceipt {
+    pub spool_sequence: u64,
+    pub cursor: u64,
+    pub transport: String,
+    pub receipt_id: String,
+}
+
+impl TransportPublishReceipt {
+    pub fn verified(
+        spool_sequence: u64,
+        cursor: u64,
+        transport: impl Into<String>,
+        receipt_id: impl Into<String>,
+    ) -> Result<Self, RuntimeChannelError> {
+        let transport = transport.into();
+        let receipt_id = receipt_id.into();
+        if transport.trim().is_empty() || receipt_id.trim().is_empty() {
+            return Err(RuntimeChannelError::InvalidPublishReceipt(
+                "transport and receipt_id must be non-empty".to_string(),
+            ));
+        }
+        Ok(Self {
+            spool_sequence,
+            cursor,
+            transport,
+            receipt_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeSendOutcome {
+    Accepted,
+    BlockedThenAccepted,
+    Throttled,
+    DurablySpooled,
+    Shed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeSendReceipt {
+    pub channel: RuntimeChannelId,
+    pub message_id: String,
+    pub outcome: RuntimeSendOutcome,
+    pub spool_sequence: Option<u64>,
+    pub cursor_may_advance: bool,
+    pub readiness: ReadinessState,
+    pub reason: &'static str,
+}
+
+#[derive(Debug)]
+pub enum RuntimeChannelError {
+    Closed(RuntimeChannelId),
+    Spool(String),
+    Serialization(String),
+    Join(String),
+    UnknownSpoolSequence(u64),
+    InvalidPublishReceipt(String),
+    NonMonotonicPublishCursor { current: u64, proposed: u64 },
+}
+
+impl fmt::Display for RuntimeChannelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Closed(channel) => write!(formatter, "runtime channel {channel:?} is closed"),
+            Self::Spool(reason) => write!(formatter, "durable spool failure: {reason}"),
+            Self::Serialization(reason) => {
+                write!(formatter, "message serialization failure: {reason}")
+            }
+            Self::Join(reason) => write!(formatter, "durable spool worker failure: {reason}"),
+            Self::UnknownSpoolSequence(sequence) => {
+                write!(
+                    formatter,
+                    "durable spool sequence {sequence} does not exist"
+                )
+            }
+            Self::InvalidPublishReceipt(reason) => {
+                write!(formatter, "invalid transport publish receipt: {reason}")
+            }
+            Self::NonMonotonicPublishCursor { current, proposed } => write!(
+                formatter,
+                "publish cursor must advance contiguously: current={current} proposed={proposed}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeChannelError {}
+
+#[derive(Debug, Default)]
+struct RuntimeChannelMetrics {
+    accepted: AtomicU64,
+    blocked: AtomicU64,
+    throttled: AtomicU64,
+    spooled: AtomicU64,
+    shed: AtomicU64,
+    cancelled: AtomicU64,
+    publish_acked: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RuntimeChannelSnapshot {
+    pub channel: RuntimeChannelId,
+    pub capacity: usize,
+    pub depth: usize,
+    pub accepted_count: u64,
+    pub blocked_count: u64,
+    pub throttled_count: u64,
+    pub durable_spool_depth: usize,
+    pub spooled_count: u64,
+    pub shed_count: u64,
+    pub cancelled_count: u64,
+    pub publish_acked_count: u64,
+    pub publish_cursor: u64,
+    pub readiness: ReadinessState,
+}
+
+#[derive(Debug)]
+struct DurableSpool {
+    database: Database,
+}
+
+impl DurableSpool {
+    fn open(path: &Path) -> Result<Self, RuntimeChannelError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        }
+        let database = Database::create(path)
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        Ok(Self { database })
+    }
+
+    fn append(&self, message: &RuntimeMessage) -> Result<u64, RuntimeChannelError> {
+        let encoded = serde_json::to_vec(message)
+            .map_err(|error| RuntimeChannelError::Serialization(error.to_string()))?;
+        let mut write = self
+            .database
+            .begin_write()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        write
+            .set_durability(Durability::Immediate)
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        let last_message_sequence = {
+            let table = write
+                .open_table(SPOOL_MESSAGES)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let sequence = table
+                .last()
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .map_or(0, |(key, _)| key.value());
+            sequence
+        };
+        let publish_cursor = {
+            let table = write
+                .open_table(PUBLISH_CURSOR)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let cursor = table
+                .get("cloud_bridge")
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .map_or(0, |value| value.value());
+            cursor
+        };
+        let sequence = {
+            let mut meta = write
+                .open_table(SPOOL_META)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let persisted_next = meta
+                .get("next_sequence")
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .map(|value| value.value());
+            let next = persisted_next.unwrap_or_else(|| {
+                last_message_sequence
+                    .max(publish_cursor)
+                    .saturating_add(1)
+                    .max(1)
+            });
+            meta.insert("next_sequence", next.saturating_add(1))
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            next
+        };
+        {
+            let mut table = write
+                .open_table(SPOOL_MESSAGES)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            table
+                .insert(sequence, encoded.as_slice())
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        }
+        write
+            .commit()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        Ok(sequence)
+    }
+
+    fn remove(&self, sequence: u64) -> Result<bool, RuntimeChannelError> {
+        let mut write = self
+            .database
+            .begin_write()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        write
+            .set_durability(Durability::Immediate)
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        let removed = {
+            let mut table = write
+                .open_table(SPOOL_MESSAGES)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let removed = table
+                .remove(sequence)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .is_some();
+            removed
+        };
+        write
+            .commit()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        Ok(removed)
+    }
+
+    fn acknowledge_published(
+        &self,
+        receipt: &TransportPublishReceipt,
+    ) -> Result<(), RuntimeChannelError> {
+        let encoded = serde_json::to_vec(receipt)
+            .map_err(|error| RuntimeChannelError::Serialization(error.to_string()))?;
+        let mut write = self
+            .database
+            .begin_write()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        write
+            .set_durability(Durability::Immediate)
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+
+        let message_exists = {
+            let messages = write
+                .open_table(SPOOL_MESSAGES)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let exists = messages
+                .get(receipt.spool_sequence)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .is_some();
+            exists
+        };
+        if !message_exists {
+            return Err(RuntimeChannelError::UnknownSpoolSequence(
+                receipt.spool_sequence,
+            ));
+        }
+        let current = {
+            let cursors = write
+                .open_table(PUBLISH_CURSOR)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            let current = cursors
+                .get("cloud_bridge")
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+                .map_or(0, |value| value.value());
+            current
+        };
+        if receipt.cursor != current.saturating_add(1) {
+            return Err(RuntimeChannelError::NonMonotonicPublishCursor {
+                current,
+                proposed: receipt.cursor,
+            });
+        }
+        {
+            let mut messages = write
+                .open_table(SPOOL_MESSAGES)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            messages
+                .remove(receipt.spool_sequence)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        }
+        {
+            let mut cursors = write
+                .open_table(PUBLISH_CURSOR)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            cursors
+                .insert("cloud_bridge", receipt.cursor)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        }
+        {
+            let mut receipts = write
+                .open_table(PUBLISH_RECEIPTS)
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+            receipts
+                .insert(receipt.cursor, encoded.as_slice())
+                .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        }
+        write
+            .commit()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))
+    }
+
+    fn publish_cursor(&self) -> Result<u64, RuntimeChannelError> {
+        let read = self
+            .database
+            .begin_read()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        let table = match read.open_table(PUBLISH_CURSOR) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(0),
+            Err(error) => return Err(RuntimeChannelError::Spool(error.to_string())),
+        };
+        Ok(table
+            .get("cloud_bridge")
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+            .map_or(0, |value| value.value()))
+    }
+
+    fn entries(&self) -> Result<Vec<(u64, RuntimeMessage)>, RuntimeChannelError> {
+        let read = self
+            .database
+            .begin_read()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+        let table = match read.open_table(SPOOL_MESSAGES) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(error) => return Err(RuntimeChannelError::Spool(error.to_string())),
+        };
+        table
+            .iter()
+            .map_err(|error| RuntimeChannelError::Spool(error.to_string()))?
+            .map(|entry| {
+                let (sequence, payload) =
+                    entry.map_err(|error| RuntimeChannelError::Spool(error.to_string()))?;
+                let message = serde_json::from_slice(payload.value())
+                    .map_err(|error| RuntimeChannelError::Serialization(error.to_string()))?;
+                Ok((sequence.value(), message))
+            })
+            .collect()
+    }
+
+    fn len(&self) -> Result<usize, RuntimeChannelError> {
+        Ok(self.entries()?.len())
+    }
+}
+
+#[derive(Clone)]
+pub struct RuntimeChannelSender {
+    policy: RuntimeChannelPolicy,
+    sender: mpsc::Sender<RuntimeEnvelope>,
+    metrics: Arc<RuntimeChannelMetrics>,
+    spool: Arc<DurableSpool>,
+    replay_in_flight: Arc<Mutex<BTreeSet<u64>>>,
+}
+
+pub struct RuntimeChannelReceiver {
+    policy: RuntimeChannelPolicy,
+    receiver: mpsc::Receiver<RuntimeEnvelope>,
+}
+
+struct RuntimeChannelNode {
+    sender: RuntimeChannelSender,
+    receiver: RuntimeChannelReceiver,
+}
+
+pub struct RuntimeChannelFabric {
+    channels: BTreeMap<RuntimeChannelId, RuntimeChannelNode>,
+}
+
+impl RuntimeChannelFabric {
+    pub fn open(spool_root: impl AsRef<Path>) -> Result<Self, RuntimeChannelError> {
+        let spool_root = spool_root.as_ref();
+        let mut channels = BTreeMap::new();
+        for id in RuntimeChannelId::ALL {
+            let (sender, receiver) = runtime_channel(
+                runtime_channel_policy(id),
+                spool_root.join(format!("{}.redb", id.as_str())),
+            )?;
+            channels.insert(id, RuntimeChannelNode { sender, receiver });
+        }
+        Ok(Self { channels })
+    }
+
+    pub async fn transit(
+        &mut self,
+        id: RuntimeChannelId,
+        message: RuntimeMessage,
+        cancellation: &CancellationToken,
+    ) -> Result<(RuntimeSendReceipt, Option<RuntimeDelivery>), RuntimeChannelError> {
+        let node = self
+            .channels
+            .get_mut(&id)
+            .expect("runtime channel fabric covers every RuntimeChannelId");
+        let receipt = node.sender.send(message, cancellation).await?;
+        let delivery = if matches!(
+            receipt.outcome,
+            RuntimeSendOutcome::Accepted | RuntimeSendOutcome::BlockedThenAccepted
+        ) {
+            node.receiver.recv().await
+        } else {
+            None
+        };
+        Ok((receipt, delivery))
+    }
+
+    pub async fn snapshots(&self) -> Result<Vec<RuntimeChannelSnapshot>, RuntimeChannelError> {
+        let mut snapshots = Vec::with_capacity(self.channels.len());
+        for id in RuntimeChannelId::ALL {
+            snapshots.push(
+                self.channels
+                    .get(&id)
+                    .expect("runtime channel fabric covers every RuntimeChannelId")
+                    .sender
+                    .snapshot()
+                    .await?,
+            );
+        }
+        Ok(snapshots)
+    }
+
+    pub async fn persist_required(
+        &self,
+        id: RuntimeChannelId,
+        message: RuntimeMessage,
+    ) -> Result<RuntimeSendReceipt, RuntimeChannelError> {
+        let node = self
+            .channels
+            .get(&id)
+            .expect("runtime channel fabric covers every RuntimeChannelId");
+        let message_id = message.id.clone();
+        node.sender
+            .spool_required_with_reason(
+                message,
+                message_id,
+                "required_message_persisted_before_external_delivery",
+            )
+            .await
+    }
+
+    pub async fn replay_next(
+        &mut self,
+        id: RuntimeChannelId,
+        cancellation: &CancellationToken,
+    ) -> Result<Option<RuntimeDelivery>, RuntimeChannelError> {
+        let node = self
+            .channels
+            .get_mut(&id)
+            .expect("runtime channel fabric covers every RuntimeChannelId");
+        if !node.sender.replay_next_spooled(cancellation).await? {
+            return Ok(None);
+        }
+        Ok(node.receiver.recv().await)
+    }
+
+    pub async fn acknowledge_processed(
+        &self,
+        id: RuntimeChannelId,
+        sequence: u64,
+    ) -> Result<(), RuntimeChannelError> {
+        self.channels
+            .get(&id)
+            .expect("runtime channel fabric covers every RuntimeChannelId")
+            .sender
+            .acknowledge_processed(sequence)
+            .await
+    }
+
+    pub fn release_replay(
+        &self,
+        id: RuntimeChannelId,
+        sequence: u64,
+    ) -> Result<(), RuntimeChannelError> {
+        self.channels
+            .get(&id)
+            .expect("runtime channel fabric covers every RuntimeChannelId")
+            .sender
+            .clear_replay_in_flight(sequence)
+    }
+
+    pub async fn acknowledge_published(
+        &self,
+        receipt: TransportPublishReceipt,
+    ) -> Result<(), RuntimeChannelError> {
+        self.channels
+            .get(&RuntimeChannelId::CloudBridgeToAwsRoutes)
+            .expect("runtime channel fabric covers cloud bridge")
+            .sender
+            .acknowledge_published(receipt)
+            .await
+    }
+}
+
+pub fn runtime_channel(
+    policy: RuntimeChannelPolicy,
+    spool_path: impl AsRef<Path>,
+) -> Result<(RuntimeChannelSender, RuntimeChannelReceiver), RuntimeChannelError> {
+    let (sender, receiver) = mpsc::channel(policy.capacity);
+    let metrics = Arc::new(RuntimeChannelMetrics::default());
+    let spool = Arc::new(DurableSpool::open(spool_path.as_ref())?);
+    let replay_in_flight = Arc::new(Mutex::new(BTreeSet::new()));
+    Ok((
+        RuntimeChannelSender {
+            policy,
+            sender,
+            metrics: Arc::clone(&metrics),
+            spool,
+            replay_in_flight,
+        },
+        RuntimeChannelReceiver { policy, receiver },
+    ))
+}
+
+impl RuntimeChannelSender {
+    pub async fn send(
+        &self,
+        message: RuntimeMessage,
+        cancellation: &CancellationToken,
+    ) -> Result<RuntimeSendReceipt, RuntimeChannelError> {
+        let message_id = message.id.clone();
+        match self.sender.try_send(RuntimeEnvelope {
+            message,
+            spool_sequence: None,
+        }) {
+            Ok(()) => {
+                self.metrics.accepted.fetch_add(1, Ordering::SeqCst);
+                Ok(self.receipt(
+                    message_id,
+                    RuntimeSendOutcome::Accepted,
+                    None,
+                    matches!(
+                        self.policy.cursor_advance_policy,
+                        CursorAdvancePolicy::OnAccept
+                    ),
+                    ReadinessState::Ready,
+                    "bounded_capacity_available",
+                ))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(RuntimeChannelError::Closed(self.policy.id))
+            }
+            Err(mpsc::error::TrySendError::Full(envelope)) => {
+                self.handle_full(envelope.message, message_id, cancellation)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_full(
+        &self,
+        message: RuntimeMessage,
+        message_id: String,
+        cancellation: &CancellationToken,
+    ) -> Result<RuntimeSendReceipt, RuntimeChannelError> {
+        match self.policy.full_queue_policy {
+            FullQueuePolicy::BlockProducer => {
+                self.metrics.blocked.fetch_add(1, Ordering::SeqCst);
+                tokio::select! {
+                    biased;
+                    () = cancellation.cancelled() => {
+                        self.metrics.cancelled.fetch_add(1, Ordering::SeqCst);
+                        self.spool_required_with_reason(
+                            message,
+                            message_id,
+                            "blocked_send_cancelled_required_message_spooled",
+                        ).await
+                    }
+                    permit = self.sender.reserve() => {
+                        let permit = permit.map_err(|_| RuntimeChannelError::Closed(self.policy.id))?;
+                        permit.send(RuntimeEnvelope { message, spool_sequence: None });
+                        self.metrics.accepted.fetch_add(1, Ordering::SeqCst);
+                        Ok(self.receipt(message_id, RuntimeSendOutcome::BlockedThenAccepted, None, matches!(self.policy.cursor_advance_policy, CursorAdvancePolicy::OnAccept), ReadinessState::Ready, "capacity_recovered_after_block"))
+                    }
+                }
+            }
+            FullQueuePolicy::ThrottleProducer => {
+                self.metrics.throttled.fetch_add(1, Ordering::SeqCst);
+                Ok(self.receipt(
+                    message_id,
+                    RuntimeSendOutcome::Throttled,
+                    None,
+                    false,
+                    ReadinessState::Degraded,
+                    "full_queue_throttles_control_plane",
+                ))
+            }
+            FullQueuePolicy::DurableSpool => self.spool_required(message, message_id).await,
+            FullQueuePolicy::ShedLowPriorityOnly if message.priority.is_required() => {
+                self.spool_required(message, message_id).await
+            }
+            FullQueuePolicy::ShedLowPriorityOnly => {
+                self.metrics.shed.fetch_add(1, Ordering::SeqCst);
+                Ok(self.receipt(
+                    message_id,
+                    RuntimeSendOutcome::Shed,
+                    None,
+                    false,
+                    ReadinessState::Degraded,
+                    "accounted_low_priority_shed",
+                ))
+            }
+        }
+    }
+
+    async fn spool_required(
+        &self,
+        message: RuntimeMessage,
+        message_id: String,
+    ) -> Result<RuntimeSendReceipt, RuntimeChannelError> {
+        self.spool_required_with_reason(message, message_id, "required_message_durably_spooled")
+            .await
+    }
+
+    async fn spool_required_with_reason(
+        &self,
+        message: RuntimeMessage,
+        message_id: String,
+        reason: &'static str,
+    ) -> Result<RuntimeSendReceipt, RuntimeChannelError> {
+        let spool = Arc::clone(&self.spool);
+        let sequence = tokio::task::spawn_blocking(move || spool.append(&message))
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        self.metrics.spooled.fetch_add(1, Ordering::SeqCst);
+        Ok(self.receipt(
+            message_id,
+            RuntimeSendOutcome::DurablySpooled,
+            Some(sequence),
+            matches!(
+                self.policy.cursor_advance_policy,
+                CursorAdvancePolicy::AfterDurableSpool
+            ),
+            ReadinessState::Degraded,
+            reason,
+        ))
+    }
+
+    pub async fn replay_spooled(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<usize, RuntimeChannelError> {
+        let spool = Arc::clone(&self.spool);
+        let entries = tokio::task::spawn_blocking(move || spool.entries())
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        let mut replayed = 0;
+        for (sequence, message) in entries {
+            {
+                let mut in_flight = self.replay_in_flight.lock().map_err(|_| {
+                    RuntimeChannelError::Spool("replay in-flight lock poisoned".to_string())
+                })?;
+                if in_flight.contains(&sequence) {
+                    return Ok(replayed);
+                }
+                in_flight.insert(sequence);
+            }
+            tokio::select! {
+                biased;
+                () = cancellation.cancelled() => {
+                    self.clear_replay_in_flight(sequence)?;
+                    break
+                },
+                result = self.sender.send(RuntimeEnvelope {
+                    message,
+                    spool_sequence: Some(sequence),
+                }) => {
+                    if result.is_err() {
+                        self.clear_replay_in_flight(sequence)?;
+                        return Err(RuntimeChannelError::Closed(self.policy.id));
+                    }
+                    self.metrics.accepted.fetch_add(1, Ordering::SeqCst);
+                    replayed += 1;
+                }
+            }
+        }
+        Ok(replayed)
+    }
+
+    async fn replay_next_spooled(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<bool, RuntimeChannelError> {
+        let spool = Arc::clone(&self.spool);
+        let entries = tokio::task::spawn_blocking(move || spool.entries())
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        for (sequence, message) in entries {
+            {
+                let mut in_flight = self.replay_in_flight.lock().map_err(|_| {
+                    RuntimeChannelError::Spool("replay in-flight lock poisoned".to_string())
+                })?;
+                if in_flight.contains(&sequence) {
+                    return Ok(false);
+                }
+                in_flight.insert(sequence);
+            }
+            let sent = tokio::select! {
+                biased;
+                () = cancellation.cancelled() => false,
+                result = self.sender.send(RuntimeEnvelope {
+                    message,
+                    spool_sequence: Some(sequence),
+                }) => {
+                    result.map_err(|_| RuntimeChannelError::Closed(self.policy.id))?;
+                    self.metrics.accepted.fetch_add(1, Ordering::SeqCst);
+                    true
+                }
+            };
+            if !sent {
+                self.clear_replay_in_flight(sequence)?;
+            }
+            return Ok(sent);
+        }
+        Ok(false)
+    }
+
+    pub async fn acknowledge_processed(&self, sequence: u64) -> Result<(), RuntimeChannelError> {
+        let spool = Arc::clone(&self.spool);
+        let removed = tokio::task::spawn_blocking(move || spool.remove(sequence))
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        if !removed {
+            return Err(RuntimeChannelError::UnknownSpoolSequence(sequence));
+        }
+        self.clear_replay_in_flight(sequence)?;
+        Ok(())
+    }
+
+    pub async fn acknowledge_published(
+        &self,
+        receipt: TransportPublishReceipt,
+    ) -> Result<(), RuntimeChannelError> {
+        if self.policy.id != RuntimeChannelId::CloudBridgeToAwsRoutes {
+            return Err(RuntimeChannelError::InvalidPublishReceipt(
+                "publish acknowledgement is valid only for cloud_bridge_to_aws_routes".to_string(),
+            ));
+        }
+        let sequence = receipt.spool_sequence;
+        let spool = Arc::clone(&self.spool);
+        tokio::task::spawn_blocking(move || spool.acknowledge_published(&receipt))
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        self.metrics.publish_acked.fetch_add(1, Ordering::SeqCst);
+        self.clear_replay_in_flight(sequence)?;
+        Ok(())
+    }
+
+    fn clear_replay_in_flight(&self, sequence: u64) -> Result<(), RuntimeChannelError> {
+        self.replay_in_flight
+            .lock()
+            .map_err(|_| RuntimeChannelError::Spool("replay in-flight lock poisoned".to_string()))?
+            .remove(&sequence);
+        Ok(())
+    }
+
+    pub async fn snapshot(&self) -> Result<RuntimeChannelSnapshot, RuntimeChannelError> {
+        let spool = Arc::clone(&self.spool);
+        let durable_spool_depth = tokio::task::spawn_blocking(move || spool.len())
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        let depth = self.policy.capacity.saturating_sub(self.sender.capacity());
+        let spool = Arc::clone(&self.spool);
+        let publish_cursor = tokio::task::spawn_blocking(move || spool.publish_cursor())
+            .await
+            .map_err(|error| RuntimeChannelError::Join(error.to_string()))??;
+        let readiness = if depth >= self.policy.capacity {
+            ReadinessState::Overloaded
+        } else if durable_spool_depth > 0
+            || self.metrics.throttled.load(Ordering::SeqCst) > 0
+            || self.metrics.shed.load(Ordering::SeqCst) > 0
+        {
+            ReadinessState::Degraded
+        } else {
+            ReadinessState::Ready
+        };
+        Ok(RuntimeChannelSnapshot {
+            channel: self.policy.id,
+            capacity: self.policy.capacity,
+            depth,
+            accepted_count: self.metrics.accepted.load(Ordering::SeqCst),
+            blocked_count: self.metrics.blocked.load(Ordering::SeqCst),
+            throttled_count: self.metrics.throttled.load(Ordering::SeqCst),
+            durable_spool_depth,
+            spooled_count: self.metrics.spooled.load(Ordering::SeqCst),
+            shed_count: self.metrics.shed.load(Ordering::SeqCst),
+            cancelled_count: self.metrics.cancelled.load(Ordering::SeqCst),
+            publish_acked_count: self.metrics.publish_acked.load(Ordering::SeqCst),
+            publish_cursor,
+            readiness,
+        })
+    }
+
+    fn receipt(
+        &self,
+        message_id: String,
+        outcome: RuntimeSendOutcome,
+        spool_sequence: Option<u64>,
+        cursor_may_advance: bool,
+        readiness: ReadinessState,
+        reason: &'static str,
+    ) -> RuntimeSendReceipt {
+        RuntimeSendReceipt {
+            channel: self.policy.id,
+            message_id,
+            outcome,
+            spool_sequence,
+            cursor_may_advance,
+            readiness,
+            reason,
+        }
+    }
+}
+
+impl RuntimeChannelReceiver {
+    pub async fn recv(&mut self) -> Option<RuntimeDelivery> {
+        self.receiver.recv().await.map(|envelope| RuntimeDelivery {
+            message: envelope.message,
+            spool_sequence: envelope.spool_sequence,
+        })
+    }
+
+    pub fn close(&mut self) {
+        self.receiver.close();
+    }
+
+    pub fn policy(&self) -> RuntimeChannelPolicy {
+        self.policy
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn backpressure_contract_keeps_required_state_fail_closed() {
@@ -18,5 +1295,616 @@ mod tests {
             CSM_BACKPRESSURE_STATE_SCHEMA,
             "adl.csm.backpressure_state.v1"
         );
+    }
+
+    #[test]
+    fn typed_matrix_covers_required_runtime_channels() {
+        let channels = typed_channel_policy_matrix()
+            .into_iter()
+            .map(|policy| policy.id.as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            channels,
+            BTreeSet::from([
+                "aee_to_checkpoint",
+                "cloud_bridge_to_aws_routes",
+                "components_to_lifelog",
+                "components_to_observability",
+                "reasoning_runtime_to_aee",
+                "runtime_api_to_control_plane",
+                "scheduler_to_reasoning_runtime",
+            ])
+        );
+    }
+
+    #[test]
+    fn critical_channels_do_not_silently_drop_when_full() {
+        for id in [
+            RuntimeChannelId::SchedulerToReasoningRuntime,
+            RuntimeChannelId::ReasoningRuntimeToAee,
+            RuntimeChannelId::AeeToCheckpoint,
+            RuntimeChannelId::ComponentsToLifelog,
+            RuntimeChannelId::CloudBridgeToAwsRoutes,
+            RuntimeChannelId::RuntimeApiToControlPlane,
+        ] {
+            let policy = runtime_channel_policy(id);
+            let decision =
+                policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority);
+
+            assert!(decision.preserves_required_state, "{id:?}");
+            assert!(!decision.drop_accounted, "{id:?}");
+            assert_ne!(decision.outcome, AdmissionOutcome::Shed, "{id:?}");
+        }
+    }
+
+    #[test]
+    fn scheduler_to_reasoning_runtime_blocks_full_queue() {
+        let policy = runtime_channel_policy(RuntimeChannelId::SchedulerToReasoningRuntime);
+        let decision = policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority);
+
+        assert_eq!(decision.outcome, AdmissionOutcome::Blocked);
+        assert_eq!(decision.readiness, ReadinessState::Overloaded);
+        assert_eq!(decision.reason, "full_queue_blocks_required_state");
+    }
+
+    #[test]
+    fn checkpoint_and_lifelog_use_durable_spool_under_pressure() {
+        for id in [
+            RuntimeChannelId::AeeToCheckpoint,
+            RuntimeChannelId::ComponentsToLifelog,
+        ] {
+            let policy = runtime_channel_policy(id);
+            let decision =
+                policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority);
+
+            assert_eq!(decision.outcome, AdmissionOutcome::Spooled, "{id:?}");
+            assert!(decision.cursor_may_advance, "{id:?}");
+            assert_eq!(decision.readiness, ReadinessState::Degraded, "{id:?}");
+        }
+    }
+
+    #[test]
+    fn observability_sheds_only_low_priority_metrics_with_accounting() {
+        let policy = runtime_channel_policy(RuntimeChannelId::ComponentsToObservability);
+        let full = ChannelQueueSnapshot::full(policy.capacity);
+
+        let audit = policy.decide(full, ChannelPriority::Audit);
+        assert_eq!(audit.outcome, AdmissionOutcome::Spooled);
+        assert!(!audit.drop_accounted);
+        assert!(audit.preserves_required_state);
+
+        let metric = policy.decide(full, ChannelPriority::LowPriorityObservability);
+        assert_eq!(metric.outcome, AdmissionOutcome::Shed);
+        assert!(metric.drop_accounted);
+        assert!(metric.preserves_required_state);
+    }
+
+    #[test]
+    fn cloud_bridge_cursor_waits_for_publishable_ack() {
+        let policy = runtime_channel_policy(RuntimeChannelId::CloudBridgeToAwsRoutes);
+        let decision = policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority);
+
+        assert_eq!(decision.outcome, AdmissionOutcome::Spooled);
+        assert!(!decision.cursor_may_advance);
+        assert_eq!(
+            policy.cursor_advance_policy,
+            CursorAdvancePolicy::AfterPublishableAck
+        );
+    }
+
+    #[test]
+    fn runtime_api_projects_overload_readiness_for_control_plane() {
+        let policy = runtime_channel_policy(RuntimeChannelId::RuntimeApiToControlPlane);
+        let decision = policy.decide(ChannelQueueSnapshot::full(policy.capacity), policy.priority);
+        let projection = readiness_projection(&[decision]);
+
+        assert_eq!(decision.outcome, AdmissionOutcome::Throttled);
+        assert_eq!(projection["state"], "degraded");
+        assert_eq!(projection["degraded_channel_count"], 1);
+        assert_eq!(projection["required_state_silently_dropped"], false);
+    }
+
+    #[test]
+    fn full_queue_projection_reports_overload_and_accounted_degrade() {
+        let projection = typed_channel_full_queue_readiness_projection_json();
+
+        assert_eq!(projection["state"], "overloaded");
+        assert_eq!(projection["required_state_silently_dropped"], false);
+        assert_eq!(projection["accounted_drop_count"], 1);
+        assert_eq!(projection["overloaded_channel_count"], 2);
+    }
+
+    fn tiny_policy(
+        id: RuntimeChannelId,
+        full_queue_policy: FullQueuePolicy,
+    ) -> RuntimeChannelPolicy {
+        RuntimeChannelPolicy {
+            id,
+            source: "test_source",
+            target: "test_target",
+            capacity: 1,
+            priority: ChannelPriority::CriticalContinuity,
+            full_queue_policy,
+            loss_policy: REQUIRED_STATE_LOSS_POLICY,
+            cursor_advance_policy: CursorAdvancePolicy::AfterDurableSpool,
+            health_signal: "test_backpressure",
+            readiness_projection: "/ready.test",
+        }
+    }
+
+    fn message(id: &str, priority: ChannelPriority) -> RuntimeMessage {
+        RuntimeMessage::new(id, priority, json!({"id": id}))
+    }
+
+    #[tokio::test]
+    async fn real_bounded_channel_blocks_until_receiver_releases_capacity() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let policy = tiny_policy(
+            RuntimeChannelId::SchedulerToReasoningRuntime,
+            FullQueuePolicy::BlockProducer,
+        );
+        let (sender, mut receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+        let cancellation = CancellationToken::new();
+
+        sender
+            .send(
+                message("first", ChannelPriority::GovernedExecution),
+                &cancellation,
+            )
+            .await
+            .expect("first send");
+        let second_sender = sender.clone();
+        let second_cancel = cancellation.clone();
+        let blocked = tokio::spawn(async move {
+            second_sender
+                .send(
+                    message("second", ChannelPriority::GovernedExecution),
+                    &second_cancel,
+                )
+                .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !blocked.is_finished(),
+            "producer must remain blocked while full"
+        );
+        assert_eq!(
+            receiver.recv().await.expect("first receive").message.id,
+            "first"
+        );
+        let receipt = blocked.await.expect("join").expect("second send");
+        assert_eq!(receipt.outcome, RuntimeSendOutcome::BlockedThenAccepted);
+        assert_eq!(
+            receiver.recv().await.expect("second receive").message.id,
+            "second"
+        );
+        let snapshot = sender.snapshot().await.expect("snapshot");
+        assert_eq!(snapshot.depth, 0);
+        assert_eq!(snapshot.blocked_count, 1);
+    }
+
+    #[tokio::test]
+    async fn blocked_send_cancellation_durably_spools_required_message() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let policy = tiny_policy(
+            RuntimeChannelId::ReasoningRuntimeToAee,
+            FullQueuePolicy::BlockProducer,
+        );
+        let (sender, mut receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+        let cancellation = CancellationToken::new();
+        sender
+            .send(
+                message("retained", ChannelPriority::GovernedExecution),
+                &cancellation,
+            )
+            .await
+            .expect("initial send");
+        cancellation.cancel();
+        let receipt = sender
+            .send(
+                message("cancelled", ChannelPriority::GovernedExecution),
+                &cancellation,
+            )
+            .await
+            .expect("cancelled receipt");
+        assert_eq!(receipt.outcome, RuntimeSendOutcome::DurablySpooled);
+        let cancelled_sequence = receipt.spool_sequence.expect("cancelled spool sequence");
+        assert_eq!(
+            receiver.recv().await.expect("retained message").message.id,
+            "retained"
+        );
+        let replay_cancellation = CancellationToken::new();
+        assert_eq!(
+            sender
+                .replay_spooled(&replay_cancellation)
+                .await
+                .expect("replay cancelled message"),
+            1
+        );
+        let replayed = receiver.recv().await.expect("cancelled message replayed");
+        assert_eq!(replayed.message.id, "cancelled");
+        assert_eq!(replayed.spool_sequence, Some(cancelled_sequence));
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("snapshot")
+                .durable_spool_depth,
+            1
+        );
+        sender
+            .acknowledge_processed(cancelled_sequence)
+            .await
+            .expect("processed acknowledgement");
+        assert_eq!(
+            sender.snapshot().await.expect("snapshot").cancelled_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn required_message_is_committed_and_replayed_from_redb_spool() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let spool_path = directory.path().join("spool.redb");
+        let policy = tiny_policy(
+            RuntimeChannelId::AeeToCheckpoint,
+            FullQueuePolicy::DurableSpool,
+        );
+        let cancellation = CancellationToken::new();
+        let (sender, receiver) = runtime_channel(policy, &spool_path).expect("channel");
+        sender
+            .send(
+                message("queued", ChannelPriority::CriticalContinuity),
+                &cancellation,
+            )
+            .await
+            .expect("queued");
+        let receipt = sender
+            .send(
+                message("spooled", ChannelPriority::CriticalContinuity),
+                &cancellation,
+            )
+            .await
+            .expect("spooled");
+        assert_eq!(receipt.outcome, RuntimeSendOutcome::DurablySpooled);
+        assert!(receipt.cursor_may_advance);
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("snapshot")
+                .durable_spool_depth,
+            1
+        );
+        drop(receiver);
+        drop(sender);
+
+        let (sender, mut receiver) = runtime_channel(policy, &spool_path).expect("reopen channel");
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("reopened snapshot")
+                .durable_spool_depth,
+            1
+        );
+        assert_eq!(
+            sender.replay_spooled(&cancellation).await.expect("replay"),
+            1
+        );
+        assert_eq!(
+            sender
+                .replay_spooled(&cancellation)
+                .await
+                .expect("duplicate replay suppression"),
+            0
+        );
+        let replayed = receiver.recv().await.expect("replayed message");
+        assert_eq!(replayed.message.id, "spooled");
+        let sequence = replayed.spool_sequence.expect("replay spool sequence");
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("unacknowledged snapshot")
+                .durable_spool_depth,
+            1
+        );
+        drop(receiver);
+        drop(sender);
+
+        let (sender, mut receiver) = runtime_channel(policy, &spool_path).expect("crash reopen");
+        assert_eq!(
+            sender
+                .replay_spooled(&cancellation)
+                .await
+                .expect("post-crash replay"),
+            1
+        );
+        let replayed_after_crash = receiver.recv().await.expect("post-crash delivery");
+        assert_eq!(replayed_after_crash.message.id, "spooled");
+        assert_eq!(replayed_after_crash.spool_sequence, Some(sequence));
+        sender
+            .acknowledge_processed(sequence)
+            .await
+            .expect("processed acknowledgement");
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("acknowledged snapshot")
+                .durable_spool_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn observability_spools_audit_and_accounts_low_priority_shed() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let policy = tiny_policy(
+            RuntimeChannelId::ComponentsToObservability,
+            FullQueuePolicy::ShedLowPriorityOnly,
+        );
+        let (sender, _receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+        let cancellation = CancellationToken::new();
+        sender
+            .send(message("capacity", ChannelPriority::Audit), &cancellation)
+            .await
+            .expect("capacity message");
+        let audit = sender
+            .send(message("audit", ChannelPriority::Audit), &cancellation)
+            .await
+            .expect("audit spool");
+        let metric = sender
+            .send(
+                message("metric", ChannelPriority::LowPriorityObservability),
+                &cancellation,
+            )
+            .await
+            .expect("metric shed");
+        assert_eq!(audit.outcome, RuntimeSendOutcome::DurablySpooled);
+        assert_eq!(metric.outcome, RuntimeSendOutcome::Shed);
+        let snapshot = sender.snapshot().await.expect("snapshot");
+        assert_eq!(snapshot.durable_spool_depth, 1);
+        assert_eq!(snapshot.shed_count, 1);
+        assert_eq!(snapshot.readiness, ReadinessState::Overloaded);
+    }
+
+    #[tokio::test]
+    async fn cloud_cursor_waits_for_explicit_publishable_ack() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut policy = tiny_policy(
+            RuntimeChannelId::CloudBridgeToAwsRoutes,
+            FullQueuePolicy::DurableSpool,
+        );
+        policy.cursor_advance_policy = CursorAdvancePolicy::AfterPublishableAck;
+        let (sender, _receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+        let cancellation = CancellationToken::new();
+        sender
+            .send(
+                message("capacity", ChannelPriority::Evidence),
+                &cancellation,
+            )
+            .await
+            .expect("capacity message");
+        let receipt = sender
+            .send(message("publish", ChannelPriority::Evidence), &cancellation)
+            .await
+            .expect("spooled publish");
+        assert!(!receipt.cursor_may_advance);
+        let sequence = receipt.spool_sequence.expect("spool sequence");
+        let transport_receipt =
+            TransportPublishReceipt::verified(sequence, 1, "aws_eventbridge", "event-1")
+                .expect("verified transport receipt");
+        sender
+            .acknowledge_published(transport_receipt)
+            .await
+            .expect("publish ack");
+        let snapshot = sender.snapshot().await.expect("snapshot");
+        assert_eq!(snapshot.durable_spool_depth, 0);
+        assert_eq!(snapshot.publish_acked_count, 1);
+        assert_eq!(snapshot.publish_cursor, 1);
+    }
+
+    #[tokio::test]
+    async fn cloud_publish_ack_rejects_unknown_spool_sequence() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let policy = tiny_policy(
+            RuntimeChannelId::CloudBridgeToAwsRoutes,
+            FullQueuePolicy::DurableSpool,
+        );
+        let (sender, _receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+
+        let transport_receipt =
+            TransportPublishReceipt::verified(404, 1, "aws_eventbridge", "event-404")
+                .expect("verified transport receipt");
+        let error = sender
+            .acknowledge_published(transport_receipt)
+            .await
+            .expect_err("unknown sequence must fail closed");
+        assert!(matches!(
+            error,
+            RuntimeChannelError::UnknownSpoolSequence(404)
+        ));
+        assert_eq!(
+            sender
+                .snapshot()
+                .await
+                .expect("snapshot")
+                .publish_acked_count,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_cursor_rejects_gaps_and_sequence_survives_restart() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let spool_path = directory.path().join("spool.redb");
+        let policy = tiny_policy(
+            RuntimeChannelId::CloudBridgeToAwsRoutes,
+            FullQueuePolicy::DurableSpool,
+        );
+        let cancellation = CancellationToken::new();
+        let (sender, receiver) = runtime_channel(policy, &spool_path).expect("channel");
+        sender
+            .send(
+                message("capacity", ChannelPriority::Evidence),
+                &cancellation,
+            )
+            .await
+            .expect("capacity");
+        let first = sender
+            .send(message("first", ChannelPriority::Evidence), &cancellation)
+            .await
+            .expect("first spool")
+            .spool_sequence
+            .expect("first sequence");
+        let second = sender
+            .send(message("second", ChannelPriority::Evidence), &cancellation)
+            .await
+            .expect("second spool")
+            .spool_sequence
+            .expect("second sequence");
+        assert_eq!((first, second), (1, 2));
+
+        let gap = sender
+            .acknowledge_published(
+                TransportPublishReceipt::verified(second, second, "eventbridge", "event-2")
+                    .expect("receipt"),
+            )
+            .await
+            .expect_err("cursor gap must fail closed");
+        assert!(matches!(
+            gap,
+            RuntimeChannelError::NonMonotonicPublishCursor {
+                current: 0,
+                proposed: 2
+            }
+        ));
+        sender
+            .acknowledge_published(
+                TransportPublishReceipt::verified(first, first, "eventbridge", "event-1")
+                    .expect("receipt"),
+            )
+            .await
+            .expect("first ack");
+        sender
+            .acknowledge_published(
+                TransportPublishReceipt::verified(second, second, "eventbridge", "event-2")
+                    .expect("receipt"),
+            )
+            .await
+            .expect("second ack");
+        drop(receiver);
+        drop(sender);
+
+        let (sender, _receiver) = runtime_channel(policy, &spool_path).expect("restart channel");
+        let third = sender
+            .spool_required_with_reason(
+                message("third", ChannelPriority::Evidence),
+                "third".to_string(),
+                "restart_sequence_probe",
+            )
+            .await
+            .expect("third spool")
+            .spool_sequence
+            .expect("third sequence");
+        assert_eq!(third, 3);
+        assert_eq!(sender.snapshot().await.expect("snapshot").publish_cursor, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_receive_cannot_underflow_queue_depth() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let policy = tiny_policy(
+            RuntimeChannelId::SchedulerToReasoningRuntime,
+            FullQueuePolicy::BlockProducer,
+        );
+        let (sender, mut receiver) =
+            runtime_channel(policy, directory.path().join("spool.redb")).expect("channel");
+        let cancellation = CancellationToken::new();
+
+        for index in 0..100 {
+            let producer = sender.clone();
+            let cancellation = cancellation.clone();
+            let send = tokio::spawn(async move {
+                producer
+                    .send(
+                        message(&format!("race-{index}"), ChannelPriority::GovernedExecution),
+                        &cancellation,
+                    )
+                    .await
+            });
+            let delivery = receiver.recv().await.expect("delivery");
+            assert_eq!(delivery.message.id, format!("race-{index}"));
+            send.await.expect("send join").expect("send result");
+            assert!(sender.snapshot().await.expect("snapshot").depth <= policy.capacity);
+        }
+        assert_eq!(sender.snapshot().await.expect("final snapshot").depth, 0);
+    }
+
+    #[tokio::test]
+    async fn runtime_channel_fabric_owns_all_channels_and_transits_messages() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut fabric = RuntimeChannelFabric::open(directory.path()).expect("fabric");
+        let cancellation = CancellationToken::new();
+        let (receipt, delivery) = fabric
+            .transit(
+                RuntimeChannelId::SchedulerToReasoningRuntime,
+                message("cycle-admission", ChannelPriority::GovernedExecution),
+                &cancellation,
+            )
+            .await
+            .expect("transit");
+
+        assert_eq!(receipt.outcome, RuntimeSendOutcome::Accepted);
+        assert_eq!(delivery.expect("delivery").message.id, "cycle-admission");
+        let snapshots = fabric.snapshots().await.expect("snapshots");
+        assert_eq!(snapshots.len(), RuntimeChannelId::ALL.len());
+        assert!(snapshots.iter().all(|snapshot| snapshot.depth == 0));
+    }
+
+    #[tokio::test]
+    async fn runtime_channel_fabric_replays_and_acknowledges_oldest_durable_record() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let cancellation = CancellationToken::new();
+        let channel = RuntimeChannelId::ComponentsToLifelog;
+        let first_sequence = {
+            let fabric = RuntimeChannelFabric::open(directory.path()).expect("fabric");
+            fabric
+                .persist_required(
+                    channel,
+                    message("retained-lifecycle", ChannelPriority::Audit),
+                )
+                .await
+                .expect("persist")
+                .spool_sequence
+                .expect("sequence")
+        };
+
+        let mut restarted = RuntimeChannelFabric::open(directory.path()).expect("restart fabric");
+        let delivery = restarted
+            .replay_next(channel, &cancellation)
+            .await
+            .expect("replay")
+            .expect("delivery");
+        assert_eq!(delivery.message.id, "retained-lifecycle");
+        assert_eq!(delivery.spool_sequence, Some(first_sequence));
+        restarted
+            .acknowledge_processed(channel, first_sequence)
+            .await
+            .expect("acknowledge");
+        assert!(restarted
+            .replay_next(channel, &cancellation)
+            .await
+            .expect("empty replay")
+            .is_none());
     }
 }

--- a/adl-runtime/src/determinism.rs
+++ b/adl-runtime/src/determinism.rs
@@ -774,8 +774,9 @@ mod tests {
             DeterministicCoreComponent::AeeGovernedExecution,
             vec![CoreDecisionInput::captured(&event)],
         );
-        let decision = evaluate_core_decision(request.clone(), &[event.clone()]).unwrap();
-        replay_core_decision(request.clone(), &[event.clone()], &decision).unwrap();
+        let decision =
+            evaluate_core_decision(request.clone(), std::slice::from_ref(&event)).unwrap();
+        replay_core_decision(request.clone(), std::slice::from_ref(&event), &decision).unwrap();
 
         let mut tampered_event = event;
         tampered_event.payload = serde_json::json!({"publishable": false, "region": "configured"});
@@ -799,7 +800,7 @@ mod tests {
             "dispersion_seconds": 1.75,
             "nested": {
                 "stratum": 2,
-                "samples": [0.1, -0.25, 3.141592653589793]
+                "samples": [0.1, -0.25, std::f64::consts::PI]
             },
             "sources": [
                 {"host": "time-a", "reachable": true},

--- a/adl-runtime/src/resident_agent.rs
+++ b/adl-runtime/src/resident_agent.rs
@@ -132,17 +132,16 @@ impl CsmResidentAgentSpec {
             "provider_target_resolved",
             "provider_binding.binding_status",
         )?;
-        if self.authority == CsmResidentAgentAuthority::ShepherdOperator {
-            if !self.policy_gates.freedom_gate_required
+        if self.authority == CsmResidentAgentAuthority::ShepherdOperator
+            && (!self.policy_gates.freedom_gate_required
                 || !self.policy_gates.cav_required
                 || !self.policy_gates.constitutional_policy_required
-                || !self.policy_gates.model_output_advisory_only
-            {
-                return Err(
-                    "shepherd resident agent must be gated by Freedom Gate, CAV, constitutional policy, and advisory output authority"
-                        .to_string(),
-                );
-            }
+                || !self.policy_gates.model_output_advisory_only)
+        {
+            return Err(
+                "shepherd resident agent must be gated by Freedom Gate, CAV, constitutional policy, and advisory output authority"
+                    .to_string(),
+            );
         }
         self.affect_model.validate()?;
         Ok(())

--- a/adl-runtime/src/supervision.rs
+++ b/adl-runtime/src/supervision.rs
@@ -1,86 +1,1394 @@
-//! CSM component supervision contracts.
+//! Typed supervision policies and the reusable CSM component supervisor.
 
-use serde::Serialize;
+use std::collections::VecDeque;
+use std::fs::{self, OpenOptions};
+use std::future::Future;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+
+pub const SUPERVISION_SCHEMA: &str = "adl.csm.supervision_policy.v1";
+pub const SUPERVISION_LIFECYCLE_SCHEMA: &str = "adl.csm.supervision_lifecycle_event.v1";
+pub const RECENT_LIFECYCLE_EVENT_LIMIT: usize = 256;
+const LIFECYCLE_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// CSM owns its process-wide panic reporting boundary and installs it at startup.
+pub fn install_csm_redacting_panic_hook() {
+    std::panic::set_hook(Box::new(|_| {
+        eprintln!(
+            "adl_event schema=adl.csm.supervision.panic.v1 result=panicked payload=<redacted>"
+        );
+    }));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentId {
+    RuntimeApi,
+    Chronosense,
+    Scheduler,
+    CuriosityEngine,
+    ReasoningRuntime,
+    Aee,
+    Checkpoint,
+    CloudBridge,
+    Lifelog,
+    Observability,
+}
+
+impl ComponentId {
+    pub const ALL: [ComponentId; 10] = [
+        ComponentId::RuntimeApi,
+        ComponentId::Chronosense,
+        ComponentId::Scheduler,
+        ComponentId::CuriosityEngine,
+        ComponentId::ReasoningRuntime,
+        ComponentId::Aee,
+        ComponentId::Checkpoint,
+        ComponentId::CloudBridge,
+        ComponentId::Lifelog,
+        ComponentId::Observability,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ComponentId::RuntimeApi => "runtime_api",
+            ComponentId::Chronosense => "chronosense",
+            ComponentId::Scheduler => "scheduler",
+            ComponentId::CuriosityEngine => "curiosity_engine",
+            ComponentId::ReasoningRuntime => "reasoning_runtime",
+            ComponentId::Aee => "aee",
+            ComponentId::Checkpoint => "checkpoint",
+            ComponentId::CloudBridge => "cloud_bridge",
+            ComponentId::Lifelog => "lifelog",
+            ComponentId::Observability => "observability",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComponentRestartPolicy {
     RestartWithBackoff,
     DegradeAndContinue,
-    EscalateToGovernedShutdown,
+    QuarantineOffendingWork,
+    EscalateFailClosed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentDecision {
+    ContinueHealthy,
+    RestartWithBackoff,
+    EscalateAndRestart,
+    DegradeAndContinue,
+    Quarantine,
+    EscalateFailClosed,
+    GovernedStop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentExit {
+    Healthy,
+    Failed,
+    Panicked,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentReadiness {
+    Ready,
+    Degraded,
+    NotReady,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleEventKind {
+    Start,
+    Healthy,
+    Degraded,
+    RestartScheduled,
+    Escalated,
+    Quarantined,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleRetention {
+    Retained,
+    NotRetained,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetainedLifecycleEvent {
+    pub schema: String,
+    pub sequence: u64,
+    pub component: ComponentId,
+    pub attempt: u32,
+    pub event: LifecycleEventKind,
+    pub readiness: ComponentReadiness,
+    pub retention: LifecycleRetention,
+    pub reason_code: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct ComponentSupervisionPolicy {
-    pub component: &'static str,
+    pub component: ComponentId,
     pub restart_policy: ComponentRestartPolicy,
+    pub backoff_base_ms: u64,
+    pub backoff_cap_ms: u64,
+    /// Emit an escalation every N consecutive failures without terminating CSM.
+    pub escalation_interval_failures: u32,
+    pub degradation_behavior: &'static str,
+    pub escalation_target: &'static str,
+    pub readiness_impact: &'static str,
     pub critical_for_continuity: bool,
     pub telemetry_can_degrade: bool,
 }
 
-pub const SUPERVISION_SCHEMA: &str = "adl.csm.supervision_policy.v1";
-
 pub fn default_component_supervision() -> Vec<ComponentSupervisionPolicy> {
     vec![
         ComponentSupervisionPolicy {
-            component: "runtime_api",
+            component: ComponentId::RuntimeApi,
             restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 100,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 3,
+            degradation_behavior: "readiness_false_while_api_unavailable",
+            escalation_target: "operator_and_runtime_observability",
+            readiness_impact: "ready_false_when_unavailable",
             critical_for_continuity: false,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "chronosense",
-            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
-            critical_for_continuity: true,
-            telemetry_can_degrade: false,
-        },
-        ComponentSupervisionPolicy {
-            component: "scheduler",
-            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
-            critical_for_continuity: true,
-            telemetry_can_degrade: false,
-        },
-        ComponentSupervisionPolicy {
-            component: "curiosity_engine",
+            component: ComponentId::Chronosense,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "continue_with_stale_time_confidence",
+            escalation_target: "block_time_sensitive_admission_below_confidence_floor",
+            readiness_impact: "ready_degraded_for_time_sensitive_work",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Scheduler,
+            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 2,
+            degradation_behavior: "quiesce_admission_until_schedule_state_recovers",
+            escalation_target: "operator_and_continuity_control",
+            readiness_impact: "ready_false_while_admission_quiesced",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::CuriosityEngine,
+            restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 500,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "disable_curiosity_admission_and_continue_core_runtime",
+            escalation_target: "operator_notice_if_curiosity_cannot_recover",
+            readiness_impact: "ready_degraded_for_curiosity_only",
             critical_for_continuity: false,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "checkpoint",
-            restart_policy: ComponentRestartPolicy::EscalateToGovernedShutdown,
+            component: ComponentId::ReasoningRuntime,
+            restart_policy: ComponentRestartPolicy::QuarantineOffendingWork,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "quarantine_offending_graph_and_preserve_input_evidence",
+            escalation_target: "recoverable_agent_state_with_quarantine_notice",
+            readiness_impact: "ready_true_when_unaffected_graphs_continue",
+            critical_for_continuity: false,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Aee,
+            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 2,
+            degradation_behavior: "close_execution_admission_until_aee_recovers",
+            escalation_target: "operator_and_execution_control",
+            readiness_impact: "ready_false_for_execution_admission",
             critical_for_continuity: true,
             telemetry_can_degrade: false,
         },
         ComponentSupervisionPolicy {
-            component: "observability",
+            component: ComponentId::Checkpoint,
+            restart_policy: ComponentRestartPolicy::EscalateFailClosed,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "block_admission_before_continuity_loss",
+            escalation_target: "emergency_safe_fail_serialization",
+            readiness_impact: "ready_false_until_checkpoint_persistence_recovers",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::CloudBridge,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 500,
+            backoff_cap_ms: 30_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "buffer_notices_without_advancing_publish_cursors",
+            escalation_target: "fail_closed_cloud_status_with_retained_notice_evidence",
+            readiness_impact: "ready_degraded_for_external_routes",
             critical_for_continuity: false,
             telemetry_can_degrade: true,
         },
         ComponentSupervisionPolicy {
-            component: "cloud_bridge",
+            component: ComponentId::Lifelog,
+            restart_policy: ComponentRestartPolicy::EscalateFailClosed,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 5_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "block_lifecycle_completion_when_append_fails",
+            escalation_target: "runtime_readiness_degraded_until_journal_persists",
+            readiness_impact: "ready_false_for_lifecycle_completion",
+            critical_for_continuity: true,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::Observability,
             restart_policy: ComponentRestartPolicy::DegradeAndContinue,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "shed_low_priority_telemetry_but_retain_audit_events",
+            escalation_target: "operator_if_audit_events_cannot_be_retained_locally",
+            readiness_impact: "ready_degraded_for_metrics_only",
             critical_for_continuity: false,
             telemetry_can_degrade: true,
         },
     ]
 }
 
+pub fn policy_for(component: ComponentId) -> ComponentSupervisionPolicy {
+    default_component_supervision()
+        .into_iter()
+        .find(|policy| policy.component == component)
+        .expect("default supervision policy must cover every ComponentId")
+}
+
+pub fn backoff_for_failure(policy: &ComponentSupervisionPolicy, failures: u32) -> Duration {
+    let exponent = failures.saturating_sub(1).min(20);
+    let multiplier = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    Duration::from_millis(
+        policy
+            .backoff_base_ms
+            .saturating_mul(multiplier)
+            .min(policy.backoff_cap_ms),
+    )
+}
+
+pub fn decide_after_exit(
+    policy: &ComponentSupervisionPolicy,
+    exit: ComponentExit,
+    consecutive_failures: u32,
+) -> ComponentDecision {
+    match exit {
+        ComponentExit::Healthy => ComponentDecision::ContinueHealthy,
+        ComponentExit::Cancelled => ComponentDecision::GovernedStop,
+        ComponentExit::Failed | ComponentExit::Panicked => match policy.restart_policy {
+            ComponentRestartPolicy::RestartWithBackoff
+                if policy.escalation_interval_failures > 0
+                    && consecutive_failures > 0
+                    && consecutive_failures.is_multiple_of(policy.escalation_interval_failures) =>
+            {
+                ComponentDecision::EscalateAndRestart
+            }
+            ComponentRestartPolicy::RestartWithBackoff => ComponentDecision::RestartWithBackoff,
+            ComponentRestartPolicy::DegradeAndContinue => ComponentDecision::DegradeAndContinue,
+            ComponentRestartPolicy::QuarantineOffendingWork => ComponentDecision::Quarantine,
+            ComponentRestartPolicy::EscalateFailClosed => ComponentDecision::EscalateFailClosed,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentFailure {
+    Failed(&'static str),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleReplay {
+    pub events: Vec<RetainedLifecycleEvent>,
+    pub invalid_lines: usize,
+    pub read_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LifecycleSink {
+    sender: mpsc::Sender<JournalCommand>,
+    acknowledgement_timeout: Duration,
+}
+
+#[derive(Debug)]
+struct JournalCommand {
+    event: RetainedLifecycleEvent,
+    response: oneshot::Sender<JournalAppend>,
+}
+
+#[derive(Debug)]
+struct JournalAppend {
+    event: RetainedLifecycleEvent,
+    errors: Vec<String>,
+}
+
+impl LifecycleSink {
+    /// Starts the one writer that all component supervisors clone and share.
+    pub fn start(path: impl Into<PathBuf>) -> Self {
+        let (sender, receiver) = mpsc::channel(256);
+        let path = path.into();
+        let _ = std::thread::Builder::new()
+            .name("csm-lifecycle-writer".to_string())
+            .spawn(move || run_journal_writer(path, receiver));
+        Self {
+            sender,
+            acknowledgement_timeout: LIFECYCLE_ACK_TIMEOUT,
+        }
+    }
+
+    async fn append(&self, event: RetainedLifecycleEvent) -> JournalAppend {
+        let (response, receive) = oneshot::channel();
+        let mut fallback_event = event.clone();
+        if let Err(error) = self.sender.try_send(JournalCommand { event, response }) {
+            let (mut failed_event, reason) = match error {
+                mpsc::error::TrySendError::Full(command) => {
+                    (command.event, "lifecycle_writer_backpressure")
+                }
+                mpsc::error::TrySendError::Closed(command) => {
+                    (command.event, "lifecycle_writer_unavailable")
+                }
+            };
+            failed_event.retention = LifecycleRetention::NotRetained;
+            return JournalAppend {
+                event: failed_event,
+                errors: vec![reason.to_string()],
+            };
+        }
+        match tokio::time::timeout(self.acknowledgement_timeout, receive).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => {
+                fallback_event.retention = LifecycleRetention::Unknown;
+                JournalAppend {
+                    event: fallback_event,
+                    errors: vec!["lifecycle_writer_acknowledgement_lost".to_string()],
+                }
+            }
+            Err(_) => {
+                fallback_event.retention = LifecycleRetention::Unknown;
+                JournalAppend {
+                    event: fallback_event,
+                    errors: vec!["lifecycle_writer_acknowledgement_timeout".to_string()],
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LifecycleJournalWriter {
+    file: fs::File,
+    _writer_lock: fs::File,
+    next_sequence: u64,
+    startup_errors: Vec<String>,
+}
+
+impl LifecycleJournalWriter {
+    fn open(path: &Path) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("lifecycle_parent_create_failed:{error}"))?;
+        }
+        let writer_lock_path = lifecycle_writer_lock_path(path);
+        let writer_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&writer_lock_path)
+            .map_err(|error| format!("lifecycle_writer_lock_open_failed:{error}"))?;
+        FileExt::try_lock_exclusive(&writer_lock)
+            .map_err(|error| format!("lifecycle_writer_lock_failed:{error}"))?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .append(true)
+            .open(path)
+            .map_err(|error| format!("lifecycle_open_failed:{error}"))?;
+        FileExt::lock_exclusive(&file)
+            .map_err(|error| format!("lifecycle_data_lock_failed:{error}"))?;
+
+        file.seek(SeekFrom::Start(0))
+            .map_err(|error| format!("lifecycle_seek_failed:{error}"))?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|error| format!("lifecycle_read_failed:{error}"))?;
+        let mut startup_errors = Vec::new();
+        if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
+            file.seek(SeekFrom::End(0))
+                .map_err(|error| format!("lifecycle_seek_failed:{error}"))?;
+            file.write_all(b"\n")
+                .and_then(|_| file.flush())
+                .and_then(|_| file.sync_data())
+                .map_err(|error| format!("lifecycle_torn_tail_repair_failed:{error}"))?;
+            startup_errors.push("recovered_torn_final_line".to_string());
+        }
+
+        let replay = replay_lifecycle_bytes(&bytes);
+        if replay.invalid_lines > 0 {
+            startup_errors.push(format!("invalid_journal_lines:{}", replay.invalid_lines));
+        }
+        let next_sequence = replay
+            .events
+            .iter()
+            .map(|event| event.sequence)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        FileExt::unlock(&file).map_err(|error| format!("lifecycle_data_unlock_failed:{error}"))?;
+        Ok(Self {
+            file,
+            _writer_lock: writer_lock,
+            next_sequence,
+            startup_errors,
+        })
+    }
+
+    fn append(&mut self, mut event: RetainedLifecycleEvent) -> JournalAppend {
+        event.sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        event.retention = LifecycleRetention::Retained;
+        let result = FileExt::lock_exclusive(&self.file).and_then(|_| {
+            let write_result = serde_json::to_vec(&event)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+                .and_then(|mut bytes| {
+                    bytes.push(b'\n');
+                    self.file.write_all(&bytes)
+                })
+                .and_then(|_| self.file.flush())
+                .and_then(|_| self.file.sync_data());
+            let unlock_result = FileExt::unlock(&self.file);
+            write_result.and(unlock_result)
+        });
+        let mut errors = self.startup_errors.clone();
+        if let Err(error) = result {
+            event.retention = LifecycleRetention::NotRetained;
+            errors.push(format!("lifecycle_append_failed:{error}"));
+        }
+        JournalAppend { event, errors }
+    }
+}
+
+fn lifecycle_writer_lock_path(path: &Path) -> PathBuf {
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".writer.lock");
+    PathBuf::from(lock_path)
+}
+
+fn run_journal_writer(path: PathBuf, mut receiver: mpsc::Receiver<JournalCommand>) {
+    let mut writer = LifecycleJournalWriter::open(&path);
+    while let Some(command) = receiver.blocking_recv() {
+        let result = match writer.as_mut() {
+            Ok(writer) => writer.append(command.event),
+            Err(error) => {
+                let mut event = command.event;
+                event.retention = LifecycleRetention::NotRetained;
+                JournalAppend {
+                    event,
+                    errors: vec![error.clone()],
+                }
+            }
+        };
+        let _ = command.response.send(result);
+    }
+}
+
+pub fn replay_lifecycle_journal(path: &Path) -> LifecycleReplay {
+    let mut file = match OpenOptions::new().read(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return replay_lifecycle_bytes(&[]),
+        Err(error) => {
+            return LifecycleReplay {
+                events: Vec::new(),
+                invalid_lines: 0,
+                read_error: Some(format!("lifecycle_read_failed:{error}")),
+            };
+        }
+    };
+    if let Err(error) = FileExt::lock_shared(&file) {
+        return LifecycleReplay {
+            events: Vec::new(),
+            invalid_lines: 0,
+            read_error: Some(format!("lifecycle_read_lock_failed:{error}")),
+        };
+    }
+    let mut text = String::new();
+    let read_result = file.read_to_string(&mut text);
+    let unlock_result = FileExt::unlock(&file);
+    if let Err(error) = read_result.and(unlock_result) {
+        return LifecycleReplay {
+            events: Vec::new(),
+            invalid_lines: 0,
+            read_error: Some(format!("lifecycle_read_failed:{error}")),
+        };
+    }
+    let mut replay = replay_lifecycle_bytes(text.as_bytes());
+    replay.read_error = None;
+    replay
+}
+
+fn replay_lifecycle_bytes(bytes: &[u8]) -> LifecycleReplay {
+    let text = String::from_utf8_lossy(bytes);
+    let mut events = Vec::new();
+    let mut invalid_lines = 0;
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        match serde_json::from_str(line) {
+            Ok(event) => events.push(event),
+            Err(_) => invalid_lines += 1,
+        }
+    }
+    LifecycleReplay {
+        events,
+        invalid_lines,
+        read_error: None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupervisionOutcome {
+    pub component: ComponentId,
+    pub decision: ComponentDecision,
+    pub readiness: ComponentReadiness,
+    pub attempts: u32,
+    pub consecutive_failures: u32,
+    pub lifecycle_events: Vec<RetainedLifecycleEvent>,
+    pub dropped_in_memory_events: u64,
+    pub retention_errors: Vec<String>,
+}
+
+impl SupervisionOutcome {
+    pub fn retention_degraded(&self) -> bool {
+        !self.retention_errors.is_empty()
+            || self
+                .lifecycle_events
+                .iter()
+                .any(|event| event.retention != LifecycleRetention::Retained)
+    }
+}
+
+#[derive(Debug, Default)]
+struct LifecycleWindow {
+    recent: VecDeque<RetainedLifecycleEvent>,
+    dropped: u64,
+}
+
+impl LifecycleWindow {
+    fn push(&mut self, event: RetainedLifecycleEvent) {
+        if self.recent.len() == RECENT_LIFECYCLE_EVENT_LIMIT {
+            self.recent.pop_front();
+            self.dropped = self.dropped.saturating_add(1);
+        }
+        self.recent.push_back(event);
+    }
+}
+
+pub async fn supervise_component<F, Fut>(
+    component: ComponentId,
+    cancellation: CancellationToken,
+    lifecycle_sink: LifecycleSink,
+    mut run_component: F,
+) -> SupervisionOutcome
+where
+    F: FnMut(u32, CancellationToken) -> Fut,
+    Fut: Future<Output = Result<(), ComponentFailure>> + Send + 'static,
+{
+    let policy = policy_for(component);
+    let mut lifecycle_events = LifecycleWindow::default();
+    let mut retention_errors = Vec::new();
+    let mut attempt = 0_u32;
+    let mut consecutive_failures = 0_u32;
+
+    loop {
+        if cancellation.is_cancelled() {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Stopped,
+                    ComponentReadiness::Stopped,
+                    "governed_cancellation",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::GovernedStop,
+                ComponentReadiness::Stopped,
+                attempt,
+                consecutive_failures,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+
+        attempt = attempt.saturating_add(1);
+        retain_event(
+            &lifecycle_sink,
+            &mut lifecycle_events,
+            &mut retention_errors,
+            lifecycle_event(
+                component,
+                attempt,
+                LifecycleEventKind::Start,
+                ComponentReadiness::NotReady,
+                "component_attempt_started",
+            ),
+        )
+        .await;
+
+        let child_token = cancellation.child_token();
+        let constructed = catch_unwind(AssertUnwindSafe(|| {
+            run_component(attempt, child_token.clone())
+        }));
+        let exit = match constructed {
+            Err(_) => ComponentExit::Panicked,
+            Ok(future) => {
+                let mut join_set = JoinSet::new();
+                join_set.spawn(future);
+                tokio::select! {
+                    _ = cancellation.cancelled() => {
+                        child_token.cancel();
+                        join_set.abort_all();
+                        while join_set.join_next().await.is_some() {}
+                        ComponentExit::Cancelled
+                    }
+                    joined = join_set.join_next() => match joined {
+                        Some(Ok(Ok(()))) => ComponentExit::Healthy,
+                        Some(Ok(Err(ComponentFailure::Cancelled))) => ComponentExit::Cancelled,
+                        Some(Ok(Err(ComponentFailure::Failed(_)))) => ComponentExit::Failed,
+                        Some(Err(error)) if error.is_panic() => ComponentExit::Panicked,
+                        Some(Err(_)) | None => ComponentExit::Failed,
+                    }
+                }
+            }
+        };
+
+        if exit == ComponentExit::Healthy {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Healthy,
+                    ComponentReadiness::Ready,
+                    "component_healthy",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::ContinueHealthy,
+                ComponentReadiness::Ready,
+                attempt,
+                0,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+        if exit == ComponentExit::Cancelled {
+            retain_event(
+                &lifecycle_sink,
+                &mut lifecycle_events,
+                &mut retention_errors,
+                lifecycle_event(
+                    component,
+                    attempt,
+                    LifecycleEventKind::Stopped,
+                    ComponentReadiness::Stopped,
+                    "governed_cancellation",
+                ),
+            )
+            .await;
+            return outcome(
+                &policy,
+                ComponentDecision::GovernedStop,
+                ComponentReadiness::Stopped,
+                attempt,
+                consecutive_failures,
+                lifecycle_events,
+                retention_errors,
+            );
+        }
+
+        consecutive_failures = consecutive_failures.saturating_add(1);
+        let decision = decide_after_exit(&policy, exit, consecutive_failures);
+        let failure_code = if exit == ComponentExit::Panicked {
+            "component_task_panicked"
+        } else {
+            "component_task_failed"
+        };
+
+        match decision {
+            ComponentDecision::RestartWithBackoff | ComponentDecision::EscalateAndRestart => {
+                let kind = if decision == ComponentDecision::EscalateAndRestart {
+                    LifecycleEventKind::Escalated
+                } else {
+                    LifecycleEventKind::RestartScheduled
+                };
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        kind,
+                        ComponentReadiness::NotReady,
+                        failure_code,
+                    ),
+                )
+                .await;
+                let backoff = backoff_for_failure(&policy, consecutive_failures);
+                tokio::select! {
+                    _ = cancellation.cancelled() => {},
+                    _ = sleep(backoff) => continue,
+                }
+            }
+            ComponentDecision::DegradeAndContinue => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Degraded,
+                        ComponentReadiness::Degraded,
+                        policy.degradation_behavior,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::Degraded,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::Quarantine => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Quarantined,
+                        ComponentReadiness::Degraded,
+                        policy.degradation_behavior,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::Degraded,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::EscalateFailClosed => {
+                retain_event(
+                    &lifecycle_sink,
+                    &mut lifecycle_events,
+                    &mut retention_errors,
+                    lifecycle_event(
+                        component,
+                        attempt,
+                        LifecycleEventKind::Escalated,
+                        ComponentReadiness::NotReady,
+                        policy.escalation_target,
+                    ),
+                )
+                .await;
+                return outcome(
+                    &policy,
+                    decision,
+                    ComponentReadiness::NotReady,
+                    attempt,
+                    consecutive_failures,
+                    lifecycle_events,
+                    retention_errors,
+                );
+            }
+            ComponentDecision::ContinueHealthy | ComponentDecision::GovernedStop => {
+                unreachable!("non-terminal failure cannot produce healthy or stopped decision")
+            }
+        }
+
+        retain_event(
+            &lifecycle_sink,
+            &mut lifecycle_events,
+            &mut retention_errors,
+            lifecycle_event(
+                component,
+                attempt,
+                LifecycleEventKind::Stopped,
+                ComponentReadiness::Stopped,
+                "governed_cancellation_during_backoff",
+            ),
+        )
+        .await;
+        return outcome(
+            &policy,
+            ComponentDecision::GovernedStop,
+            ComponentReadiness::Stopped,
+            attempt,
+            consecutive_failures,
+            lifecycle_events,
+            retention_errors,
+        );
+    }
+}
+
+fn lifecycle_event(
+    component: ComponentId,
+    attempt: u32,
+    event: LifecycleEventKind,
+    readiness: ComponentReadiness,
+    reason_code: impl Into<String>,
+) -> RetainedLifecycleEvent {
+    RetainedLifecycleEvent {
+        schema: SUPERVISION_LIFECYCLE_SCHEMA.to_string(),
+        sequence: 0,
+        component,
+        attempt,
+        event,
+        readiness,
+        retention: LifecycleRetention::NotRetained,
+        reason_code: reason_code.into(),
+    }
+}
+
+async fn retain_event(
+    sink: &LifecycleSink,
+    events: &mut LifecycleWindow,
+    retention_errors: &mut Vec<String>,
+    event: RetainedLifecycleEvent,
+) {
+    let appended = sink.append(event).await;
+    for error in appended.errors {
+        if !retention_errors.contains(&error) {
+            retention_errors.push(error);
+        }
+    }
+    events.push(appended.event);
+}
+
+fn outcome(
+    policy: &ComponentSupervisionPolicy,
+    mut decision: ComponentDecision,
+    mut readiness: ComponentReadiness,
+    attempts: u32,
+    consecutive_failures: u32,
+    lifecycle_events: LifecycleWindow,
+    retention_errors: Vec<String>,
+) -> SupervisionOutcome {
+    let LifecycleWindow {
+        recent: lifecycle_events,
+        dropped: dropped_in_memory_events,
+    } = lifecycle_events;
+    let lifecycle_events: Vec<_> = lifecycle_events.into_iter().collect();
+    let retention_degraded = !retention_errors.is_empty()
+        || lifecycle_events
+            .iter()
+            .any(|event| event.retention != LifecycleRetention::Retained);
+    if retention_degraded && readiness == ComponentReadiness::Ready {
+        if policy.telemetry_can_degrade {
+            decision = ComponentDecision::DegradeAndContinue;
+            readiness = ComponentReadiness::Degraded;
+        } else {
+            decision = ComponentDecision::EscalateFailClosed;
+            readiness = ComponentReadiness::NotReady;
+        }
+    }
+    SupervisionOutcome {
+        component: policy.component,
+        decision,
+        readiness,
+        attempts,
+        consecutive_failures,
+        lifecycle_events,
+        dropped_in_memory_events,
+        retention_errors,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestRoot(PathBuf);
+
+    impl TestRoot {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos();
+            Self(std::env::temp_dir().join(format!("adl-supervision-{name}-{unique}")))
+        }
+
+        fn journal(&self) -> PathBuf {
+            self.0.join("lifecycle.jsonl")
+        }
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
 
     #[test]
-    fn checkpoint_policy_is_continuity_critical() {
-        let checkpoint = default_component_supervision()
-            .into_iter()
-            .find(|policy| policy.component == "checkpoint")
-            .expect("checkpoint policy");
-        assert!(checkpoint.critical_for_continuity);
+    fn matrix_covers_every_runtime_component_with_explicit_policy() {
+        let policies = default_component_supervision();
+        assert_eq!(policies.len(), ComponentId::ALL.len());
+        for component in ComponentId::ALL {
+            let policy = policy_for(component);
+            assert_eq!(policy.component, component);
+            assert!(policy.backoff_cap_ms >= policy.backoff_base_ms);
+            assert!(policy.escalation_interval_failures > 0);
+            assert!(!policy.degradation_behavior.is_empty());
+            assert!(!policy.escalation_target.is_empty());
+            assert!(!policy.readiness_impact.is_empty());
+        }
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped_without_a_stop_budget() {
+        let policy = policy_for(ComponentId::RuntimeApi);
+        assert_eq!(backoff_for_failure(&policy, 1), Duration::from_millis(100));
+        assert_eq!(backoff_for_failure(&policy, 2), Duration::from_millis(200));
         assert_eq!(
-            checkpoint.restart_policy,
-            ComponentRestartPolicy::EscalateToGovernedShutdown
+            backoff_for_failure(&policy, 99),
+            Duration::from_millis(5_000)
         );
+        assert_eq!(
+            decide_after_exit(&policy, ComponentExit::Failed, 3),
+            ComponentDecision::EscalateAndRestart
+        );
+        assert_eq!(
+            decide_after_exit(&policy, ComponentExit::Failed, 4),
+            ComponentDecision::RestartWithBackoff
+        );
+    }
+
+    #[test]
+    fn in_memory_lifecycle_window_is_bounded_while_durable_history_remains_external() {
+        let mut window = LifecycleWindow::default();
+        for attempt in 1..=(RECENT_LIFECYCLE_EVENT_LIMIT as u32 + 10) {
+            window.push(lifecycle_event(
+                ComponentId::RuntimeApi,
+                attempt,
+                LifecycleEventKind::RestartScheduled,
+                ComponentReadiness::NotReady,
+                "component_task_failed",
+            ));
+        }
+        assert_eq!(window.recent.len(), RECENT_LIFECYCLE_EVENT_LIMIT);
+        assert_eq!(window.dropped, 10);
+        assert_eq!(window.recent.front().unwrap().attempt, 11);
+    }
+
+    #[tokio::test]
+    async fn restartable_component_recovers_and_replays_durable_lifecycle() {
+        let root = TestRoot::new("recover");
+        let attempts = Arc::new(AtomicU32::new(0));
+        let run_attempts = Arc::clone(&attempts);
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            move |_, _| {
+                let run_attempts = Arc::clone(&run_attempts);
+                async move {
+                    if run_attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                        Err(ComponentFailure::Failed("bind_failed"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.readiness, ComponentReadiness::Ready);
+        assert_eq!(outcome.attempts, 3);
+        assert!(!outcome.retention_degraded());
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events, outcome.lifecycle_events);
+        assert!(replay.events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.readiness == ComponentReadiness::NotReady
+        }));
+        assert_eq!(
+            replay.events.last().unwrap().event,
+            LifecycleEventKind::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_failure_escalates_but_never_exhausts_into_runtime_stop() {
+        let root = TestRoot::new("repeat");
+        let cancellation = CancellationToken::new();
+        let cancel_from_task = cancellation.clone();
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            cancellation,
+            LifecycleSink::start(root.journal()),
+            move |attempt, _| {
+                let cancel_from_task = cancel_from_task.clone();
+                async move {
+                    if attempt == 4 {
+                        cancel_from_task.cancel();
+                    }
+                    Err(ComponentFailure::Failed("bind_failed"))
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::GovernedStop);
+        assert_eq!(outcome.readiness, ComponentReadiness::Stopped);
+        assert_eq!(outcome.attempts, 4);
+        assert!(outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Escalated));
+        assert!(!outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Healthy));
+    }
+
+    #[tokio::test]
+    async fn component_panic_is_governed_and_then_restarted() {
+        install_csm_redacting_panic_hook();
+        let root = TestRoot::new("panic");
+        let outcome = supervise_component(
+            ComponentId::Scheduler,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |attempt, _| async move {
+                if attempt == 1 {
+                    panic!("test component panic");
+                }
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.attempts, 2);
+        assert!(outcome.lifecycle_events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.reason_code == "component_task_panicked"
+        }));
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_uncooperative_child_and_records_stop() {
+        let root = TestRoot::new("cancel");
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let outcome = supervise_component(
+            ComponentId::Aee,
+            cancellation,
+            LifecycleSink::start(root.journal()),
+            |_, _| async {
+                sleep(Duration::from_secs(60)).await;
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::GovernedStop);
+        assert_eq!(outcome.attempts, 0);
+        assert_eq!(outcome.lifecycle_events.len(), 1);
+        assert_eq!(
+            outcome.lifecycle_events[0].event,
+            LifecycleEventKind::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_failure_is_fail_closed_without_panicking_or_false_health() {
+        let root = TestRoot::new("checkpoint");
+        let outcome = supervise_component(
+            ComponentId::Checkpoint,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Err(ComponentFailure::Failed("storage_unavailable")) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::EscalateFailClosed);
+        assert_eq!(outcome.readiness, ComponentReadiness::NotReady);
+        assert_eq!(outcome.attempts, 1);
+        assert_eq!(
+            outcome.lifecycle_events.last().unwrap().reason_code,
+            "emergency_safe_fail_serialization"
+        );
+    }
+
+    #[tokio::test]
+    async fn chronosense_failure_degrades_truthfully() {
+        let root = TestRoot::new("chronosense");
+        let outcome = supervise_component(
+            ComponentId::Chronosense,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Err(ComponentFailure::Failed("time_source_unavailable")) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert_eq!(outcome.readiness, ComponentReadiness::Degraded);
+        assert!(!outcome
+            .lifecycle_events
+            .iter()
+            .any(|event| event.event == LifecycleEventKind::Healthy));
+    }
+
+    #[tokio::test]
+    async fn corrupt_prior_jsonl_does_not_stop_component_supervision() {
+        let root = TestRoot::new("corrupt");
+        fs::create_dir_all(&root.0).unwrap();
+        fs::write(root.journal(), b"not-json\n").unwrap();
+        let outcome = supervise_component(
+            ComponentId::Observability,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert_eq!(outcome.readiness, ComponentReadiness::Degraded);
+        assert!(outcome
+            .retention_errors
+            .iter()
+            .any(|error| error == "invalid_journal_lines:1"));
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 1);
+        assert_eq!(replay.events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn unwritable_lifecycle_target_degrades_retention_without_crashing_component() {
+        let root = TestRoot::new("unwritable");
+        fs::create_dir_all(root.journal()).unwrap();
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::EscalateFailClosed);
+        assert_eq!(outcome.readiness, ComponentReadiness::NotReady);
+        assert!(outcome.retention_degraded());
+        assert!(outcome
+            .lifecycle_events
+            .iter()
+            .all(|event| event.retention == LifecycleRetention::NotRetained));
+    }
+
+    #[tokio::test]
+    async fn torn_final_jsonl_record_is_preserved_and_separated_from_new_events() {
+        let root = TestRoot::new("torn");
+        fs::create_dir_all(&root.0).unwrap();
+        fs::write(root.journal(), b"torn-json").unwrap();
+        let outcome = supervise_component(
+            ComponentId::Observability,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |_, _| async { Ok(()) },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::DegradeAndContinue);
+        assert!(outcome
+            .retention_errors
+            .iter()
+            .any(|error| error == "recovered_torn_final_line"));
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 1);
+        assert_eq!(replay.events.len(), 2);
+        assert_eq!(replay.events[0].sequence, 1);
+        assert_eq!(replay.events[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn shared_lifecycle_sink_serializes_concurrent_component_events() {
+        let root = TestRoot::new("concurrent");
+        let sink = LifecycleSink::start(root.journal());
+        let (api, scheduler) = tokio::join!(
+            supervise_component(
+                ComponentId::RuntimeApi,
+                CancellationToken::new(),
+                sink.clone(),
+                |_, _| async { Ok(()) },
+            ),
+            supervise_component(
+                ComponentId::Scheduler,
+                CancellationToken::new(),
+                sink,
+                |_, _| async { Ok(()) },
+            )
+        );
+        assert_eq!(api.readiness, ComponentReadiness::Ready);
+        assert_eq!(scheduler.readiness, ComponentReadiness::Ready);
+        let replay = replay_lifecycle_journal(&root.journal());
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events.len(), 4);
+        assert_eq!(
+            replay
+                .events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+    }
+
+    #[tokio::test]
+    async fn synchronous_future_construction_panic_is_governed_and_restarted() {
+        install_csm_redacting_panic_hook();
+        let root = TestRoot::new("construction-panic");
+        let outcome = supervise_component(
+            ComponentId::RuntimeApi,
+            CancellationToken::new(),
+            LifecycleSink::start(root.journal()),
+            |attempt, _| {
+                if attempt == 1 {
+                    panic!("future construction panic");
+                }
+                std::future::ready(Ok(()))
+            },
+        )
+        .await;
+        assert_eq!(outcome.decision, ComponentDecision::ContinueHealthy);
+        assert_eq!(outcome.attempts, 2);
+        assert!(outcome.lifecycle_events.iter().any(|event| {
+            event.event == LifecycleEventKind::RestartScheduled
+                && event.reason_code == "component_task_panicked"
+        }));
+    }
+
+    #[tokio::test]
+    async fn acknowledgement_timeout_reports_unknown_instead_of_false_retention() {
+        let (sender, mut receiver) = mpsc::channel::<JournalCommand>(1);
+        let writer = std::thread::spawn(move || {
+            let command = receiver.blocking_recv().unwrap();
+            std::thread::sleep(Duration::from_millis(100));
+            let mut event = command.event;
+            event.sequence = 7;
+            event.retention = LifecycleRetention::Retained;
+            let _ = command.response.send(JournalAppend {
+                event,
+                errors: Vec::new(),
+            });
+        });
+        let sink = LifecycleSink {
+            sender,
+            acknowledgement_timeout: Duration::from_millis(50),
+        };
+        let result = sink
+            .append(lifecycle_event(
+                ComponentId::RuntimeApi,
+                1,
+                LifecycleEventKind::Start,
+                ComponentReadiness::NotReady,
+                "component_attempt_started",
+            ))
+            .await;
+        assert_eq!(result.event.retention, LifecycleRetention::Unknown);
+        assert_eq!(result.event.sequence, 0);
+        assert_eq!(
+            result.errors,
+            vec!["lifecycle_writer_acknowledgement_timeout"]
+        );
+        writer.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn replay_waits_for_data_lock_and_never_reads_partial_record() {
+        let root = TestRoot::new("replay-lock");
+        fs::create_dir_all(&root.0).unwrap();
+        let mut event = lifecycle_event(
+            ComponentId::RuntimeApi,
+            1,
+            LifecycleEventKind::Healthy,
+            ComponentReadiness::Ready,
+            "component_healthy",
+        );
+        event.sequence = 1;
+        event.retention = LifecycleRetention::Retained;
+        fs::write(
+            root.journal(),
+            format!("{}\n", serde_json::to_string(&event).unwrap()),
+        )
+        .unwrap();
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(root.journal())
+            .unwrap();
+        FileExt::lock_exclusive(&lock_file).unwrap();
+        let path = root.journal();
+        let replay = tokio::task::spawn_blocking(move || replay_lifecycle_journal(&path));
+        sleep(Duration::from_millis(25)).await;
+        FileExt::unlock(&lock_file).unwrap();
+        let replay = replay.await.unwrap();
+        assert_eq!(replay.invalid_lines, 0);
+        assert_eq!(replay.events, vec![event]);
     }
 }

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -71,6 +72,7 @@ name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
  "fs2",
+ "redb",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -3318,6 +3320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -70,10 +70,13 @@ dependencies = [
 name = "adl-runtime"
 version = "0.91.7"
 dependencies = [
+ "fs2",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1759,6 +1762,16 @@ checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4328,6 +4341,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -4726,6 +4740,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -218,6 +218,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Shared async runtime floor for long-lived cadence, ACIP runtime work, and
 # later bounded recurring verification on the existing ADL runtime.
 tokio = { version = "1", features = ["fs", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tokio-tungstenite = "0.24"
 axum = "0.7"
 tower = "0.5"

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -89,6 +89,7 @@ pub fn run_runtime_main() {
 
 #[allow(dead_code)]
 pub fn run_csm_main() {
+    adl_runtime::supervision::install_csm_redacting_panic_hook();
     if let Err(err) = real_csm_main() {
         print_error_chain(&err);
         std::process::exit(1);

--- a/adl/src/csm_backpressure.rs
+++ b/adl/src/csm_backpressure.rs
@@ -6,11 +6,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
+use tokio_util::sync::CancellationToken;
 
 use crate::long_lived_agent;
 use crate::observability;
 
 pub use adl_runtime::backpressure::{
+    runtime_channel, runtime_channel_policy, typed_channel_policy_matrix_json, ChannelPriority,
+    FullQueuePolicy, RuntimeChannelId, RuntimeMessage, RuntimeSendOutcome,
     CSM_BACKPRESSURE_COMMAND_RESULT_SCHEMA, CSM_BACKPRESSURE_REPORT_SCHEMA,
     CSM_BACKPRESSURE_STATE_SCHEMA, NONCRITICAL_LOSS_POLICY, REQUIRED_STATE_LOSS_POLICY,
 };
@@ -51,6 +54,7 @@ pub fn prove_backpressure(options: BackpressureProofOptions) -> Result<Backpress
     let summary = summarize_cases(&cases);
     let safe_fail_bundle_path = loaded.state_root.join("safe_fail_bundle.json");
     let safe_fail_bundle = read_required_safe_fail_bundle(&safe_fail_bundle_path)?;
+    let live_channel_proof = run_live_channel_proof(&options.out_dir.join("channel_spools"))?;
     let safe_fail_action = json!({
         "status": "verified",
         "trigger": "survival_threshold_breached",
@@ -68,6 +72,8 @@ pub fn prove_backpressure(options: BackpressureProofOptions) -> Result<Backpress
         "profile": options.profile,
         "updated_at": Utc::now(),
         "queues": queue_state(),
+        "typed_channel_policy_matrix": typed_channel_policy_matrix_json(),
+        "typed_channel_runtime_proof": live_channel_proof,
         "summary": summary,
         "safe_fail_action": safe_fail_action,
         "observability": observability_contract(),
@@ -81,6 +87,8 @@ pub fn prove_backpressure(options: BackpressureProofOptions) -> Result<Backpress
         "status": "passed",
         "resource_taxonomy": taxonomy,
         "policy_matrix": policies,
+        "typed_channel_policy_matrix": typed_channel_policy_matrix_json(),
+        "typed_channel_runtime_proof": live_channel_proof,
         "proof_cases": cases,
         "summary": summary,
         "safe_fail_action": safe_fail_action,
@@ -131,6 +139,145 @@ pub fn prove_backpressure(options: BackpressureProofOptions) -> Result<Backpress
         event_count: 1,
         non_claims: non_claims(),
     })
+}
+
+fn run_live_channel_proof(spool_root: &Path) -> Result<Value> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed creating typed-channel proof runtime")?
+        .block_on(run_live_channel_proof_async(spool_root))
+}
+
+async fn run_live_channel_proof_async(spool_root: &Path) -> Result<Value> {
+    let cancellation = CancellationToken::new();
+    let mut observations = Vec::new();
+
+    for id in [
+        RuntimeChannelId::RuntimeApiToControlPlane,
+        RuntimeChannelId::SchedulerToReasoningRuntime,
+        RuntimeChannelId::ReasoningRuntimeToAee,
+        RuntimeChannelId::AeeToCheckpoint,
+        RuntimeChannelId::ComponentsToObservability,
+        RuntimeChannelId::ComponentsToLifelog,
+        RuntimeChannelId::CloudBridgeToAwsRoutes,
+    ] {
+        let policy = runtime_channel_policy(id);
+        let spool_path = spool_root.join(format!("{:?}.redb", id).to_ascii_lowercase());
+        let (sender, mut receiver) = runtime_channel(policy, &spool_path)
+            .with_context(|| format!("failed opening live channel {id:?}"))?;
+
+        for index in 0..policy.capacity {
+            sender
+                .send(
+                    RuntimeMessage::new(
+                        format!("{id:?}-capacity-{index}"),
+                        policy.priority,
+                        json!({"probe": "capacity", "index": index}),
+                    ),
+                    &cancellation,
+                )
+                .await
+                .with_context(|| format!("failed filling live channel {id:?}"))?;
+        }
+
+        let probe = RuntimeMessage::new(
+            format!("{id:?}-overload"),
+            if id == RuntimeChannelId::ComponentsToObservability {
+                ChannelPriority::LowPriorityObservability
+            } else {
+                policy.priority
+            },
+            json!({"probe": "overload"}),
+        );
+        let receipt = match policy.full_queue_policy {
+            FullQueuePolicy::BlockProducer => {
+                let sender = sender.clone();
+                let cancellation = cancellation.clone();
+                let blocked = tokio::spawn(async move { sender.send(probe, &cancellation).await });
+                tokio::task::yield_now().await;
+                let _ = receiver
+                    .recv()
+                    .await
+                    .context("full channel lost capacity message")?;
+                blocked
+                    .await
+                    .context("blocked channel task failed")?
+                    .with_context(|| format!("blocked live channel {id:?} failed"))?
+            }
+            _ => sender
+                .send(probe, &cancellation)
+                .await
+                .with_context(|| format!("overload live channel {id:?} failed"))?,
+        };
+
+        let before_ack = sender.snapshot().await?;
+        let publish_ack_status = if id == RuntimeChannelId::CloudBridgeToAwsRoutes {
+            receipt
+                .spool_sequence
+                .context("cloud bridge overload did not retain a spool sequence")?;
+            if receipt.cursor_may_advance {
+                bail!("cloud bridge cursor advanced before publishable acknowledgement");
+            }
+            "waiting_for_live_transport_receipt"
+        } else {
+            "not_applicable"
+        };
+
+        observations.push(json!({
+            "channel": id,
+            "full_queue_policy": policy.full_queue_policy,
+            "receipt": receipt,
+            "snapshot_before_publish_ack": before_ack,
+            "publish_ack_status": publish_ack_status,
+            "spool_path": spool_path.strip_prefix(spool_root.parent().unwrap_or(spool_root))
+                .unwrap_or(&spool_path),
+        }));
+    }
+
+    let required_state_silently_dropped = observations.iter().any(|observation| {
+        observation["receipt"]["outcome"] == json!(RuntimeSendOutcome::Cancelled)
+            || (observation["receipt"]["outcome"] == json!(RuntimeSendOutcome::Shed)
+                && observation["channel"] != json!(RuntimeChannelId::ComponentsToObservability))
+    });
+    if required_state_silently_dropped {
+        bail!("live typed-channel proof silently shed required state");
+    }
+    let durable_spool_depth = observations
+        .iter()
+        .filter_map(|observation| {
+            observation["snapshot_before_publish_ack"]["durable_spool_depth"].as_u64()
+        })
+        .sum::<u64>();
+    let shed_count = observations
+        .iter()
+        .filter_map(|observation| observation["snapshot_before_publish_ack"]["shed_count"].as_u64())
+        .sum::<u64>();
+    let blocked_count = observations
+        .iter()
+        .filter_map(|observation| {
+            observation["snapshot_before_publish_ack"]["blocked_count"].as_u64()
+        })
+        .sum::<u64>();
+    let throttled_count = observations
+        .iter()
+        .filter_map(|observation| {
+            observation["snapshot_before_publish_ack"]["throttled_count"].as_u64()
+        })
+        .sum::<u64>();
+
+    Ok(json!({
+        "schema": "adl.csm.typed_channel_runtime_proof.v1",
+        "status": "passed",
+        "channel_count": observations.len(),
+        "required_state_silently_dropped": required_state_silently_dropped,
+        "readiness": "overloaded_observed",
+        "durable_spool_depth": durable_spool_depth,
+        "blocked_count": blocked_count,
+        "throttled_count": throttled_count,
+        "shed_count": shed_count,
+        "observations": observations,
+    }))
 }
 
 fn validate_profile(profile: &str) -> Result<()> {

--- a/adl/src/csm_runtime_api.rs
+++ b/adl/src/csm_runtime_api.rs
@@ -261,6 +261,8 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
     let safe_fail_bundle = read_json_artifact(&artifact_path(loaded, "safe_fail_bundle.json"));
     let backpressure_state =
         read_json_artifact(&artifact_path(loaded, "csm_backpressure_state.json"));
+    let typed_channel_state =
+        read_json_artifact(&artifact_path(loaded, "csm_typed_channel_state.json"));
     let otel_status_path = resolve_otel_status_path(loaded, options);
     let otel_log_path = resolve_otel_log_path(loaded, options);
     let otel_status = otel_status_path
@@ -342,6 +344,7 @@ fn status_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) -> 
             "safe_fail_bundle": compact_artifact_status(&safe_fail_bundle, "safe_fail_bundle.json")
         },
         "backpressure": compact_artifact_status(&backpressure_state, "csm_backpressure_state.json"),
+        "typed_channels": compact_typed_channel_status(&typed_channel_state),
         "api_gateway_bridge": api_gateway_bridge_runtime_status(loaded),
         "otel": {
             "status": compact_artifact_status(&otel_status, "ADL_OTEL_STATUS"),
@@ -501,6 +504,8 @@ fn metrics_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) ->
     let daemon = read_json_artifact(&artifact_path(loaded, "daemon_status.json"));
     let backpressure_state =
         read_json_artifact(&artifact_path(loaded, "csm_backpressure_state.json"));
+    let typed_channel_state =
+        read_json_artifact(&artifact_path(loaded, "csm_typed_channel_state.json"));
     let event_count = read_jsonl_tail(&artifact_path(loaded, "operator_events.jsonl"), usize::MAX)
         .get("entries")
         .and_then(Value::as_array)
@@ -521,6 +526,12 @@ fn metrics_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) ->
             "backpressure_deferred_count": backpressure_state.pointer("/value/summary/deferred_count").cloned().unwrap_or(Value::Null),
             "backpressure_shed_count": backpressure_state.pointer("/value/summary/shed_count").cloned().unwrap_or(Value::Null),
             "backpressure_retry_capacity_remaining": backpressure_state.pointer("/value/summary/retry_budget_remaining").cloned().unwrap_or(Value::Null),
+            "typed_channel_count": typed_channel_state.pointer("/value/summary/channel_count").cloned().unwrap_or(Value::Null),
+            "typed_channel_queue_depth": typed_channel_state.pointer("/value/summary/queue_depth").cloned().unwrap_or(Value::Null),
+            "typed_channel_durable_spool_depth": typed_channel_state.pointer("/value/summary/durable_spool_depth").cloned().unwrap_or(Value::Null),
+            "typed_channel_blocked_count": typed_channel_state.pointer("/value/summary/blocked_count").cloned().unwrap_or(Value::Null),
+            "typed_channel_throttled_count": typed_channel_state.pointer("/value/summary/throttled_count").cloned().unwrap_or(Value::Null),
+            "typed_channel_shed_count": typed_channel_state.pointer("/value/summary/shed_count").cloned().unwrap_or(Value::Null),
             "storage_available_bytes": backpressure_state.pointer("/value/storage_pressure/available_bytes").cloned().unwrap_or(Value::Null),
             "storage_disk_floor_bytes": backpressure_state.pointer("/value/storage_pressure/disk_floor_bytes").cloned().unwrap_or(Value::Null)
         },
@@ -529,6 +540,7 @@ fn metrics_response(loaded: &LoadedAgentSpec, options: &CsmRuntimeApiOptions) ->
             "ready": status["ready"],
             "agent_state": status["agent_status"]["state"],
             "backpressure_health": backpressure_state.pointer("/value/summary/health").cloned().unwrap_or(Value::Null),
+            "typed_channel_readiness": typed_channel_state.pointer("/value/status").cloned().unwrap_or(Value::Null),
             "backpressure_safe_fail_action": backpressure_state.pointer("/value/safe_fail_action/action").cloned().unwrap_or(Value::Null),
             "storage_pressure": backpressure_state.pointer("/value/storage_pressure/state").cloned().unwrap_or(Value::Null)
         }
@@ -904,6 +916,19 @@ fn compact_artifact_status(artifact: &Value, reference: &str) -> Value {
     })
 }
 
+fn compact_typed_channel_status(artifact: &Value) -> Value {
+    json!({
+        "status": artifact.pointer("/value/status").cloned().unwrap_or_else(|| json!("missing")),
+        "ref": "csm_typed_channel_state.json",
+        "schema": artifact.pointer("/value/schema").cloned().unwrap_or(Value::Null),
+        "required_channel_not_ready": artifact.pointer("/value/required_channel_not_ready").cloned().unwrap_or(Value::Null),
+        "last_event": artifact.pointer("/value/last_event").cloned().unwrap_or(Value::Null),
+        "last_receipt": artifact.pointer("/value/last_receipt").cloned().unwrap_or(Value::Null),
+        "summary": artifact.pointer("/value/summary").cloned().unwrap_or(Value::Null),
+        "channels": artifact.pointer("/value/channels").cloned().unwrap_or(Value::Null)
+    })
+}
+
 fn artifact_liveness(daemon_status: &Value) -> Value {
     let status = daemon_status
         .get("status")
@@ -1132,6 +1157,13 @@ fn readiness_blockers(status: &Value) -> Vec<String> {
         == Some("low_disk")
     {
         blockers.push("storage_low_disk".to_string());
+    }
+    if status
+        .pointer("/typed_channels/status")
+        .and_then(Value::as_str)
+        != Some("ready")
+    {
+        blockers.push("typed_channels_not_ready".to_string());
     }
     if status
         .pointer("/curiosity_engine/value/readiness")

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1,4 +1,8 @@
 //! Long-lived agent orchestration surfaces.
+use adl_runtime::backpressure::{
+    ChannelPriority, ReadinessState, RuntimeChannelFabric, RuntimeChannelId, RuntimeDelivery,
+    RuntimeMessage, TransportPublishReceipt,
+};
 use adl_runtime::determinism::{
     cycle_record_fingerprint, evaluate_core_decision, CapturedShellInputEvent, CoreDecisionInput,
     CoreDecisionRequest, CsmCycleDeterminismBoundaryRecord, DeterministicCoreComponent,
@@ -14,6 +18,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -160,7 +165,8 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
     ensure_state_root(&loaded)?;
     let checkpoint_interval_secs =
         effective_checkpoint_interval_secs(&loaded, options.checkpoint_interval_secs)?;
-    let runtime_context = CsmRuntimeContext::new()?;
+    let runtime_context = CsmRuntimeContext::new(&loaded)?;
+    let _startup_cloud_replay = drain_pending_cloud_notices(&runtime_context, &loaded, None)?;
     let runtime_api_shutdown = embedded_runtime_api_shutdown_path(&loaded);
     let _runtime_api_shutdown_guard = RuntimeApiShutdownGuard {
         path: runtime_api_shutdown.clone(),
@@ -297,12 +303,52 @@ pub fn daemon(spec_path: &Path, options: DaemonOptions) -> Result<DaemonStatusRe
             },
         )?;
 
-        match tick(
-            spec_path,
-            TickOptions {
-                recover_stale_lease: options.recover_stale_lease,
-            },
-        ) {
+        let cycle_result = runtime_context
+            .transit(
+                RuntimeChannelId::SchedulerToReasoningRuntime,
+                "cycle_admission",
+                ChannelPriority::GovernedExecution,
+                json!({"restart_count": restart_count}),
+            )
+            .and_then(|_| {
+                runtime_context.transit(
+                    RuntimeChannelId::ReasoningRuntimeToAee,
+                    "governed_execution_admission",
+                    ChannelPriority::GovernedExecution,
+                    json!({"restart_count": restart_count}),
+                )
+            })
+            .and_then(|_| {
+                tick(
+                    spec_path,
+                    TickOptions {
+                        recover_stale_lease: options.recover_stale_lease,
+                    },
+                )
+            })
+            .and_then(|status| {
+                runtime_context.transit(
+                    RuntimeChannelId::AeeToCheckpoint,
+                    "cycle_checkpoint",
+                    ChannelPriority::CriticalContinuity,
+                    json!({"state": status.state.clone(), "cycle_id": status.last_cycle_id.clone()}),
+                )?;
+                runtime_context.transit(
+                    RuntimeChannelId::ComponentsToLifelog,
+                    "cycle_lifecycle_record",
+                    ChannelPriority::Evidence,
+                    json!({"state": status.state.clone(), "cycle_id": status.last_cycle_id.clone()}),
+                )?;
+                runtime_context.transit(
+                    RuntimeChannelId::ComponentsToObservability,
+                    "cycle_observability_record",
+                    ChannelPriority::Audit,
+                    json!({"state": status.state.clone(), "cycle_id": status.last_cycle_id.clone()}),
+                )?;
+                Ok(status)
+            });
+
+        match cycle_result {
             Ok(status) => {
                 last_child_exit = Some("success".to_string());
                 emit_daemon_event(
@@ -883,7 +929,7 @@ pub fn governed_stop(spec_path: &Path, request: GovernedStopRequest) -> Result<V
     validate_governed_stop_request(&request)?;
     let loaded = load_spec(spec_path)?;
     ensure_state_root(&loaded)?;
-    let runtime_context = CsmRuntimeContext::new()?;
+    let runtime_context = CsmRuntimeContext::observer()?;
     let restart_count = daemon_restart_count_hint(&loaded);
     let governed_stop_id = governed_stop_id(&loaded, &request);
 
@@ -2572,6 +2618,99 @@ struct GovernedNoticeInput<'a> {
     details: Value,
 }
 
+struct CloudNoticeDrainResult {
+    target_attempts: Vec<Value>,
+    target_delivery: Option<Value>,
+    acknowledged_count: u64,
+}
+
+fn drain_pending_cloud_notices(
+    runtime_context: &CsmRuntimeContext,
+    loaded: &LoadedAgentSpec,
+    target_sequence: Option<u64>,
+) -> Result<CloudNoticeDrainResult> {
+    let mut target_attempts = Vec::new();
+    let mut target_delivery = None;
+    let mut acknowledged_count = 0u64;
+    loop {
+        let Some(delivery) =
+            runtime_context.replay_next(RuntimeChannelId::CloudBridgeToAwsRoutes)?
+        else {
+            break;
+        };
+        let sequence = delivery
+            .spool_sequence
+            .context("cloud replay delivery missing durable spool sequence")?;
+        let attempts = publish_csm_governed_notice_signal(loaded, &delivery.message.payload);
+        let verified_attempt = attempts.iter().find(|attempt| {
+            attempt.get("status").and_then(Value::as_str) == Some("published_live")
+                && attempt
+                    .get("provider_message_id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.trim().is_empty())
+        });
+        let delivery_state = if let Some(attempt) = verified_attempt {
+            let transport = attempt
+                .get("channel")
+                .and_then(Value::as_str)
+                .context("verified cloud attempt missing channel")?;
+            let provider_receipt_id = attempt
+                .get("provider_message_id")
+                .and_then(Value::as_str)
+                .context("verified cloud attempt missing provider receipt")?;
+            if let Err(error) =
+                runtime_context.acknowledge_cloud_publish(sequence, transport, provider_receipt_id)
+            {
+                runtime_context
+                    .release_replay(RuntimeChannelId::CloudBridgeToAwsRoutes, sequence)?;
+                return Err(error)
+                    .context("cloud transport succeeded but durable acknowledgement failed");
+            }
+            acknowledged_count = acknowledged_count.saturating_add(1);
+            json!({
+                "status": "published_and_atomically_acknowledged",
+                "spool_sequence": sequence,
+                "publish_cursor": sequence,
+                "transport": transport,
+                "provider_receipt_id": provider_receipt_id
+            })
+        } else {
+            runtime_context.release_replay(RuntimeChannelId::CloudBridgeToAwsRoutes, sequence)?;
+            json!({
+                "status": "durably_spooled_waiting_for_verified_transport_receipt",
+                "spool_sequence": sequence,
+                "cursor_advanced": false
+            })
+        };
+        if target_sequence == Some(sequence) {
+            target_attempts = attempts;
+            target_delivery = Some(delivery_state.clone());
+        }
+        if delivery_state
+            .get("cursor_advanced")
+            .and_then(Value::as_bool)
+            == Some(false)
+        {
+            if let Some(target) = target_sequence {
+                if target != sequence && target_delivery.is_none() {
+                    target_delivery = Some(json!({
+                        "status": "durably_spooled_behind_unacknowledged_sequence",
+                        "spool_sequence": target,
+                        "blocking_spool_sequence": sequence,
+                        "cursor_advanced": false
+                    }));
+                }
+            }
+            break;
+        }
+    }
+    Ok(CloudNoticeDrainResult {
+        target_attempts,
+        target_delivery,
+        acknowledged_count,
+    })
+}
+
 fn record_governed_runtime_notice(
     runtime_context: &CsmRuntimeContext,
     loaded: &LoadedAgentSpec,
@@ -2629,14 +2768,34 @@ fn record_governed_runtime_notice(
     append_jsonl(&csm_notice_ledger_path(loaded), &local_notice)?;
 
     let mut final_notice = local_notice;
+    let cloud_spool_sequence =
+        runtime_context.persist_cloud_notice(&notice_id, final_notice.clone())?;
     let mut attempts = vec![json!({
         "channel": "local_notice_ledger",
         "status": "recorded",
         "artifact_ref": "csm_governed_notices.jsonl"
     })];
-    attempts.extend(publish_csm_governed_notice_signal(loaded, &final_notice));
+    let typed_channel_delivery = match cloud_spool_sequence {
+        Some(sequence) => {
+            let drain = drain_pending_cloud_notices(runtime_context, loaded, Some(sequence))?;
+            attempts.extend(drain.target_attempts);
+            drain.target_delivery.unwrap_or_else(|| {
+                json!({
+                    "status": "durably_spooled_waiting_for_replay",
+                    "spool_sequence": sequence,
+                    "acknowledged_predecessor_count": drain.acknowledged_count,
+                    "cursor_advanced": false
+                })
+            })
+        }
+        None => json!({
+            "status": "observer_command_defers_to_daemon_channel_owner",
+            "cursor_advanced": false
+        }),
+    };
     if let Some(object) = final_notice.as_object_mut() {
         object.insert("delivery_attempts".to_string(), json!(attempts));
+        object.insert("typed_channel_delivery".to_string(), typed_channel_delivery);
         object.insert("delivery_completed_at".to_string(), json!(Utc::now()));
     }
     write_json_pretty(&csm_notice_latest_path(loaded), &final_notice)?;
@@ -3083,21 +3242,323 @@ struct PartialCheckpointSleep<'a> {
 
 struct CsmRuntimeContext {
     chronosense: ChronosenseRuntimeService,
+    channel_runtime: Option<tokio::runtime::Runtime>,
+    channel_fabric: Option<Mutex<RuntimeChannelFabric>>,
+    channel_state_path: Option<PathBuf>,
 }
 
 impl CsmRuntimeContext {
-    fn new() -> Result<Self> {
+    fn new(loaded: &LoadedAgentSpec) -> Result<Self> {
+        let state_root = &loaded.state_root;
         let started_at_epoch_ms = epoch_millis_now();
         let chronosense = ChronosenseRuntimeService::new(ChronosenseRuntimeServiceConfig::utc(
             started_at_epoch_ms,
         ))
         .context("failed initializing CSM Chronosense runtime service")?;
         let _initial_time_sync = start_runtime_time_observation();
-        Ok(Self { chronosense })
+        let channel_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed creating CSM typed-channel runtime")?;
+        let channel_fabric = RuntimeChannelFabric::open(state_root.join("channel_spools"))
+            .context("failed opening CSM typed-channel fabric")?;
+        let context = Self {
+            chronosense,
+            channel_runtime: Some(channel_runtime),
+            channel_fabric: Some(Mutex::new(channel_fabric)),
+            channel_state_path: Some(state_root.join("csm_typed_channel_state.json")),
+        };
+        context.recover_required_channels(loaded)?;
+        context.persist_channel_state("runtime_started", None)?;
+        Ok(context)
+    }
+
+    fn observer() -> Result<Self> {
+        let started_at_epoch_ms = epoch_millis_now();
+        let chronosense = ChronosenseRuntimeService::new(ChronosenseRuntimeServiceConfig::utc(
+            started_at_epoch_ms,
+        ))
+        .context("failed initializing CSM Chronosense observer context")?;
+        let _initial_time_sync = start_runtime_time_observation();
+        Ok(Self {
+            chronosense,
+            channel_runtime: None,
+            channel_fabric: None,
+            channel_state_path: None,
+        })
     }
 
     fn time_sync_status(&self) -> crate::chronosense::ChronosenseTimeSyncStatus {
         capture_runtime_time_sync_status()
+    }
+
+    fn transit(
+        &self,
+        channel: RuntimeChannelId,
+        event: &str,
+        priority: ChannelPriority,
+        payload: Value,
+    ) -> Result<Value> {
+        let message = RuntimeMessage::new(
+            format!(
+                "{}-{}",
+                event,
+                Utc::now().timestamp_nanos_opt().unwrap_or_default()
+            ),
+            priority,
+            payload,
+        );
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut fabric = self
+            .channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot own typed-channel transit")?
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        let (receipt, delivery) = self
+            .channel_runtime
+            .as_ref()
+            .context("CSM observer context has no typed-channel runtime")?
+            .block_on(fabric.transit(channel, message, &cancellation))
+            .context("CSM typed-channel transit failed")?;
+        let delivery = delivery.context("CSM typed-channel admission did not reach component")?;
+        if delivery.message.id != receipt.message_id {
+            return Err(anyhow!("CSM typed-channel delivery identity mismatch"));
+        }
+        drop(fabric);
+        self.persist_channel_state(event, Some(serde_json::to_value(&receipt)?))?;
+        Ok(serde_json::to_value(receipt)?)
+    }
+
+    fn recover_required_channels(&self, loaded: &LoadedAgentSpec) -> Result<()> {
+        for channel in RuntimeChannelId::ALL {
+            if channel == RuntimeChannelId::CloudBridgeToAwsRoutes {
+                continue;
+            }
+            while let Some(delivery) = self.replay_next(channel)? {
+                let sequence = delivery
+                    .spool_sequence
+                    .context("replayed runtime delivery missing durable spool sequence")?;
+                if let Err(error) = self.process_replayed_delivery(loaded, channel, &delivery) {
+                    self.release_replay(channel, sequence)?;
+                    return Err(error).context("failed processing durable CSM channel replay");
+                }
+                if let Err(error) = self.acknowledge_processed(channel, sequence) {
+                    self.release_replay(channel, sequence)?;
+                    return Err(error).context("failed acknowledging processed CSM channel replay");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn process_replayed_delivery(
+        &self,
+        loaded: &LoadedAgentSpec,
+        channel: RuntimeChannelId,
+        delivery: &RuntimeDelivery,
+    ) -> Result<()> {
+        let sequence = delivery
+            .spool_sequence
+            .context("replayed runtime delivery missing durable spool sequence")?;
+        match channel {
+            RuntimeChannelId::AeeToCheckpoint => {
+                let status = read_status(loaded)?
+                    .context("cannot process checkpoint replay without retained agent status")?;
+                persist_status(loaded, &status, "typed_channel_replay")?;
+            }
+            RuntimeChannelId::ComponentsToLifelog => {
+                append_operator_event(
+                    loaded,
+                    "typed_channel_lifelog_replay",
+                    delivery.message.payload.clone(),
+                )?;
+            }
+            RuntimeChannelId::ComponentsToObservability => {
+                append_operator_event(
+                    loaded,
+                    "typed_channel_observability_replay",
+                    delivery.message.payload.clone(),
+                )?;
+                crate::observability::emit_event(
+                    "csm",
+                    "typed_channel_observability_replay",
+                    "processed",
+                    &[
+                        ("channel", channel.as_str()),
+                        ("message_id", delivery.message.id.as_str()),
+                    ],
+                );
+            }
+            RuntimeChannelId::SchedulerToReasoningRuntime
+            | RuntimeChannelId::ReasoningRuntimeToAee
+            | RuntimeChannelId::RuntimeApiToControlPlane => {
+                append_operator_event(
+                    loaded,
+                    "typed_channel_replay_reconciled",
+                    json!({
+                        "channel": channel.as_str(),
+                        "message_id": delivery.message.id,
+                        "spool_sequence": sequence,
+                        "payload": delivery.message.payload,
+                        "recovery_action": "reconciled_with_retained_runtime_state_before_new_admission"
+                    }),
+                )?;
+            }
+            RuntimeChannelId::CloudBridgeToAwsRoutes => {
+                return Err(anyhow!(
+                    "cloud replay requires verified transport processing"
+                ));
+            }
+        }
+        append_operator_event(
+            loaded,
+            "typed_channel_replay_processed",
+            json!({
+                "channel": channel.as_str(),
+                "message_id": delivery.message.id,
+                "spool_sequence": sequence
+            }),
+        )
+    }
+
+    fn replay_next(&self, channel: RuntimeChannelId) -> Result<Option<RuntimeDelivery>> {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut fabric = self
+            .channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot replay typed-channel state")?
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        self.channel_runtime
+            .as_ref()
+            .context("CSM observer context has no typed-channel runtime")?
+            .block_on(fabric.replay_next(channel, &cancellation))
+            .context("failed replaying durable CSM typed-channel record")
+    }
+
+    fn acknowledge_processed(&self, channel: RuntimeChannelId, sequence: u64) -> Result<()> {
+        let fabric = self
+            .channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot acknowledge typed-channel processing")?
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        self.channel_runtime
+            .as_ref()
+            .context("CSM observer context has no typed-channel runtime")?
+            .block_on(fabric.acknowledge_processed(channel, sequence))
+            .context("failed acknowledging durable CSM typed-channel record")
+    }
+
+    fn release_replay(&self, channel: RuntimeChannelId, sequence: u64) -> Result<()> {
+        self.channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot release typed-channel replay")?
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?
+            .release_replay(channel, sequence)
+            .context("failed releasing durable CSM typed-channel replay")
+    }
+
+    fn persist_channel_state(&self, event: &str, receipt: Option<Value>) -> Result<()> {
+        let fabric = self
+            .channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot persist typed-channel state")?
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        let snapshots = self
+            .channel_runtime
+            .as_ref()
+            .context("CSM observer context has no typed-channel runtime")?
+            .block_on(fabric.snapshots())
+            .context("failed capturing CSM typed-channel snapshots")?;
+        let required_channel_not_ready = snapshots.iter().any(|snapshot| {
+            snapshot.readiness != ReadinessState::Ready
+                && !matches!(
+                    snapshot.channel,
+                    RuntimeChannelId::ComponentsToObservability
+                        | RuntimeChannelId::CloudBridgeToAwsRoutes
+                )
+        });
+        let summary = json!({
+            "channel_count": snapshots.len(),
+            "queue_depth": snapshots.iter().map(|snapshot| snapshot.depth as u64).sum::<u64>(),
+            "durable_spool_depth": snapshots.iter().map(|snapshot| snapshot.durable_spool_depth as u64).sum::<u64>(),
+            "blocked_count": snapshots.iter().map(|snapshot| snapshot.blocked_count).sum::<u64>(),
+            "throttled_count": snapshots.iter().map(|snapshot| snapshot.throttled_count).sum::<u64>(),
+            "shed_count": snapshots.iter().map(|snapshot| snapshot.shed_count).sum::<u64>(),
+        });
+        let state = json!({
+            "schema": "adl.csm.typed_channel_state.v1",
+            "runtime_owner": "csm",
+            "status": if required_channel_not_ready { "not_ready" } else { "ready" },
+            "required_channel_not_ready": required_channel_not_ready,
+            "last_event": event,
+            "last_receipt": receipt,
+            "summary": summary,
+            "channels": snapshots,
+            "updated_at": Utc::now(),
+        });
+        write_json_pretty(
+            self.channel_state_path
+                .as_ref()
+                .context("CSM observer context has no typed-channel state path")?,
+            &state,
+        )
+        .context("failed retaining CSM typed-channel state")
+    }
+
+    fn persist_cloud_notice(&self, notice_id: &str, notice: Value) -> Result<Option<u64>> {
+        let Some(channel_fabric) = self.channel_fabric.as_ref() else {
+            return Ok(None);
+        };
+        let channel_runtime = self
+            .channel_runtime
+            .as_ref()
+            .context("CSM channel owner has no typed-channel runtime")?;
+        let fabric = channel_fabric
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        let receipt = channel_runtime
+            .block_on(fabric.persist_required(
+                RuntimeChannelId::CloudBridgeToAwsRoutes,
+                RuntimeMessage::new(notice_id, ChannelPriority::Evidence, notice),
+            ))
+            .context("failed persisting governed notice before cloud delivery")?;
+        drop(fabric);
+        self.persist_channel_state(
+            "cloud_notice_persisted",
+            Some(serde_json::to_value(&receipt)?),
+        )?;
+        Ok(receipt.spool_sequence)
+    }
+
+    fn acknowledge_cloud_publish(
+        &self,
+        sequence: u64,
+        transport: &str,
+        provider_receipt_id: &str,
+    ) -> Result<()> {
+        let channel_fabric = self
+            .channel_fabric
+            .as_ref()
+            .context("CSM observer context cannot acknowledge cloud publication")?;
+        let channel_runtime = self
+            .channel_runtime
+            .as_ref()
+            .context("CSM observer context has no typed-channel runtime")?;
+        let receipt =
+            TransportPublishReceipt::verified(sequence, sequence, transport, provider_receipt_id)?;
+        let fabric = channel_fabric
+            .lock()
+            .map_err(|_| anyhow!("CSM typed-channel fabric lock poisoned"))?;
+        channel_runtime
+            .block_on(fabric.acknowledge_published(receipt))
+            .context("failed atomically acknowledging cloud publication")?;
+        drop(fabric);
+        self.persist_channel_state("cloud_publish_acknowledged", None)
     }
 }
 
@@ -3499,6 +3960,16 @@ fn csm_runtime_capabilities_with_resident_agents(
             "restart_backoff": "bounded_exponential",
             "partial_checkpoints": "daemon_partial_checkpoint",
             "safe_fail_serialization": "integrated_safe_fail_bundle"
+        },
+        "typed_channels": {
+            "status": "integrated",
+            "fabric_owner": "csm_runtime_context",
+            "channel_count": RuntimeChannelId::ALL.len(),
+            "state_ref": "csm_typed_channel_state.json",
+            "spool_root": "channel_spools/",
+            "durability": "redb_immediate_commit",
+            "delivery_semantics": "at_least_once_until_component_acknowledgement",
+            "cloud_cursor_policy": "atomic_transport_receipt_cursor_and_spool_commit"
         },
         "resident_agents": resident_agents_status,
         "polis_shepherd_agent": csm_shepherd_agent::runtime_capability(),

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1302,7 +1302,7 @@ fn daemon_partial_checkpoint_preserves_recoverable_failure_reason() {
     let spec = write_spec_with_workflow_kind(&root, "unsupported_adapter");
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
     let error = StatusError {
         class: "daemon_child_failed".to_string(),
         message: "cycle failed before restart".to_string(),
@@ -1370,7 +1370,7 @@ fn safe_fail_bundle_preserves_malformed_artifacts_and_quarantines_active_lease()
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
     let lease = LeaseRecord {
         schema: LEASE_SCHEMA.to_string(),
         agent_instance_id: loaded.spec.agent_instance_id.clone(),
@@ -1444,7 +1444,7 @@ fn safe_fail_bundle_suppresses_sequence_artifact_under_low_disk() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
     let status = status_with_state(
         &loaded,
         AgentStatusState::Failed,
@@ -1572,7 +1572,7 @@ fn daemon_status_records_restart_always_permanent_service_contract() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
 
     let running = write_daemon_status(
         &runtime_context,
@@ -1672,7 +1672,7 @@ memory:
         r#"{"schema":"adl.csm.agent_checkpoint_request.v1","reason":"agent-local state changed","requested_at":"2026-07-06T00:00:00Z"}"#,
     )
     .expect("write checkpoint request");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("runtime context");
     let accepted = observe_agent_checkpoint_request(
         &runtime_context,
         &loaded,
@@ -1727,7 +1727,7 @@ fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
     let mut daemon_status = write_daemon_status(
         &runtime_context,
         &loaded,
@@ -1778,7 +1778,7 @@ fn daemon_partial_checkpoint_reports_stop_observed_before_restart_attempt() {
         "operator_stop_requested",
     )
     .expect("write stop");
-    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
     let mut daemon_status = write_daemon_status(
         &runtime_context,
         &loaded,

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1302,7 +1302,7 @@ fn daemon_partial_checkpoint_preserves_recoverable_failure_reason() {
     let spec = write_spec_with_workflow_kind(&root, "unsupported_adapter");
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
     let error = StatusError {
         class: "daemon_child_failed".to_string(),
         message: "cycle failed before restart".to_string(),
@@ -1370,7 +1370,7 @@ fn safe_fail_bundle_preserves_malformed_artifacts_and_quarantines_active_lease()
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
     let lease = LeaseRecord {
         schema: LEASE_SCHEMA.to_string(),
         agent_instance_id: loaded.spec.agent_instance_id.clone(),
@@ -1444,7 +1444,7 @@ fn safe_fail_bundle_suppresses_sequence_artifact_under_low_disk() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
     let status = status_with_state(
         &loaded,
         AgentStatusState::Failed,
@@ -1572,7 +1572,7 @@ fn daemon_status_records_restart_always_permanent_service_contract() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
 
     let running = write_daemon_status(
         &runtime_context,
@@ -1672,7 +1672,7 @@ memory:
         r#"{"schema":"adl.csm.agent_checkpoint_request.v1","reason":"agent-local state changed","requested_at":"2026-07-06T00:00:00Z"}"#,
     )
     .expect("write checkpoint request");
-    let runtime_context = CsmRuntimeContext::new().expect("runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("runtime context");
     let accepted = observe_agent_checkpoint_request(
         &runtime_context,
         &loaded,
@@ -1727,7 +1727,7 @@ fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");
     ensure_state_root(&loaded).expect("state root");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
     let mut daemon_status = write_daemon_status(
         &runtime_context,
         &loaded,
@@ -1778,7 +1778,7 @@ fn daemon_partial_checkpoint_reports_stop_observed_before_restart_attempt() {
         "operator_stop_requested",
     )
     .expect("write stop");
-    let runtime_context = CsmRuntimeContext::new().expect("csm runtime context");
+    let runtime_context = CsmRuntimeContext::new(&loaded.state_root).expect("csm runtime context");
     let mut daemon_status = write_daemon_status(
         &runtime_context,
         &loaded,

--- a/adl/src/runtime_aws_signal.rs
+++ b/adl/src/runtime_aws_signal.rs
@@ -10,6 +10,7 @@ use aws_sdk_eventbridge as eventbridge;
 use aws_sdk_lambda as lambda;
 use aws_sdk_sns as sns;
 use chrono::{DateTime, Utc};
+use cloudwatchlogs::operation::RequestId;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::env;
@@ -765,7 +766,9 @@ fn publish_csm_notice_cloudwatch(
                 Utc::now().timestamp_millis(),
                 message,
             ) {
-                Ok(()) => csm_notice_attempt(base, "published_live", None, None),
+                Ok(provider_receipt_id) => {
+                    csm_notice_attempt(base, "published_live", None, provider_receipt_id)
+                }
                 Err(_) => csm_notice_attempt(
                     base,
                     "failed",
@@ -973,13 +976,36 @@ fn publish_csm_notice_control_plane(
                     None,
                 );
             };
+            let idempotency_key = envelope
+                .get("correlation_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("csm-notice")
+                .to_string();
             match reqwest::blocking::Client::builder()
                 .timeout(Duration::from_secs(10))
                 .build()
-                .and_then(|client| client.post(endpoint).json(&envelope).send())
-            {
+                .and_then(|client| {
+                    client
+                        .post(endpoint)
+                        .header("Idempotency-Key", idempotency_key.as_str())
+                        .json(&envelope)
+                        .send()
+                }) {
                 Ok(response) if response.status().is_success() => {
-                    csm_notice_attempt(base, "published_live", None, None)
+                    let status = response.status().as_u16();
+                    let provider_receipt_id = ["x-amzn-requestid", "x-request-id", "request-id"]
+                        .into_iter()
+                        .find_map(|name| {
+                            response
+                                .headers()
+                                .get(name)
+                                .and_then(|value| value.to_str().ok())
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_else(|| {
+                            format!("http-{status}-idempotency-ack:{idempotency_key}")
+                        });
+                    csm_notice_attempt(base, "published_live", None, Some(provider_receipt_id))
                 }
                 Ok(response) => csm_notice_attempt(
                     base,
@@ -1506,7 +1532,7 @@ fn publish_live_cloudwatch_heartbeat(
         .context("ADL_AWS_HEARTBEAT_LOG_STREAM is required for live heartbeat publish")?;
     let message = serde_json::to_string(envelope)?;
     let timestamp = envelope.timestamp.timestamp_millis();
-    run_cloudwatch_put(config, log_group, log_stream, timestamp, message)
+    run_cloudwatch_put(config, log_group, log_stream, timestamp, message).map(|_| ())
 }
 
 fn run_cloudwatch_put(
@@ -1515,7 +1541,7 @@ fn run_cloudwatch_put(
     log_stream: &str,
     timestamp: i64,
     message: String,
-) -> Result<()> {
+) -> Result<Option<String>> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -1545,7 +1571,7 @@ fn run_cloudwatch_put(
             .message(message)
             .build()
             .context("failed to build CloudWatch heartbeat log event")?;
-        client
+        let response = client
             .put_log_events()
             .log_group_name(log_group)
             .log_stream_name(log_stream)
@@ -1553,7 +1579,12 @@ fn run_cloudwatch_put(
             .send()
             .await
             .context("failed to publish runtime heartbeat to CloudWatch Logs")?;
-        Ok::<(), anyhow::Error>(())
+        Ok::<Option<String>, anyhow::Error>(
+            response
+                .request_id()
+                .map(ToString::to_string)
+                .or_else(|| response.next_sequence_token().map(ToString::to_string)),
+        )
     })
 }
 

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -207,7 +207,7 @@ fn request_governed_stop_and_wait(spec: &std::path::Path, child: &mut std::proce
         {
             break;
         }
-        if started.elapsed() > std::time::Duration::from_secs(8) {
+        if started.elapsed() > std::time::Duration::from_secs(20) {
             let _ = child.kill();
             panic!("CSM daemon did not exit after governed stop request");
         }
@@ -948,6 +948,38 @@ memory:
         false
     );
     assert_eq!(
+        backpressure_report["typed_channel_runtime_proof"]["status"],
+        "passed"
+    );
+    assert_eq!(
+        backpressure_report["typed_channel_runtime_proof"]["channel_count"],
+        7
+    );
+    assert_eq!(
+        backpressure_report["typed_channel_runtime_proof"]["required_state_silently_dropped"],
+        false
+    );
+    let channel_observations = backpressure_report["typed_channel_runtime_proof"]["observations"]
+        .as_array()
+        .expect("live channel observations");
+    assert!(channel_observations.iter().any(|observation| {
+        observation["receipt"]["outcome"] == "durably_spooled"
+            && observation["snapshot_before_publish_ack"]["durable_spool_depth"] == 1
+    }));
+    let cloud_observation = channel_observations
+        .iter()
+        .find(|observation| observation["channel"] == "cloud_bridge_to_aws_routes")
+        .expect("cloud bridge observation");
+    assert_eq!(cloud_observation["receipt"]["cursor_may_advance"], false);
+    assert_eq!(
+        cloud_observation["snapshot_before_publish_ack"]["durable_spool_depth"],
+        1
+    );
+    assert_eq!(
+        cloud_observation["publish_ack_status"],
+        "waiting_for_live_transport_receipt"
+    );
+    assert_eq!(
         backpressure_report["safe_fail_action"]["action"],
         "safe_fail_serialize"
     );
@@ -1061,8 +1093,10 @@ memory:
 
     let mut status = http_get_json(&addr, "/status");
     let status_wait_started = std::time::Instant::now();
-    while status["daemon_liveness"]["state"] != "running" {
-        if status_wait_started.elapsed() > std::time::Duration::from_secs(5) {
+    while status["daemon_liveness"]["state"] != "running"
+        || status["typed_channels"]["last_event"] != "cycle_observability_record"
+    {
+        if status_wait_started.elapsed() > std::time::Duration::from_secs(20) {
             panic!(
                 "embedded CSM API did not report ready running daemon state:\n{}",
                 serde_json::to_string_pretty(&status).expect("serialize status")
@@ -1115,6 +1149,16 @@ memory:
         status["backpressure"]["schema"],
         "adl.csm.backpressure_state.v1"
     );
+    assert_eq!(status["typed_channels"]["status"], "ready");
+    assert_eq!(
+        status["typed_channels"]["schema"],
+        "adl.csm.typed_channel_state.v1"
+    );
+    assert_eq!(status["typed_channels"]["summary"]["channel_count"], 7);
+    assert_eq!(
+        status["typed_channels"]["last_event"],
+        "cycle_observability_record"
+    );
     assert_eq!(status["scheduler"]["status"], "integrated");
     assert_eq!(status["chronosense"]["status"], "integrated");
     assert_eq!(status["aee_resilience"]["status"], "integrated");
@@ -1152,6 +1196,12 @@ memory:
     assert_eq!(metrics["gauges"]["backpressure_lag_ms"], 3100);
     assert_eq!(metrics["gauges"]["backpressure_deferred_count"], 23);
     assert_eq!(metrics["gauges"]["backpressure_shed_count"], 7);
+    assert_eq!(metrics["gauges"]["typed_channel_count"], 7);
+    assert_eq!(metrics["gauges"]["typed_channel_queue_depth"], 0);
+    assert_eq!(metrics["gauges"]["typed_channel_durable_spool_depth"], 0);
+    assert_eq!(metrics["gauges"]["typed_channel_blocked_count"], 0);
+    assert_eq!(metrics["gauges"]["typed_channel_throttled_count"], 0);
+    assert_eq!(metrics["gauges"]["typed_channel_shed_count"], 0);
     assert_eq!(
         metrics["states"]["backpressure_health"],
         "capacity_degraded"
@@ -1160,6 +1210,7 @@ memory:
         metrics["states"]["backpressure_safe_fail_action"],
         "safe_fail_serialize"
     );
+    assert_eq!(metrics["states"]["typed_channel_readiness"], "ready");
     assert!(
         matches!(
             metrics["states"]["agent_state"].as_str(),


### PR DESCRIPTION
Closes #5113

## Summary
Implemented the daemon-owned typed runtime channel fabric across all seven canonical CSM channels. The implementation uses bounded Tokio channels, immediate-durability redb spools, oldest-first at-least-once replay, channel-specific recovery processing, verified transport receipts, atomic cloud cursor acknowledgement, live API readiness projection, and explicit low-priority observability shedding. Independent review ran in three repair passes and the final pass reported no P1/P2 findings.

## Artifacts
- Issue output card at `.adl/v0.91.7/tasks/issue-5113__v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix/sor.md`
- Runtime implementation: `adl-runtime/src/backpressure.rs`, `adl/src/csm_backpressure.rs`, `adl/src/long_lived_agent.rs`, `adl/src/csm_runtime_api.rs`, and `adl/src/runtime_aws_signal.rs`
- Runtime proof: focused `adl-runtime` tests, crate-independence test, CSM compile/Clippy lanes, and embedded daemon/API smoke

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl-runtime/Cargo.toml --all-targets` verified the channel matrix, backpressure, durable replay, cursor ordering, crash reopen, concurrency, and crate independence; 49 unit tests and one independence test passed.
  - `cargo check --manifest-path adl/Cargo.toml --bin csm` verified the integrated CSM binary compiles with daemon replay and AWS receipt paths.
  - `cargo clippy --manifest-path adl/Cargo.toml --lib --bin csm --test cli_smoke -- -D warnings` verified the touched CSM and smoke surfaces under strict Clippy.
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke csm_runtime_api_serves_status_health_ready_metrics_and_events -- --nocapture` verified the assembled runtime/API path and governed shutdown; passed in 65.70 seconds.
  - `git diff --check` verified patch hygiene.
  - `adl-csdlc tooling prompt-template validate-structure --kind spp|vpp` verified changed planning-card structure.
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5113__v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5113__v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix/sor.md
- Idempotency-Key: v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix-adl-v0-91-7-tasks-issue-5113-v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix-sip-md-adl-v0-91-7-tasks-issue-5113-v0-91-7-wp-07-runtime-implement-typed-channel-backpressure-policy-matrix-sor-md