### PR TITLE
[v0.91.7][WP-07][cloud][runtime] Make CSM cloud_bridge fail closed for AWS publishability and cursors

### DIFF
--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -31,7 +31,9 @@ use crate::csm_godel_snapshot::{validate_recovery_read, write_checkpoint_snapsho
 use crate::csm_resident_agents;
 use crate::csm_runtime_api::{serve_runtime_api, CsmRuntimeApiOptions};
 use crate::csm_shepherd_agent;
-use crate::runtime_aws_signal::publish_csm_governed_notice_signal;
+use crate::runtime_aws_signal::{
+    preflight_csm_governed_notice_signal, publish_csm_governed_notice_signal_for_channel,
+};
 use crate::{adl, execute, resolve, trace};
 
 mod inspection;
@@ -2641,14 +2643,38 @@ fn drain_pending_cloud_notices(
         let sequence = delivery
             .spool_sequence
             .context("cloud replay delivery missing durable spool sequence")?;
-        let attempts = publish_csm_governed_notice_signal(loaded, &delivery.message.payload);
-        let verified_attempt = attempts.iter().find(|attempt| {
-            attempt.get("status").and_then(Value::as_str) == Some("published_live")
-                && attempt
-                    .get("provider_message_id")
-                    .and_then(Value::as_str)
-                    .is_some_and(|value| !value.trim().is_empty())
-        });
+        let preflight = preflight_csm_governed_notice_signal(&delivery.message.payload);
+        if preflight.status != "publishable"
+            || !persisted_route_contract_matches(&delivery.message.payload, &preflight)?
+        {
+            runtime_context.release_replay(RuntimeChannelId::CloudBridgeToAwsRoutes, sequence)?;
+            let delivery_state = json!({
+                "status": if preflight.status == "publishable" {
+                    "durably_spooled_route_contract_mismatch"
+                } else {
+                    "durably_spooled_waiting_for_publishable_route"
+                },
+                "spool_sequence": sequence,
+                "cursor_advanced": false,
+                "preflight": preflight,
+                "stored_route_contract": delivery.message.payload["publish_route_contract"].clone()
+            });
+            runtime_context.persist_channel_state(
+                "cloud_notice_route_blocked",
+                Some(delivery_state.clone()),
+            )?;
+            if target_sequence == Some(sequence) {
+                target_delivery = Some(delivery_state);
+            }
+            break;
+        }
+        let required_channel = preflight.required_channel.as_deref().unwrap_or_default();
+        let attempts = vec![publish_csm_governed_notice_signal_for_channel(
+            loaded,
+            &delivery.message.payload,
+            required_channel,
+        )];
+        let verified_attempt = verified_route_attempt(&attempts, required_channel);
         let delivery_state = if let Some(attempt) = verified_attempt {
             let transport = attempt
                 .get("channel")
@@ -2671,6 +2697,7 @@ fn drain_pending_cloud_notices(
                 "status": "published_and_atomically_acknowledged",
                 "spool_sequence": sequence,
                 "publish_cursor": sequence,
+                "cursor_advanced": true,
                 "transport": transport,
                 "provider_receipt_id": provider_receipt_id
             })
@@ -2679,9 +2706,18 @@ fn drain_pending_cloud_notices(
             json!({
                 "status": "durably_spooled_waiting_for_verified_transport_receipt",
                 "spool_sequence": sequence,
-                "cursor_advanced": false
+                "cursor_advanced": false,
+                "attempts": attempts.clone()
             })
         };
+        if delivery_state
+            .get("cursor_advanced")
+            .and_then(Value::as_bool)
+            == Some(false)
+        {
+            runtime_context
+                .persist_channel_state("cloud_publish_pending", Some(delivery_state.clone()))?;
+        }
         if target_sequence == Some(sequence) {
             target_attempts = attempts;
             target_delivery = Some(delivery_state.clone());
@@ -2711,6 +2747,36 @@ fn drain_pending_cloud_notices(
     })
 }
 
+fn persisted_route_contract_matches(
+    notice: &Value,
+    current: &crate::runtime_aws_signal::CsmCloudPublishPreflight,
+) -> Result<bool> {
+    let Some(stored) = notice.get("publish_route_contract") else {
+        return Ok(false);
+    };
+    let current = serde_json::to_value(current)?;
+    Ok([
+        "required_channel",
+        "route_kind",
+        "route_class",
+        "idempotency_key",
+        "target_sha256",
+    ]
+    .into_iter()
+    .all(|field| stored.get(field) == current.get(field)))
+}
+
+fn verified_route_attempt<'a>(attempts: &'a [Value], required_channel: &str) -> Option<&'a Value> {
+    attempts.iter().find(|attempt| {
+        attempt.get("status").and_then(Value::as_str) == Some("published_live")
+            && attempt.get("channel").and_then(Value::as_str) == Some(required_channel)
+            && attempt
+                .get("provider_message_id")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
 fn record_governed_runtime_notice(
     runtime_context: &CsmRuntimeContext,
     loaded: &LoadedAgentSpec,
@@ -2718,7 +2784,7 @@ fn record_governed_runtime_notice(
 ) -> Result<Value> {
     let captured_at = Utc::now();
     let notice_id = governed_notice_id(loaded, input.trigger, input.restart_count, captured_at);
-    let local_notice = json!({
+    let mut local_notice = json!({
         "schema": "adl.csm.governed_notice.v1",
         "notice_id": notice_id,
         "runtime_owner": "csm",
@@ -2764,38 +2830,110 @@ fn record_governed_runtime_notice(
         }],
         "details": input.details
     });
+    let preflight = preflight_csm_governed_notice_signal(&local_notice);
+    if preflight.failure_class.as_deref() == Some("csm_notice_redaction_failed") {
+        local_notice = json!({
+            "schema": "adl.csm.governed_notice.v1",
+            "notice_id": notice_id,
+            "runtime_owner": "csm",
+            "agent_instance_id": loaded.spec.agent_instance_id.clone(),
+            "notice_kind": input.notice_kind,
+            "severity": input.severity,
+            "trigger": input.trigger,
+            "captured_at": captured_at,
+            "redaction": {
+                "status": "rejected_before_persistence",
+                "failure_class": "csm_notice_redaction_failed",
+                "retained_payload": false
+            },
+            "delivery_attempts": [{
+                "channel": "local_notice_ledger",
+                "status": "recorded_redacted_rejection",
+                "artifact_ref": "csm_governed_notices.jsonl"
+            }]
+        });
+    }
+    if let Some(object) = local_notice.as_object_mut() {
+        object.insert(
+            "publish_preflight".to_string(),
+            serde_json::to_value(&preflight)?,
+        );
+        if preflight.status == "publishable" {
+            object.insert(
+                "publish_route_contract".to_string(),
+                serde_json::to_value(&preflight)?,
+            );
+        }
+    }
     write_json_pretty(&csm_notice_latest_path(loaded), &local_notice)?;
     append_jsonl(&csm_notice_ledger_path(loaded), &local_notice)?;
 
     let mut final_notice = local_notice;
-    let cloud_spool_sequence =
-        runtime_context.persist_cloud_notice(&notice_id, final_notice.clone())?;
+    let cloud_spool_sequence = if preflight.status == "publishable" {
+        runtime_context.persist_cloud_notice(&notice_id, final_notice.clone())?
+    } else {
+        None
+    };
     let mut attempts = vec![json!({
         "channel": "local_notice_ledger",
         "status": "recorded",
         "artifact_ref": "csm_governed_notices.jsonl"
     })];
-    let typed_channel_delivery = match cloud_spool_sequence {
-        Some(sequence) => {
-            let drain = drain_pending_cloud_notices(runtime_context, loaded, Some(sequence))?;
-            attempts.extend(drain.target_attempts);
-            drain.target_delivery.unwrap_or_else(|| {
-                json!({
-                    "status": "durably_spooled_waiting_for_replay",
-                    "spool_sequence": sequence,
-                    "acknowledged_predecessor_count": drain.acknowledged_count,
-                    "cursor_advanced": false
+    let typed_channel_delivery = if preflight.status != "publishable" {
+        json!({
+            "status": "blocked_before_sequence_reservation",
+            "cursor_advanced": false,
+            "spool_sequence": Value::Null,
+            "preflight": preflight.clone()
+        })
+    } else {
+        match cloud_spool_sequence {
+            Some(sequence) => {
+                let drain = drain_pending_cloud_notices(runtime_context, loaded, Some(sequence))?;
+                attempts.extend(drain.target_attempts);
+                drain.target_delivery.unwrap_or_else(|| {
+                    json!({
+                        "status": "durably_spooled_waiting_for_replay",
+                        "spool_sequence": sequence,
+                        "acknowledged_predecessor_count": drain.acknowledged_count,
+                        "cursor_advanced": false
+                    })
                 })
-            })
+            }
+            None => json!({
+                "status": "observer_command_defers_to_daemon_channel_owner",
+                "cursor_advanced": false
+            }),
         }
-        None => json!({
-            "status": "observer_command_defers_to_daemon_channel_owner",
-            "cursor_advanced": false
-        }),
     };
+    let publish_transaction = json!({
+        "schema": "adl.csm.cloud_publish_transaction.v1",
+        "status": typed_channel_delivery["status"].clone(),
+        "idempotency_key": preflight.idempotency_key.clone(),
+        "required_channel": preflight.required_channel.clone(),
+        "route_kind": preflight.route_kind.clone(),
+        "route_class": preflight.route_class.clone(),
+        "target_sha256": preflight.target_sha256.clone(),
+        "preflight_status": preflight.status,
+        "spool_sequence": typed_channel_delivery["spool_sequence"].clone(),
+        "provider_receipt_id": typed_channel_delivery["provider_receipt_id"].clone(),
+        "cursor_advanced": typed_channel_delivery["cursor_advanced"].clone(),
+        "phase_order": [
+            "route_preflight",
+            "durable_spool_commit",
+            "selected_transport_publish",
+            "provider_receipt_verification",
+            "atomic_cursor_acknowledgement"
+        ]
+    });
     if let Some(object) = final_notice.as_object_mut() {
+        object.insert(
+            "publish_preflight".to_string(),
+            serde_json::to_value(&preflight)?,
+        );
         object.insert("delivery_attempts".to_string(), json!(attempts));
         object.insert("typed_channel_delivery".to_string(), typed_channel_delivery);
+        object.insert("publish_transaction".to_string(), publish_transaction);
         object.insert("delivery_completed_at".to_string(), json!(Utc::now()));
     }
     write_json_pretty(&csm_notice_latest_path(loaded), &final_notice)?;
@@ -2823,7 +2961,10 @@ fn record_governed_runtime_notice(
         "trigger": input.trigger,
         "notice_ref": "csm_governed_notice_latest.json",
         "notice_ledger_ref": "csm_governed_notices.jsonl",
-        "delivery_attempts": final_notice["delivery_attempts"].clone()
+        "publish_transaction_ref": "csm_governed_notice_latest.json#publish_transaction",
+        "delivery_attempts": final_notice["delivery_attempts"].clone(),
+        "typed_channel_delivery": final_notice["typed_channel_delivery"].clone(),
+        "delivery_completed_at": final_notice["delivery_completed_at"].clone()
     }))
 }
 

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::ffi::OsString;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::MutexGuard;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -158,6 +158,82 @@ impl Drop for MultiEnvGuard {
             }
         }
     }
+}
+
+fn record_notice_for_http_failure(
+    prefix: &str,
+    response_status: u16,
+    response_delay: Duration,
+    timeout_ms: u64,
+) -> Value {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind failure route");
+    let address = listener.local_addr().expect("failure route address");
+    let server = tiny_http::Server::from_listener(listener, None).expect("failure route server");
+    let receiver = thread::spawn(move || {
+        let request = server.recv().expect("receive failure notice");
+        thread::sleep(response_delay);
+        let _ = request.respond(tiny_http::Response::empty(response_status));
+    });
+    let endpoint = format!("http://{address}/{prefix}");
+    let timeout_ms = timeout_ms.to_string();
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "control_plane"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "https"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_URL", endpoint.as_str()),
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_HEARTBEAT_TARGET", "cloudwatch_logs"),
+        (
+            "ADL_AWS_SNS_TOPIC_ARN",
+            "arn:aws:sns:us-west-2:000000000000:unselected-route",
+        ),
+        ("ADL_CSM_NOTICE_HTTP_TIMEOUT_MS", timeout_ms.as_str()),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir(prefix);
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        None,
+    );
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: prefix,
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"proof": prefix}),
+        },
+    )
+    .expect("retain failed notice");
+    receiver.join().expect("failure route join");
+    let notice = read_json_required(&csm_notice_latest_path(&loaded))
+        .expect("latest failed governed notice");
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("failed typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 1);
+    assert!(!loaded
+        .state_root
+        .join("aws_csm_governed_notice_sns_mock.jsonl")
+        .exists());
+    notice
 }
 
 #[test]
