### PR TITLE
[v0.91.7][WP-07][soak][runtime] Stop CSM safe-fail storms on healthy partial checkpoints

### DIFF
--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1831,7 +1831,7 @@ fn acquire_lease(
                 .unwrap_or_else(|| "operator stop requested".to_string());
             let status = stopped_status(loaded, reason.clone());
             write_status(loaded, &status)?;
-            write_continuity_restore_artifacts(
+            let _ = write_continuity_restore_artifacts(
                 loaded,
                 &status,
                 "stop_requested_during_activation",
@@ -2791,6 +2791,15 @@ fn persist_status(
     status: &StatusRecord,
     checkpoint_reason: &str,
 ) -> Result<()> {
+    let _ = persist_status_with_retention(loaded, status, checkpoint_reason)?;
+    Ok(())
+}
+
+fn persist_status_with_retention(
+    loaded: &LoadedAgentSpec,
+    status: &StatusRecord,
+    checkpoint_reason: &str,
+) -> Result<bool> {
     write_status(loaded, status)?;
     write_continuity_restore_artifacts(loaded, status, checkpoint_reason)
 }
@@ -3354,14 +3363,14 @@ fn safe_fail_trigger_model() -> Value {
         "schema": "adl.csm.safe_fail_trigger_model.v1",
         "supported_triggers": [
             "graceful_stop",
-            "daemon_partial_checkpoint",
+            "daemon_partial_checkpoint_degraded",
             "daemon_child_failed",
             "bounded_test_supervisor_failure",
             "restart_backoff",
             "daemon_heartbeat"
         ],
         "observability_exporter_failure_policy": "recorded_in_observability_status_when_exporter_reports_failure",
-        "checkpoint_failure_policy": "best_effort_fallback_refs_if_safe_fail_writer_cannot_complete",
+        "checkpoint_failure_policy": "ordinary_partial_checkpoints_do_not_emit_safe_fail; degraded_or_failed_partial_checkpoints_emit_safe_fail_with_fallback_refs",
         "unclaimed_triggers": [
             "kill_9",
             "host_power_loss_before_last_checkpoint_flush",
@@ -4357,7 +4366,19 @@ fn sleep_with_partial_checkpoints(
             current.state = AgentStatusState::Failed;
             current.last_error = Some(error);
         }
-        persist_status(loaded, &current, "daemon_partial_checkpoint")?;
+        let checkpoint_retained =
+            match persist_status_with_retention(loaded, &current, "daemon_partial_checkpoint") {
+                Ok(retained) => retained,
+                Err(err) => {
+                    emit_storage_degraded_event(
+                        loaded,
+                        "continuity_checkpoint_write",
+                        "daemon_partial_checkpoint",
+                        &err,
+                    );
+                    false
+                }
+            };
         *daemon_status = write_daemon_status(
             runtime_context,
             loaded,
@@ -4382,7 +4403,8 @@ fn sleep_with_partial_checkpoints(
                 "checkpoint_reason": "daemon_partial_checkpoint",
                 "checkpoint_ref": "continuity_checkpoint.json",
                 "status_ref": "status.json",
-                "trigger": sleep.event
+                "trigger": sleep.event,
+                "checkpoint_retained": checkpoint_retained
             }),
         )?;
         let agent_checkpoint_request = observe_agent_checkpoint_request(
@@ -4391,24 +4413,27 @@ fn sleep_with_partial_checkpoints(
             sleep.restart_count,
             last_checkpoint_at,
         )?;
-        let _ = record_safe_fail_event(
-            runtime_context,
-            loaded,
-            SafeFailRecord {
-                status: &current,
-                trigger: "daemon_partial_checkpoint",
-                restart_count: sleep.restart_count,
-                bounded_test_restart_limit: sleep.bounded_test_restart_limit,
-                last_child_exit: sleep.last_child_exit.clone(),
-                details: json!({
-                    "checkpoint_reason": "daemon_partial_checkpoint",
-                    "trigger": sleep.event,
-                    "checkpoint_ref": "continuity_checkpoint.json",
-                    "status_ref": "status.json",
-                    "agent_checkpoint_request": agent_checkpoint_request
-                }),
-            },
-        )?;
+        if sleep.recoverable_error.is_some() || !checkpoint_retained {
+            let _ = record_safe_fail_event(
+                runtime_context,
+                loaded,
+                SafeFailRecord {
+                    status: &current,
+                    trigger: "daemon_partial_checkpoint_degraded",
+                    restart_count: sleep.restart_count,
+                    bounded_test_restart_limit: sleep.bounded_test_restart_limit,
+                    last_child_exit: sleep.last_child_exit.clone(),
+                    details: json!({
+                        "checkpoint_reason": "daemon_partial_checkpoint",
+                        "trigger": sleep.event,
+                        "checkpoint_ref": "continuity_checkpoint.json",
+                        "status_ref": "status.json",
+                        "checkpoint_retained": checkpoint_retained,
+                        "agent_checkpoint_request": agent_checkpoint_request
+                    }),
+                },
+            )?;
+        }
         return Ok(false);
     }
 
@@ -4424,7 +4449,19 @@ fn sleep_with_partial_checkpoints(
             current.state = AgentStatusState::Failed;
             current.last_error = Some(error);
         }
-        persist_status(loaded, &current, "daemon_partial_checkpoint")?;
+        let checkpoint_retained =
+            match persist_status_with_retention(loaded, &current, "daemon_partial_checkpoint") {
+                Ok(retained) => retained,
+                Err(err) => {
+                    emit_storage_degraded_event(
+                        loaded,
+                        "continuity_checkpoint_write",
+                        "daemon_partial_checkpoint",
+                        &err,
+                    );
+                    false
+                }
+            };
         let next_backoff_secs = if sleep.event == "restart_backoff" {
             remaining
         } else {
@@ -4455,7 +4492,8 @@ fn sleep_with_partial_checkpoints(
                 "checkpoint_ref": "continuity_checkpoint.json",
                 "status_ref": "status.json",
                 "trigger": sleep.event,
-                "remaining_sleep_secs": remaining
+                "remaining_sleep_secs": remaining,
+                "checkpoint_retained": checkpoint_retained
             }),
         )?;
         let agent_checkpoint_request = observe_agent_checkpoint_request(
@@ -4464,25 +4502,28 @@ fn sleep_with_partial_checkpoints(
             sleep.restart_count,
             last_checkpoint_at,
         )?;
-        let _ = record_safe_fail_event(
-            runtime_context,
-            loaded,
-            SafeFailRecord {
-                status: &current,
-                trigger: "daemon_partial_checkpoint",
-                restart_count: sleep.restart_count,
-                bounded_test_restart_limit: sleep.bounded_test_restart_limit,
-                last_child_exit: sleep.last_child_exit.clone(),
-                details: json!({
-                    "checkpoint_reason": "daemon_partial_checkpoint",
-                    "trigger": sleep.event,
-                    "remaining_sleep_secs": remaining,
-                    "checkpoint_ref": "continuity_checkpoint.json",
-                    "status_ref": "status.json",
-                    "agent_checkpoint_request": agent_checkpoint_request
-                }),
-            },
-        )?;
+        if sleep.recoverable_error.is_some() || !checkpoint_retained {
+            let _ = record_safe_fail_event(
+                runtime_context,
+                loaded,
+                SafeFailRecord {
+                    status: &current,
+                    trigger: "daemon_partial_checkpoint_degraded",
+                    restart_count: sleep.restart_count,
+                    bounded_test_restart_limit: sleep.bounded_test_restart_limit,
+                    last_child_exit: sleep.last_child_exit.clone(),
+                    details: json!({
+                        "checkpoint_reason": "daemon_partial_checkpoint",
+                        "trigger": sleep.event,
+                        "remaining_sleep_secs": remaining,
+                        "checkpoint_ref": "continuity_checkpoint.json",
+                        "status_ref": "status.json",
+                        "checkpoint_retained": checkpoint_retained,
+                        "agent_checkpoint_request": agent_checkpoint_request
+                    }),
+                },
+            )?;
+        }
         if read_stop(loaded)?.is_some() {
             stop_observed = true;
             emit_daemon_event(
@@ -4983,7 +5024,7 @@ fn write_continuity_restore_artifacts(
     loaded: &LoadedAgentSpec,
     status: &StatusRecord,
     checkpoint_reason: &str,
-) -> Result<()> {
+) -> Result<bool> {
     let continuity: Value = read_json_required(&continuity_path(loaded))?;
     let ledger = ledger_cursor(loaded)?;
     let status_cycle_number = status
@@ -5076,7 +5117,7 @@ fn write_continuity_restore_artifacts(
             checkpoint_reason,
             &anyhow!("low disk preflight blocked Godel snapshot chain advancement"),
         );
-        return Ok(());
+        return Ok(false);
     }
 
     let godel_snapshot_diff = write_checkpoint_snapshot_diff(
@@ -5123,7 +5164,7 @@ fn write_continuity_restore_artifacts(
         ]
     });
     write_json_pretty(&replay_manifest_path, &replay_manifest)?;
-    Ok(())
+    Ok(true)
 }
 
 fn update_memory_index(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<()> {

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -2359,9 +2359,10 @@ fn continuity_checkpoint_low_disk_does_not_advance_godel_chain() {
         None,
     );
 
-    write_continuity_restore_artifacts(&loaded, &status, "low_disk_checkpoint")
+    let retained = write_continuity_restore_artifacts(&loaded, &status, "low_disk_checkpoint")
         .expect("low disk degrades without advancing chain");
 
+    assert!(!retained);
     assert!(!root.join("state/godel_snapshots").exists());
     assert!(root
         .join("state/csm_low_disk_recovery_manifest.json")
@@ -2623,6 +2624,56 @@ fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
 
     assert!(!stop_observed);
     assert_eq!(daemon_status.next_backoff_secs, 0);
+}
+
+#[test]
+fn daemon_healthy_partial_checkpoint_does_not_emit_safe_fail_bundle() {
+    let root = temp_dir("daemon-healthy-partial-no-safe-fail");
+    let spec = write_spec(&root);
+    let loaded = load_spec(&spec).expect("load spec");
+    ensure_state_root(&loaded).expect("state root");
+    let runtime_context = CsmRuntimeContext::new(&loaded).expect("csm runtime context");
+    let mut daemon_status = write_daemon_status(
+        &runtime_context,
+        &loaded,
+        DaemonStatusInput {
+            state: "running",
+            bounded_test_mode: true,
+            restart_count: 0,
+            bounded_test_restart_limit: Some(1),
+            checkpoint_interval_secs: 1,
+            last_event: "daemon_started",
+            last_child_exit: None,
+            next_backoff_secs: 0,
+        },
+    )
+    .expect("daemon status");
+
+    let stop_observed = sleep_with_partial_checkpoints(
+        &runtime_context,
+        &loaded,
+        &mut daemon_status,
+        PartialCheckpointSleep {
+            total_sleep_secs: 0,
+            checkpoint_interval_secs: 1,
+            restart_count: 0,
+            bounded_test_restart_limit: Some(1),
+            last_child_exit: None,
+            recoverable_error: None,
+            event: "daemon_heartbeat",
+            no_sleep: true,
+        },
+    )
+    .expect("healthy partial checkpoint");
+
+    assert!(!stop_observed);
+    assert!(continuity_checkpoint_path(&loaded).exists());
+    assert!(status_path(&loaded).exists());
+    assert!(!safe_fail_bundle_path(&loaded).exists());
+    assert!(!safe_fail_artifacts_dir(&loaded).exists());
+    let operator_events =
+        fs::read_to_string(operator_events_path(&loaded)).expect("operator events");
+    assert!(!operator_events.contains("\"event\":\"safe_fail_serialization\""));
 }
 
 #[test]

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -2628,6 +2628,10 @@ fn daemon_heartbeat_partial_checkpoint_does_not_report_backoff() {
 
 #[test]
 fn daemon_healthy_partial_checkpoint_does_not_emit_safe_fail_bundle() {
+    let _env = MultiEnvGuard::set_all(&[
+        ("ADL_CSM_DISK_FLOOR_BYTES", "0"),
+        ("ADL_CSM_TEST_AVAILABLE_BYTES", "1073741824"),
+    ]);
     let root = temp_dir("daemon-healthy-partial-no-safe-fail");
     let spec = write_spec(&root);
     let loaded = load_spec(&spec).expect("load spec");

--- a/docs/milestones/v0.91.7/review/runtime/csm_assembled_topology_soak_5120_gate.md
+++ b/docs/milestones/v0.91.7/review/runtime/csm_assembled_topology_soak_5120_gate.md
@@ -1,0 +1,73 @@
+# CSM Assembled Topology Soak Gate for #5120
+
+Issue: `#5120 [v0.91.7][WP-07][soak][runtime] Prove assembled CSM runtime topology soak`
+
+## Gate Decision
+
+Status: `HELD`
+
+The assembled topology soak is prepared but must not be counted as executed until the remaining WP-07 prerequisite issues are merged or explicitly dispositioned. This packet records the current gate truth so the eventual soak can start from a reviewable dependency boundary instead of chat memory.
+
+Last gate refresh: 2026-07-12.
+
+## Current Runtime Baseline
+
+- Runtime owner: `csm`
+- Control plane: `csmctl` (architecture role; stable `.adl/bin/csmctl` was
+  not present during this gate refresh)
+- ADL language tooling: `adl`
+- C-SDLC tooling: `csdlc`
+- Main runtime API port: `127.0.0.1:19997`
+- Service binary source of truth: `.adl/bin/csm`
+- Current observed liveness at gate update: `bound_port`
+
+The main CSM service manifest was repaired during #5120 preparation to point at `.adl/bin/csm` instead of a disposable issue-worktree `target/debug/csm`. That operational repair restored the embedded runtime API and must remain true before any soak starts.
+
+## Prerequisite State
+
+| Issue | Component / proof area | Current gate state | Action before soak |
+| --- | --- | --- | --- |
+| `#5110` | runtime crate boundary | `settled` | none |
+| `#5111` | deterministic core / nondeterministic shell | `settled` | none |
+| `#5112` | component supervision policy matrix | `settled` | none |
+| `#5113` | typed channel backpressure matrix | `settled` | none |
+| `#5114` | governed shutdown DAG | `settled` | none |
+| `#5115` | cloud bridge fail-closed cursors | `settled` | none |
+| `#5116` | runtime API auth | `settled` | none |
+| `#5117` | CSM-managed Vector observability | `settled` | none |
+| `#5118` | native reasoning runtime | `settled` | none |
+| `#5119` | checkpoint continuity vs lifelog history | `settled` | none |
+| `#5169` | recovered storage-pressure state without restart | `settled` | none |
+| `#5122` | Freedom Gate runtime component | `settled` | none |
+| `#5123` | CAV runtime component | `checks_pending_no_checks_attached` | wait for PR #5158 checks on `d04e51ace866b6fef47bae96c7bf83d1f19dce84`; if checks attach and pass, merge and close out |
+| `#5125` | Constructability Gate runtime component | `draft_pr_checks_running_after_coverage_repair` | wait for PR #5255 checks on `00f99206d31ab6171e302821342f17e681d02548`; if green, publish/merge and close out |
+| `#5126` | ACIP carrier / protobuf / WebSocket runtime paths | `merged_pending_closeout` | run normal closeout for merged PR #5241 or explicitly accept closeout handoff evidence |
+| `#5164` | CodeBuild Rust validation determinism | `checks_pending_after_clippy_repair` | wait for PR #5210 checks on `1f04c8a026745f5f4b40f01ac2721d8a2a3592cc`; if green, merge and close out |
+
+## Required Soak Proof When Gate Opens
+
+The soak must not start while `#5123`, `#5125`, `#5126`, or `#5164/#5210`
+remain open/pending unless the operator explicitly dispositiones them out of the
+soak dependency set with retained evidence. When the gate opens, the soak must
+use one continuous real CSM process identity and retain a correlated artifact
+packet proving:
+
+- startup and API readiness on the canonical `19997` port
+- supervised component health for runtime API, Chronosense, scheduler, reasoning runtime, Freedom Gate, CAV, AEE, checkpoint, lifelog, cloud bridge, Shepherd, and Vector observability
+- typed-channel flow and backpressure behavior
+- authenticated API status, health, ready, metrics, events, chronosense, shepherd, and API-gateway-bridge truth
+- checkpoint continuity and lifelog history as distinct primitives
+- storage-pressure recovery without process replacement
+- cloud bridge fail-closed behavior without false cursor advancement
+- observability through the CSM-managed Vector path with retained local evidence
+- governed shutdown-DAG disposition without hidden kill/request/cycle budgets
+- negative cases for unavailable component, failed observability sink, failed cloud bridge, checkpoint failure, and shutdown timeout
+
+Mocks, fake transports, detached prototypes, stale evidence packets, skipped negative cases, and prose-only records do not satisfy this gate.
+
+## Non-Claims
+
+- This packet does not claim the #5120 soak has run.
+- This packet does not claim product readiness.
+- This packet does not close or supersede any prerequisite issue.
+- This packet does not rename Observability to Evidence.


### PR DESCRIPTION
Closes #5120

## Summary
Issue #5120 is now a bounded runtime repair and soak-gate update for the observed CSM safe-fail artifact storm. Healthy daemon partial checkpoints now retain continuity evidence without emitting `safe_fail_bundle.json` or safe-fail artifact directories; degraded partial checkpoints still emit explicit storage-degraded and safe-fail evidence. The full assembled topology soak remains a downstream operational run after this fix is merged, installed into the stable CSM binary, and the main runtime is restarted under the repaired behavior.

## Artifacts
- Local ignored output-card readiness surface at `.adl/v0.91.7/tasks/issue-5120__v0-91-7-wp-07-soak-runtime-prove-assembled-csm-runtime-topology-soak/sor.md`
- Tracked implementation artifacts: `adl/src/long_lived_agent.rs`, `adl/src/long_lived_agent/tests.rs`
- Additional proof artifact: `docs/milestones/v0.91.7/review/runtime/csm_assembled_topology_soak_5120_gate.md`

The later full soak packet must still correlate one continuous real CSM process identity with measured uptime/readiness, live integrated components, provider-backed resident agents, deterministic-boundary capture, supervision, typed channels, shutdown-DAG dispositions, cloud/API fail-closed authorization, managed Vector output, native reasoning-runtime traffic, distinct checkpoint and lifelog evidence, #5169 same-process storage-pressure recovery, and negative injections. This repair removes one observed blocker to that soak; it does not claim the full soak has completed.

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    `Verified whitespace and patch hygiene.`
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-target-5120 cargo check --manifest-path adl/Cargo.toml -p adl`
    `Verified the touched runtime crate surface compiles.`
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-target-5120 cargo test --manifest-path adl/Cargo.toml long_lived_agent::tests::daemon_healthy_partial_checkpoint_does_not_emit_safe_fail_bundle -- --exact --nocapture`
    `Verified healthy partial checkpoints no longer emit safe-fail evidence.`
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-target-5120 cargo test --manifest-path adl/Cargo.toml long_lived_agent::tests::continuity_checkpoint_low_disk_does_not_advance_godel_chain -- --exact --nocapture`
    `Verified degraded checkpoint suppression remains explicit and non-advancing.`
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-target-5120 cargo test --manifest-path adl/Cargo.toml long_lived_agent::tests::daemon_partial_checkpoint -- --nocapture`
    `Verified existing daemon partial checkpoint negative/stop cases still pass.`
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files <changed-files>`
    `Verified the repo-native focused long_lived_agent lane during finish.`
- Results:
  - `PASS`
  - `SOAK_HELD`: the full assembled topology soak must run after this fix is merged, installed, and the main runtime is restarted under repaired code.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5120__v0-91-7-wp-07-soak-runtime-prove-assembled-csm-runtime-topology-soak/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5120__v0-91-7-wp-07-soak-runtime-prove-assembled-csm-runtime-topology-soak/sor.md
- Idempotency-Key: v0-91-7-wp-07-soak-runtime-stop-csm-safe-fail-storms-on-healthy-partial-checkpoints-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-tests-rs-docs-milestones-v0-91-7-review-runtime-csm-assembled-topology-soak-5120-gate-md-adl-v0-91-7-tasks-issue-5120-v0-91-7-wp-07-soak-runtime-prove-assembled-csm-runtime-topology-soak-sip-md-adl-v0-91-7-tasks-issue-5120-v0-91-7-wp-07-soak-runtime-prove-assembled-csm-runtime-topology-soak-sor-md