### PR TITLE
[v0.91.7][tools][validation] Teach PR-fast validation lane about adl-runtime crate surfaces

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -112,6 +112,7 @@ changed_rows() {
 is_relevant_fast_lane_surface() {
   local path="$1"
   case "$path" in
+    adl-runtime/src/*.rs|adl-runtime/tests/*.rs|adl-runtime/examples/*.rs|adl-runtime/Cargo.toml|adl-runtime/Cargo.lock|\
     adl/src/*.rs|adl/tests/*.rs|adl/build.rs|adl/Cargo.toml|adl/Cargo.lock|\
     docs/default_workflow.md|\
     docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
@@ -225,6 +226,10 @@ is_broad_rust_surface() {
 filter_token_for_path() {
   local path="$1"
   case "$path" in
+    adl-runtime/Cargo.toml|adl-runtime/Cargo.lock|adl-runtime/src/*.rs|adl-runtime/tests/*.rs|adl-runtime/examples/*.rs)
+      printf 'adl_runtime'
+      return 0
+      ;;
     adl/Cargo.toml|adl/Cargo.lock)
       printf 'manifest_support'
       return 0
@@ -474,6 +479,10 @@ filter_token_for_path() {
 family_token_for_path() {
   local path="$1"
   case "$path" in
+    adl-runtime/Cargo.toml|adl-runtime/Cargo.lock|adl-runtime/src/*.rs|adl-runtime/tests/*.rs|adl-runtime/examples/*.rs)
+      printf 'adl_runtime'
+      return 0
+      ;;
     adl/Cargo.toml|adl/Cargo.lock|\
     adl/src/bin/adl_pr_*.rs|\
     adl/src/cli/pr_cmd.rs|\
@@ -565,6 +574,7 @@ TOKEN_MAP = {
     "github_release_": 'test(/^cli::tooling_cmd::github_release::/)',
     "long_lived_agent": 'test(/^long_lived_agent::/)',
     "manifest_support": 'test(/^cli::pr_cmd::github::/) or test(/^cli::pr_cmd::github_client::/) or test(/^cli::tooling_cmd::github_release::/) or test(/^long_lived_agent::/)',
+    "adl_runtime": 'all()',
 }
 
 clauses = []
@@ -614,6 +624,9 @@ saw_tokio_bootstrap_related_surface=false
 saw_process_status_related_surface=false
 saw_scheduler_related_surface=false
 saw_csdlc_binary_taxonomy_surface=false
+saw_adl_crate_surface=false
+saw_adl_runtime_crate_surface=false
+saw_other_relevant_fast_lane_surface=false
 
 declare -a tokens=()
 declare -a family_tokens=()
@@ -661,6 +674,17 @@ while IFS= read -r path; do
   if ! is_relevant_fast_lane_surface "$path"; then
     continue
   fi
+  case "$path" in
+    adl-runtime/*)
+      saw_adl_runtime_crate_surface=true
+      ;;
+    adl/*)
+      saw_adl_crate_surface=true
+      ;;
+    *)
+      saw_other_relevant_fast_lane_surface=true
+      ;;
+  esac
   if [ "$path" = "docs/default_workflow.md" ] && [ "$saw_csdlc_binary_taxonomy_surface" = true ]; then
     continue
   fi
@@ -717,6 +741,9 @@ EOF
 
 if [ "$classification_locked" = true ]; then
   :
+elif [ "$saw_adl_runtime_crate_surface" = true ] && { [ "$saw_adl_crate_surface" = true ] || [ "$saw_other_relevant_fast_lane_surface" = true ]; }; then
+  mode="full"
+  reason="mixed_adl_runtime_with_other_fast_lane_surfaces_requires_full_nextest"
 elif is_manifest_only_rust_wave; then
   mode="focused"
   reason="manifest_only_rust_wave_runs_focused_nextest"
@@ -821,7 +848,13 @@ if [ "$mode" = "full" ] && [ "${ADL_PR_FAST_ALLOW_FULL_NEXTEST:-0}" != "1" ]; th
   exit 3
 fi
 
-cd "$ROOT_DIR/adl"
+selected_crate_dir="$ROOT_DIR/adl"
+if [ "$filter_tokens" = "adl_runtime" ]; then
+  selected_crate_dir="$ROOT_DIR/adl-runtime"
+  cd "$selected_crate_dir"
+else
+  cd "$selected_crate_dir"
+fi
 
 warm_cache_output_path="${ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT:-}"
 warm_cache_temp_output=""
@@ -838,7 +871,7 @@ run_warm_cache() {
     warm_cache_output_path="$warm_cache_temp_output"
   fi
   ADL_RUST_WARM_CACHE_SOURCE_TARGET="${ADL_PR_FAST_TEST_WARM_SOURCE_TARGET:-}" \
-  ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$ROOT_DIR/adl/target}" \
+  ADL_RUST_WARM_CACHE_DEST_TARGET="${CARGO_TARGET_DIR:-$selected_crate_dir/target}" \
   ADL_RUST_WARM_CACHE_OUTPUT="$warm_cache_output_path" \
     bash "$ROOT_DIR/adl/tools/rust_validation_warm_cache.sh"
 }

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -46,6 +46,42 @@ assert plan["mode"] == "focused"
 assert plan["filter_expression"] == "test(contract_schema)"
 PY
 
+focused_adl_runtime="$TMP/focused_adl_runtime.txt"
+cat >"$focused_adl_runtime" <<'EOF'
+M	adl-runtime/Cargo.toml
+M	adl-runtime/Cargo.lock
+M	adl-runtime/src/weather.rs
+EOF
+focused_adl_runtime_output="$(bash "$SCRIPT" --changed-files "$focused_adl_runtime" --print-plan)"
+assert_has "$focused_adl_runtime_output" "mode=focused"
+assert_has "$focused_adl_runtime_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$focused_adl_runtime_output" "filter_tokens=adl_runtime"
+assert_has "$focused_adl_runtime_output" "filter_expression=all()"
+
+focused_adl_runtime_example="$TMP/focused_adl_runtime_example.txt"
+printf 'M\tadl-runtime/examples/observability_vector_proof.rs\n' >"$focused_adl_runtime_example"
+focused_adl_runtime_example_output="$(bash "$SCRIPT" --changed-files "$focused_adl_runtime_example" --print-plan)"
+assert_has "$focused_adl_runtime_example_output" "mode=focused"
+assert_has "$focused_adl_runtime_example_output" "filter_tokens=adl_runtime"
+
+mixed_adl_runtime="$TMP/mixed_adl_runtime.txt"
+cat >"$mixed_adl_runtime" <<'EOF'
+M	adl-runtime/src/weather.rs
+M	adl/src/cli/mod.rs
+EOF
+mixed_adl_runtime_output="$(bash "$SCRIPT" --changed-files "$mixed_adl_runtime" --print-plan)"
+assert_has "$mixed_adl_runtime_output" "mode=full"
+assert_has "$mixed_adl_runtime_output" "reason=mixed_adl_runtime_with_other_fast_lane_surfaces_requires_full_nextest"
+
+mixed_adl_runtime_docs="$TMP/mixed_adl_runtime_docs.txt"
+cat >"$mixed_adl_runtime_docs" <<'EOF'
+M	adl-runtime/src/weather.rs
+M	docs/default_workflow.md
+EOF
+mixed_adl_runtime_docs_output="$(bash "$SCRIPT" --changed-files "$mixed_adl_runtime_docs" --print-plan)"
+assert_has "$mixed_adl_runtime_docs_output" "mode=full"
+assert_has "$mixed_adl_runtime_docs_output" "reason=mixed_adl_runtime_with_other_fast_lane_surfaces_requires_full_nextest"
+
 focused_control_plane="$TMP/focused_control_plane.txt"
 printf 'M\tdocs/default_workflow.md\n' >"$focused_control_plane"
 focused_control_plane_output="$(bash "$SCRIPT" --changed-files "$focused_control_plane" --print-plan)"

--- a/adl/tools/test_select_validation_lanes.sh
+++ b/adl/tools/test_select_validation_lanes.sh
@@ -50,6 +50,25 @@ assert_has "$TMP/focused.out" "mode=focused"
 assert_has "$TMP/focused.out" "filter_expression=test(contract_schema)"
 assert_not_has "$TMP/focused.out" "runtime_owner_lane status=selected"
 
+focused_adl_runtime="$TMP/focused-adl-runtime.txt"
+cat >"$focused_adl_runtime" <<'EOF'
+M	adl-runtime/Cargo.toml
+M	adl-runtime/Cargo.lock
+M	adl-runtime/src/weather.rs
+EOF
+bash "$SCRIPT" --changed-files "$focused_adl_runtime" >"$TMP/focused-adl-runtime.out"
+assert_has "$TMP/focused-adl-runtime.out" "rust_pr_fast status=selected"
+assert_has "$TMP/focused-adl-runtime.out" "runtime_owner_lane status=selected"
+assert_has "$TMP/focused-adl-runtime.out" "mode=focused"
+assert_has "$TMP/focused-adl-runtime.out" "filter_expression=all()"
+
+focused_adl_runtime_example="$TMP/focused-adl-runtime-example.txt"
+printf 'M\tadl-runtime/examples/observability_vector_proof.rs\n' >"$focused_adl_runtime_example"
+bash "$SCRIPT" --changed-files "$focused_adl_runtime_example" >"$TMP/focused-adl-runtime-example.out"
+assert_has "$TMP/focused-adl-runtime-example.out" "rust_pr_fast status=selected"
+assert_has "$TMP/focused-adl-runtime-example.out" "runtime_owner_lane status=selected"
+assert_has "$TMP/focused-adl-runtime-example.out" "mode=focused"
+
 runtime_kernel="$TMP/runtime-kernel.txt"
 cat >"$runtime_kernel" <<'EOF'
 A	adl-runtime-kernel/src/lib.rs


### PR DESCRIPTION
Closes #5229

## Summary
Implemented the narrow #5229 validation-lane unblocker. `run_pr_fast_test_lane.sh`
now recognizes pure `adl-runtime` crate changes, plans them as a focused
`adl_runtime` lane, runs nextest from the `adl-runtime` crate, and fails closed
when `adl-runtime` changes are mixed with other relevant PR-fast surfaces. This
unblocks Runtime v3 cutover children such as #5222 without widening runtime
feature scope.

## Artifacts
- Updated `adl/tools/run_pr_fast_test_lane.sh`.
- Updated `adl/tools/test_run_pr_fast_test_lane.sh`.
- Updated `adl/tools/test_select_validation_lanes.sh`.
- Updated `.adl/v0.91.7/tasks/issue-5229__v0-91-7-tools-validation-adl-runtime-pr-fast-lane/srp.md`.
- Updated `.adl/v0.91.7/tasks/issue-5229__v0-91-7-tools-validation-adl-runtime-pr-fast-lane/sor.md`.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    `Verified the direct PR-fast classifier, focused tokens, mixed-surface fail-closed behavior, and JSON planning contract.`
  - `bash adl/tools/test_select_validation_lanes.sh`
    `Verified the validation-lane selector reports selected Rust PR-fast coverage for pure adl-runtime changes and preserves runtime owner lane routing.`
  - `ADL_PR_FAST_TEST_WARM_CACHE_OUTPUT=.adl/pr-fast-adl-runtime-warm-cache-3.json bash adl/tools/run_pr_fast_test_lane.sh --changed-files changed-files-fixture`
    `Verified the actual PR-fast runner executes `cargo nextest` against the adl-runtime crate; 83 tests passed.`
- Results:
  - `PASS test_run_pr_fast_test_lane`
  - `PASS test_select_validation_lanes`
  - `PASS adl-runtime nextest run: 83 tests passed, 0 skipped`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5229__v0-91-7-tools-validation-adl-runtime-pr-fast-lane/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5229__v0-91-7-tools-validation-adl-runtime-pr-fast-lane/sor.md
- Idempotency-Key: v0-91-7-tools-validation-teach-pr-fast-validation-lane-about-adl-runtime-crate-surfaces-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-tools-test-select-validation-lanes-sh-adl-v0-91-7-tasks-issue-5229-v0-91-7-tools-validation-adl-runtime-pr-fast-lane-sip-md-adl-v0-91-7-tasks-issue-5229-v0-91-7-tools-validation-adl-runtime-pr-fast-lane-sor-md