@@ -1362,6 +1438,513 @@ fn daemon_partial_checkpoint_preserves_recoverable_failure_reason() {
     let checkpoint: serde_json::Value =
         read_json_required(&continuity_checkpoint_path(&loaded)).expect("checkpoint");
     assert_eq!(checkpoint["state"], "failed");
+}
+
+#[test]
+fn governed_notice_blocks_before_cloud_sequence_reservation_without_publishable_route() {
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir("governed-notice-preflight-blocked");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        Some(StatusError {
+            class: "cloud_route_unavailable".to_string(),
+            message: "publish route is not configured".to_string(),
+        }),
+    );
+
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: "cloud_route_unavailable",
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"authorization_policy": {"decision": "allow"}}),
+        },
+    )
+    .expect("record blocked notice");
+    let notice: Value =
+        read_json_required(&csm_notice_latest_path(&loaded)).expect("latest governed notice");
+
+    assert_eq!(notice["publish_preflight"]["status"], "blocked");
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "blocked_before_sequence_reservation"
+    );
+    assert_eq!(
+        notice["typed_channel_delivery"]["spool_sequence"],
+        Value::Null
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], false);
+    assert_eq!(
+        notice["publish_transaction"]["status"],
+        "blocked_before_sequence_reservation"
+    );
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 0);
+}
+
+#[test]
+fn governed_notice_rejects_secret_material_before_any_durable_payload_write() {
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir("governed-notice-redaction-rejected");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        None,
+    );
+    let forbidden = "Bearer must-never-be-retained-5115";
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: "redaction_rejection_proof",
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"authorization": forbidden}),
+        },
+    )
+    .expect("record redacted rejection");
+
+    let latest = fs::read_to_string(csm_notice_latest_path(&loaded)).expect("latest notice");
+    let ledger = fs::read_to_string(csm_notice_ledger_path(&loaded)).expect("notice ledger");
+    assert!(!latest.contains(forbidden));
+    assert!(!ledger.contains(forbidden));
+    let notice: Value = serde_json::from_str(&latest).expect("parse latest notice");
+    assert_eq!(notice["redaction"]["status"], "rejected_before_persistence");
+    assert_eq!(notice["redaction"]["retained_payload"], false);
+    assert_eq!(notice["publish_preflight"]["status"], "blocked");
+    assert_eq!(
+        notice["publish_preflight"]["failure_class"],
+        "csm_notice_redaction_failed"
+    );
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 0);
+}
+
+#[test]
+fn cloud_publish_acknowledgement_requires_the_preflight_selected_route() {
+    let attempts = vec![
+        json!({
+            "channel": "cloudwatch_logs",
+            "status": "published_live",
+            "provider_message_id": "cloudwatch-receipt"
+        }),
+        json!({
+            "channel": "cloudfront_control_plane",
+            "status": "blocked",
+            "provider_message_id": Value::Null
+        }),
+    ];
+    assert!(verified_route_attempt(&attempts, "cloudfront_control_plane").is_none());
+    assert_eq!(
+        verified_route_attempt(&attempts, "cloudwatch_logs")
+            .and_then(|attempt| attempt["provider_message_id"].as_str()),
+        Some("cloudwatch-receipt")
+    );
+}
+
+#[test]
+fn governed_notice_advances_once_after_selected_live_route_confirms_publication() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind receipt server");
+    let address = listener.local_addr().expect("receipt server address");
+    let server = tiny_http::Server::from_listener(listener, None).expect("receipt server");
+    let receiver = thread::spawn(move || {
+        let request = server.recv().expect("receive governed notice");
+        let idempotency_key = request
+            .headers()
+            .iter()
+            .find(|header| header.field.equiv("Idempotency-Key"))
+            .map(|header| header.value.as_str().to_string())
+            .expect("idempotency key");
+        let response = tiny_http::Response::empty(202).with_header(
+            tiny_http::Header::from_bytes("x-request-id", "receipt-5115").expect("receipt header"),
+        );
+        request.respond(response).expect("respond to notice");
+        idempotency_key
+    });
+    let endpoint = format!("http://{address}/polis/runtime-events");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "control_plane"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "https"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_URL", endpoint.as_str()),
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_HEARTBEAT_TARGET", "cloudwatch_logs"),
+        (
+            "ADL_AWS_SNS_TOPIC_ARN",
+            "arn:aws:sns:us-west-2:000000000000:unselected-route",
+        ),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir("governed-notice-live-receipt");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        None,
+    );
+
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: "live_route_receipt_proof",
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"proof": "selected_route_receipt"}),
+        },
+    )
+    .expect("publish governed notice");
+    let received_idempotency_key = receiver.join().expect("receipt server join");
+    let notice: Value =
+        read_json_required(&csm_notice_latest_path(&loaded)).expect("latest governed notice");
+
+    assert_eq!(notice["publish_preflight"]["status"], "publishable");
+    assert_eq!(
+        notice["publish_preflight"]["idempotency_key"],
+        received_idempotency_key
+    );
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "published_and_atomically_acknowledged"
+    );
+    assert_eq!(
+        notice["typed_channel_delivery"]["provider_receipt_id"],
+        "receipt-5115"
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], true);
+    assert_eq!(
+        notice["publish_transaction"]["status"],
+        "published_and_atomically_acknowledged"
+    );
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 0);
+}
+
+#[test]
+fn governed_notice_retains_spool_and_cursor_when_selected_live_route_is_unreachable() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve unreachable port");
+    let address = listener.local_addr().expect("unreachable address");
+    drop(listener);
+    let endpoint = format!("http://{address}/unreachable");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "control_plane"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "https"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_URL", endpoint.as_str()),
+        ("ADL_AWS_SIGNAL_MODE", "mock"),
+        ("ADL_AWS_HEARTBEAT_TARGET", "cloudwatch_logs"),
+        (
+            "ADL_AWS_SNS_TOPIC_ARN",
+            "arn:aws:sns:us-west-2:000000000000:unselected-route",
+        ),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir("governed-notice-unreachable");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        None,
+    );
+
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: "unreachable_route_proof",
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"proof": "unreachable_selected_route"}),
+        },
+    )
+    .expect("retain unreachable notice");
+    let notice: Value =
+        read_json_required(&csm_notice_latest_path(&loaded)).expect("latest governed notice");
+
+    assert_eq!(notice["publish_preflight"]["status"], "publishable");
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "durably_spooled_waiting_for_verified_transport_receipt"
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], false);
+    assert_eq!(
+        notice["publish_transaction"]["status"],
+        "durably_spooled_waiting_for_verified_transport_receipt"
+    );
+    assert!(notice["typed_channel_delivery"]["spool_sequence"].is_number());
+    assert!(notice["delivery_attempts"]
+        .as_array()
+        .expect("delivery attempts")
+        .iter()
+        .any(|attempt| {
+            attempt["channel"] == "cloudfront_control_plane"
+                && attempt["status"] == "failed"
+                && attempt["failure_class"] == "control_plane_http_unreachable"
+        }));
+    let attempted_channels: Vec<_> = notice["delivery_attempts"]
+        .as_array()
+        .expect("delivery attempts")
+        .iter()
+        .filter_map(|attempt| attempt["channel"].as_str())
+        .collect();
+    assert_eq!(
+        attempted_channels,
+        vec!["local_notice_ledger", "cloudfront_control_plane"]
+    );
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 1);
+    assert!(!loaded
+        .state_root
+        .join("aws_csm_governed_notice_sns_mock.jsonl")
+        .exists());
+
+    unsafe {
+        env::set_var(
+            "ADL_CSM_NOTICE_CONTROL_PLANE_URL",
+            "http://127.0.0.1:1/configuration-changed",
+        );
+    }
+    let mismatched = drain_pending_cloud_notices(&runtime_context, &loaded, None)
+        .expect("fail closed on changed route contract");
+    assert_eq!(mismatched.acknowledged_count, 0);
+    let mismatched_channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("mismatched typed channel state");
+    assert_eq!(
+        mismatched_channel_state["summary"]["durable_spool_depth"],
+        1
+    );
+    assert_eq!(
+        mismatched_channel_state["last_receipt"]["status"],
+        "durably_spooled_route_contract_mismatch"
+    );
+    assert_eq!(
+        mismatched_channel_state["last_receipt"]["cursor_advanced"],
+        false
+    );
+    unsafe {
+        env::set_var("ADL_CSM_NOTICE_CONTROL_PLANE_URL", endpoint.as_str());
+    }
+
+    let listener = std::net::TcpListener::bind(address).expect("restore selected route");
+    let server = tiny_http::Server::from_listener(listener, None).expect("recovery server");
+    let receiver = thread::spawn(move || {
+        let request = server.recv().expect("receive replayed notice");
+        let idempotency_key = request
+            .headers()
+            .iter()
+            .find(|header| header.field.equiv("Idempotency-Key"))
+            .map(|header| header.value.as_str().to_string())
+            .expect("replay idempotency key");
+        request
+            .respond(
+                tiny_http::Response::empty(202).with_header(
+                    tiny_http::Header::from_bytes("x-request-id", "recovery-receipt-5115")
+                        .expect("recovery receipt header"),
+                ),
+            )
+            .expect("respond to replay");
+        idempotency_key
+    });
+    let recovered = drain_pending_cloud_notices(&runtime_context, &loaded, None)
+        .expect("replay retained notice");
+    let replay_idempotency_key = receiver.join().expect("recovery server join");
+    assert_eq!(recovered.acknowledged_count, 1);
+    assert_eq!(
+        notice["publish_preflight"]["idempotency_key"],
+        replay_idempotency_key
+    );
+    let duplicate_drain =
+        drain_pending_cloud_notices(&runtime_context, &loaded, None).expect("second replay drain");
+    assert_eq!(duplicate_drain.acknowledged_count, 0);
+    let recovered_channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("recovered typed channel state");
+    assert_eq!(recovered_channel_state["summary"]["durable_spool_depth"], 0);
+}
+
+#[test]
+fn governed_notice_retains_spool_and_cursor_when_selected_route_denies_access() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind denied route");
+    let address = listener.local_addr().expect("denied route address");
+    let server = tiny_http::Server::from_listener(listener, None).expect("denied route server");
+    let receiver = thread::spawn(move || {
+        let request = server.recv().expect("receive denied notice");
+        request
+            .respond(tiny_http::Response::empty(403))
+            .expect("deny notice");
+    });
+    let endpoint = format!("http://{address}/denied");
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "control_plane"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "https"),
+        ("ADL_CSM_NOTICE_CONTROL_PLANE_URL", endpoint.as_str()),
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
+    let root = temp_dir("governed-notice-denied");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let status = status_with_state(
+        &loaded,
+        AgentStatusState::Failed,
+        None,
+        None,
+        None,
+        false,
+        None,
+    );
+
+    record_governed_runtime_notice(
+        &runtime_context,
+        &loaded,
+        GovernedNoticeInput {
+            notice_kind: "runtime_degraded",
+            severity: "critical",
+            trigger: "denied_route_proof",
+            status: &status,
+            restart_count: 0,
+            bounded_test_restart_limit: None,
+            last_child_exit: None,
+            safe_fail: json!({"status": "serialized"}),
+            details: json!({"proof": "authorization_denial"}),
+        },
+    )
+    .expect("retain denied notice");
+    receiver.join().expect("denied route join");
+    let notice: Value =
+        read_json_required(&csm_notice_latest_path(&loaded)).expect("latest governed notice");
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "durably_spooled_waiting_for_verified_transport_receipt"
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], false);
+    assert!(notice["delivery_attempts"]
+        .as_array()
+        .expect("delivery attempts")
+        .iter()
+        .any(|attempt| {
+            attempt["channel"] == "cloudfront_control_plane"
+                && attempt["status"] == "failed"
+                && attempt["failure_class"] == "control_plane_http_access_denied_403"
+        }));
+    let channel_state: Value =
+        read_json_required(&loaded.state_root.join("csm_typed_channel_state.json"))
+            .expect("typed channel state");
+    assert_eq!(channel_state["summary"]["durable_spool_depth"], 1);
+}
+
+#[test]
+fn governed_notice_retains_spool_and_cursor_when_selected_route_throttles() {
+    let notice =
+        record_notice_for_http_failure("governed-notice-throttled", 429, Duration::ZERO, 1_000);
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "durably_spooled_waiting_for_verified_transport_receipt"
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], false);
+    assert!(notice["delivery_attempts"]
+        .as_array()
+        .expect("delivery attempts")
+        .iter()
+        .any(|attempt| attempt["failure_class"] == "control_plane_http_throttled_429"));
+}
+
+#[test]
+fn governed_notice_retains_spool_and_cursor_for_ambiguous_timeout() {
+    let notice = record_notice_for_http_failure(
+        "governed-notice-timeout-ambiguous",
+        202,
+        Duration::from_millis(100),
+        10,
+    );
+    assert_eq!(
+        notice["typed_channel_delivery"]["status"],
+        "durably_spooled_waiting_for_verified_transport_receipt"
+    );
+    assert_eq!(notice["typed_channel_delivery"]["cursor_advanced"], false);
+    assert!(notice["delivery_attempts"]
+        .as_array()
+        .expect("delivery attempts")
+        .iter()
+        .any(|attempt| attempt["failure_class"] == "control_plane_http_timeout_ambiguous"));
 }
 
 #[test]

