### PR TITLE
[v0.91.7][tools][watch] Bound pr watch/shepherd classification after validation fetch

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -956,36 +956,53 @@ fn build_issue_lifecycle_snapshot(parsed: &WatchArgs) -> Result<IssueLifecycleSn
             ),
         }
     };
-    let ready = doctor::run_doctor_ready(
-        &repo_root,
-        &repo,
-        &issue_ref,
-        &issue_ref.branch_name("codex"),
-    );
     let local_readiness_command = doctor_ready_command(&issue_ref);
-    let (ready_lifecycle_state, pr_finish_readiness, local_readiness) = match ready {
-        Ok(ready) => (
-            ready.lifecycle_state,
-            ready.card_lifecycle.pr_finish_readiness,
-            github::IssueWatchLocalReadinessReport {
-                status: "ready".to_string(),
-                pr_run_readiness: ready.card_lifecycle.pr_run_readiness.to_string(),
-                reason: "doctor_ready_pass".to_string(),
-                check: "doctor_ready".to_string(),
-                command: local_readiness_command.clone(),
-            },
-        ),
-        Err(err) => (
+    let needs_local_readiness =
+        issue_watch_needs_local_readiness(&issue_record.state, linked_pr.is_some());
+    let (ready_lifecycle_state, pr_finish_readiness, local_readiness) = if needs_local_readiness {
+        let ready = doctor::run_doctor_ready(
+            &repo_root,
+            &repo,
+            &issue_ref,
+            &issue_ref.branch_name("codex"),
+        );
+        match ready {
+            Ok(ready) => (
+                ready.lifecycle_state,
+                ready.card_lifecycle.pr_finish_readiness,
+                github::IssueWatchLocalReadinessReport {
+                    status: "ready".to_string(),
+                    pr_run_readiness: ready.card_lifecycle.pr_run_readiness.to_string(),
+                    reason: "doctor_ready_pass".to_string(),
+                    check: "doctor_ready".to_string(),
+                    command: local_readiness_command.clone(),
+                },
+            ),
+            Err(err) => (
+                "unknown",
+                "unknown",
+                github::IssueWatchLocalReadinessReport {
+                    status: "failed".to_string(),
+                    pr_run_readiness: "unknown".to_string(),
+                    reason: err.to_string(),
+                    check: "doctor_ready".to_string(),
+                    command: local_readiness_command,
+                },
+            ),
+        }
+    } else {
+        (
             "unknown",
             "unknown",
             github::IssueWatchLocalReadinessReport {
-                status: "failed".to_string(),
-                pr_run_readiness: "unknown".to_string(),
-                reason: err.to_string(),
+                status: "skipped".to_string(),
+                pr_run_readiness: "not_applicable".to_string(),
+                reason: "linked_pr_or_closed_issue_classification_does_not_require_local_readiness"
+                    .to_string(),
                 check: "doctor_ready".to_string(),
                 command: local_readiness_command,
             },
-        ),
+        )
     };
     let closeout_validated = if !closed_completed {
         false
@@ -1023,6 +1040,10 @@ fn doctor_ready_command(issue_ref: &IssueRef) -> String {
         issue_ref.scope(),
         issue_ref.slug()
     )
+}
+
+fn issue_watch_needs_local_readiness(issue_state: &str, has_linked_pr: bool) -> bool {
+    issue_state.eq_ignore_ascii_case("open") && !has_linked_pr
 }
 
 fn parse_issue_ref_number(command: &str, issue_ref: &str) -> Result<u32> {
@@ -2359,7 +2380,10 @@ fn bootstrap_ready_status_label(status: &str) -> &str {
 
 #[cfg(test)]
 mod bootstrap_output_tests {
-    use super::{bootstrap_ready_status_label, doctor_ready_command, read_issue_goal_metric_refs};
+    use super::{
+        bootstrap_ready_status_label, doctor_ready_command, issue_watch_needs_local_readiness,
+        read_issue_goal_metric_refs,
+    };
     use ::adl::control_plane::IssueRef;
     use std::fs;
 
@@ -2380,6 +2404,30 @@ mod bootstrap_output_tests {
         assert_eq!(
             doctor_ready_command(&issue_ref),
             "adl pr doctor 5002 --version v0.91.7 --slug watch-target-with-spaces --mode ready --json"
+        );
+    }
+
+    #[test]
+    fn issue_watch_skips_local_readiness_when_pr_or_closed_issue_already_classifies_tail() {
+        assert!(
+            issue_watch_needs_local_readiness("OPEN", false),
+            "open issue without linked PR needs doctor readiness to decide pr-run routing"
+        );
+        assert!(
+            !issue_watch_needs_local_readiness("OPEN", true),
+            "linked PR validation state already classifies watcher/shepherd tail states"
+        );
+        assert!(
+            !issue_watch_needs_local_readiness("CLOSED", false),
+            "closed issue closeout routing does not need pre-run readiness"
+        );
+        assert!(
+            !issue_watch_needs_local_readiness("closed", true),
+            "closed issue with linked PR should avoid extra readiness work"
+        );
+        assert!(
+            !issue_watch_needs_local_readiness("not_planned", false),
+            "non-open issue states should avoid extra readiness work"
         );
     }
 


### PR DESCRIPTION
Closes #5076

## Summary
Implemented a bounded `pr watch` / `pr shepherd` liveness fix for issue #5076. The watcher now skips the local `doctor ready` pass when a linked PR or non-open issue state already provides the lifecycle-tail classification, avoiding an extra post-validation readiness path that could hang after PR validation state was fetched.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.7/tasks/issue-5076__v0-91-7-tools-watch-pr-watch-shepherd-can-hang-after-pr-validation-fetch/sor.md`
- Tracked implementation artifacts: `adl/src/cli/pr_cmd.rs`
- Additional proof artifacts: `not_applicable; focused Rust tests are the proof surface`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    `Formatted the Rust implementation.`
  - `cargo test --manifest-path adl/Cargo.toml issue_watch_skips_local_readiness_when_pr_or_closed_issue_already_classifies_tail`
    `Verified the #5076 regression helper.`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_watch_reports_json_for_linked_green_pr`
    `Verified linked-PR watch JSON behavior.`
  - `cargo test --manifest-path adl/Cargo.toml issue_watch_routes_pending_checks_to_issue_watcher`
    `Verified pending-check watcher routing remains issue-watcher-owned.`
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd`
    `Started broader PR command validation; stopped after relevant watch/shepherd tests passed and one unrelated finish-validation-profile cleanup test failed. This broad run is not claimed as passing proof.`
- Results:
  - `PASS` for focused validation commands.
  - `NOT_CLAIMED` for the broad `pr_cmd` run because it was stopped after an unrelated failure in `load_finish_validation_profile_cleans_tempfile_on_invalid_manager_json`.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5076__v0-91-7-tools-watch-pr-watch-shepherd-can-hang-after-pr-validation-fetch/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5076__v0-91-7-tools-watch-pr-watch-shepherd-can-hang-after-pr-validation-fetch/sor.md
- Idempotency-Key: v0-91-7-tools-watch-bound-pr-watch-shepherd-classification-after-validation-fetch-adl-src-cli-pr-cmd-rs-adl-v0-91-7-tasks-issue-5076-v0-91-7-tools-watch-pr-watch-shepherd-can-hang-after-pr-validation-fetch-sip-md-adl-v0-91-7-tasks-issue-5076-v0-91-7-tools-watch-pr-watch-shepherd-can-hang-after-pr-validation-fetch-sor-md