### PR TITLE
[v0.92][runtime-v3][guardian] Evaluate COTS guardian fallbacks

### DIFF
--- a/docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md
+++ b/docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md
@@ -36,6 +36,7 @@ guardian cutover blocker for #5211, and it is not counted as passed proof here.
 | Horust adoption and qualification | #5211 | open | Evidence merged; adoption blocked by Horust 0.1.13 restart-budget defect. |
 | Fixed Horust rollout | #5221 | open | Required successor before guardian cutover can be reconsidered. |
 | Weather/GPU qualification | #5222 | open | GPU proof deferred to #5222; no GPU-runtime claim is made here. |
+| Guardian fallback review | #5224 | open | No reviewed COTS candidate is a drop-in cross-platform external guardian replacement. |
 
 ## Go / No-Go
 
@@ -70,4 +71,4 @@ Required before reconsidering:
 - #5220: run release proof gate.
 - #5221: pin fixed Horust release and rollout guardian.
 - #5222: qualify resource and GPU monitoring.
-
+- #5224: review guardian fallback candidates while fixed Horust remains blocked.

--- a/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
+++ b/docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md
@@ -81,6 +81,16 @@ Horust adoption remains blocked by upstream issue 318. Passing platform,
 containment, and isolation gates does not compensate for an unbounded restart
 loop.
 
+Issue `#5224` reviews fallback candidates while that upstream Horust path is
+blocked. The retained fallback decision is
+`docs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md`: no reviewed COTS
+candidate is a drop-in cross-platform external guardian replacement. If Horust
+remains blocked, the next path is a separate follow-on that first tests whether
+`rust-tokio-supervisor` can supervise a narrow wrapper task that owns the
+runtime kernel as a `tokio::process` child, and otherwise builds a small
+ADL-owned Tokio process guardian shim that preserves the same child contract
+and uses COTS crates only for bounded supporting concerns.
+
 ## Soak Gate
 
 The bounded soak repeats integrated kernel execution and continuity recovery,

