### PR TITLE
[v0.91.7][csdlc-v2] Gate 4: PVF, scheduler, shepherd, and validation

### DIFF
--- a/csdlc-v2/Cargo.lock
+++ b/csdlc-v2/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "blake3",
  "clap",
  "fs2",
+ "libc",
  "markdown",
  "schemars",
  "serde",

--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -26,6 +26,18 @@ path = "src/bin/csdlc-init.rs"
 name = "csdlc-bind"
 path = "src/bin/csdlc-bind.rs"
 
+[[bin]]
+name = "csdlc-validate"
+path = "src/bin/csdlc-validate.rs"
+
+[[bin]]
+name = "csdlc-schedule"
+path = "src/bin/csdlc-schedule.rs"
+
+[[bin]]
+name = "csdlc-shepherd"
+path = "src/bin/csdlc-shepherd.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }
@@ -36,6 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -11,6 +11,12 @@ the control plane contains no shell or Python lifecycle logic. Later gates add
 PVF, review truth, publication, and closeout without widening this core's
 authority.
 
+Gate 4 adds `csdlc-validate`, `csdlc-schedule`, and `csdlc-shepherd`. Validation
+manifests contain executable-plus-argv commands, deterministic dependencies,
+resource costs, network/credential posture, timeouts, and bounded evidence
+policy. The scheduler and shepherd are pure read-only classifiers; only
+`csdlc-validate` can execute a declared proof DAG.
+
 ## Focused validation
 
 ```text

--- a/csdlc-v2/src/bin/csdlc-schedule.rs
+++ b/csdlc-v2/src/bin/csdlc-schedule.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use csdlc_v2::{classify_schedule, ScheduleInput};
+use std::{fs, path::PathBuf};
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    input: PathBuf,
+}
+fn main() {
+    let cli = Cli::parse();
+    let bytes = fs::read(cli.input).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(74)
+    });
+    let input: ScheduleInput = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(64)
+    });
+    println!(
+        "{}",
+        serde_json::to_string(&classify_schedule(&input)).expect("JSON")
+    );
+}

--- a/csdlc-v2/src/bin/csdlc-shepherd.rs
+++ b/csdlc-v2/src/bin/csdlc-shepherd.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use csdlc_v2::{classify_shepherd, ShepherdInput};
+use std::{fs, path::PathBuf};
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    input: PathBuf,
+}
+fn main() {
+    let cli = Cli::parse();
+    let bytes = fs::read(cli.input).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(74)
+    });
+    let input: ShepherdInput = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(64)
+    });
+    println!(
+        "{}",
+        serde_json::to_string(&classify_shepherd(&input)).expect("JSON")
+    );
+}

--- a/csdlc-v2/src/bin/csdlc-validate.rs
+++ b/csdlc-v2/src/bin/csdlc-validate.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+use csdlc_v2::{execute, ExecutionRequest};
+use std::{fs, path::PathBuf};
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    request: PathBuf,
+}
+fn main() {
+    let cli = Cli::parse();
+    let result = fs::read(cli.request)
+        .map_err(csdlc_v2::V2Error::from)
+        .and_then(|b| {
+            serde_json::from_slice::<ExecutionRequest>(&b).map_err(csdlc_v2::V2Error::from)
+        })
+        .and_then(execute);
+    match result {
+        Ok(v) => println!("{}", serde_json::to_string(&v).expect("JSON")),
+        Err(e) => {
+            println!(
+                "{}",
+                serde_json::json!({"schema":"csdlc.error.v1","code":e.code,"message":e.message})
+            );
+            std::process::exit(e.code.exit_code())
+        }
+    }
+}

--- a/csdlc-v2/src/error.rs
+++ b/csdlc-v2/src/error.rs
@@ -20,6 +20,8 @@ pub enum ErrorCode {
     GitFailure,
     UnsafeCheckout,
     ReconciliationRequired,
+    InvalidManifest,
+    ValidationFailed,
     FieldOwnership,
     CardInvalid,
     CorruptRecord,
@@ -30,6 +32,7 @@ impl ErrorCode {
     pub fn exit_code(self) -> i32 {
         match self {
             Self::InvalidInput => 64,
+            Self::InvalidManifest => 64,
             Self::InvalidTransition | Self::FieldOwnership => 65,
             Self::StaleGeneration | Self::StaleDigest => 66,
             Self::MissingClaim | Self::ExpiredClaim | Self::InvalidClaim => 67,
@@ -38,6 +41,7 @@ impl ErrorCode {
             Self::ClaimCollision | Self::UnsafeCheckout => 73,
             Self::Io | Self::GitFailure => 74,
             Self::ReconciliationRequired => 75,
+            Self::ValidationFailed => 76,
         }
     }
 }

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod git;
 pub mod lifecycle;
 pub mod model;
+pub mod pvf;
 pub mod schema;
 pub mod store;
 
@@ -17,6 +18,10 @@ pub use lifecycle::{
     RecoverClaimRequest,
 };
 pub use model::{Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase};
+pub use pvf::{
+    classify_schedule, classify_shepherd, execute, select, ExecutionRequest, PvfManifest,
+    ScheduleInput, ShepherdInput,
+};
 pub use schema::public_schema_bundle;
 pub use store::{
     approve_design, bootstrap_issue, edit_issue, ApproveDesignRequest, BootstrapRequest,

--- a/csdlc-v2/src/pvf.rs
+++ b/csdlc-v2/src/pvf.rs
@@ -1,0 +1,813 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumString};
+
+use crate::{ErrorCode, Result, V2Error};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum Determinism {
+    Deterministic,
+    ControlledExternal,
+    Live,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum NetworkPolicy {
+    Denied,
+    Loopback,
+    External,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ReleaseGate {
+    Required,
+    Optional,
+    NonGoal,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ExecutionMode {
+    Local,
+    DeferredCi,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ResourceCost {
+    pub cpu_units: u32,
+    pub memory_mib: u32,
+    pub tokens: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct EvidencePolicy {
+    pub max_log_bytes: usize,
+    pub redact_values: Vec<String>,
+    pub require_relative_paths: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PvfLane {
+    pub id: String,
+    pub proof_role: String,
+    pub purpose: String,
+    pub determinism: Determinism,
+    pub resources: ResourceCost,
+    pub credentials: Vec<String>,
+    pub network: NetworkPolicy,
+    pub dependencies: Vec<String>,
+    pub parallel_group: String,
+    pub release_gate: ReleaseGate,
+    pub execution: ExecutionMode,
+    pub timeout_seconds: u64,
+    pub executable: String,
+    pub argv: Vec<String>,
+    pub evidence: EvidencePolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PvfManifest {
+    pub schema: String,
+    pub lanes: Vec<PvfLane>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SelectionRequest {
+    pub requested_lanes: Vec<String>,
+    pub allow_network: bool,
+    pub available_credentials: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SelectedDag {
+    pub schema: String,
+    pub waves: Vec<Vec<String>>,
+    pub lanes: BTreeMap<String, PvfLane>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ExecutionBudget {
+    pub max_parallel: usize,
+    pub cpu_units: u32,
+    pub memory_mib: u32,
+    pub tokens: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ExecutionRequest {
+    pub manifest: PvfManifest,
+    pub selection: SelectionRequest,
+    pub budget: ExecutionBudget,
+    pub root: PathBuf,
+    pub evidence_dir: PathBuf,
+    pub cancellation_file: Option<PathBuf>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum LaneStatus {
+    Passed,
+    DeferredCi,
+    Failed,
+    TimedOut,
+    Blocked,
+    AcceptedNonGoal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LaneEvidence {
+    pub lane: String,
+    pub command: Vec<String>,
+    pub purpose: String,
+    pub status: LaneStatus,
+    pub duration_ms: u128,
+    pub log_ref: Option<String>,
+    pub redaction_ok: bool,
+    pub redactions_applied: usize,
+    pub path_hygiene_ok: bool,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ValidationDisposition {
+    LocalPass,
+    DeferredCi,
+    Waiting,
+    Failed,
+    Blocked,
+    AcceptedNonGoal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ExecutionReport {
+    pub schema: String,
+    pub disposition: ValidationDisposition,
+    pub selected_waves: Vec<Vec<String>>,
+    pub evidence: Vec<LaneEvidence>,
+}
+
+pub fn select(manifest: &PvfManifest, request: &SelectionRequest) -> Result<SelectedDag> {
+    validate_manifest(manifest)?;
+    let all: BTreeMap<_, _> = manifest
+        .lanes
+        .iter()
+        .map(|lane| (lane.id.clone(), lane.clone()))
+        .collect();
+    let mut selected: BTreeSet<String> = request.requested_lanes.iter().cloned().collect();
+    for lane in &manifest.lanes {
+        if lane.release_gate == ReleaseGate::Required {
+            selected.insert(lane.id.clone());
+        }
+    }
+    let mut pending: Vec<_> = selected.iter().cloned().collect();
+    while let Some(id) = pending.pop() {
+        let lane = all.get(&id).ok_or_else(|| {
+            V2Error::new(
+                ErrorCode::InvalidManifest,
+                format!("unknown selected lane {id}"),
+            )
+        })?;
+        for dep in &lane.dependencies {
+            if selected.insert(dep.clone()) {
+                pending.push(dep.clone());
+            }
+        }
+    }
+    for id in &selected {
+        let lane = &all[id];
+        if lane.network == NetworkPolicy::External && !request.allow_network {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                format!("lane {id} requires external network"),
+            ));
+        }
+        if lane
+            .credentials
+            .iter()
+            .any(|name| !request.available_credentials.contains(name))
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                format!("lane {id} requires unavailable credentials"),
+            ));
+        }
+    }
+    let mut remaining = selected.clone();
+    let mut done = BTreeSet::new();
+    let mut waves = Vec::new();
+    while !remaining.is_empty() {
+        let wave: Vec<_> = remaining
+            .iter()
+            .filter(|id| all[*id].dependencies.iter().all(|dep| done.contains(dep)))
+            .cloned()
+            .collect();
+        if wave.is_empty() {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                "validation dependency cycle",
+            ));
+        }
+        for id in &wave {
+            remaining.remove(id);
+            done.insert(id.clone());
+        }
+        waves.push(wave);
+    }
+    Ok(SelectedDag {
+        schema: "csdlc.pvf.selected.v1".into(),
+        waves,
+        lanes: all
+            .into_iter()
+            .filter(|(id, _)| selected.contains(id))
+            .collect(),
+    })
+}
+
+fn validate_manifest(manifest: &PvfManifest) -> Result<()> {
+    if manifest.schema != "csdlc.pvf.manifest.v1" || manifest.lanes.is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "invalid PVF schema or empty lanes",
+        ));
+    }
+    let ids: BTreeSet<_> = manifest.lanes.iter().map(|lane| lane.id.as_str()).collect();
+    if ids.len() != manifest.lanes.len() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "duplicate lane id",
+        ));
+    }
+    for lane in &manifest.lanes {
+        if lane.id.trim().is_empty()
+            || !lane
+                .id
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+            || lane.proof_role.trim().is_empty()
+            || lane.purpose.trim().is_empty()
+            || lane.executable.trim().is_empty()
+            || lane.parallel_group.trim().is_empty()
+            || lane.timeout_seconds == 0
+            || lane.evidence.max_log_bytes == 0
+            || lane
+                .dependencies
+                .iter()
+                .any(|dep| !ids.contains(dep.as_str()) || dep == &lane.id)
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                format!("lane {} is incomplete", lane.id),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn execute(request: ExecutionRequest) -> Result<ExecutionReport> {
+    if request.budget.max_parallel == 0 {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "max_parallel must be positive",
+        ));
+    }
+    let dag = select(&request.manifest, &request.selection)?;
+    let batches = plan_batches(&dag, &request.budget)?;
+    fs::create_dir_all(&request.evidence_dir)?;
+    let evidence = Arc::new(Mutex::new(Vec::new()));
+    let outcomes = Arc::new(Mutex::new(BTreeMap::<String, LaneStatus>::new()));
+    let cancelled = Arc::new(AtomicBool::new(false));
+    for (wave_index, wave) in dag.waves.iter().enumerate() {
+        if request
+            .cancellation_file
+            .as_ref()
+            .is_some_and(|path| path.exists())
+        {
+            cancelled.store(true, Ordering::SeqCst);
+            break;
+        }
+        for id in wave {
+            let lane = &dag.lanes[id];
+            let dependency_statuses: Vec<_> = lane
+                .dependencies
+                .iter()
+                .filter_map(|dep| outcomes.lock().expect("outcomes").get(dep).copied())
+                .collect();
+            let inherited = if dependency_statuses.iter().any(|s| {
+                matches!(
+                    s,
+                    LaneStatus::Failed | LaneStatus::TimedOut | LaneStatus::Blocked
+                )
+            }) {
+                Some(LaneStatus::Blocked)
+            } else if dependency_statuses.contains(&LaneStatus::DeferredCi) {
+                Some(LaneStatus::DeferredCi)
+            } else if dependency_statuses.contains(&LaneStatus::AcceptedNonGoal) {
+                Some(LaneStatus::Blocked)
+            } else {
+                None
+            };
+            let status = inherited.or_else(|| {
+                if lane.release_gate == ReleaseGate::NonGoal {
+                    Some(LaneStatus::AcceptedNonGoal)
+                } else if lane.execution == ExecutionMode::DeferredCi {
+                    Some(LaneStatus::DeferredCi)
+                } else {
+                    None
+                }
+            });
+            if let Some(status) = status {
+                outcomes
+                    .lock()
+                    .expect("outcomes")
+                    .insert(id.clone(), status);
+                evidence
+                    .lock()
+                    .expect("evidence")
+                    .push(skipped_evidence(lane, status));
+            }
+        }
+        for batch in &batches[wave_index] {
+            if cancelled.load(Ordering::SeqCst) {
+                break;
+            }
+            let runnable: Vec<_> = batch
+                .iter()
+                .filter(|id| !outcomes.lock().expect("outcomes").contains_key(*id))
+                .cloned()
+                .collect();
+            let mut handles = Vec::new();
+            for id in runnable {
+                let lane = dag.lanes[&id].clone();
+                let root = request.root.clone();
+                let dir = request.evidence_dir.clone();
+                let cancel = Arc::clone(&cancelled);
+                let cancel_path = request.cancellation_file.clone();
+                handles.push(thread::spawn(move || {
+                    run_lane(&root, &dir, &lane, &cancel, cancel_path.as_deref())
+                }));
+            }
+            for handle in handles {
+                let item = handle.join().map_err(|_| {
+                    V2Error::new(ErrorCode::ValidationFailed, "validation worker panicked")
+                })?;
+                if matches!(
+                    item.status,
+                    LaneStatus::Failed | LaneStatus::TimedOut | LaneStatus::Blocked
+                ) {
+                    cancelled.store(true, Ordering::SeqCst);
+                }
+                outcomes
+                    .lock()
+                    .expect("outcomes")
+                    .insert(item.lane.clone(), item.status);
+                evidence.lock().expect("evidence").push(item);
+            }
+        }
+        if cancelled.load(Ordering::SeqCst) {
+            break;
+        }
+    }
+    let mut evidence = Arc::try_unwrap(evidence)
+        .expect("workers complete")
+        .into_inner()
+        .expect("evidence lock");
+    evidence.sort_by(|a, b| a.lane.cmp(&b.lane));
+    let disposition = converge(
+        &evidence,
+        cancelled.load(Ordering::SeqCst),
+        request
+            .cancellation_file
+            .as_ref()
+            .is_some_and(|p| p.exists()),
+    );
+    Ok(ExecutionReport {
+        schema: "csdlc.pvf.report.v1".into(),
+        disposition,
+        selected_waves: dag.waves,
+        evidence,
+    })
+}
+
+fn skipped_evidence(lane: &PvfLane, status: LaneStatus) -> LaneEvidence {
+    LaneEvidence {
+        lane: lane.id.clone(),
+        command: redacted_command(lane),
+        purpose: lane.purpose.clone(),
+        status,
+        duration_ms: 0,
+        log_ref: None,
+        redaction_ok: true,
+        redactions_applied: 0,
+        path_hygiene_ok: true,
+    }
+}
+
+fn plan_batches(dag: &SelectedDag, budget: &ExecutionBudget) -> Result<Vec<Vec<Vec<String>>>> {
+    let total: u64 = dag
+        .lanes
+        .values()
+        .filter(|l| l.execution == ExecutionMode::Local && l.release_gate != ReleaseGate::NonGoal)
+        .map(|l| l.resources.tokens)
+        .sum();
+    if total > budget.tokens {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "selected local lanes exceed total token budget",
+        ));
+    }
+    let mut result = Vec::new();
+    for wave in &dag.waves {
+        let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for id in wave {
+            let lane = &dag.lanes[id];
+            if lane.execution != ExecutionMode::Local || lane.release_gate == ReleaseGate::NonGoal {
+                continue;
+            }
+            if lane.resources.cpu_units > budget.cpu_units
+                || lane.resources.memory_mib > budget.memory_mib
+            {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidManifest,
+                    format!("lane {id} exceeds resource budget"),
+                ));
+            }
+            groups
+                .entry(lane.parallel_group.clone())
+                .or_default()
+                .push(id.clone());
+        }
+        let mut batches = Vec::new();
+        for (_, ids) in groups {
+            let mut batch = Vec::new();
+            let (mut cpu, mut mem) = (0, 0);
+            for id in ids {
+                let c = &dag.lanes[&id].resources;
+                if batch.len() == budget.max_parallel
+                    || cpu + c.cpu_units > budget.cpu_units
+                    || mem + c.memory_mib > budget.memory_mib
+                {
+                    batches.push(batch);
+                    batch = Vec::new();
+                    cpu = 0;
+                    mem = 0;
+                }
+                cpu += c.cpu_units;
+                mem += c.memory_mib;
+                batch.push(id);
+            }
+            if !batch.is_empty() {
+                batches.push(batch);
+            }
+        }
+        result.push(batches);
+    }
+    Ok(result)
+}
+
+fn converge(
+    evidence: &[LaneEvidence],
+    cancelled: bool,
+    external_cancel: bool,
+) -> ValidationDisposition {
+    if external_cancel {
+        return ValidationDisposition::Waiting;
+    }
+    if evidence
+        .iter()
+        .any(|e| matches!(e.status, LaneStatus::Failed | LaneStatus::TimedOut))
+    {
+        return ValidationDisposition::Failed;
+    }
+    if evidence.iter().any(|e| e.status == LaneStatus::Blocked) {
+        return ValidationDisposition::Blocked;
+    }
+    if cancelled {
+        return ValidationDisposition::Blocked;
+    }
+    if evidence.iter().any(|e| e.status == LaneStatus::DeferredCi) {
+        return ValidationDisposition::DeferredCi;
+    }
+    if !evidence.is_empty()
+        && evidence
+            .iter()
+            .all(|e| e.status == LaneStatus::AcceptedNonGoal)
+    {
+        return ValidationDisposition::AcceptedNonGoal;
+    }
+    if evidence.is_empty() {
+        ValidationDisposition::Waiting
+    } else {
+        ValidationDisposition::LocalPass
+    }
+}
+
+fn redacted_command(lane: &PvfLane) -> Vec<String> {
+    std::iter::once(lane.executable.clone())
+        .chain(lane.argv.clone())
+        .map(|mut value| {
+            for secret in &lane.evidence.redact_values {
+                if !secret.is_empty() {
+                    value = value.replace(secret, "[REDACTED]");
+                }
+            }
+            value
+        })
+        .collect()
+}
+
+fn run_lane(
+    root: &Path,
+    evidence_dir: &Path,
+    lane: &PvfLane,
+    cancelled: &AtomicBool,
+    cancellation_file: Option<&Path>,
+) -> LaneEvidence {
+    let started = Instant::now();
+    let command = redacted_command(lane);
+    let result = (|| -> Result<(LaneStatus, Vec<u8>)> {
+        use std::os::unix::process::CommandExt;
+        let mut child = Command::new(&lane.executable)
+            .args(&lane.argv)
+            .current_dir(root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0)
+            .spawn()?;
+        let stdout = child.stdout.take().expect("stdout");
+        let stderr = child.stderr.take().expect("stderr");
+        let limit = lane.evidence.max_log_bytes;
+        let out = thread::spawn(move || drain(stdout, limit));
+        let err = thread::spawn(move || drain(stderr, limit));
+        let deadline = Instant::now() + Duration::from_secs(lane.timeout_seconds);
+        let timed_out = loop {
+            if let Some(status) = child.try_wait()? {
+                let mut bytes = out.join().unwrap_or_default();
+                bytes.extend(err.join().unwrap_or_default());
+                return Ok((
+                    if status.success() {
+                        LaneStatus::Passed
+                    } else {
+                        LaneStatus::Failed
+                    },
+                    bytes,
+                ));
+            }
+            if cancellation_file.is_some_and(|path| path.exists()) {
+                cancelled.store(true, Ordering::SeqCst);
+            }
+            if cancelled.load(Ordering::SeqCst) || Instant::now() >= deadline {
+                let timed_out = Instant::now() >= deadline;
+                unsafe {
+                    libc::kill(-(child.id() as i32), libc::SIGKILL);
+                }
+                let _ = child.wait();
+                break timed_out;
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+        let mut bytes = out.join().unwrap_or_default();
+        bytes.extend(err.join().unwrap_or_default());
+        Ok((
+            if timed_out {
+                LaneStatus::TimedOut
+            } else {
+                LaneStatus::Blocked
+            },
+            bytes,
+        ))
+    })();
+    let (status, mut bytes) =
+        result.unwrap_or_else(|error| (LaneStatus::Blocked, error.message.into_bytes()));
+    if matches!(
+        status,
+        LaneStatus::Failed | LaneStatus::TimedOut | LaneStatus::Blocked
+    ) {
+        cancelled.store(true, Ordering::SeqCst);
+    }
+    let mut redactions_applied = 0;
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    for secret in &lane.evidence.redact_values {
+        if !secret.is_empty() && text.contains(secret) {
+            text = text.replace(secret, "[REDACTED]");
+            redactions_applied += 1;
+        }
+    }
+    bytes = text.into_bytes();
+    bytes.truncate(lane.evidence.max_log_bytes);
+    let log_name = format!("{}.log", lane.id);
+    let path = evidence_dir.join(&log_name);
+    let path_ok = clean_relative(Path::new(&log_name));
+    let log_ref = if fs::write(&path, &bytes).is_ok() {
+        Some(log_name)
+    } else {
+        None
+    };
+    LaneEvidence {
+        lane: lane.id.clone(),
+        command,
+        purpose: lane.purpose.clone(),
+        status,
+        duration_ms: started.elapsed().as_millis(),
+        log_ref,
+        redaction_ok: true,
+        redactions_applied,
+        path_hygiene_ok: path_ok,
+    }
+}
+
+fn drain(mut reader: impl Read, limit: usize) -> Vec<u8> {
+    let mut kept = Vec::new();
+    let mut buf = [0u8; 8192];
+    while let Ok(n) = reader.read(&mut buf) {
+        if n == 0 {
+            break;
+        }
+        let remaining = limit.saturating_sub(kept.len());
+        kept.extend_from_slice(&buf[..n.min(remaining)]);
+    }
+    kept
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ScheduleInput {
+    pub phase_ready: bool,
+    pub cards_ready: bool,
+    pub design_ready: bool,
+    pub dependencies_ready: bool,
+    pub claim_live: bool,
+    pub paths_clear: bool,
+    pub budget_available: bool,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ScheduleReport {
+    pub schema: String,
+    pub eligible_operations: Vec<String>,
+    pub blockers: Vec<String>,
+    pub authority: String,
+}
+pub fn classify_schedule(input: &ScheduleInput) -> ScheduleReport {
+    let checks = [
+        ("phase", input.phase_ready),
+        ("cards", input.cards_ready),
+        ("design", input.design_ready),
+        ("dependencies", input.dependencies_ready),
+        ("claim", input.claim_live),
+        ("paths", input.paths_clear),
+        ("budget", input.budget_available),
+    ];
+    let blockers = checks
+        .iter()
+        .filter(|(_, ok)| !*ok)
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<_>>();
+    ScheduleReport {
+        schema: "csdlc.scheduler.report.v1".into(),
+        eligible_operations: if blockers.is_empty() {
+            vec!["validate".into()]
+        } else {
+            vec![]
+        },
+        blockers,
+        authority: "read_only; cannot claim, execute, publish, merge, or close".into(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ShepherdInput {
+    pub validation: Option<ValidationDisposition>,
+    pub dependency_wait: bool,
+    pub retryable_failure: bool,
+    pub repair_needed: bool,
+    pub operator_decision_needed: bool,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum ShepherdState {
+    Ready,
+    Waiting,
+    Retryable,
+    RepairRequired,
+    OperatorRequired,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ShepherdReport {
+    pub schema: String,
+    pub state: ShepherdState,
+    pub authority: String,
+}
+pub fn classify_shepherd(input: &ShepherdInput) -> ShepherdReport {
+    let state = if input.operator_decision_needed {
+        ShepherdState::OperatorRequired
+    } else if input.repair_needed {
+        ShepherdState::RepairRequired
+    } else if input.retryable_failure {
+        ShepherdState::Retryable
+    } else if input.dependency_wait || input.validation.is_none() {
+        ShepherdState::Waiting
+    } else {
+        ShepherdState::Ready
+    };
+    ShepherdReport {
+        schema: "csdlc.shepherd.report.v1".into(),
+        state,
+        authority: "observe only; cannot edit, execute, publish, merge, or close".into(),
+    }
+}
+
+pub fn clean_relative(path: &Path) -> bool {
+    path.components()
+        .all(|part| matches!(part, Component::Normal(_)))
+}

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -3,6 +3,7 @@ use serde_json::{json, Value};
 use crate::doctor::DoctorReport;
 use crate::lifecycle::{BindRequest, BindResult, RecoverClaimRequest};
 use crate::model::IssueRecord;
+use crate::pvf::{ExecutionReport, ExecutionRequest, PvfManifest, ScheduleReport, ShepherdReport};
 use crate::store::ApproveDesignRequest;
 use crate::store::{BootstrapRequest, EditRequest};
 
@@ -17,5 +18,10 @@ pub fn public_schema_bundle() -> Value {
         "recover_claim_request": schemars::schema_for!(RecoverClaimRequest),
         "issue_record": schemars::schema_for!(IssueRecord),
         "doctor_report": schemars::schema_for!(DoctorReport),
+        "pvf_manifest": schemars::schema_for!(PvfManifest),
+        "pvf_execution_request": schemars::schema_for!(ExecutionRequest),
+        "pvf_execution_report": schemars::schema_for!(ExecutionReport),
+        "scheduler_report": schemars::schema_for!(ScheduleReport),
+        "shepherd_report": schemars::schema_for!(ShepherdReport),
     })
 }

--- a/csdlc-v2/tests/gate4.rs
+++ b/csdlc-v2/tests/gate4.rs
@@ -1,0 +1,618 @@
+use std::time::Instant;
+
+use csdlc_v2::pvf::*;
+use csdlc_v2::{classify_schedule, classify_shepherd, execute, select, ErrorCode};
+
+fn lane(id: &str, deps: &[&str], executable: &str, argv: &[&str]) -> PvfLane {
+    PvfLane {
+        id: id.into(),
+        proof_role: format!("prove {id}"),
+        purpose: format!("validate {id}"),
+        determinism: Determinism::Deterministic,
+        resources: ResourceCost {
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        credentials: vec![],
+        network: NetworkPolicy::Denied,
+        dependencies: deps.iter().map(|v| (*v).into()).collect(),
+        parallel_group: "local".into(),
+        release_gate: ReleaseGate::Optional,
+        execution: ExecutionMode::Local,
+        timeout_seconds: 2,
+        executable: executable.into(),
+        argv: argv.iter().map(|v| (*v).into()).collect(),
+        evidence: EvidencePolicy {
+            max_log_bytes: 256,
+            redact_values: vec!["secret".into()],
+            require_relative_paths: true,
+        },
+    }
+}
+
+fn manifest() -> PvfManifest {
+    PvfManifest {
+        schema: "csdlc.pvf.manifest.v1".into(),
+        lanes: vec![
+            lane("a", &[], "/bin/sleep", &["0.1"]),
+            lane("b", &[], "/bin/sleep", &["0.1"]),
+            lane("c", &["a", "b"], "/usr/bin/true", &[]),
+        ],
+    }
+}
+
+#[test]
+fn selection_is_stable_topological_and_includes_dependencies() {
+    let request = SelectionRequest {
+        requested_lanes: vec!["c".into()],
+        allow_network: false,
+        available_credentials: vec![],
+    };
+    let first = select(&manifest(), &request).expect("select");
+    let second = select(&manifest(), &request).expect("select");
+    assert_eq!(
+        first.waves,
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c".to_string()]
+        ]
+    );
+    assert_eq!(first.waves, second.waves);
+}
+
+#[test]
+fn invalid_cycle_network_credentials_and_budget_fail_closed() {
+    let mut cyclic = manifest();
+    cyclic.lanes[0].dependencies = vec!["c".into()];
+    let request = SelectionRequest {
+        requested_lanes: vec!["c".into()],
+        allow_network: false,
+        available_credentials: vec![],
+    };
+    assert!(matches!(
+        select(&cyclic, &request).expect_err("cycle").code,
+        ErrorCode::InvalidManifest
+    ));
+    let mut external = manifest();
+    external.lanes[2].network = NetworkPolicy::External;
+    assert!(matches!(
+        select(&external, &request).expect_err("network").code,
+        ErrorCode::InvalidManifest
+    ));
+    let temp = tempfile::tempdir().expect("temp");
+    let mut over_budget = manifest();
+    over_budget.lanes[0].resources.cpu_units = 2;
+    let error = execute(ExecutionRequest {
+        manifest: over_budget,
+        selection: request,
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 1,
+            memory_mib: 16,
+            tokens: 30,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("evidence"),
+        cancellation_file: None,
+    })
+    .expect_err("budget");
+    assert!(matches!(error.code, ErrorCode::InvalidManifest));
+}
+
+#[test]
+fn independent_lanes_run_concurrently_and_converge_with_typed_evidence() {
+    let temp = tempfile::tempdir().expect("temp");
+    let started = Instant::now();
+    let report = execute(ExecutionRequest {
+        manifest: manifest(),
+        selection: SelectionRequest {
+            requested_lanes: vec!["c".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 30,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("evidence"),
+        cancellation_file: None,
+    })
+    .expect("execute");
+    assert_eq!(report.disposition, ValidationDisposition::LocalPass);
+    assert_eq!(report.evidence.len(), 3);
+    assert!(
+        started.elapsed().as_millis() < 190,
+        "parallel wave was serialized"
+    );
+    assert!(report
+        .evidence
+        .iter()
+        .all(|item| item.status == LaneStatus::Passed && item.path_hygiene_ok));
+}
+
+#[test]
+fn deterministic_budget_packing_accepts_feasible_uneven_wave() {
+    let temp = tempfile::tempdir().expect("temp");
+    let mut heavy = lane("a", &[], "/usr/bin/true", &[]);
+    heavy.resources.cpu_units = 2;
+    let one = lane("b", &[], "/usr/bin/true", &[]);
+    let two = lane("c", &[], "/usr/bin/true", &[]);
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![heavy, one, two],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["a".into(), "b".into(), "c".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 30,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("packed"),
+        cancellation_file: None,
+    })
+    .expect("feasible packing");
+    assert_eq!(report.disposition, ValidationDisposition::LocalPass);
+    assert_eq!(report.evidence.len(), 3);
+}
+
+#[test]
+fn timeout_failure_redaction_and_deferred_ci_are_truthful() {
+    let temp = tempfile::tempdir().expect("temp");
+    let mut lanes = vec![
+        lane("redact", &[], "/usr/bin/printf", &["secret"]),
+        lane("fail", &[], "/usr/bin/false", &[]),
+    ];
+    lanes[1].release_gate = ReleaseGate::NonGoal;
+    let mut deferred = lane("ci", &[], "/usr/bin/true", &[]);
+    deferred.execution = ExecutionMode::DeferredCi;
+    lanes.push(deferred);
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes,
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["redact".into(), "fail".into(), "ci".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 20,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("evidence"),
+        cancellation_file: None,
+    })
+    .expect("execute");
+    assert_eq!(report.disposition, ValidationDisposition::DeferredCi);
+    assert!(report
+        .evidence
+        .iter()
+        .any(|e| e.status == LaneStatus::AcceptedNonGoal));
+    assert!(report
+        .evidence
+        .iter()
+        .any(|e| e.status == LaneStatus::DeferredCi));
+    let redacted = std::fs::read_to_string(temp.path().join("evidence/redact.log")).expect("log");
+    assert_eq!(redacted, "[REDACTED]");
+    assert!(!serde_json::to_string(&report)
+        .expect("report JSON")
+        .contains("secret"));
+    assert!(
+        report
+            .evidence
+            .iter()
+            .find(|e| e.lane == "redact")
+            .expect("redact")
+            .redaction_ok
+    );
+    assert_eq!(
+        report
+            .evidence
+            .iter()
+            .find(|e| e.lane == "redact")
+            .expect("redact")
+            .redactions_applied,
+        1
+    );
+}
+
+#[test]
+fn unsafe_lane_ids_are_rejected_before_evidence_paths_exist() {
+    for id in ["../escape", "a/b", "/absolute"] {
+        let manifest = PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![lane(id, &[], "/usr/bin/true", &[])],
+        };
+        let error = select(
+            &manifest,
+            &SelectionRequest {
+                requested_lanes: vec![id.into()],
+                allow_network: false,
+                available_credentials: vec![],
+            },
+        )
+        .expect_err("unsafe id");
+        assert!(matches!(error.code, ErrorCode::InvalidManifest));
+    }
+}
+
+#[test]
+fn deferred_dependency_blocks_local_dependent_and_non_goal_only_converges() {
+    let temp = tempfile::tempdir().expect("temp");
+    let mut prerequisite = lane("ci", &[], "/usr/bin/true", &[]);
+    prerequisite.execution = ExecutionMode::DeferredCi;
+    let dependent = lane("release", &["ci"], "/usr/bin/true", &[]);
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![prerequisite, dependent],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["release".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("evidence"),
+        cancellation_file: None,
+    })
+    .expect("report");
+    assert_eq!(report.disposition, ValidationDisposition::DeferredCi);
+    assert_eq!(
+        report
+            .evidence
+            .iter()
+            .find(|e| e.lane == "release")
+            .expect("release")
+            .status,
+        LaneStatus::DeferredCi
+    );
+    let mut non_goal = lane("optional", &[], "/usr/bin/false", &[]);
+    non_goal.release_gate = ReleaseGate::NonGoal;
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![non_goal],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["optional".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 0,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("non-goal"),
+        cancellation_file: None,
+    })
+    .expect("non-goal");
+    assert_eq!(report.disposition, ValidationDisposition::AcceptedNonGoal);
+    let mut skipped = lane("skip", &[], "/usr/bin/true", &[]);
+    skipped.release_gate = ReleaseGate::NonGoal;
+    let dependent = lane("dependent", &["skip"], "/usr/bin/true", &[]);
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![skipped, dependent],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["dependent".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("blocked"),
+        cancellation_file: None,
+    })
+    .expect("blocked dependent");
+    assert_eq!(report.disposition, ValidationDisposition::Blocked);
+}
+
+#[test]
+fn failed_lane_produces_failed_aggregate() {
+    let temp = tempfile::tempdir().expect("temp");
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![lane("fail", &[], "/usr/bin/false", &[])],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["fail".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("failed"),
+        cancellation_file: None,
+    })
+    .expect("failed report");
+    assert_eq!(report.disposition, ValidationDisposition::Failed);
+}
+
+#[test]
+fn deadline_timeout_is_typed_and_fails_aggregate() {
+    let temp = tempfile::tempdir().expect("temp");
+    let pid_file = temp.path().join("timeout-child.pid");
+    let script = format!("sleep 30 & echo $! > {}; wait", pid_file.display());
+    let mut slow = lane("timeout", &[], "/bin/sh", &["-c", &script]);
+    slow.timeout_seconds = 1;
+    let started = Instant::now();
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![slow],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["timeout".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("timeout"),
+        cancellation_file: None,
+    })
+    .expect("timeout report");
+    assert_eq!(report.disposition, ValidationDisposition::Failed);
+    assert_eq!(report.evidence[0].status, LaneStatus::TimedOut);
+    assert!(started.elapsed() < std::time::Duration::from_millis(1500));
+    let pid: i32 = std::fs::read_to_string(pid_file)
+        .expect("pid")
+        .trim()
+        .parse()
+        .expect("pid number");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert_eq!(
+        unsafe { libc::kill(pid, 0) },
+        -1,
+        "timeout descendant survived"
+    );
+}
+
+#[test]
+fn validate_cli_redacts_machine_readable_command() {
+    let temp = tempfile::tempdir().expect("temp");
+    let request = ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![lane("redact", &[], "/usr/bin/printf", &["secret"])],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["redact".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("cli-evidence"),
+        cancellation_file: None,
+    };
+    let path = temp.path().join("request.json");
+    std::fs::write(&path, serde_json::to_vec(&request).expect("JSON")).expect("request");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_csdlc-validate"))
+        .args(["--request", path.to_str().expect("path")])
+        .output()
+        .expect("CLI");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8");
+    assert!(!stdout.contains("secret"));
+    assert!(stdout.contains("[REDACTED]"));
+}
+
+#[test]
+fn high_output_drains_and_failed_peer_cancels_process_group() {
+    let temp = tempfile::tempdir().expect("temp");
+    let high = lane("high", &[], "/usr/bin/head", &["-c", "200000", "/dev/zero"]);
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![high],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["high".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("high"),
+        cancellation_file: None,
+    })
+    .expect("high output");
+    assert_eq!(report.disposition, ValidationDisposition::LocalPass);
+    assert_eq!(
+        std::fs::metadata(temp.path().join("high/high.log"))
+            .expect("log")
+            .len(),
+        256
+    );
+    let mut slow = lane("slow", &[], "/bin/sleep", &["2"]);
+    slow.timeout_seconds = 3;
+    let fail = lane("fail", &[], "/usr/bin/false", &[]);
+    let started = Instant::now();
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![fail, slow],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["fail".into(), "slow".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 20,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("peers"),
+        cancellation_file: None,
+    })
+    .expect("peer cancellation");
+    assert_eq!(report.disposition, ValidationDisposition::Failed);
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+}
+
+#[test]
+fn cancellation_is_observed_before_process_start() {
+    let temp = tempfile::tempdir().expect("temp");
+    let cancel = temp.path().join("cancel");
+    std::fs::write(&cancel, "stop").expect("cancel");
+    let report = execute(ExecutionRequest {
+        manifest: manifest(),
+        selection: SelectionRequest {
+            requested_lanes: vec!["c".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 2,
+            cpu_units: 2,
+            memory_mib: 16,
+            tokens: 30,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("evidence"),
+        cancellation_file: Some(cancel),
+    })
+    .expect("cancelled report");
+    assert_eq!(report.disposition, ValidationDisposition::Waiting);
+    assert!(report.evidence.is_empty());
+}
+
+#[test]
+fn cancellation_during_execution_terminates_process_group() {
+    let temp = tempfile::tempdir().expect("temp");
+    let cancel = temp.path().join("cancel");
+    let pid_file = temp.path().join("child.pid");
+    let script = format!("sleep 30 & echo $! > {}; wait", pid_file.display());
+    let mut tree = lane("tree", &[], "/bin/sh", &["-c", &script]);
+    tree.timeout_seconds = 5;
+    let cancel_writer = cancel.clone();
+    let trigger = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::fs::write(cancel_writer, "stop").expect("cancel");
+    });
+    let started = Instant::now();
+    let report = execute(ExecutionRequest {
+        manifest: PvfManifest {
+            schema: "csdlc.pvf.manifest.v1".into(),
+            lanes: vec![tree],
+        },
+        selection: SelectionRequest {
+            requested_lanes: vec!["tree".into()],
+            allow_network: false,
+            available_credentials: vec![],
+        },
+        budget: ExecutionBudget {
+            max_parallel: 1,
+            cpu_units: 1,
+            memory_mib: 8,
+            tokens: 10,
+        },
+        root: temp.path().into(),
+        evidence_dir: temp.path().join("tree-evidence"),
+        cancellation_file: Some(cancel),
+    })
+    .expect("cancel tree");
+    trigger.join().expect("trigger");
+    assert_eq!(report.disposition, ValidationDisposition::Waiting);
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+    let pid: i32 = std::fs::read_to_string(pid_file)
+        .expect("pid")
+        .trim()
+        .parse()
+        .expect("pid number");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert_eq!(
+        unsafe { libc::kill(pid, 0) },
+        -1,
+        "descendant survived process-group cancellation"
+    );
+}
+
+#[test]
+fn scheduler_and_shepherd_are_read_only_classifiers() {
+    let schedule = classify_schedule(&ScheduleInput {
+        phase_ready: true,
+        cards_ready: true,
+        design_ready: true,
+        dependencies_ready: true,
+        claim_live: true,
+        paths_clear: true,
+        budget_available: true,
+    });
+    assert_eq!(schedule.eligible_operations, vec!["validate"]);
+    assert!(schedule.authority.contains("cannot claim"));
+    let waiting = classify_shepherd(&ShepherdInput {
+        validation: None,
+        dependency_wait: true,
+        retryable_failure: false,
+        repair_needed: false,
+        operator_decision_needed: false,
+    });
+    assert_eq!(waiting.state, ShepherdState::Waiting);
+    assert!(waiting.authority.contains("observe only"));
+    let operator = classify_shepherd(&ShepherdInput {
+        validation: Some(ValidationDisposition::Failed),
+        dependency_wait: false,
+        retryable_failure: true,
+        repair_needed: true,
+        operator_decision_needed: true,
+    });
+    assert_eq!(operator.state, ShepherdState::OperatorRequired);
+}

--- a/docs/architecture/csdlc-v2/gate4/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate4/DESIGN.md
@@ -1,0 +1,21 @@
+# C-SDLC v2 Gate 4 design
+
+Gate 4 retains the Parallel Validation Fabric, scheduler, and shepherd ideas while separating their authority. `csdlc-validate` validates and executes a typed DAG. `csdlc-schedule` only reports eligible operations and blockers. `csdlc-shepherd` only classifies observed state. None depends on ADL or Runtime.
+
+## PVF manifest
+
+Every lane declares an id, proof role, purpose, determinism posture, CPU/memory/token cost, credential names, network policy, dependency ids, parallel group, release-gate status, local/deferred-CI execution mode, timeout, executable, argv, and bounded evidence policy. Validation rejects duplicate or missing ids, unknown dependencies, self-dependencies, cycles, undeclared network/credential authority, and waves exceeding the execution budget before commands run.
+
+Commands are passed directly to `std::process::Command`; the control plane never interprets a shell string. Independent lanes are deterministically packed by parallel group and CPU/memory limits after whole-DAG token/resource preflight. Dependent waves wait for successful predecessors; deferred and non-goal truth propagates without executing an invalid dependent. Local results converge through an explicit disposition lattice.
+
+Lane identifiers are restricted to safe filename characters before execution. Logs are drained concurrently to prevent pipe deadlock, retained only to the byte limit, stored behind relative references, and scrub declared sensitive values. Structured argv evidence is scrubbed by the same policy. Each command runs in a process group; timeout, an external cancellation marker, or a failed peer terminates the group so descendants do not survive.
+
+## Authority
+
+- Validator: may execute only manifest-declared commands and write local evidence.
+- Scheduler: pure eligibility report; cannot claim, execute, publish, merge, or close.
+- Shepherd: pure ready/waiting/retryable/repair/operator classification; cannot edit or acquire workflow authority.
+
+## Performance
+
+The focused Gate 4 tests use local deterministic executables and complete in well under one second warm. The complete standalone workspace remains the only build/test surface. Live network and cross-product proof are explicit optional lanes, not default validation.

--- a/docs/architecture/csdlc-v2/gate4/PVF_DAG.mmd
+++ b/docs/architecture/csdlc-v2/gate4/PVF_DAG.mmd
@@ -1,0 +1,12 @@
+flowchart LR
+  M["Typed PVF manifest"] --> V["Fail-closed schema and policy validation"]
+  V --> S["Deterministic dependency selection"]
+  S --> W1["Wave 1: independent lanes"]
+  W1 --> B["Concurrency and resource budgets"]
+  B --> L1["Lane A argv process"]
+  B --> L2["Lane B argv process"]
+  L1 --> W2["Wave 2: dependent lanes"]
+  L2 --> W2
+  W2 --> E["Bounded redacted evidence"]
+  E --> C["Typed convergence disposition"]
+  V -->|"invalid/cycle/authority gap"| F["Fail closed before execution"]

--- a/docs/architecture/csdlc-v2/gate4/SCHEDULER_SHEPHERD.mmd
+++ b/docs/architecture/csdlc-v2/gate4/SCHEDULER_SHEPHERD.mmd
@@ -1,0 +1,12 @@
+flowchart TB
+  T["Canonical issue/card/claim/PVF truth"] --> Q["Scheduler classifier"]
+  Q --> O["Eligible operations + blockers"]
+  O -. "report only" .-> X["Authorized lifecycle binary"]
+  T --> H["Shepherd observer"]
+  H --> R["ready"]
+  H --> W["waiting"]
+  H --> Y["retryable"]
+  H --> P["repair required"]
+  H --> U["operator required"]
+  Q --> N["No claim, execute, publish, merge, close"]
+  H --> N2["No edit, execute, publish, merge, close"]

--- a/docs/architecture/csdlc-v2/gate4/SHEPHERD_STATE.mmd
+++ b/docs/architecture/csdlc-v2/gate4/SHEPHERD_STATE.mmd
@@ -1,0 +1,10 @@
+stateDiagram-v2
+  [*] --> Waiting: dependency or proof pending
+  Waiting --> Ready: dependencies and proof settle
+  Waiting --> Retryable: transient failure
+  Retryable --> Waiting: retry observed
+  Waiting --> RepairRequired: deterministic defect
+  RepairRequired --> Waiting: repair observed
+  Waiting --> OperatorRequired: authority or policy decision
+  OperatorRequired --> Waiting: operator disposition observed
+  Ready --> [*]


### PR DESCRIPTION
Closes #5234

## Summary
Implemented the standalone typed PVF manifest, deterministic dependency and resource scheduler, bounded concurrent executor, evidence retention, and read-only scheduler/shepherd classifiers. The exact revision passed focused validation and bounded subagent review with no findings.

## Artifacts
- Local output record at `.adl/v0.91.7/tasks/issue-5234__v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation/sor.md`
- Tracked implementation artifacts: `csdlc-v2/`
- Design and diagram packet: `docs/architecture/csdlc-v2/gate4/`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --check` - Prove deterministic standalone Rust formatting.
  - `cargo clippy --all-targets -- -D warnings` - Prove all standalone targets are warning-free.
  - `cargo test` - Run 34 focused state, claim, PVF, scheduler, shepherd, process, and evidence tests.
  - `git diff --check` - Prove patch hygiene.
- Results:
  - `cargo fmt --check`: passed
  - `cargo clippy --all-targets -- -D warnings`: passed
  - `cargo test`: passed
  - `git diff --check`: passed

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5234__v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5234__v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation/sor.md
- Idempotency-Key: v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation-csdlc-v2-docs-architecture-csdlc-v2-gate4-adl-v0-91-7-tasks-issue-5234-v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation-sip-md-adl-v0-91-7-tasks-issue-5234-v0-91-7-csdlc-v2-gate-4-pvf-scheduler-shepherd-and-validation-sor-md