### PR TITLE
[v0.91.7][runtime-v3][cutover] Add explicit Runtime v3 entrypoint switch

### DIFF
--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -23,6 +23,7 @@ mod run;
 pub(crate) mod run_artifacts;
 mod run_artifacts_types;
 mod runtime_v2_cmd;
+mod runtime_v3_cmd;
 mod scheduler_cmd;
 mod session_cmd;
 #[cfg(test)]
@@ -44,6 +45,7 @@ use process_cmd::real_process;
 use provider_cmd::real_provider;
 use run::{real_resume, run_workflow};
 use runtime_v2_cmd::real_runtime_v2;
+use runtime_v3_cmd::real_runtime_v3;
 use scheduler_cmd::real_scheduler;
 use session_cmd::real_session;
 use tooling_cmd::real_tooling;
@@ -194,6 +196,7 @@ fn dispatch_args(args: &[String]) -> Result<()> {
         Some("process") => real_process(&args[1..]),
         Some("provider") => real_provider(&args[1..]),
         Some("runtime-v2") => real_runtime_v2(&args[1..]),
+        Some("runtime-v3") => real_runtime_v3(&args[1..]),
         Some("scheduler") => real_scheduler(&args[1..]),
         Some("session") => real_session(&args[1..]),
         Some("pr") => real_pr(&args[1..]),
@@ -224,6 +227,7 @@ Usage:\n\
   adl-runtime instrument <graph|replay|replay-bundle|diff-plan|diff-trace|trace-schema|validate-trace-v1|provider-substrate|provider-substrate-schema> ...\n\
   adl-runtime learn export --format <jsonl|bundle-v1|trace-bundle-v2> ...\n\
   adl-runtime provider setup <family> [--model <provider_model_id>] [--out <dir>] [--force]\n\
+  adl-runtime runtime-v3 select [--runtime v2|v3] [--json]\n\
   adl-runtime keygen --out-dir <dir>\n\
   adl-runtime sign <adl.yaml> --key <private_key_path> [--key-id <id>] [--out <signed_file>]\n\
   adl-runtime verify <adl.yaml> [--key <public_key_path>]\n\
@@ -270,6 +274,7 @@ fn dispatch_runtime_args(args: &[String]) -> Result<()> {
         Some("learn") => real_learn(&args[1..]),
         Some("provider") => real_provider(&args[1..]),
         Some("runtime-v2") => real_runtime_v2(&args[1..]),
+        Some("runtime-v3") => real_runtime_v3(&args[1..]),
         Some("session") => Err(anyhow::anyhow!(
             "adl-runtime does not own polis/session coordination commands. Use adl session <status|claim|heartbeat|release>."
         )),
@@ -280,7 +285,7 @@ fn dispatch_runtime_args(args: &[String]) -> Result<()> {
             "adl-runtime does not own C-SDLC workflow commands. Use adl/tools/pr.sh run <issue> for issue work or adl-csdlc for C-SDLC compatibility surfaces."
         )),
         Some(other) => Err(anyhow::anyhow!(
-            "unknown adl-runtime command '{other}'. Expected run, resume, agent, artifact, scheduler, csm, demo, godel, identity, instrument, learn, provider, runtime-v2, keygen, sign, verify, help, or --version."
+            "unknown adl-runtime command '{other}'. Expected run, resume, agent, artifact, scheduler, csm, demo, godel, identity, instrument, learn, provider, runtime-v2, runtime-v3, keygen, sign, verify, help, or --version."
         )),
         None => Err(anyhow::anyhow!(
             "adl-runtime requires a command. Run `adl-runtime --help` for usage."
@@ -415,7 +420,7 @@ fn dispatch_review_args(args: &[String]) -> Result<()> {
         )),
         Some("run") | Some("resume") | Some("agent") | Some("artifact") | Some("csm")
         | Some("demo") | Some("godel") | Some("identity") | Some("instrument") | Some("learn")
-        | Some("provider") | Some("runtime-v2") | Some("keygen") | Some("sign")
+        | Some("provider") | Some("runtime-v2") | Some("runtime-v3") | Some("keygen") | Some("sign")
         | Some("verify") => Err(anyhow::anyhow!(
             "adl-review does not run ADL runtime commands. Use adl-runtime run <adl.yaml> for runtime workflows."
         )),

--- a/adl/src/cli/runtime_v3_cmd.rs
+++ b/adl/src/cli/runtime_v3_cmd.rs
@@ -1,0 +1,202 @@
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+
+const DEFAULT_RUNTIME: RuntimeSelection = RuntimeSelection::V2;
+const RUNTIME_V3_CONTROL_HOST: &str = "127.0.0.1";
+const RUNTIME_V3_CONTROL_PORT: u16 = 20_997;
+const RUNTIME_V3_KERNEL_BIN: &str = "adl-runtime-kernel";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum RuntimeSelection {
+    V2,
+    V3,
+}
+
+impl RuntimeSelection {
+    fn parse(value: &str, source: &str) -> Result<Self> {
+        match value {
+            "v2" | "runtime-v2" => Ok(Self::V2),
+            "v3" | "runtime-v3" => Ok(Self::V3),
+            other => Err(anyhow!(
+                "unsupported runtime selection '{other}' from {source}; expected v2, runtime-v2, v3, or runtime-v3"
+            )),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::V2 => "runtime-v2",
+            Self::V3 => "runtime-v3",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeV3SelectionReport {
+    schema: &'static str,
+    selected_runtime: &'static str,
+    default_runtime: &'static str,
+    selector_source: &'static str,
+    default_changed: bool,
+    selection_differs_from_default: bool,
+    runtime_v2_available: bool,
+    runtime_v3_available: bool,
+    runtime_v3_control_host: &'static str,
+    runtime_v3_control_port: u16,
+    runtime_v3_control_endpoint: String,
+    runtime_v3_kernel_command: Vec<&'static str>,
+    compatibility_boundary: &'static str,
+}
+
+pub(crate) fn real_runtime_v3(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("--help" | "-h" | "help") => {
+            println!("{}", runtime_v3_usage());
+            Ok(())
+        }
+        Some("select") => select_runtime(&args[1..]),
+        None => select_runtime(&[]),
+        Some(other) => Err(anyhow!(
+            "unknown runtime-v3 command '{other}'. Expected select, help, or --help."
+        )),
+    }
+}
+
+fn select_runtime(args: &[String]) -> Result<()> {
+    let mut explicit_runtime: Option<RuntimeSelection> = None;
+    let mut json = false;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--runtime" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!("runtime-v3 select requires --runtime <v2|v3>"));
+                };
+                explicit_runtime = Some(RuntimeSelection::parse(value, "--runtime")?);
+                i += 1;
+            }
+            "--json" => {
+                json = true;
+            }
+            "--help" | "-h" => {
+                println!("{}", runtime_v3_usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!("unknown arg for runtime-v3 select: {other}"));
+            }
+        }
+        i += 1;
+    }
+
+    let (selected, source) = match explicit_runtime {
+        Some(selection) => (selection, "--runtime"),
+        None => match std::env::var("ADL_RUNTIME_SELECTION") {
+            Ok(value) if !value.trim().is_empty() => (
+                RuntimeSelection::parse(value.trim(), "ADL_RUNTIME_SELECTION")?,
+                "ADL_RUNTIME_SELECTION",
+            ),
+            _ => (DEFAULT_RUNTIME, "default"),
+        },
+    };
+
+    let report = selection_report(selected, source);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("SELECTED_RUNTIME={}", report.selected_runtime);
+        println!("DEFAULT_RUNTIME={}", report.default_runtime);
+        println!("SELECTOR_SOURCE={}", report.selector_source);
+        println!("DEFAULT_CHANGED={}", report.default_changed);
+        println!(
+            "SELECTION_DIFFERS_FROM_DEFAULT={}",
+            report.selection_differs_from_default
+        );
+        println!(
+            "RUNTIME_V3_CONTROL_ENDPOINT={}",
+            report.runtime_v3_control_endpoint
+        );
+        println!(
+            "RUNTIME_V3_KERNEL_COMMAND={}",
+            report.runtime_v3_kernel_command.join(" ")
+        );
+    }
+    Ok(())
+}
+
+fn selection_report(
+    selected: RuntimeSelection,
+    selector_source: &'static str,
+) -> RuntimeV3SelectionReport {
+    RuntimeV3SelectionReport {
+        schema: "adl.runtime_v3.entrypoint_selection.v1",
+        selected_runtime: selected.label(),
+        default_runtime: DEFAULT_RUNTIME.label(),
+        selector_source,
+        default_changed: false,
+        selection_differs_from_default: selected != DEFAULT_RUNTIME,
+        runtime_v2_available: true,
+        runtime_v3_available: true,
+        runtime_v3_control_host: RUNTIME_V3_CONTROL_HOST,
+        runtime_v3_control_port: RUNTIME_V3_CONTROL_PORT,
+        runtime_v3_control_endpoint: format!(
+            "http://{RUNTIME_V3_CONTROL_HOST}:{RUNTIME_V3_CONTROL_PORT}"
+        ),
+        runtime_v3_kernel_command: vec![RUNTIME_V3_KERNEL_BIN, "serve"],
+        compatibility_boundary:
+            "explicit selector only; Runtime v2 remains the default until the cutover gate changes it",
+    }
+}
+
+pub(crate) fn runtime_v3_usage() -> &'static str {
+    "adl runtime-v3 - explicit Runtime v3 entrypoint selection\n\n\
+Usage:\n\
+  adl runtime-v3 select [--runtime v2|v3] [--json]\n\
+  adl runtime-v3 --help\n\n\
+Environment:\n\
+  ADL_RUNTIME_SELECTION=v3 selects Runtime v3 when --runtime is omitted.\n\n\
+Notes:\n\
+  Runtime v2 remains the default unless --runtime v3 or ADL_RUNTIME_SELECTION=v3 is supplied.\n\
+  Runtime v3 uses the local control API endpoint http://127.0.0.1:20997.\n\
+  Launch the Runtime v3 kernel with: adl-runtime-kernel serve"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_selection_keeps_runtime_v2() {
+        let report = selection_report(RuntimeSelection::V2, "default");
+        assert_eq!(report.selected_runtime, "runtime-v2");
+        assert_eq!(report.default_runtime, "runtime-v2");
+        assert!(!report.default_changed);
+        assert!(!report.selection_differs_from_default);
+        assert_eq!(report.runtime_v3_control_port, 20_997);
+    }
+
+    #[test]
+    fn explicit_v3_selection_reports_cutover_boundary() {
+        let report = selection_report(RuntimeSelection::V3, "--runtime");
+        assert_eq!(report.selected_runtime, "runtime-v3");
+        assert_eq!(report.default_runtime, "runtime-v2");
+        assert!(!report.default_changed);
+        assert!(report.selection_differs_from_default);
+        assert!(report.runtime_v2_available);
+        assert!(report.runtime_v3_available);
+        assert_eq!(report.runtime_v3_control_endpoint, "http://127.0.0.1:20997");
+        assert_eq!(
+            report.runtime_v3_kernel_command,
+            ["adl-runtime-kernel", "serve"]
+        );
+    }
+
+    #[test]
+    fn unknown_runtime_selection_fails_closed() {
+        let err = RuntimeSelection::parse("v4", "--runtime").expect_err("v4 must fail closed");
+        assert!(err
+            .to_string()
+            .contains("unsupported runtime selection 'v4'"));
+    }
+}

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -170,6 +170,7 @@ fn top_level_dispatch_routes_safe_help_branches_without_workflow_execution() {
     for command in [
         "provider",
         "runtime-v2",
+        "runtime-v3",
         "keygen",
         "tooling",
         "resume",
@@ -226,11 +227,60 @@ fn runtime_dispatch_exposes_help_and_version_without_csdlc_dispatch() {
 
     let usage = runtime_usage();
     assert!(usage.contains("adl-runtime run <adl.yaml>"));
+    assert!(usage.contains("adl-runtime runtime-v3 select [--runtime v2|v3] [--json]"));
     assert!(
         usage.contains("adl-runtime scheduler plan --input <bundle.json> [--out <path>] [--json]")
     );
     assert!(usage.contains("adl <adl.yaml> remains available as a compatibility shortcut"));
     assert!(usage.contains("C-SDLC issue work belongs to adl/tools/pr.sh run <issue>"));
+}
+
+#[test]
+fn runtime_v3_selection_dispatch_is_explicit_and_reversible() {
+    dispatch_args(&["runtime-v3".to_string(), "--help".to_string()])
+        .expect("runtime-v3 help should succeed");
+    dispatch_args(&[
+        "runtime-v3".to_string(),
+        "select".to_string(),
+        "--runtime".to_string(),
+        "v3".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("explicit runtime-v3 selection should succeed");
+    dispatch_args(&[
+        "runtime-v3".to_string(),
+        "select".to_string(),
+        "--runtime".to_string(),
+        "v2".to_string(),
+    ])
+    .expect("runtime-v2 fallback selection should remain available");
+
+    let err = dispatch_args(&[
+        "runtime-v3".to_string(),
+        "select".to_string(),
+        "--runtime".to_string(),
+        "v4".to_string(),
+    ])
+    .expect_err("unknown runtime selection should fail closed");
+    assert!(err
+        .to_string()
+        .contains("unsupported runtime selection 'v4'"));
+}
+
+#[test]
+fn runtime_v3_selection_routes_through_runtime_compatibility_binary() {
+    let _env = EnvGuard::set("ADL_RUNTIME_SELECTION", "v3");
+
+    dispatch_runtime_args(&["runtime-v3".to_string(), "select".to_string()])
+        .expect("runtime compatibility binary should route runtime-v3 selection");
+    dispatch_runtime_args(&[
+        "runtime-v3".to_string(),
+        "select".to_string(),
+        "--runtime".to_string(),
+        "v2".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("--runtime should override ADL_RUNTIME_SELECTION");
 }
 
 #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -55,6 +55,7 @@ pub fn usage() -> &'static str {
   adl runtime-v2 constructability-anchor-validator [--input <packet.json>] [--out <path>]
   adl runtime-v2 loop-runtime [--out <path>]
   adl runtime-v2 godel-agent-runtime [--agents <count>] [--out <path>]
+  adl runtime-v3 select [--runtime v2|v3] [--json]
   adl scheduler plan --input <bundle.json> [--out <path>] [--json]
   adl provider setup <family> [--model <provider_model_id>] [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
@@ -146,6 +147,7 @@ Examples:
   adl runtime-v2 constructability-anchor-validator --input artifacts/v0917/constructability-candidate.json --out artifacts/v0917/constructability-decision.json
   adl runtime-v2 loop-runtime --out artifacts/v0917/loop-runtime.json
   adl runtime-v2 godel-agent-runtime --agents 10 --out artifacts/v0917/godel-agent-runtime.json
+  adl runtime-v3 select --runtime v3 --json
   adl scheduler plan --input adl/tests/fixtures/scheduler/economics_inputs_v1.json --out artifacts/examples/scheduler-plan.json
   adl provider setup chatgpt
   adl provider setup claude

--- a/docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md
+++ b/docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md
@@ -1,0 +1,57 @@
+# Runtime v3 Entrypoint Switch
+
+## Status
+
+As of v0.91.7, Runtime v3 is selectable through an explicit CLI compatibility
+boundary. Runtime v2 remains the default runtime until the cutover proof gate
+authorizes a default switch.
+
+## Covered Entrypoints
+
+- `adl runtime-v3 select [--runtime v2|v3] [--json]`
+- `adl-runtime runtime-v3 select [--runtime v2|v3] [--json]`
+
+These entrypoints report the selected runtime and the Runtime v3 control API
+policy without launching a daemon or changing global defaults.
+
+The selector reports `DEFAULT_CHANGED=false` for both Runtime v2 and Runtime v3
+selection. `SELECTION_DIFFERS_FROM_DEFAULT=true` is the reversible selection
+signal for explicit Runtime v3 use while Runtime v2 remains the default.
+
+## Selection Rules
+
+- No selector: Runtime v2 remains selected.
+- `--runtime v3`: Runtime v3 is selected explicitly.
+- `--runtime v2`: Runtime v2 fallback is selected explicitly.
+- `ADL_RUNTIME_SELECTION=v3`: Runtime v3 is selected when `--runtime` is
+  omitted.
+- Unknown values fail closed.
+
+`--runtime` takes precedence over `ADL_RUNTIME_SELECTION`.
+
+## Runtime v3 Control Policy
+
+Runtime v3 uses the local control API endpoint:
+
+```text
+http://127.0.0.1:20997
+```
+
+The Runtime v3 kernel launch command reported by the selector is:
+
+```text
+adl-runtime-kernel serve
+```
+
+## Non-Covered Surfaces
+
+This issue does not:
+
+- make Runtime v3 the default;
+- delete or decommission Runtime v2;
+- migrate every Runtime v2 demo command;
+- introduce a custom supervisor;
+- start the Runtime v3 daemon implicitly.
+
+Runtime v2 decommission remains gated by the aggregate Runtime v3 cutover proof
+and an explicit default-switch decision.


### PR DESCRIPTION
Closes #5219

## Summary
Implemented an explicit Runtime v3 selector surface without changing the default runtime. Runtime v2 remains the default unless `--runtime v3` or `ADL_RUNTIME_SELECTION=v3` is supplied, and unknown runtime selections fail closed.

## Artifacts
- Runtime v3 selector implementation: `adl/src/cli/runtime_v3_cmd.rs`
- CLI dispatch wiring: `adl/src/cli/mod.rs`, `adl/src/cli/usage.rs`, `adl/src/cli/tests.rs`
- Architecture note: `docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    `Verified formatting for the touched Rust CLI files.`
  - `cargo check --manifest-path adl/Cargo.toml`
    `Verified compile correctness across the ADL crate after adding Runtime v3 dispatch.`
  - `cargo test --manifest-path adl/Cargo.toml runtime_v3 -- --nocapture`
    `Verified focused Runtime v3 selector behavior, compatibility routing, and fail-closed unknown-runtime handling.`
  - `./adl/target/debug/adl runtime-v3 select --runtime v3 --json`
    `Verified operator-visible JSON selection output from the compiled top-level binary.`
  - `./adl/target/debug/adl-runtime runtime-v3 select --runtime v2`
    `Verified Runtime v2 fallback through the compatibility binary.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5219__v0-91-7-runtime-v3-cutover-add-explicit-runtime-v3-entrypoint-switch/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5219__v0-91-7-runtime-v3-cutover-add-explicit-runtime-v3-entrypoint-switch/sor.md
- Idempotency-Key: v0-91-7-runtime-v3-cutover-add-explicit-runtime-v3-entrypoint-switch-adl-src-cli-mod-rs-adl-src-cli-tests-rs-adl-src-cli-usage-rs-adl-src-cli-runtime-v3-cmd-rs-docs-architecture-runtime-v3-entrypoint-switch-md-adl-v0-91-7-tasks-issue-5219-v0-91-7-runtime-v3-cutover-add-explicit-runtime-v3-entrypoint-switch-sip-md-adl-v0-91-7-tasks-issue-5219-v0-91-7-runtime-v3-cutover-add-explicit-runtime-v3-entrypoint-switch-sor-md