--- a/docs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md
+++ b/docs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md
@@ -1,0 +1,137 @@
+# Runtime v3 Guardian Fallback Decision
+
+Issue: #5224
+Sprint: #5174
+Decision date: 2026-07-12
+cutover_authorized: false
+
+## Decision
+
+Do not replace the Runtime v3 guardian with any newly reviewed COTS candidate
+as a drop-in dependency.
+
+Horust remains the selected portable Unix guardian candidate, but adoption
+remains blocked by the restart-budget defect recorded by #5211 and tracked for
+rollout by #5221. The fallback review found useful libraries and design
+evidence, but no reviewed candidate directly satisfies the ADL external
+guardian contract without adding an ADL-owned OS-process supervision layer.
+
+If the Horust release path remains blocked, #5225 is the next actionable path.
+It tests two options against the same contract:
+
+1. adopt or extend `rust-tokio-supervisor` by writing a narrow wrapper task
+   whose supervised task owns the runtime kernel as an external OS process
+2. otherwise build the smallest ADL-owned external guardian shim using Tokio
+   process management and COTS crates for policy, telemetry, serialization,
+   and configuration
+
+That follow-on must stay outside Runtime v2 and must preserve the same
+`adl-runtime-kernel serve <continuity-path>` child contract.
+
+## Guardian Contract
+
+The runtime kernel process remains the boundary:
+
+- the guardian starts `adl-runtime-kernel serve <continuity-path>`
+- the guardian owns environment injection, stdout/stderr capture, signal
+  delivery, child reaping, restart delay, and process restart
+- the child owns component supervision, typed channels, readiness, continuity,
+  graceful shutdown, and serialization
+- the control API remains on `127.0.0.1:20997`
+- a guardian candidate is not acceptable if it only supervises in-process
+  Rust tasks unless ADL explicitly wraps it with an OS-process guardian layer
+
+## Candidate Review
+
+| Candidate | Direct guardian fit | Useful pieces | Disposition |
+|---|---|---|---|
+| Horust 0.1.13 | Yes, but blocked by unbounded post-start crash loops | Portable Unix process supervision, signal forwarding, restart delay | Retain selected candidate; adoption blocked until fixed release qualifies |
+| rustysd | No default fit; prior matrix records macOS build gaps and proof-candidate status | systemd-like unit model, Linux-oriented service-manager ideas | Retain Linux proof candidate only |
+| systemd | Linux-only external guardian | cgroups, `DynamicUser`, resource bounds, native journal capture | Retain optional Linux containment adapter |
+| rust_supervisor 0.2.0 | No; supervises thread factories, not the runtime kernel OS process | Erlang-style supervision concepts and restart policy vocabulary | Do not adopt as guardian |
+| rust-tokio-supervisor 0.1.4 | Not directly; supervises Tokio task factories, so the OS child boundary needs a wrapper task | restart budgets, restart limits, task roles, health, control commands, graceful shutdown model | Try wrapper-task adoption in #5225; retain as component supervisor reference if that fails |
+| launchd | macOS-only external guardian | native macOS process ownership and logs | Retain future platform adapter candidate |
+
+## Source Evidence
+
+- `docs/architecture/runtime_v3_guardian_matrix.v1.json` already records
+  Horust, rustysd, and systemd bakeoff evidence from #5175.
+- `docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md` records the #5211
+  qualification result and the Horust restart-budget blocker.
+- `infra/rustysd/adl-runtime-kernel.service` is a compatibility fixture using
+  a systemd-style `Restart=always` shape, not a production recommendation.
+- `rust_supervisor` 0.2.0 is published at
+  `https://crates.io/crates/rust_supervisor/0.2.0`, with documentation at
+  `https://docs.rs/rust_supervisor/0.2.0` and repository metadata pointing to
+  `https://github.com/roquess/rust_supervisor`. The reviewed crate source uses
+  `ChildSpec` factories returning `thread::JoinHandle<()>` rather than
+  external OS child processes.
+- `rust-tokio-supervisor` 0.1.4 publishes the user-provided source at
+  `developerworks/rust-supervisor` commit
+  `66d6f691f5679d5253682473d50eb912ef003997`. Its child runner builds a task
+  factory and runs it with `tokio::spawn(factory.build(ctx))`; the checked
+  source does not provide a direct `tokio::process::Command` guardian for
+  `adl-runtime-kernel`.
+
+## Why Not Adopt rust-tokio-supervisor Directly
+
+`rust-tokio-supervisor` is the strongest reviewed COTS design reference. It
+has useful concepts for Runtime v3's component plane: restart budgets, typed
+control commands, readiness, health state, restart limits, role defaults, and
+graceful shutdown.
+
+It is not a direct guardian because the ADL guardian must supervise an external
+runtime kernel process. The crate's current child runner supervises async task
+factories inside the same Rust runtime. Adopting it directly would either move
+guardian responsibilities back inside the child process or require ADL to write
+the missing process wrapper anyway.
+
+That makes it a good reference for the component supervisor and a plausible
+guardian dependency only through a wrapper task that owns the external process
+boundary. It is not, by itself, the replacement for Horust or systemd at that
+boundary.
+
+## Follow-On Shape If Horust Remains Blocked
+
+#5225 should first attempt the `rust-tokio-supervisor` adoption path.
+The most promising shape is a wrapper task: `rust-tokio-supervisor` supervises
+one guardian task, and that task owns a `tokio::process::Child` for
+`adl-runtime-kernel serve <continuity-path>`. The wrapper translates child
+exit, configuration exit, signal handling, readiness, output capture, and
+restart-budget results into the crate's task-result model.
+
+Adoption is acceptable only if the wrapper stays narrow and the actual runtime
+kernel remains an external OS child process. If that requires a substantial
+local fork or a broad adapter that is effectively a new service manager, stop
+calling it adoption and build the small shim directly.
+
+Either path should be constrained to the smallest surface that satisfies the
+existing contract:
+
+1. load a small declarative child spec
+2. spawn `adl-runtime-kernel serve <continuity-path>` with `tokio::process`
+3. capture stdout and stderr through the existing logging contract
+4. forward `SIGINT` and `SIGTERM`
+5. reap the child and fail closed on unsupported platform guarantees
+6. enforce a bounded restart budget with jittered backoff
+7. stop restarting after configuration exits and exhausted budgets
+8. expose a tiny status surface for local qualification
+9. use existing crates for serialization, tracing, sysinfo, and policy where
+   they reduce code
+10. keep Runtime v2 files untouched
+
+This is intentionally smaller than a general service manager. Backpressure,
+disk cleanup, cloud telemetry, component health, checkpointing, and adaptive
+runtime behavior remain child/runtime component responsibilities unless a later
+issue explicitly moves a narrow piece across the boundary.
+
+## Non-Claims
+
+- This packet does not authorize Runtime v3 cutover.
+- This packet does not switch the default runtime.
+- This packet does not delete or modify Runtime v2.
+- This packet does not claim Horust 0.1.13 enforces bounded restart attempts.
+- This packet does not claim rustysd is cross-platform production ready.
+- This packet does not claim `rust_supervisor` or `rust-tokio-supervisor`
+  directly supervise external OS child processes.
+- This packet does not implement a new ADL-owned guardian.