--- a/adl/src/runtime_aws_signal.rs
+++ b/adl/src/runtime_aws_signal.rs
@@ -76,6 +76,7 @@ struct ControlPlaneNoticeConfig {
     endpoint: Option<String>,
     lambda_function: Option<String>,
     event_bus: Option<String>,
+    http_timeout: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +92,19 @@ pub struct PublishOutcome {
     pub disposition: PublishDisposition,
     pub failure_class: Option<String>,
     pub provider_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CsmCloudPublishPreflight {
+    pub schema: &'static str,
+    pub status: &'static str,
+    pub required_channel: Option<String>,
+    pub route_kind: Option<String>,
+    pub route_class: Option<String>,
+    pub idempotency_key: Option<String>,
+    pub target_sha256: Option<String>,
+    pub failure_class: Option<String>,
+    pub cursor_may_advance: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -358,6 +372,12 @@ impl ControlPlaneNoticeConfig {
             .ok()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+        let http_timeout = env::var("ADL_CSM_NOTICE_HTTP_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .map(|value| value.clamp(1, 60_000))
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_secs(10));
         let mode = match mode_env
             .as_deref()
             .map(str::trim)
@@ -387,6 +407,7 @@ impl ControlPlaneNoticeConfig {
             endpoint,
             lambda_function,
             event_bus,
+            http_timeout,
         }
     }
 
@@ -468,6 +489,7 @@ fn heartbeat_cursor_path(loaded: &LoadedAgentSpec) -> PathBuf {
     loaded.state_root.join(HEARTBEAT_CURSOR_ARTIFACT)
 }
 
+#[cfg(test)]
 pub(crate) fn publish_csm_governed_notice_signal(
     loaded: &LoadedAgentSpec,
     notice: &serde_json::Value,
@@ -477,6 +499,186 @@ pub(crate) fn publish_csm_governed_notice_signal(
         publish_csm_notice_sns(loaded, notice),
         publish_csm_notice_control_plane(loaded, notice),
     ]
+}
+
+pub(crate) fn publish_csm_governed_notice_signal_for_channel(
+    loaded: &LoadedAgentSpec,
+    notice: &serde_json::Value,
+    required_channel: &str,
+) -> serde_json::Value {
+    match required_channel {
+        "cloudwatch_logs" => publish_csm_notice_cloudwatch(loaded, notice),
+        "acip_sns" => publish_csm_notice_sns(loaded, notice),
+        "cloudfront_control_plane" => publish_csm_notice_control_plane(loaded, notice),
+        _ => csm_notice_attempt(
+            csm_notice_attempt_base(required_channel, "blocked"),
+            "blocked",
+            Some("csm_notice_required_channel_unsupported".to_string()),
+            None,
+        ),
+    }
+}
+
+pub(crate) fn preflight_csm_governed_notice_signal(
+    notice: &serde_json::Value,
+) -> CsmCloudPublishPreflight {
+    let blocked = |failure_class: &str| CsmCloudPublishPreflight {
+        schema: "adl.csm.cloud_publish_preflight.v1",
+        status: "blocked",
+        required_channel: None,
+        route_kind: None,
+        route_class: None,
+        idempotency_key: notice
+            .get("notice_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        target_sha256: None,
+        failure_class: Some(failure_class.to_string()),
+        cursor_may_advance: false,
+    };
+    let Some(notice_id) = notice
+        .get("notice_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return blocked("csm_notice_id_missing");
+    };
+    if notice_contains_unredacted_secret(notice) {
+        return blocked("csm_notice_redaction_failed");
+    }
+
+    let control = ControlPlaneNoticeConfig::from_env();
+    let sns = AcipProjectionPublisherConfig::from_env();
+    let cloudwatch = HeartbeatPublisherConfig::from_env();
+    let selected = env::var("ADL_CSM_NOTICE_REQUIRED_CHANNEL")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .or_else(|| control.configured.then(|| "control_plane".to_string()))
+        .or_else(|| sns.topic_configured.then(|| "sns".to_string()))
+        .or_else(|| cloudwatch.configured.then(|| "cloudwatch".to_string()));
+
+    let (required_channel, route_kind, route_class, target_sha256, failure_class) = match selected
+        .as_deref()
+    {
+        Some(requested @ ("control_plane" | "eventbridge" | "https" | "lambda")) => {
+            if requested != "control_plane" && control.target != requested {
+                return blocked("csm_notice_control_plane_target_mismatch");
+            }
+            let route_class = if control.target == "eventbridge" {
+                Some(
+                    env::var("ADL_CSM_NOTICE_EVENTBRIDGE_ROUTE_CLASS")
+                        .map(|value| value.trim().to_ascii_lowercase())
+                        .ok()
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or_else(|| "native_event_bus".to_string()),
+                )
+            } else {
+                None
+            };
+            if route_class.as_deref().is_some_and(|value| {
+                !matches!(
+                    value,
+                    "native_event_bus" | "sqs" | "sns" | "cloudwatch" | "api_gateway" | "lambda"
+                )
+            }) {
+                return blocked("csm_notice_eventbridge_route_class_unsupported");
+            }
+            let failure = control.live_block_reason();
+            let ready = matches!(control.mode, AwsSignalMode::Live)
+                && matches!(
+                    failure,
+                    "control_plane_http_transport_failed"
+                        | "control_plane_lambda_invoke_failed"
+                        | "control_plane_eventbridge_put_failed"
+                );
+            (
+                "cloudfront_control_plane",
+                control.target.clone(),
+                route_class,
+                control.target_hash(),
+                (!ready).then(|| failure.to_string()),
+            )
+        }
+        Some("sns") => {
+            let failure = sns.live_block_reason();
+            let ready =
+                matches!(sns.mode, AwsSignalMode::Live) && failure == "aws_acip_sns_publish_failed";
+            (
+                "acip_sns",
+                "sns".to_string(),
+                None,
+                sns.topic_arn.as_ref().map(|target| sha256_text(target)),
+                (!ready).then(|| failure.to_string()),
+            )
+        }
+        Some("cloudwatch") => {
+            let failure = cloudwatch.live_block_reason();
+            let ready = matches!(cloudwatch.mode, AwsSignalMode::Live)
+                && failure == "aws_signal_live_publish_failed";
+            (
+                "cloudwatch_logs",
+                "cloudwatch_logs".to_string(),
+                None,
+                cloudwatch
+                    .log_group
+                    .as_ref()
+                    .map(|target| sha256_text(target)),
+                (!ready).then(|| failure.to_string()),
+            )
+        }
+        Some(_) => return blocked("csm_notice_required_channel_unsupported"),
+        None => return blocked("csm_notice_route_not_configured"),
+    };
+
+    if let Some(failure_class) = failure_class {
+        return CsmCloudPublishPreflight {
+            required_channel: Some(required_channel.to_string()),
+            route_kind: Some(route_kind),
+            route_class,
+            target_sha256,
+            failure_class: Some(failure_class),
+            ..blocked("csm_notice_preflight_blocked")
+        };
+    }
+    CsmCloudPublishPreflight {
+        schema: "adl.csm.cloud_publish_preflight.v1",
+        status: "publishable",
+        required_channel: Some(required_channel.to_string()),
+        route_kind: Some(route_kind),
+        route_class,
+        idempotency_key: Some(notice_id.to_string()),
+        target_sha256,
+        failure_class: None,
+        cursor_may_advance: false,
+    }
+}
+
+fn sha256_text(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn notice_contains_unredacted_secret(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(object) => object.iter().any(|(key, value)| {
+            let key = key.to_ascii_lowercase();
+            let sensitive = ["secret", "password", "credential", "authorization", "token"]
+                .iter()
+                .any(|needle| key.contains(needle));
+            let contains_secret_material = matches!(value, serde_json::Value::String(value) if !value.trim().is_empty())
+                || matches!(value, serde_json::Value::Number(_) | serde_json::Value::Bool(_));
+            (sensitive
+                && contains_secret_material
+                && !key.ends_with("_ref")
+                && !key.ends_with("_sha256"))
+                || notice_contains_unredacted_secret(value)
+        }),
+        serde_json::Value::Array(values) => values.iter().any(notice_contains_unredacted_secret),
+        _ => false,
+    }
 }
 
 pub(crate) fn publish_runtime_heartbeat_signal(
@@ -982,7 +1184,7 @@ fn publish_csm_notice_control_plane(
                 .unwrap_or("csm-notice")
                 .to_string();
             match reqwest::blocking::Client::builder()
-                .timeout(Duration::from_secs(10))
+                .timeout(config.http_timeout)
                 .build()
                 .and_then(|client| {
                     client
@@ -1007,21 +1209,26 @@ fn publish_csm_notice_control_plane(
                         });
                     csm_notice_attempt(base, "published_live", None, Some(provider_receipt_id))
                 }
-                Ok(response) => csm_notice_attempt(
-                    base,
-                    "failed",
-                    Some(format!(
-                        "control_plane_http_status_{}",
-                        response.status().as_u16()
-                    )),
-                    None,
-                ),
-                Err(_) => csm_notice_attempt(
-                    base,
-                    "failed",
-                    Some("control_plane_http_transport_failed".to_string()),
-                    None,
-                ),
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let failure_class = match status {
+                        401 | 403 => format!("control_plane_http_access_denied_{status}"),
+                        408 | 504 => format!("control_plane_http_timeout_ambiguous_{status}"),
+                        429 => "control_plane_http_throttled_429".to_string(),
+                        _ => format!("control_plane_http_status_{status}"),
+                    };
+                    csm_notice_attempt(base, "failed", Some(failure_class), None)
+                }
+                Err(error) => {
+                    let failure_class = if error.is_timeout() {
+                        "control_plane_http_timeout_ambiguous"
+                    } else if error.is_connect() {
+                        "control_plane_http_unreachable"
+                    } else {
+                        "control_plane_http_transport_ambiguous"
+                    };
+                    csm_notice_attempt(base, "failed", Some(failure_class.to_string()), None)
+                }
             }
         }
     }
@@ -1920,6 +2127,9 @@ mod tests {
                 "ADL_CSM_NOTICE_CONTROL_PLANE_URL",
                 "ADL_CSM_NOTICE_LAMBDA_FUNCTION",
                 "ADL_CSM_NOTICE_EVENT_BUS",
+                "ADL_CSM_NOTICE_REQUIRED_CHANNEL",
+                "ADL_CSM_NOTICE_EVENTBRIDGE_ROUTE_CLASS",
+                "ADL_CSM_NOTICE_HTTP_TIMEOUT_MS",
             ];
             let mut saved = Vec::with_capacity(tracked.len());
             for key in tracked {
@@ -2060,6 +2270,151 @@ mod tests {
                 "bounded_test_restart_limit": 1
             }
         })
+    }
+
+    #[test]
+    fn csm_notice_preflight_requires_a_live_publishable_route() {
+        let _guard = MultiEnvGuard::set_all(&[]);
+        let preflight = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(preflight.status, "blocked");
+        assert_eq!(
+            preflight.failure_class.as_deref(),
+            Some("csm_notice_route_not_configured")
+        );
+        assert!(!preflight.cursor_may_advance);
+    }
+
+    #[test]
+    fn csm_notice_preflight_retains_stable_identity_for_live_eventbridge_sqs_route() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "eventbridge"),
+            ("ADL_CSM_NOTICE_EVENT_BUS", "adl-csm-runtime-events"),
+            ("ADL_CSM_NOTICE_EVENTBRIDGE_ROUTE_CLASS", "sqs"),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+        ]);
+        let first = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        let second = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(first.status, "publishable");
+        assert_eq!(
+            first.required_channel.as_deref(),
+            Some("cloudfront_control_plane")
+        );
+        assert_eq!(first.route_kind.as_deref(), Some("eventbridge"));
+        assert_eq!(first.route_class.as_deref(), Some("sqs"));
+        assert_eq!(first.idempotency_key, second.idempotency_key);
+        assert_eq!(first.target_sha256.as_deref().map(str::len), Some(64));
+        assert!(!first.cursor_may_advance);
+    }
+
+    #[test]
+    fn csm_notice_preflight_supports_live_sns_adapter_boundary() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "sns"),
+            ("ADL_AWS_SIGNAL_MODE", "live"),
+            ("ADL_AWS_SIGNAL_APPROVED", "1"),
+            (
+                "ADL_AWS_SNS_TOPIC_ARN",
+                "arn:aws:sns:us-west-2:000000000000:adl-csm-runtime-events",
+            ),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+        ]);
+        let preflight = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(preflight.status, "publishable");
+        assert_eq!(preflight.required_channel.as_deref(), Some("acip_sns"));
+        assert_eq!(preflight.route_kind.as_deref(), Some("sns"));
+        assert_eq!(preflight.target_sha256.as_deref().map(str::len), Some(64));
+        assert!(!preflight.cursor_may_advance);
+    }
+
+    #[test]
+    fn csm_notice_preflight_supports_eventbridge_to_sns_route_class() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "eventbridge"),
+            ("ADL_CSM_NOTICE_EVENT_BUS", "adl-csm-runtime-events"),
+            ("ADL_CSM_NOTICE_EVENTBRIDGE_ROUTE_CLASS", "sns"),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+        ]);
+        let preflight = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(preflight.status, "publishable");
+        assert_eq!(preflight.route_kind.as_deref(), Some("eventbridge"));
+        assert_eq!(preflight.route_class.as_deref(), Some("sns"));
+    }
+
+    #[test]
+    fn csm_notice_preflight_rejects_raw_secrets_but_allows_policy_and_refs() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "eventbridge"),
+            ("ADL_CSM_NOTICE_EVENT_BUS", "adl-csm-runtime-events"),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+        ]);
+        let mut safe = sample_csm_notice();
+        safe["details"]["authorization_policy"] = json!({"decision": "allow"});
+        safe["details"]["credential_ref"] = json!("aws-profile:agent-logic-admin");
+        assert_eq!(
+            preflight_csm_governed_notice_signal(&safe).status,
+            "publishable"
+        );
+
+        safe["details"]["authorization"] = json!("Bearer not-retained");
+        let blocked = preflight_csm_governed_notice_signal(&safe);
+        assert_eq!(blocked.status, "blocked");
+        assert_eq!(
+            blocked.failure_class.as_deref(),
+            Some("csm_notice_redaction_failed")
+        );
+    }
+
+    #[test]
+    fn csm_notice_preflight_rejects_unknown_eventbridge_route_class() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "eventbridge"),
+            ("ADL_CSM_NOTICE_EVENT_BUS", "adl-csm-runtime-events"),
+            ("ADL_CSM_NOTICE_EVENTBRIDGE_ROUTE_CLASS", "unknown"),
+            ("ADL_AWS_REGION", "us-west-2"),
+            ("ADL_AWS_PROFILE", "agent-logic-admin"),
+        ]);
+        let blocked = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(blocked.status, "blocked");
+        assert_eq!(
+            blocked.failure_class.as_deref(),
+            Some("csm_notice_eventbridge_route_class_unsupported")
+        );
+    }
+
+    #[test]
+    fn csm_notice_preflight_rejects_required_route_target_mismatch() {
+        let _guard = MultiEnvGuard::set_all(&[
+            ("ADL_CSM_NOTICE_REQUIRED_CHANNEL", "eventbridge"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_MODE", "live"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_APPROVED", "1"),
+            ("ADL_CSM_NOTICE_CONTROL_PLANE_TARGET", "https"),
+            (
+                "ADL_CSM_NOTICE_CONTROL_PLANE_URL",
+                "https://example.invalid/runtime",
+            ),
+        ]);
+        let blocked = preflight_csm_governed_notice_signal(&sample_csm_notice());
+        assert_eq!(blocked.status, "blocked");
+        assert_eq!(
+            blocked.failure_class.as_deref(),
+            Some("csm_notice_control_plane_target_mismatch")
+        );
     }
 
     #[test]
