### PR TITLE
[v0.92][runtime-v3][guardian] Retain blocked Horust qualification evidence

### DIFF
--- a/adl-runtime-kernel/tests/guardian_soak.rs
+++ b/adl-runtime-kernel/tests/guardian_soak.rs
@@ -41,6 +41,18 @@ fn packaging_preserves_one_guardian_neutral_child_contract() {
     ))
     .unwrap();
     assert_eq!(matrix["candidates"].as_array().unwrap().len(), 3);
+    let provenance: serde_json::Value = serde_json::from_str(include_str!(
+        "../../infra/horust/horust-0.1.13.provenance.json"
+    ))
+    .unwrap();
+    assert_eq!(provenance["name"], "horust");
+    assert_eq!(provenance["version"], "0.1.13");
+    assert_eq!(provenance["license"], "MIT");
+    assert_eq!(
+        provenance["crate_sha256"],
+        "a1ee5cbfda91cd77652dfd8849f68ecb40af8d2359ccc91f96fbff3d5a3976a3"
+    );
+    assert_eq!(provenance["qualification"]["bounded_restart"], "blocked");
 }
 
 #[cfg(unix)]
@@ -97,6 +109,148 @@ fn horust_does_not_restart_configuration_failure() {
         1,
         "configuration failure must execute exactly once: {combined}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "requires ADL_HORUST_BIN and reproduces upstream Horust issue 318"]
+fn horust_qualification_detects_unbounded_restart_budget() {
+    let directory = tempfile::tempdir().unwrap();
+    let attempt_log = directory.path().join("attempts.log");
+    let child = directory.path().join("always-fail.sh");
+    write_executable(
+        &child,
+        "#!/bin/sh\nprintf 'run\\n' >> \"$ADL_ATTEMPT_LOG\"\nexit 70\n",
+    );
+    let service = directory.path().join("exhaustion.toml");
+    std::fs::write(
+        &service,
+        format!(
+            r#"name = "adl-runtime-kernel-exhaustion"
+command = "{}"
+stdout = "STDOUT"
+stderr = "STDERR"
+
+[restart]
+strategy = "on-failure"
+backoff = "50ms"
+attempts = 3
+
+[failure]
+successful-exit-code = [0]
+strategy = "ignore"
+
+[environment]
+keep-env = false
+re-export = ["ADL_ATTEMPT_LOG"]
+
+[termination]
+signal = "TERM"
+wait = "1s"
+"#,
+            toml_path(&child)
+        ),
+    )
+    .unwrap();
+
+    let mut guardian = Command::new(horust_binary())
+        .arg("--services-path")
+        .arg(&service)
+        .arg("--uds-folder-path")
+        .arg(directory.path().join("uds"))
+        .env("ADL_ATTEMPT_LOG", &attempt_log)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut observed_attempts = 0;
+    let attempts = loop {
+        if let Ok(contents) = std::fs::read_to_string(&attempt_log) {
+            let attempts = contents.lines().count();
+            observed_attempts = attempts;
+            if attempts > 4 {
+                break attempts;
+            }
+        }
+        if let Some(status) = guardian.try_wait().unwrap() {
+            panic!("Horust unexpectedly exhausted the configured budget: {status}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Horust did not reproduce the restart-budget defect before the deadline; observed {observed_attempts} launches"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    assert_eq!(
+        unsafe { libc::kill(guardian.id() as i32, libc::SIGTERM) },
+        0
+    );
+    assert!(guardian.wait().unwrap().success());
+    assert!(
+        attempts > 4,
+        "Horust unexpectedly respected attempts=3: observed {attempts} launches"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "requires ADL_HORUST_BIN and exercises native environment isolation"]
+fn horust_allowlists_child_environment() {
+    let directory = tempfile::tempdir().unwrap();
+    let environment_log = directory.path().join("environment.log");
+    let child = directory.path().join("capture-env.sh");
+    write_executable(&child, "#!/bin/sh\nenv > \"$ADL_ENV_OUT\"\n");
+    let service = directory.path().join("environment.toml");
+    std::fs::write(
+        &service,
+        format!(
+            r#"name = "adl-runtime-kernel-environment"
+command = "{}"
+stdout = "STDOUT"
+stderr = "STDERR"
+
+[restart]
+strategy = "never"
+backoff = "10ms"
+attempts = 1
+
+[failure]
+successful-exit-code = [0]
+strategy = "ignore"
+
+[environment]
+keep-env = false
+re-export = ["ADL_ENV_OUT", "ADL_ALLOWED_TEST"]
+
+[termination]
+signal = "TERM"
+wait = "1s"
+"#,
+            toml_path(&child)
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(horust_binary())
+        .arg("--services-path")
+        .arg(&service)
+        .arg("--uds-folder-path")
+        .arg(directory.path().join("uds"))
+        .env("ADL_ENV_OUT", &environment_log)
+        .env("ADL_ALLOWED_TEST", "visible")
+        .env("OPENAI_API_KEY", "must-not-leak")
+        .env("AWS_SECRET_ACCESS_KEY", "must-not-leak")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let captured = std::fs::read_to_string(environment_log).unwrap();
+    assert!(captured
+        .lines()
+        .any(|line| line == "ADL_ALLOWED_TEST=visible"));
+    assert!(!captured.contains("OPENAI_API_KEY"));
+    assert!(!captured.contains("AWS_SECRET_ACCESS_KEY"));
+    assert!(!captured.contains("must-not-leak"));
 }
 
 #[cfg(unix)]
@@ -165,6 +319,21 @@ fn repo_path(relative: &str) -> PathBuf {
         .parent()
         .unwrap()
         .join(relative)
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, contents: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(path, contents).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[cfg(unix)]
+fn toml_path(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    assert!(!value.contains(['\n', '\r']));
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(unix)]

--- a/adl-runtime-kernel/tests/guardian_soak.rs
+++ b/adl-runtime-kernel/tests/guardian_soak.rs
@@ -65,7 +65,7 @@ fn packaging_preserves_one_guardian_neutral_child_contract() {
     .unwrap();
     assert_eq!(
         evidence["tested_commit"],
-        "681445e614355bafa092998da45a6af792ad7f03"
+        "85326915d25bfedfa78e8cad7496126ca647921c"
     );
     assert_eq!(evidence["runs"].as_array().unwrap().len(), 4);
     assert_eq!(qualification["runtime_source_loc"], 8446);

--- a/adl-runtime-kernel/tests/guardian_soak.rs
+++ b/adl-runtime-kernel/tests/guardian_soak.rs
@@ -1,5 +1,6 @@
 use std::{
     future::pending,
+    io::Read,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
@@ -53,6 +54,42 @@ fn packaging_preserves_one_guardian_neutral_child_contract() {
         "a1ee5cbfda91cd77652dfd8849f68ecb40af8d2359ccc91f96fbff3d5a3976a3"
     );
     assert_eq!(provenance["qualification"]["bounded_restart"], "blocked");
+    let qualification: serde_json::Value = serde_json::from_str(include_str!(
+        "../../docs/architecture/runtime_v3_horust_qualification_report.v1.json"
+    ))
+    .unwrap();
+    assert_eq!(qualification["issue"], 5211);
+    let evidence: serde_json::Value = serde_json::from_str(include_str!(
+        "../../docs/architecture/runtime_v3_horust_qualification_evidence.v1.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        evidence["tested_commit"],
+        "681445e614355bafa092998da45a6af792ad7f03"
+    );
+    assert_eq!(evidence["runs"].as_array().unwrap().len(), 4);
+    assert_eq!(qualification["runtime_source_loc"], 8446);
+    assert_eq!(
+        qualification["gates"]["macos_native_lifecycle"]["status"],
+        "passed"
+    );
+    assert_eq!(
+        qualification["gates"]["linux_native_lifecycle"]["status"],
+        "focused_pass"
+    );
+    assert_eq!(
+        qualification["gates"]["linux_systemd_containment"]["status"],
+        "passed"
+    );
+    assert_eq!(
+        qualification["gates"]["bounded_restart"]["status"],
+        "blocked"
+    );
+    assert_eq!(
+        qualification["gates"]["smallest_gpu_spot"]["status"],
+        "blocked_before_launch"
+    );
+    assert_eq!(qualification["cutover_authorized"], false);
 }
 
 #[cfg(unix)]
@@ -61,15 +98,15 @@ fn packaging_preserves_one_guardian_neutral_child_contract() {
 fn horust_restarts_once_and_restores_continuity() {
     let directory = tempfile::tempdir().unwrap();
     let capsule = directory.path().join("horust-restart.json");
-    let output = Command::new(horust_binary())
+    let mut command = Command::new(horust_binary());
+    command
         .arg("--services-path")
         .arg(repo_path("infra/horust/adl-runtime-kernel-bakeoff.toml"))
         .arg("--uds-folder-path")
         .arg(directory.path().join("uds"))
         .env("ADL_RUNTIME_BIN", env!("CARGO_BIN_EXE_adl-runtime-kernel"))
-        .env("ADL_RUNTIME_CAPSULE", &capsule)
-        .output()
-        .unwrap();
+        .env("ADL_RUNTIME_CAPSULE", &capsule);
+    let output = bounded_output(&mut command);
     assert!(
         output.status.success(),
         "Horust failed: stdout={} stderr={}",
@@ -87,15 +124,15 @@ fn horust_restarts_once_and_restores_continuity() {
 #[ignore = "requires ADL_HORUST_BIN and exercises native process supervision"]
 fn horust_does_not_restart_configuration_failure() {
     let directory = tempfile::tempdir().unwrap();
-    let output = Command::new(horust_binary())
+    let mut command = Command::new(horust_binary());
+    command
         .arg("--services-path")
         .arg(repo_path("infra/horust/adl-runtime-kernel.toml"))
         .arg("--uds-folder-path")
         .arg(directory.path().join("uds"))
         .env("ADL_RUNTIME_BIN", env!("CARGO_BIN_EXE_adl-runtime-kernel"))
-        .env("ADL_RUNTIME_CAPSULE", directory.path().join("config.json"))
-        .output()
-        .unwrap();
+        .env("ADL_RUNTIME_CAPSULE", directory.path().join("config.json"));
+    let output = bounded_output(&mut command);
     assert!(output.status.success());
     let combined = format!(
         "{}{}",
@@ -153,16 +190,20 @@ wait = "1s"
     )
     .unwrap();
 
-    let mut guardian = Command::new(horust_binary())
-        .arg("--services-path")
-        .arg(&service)
-        .arg("--uds-folder-path")
-        .arg(directory.path().join("uds"))
-        .env("ADL_ATTEMPT_LOG", &attempt_log)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .unwrap();
+    let mut guardian = ChildGuard::new({
+        let mut command = Command::new(horust_binary());
+        configure_process_group(&mut command);
+        command
+            .arg("--services-path")
+            .arg(&service)
+            .arg("--uds-folder-path")
+            .arg(directory.path().join("uds"))
+            .env("ADL_ATTEMPT_LOG", &attempt_log)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap()
+    });
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     let mut observed_attempts = 0;
     let attempts = loop {
@@ -173,7 +214,7 @@ wait = "1s"
                 break attempts;
             }
         }
-        if let Some(status) = guardian.try_wait().unwrap() {
+        if let Some(status) = guardian.0.as_mut().unwrap().try_wait().unwrap() {
             panic!("Horust unexpectedly exhausted the configured budget: {status}");
         }
         assert!(
@@ -183,10 +224,10 @@ wait = "1s"
         std::thread::sleep(Duration::from_millis(20));
     };
     assert_eq!(
-        unsafe { libc::kill(guardian.id() as i32, libc::SIGTERM) },
+        unsafe { libc::kill(guardian.0.as_ref().unwrap().id() as i32, libc::SIGTERM) },
         0
     );
-    assert!(guardian.wait().unwrap().success());
+    assert!(guardian.0.as_mut().unwrap().wait().unwrap().success());
     assert!(
         attempts > 4,
         "Horust unexpectedly respected attempts=3: observed {attempts} launches"
@@ -232,7 +273,8 @@ wait = "1s"
     )
     .unwrap();
 
-    let output = Command::new(horust_binary())
+    let mut command = Command::new(horust_binary());
+    command
         .arg("--services-path")
         .arg(&service)
         .arg("--uds-folder-path")
@@ -240,9 +282,8 @@ wait = "1s"
         .env("ADL_ENV_OUT", &environment_log)
         .env("ADL_ALLOWED_TEST", "visible")
         .env("OPENAI_API_KEY", "must-not-leak")
-        .env("AWS_SECRET_ACCESS_KEY", "must-not-leak")
-        .output()
-        .unwrap();
+        .env("AWS_SECRET_ACCESS_KEY", "must-not-leak");
+    let output = bounded_output(&mut command);
     assert!(output.status.success());
     let captured = std::fs::read_to_string(environment_log).unwrap();
     assert!(captured
@@ -262,30 +303,34 @@ fn horust_forwards_sigterm_and_runtime_checkpoints_cleanly() {
     let directory = tempfile::tempdir().unwrap();
     let capsule = directory.path().join("horust-sigterm.json");
     let verifying_key = SigningKey::from_bytes(&[19_u8; 32]).verifying_key();
-    let mut guardian = Command::new(horust_binary())
-        .arg("--services-path")
-        .arg(repo_path("infra/horust/adl-runtime-kernel.toml"))
-        .arg("--uds-folder-path")
-        .arg(directory.path().join("uds"))
-        .env("ADL_RUNTIME_BIN", env!("CARGO_BIN_EXE_adl-runtime-kernel"))
-        .env("ADL_RUNTIME_CAPSULE", &capsule)
-        .env(
-            "ADL_RUNTIME_CONTROL_PUBLIC_KEY_HEX",
-            hex::encode(verifying_key.as_bytes()),
-        )
-        .env("ADL_RUNTIME_CONTROL_KEY_ID", "guardian-test")
-        .env("ADL_RUNTIME_CONTROL_PRINCIPAL", "guardian-test")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .unwrap();
+    let mut command = Command::new(horust_binary());
+    configure_process_group(&mut command);
+    let mut guardian = ChildGuard::new(
+        command
+            .arg("--services-path")
+            .arg(repo_path("infra/horust/adl-runtime-kernel.toml"))
+            .arg("--uds-folder-path")
+            .arg(directory.path().join("uds"))
+            .env("ADL_RUNTIME_BIN", env!("CARGO_BIN_EXE_adl-runtime-kernel"))
+            .env("ADL_RUNTIME_CAPSULE", &capsule)
+            .env(
+                "ADL_RUNTIME_CONTROL_PUBLIC_KEY_HEX",
+                hex::encode(verifying_key.as_bytes()),
+            )
+            .env("ADL_RUNTIME_CONTROL_KEY_ID", "guardian-test")
+            .env("ADL_RUNTIME_CONTROL_PRINCIPAL", "guardian-test")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
 
-    wait_for_control_port(&mut guardian);
+    wait_for_control_port(guardian.0.as_mut().unwrap());
     assert_eq!(
-        unsafe { libc::kill(guardian.id() as i32, libc::SIGTERM) },
+        unsafe { libc::kill(-(guardian.0.as_ref().unwrap().id() as i32), libc::SIGTERM) },
         0
     );
-    let status = guardian.wait().unwrap();
+    let status = guardian.0.as_mut().unwrap().wait().unwrap();
     assert!(status.success(), "Horust exited with {status}");
 
     let deadline = std::time::Instant::now() + Duration::from_secs(3);
@@ -311,6 +356,94 @@ fn horust_binary() -> PathBuf {
         configured
     } else {
         repo_path(configured.to_str().expect("Horust path must be UTF-8"))
+    }
+}
+
+#[cfg(unix)]
+struct ChildGuard(Option<std::process::Child>, i32);
+
+#[cfg(unix)]
+impl ChildGuard {
+    fn new(child: std::process::Child) -> Self {
+        let pgid = child.id() as i32;
+        Self(Some(child), pgid)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        cleanup_process_group(self.1);
+        if let Some(child) = self.0.as_mut() {
+            if matches!(child.try_wait(), Ok(None)) {
+                let _ = child.kill();
+            }
+            let _ = child.wait();
+        }
+    }
+}
+
+#[cfg(unix)]
+fn bounded_output(command: &mut Command) -> std::process::Output {
+    configure_process_group(command);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = ChildGuard::new(command.spawn().unwrap());
+    let mut stdout = child.0.as_mut().unwrap().stdout.take().unwrap();
+    let mut stderr = child.0.as_mut().unwrap().stderr.take().unwrap();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).unwrap();
+        bytes
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).unwrap();
+        bytes
+    });
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if child.0.as_mut().unwrap().try_wait().unwrap().is_some() {
+            let status = child.0.as_mut().unwrap().wait().unwrap();
+            let output = std::process::Output {
+                status,
+                stdout: stdout_reader.join().unwrap(),
+                stderr: stderr_reader.join().unwrap(),
+            };
+            drop(child);
+            return output;
+        }
+        if std::time::Instant::now() >= deadline {
+            drop(child);
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            panic!("Horust did not terminate within the bounded test deadline");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[cfg(unix)]
+fn cleanup_process_group(pgid: i32) {
+    let signaled = unsafe { libc::kill(-pgid, libc::SIGTERM) == 0 };
+    if signaled {
+        std::thread::sleep(Duration::from_millis(100));
+        unsafe {
+            let _ = libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn configure_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
     }
 }
 

--- a/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
+++ b/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
@@ -20,7 +20,7 @@ classifies fatal exits, and never embeds guardian-specific configuration.
 
 | Guardian | Liveness/restart | Signals/reaping/output | Portability and maintenance | Security posture | Disposition |
 |---|---|---|---|---|---|
-| systemd | Native service and restart/backoff; cgroup ownership | `SIGTERM`, `KillMode=control-group`, journal capture | Linux only | Dynamic user, state directory, resource and capability bounds | Optional Linux adapter; Linux-host execution pending |
+| systemd | Native service and restart/backoff; cgroup ownership | `SIGTERM`, `KillMode=control-group`, journal capture | Linux only | Dynamic user, state directory, resource and capability bounds | Qualified optional Linux containment adapter |
 | rustysd | Common unit subset supports `Restart=always`; fixed pre-start delay | Process supervision and output capture | Linux proof candidate; upstream describes itself as work in progress | Smaller surface, insufficient production hardening evidence | Retained proof candidate only |
 | Horust 0.1.13 | Executed `on-failure` restart with 100ms incremental backoff; configured attempts do not bound repeated post-start crashes | `SIGTERM`, output forwarding, child supervision | Built on macOS and targets Unix hosts; upstream documents macOS orphan-reaping limitations | Inherits launcher identity and limits; dedicated unprivileged account required | Selected portable Unix candidate; bounded-restart qualification blocked by upstream #318 |
 | launchd | KeepAlive and native process ownership | Native signal/log integration | Supported macOS platform service | Native service isolation controls | Compatible future adapter; not packaged here |
@@ -42,10 +42,40 @@ reported upstream at `https://github.com/FedericoPonzi/Horust/issues/318`.
 ## Packaging
 
 - `infra/horust/adl-runtime-kernel.toml` is the selected portable Unix
-  guardian package.
+  guardian candidate; adoption remains blocked.
 - `infra/systemd/adl-runtime-kernel.service` is an optional Linux adapter.
 - `infra/rustysd/adl-runtime-kernel.service` remains a compatibility fixture,
   not a production recommendation.
+
+## Issue 5211 Qualification
+
+The retained `runtime_v3_horust_qualification_report.v1.json` records the
+cross-platform qualification result without promoting local artifact paths or
+cloud account identifiers into repository truth.
+
+- macOS passed seven guardian-package tests, five of which exercise native
+  Horust supervision; the packet also includes a 100-cycle runtime soak and a
+  direct `serve` SIGTERM test.
+- Linux on Nessus passed focused Horust packaging, restart-budget, isolation,
+  restart-continuity, and configuration-failure tests on an NVIDIA RTX 3090
+  host. This is focused coverage, not a complete Linux soak or
+  signal-forwarding qualification. Nessus could not prove systemd containment
+  because its
+  WSL2 environment exposes an offline systemd and hybrid cgroup-v1 surface.
+- A disposable Linux Spot host proved the checked-in systemd unit starts in
+  `/system.slice/adl-runtime-kernel.service`, applies `DynamicUser=yes`,
+  `KillMode=control-group`, strict filesystem protections, a 2 GiB memory
+  ceiling, and a 512-task ceiling, then stops and terminates cleanly.
+- The smallest practical GPU Spot launch was attempted separately. No GPU
+  instance launched: `g4dn.xlarge` and `g5.xlarge` are offered in multiple
+  regions, but the account's G/VT Spot quota is zero. The only advertised P3
+  shape, `p3dn.24xlarge`, needs 96 vCPUs against the approved eight-vCPU
+  P-family Spot quota. This is retained as a blocked infrastructure proof and
+  makes no GPU-runtime claim.
+
+Horust adoption remains blocked by upstream issue 318. Passing platform,
+containment, and isolation gates does not compensate for an unbounded restart
+loop.
 
 ## Soak Gate
 
@@ -72,6 +102,6 @@ is never an available outcome.
 Process groups bound ordinary descendants during the parity soak, but they are
 not an OS security boundary against a trusted fixture that deliberately creates
 a new session. Killing a numeric process group after reaping its leader also has
-a theoretical identifier-reuse race when no descendants remain. Linux cgroup
-containment and production host resource limits are deployment qualification
-work tracked by `#5211`.
+a theoretical identifier-reuse race when no descendants remain. Issue `#5211`
+qualified the optional systemd adapter's Linux cgroup and host resource bounds;
+the Horust process-group gap and upstream restart-budget defect remain blockers.

--- a/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
+++ b/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
@@ -22,7 +22,7 @@ classifies fatal exits, and never embeds guardian-specific configuration.
 |---|---|---|---|---|---|
 | systemd | Native service and restart/backoff; cgroup ownership | `SIGTERM`, `KillMode=control-group`, journal capture | Linux only | Dynamic user, state directory, resource and capability bounds | Optional Linux adapter; Linux-host execution pending |
 | rustysd | Common unit subset supports `Restart=always`; fixed pre-start delay | Process supervision and output capture | Linux proof candidate; upstream describes itself as work in progress | Smaller surface, insufficient production hardening evidence | Retained proof candidate only |
-| Horust 0.1.13 | Executed `on-failure` restart with 100ms backoff and bounded attempts | `SIGTERM`, output forwarding, child supervision | Built on macOS and targets Unix hosts; upstream documents macOS orphan-reaping limitations | Inherits launcher identity and limits; dedicated unprivileged account required | Selected portable Unix guardian; executable restart proof passed |
+| Horust 0.1.13 | Executed `on-failure` restart with 100ms incremental backoff; configured attempts do not bound repeated post-start crashes | `SIGTERM`, output forwarding, child supervision | Built on macOS and targets Unix hosts; upstream documents macOS orphan-reaping limitations | Inherits launcher identity and limits; dedicated unprivileged account required | Selected portable Unix candidate; bounded-restart qualification blocked by upstream #318 |
 | launchd | KeepAlive and native process ownership | Native signal/log integration | Supported macOS platform service | Native service isolation controls | Compatible future adapter; not packaged here |
 
 `initd` remains out of scope because it is a PID 1 bootstrap layer rather than
@@ -32,6 +32,12 @@ The retained native Horust proof executes both sides of the guardian contract:
 one injected fatal child exit is restarted and restores continuity at generation
 2; terminating Horust forwards `SIGTERM`, lets the kernel checkpoint generation
 1, and leaves control port `20997` closed.
+
+Horust 0.1.13's `OnFailure` path does not apply the configured attempt limit,
+and its `Never` startup-failure counter resets when a child reaches `Started`.
+A native always-failing child therefore remains in a crash loop instead of
+exhausting the configured budget. This is retained as a cutover blocker and
+reported upstream at `https://github.com/FedericoPonzi/Horust/issues/318`.
 
 ## Packaging
 

--- a/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
+++ b/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
@@ -38,6 +38,10 @@ and its `Never` startup-failure counter resets when a child reaches `Started`.
 A native always-failing child therefore remains in a crash loop instead of
 exhausting the configured budget. This is retained as a cutover blocker and
 reported upstream at `https://github.com/FedericoPonzi/Horust/issues/318`.
+The proposed upstream repair is under review at
+`https://github.com/FedericoPonzi/Horust/pull/319`; ADL remains pinned to the
+published 0.1.13 release and blocked until a corrected release is available and
+the native qualification suite passes against that release.
 
 ## Packaging
 

--- a/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
+++ b/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema": "adl.runtime_v3.horust_qualification_evidence.v1",
   "issue": 5211,
-  "tested_commit": "681445e614355bafa092998da45a6af792ad7f03",
+  "tested_commit": "85326915d25bfedfa78e8cad7496126ca647921c",
   "artifact_policy": "remote and host artifacts remain local and ignored; this redacted index retains stable identifiers and hashes without credentials or account identifiers",
   "unit_sha256": "c344a70df9e7bb57911b2c675b5bb0f7d22ffb680fd72277d3f6c6b2655eff27",
   "horust_crate_provenance_sha256": "b0a9ae88756ba4ac9187b9844ccb5bfcb5503905e2dac199f094886a0bc6e9b1",

--- a/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
+++ b/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
@@ -4,7 +4,7 @@
   "tested_commit": "85326915d25bfedfa78e8cad7496126ca647921c",
   "artifact_policy": "remote and host artifacts remain local and ignored; this redacted index retains stable identifiers and hashes without credentials or account identifiers",
   "unit_sha256": "c344a70df9e7bb57911b2c675b5bb0f7d22ffb680fd72277d3f6c6b2655eff27",
-  "horust_crate_provenance_sha256": "b0a9ae88756ba4ac9187b9844ccb5bfcb5503905e2dac199f094886a0bc6e9b1",
+  "horust_crate_provenance_sha256": "2e59a679087e227438c72b4cdef44815406ff2d118cf5b4134ae06780c90e5b2",
   "local_horust_binary_sha256": "707940ff4e569f416f2b3cb42801b1d9e5af8a6ea1ec842abf32b01b91f7cb9f",
   "runs": [
     {

--- a/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
+++ b/docs/architecture/runtime_v3_horust_qualification_evidence.v1.json
@@ -1,0 +1,73 @@
+{
+  "schema": "adl.runtime_v3.horust_qualification_evidence.v1",
+  "issue": 5211,
+  "tested_commit": "681445e614355bafa092998da45a6af792ad7f03",
+  "artifact_policy": "remote and host artifacts remain local and ignored; this redacted index retains stable identifiers and hashes without credentials or account identifiers",
+  "unit_sha256": "c344a70df9e7bb57911b2c675b5bb0f7d22ffb680fd72277d3f6c6b2655eff27",
+  "horust_crate_provenance_sha256": "b0a9ae88756ba4ac9187b9844ccb5bfcb5503905e2dac199f094886a0bc6e9b1",
+  "local_horust_binary_sha256": "707940ff4e569f416f2b3cb42801b1d9e5af8a6ea1ec842abf32b01b91f7cb9f",
+  "runs": [
+    {
+      "surface": "macos",
+      "artifact": ".adl/local-artifacts/issue-5211/macos/guardian-tests-final.log",
+      "artifact_sha256": "69d6a759ebcd35191bd0a58013ea785c021d2b5cad48a1ce71e407c0763d2cea",
+      "command_summary": "ADL_HORUST_BIN=... cargo test guardian_soak qualification suite",
+      "status": "passed",
+      "tests": 7,
+      "horust_tests": 5,
+      "runtime_soak_cycles": 100
+    },
+    {
+      "surface": "nessus-linux",
+      "run_id": "issue-5211-horust-linux-retry",
+      "artifact": ".adl/local-artifacts/issue-5211/nessus/summary.json",
+      "artifact_sha256": "4c174fd4bf73f6ca6edcbc6331be9e3866663ed6ee2eed0a4546aec2f24d7b10",
+      "started_at": "2026-07-12T03:37:51Z",
+      "finished_at": "2026-07-12T03:39:45Z",
+      "command_summary": "nvidia-smi; cargo install --locked horust 0.1.13; focused guardian_soak tests",
+      "status": "passed",
+      "scope": ["packaging", "restart-budget-reproduction", "environment-isolation", "restart-continuity", "configuration-failure"]
+    },
+    {
+      "surface": "aws-systemd-linux",
+      "run_id": "issue-5211-systemd-containment",
+      "artifact": ".adl/local-artifacts/issue-5211/aws-systemd/summary.json",
+      "artifact_sha256": "c1fc86430749bc9dc754b518eaff9be16c8ff1b9d1167035cc52ab895123dfa7",
+      "started_at": "2026-07-12T03:46:11Z",
+      "finished_at": "2026-07-12T03:49:01Z",
+      "command_summary": "install fixture; systemd-analyze verify; systemctl start/show/stop; cgroup inspection",
+      "status": "passed",
+      "scope": ["systemd-unit-verification", "cgroup-containment", "resource-bounds", "clean-stop", "instance-termination"]
+    },
+    {
+      "surface": "aws-gpu-spot",
+      "artifacts": [
+        ".adl/local-artifacts/issue-5211/aws-gpu-smallest/summary.json",
+        ".adl/local-artifacts/issue-5211/aws-gpu-v100-smallest/summary.json",
+        ".adl/local-artifacts/issue-5211/aws-gpu-v100-smallest-ubuntu/summary.json",
+        ".adl/local-artifacts/issue-5211/aws-gpu-v100-available/summary.json"
+      ],
+      "artifact_sha256": [
+        "6b19d6d6a1dbf018c896f06fcf7ec27e1dfd8d6fadcf8091bb31fc3f9ae41822",
+        "cf8baf9e366f02f245f797676f7ae31536c1b04ef14f351e9e49d6263e99a113",
+        "f7a1474cd14890499cd44ce0e8d1aec94db17fca32fdddace0fbfd4cb6678142",
+        "94c0517070848888f6702c37ae7addc1e685b8b5ca7542c9ff2ba0d2af2f5bf4"
+      ],
+      "attempts": [
+        {"run_id": "issue-5211-gpu-smallest", "started_at": "2026-07-12T03:51:16Z", "finished_at": "2026-07-12T03:51:20Z", "reason": "G/VT Spot quota 0"},
+        {"run_id": "issue-5211-gpu-v100-smallest", "started_at": "2026-07-12T03:53:11Z", "finished_at": "2026-07-12T03:53:13Z", "reason": "p3.2xlarge unavailable"},
+        {"run_id": "issue-5211-gpu-v100-smallest-ubuntu", "started_at": "2026-07-12T03:54:35Z", "finished_at": "2026-07-12T03:54:39Z", "reason": "p3.2xlarge unavailable"},
+        {"run_id": "issue-5211-gpu-v100-available", "started_at": "2026-07-12T03:57:54Z", "finished_at": "2026-07-12T03:57:57Z", "reason": "p3dn.24xlarge exceeds P Spot quota"}
+      ],
+      "command_summary": "nvidia-smi probe and focused guardian test; all attempts stopped before instance launch",
+      "status": "blocked_before_launch",
+      "scope": ["g4dn.xlarge", "p3.2xlarge", "p3dn.24xlarge"],
+      "claim": "no GPU runtime qualification"
+    }
+  ],
+  "non_claims": [
+    "Linux native lifecycle is focused coverage, not a complete soak or signal-forwarding qualification.",
+    "The local Horust binary hash does not by itself prove the remote binary hash; remote binary provenance remains a follow-up evidence gap.",
+    "The AWS GPU attempts launched no instance and produced no GPU-runtime result."
+  ]
+}

--- a/docs/architecture/runtime_v3_horust_qualification_report.v1.json
+++ b/docs/architecture/runtime_v3_horust_qualification_report.v1.json
@@ -1,0 +1,60 @@
+{
+  "schema": "adl.runtime_v3.horust_qualification.v1",
+  "issue": 5211,
+  "runtime_source_loc": 8446,
+  "guardian": {
+    "name": "horust",
+    "version": "0.1.13",
+    "crate_sha256": "a1ee5cbfda91cd77652dfd8849f68ecb40af8d2359ccc91f96fbff3d5a3976a3"
+  },
+  "gates": {
+    "macos_native_lifecycle": {
+      "status": "passed",
+      "tests_passed": 7,
+      "soak_cycles": 100
+    },
+    "linux_native_lifecycle": {
+      "status": "focused_pass",
+      "host_class": "wsl2-nvidia-rtx-3090",
+      "scope": ["packaging", "restart-budget-reproduction", "environment-isolation", "restart-continuity", "configuration-failure"],
+      "non_claim": "not a complete Linux soak or signal-forwarding qualification"
+    },
+    "linux_systemd_containment": {
+      "status": "passed",
+      "host_class": "disposable-aws-spot",
+      "control_group": "/system.slice/adl-runtime-kernel.service",
+      "dynamic_user": true,
+      "kill_mode": "control-group",
+      "memory_max_bytes": 2147483648,
+      "tasks_max": 512,
+      "instance_terminated": true
+    },
+    "bounded_restart": {
+      "status": "blocked",
+      "upstream_issue": "https://github.com/FedericoPonzi/Horust/issues/318",
+      "reason": "Horust 0.1.13 does not enforce restart.attempts for repeated post-start failures under RestartStrategy::OnFailure"
+    },
+    "smallest_gpu_spot": {
+      "status": "blocked_before_launch",
+      "requested_smallest_shape": "g4dn.xlarge",
+      "fallback_family": "p3",
+      "reason": "All G and VT Spot Instance Requests quota was zero; g4dn.xlarge and g5.xlarge are offered in multiple regions but cannot launch, while the only advertised P3 shape required 96 vCPUs against the approved 8-vCPU P-family Spot quota",
+      "quota_evidence": {
+        "g_and_vt_spot_vcpus": 0,
+        "p_spot_vcpus": 8,
+        "available_p_shape": "p3dn.24xlarge",
+        "available_p_shape_vcpus": 96,
+        "small_gpu_shapes_offered": ["g4dn.xlarge", "g5.xlarge"]
+      },
+      "instance_launched": false,
+      "runtime_claim": false
+    }
+  },
+  "disposition": "blocked",
+  "cutover_authorized": false,
+  "non_claims": [
+    "This report does not authorize Runtime v3 cutover.",
+    "This report does not claim GPU monitoring or GPU runtime qualification from AWS Spot.",
+    "This report does not claim Horust enforces a bounded restart budget."
+  ]
+}

--- a/docs/architecture/runtime_v3_horust_qualification_report.v1.json
+++ b/docs/architecture/runtime_v3_horust_qualification_report.v1.json
@@ -32,6 +32,7 @@
     "bounded_restart": {
       "status": "blocked",
       "upstream_issue": "https://github.com/FedericoPonzi/Horust/issues/318",
+      "upstream_fix_pr": "https://github.com/FedericoPonzi/Horust/pull/319",
       "reason": "Horust 0.1.13 does not enforce restart.attempts for repeated post-start failures under RestartStrategy::OnFailure"
     },
     "smallest_gpu_spot": {

--- a/infra/horust/README.md
+++ b/infra/horust/README.md
@@ -3,6 +3,11 @@
 Horust `0.1.13` is the selected portable Unix external guardian for
 Runtime v3. It is not linked into `adl-runtime-kernel`.
 
+The pinned source record is
+`infra/horust/horust-0.1.13.provenance.json`. It records the crates.io source,
+MIT license, Rust baseline, and SHA-256 of the published crate archive. Verify
+the archive checksum before installing with Cargo.
+
 Install the pinned guardian outside the repository build:
 
 ```sh
@@ -21,10 +26,15 @@ export ADL_RUNTIME_CONTROL_PRINCIPAL=operator
 horust --services-path infra/horust/adl-runtime-kernel.toml
 ```
 
-The service uses `on-failure` restart, 100ms incremental backoff, three startup
-attempts, direct stdout/stderr forwarding, and `SIGTERM` with a ten-second
-grace period. Configuration exit `78` is terminal and is not restarted.
-Platform-native managers remain optional adapters around the same child contract.
+The service currently uses Horust 0.1.13's `on-failure` strategy with 100ms
+incremental backoff. Native qualification found that this release does not
+enforce `restart.attempts` for repeated post-start crashes. The blocker is
+reported upstream as `FedericoPonzi/Horust#318`; this package must not claim a
+bounded crash-loop budget until a corrected upstream release is pinned and
+proved. Successful exits finish, configuration exit `78` is terminal, output
+is forwarded directly, and shutdown uses `SIGTERM` with a ten-second grace
+period. Platform-native managers remain optional adapters around the same child
+contract.
 
 Run Horust under a dedicated unprivileged host account. The service inherits
 the launcher's OS identity and resource limits; the optional systemd adapter

--- a/infra/horust/README.md
+++ b/infra/horust/README.md
@@ -1,12 +1,17 @@
 # Runtime v3 Horust Guardian
 
-Horust `0.1.13` is the selected portable Unix external guardian for
-Runtime v3. It is not linked into `adl-runtime-kernel`.
+Horust `0.1.13` is the portable Unix external-guardian candidate for Runtime
+v3. It is not linked into `adl-runtime-kernel`, and it is not approved for
+production use while the qualification blocker below remains open.
 
 The pinned source record is
 `infra/horust/horust-0.1.13.provenance.json`. It records the crates.io source,
 MIT license, Rust baseline, and SHA-256 of the published crate archive. Verify
-the archive checksum before installing with Cargo.
+the archive checksum before installing with Cargo:
+
+```sh
+infra/horust/verify-provenance.sh /path/to/horust-0.1.13.crate
+```
 
 Install the pinned guardian outside the repository build:
 
@@ -40,8 +45,10 @@ Run Horust under a dedicated unprivileged host account. The service inherits
 the launcher's OS identity and resource limits; the optional systemd adapter
 adds Linux cgroup and service-account bounds. Use administrator-controlled,
 absolute binary and continuity paths without whitespace or quoting characters,
-because Horust parses the interpolated command string. Production packaging and
-cross-host qualification continue in `#5211`.
+because Horust parses the interpolated command string. Production adoption
+remains blocked by upstream issue 318. The qualification evidence and remaining
+provenance gap are recorded in
+`docs/architecture/runtime_v3_horust_qualification_evidence.v1.json`.
 
 `adl-runtime-kernel-bakeoff.toml` is test-only. It injects one classified fatal
 exit and proves that Horust restarts a fresh child which restores continuity.

--- a/infra/horust/horust-0.1.13.provenance.json
+++ b/infra/horust/horust-0.1.13.provenance.json
@@ -1,0 +1,17 @@
+{
+  "schema": "adl.runtime_v3.guardian_provenance.v1",
+  "name": "horust",
+  "version": "0.1.13",
+  "license": "MIT",
+  "minimum_rust_version": "1.85.1",
+  "registry": "https://crates.io/crates/horust/0.1.13",
+  "repository": "https://github.com/FedericoPonzi/horust",
+  "crate_sha256": "a1ee5cbfda91cd77652dfd8849f68ecb40af8d2359ccc91f96fbff3d5a3976a3",
+  "install": "cargo install --locked horust --version 0.1.13",
+  "feature_set": "default",
+  "qualification": {
+    "bounded_restart": "blocked",
+    "upstream_issue": "https://github.com/FedericoPonzi/Horust/issues/318",
+    "reason": "Horust 0.1.13 does not enforce restart.attempts for repeated post-start failures under RestartStrategy::OnFailure"
+  }
+}

--- a/infra/horust/horust-0.1.13.provenance.json
+++ b/infra/horust/horust-0.1.13.provenance.json
@@ -12,6 +12,7 @@
   "qualification": {
     "bounded_restart": "blocked",
     "upstream_issue": "https://github.com/FedericoPonzi/Horust/issues/318",
+    "upstream_fix_pr": "https://github.com/FedericoPonzi/Horust/pull/319",
     "reason": "Horust 0.1.13 does not enforce restart.attempts for repeated post-start failures under RestartStrategy::OnFailure"
   }
 }

--- a/infra/horust/verify-provenance.sh
+++ b/infra/horust/verify-provenance.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+archive=${1:?usage: verify-provenance.sh /path/to/horust-0.1.13.crate}
+expected=$(jq -r '.crate_sha256' "$(dirname "$0")/horust-0.1.13.provenance.json")
+actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+
+if [ "$actual" != "$expected" ]; then
+  printf '%s\n' "Horust archive checksum mismatch" >&2
+  exit 1
+fi
+printf '%s\n' "Horust archive checksum verified: $actual"


### PR DESCRIPTION
Non-closing lifecycle PR: issue #5211 remains open.

## Summary
Pinned and qualified Horust 0.1.13 across macOS and focused Linux surfaces, proved the optional systemd containment adapter on a disposable Linux Spot host, and retained a redacted evidence index. The requested adoption outcome failed because Horust does not enforce `restart.attempts` for repeated post-start failures. Upstream issue 318 records the defect. This branch publishes a blocked qualification result and does not authorize Runtime v3 cutover.

## Artifacts
- `infra/horust/horust-0.1.13.provenance.json`
- `infra/horust/verify-provenance.sh`
- `infra/horust/adl-runtime-kernel.toml`
- `docs/architecture/runtime_v3_horust_qualification_report.v1.json`
- `docs/architecture/runtime_v3_horust_qualification_evidence.v1.json`
- `docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md`
- `adl-runtime-kernel/tests/guardian_soak.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl-runtime-kernel/Cargo.toml -- --check` verified Rust formatting.
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test guardian_soak packaging_preserves_one_guardian_neutral_child_contract -- --exact --nocapture` verified static qualification contracts.
  - `ADL_HORUST_BIN=.adl/local-tools/horust/bin/horust cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test guardian_soak -- --ignored --test-threads=1` verified native macOS lifecycle and bounded cleanup; 7 passed.
  - `cargo clippy --manifest-path adl-runtime-kernel/Cargo.toml --all-targets -- -D warnings` verified lint cleanliness.
  - `sh -n infra/horust/verify-provenance.sh` verified checksum-script syntax.
  - `jq empty docs/architecture/runtime_v3_horust_qualification_report.v1.json docs/architecture/runtime_v3_horust_qualification_evidence.v1.json` verified tracked JSON syntax.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.92/tasks/issue-5211__v0-92-runtime-v3-guardian-adopt-and-qualify-horust/srp.md` verified final review-card structure.
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml` passed all tests until `parity_baseline_manifest_covers_every_current_runtime_module`, which failed 195 declared vs 196 observed after current main added `adl-runtime/src/runtime_api_auth.rs` in #5204 without refreshing the Runtime v3 baseline inventory. This is inherited integration drift and is not repaired in #5211.
- Results:
  - `PASS` for branch implementation, native macOS proof, systemd containment, focused Linux proof, docs, and review remediation.
  - `FAIL` for deterministic restart exhaustion under Horust 0.1.13; more than four launches occurred with `attempts = 3`.
  - `BLOCKED_BEFORE_LAUNCH` for AWS GPU Spot qualification.
  - `FAIL` for the repository-wide Runtime v3 parity inventory gate inherited from current main; focused #5211 validation remains green.

## Local Artifacts
- Input card:  .adl/v0.92/tasks/issue-5211__v0-92-runtime-v3-guardian-adopt-and-qualify-horust/sip.md
- Output card: .adl/v0.92/tasks/issue-5211__v0-92-runtime-v3-guardian-adopt-and-qualify-horust/sor.md
- Idempotency-Key: v0-92-runtime-v3-guardian-retain-blocked-horust-qualification-evidence-adl-runtime-kernel-tests-guardian-soak-rs-docs-architecture-runtime-v3-guardian-and-soak-md-docs-architecture-runtime-v3-horust-qualification-evidence-v1-json-docs-architecture-runtime-v3-horust-qualification-report-v1-json-infra-horust-readme-md-infra-horust-verify-provenance-sh-infra-horust-horust-0-1-13-provenance-json-adl-v0-92-tasks-issue-5211-v0-92-runtime-v3-guardian-adopt-and-qualify-horust-sip-md-adl-v0-92-tasks-issue-5211-v0-92-runtime-v3-guardian-adopt-and-qualify-horust-sor-md