--- a/docs/architecture/runtime_v3_cutover_checklist.v1.json
+++ b/docs/architecture/runtime_v3_cutover_checklist.v1.json
@@ -27,7 +27,8 @@
     {"issue": 5183, "state": "closed", "role": "operations_integrations", "cutover_effect": "required_input_present"},
     {"issue": 5211, "state": "open", "role": "horust_adoption_qualification", "cutover_effect": "blocked_by_unreleased_restart_budget_fix"},
     {"issue": 5221, "state": "open", "role": "fixed_horust_release_rollout", "cutover_effect": "required_before_guardian_cutover"},
-    {"issue": 5222, "state": "open", "role": "weather_gpu_qualification", "cutover_effect": "gpu_proof_deferred"}
+    {"issue": 5222, "state": "open", "role": "weather_gpu_qualification", "cutover_effect": "gpu_proof_deferred"},
+    {"issue": 5224, "state": "open", "role": "guardian_fallback_review", "cutover_effect": "no_drop_in_cots_replacement_identified"}
   ],
   "gates": [
     {
@@ -60,6 +61,12 @@
       "status": "deferred",
       "source": "#5222",
       "reason": "GPU proof deferred to #5222; no GPU-runtime claim is made by #5211 or #5218."
+    },
+    {
+      "id": "guardian.fallback",
+      "status": "routed_follow_on",
+      "source": "#5224",
+      "reason": "No reviewed COTS candidate is a drop-in cross-platform external guardian replacement; #5225 tests rust-tokio-supervisor wrapper-task adoption before a tiny custom shim."
     }
   ],
   "non_claims": [

--- a/docs/architecture/runtime_v3_guardian_fallback_matrix.v1.json
+++ b/docs/architecture/runtime_v3_guardian_fallback_matrix.v1.json
@@ -1,0 +1,119 @@
+{
+  "schema": "adl.runtime_v3.guardian_fallback_matrix.v1",
+  "issue": 5224,
+  "decision_date": "2026-07-12",
+  "child_contract": {
+    "command": "adl-runtime-kernel serve <continuity-path>",
+    "control_port": "127.0.0.1:20997",
+    "guardian_responsibilities": [
+      "environment_injection",
+      "stdout_stderr_capture",
+      "signal_delivery",
+      "child_reaping",
+      "restart_delay",
+      "bounded_process_restart"
+    ],
+    "child_responsibilities": [
+      "component_supervision",
+      "typed_channels",
+      "readiness",
+      "continuity",
+      "graceful_shutdown",
+      "serialization"
+    ]
+  },
+  "candidates": [
+    {
+      "id": "horust-0.1.13",
+      "source": "docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md",
+      "direct_external_process_guardian": true,
+      "cross_platform_default_fit": "blocked",
+      "useful_capabilities": [
+        "portable_unix_process_supervision",
+        "signal_forwarding",
+        "restart_delay"
+      ],
+      "blocking_evidence": "Horust 0.1.13 does not enforce bounded on-failure restart attempts for repeated post-start crashes.",
+      "disposition": "retain_selected_candidate_pending_fixed_release"
+    },
+    {
+      "id": "rustysd-b200759c",
+      "source": "docs/architecture/runtime_v3_guardian_matrix.v1.json",
+      "direct_external_process_guardian": true,
+      "cross_platform_default_fit": "no",
+      "useful_capabilities": [
+        "systemd_style_units",
+        "linux_service_manager_model",
+        "restart_always_fixture"
+      ],
+      "blocking_evidence": "Prior matrix records macOS build gaps and proof-of-concept maintenance status.",
+      "disposition": "retain_linux_only_proof_candidate"
+    },
+    {
+      "id": "systemd",
+      "source": "infra/systemd/adl-runtime-kernel.service",
+      "direct_external_process_guardian": true,
+      "cross_platform_default_fit": "no",
+      "useful_capabilities": [
+        "cgroup_ownership",
+        "dynamic_user",
+        "resource_bounds",
+        "journal_capture"
+      ],
+      "blocking_evidence": "Linux-only platform service.",
+      "disposition": "retain_optional_linux_containment_adapter"
+    },
+    {
+      "id": "rust_supervisor-0.2.0",
+      "source": "https://crates.io/crates/rust_supervisor/0.2.0",
+      "docs": "https://docs.rs/rust_supervisor/0.2.0",
+      "repository": "https://github.com/roquess/rust_supervisor",
+      "direct_external_process_guardian": false,
+      "cross_platform_default_fit": "no",
+      "useful_capabilities": [
+        "supervision_tree_concepts",
+        "restart_strategy_vocabulary",
+        "graceful_shutdown_callbacks"
+      ],
+      "blocking_evidence": "The child model is thread factory supervision rather than OS process supervision.",
+      "disposition": "do_not_adopt_as_runtime_v3_guardian"
+    },
+    {
+      "id": "rust-tokio-supervisor-0.1.4",
+      "source": "developerworks/rust-supervisor@66d6f691f5679d5253682473d50eb912ef003997",
+      "direct_external_process_guardian": false,
+      "cross_platform_default_fit": "no",
+      "useful_capabilities": [
+        "restart_budget_tracker",
+        "restart_limit_state",
+        "typed_control_commands",
+        "health_and_readiness_state",
+        "role_defaults",
+        "graceful_shutdown_model"
+      ],
+      "blocking_evidence": "The checked child runner builds a task factory and runs it with tokio::spawn(factory.build(ctx)); no direct tokio::process::Command guardian was found.",
+      "disposition": "try_wrapper_task_adoption_in_issue_5225"
+    },
+    {
+      "id": "launchd",
+      "source": "docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md",
+      "direct_external_process_guardian": true,
+      "cross_platform_default_fit": "no",
+      "useful_capabilities": [
+        "native_macos_process_ownership",
+        "native_macos_log_integration"
+      ],
+      "blocking_evidence": "macOS-only platform service.",
+      "disposition": "retain_future_platform_adapter_candidate"
+    }
+  ],
+  "selected_drop_in_replacement": null,
+  "recommended_follow_on": {
+    "needed": true,
+    "issue": 5225,
+    "url": "https://github.com/danielbaustin/agent-design-language/issues/5225",
+    "condition": "Horust fixed release remains blocked or fails requalification.",
+    "shape": "First test whether rust-tokio-supervisor can supervise a narrow wrapper task whose job is to own the runtime kernel as a tokio::process child; otherwise build the smallest ADL-owned Tokio process guardian shim using COTS crates for policy, telemetry, serialization, and configuration while preserving the existing external child contract."
+  },
+  "automatic_cutover": false
+}


### PR DESCRIPTION
Non-closing lifecycle PR: issue #5224 remains open.

## Summary
Issue #5224 evaluated guardian fallback candidates while Horust remains blocked
by the #5211 restart-budget defect. The execution produced a docs-only decision
packet and a machine-readable fallback matrix. No Runtime v2 files were
modified and no Runtime v3 default cutover was authorized.

The retained decision is:
- no newly reviewed COTS candidate is a drop-in cross-platform external
  guardian replacement
- #5225 is the routed follow-on
- #5225 should first test a `rust-tokio-supervisor` wrapper-task adoption path,
  where the supervised task owns `adl-runtime-kernel` as a `tokio::process`
  child
- if that wrapper path becomes a broad fork or disguised rewrite, #5225 should
  build the smallest ADL-owned Tokio process guardian shim instead

## Artifacts
- Tracked decision document: `docs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md`
- Tracked fallback matrix: `docs/architecture/runtime_v3_guardian_fallback_matrix.v1.json`
- Updated guardian overview: `docs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md`
- Updated cutover decision: `docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md`
- Updated cutover checklist: `docs/architecture/runtime_v3_cutover_checklist.v1.json`
- Routed follow-on issue: `https://github.com/danielbaustin/agent-design-language/issues/5225`

## Validation
- Validation commands and their purpose:
  - `jq empty docs/architecture/runtime_v3_guardian_fallback_matrix.v1.json`
    `Verified the fallback matrix parses as JSON.`
  - `jq empty docs/architecture/runtime_v3_cutover_checklist.v1.json`
    `Verified the cutover checklist still parses as JSON after adding #5224 and the guardian fallback gate.`
  - `git diff --check`
    `Verified the docs diff has no whitespace errors.`
  - `cargo info rust_supervisor`
    `Verified rust_supervisor 0.2.0 crate metadata and durable source links.`
  - `rg -n "JoinHandle|thread::spawn|ChildSpec|factory|tokio::process|std::process" <local rust_supervisor crate source>`
    `Verified the rust_supervisor source evidence used by the decision.`
  - `rg -n "tokio::process|std::process|Command|child_runner|TaskKind|RestartBudget|RestartLimit" <local rust-tokio-supervisor crate source>`
    `Verified the rust-tokio-supervisor source evidence used by the decision.`

  - `bash adl/tools/check_no_tracked_adl_issue_record_residue.sh`
    Verified no tracked local-only ADL issue-record residue remained staged for publication.
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.92/tasks/issue-5224__v0-92-runtime-v3-rustysd-fallback-guardian/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.92/tasks/issue-5224__v0-92-runtime-v3-rustysd-fallback-guardian/sor.md
- Idempotency-Key: v0-92-runtime-v3-guardian-evaluate-cots-guardian-fallbacks-docs-architecture-runtime-v3-guardian-fallback-decision-md-docs-architecture-runtime-v3-guardian-fallback-matrix-v1-json-docs-architecture-runtime-v3-guardian-and-soak-md-docs-architecture-runtime-v3-cutover-decision-md-docs-architecture-runtime-v3-cutover-checklist-v1-json-adl-v0-92-tasks-issue-5224-v0-92-runtime-v3-rustysd-fallback-guardian-sip-md-users-daniel-git-agent-design-language-adl-v0-92-tasks-issue-5224-v0-92-runtime-v3-rustysd-fallback-guardian-sor-md