@@ -2961,6 +3316,7 @@ mod tests {
             endpoint: None,
             lambda_function: None,
             event_bus: None,
+            http_timeout: Duration::from_secs(10),
         };
         let csm_envelope = csm_notice_envelope(
             &loaded,
@@ -2982,6 +3338,7 @@ mod tests {
             endpoint: None,
             lambda_function: None,
             event_bus: None,
+            http_timeout: Duration::from_secs(10),
         };
         let eventbridge_missing_region =
             put_csm_notice_eventbridge(&eventbridge_config, &csm_envelope)


### PR DESCRIPTION
Closes #5115

## Summary
Implemented fail-closed CSM cloud publication in the bound issue worktree. The runtime now preflights before sequence reservation, persists and enforces the selected route contract, dispatches only that route, rejects secret material before durable writes, advances the publish cursor only after a verified provider receipt, and replays retained publications exactly once. Focused local validation and two bounded reviews passed; live AWS proof remains explicitly deferred by the VPP, and publication waits for ordered predecessor #5114.

## Artifacts
- Local output and review truth at `.adl/v0.91.7/tasks/issue-5115__v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors/`.
- Tracked implementation artifacts: `adl/src/runtime_aws_signal.rs`, `adl/src/long_lived_agent.rs`, and `adl/src/long_lived_agent/tests.rs`.
- Additional proof artifacts: retained `csm_governed_notice_latest.json`, `csm_governed_notices.jsonl`, typed-channel state, durable redb spool, and provider receipt surfaces created by focused tests.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml --lib runtime_aws_signal::tests::csm_notice_preflight -- --nocapture` - Prove route preflight, EventBridge/SNS/SQS boundaries, stable identity, route mismatch, and redaction rejection.
  - `cargo test --manifest-path adl/Cargo.toml --lib long_lived_agent::tests::governed_notice -- --nocapture` - Prove selected-route publication, denied/throttled/unreachable/ambiguous outcomes, durable replay, route pinning, and redaction artifact hygiene.
  - `cargo test --manifest-path adl-runtime/Cargo.toml cloud_cursor -- --nocapture` - Prove explicit publish acknowledgement, cursor gap rejection, and restart sequence continuity.
  - `cargo test --manifest-path adl-runtime/Cargo.toml cloud_publish_ack_rejects_unknown_spool_sequence -- --nocapture` - Prove unknown acknowledgement fails closed without cursor movement.
  - `cargo clippy --manifest-path adl/Cargo.toml --lib -- -D warnings` - Compile and lint the changed runtime library with warnings denied.
  - `git diff --check` - Verify patch whitespace integrity.
- Results:
  - `cargo test --manifest-path adl/Cargo.toml --lib runtime_aws_signal::tests::csm_notice_preflight -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml --lib long_lived_agent::tests::governed_notice -- --nocapture`: PASS
  - `cargo test --manifest-path adl-runtime/Cargo.toml cloud_cursor -- --nocapture`: PASS
  - `cargo test --manifest-path adl-runtime/Cargo.toml cloud_publish_ack_rejects_unknown_spool_sequence -- --nocapture`: PASS
  - `cargo clippy --manifest-path adl/Cargo.toml --lib -- -D warnings`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5115__v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5115__v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors/sor.md
- Idempotency-Key: v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-tests-rs-adl-src-runtime-aws-signal-rs-adl-v0-91-7-tasks-issue-5115-v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors-sip-md-adl-v0-91-7-tasks-issue-5115-v0-91-7-wp-07-cloud-runtime-make-csm-cloud-bridge-fail-closed-for-aws-publishability-and-cursors-sor-md