### PR TITLE
[v0.91.7][tools][shepherd] Prune merged issue worktrees automatically

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -502,13 +502,24 @@ fn real_pr_watch(args: &[String]) -> Result<()> {
 
 fn real_pr_shepherd(args: &[String]) -> Result<()> {
     let parsed: ShepherdArgs = parse_shepherd_args(args)?;
-    let snapshot = build_issue_lifecycle_snapshot(&WatchArgs {
-        issue_ref: parsed.issue_ref,
-        repo: parsed.repo,
-        slug: parsed.slug,
-        version: parsed.version,
+    let watch_args = WatchArgs {
+        issue_ref: parsed.issue_ref.clone(),
+        repo: parsed.repo.clone(),
+        slug: parsed.slug.clone(),
+        version: parsed.version.clone(),
         json: parsed.json,
-    })?;
+    };
+    let mut snapshot = build_issue_lifecycle_snapshot(&watch_args)?;
+    if snapshot.watch_report.classification == "merged_pending_closeout" {
+        let issue = parse_issue_ref_number("shepherd", &parsed.issue_ref)?;
+        let repo = parsed
+            .repo
+            .clone()
+            .or_else(|| repo_from_issue_ref(&parsed.issue_ref))
+            .or_else(|| repo_from_pr_ref(&parsed.issue_ref));
+        closeout_closed_completed_issue(issue, parsed.version.clone(), parsed.slug.clone(), repo)?;
+        snapshot = build_issue_lifecycle_snapshot(&watch_args)?;
+    }
     let report = github::build_issue_lifecycle_shepherd_report(
         &snapshot.watch_report,
         snapshot.ready_lifecycle_state,
@@ -2155,38 +2166,47 @@ fn real_pr_doctor(args: &[String]) -> Result<()> {
 
 fn real_pr_closeout(args: &[String]) -> Result<()> {
     let parsed = parse_closeout_args(args)?;
+    let output_path = closeout_closed_completed_issue(
+        parsed.issue,
+        parsed.version.clone(),
+        parsed.slug.clone(),
+        None,
+    )?;
+    let primary_root = primary_checkout_root()?;
+    let task_bundle = output_path.parent().ok_or_else(|| {
+        anyhow!(
+            "closeout: output path has no parent: {}",
+            output_path.display()
+        )
+    })?;
+    println!("{}", path_relative_to_repo(&primary_root, task_bundle));
+    Ok(())
+}
+
+fn closeout_closed_completed_issue(
+    issue: u32,
+    version: Option<String>,
+    slug: Option<String>,
+    repo_override: Option<String>,
+) -> Result<PathBuf> {
     let repo_root = repo_root()?;
     let primary_root = primary_checkout_root()?;
-    let repo = default_repo(&primary_root)?;
-    let inferred =
-        resolve_issue_scope_and_slug_from_available_local_state(&primary_root, parsed.issue)?
-            .unwrap_or((
-                parsed
-                    .version
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
-                parsed
-                    .slug
-                    .clone()
-                    .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
-            ));
-    let issue_ref = IssueRef::new(parsed.issue, inferred.0, inferred.1)?;
+    let repo = repo_override.unwrap_or(default_repo(&primary_root)?);
+    let inferred = resolve_issue_scope_and_slug_from_available_local_state(&primary_root, issue)?
+        .unwrap_or((
+            version.unwrap_or_else(|| DEFAULT_VERSION.to_string()),
+            slug.unwrap_or_else(|| format!("issue-{issue}")),
+        ));
+    let issue_ref = IssueRef::new(issue, inferred.0, inferred.1)?;
     let output_path = issue_ref.task_bundle_output_path(&primary_root);
-    lifecycle::ensure_issue_closed_completed_for_closeout(parsed.issue, &repo)?;
+    lifecycle::ensure_issue_closed_completed_for_closeout(issue, &repo)?;
     lifecycle::closeout_closed_completed_issue_bundle(
         &repo_root,
         &primary_root,
         &issue_ref,
         &output_path,
     )?;
-    println!(
-        "{}",
-        path_relative_to_repo(
-            &primary_root,
-            &issue_ref.task_bundle_dir_path(&primary_root)
-        )
-    );
-    Ok(())
+    Ok(output_path)
 }
 
 fn print_json<T: Serialize>(value: &T) -> Result<()> {

--- a/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/reconciliation.rs
@@ -94,7 +94,7 @@ pub(crate) fn validated_closeout_marker_is_current(
     }
     let canonical_output = repo_root.join(&marker.canonical_sor);
     ensure_closed_completed_issue_bundle_truth(repo_root, issue_ref, &canonical_output)?;
-    Ok(true)
+    closeout_worktree_settlement_is_current(repo_root, issue_ref, &canonical_output)
 }
 
 pub(crate) fn validated_closeout_state_is_current(
@@ -106,7 +106,7 @@ pub(crate) fn validated_closeout_state_is_current(
     }
     let canonical_output = issue_ref.task_bundle_output_path(repo_root);
     ensure_closed_completed_issue_bundle_truth(repo_root, issue_ref, &canonical_output)?;
-    Ok(true)
+    closeout_worktree_settlement_is_current(repo_root, issue_ref, &canonical_output)
 }
 
 pub(crate) fn validated_closeout_state_matches_linked_pr(
@@ -147,6 +147,45 @@ fn closeout_sor_names_linked_pr(text: &str, linked_pr_url: &str, _linked_pr_numb
         let value = value.trim().trim_matches('`').trim_matches('"');
         value.trim_end_matches('/') == expected_url
     })
+}
+
+fn closeout_worktree_settlement_is_current(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    canonical_output: &Path,
+) -> Result<bool> {
+    let worktree_path = issue_ref.default_worktree_path(
+        repo_root,
+        std::env::var_os("ADL_WORKTREE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+    );
+    if !worktree_path.is_dir() {
+        return Ok(true);
+    }
+
+    let text = fs::read_to_string(canonical_output).with_context(|| {
+        format!(
+            "watch: failed to read canonical SOR '{}'",
+            canonical_output.display()
+        )
+    })?;
+    let worktree_prune_result = line_value_after_prefix(&text, "- Worktree prune result:");
+    let worktree_only_paths = line_value_after_prefix(&text, "- Worktree-only paths remaining:");
+    let retained_is_recorded = worktree_prune_result
+        .as_deref()
+        .unwrap_or_default()
+        .starts_with("retained_with_reason:")
+        || worktree_prune_result
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("blocked_dirty:");
+    let remaining_paths_record_retention = worktree_only_paths
+        .as_deref()
+        .unwrap_or_default()
+        .starts_with("issue worktree retained:");
+
+    Ok(retained_is_recorded && remaining_paths_record_retention)
 }
 
 fn closeout_sor_pr_url(text: &str) -> Option<String> {

--- a/adl/src/cli/pr_cmd/lifecycle/tests.rs
+++ b/adl/src/cli/pr_cmd/lifecycle/tests.rs
@@ -1149,6 +1149,43 @@ fn validated_closeout_state_accepts_legacy_canonical_truth_without_marker() {
 }
 
 #[test]
+fn validated_closeout_state_rejects_unpruned_clean_worktree_residue() {
+    let temp = temp_dir("adl-pr-lifecycle-closeout-unpruned-worktree");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+    let canonical_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&canonical_dir).expect("canonical dir");
+    fs::write(
+        canonical_dir.join("stp.md"),
+        "status: \"complete\"\n# STP\n",
+    )
+    .expect("write stp");
+    fs::write(
+        canonical_dir.join("sip.md"),
+        "Branch: codex/1410-canonical-slug\n# SIP\n",
+    )
+    .expect("write sip");
+    fs::write(
+        canonical_dir.join("srp.md"),
+        issue_ref_completed_srp_content(),
+    )
+    .expect("write srp");
+    fs::write(
+        canonical_dir.join("sor.md"),
+        issue_ref_sync_completed_output_content(),
+    )
+    .expect("write sor");
+    fs::create_dir_all(issue_ref.default_worktree_path(&repo, None)).expect("worktree residue");
+
+    assert!(
+        !validated_closeout_state_is_current(&repo, &issue_ref)
+            .expect("valid SOR with unpruned worktree should be classified"),
+        "valid SOR truth alone must not settle a merged issue while its clean worktree remains"
+    );
+}
+
+#[test]
 fn validated_closeout_state_ignores_corrupt_marker_when_canonical_truth_is_valid() {
     let temp = temp_dir("adl-pr-lifecycle-closeout-corrupt-marker");
     let repo = temp.join("repo");
@@ -1848,6 +1885,11 @@ fn closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete() {
     assert!(text.contains("- Worktree-only paths remaining: issue worktree retained: adl-wp-1410"));
     ensure_closed_completed_issue_bundle_truth(&repo, &issue_ref, &output)
         .expect("canonical truth accepts retained stale worktree");
+    assert!(
+        validated_closeout_state_is_current(&repo, &issue_ref)
+            .expect("retained dirty closeout state should classify"),
+        "dirty retained worktree remains settled only when SOR records the retained reason"
+    );
 }
 
 #[test]

--- a/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
+++ b/docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md
@@ -86,6 +86,10 @@ The canonical issue-lifecycle shepherd states are:
 6. `merged_needs_closeout`
    - The PR outcome is settled, but local closeout truth is not yet finalized.
    - Typical owner: `pr-closeout`.
+   - `adl pr shepherd` may run repo-native closeout for this state. Clean issue
+     worktrees are removed with `git worktree remove`; dirty worktrees are
+     retained and must be named in closeout diagnostics instead of being
+     force-deleted.
 7. `closed_no_pr`
    - The issue settled without PR merge, for example duplicate, superseded, or
      other explicit no-PR closeout.
@@ -119,7 +123,8 @@ The canonical issue-lifecycle shepherd states are:
 - `janitor_active -> merged_needs_closeout`
   - triggered when the PR merges after remediation
 - `merged_needs_closeout -> settled`
-  - requires truthful local closeout completion
+  - requires truthful local closeout completion, including issue worktree
+    absence or an explicit dirty-retention reason in the SOR
 - `closed_no_pr -> settled`
   - requires truthful local closeout completion with explicit no-PR rationale
 - `any_state -> blocked`


### PR DESCRIPTION
Closes #5194

## Summary
Implemented merged-tail shepherd closeout pruning for issue worktrees. `adl pr shepherd` now runs the repo-native closeout path when watch classification is `merged_pending_closeout`, then rebuilds the lifecycle snapshot before reporting. Closeout validation now refuses to classify a closed merged issue as settled while its default clean issue worktree still exists; retained dirty worktrees remain accepted only when the SOR records the explicit retention reason.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/lifecycle/reconciliation.rs`
- `adl/src/cli/pr_cmd/lifecycle/tests.rs`
- `docs/tooling/ISSUE_LIFECYCLE_SHEPHERD_CONTRACT.md`
- `.adl/v0.91.7/tasks/issue-5194__v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Formatted changed Rust files.`
  - `cargo test --manifest-path adl/Cargo.toml validated_closeout_state_rejects_unpruned_clean_worktree_residue -- --nocapture`
    `Proved valid closeout SOR truth does not settle while a clean default issue worktree still exists.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_closed_completed_issue_bundle_records_prune_result_on_canonical_output -- --nocapture`
    `Proved clean closeout pruning still records the prune result and removes the worktree.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl closeout_retains_dirty_stale_worktree_when_canonical_truth_is_complete -- --nocapture`
    `Proved dirty retained worktrees are not force-pruned and remain valid only with retention truth.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl validated_closeout_state_rejects_unpruned_clean_worktree_residue -- --nocapture`
    `Re-ran the new regression on the focused main binary target.`
  - `cargo test --manifest-path adl/Cargo.toml --bin adl-pr-shepherd validated_closeout_state_rejects_unpruned_clean_worktree_residue -- --nocapture`
    `Compiled the shepherd CLI target and reran the focused regression after fixing repository propagation.`
  - `git diff --check`
    `Checked whitespace on the final implementation diff.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5194__v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5194__v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically/sor.md
- Idempotency-Key: v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-lifecycle-reconciliation-rs-adl-src-cli-pr-cmd-lifecycle-tests-rs-docs-tooling-issue-lifecycle-shepherd-contract-md-adl-v0-91-7-tasks-issue-5194-v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically-sip-md-adl-v0-91-7-tasks-issue-5194-v0-91-7-tools-shepherd-prune-merged-issue-worktrees-automatically-sor-md