### PR TITLE
[v0.91.7][csdlc-v2] Gate 5: pre-publication review truth

### DIFF
--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -38,6 +38,10 @@ path = "src/bin/csdlc-schedule.rs"
 name = "csdlc-shepherd"
 path = "src/bin/csdlc-shepherd.rs"
 
+[[bin]]
+name = "csdlc-review"
+path = "src/bin/csdlc-review.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -17,6 +17,10 @@ resource costs, network/credential posture, timeouts, and bounded evidence
 policy. The scheduler and shepherd are pure read-only classifiers; only
 `csdlc-validate` can execute a declared proof DAG.
 
+Gate 5 adds `csdlc-review` for live-claim review assignment, exact-revision
+review recording, finding/fix/route evidence, and a read-only publication
+guard. Review has no GitHub or lifecycle publication authority.
+
 ## Focused validation
 
 ```text

--- a/csdlc-v2/src/bin/csdlc-review.rs
+++ b/csdlc-v2/src/bin/csdlc-review.rs
@@ -1,0 +1,70 @@
+use clap::{Parser, Subcommand};
+use csdlc_v2::{
+    assign_review, evaluate_publication_review_in_repo, record_review, ReviewAssignmentRequest,
+    ReviewEvidence, ReviewRecordRequest, Store,
+};
+use serde::Deserialize;
+use std::{fs, path::PathBuf};
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, default_value = ".")]
+    root: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+#[derive(Subcommand)]
+enum Command {
+    Assign {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    Record {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    Guard {
+        #[arg(long)]
+        request: PathBuf,
+    },
+}
+#[derive(Deserialize)]
+struct GuardRequest {
+    evidence: Option<ReviewEvidence>,
+    scope: Vec<String>,
+}
+fn read<T: for<'a> Deserialize<'a>>(path: &PathBuf) -> csdlc_v2::Result<T> {
+    Ok(serde_json::from_slice(&fs::read(path)?)?)
+}
+fn main() {
+    let cli = Cli::parse();
+    let store = Store::new(cli.root);
+    let result = match cli.command {
+        Command::Assign { request } => read::<ReviewAssignmentRequest>(&request)
+            .and_then(|v| assign_review(&store, v))
+            .and_then(json),
+        Command::Record { request } => read::<ReviewRecordRequest>(&request)
+            .and_then(|v| record_review(&store, v))
+            .and_then(json),
+        Command::Guard { request } => read::<GuardRequest>(&request).and_then(|v| {
+            let current = csdlc_v2::git::substantive_revision(store.root(), &v.scope)?;
+            json(evaluate_publication_review_in_repo(
+                store.root(),
+                v.evidence.as_ref(),
+                &current,
+            ))
+        }),
+    };
+    match result {
+        Ok(v) => println!("{v}"),
+        Err(e) => {
+            println!(
+                "{}",
+                serde_json::json!({"schema":"csdlc.error.v1","code":e.code,"message":e.message})
+            );
+            std::process::exit(e.code.exit_code())
+        }
+    }
+}
+fn json<T: serde::Serialize>(value: T) -> csdlc_v2::Result<String> {
+    Ok(serde_json::to_string(&value)?)
+}

--- a/csdlc-v2/src/cards.rs
+++ b/csdlc-v2/src/cards.rs
@@ -356,7 +356,17 @@ pub struct ReviewFinding {
     pub severity: FindingSeverity,
     pub summary: String,
     pub actionable: bool,
+    #[serde(default = "default_true")]
+    pub in_scope: bool,
     pub disposition: FindingDisposition,
+    #[serde(default)]
+    pub fix_revision: Option<String>,
+    #[serde(default)]
+    pub route: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/csdlc-v2/src/git.rs
+++ b/csdlc-v2/src/git.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -49,4 +50,114 @@ pub fn worktrees(root: &Path) -> Result<Vec<(String, String)>> {
         }
     }
     Ok(result)
+}
+
+pub fn substantive_revision(root: &Path, scope: &[String]) -> Result<String> {
+    if scope.is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "revision scope is empty",
+        ));
+    }
+    let head = run(root, &["rev-parse", "HEAD"])?.stdout;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(head.as_bytes());
+    let mut diff = Command::new("git");
+    diff.current_dir(root).args([
+        "diff",
+        "--no-ext-diff",
+        "--binary",
+        "HEAD",
+        "--",
+        ".",
+        ":(exclude).csdlc/**",
+    ]);
+    let output = diff
+        .output()
+        .map_err(|e| V2Error::new(ErrorCode::GitFailure, e.to_string()))?;
+    if !output.status.success() {
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    hasher.update(&output.stdout);
+    let mut others = Command::new("git");
+    others.current_dir(root).args([
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "--",
+        ".",
+        ":(exclude).csdlc/**",
+    ]);
+    let output = others
+        .output()
+        .map_err(|e| V2Error::new(ErrorCode::GitFailure, e.to_string()))?;
+    if !output.status.success() {
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    let mut paths: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    paths.sort();
+    for path in paths {
+        hasher.update(path.as_bytes());
+        hasher.update(&fs::read(root.join(path))?);
+    }
+    Ok(format!("git-blake3:{head}:{}", hasher.finalize().to_hex()))
+}
+
+pub fn clean_commit_revision(commit: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(commit.as_bytes());
+    format!("git-blake3:{commit}:{}", hasher.finalize().to_hex())
+}
+
+pub fn metadata_only_changed_paths(
+    root: &Path,
+    from_commit: &str,
+    to_commit: &str,
+) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args([
+            "diff",
+            "--name-only",
+            "--no-renames",
+            from_commit,
+            to_commit,
+            "--",
+        ])
+        .output()
+        .map_err(|e| V2Error::new(ErrorCode::GitFailure, e.to_string()))?;
+    if !output.status.success() {
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    let mut paths: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    paths.sort();
+    if paths.iter().any(|p| !safe_metadata_path(p)) {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "revision includes substantive paths",
+        ));
+    }
+    Ok(paths)
+}
+fn safe_metadata_path(path: &str) -> bool {
+    let value = Path::new(path);
+    value
+        .components()
+        .all(|c| matches!(c, std::path::Component::Normal(_)))
+        && (path.starts_with(".csdlc/review/") || path.starts_with(".csdlc/evidence/"))
 }

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -5,6 +5,7 @@ pub mod git;
 pub mod lifecycle;
 pub mod model;
 pub mod pvf;
+pub mod review;
 pub mod schema;
 pub mod store;
 
@@ -17,10 +18,17 @@ pub use lifecycle::{
     bind_issue, heartbeat_claim, initialize_issue, recover_claim, BindRequest, BindResult,
     RecoverClaimRequest,
 };
-pub use model::{Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase};
+pub use model::{
+    Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase, NonSubstantiveProof,
+    ReviewAssignment, ReviewEvidence, ReviewFindingEvidence,
+};
 pub use pvf::{
     classify_schedule, classify_shepherd, execute, select, ExecutionRequest, PvfManifest,
     ScheduleInput, ShepherdInput,
+};
+pub use review::{
+    assign_review, evaluate_publication_review, evaluate_publication_review_in_repo, record_review,
+    PublicationReviewReport, ReviewAssignmentRequest, ReviewRecordRequest,
 };
 pub use schema::public_schema_bundle;
 pub use store::{

--- a/csdlc-v2/src/model.rs
+++ b/csdlc-v2/src/model.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
-use crate::cards::CardKind;
+use crate::cards::{CardKind, FindingDisposition, FindingSeverity};
 use crate::error::{ErrorCode, Result, V2Error};
 
 #[derive(
@@ -73,6 +73,47 @@ pub struct ClaimRecovery {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReviewAssignment {
+    pub reviewer: String,
+    pub assigned_by: String,
+    pub revision: String,
+    pub scope: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReviewFindingEvidence {
+    pub id: String,
+    pub severity: FindingSeverity,
+    pub summary: String,
+    pub actionable: bool,
+    pub in_scope: bool,
+    pub disposition: FindingDisposition,
+    pub fix_revision: Option<String>,
+    pub route: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct NonSubstantiveProof {
+    pub policy: String,
+    pub from_revision: String,
+    pub to_revision: String,
+    pub from_commit: String,
+    pub to_commit: String,
+    pub changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReviewEvidence {
+    pub reviewer: String,
+    pub scope: Vec<String>,
+    pub reviewed_revision: String,
+    pub findings: Vec<ReviewFindingEvidence>,
+    pub residual_risks: Vec<String>,
+    pub completed: bool,
+    pub non_substantive_proof: Option<NonSubstantiveProof>,
+}
+
 impl Claim {
     pub fn validate(&self, claim_id: &str, now: u64) -> Result<()> {
         if self.id != claim_id {
@@ -137,6 +178,8 @@ pub struct IssueRecord {
     pub generation: u64,
     pub digest: String,
     pub claim: Option<Claim>,
+    pub review_assignment: Option<ReviewAssignment>,
+    pub review: Option<ReviewEvidence>,
     pub design_path: String,
     pub diagram_path: String,
     pub design_review: DesignReview,

--- a/csdlc-v2/src/review.rs
+++ b/csdlc-v2/src/review.rs
@@ -1,0 +1,288 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::cards::{FindingDisposition, ReviewResult};
+use crate::model::{LifecyclePhase, ReviewAssignment, ReviewEvidence};
+use crate::store::Store;
+use crate::{ErrorCode, IssueRecord, Result, V2Error};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ReviewAssignmentRequest {
+    pub issue: u64,
+    pub expected_generation: u64,
+    pub expected_digest: String,
+    pub claim_id: String,
+    pub reviewer: String,
+    pub assigned_by: String,
+    pub scope: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ReviewRecordRequest {
+    pub issue: u64,
+    pub expected_generation: u64,
+    pub expected_digest: String,
+    pub claim_id: String,
+    pub actor: String,
+    pub evidence: ReviewEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct PublicationReviewReport {
+    pub schema: String,
+    pub ready: bool,
+    pub blocker_codes: Vec<String>,
+    pub reviewed_revision: Option<String>,
+    pub accepted_revision: String,
+}
+
+pub fn assign_review(store: &Store, request: ReviewAssignmentRequest) -> Result<IssueRecord> {
+    let record = store.load_record(request.issue)?;
+    require_cas_claim(
+        &record,
+        request.expected_generation,
+        &request.expected_digest,
+        &request.claim_id,
+    )?;
+    if record.phase != LifecyclePhase::Implemented {
+        return Err(V2Error::new(
+            ErrorCode::InvalidTransition,
+            "review assignment requires implemented phase",
+        ));
+    }
+    if request.reviewer.trim().is_empty()
+        || request.assigned_by.trim().is_empty()
+        || request.scope.is_empty()
+        || request.scope.iter().any(|s| s.trim().is_empty())
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "review assignment is incomplete",
+        ));
+    }
+    let revision = crate::git::substantive_revision(store.root(), &request.scope)?;
+    let assignment = ReviewAssignment {
+        reviewer: request.reviewer,
+        assigned_by: request.assigned_by.clone(),
+        revision,
+        scope: request.scope,
+    };
+    store.commit_review_assignment(
+        request.issue,
+        &request.expected_digest,
+        &request.claim_id,
+        assignment,
+    )
+}
+
+pub fn record_review(store: &Store, request: ReviewRecordRequest) -> Result<IssueRecord> {
+    let record = store.load_record(request.issue)?;
+    require_cas_claim(
+        &record,
+        request.expected_generation,
+        &request.expected_digest,
+        &request.claim_id,
+    )?;
+    let assignment = record
+        .review_assignment
+        .as_ref()
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "review assignment missing"))?;
+    validate_evidence(assignment, &request.evidence)?;
+    let result = if request.evidence.completed
+        && request.evidence.findings.iter().all(|f| {
+            !f.actionable
+                || !f.in_scope
+                || matches!(
+                    f.disposition,
+                    FindingDisposition::Fixed | FindingDisposition::AcceptedRisk
+                )
+        }) {
+        ReviewResult::Pass
+    } else {
+        ReviewResult::ChangesRequired
+    };
+    store.commit_review(
+        request.issue,
+        &record.digest,
+        request.actor,
+        &request.claim_id,
+        request.evidence,
+        result,
+    )
+}
+
+fn require_cas_claim(
+    record: &IssueRecord,
+    generation: u64,
+    digest: &str,
+    claim_id: &str,
+) -> Result<()> {
+    if record.generation != generation {
+        return Err(V2Error::new(
+            ErrorCode::StaleGeneration,
+            "review generation is stale",
+        ));
+    }
+    if record.digest != digest {
+        return Err(V2Error::new(
+            ErrorCode::StaleDigest,
+            "review digest is stale",
+        ));
+    }
+    record
+        .claim
+        .as_ref()
+        .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?
+        .validate(claim_id, unix_now()?)
+}
+
+fn validate_evidence(assignment: &ReviewAssignment, evidence: &ReviewEvidence) -> Result<()> {
+    if evidence.reviewer != assignment.reviewer
+        || evidence.scope != assignment.scope
+        || evidence.reviewed_revision != assignment.revision
+        || evidence.reviewer.trim().is_empty()
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "review evidence does not match assignment",
+        ));
+    }
+    let mut ids = std::collections::BTreeSet::new();
+    for f in &evidence.findings {
+        if f.id.trim().is_empty() || f.summary.trim().is_empty() || !ids.insert(&f.id) {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "review finding identity is invalid",
+            ));
+        }
+        if f.actionable
+            && f.in_scope
+            && f.disposition == FindingDisposition::Fixed
+            && f.fix_revision.as_deref() != Some(evidence.reviewed_revision.as_str())
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "fixed finding must name the reviewed revision",
+            ));
+        }
+        if f.actionable
+            && f.in_scope
+            && f.disposition == FindingDisposition::AcceptedRisk
+            && evidence.residual_risks.is_empty()
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "accepted actionable risk requires residual-risk evidence",
+            ));
+        }
+        if !f.in_scope
+            && (f.disposition != FindingDisposition::OutOfScope
+                || f.route.as_deref().unwrap_or_default().is_empty())
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "out-of-scope finding requires route",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn evaluate_publication_review(
+    evidence: Option<&ReviewEvidence>,
+    current_revision: &str,
+) -> PublicationReviewReport {
+    evaluate(evidence, current_revision, false)
+}
+
+pub fn evaluate_publication_review_in_repo(
+    root: &std::path::Path,
+    evidence: Option<&ReviewEvidence>,
+    current_revision: &str,
+) -> PublicationReviewReport {
+    let proof_ok = evidence
+        .and_then(|e| e.non_substantive_proof.as_ref())
+        .is_some_and(|proof| {
+            verify_non_substantive(root, evidence.expect("evidence"), current_revision, proof)
+        });
+    evaluate(evidence, current_revision, proof_ok)
+}
+
+fn evaluate(
+    evidence: Option<&ReviewEvidence>,
+    current_revision: &str,
+    proof_ok: bool,
+) -> PublicationReviewReport {
+    let mut blockers = Vec::new();
+    let reviewed = evidence.map(|e| e.reviewed_revision.clone());
+    match evidence {
+        None => blockers.push("review_missing".into()),
+        Some(e) => {
+            if !e.completed {
+                blockers.push("review_incomplete".into());
+            }
+            if e.reviewer.trim().is_empty() || e.scope.is_empty() {
+                blockers.push("review_identity_or_scope_missing".into());
+            }
+            if e.findings.iter().any(|f| {
+                (f.disposition == FindingDisposition::Fixed
+                    && f.fix_revision.as_deref() != Some(e.reviewed_revision.as_str()))
+                    || (f.disposition == FindingDisposition::AcceptedRisk
+                        && e.residual_risks.is_empty())
+            }) {
+                blockers.push("review_evidence_invalid".into());
+            }
+            if e.reviewed_revision != current_revision && !proof_ok {
+                blockers.push("review_stale".into());
+            }
+            if e.findings.iter().any(|f| {
+                f.actionable
+                    && f.in_scope
+                    && !matches!(
+                        f.disposition,
+                        FindingDisposition::Fixed | FindingDisposition::AcceptedRisk
+                    )
+            }) {
+                blockers.push("actionable_finding_unresolved".into());
+            }
+            if e.findings.iter().any(|f| {
+                !f.in_scope
+                    && (f.disposition != FindingDisposition::OutOfScope
+                        || f.route.as_deref().unwrap_or_default().is_empty())
+            }) {
+                blockers.push("out_of_scope_finding_unrouted".into());
+            }
+        }
+    }
+    PublicationReviewReport {
+        schema: "csdlc.publication_review.v1".into(),
+        ready: blockers.is_empty(),
+        blocker_codes: blockers,
+        reviewed_revision: reviewed,
+        accepted_revision: current_revision.into(),
+    }
+}
+
+fn verify_non_substantive(
+    root: &std::path::Path,
+    e: &ReviewEvidence,
+    current: &str,
+    p: &crate::NonSubstantiveProof,
+) -> bool {
+    if p.policy != "review_metadata_only_v1"
+        || p.from_revision != e.reviewed_revision
+        || p.to_revision != current
+        || p.from_revision != crate::git::clean_commit_revision(&p.from_commit)
+        || p.to_revision != crate::git::clean_commit_revision(&p.to_commit)
+    {
+        return false;
+    }
+    crate::git::metadata_only_changed_paths(root, &p.from_commit, &p.to_commit)
+        .is_ok_and(|paths| !paths.is_empty() && paths == p.changed_paths)
+}
+fn unix_now() -> Result<u64> {
+    Ok(std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| V2Error::new(ErrorCode::InvalidInput, e.to_string()))?
+        .as_secs())
+}

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -4,6 +4,7 @@ use crate::doctor::DoctorReport;
 use crate::lifecycle::{BindRequest, BindResult, RecoverClaimRequest};
 use crate::model::IssueRecord;
 use crate::pvf::{ExecutionReport, ExecutionRequest, PvfManifest, ScheduleReport, ShepherdReport};
+use crate::review::{PublicationReviewReport, ReviewAssignmentRequest, ReviewRecordRequest};
 use crate::store::ApproveDesignRequest;
 use crate::store::{BootstrapRequest, EditRequest};
 
@@ -23,5 +24,8 @@ pub fn public_schema_bundle() -> Value {
         "pvf_execution_report": schemars::schema_for!(ExecutionReport),
         "scheduler_report": schemars::schema_for!(ScheduleReport),
         "shepherd_report": schemars::schema_for!(ShepherdReport),
+        "review_assignment_request": schemars::schema_for!(ReviewAssignmentRequest),
+        "review_record_request": schemars::schema_for!(ReviewRecordRequest),
+        "publication_review_report": schemars::schema_for!(PublicationReviewReport),
     })
 }

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -13,7 +13,11 @@ use crate::cards::{
     InitialCardInput, SemanticOperation,
 };
 use crate::error::{ErrorCode, Result, V2Error};
-use crate::model::{AuditEvent, CardProjection, Claim, DesignReview, IssueRecord, LifecyclePhase};
+use crate::model::{
+    AuditEvent, CardProjection, Claim, DesignReview, IssueRecord, LifecyclePhase, ReviewAssignment,
+    ReviewEvidence,
+};
+use crate::review::evaluate_publication_review_in_repo;
 
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -154,6 +158,119 @@ impl Store {
         let cards = self.load_cards(issue)?;
         verify_cards(self, &current, &cards)?;
         self.commit(issue, record, &cards, false)
+    }
+
+    pub(crate) fn commit_review(
+        &self,
+        issue: u64,
+        expected_digest: &str,
+        actor: String,
+        claim_id: &str,
+        evidence: ReviewEvidence,
+        result: crate::cards::ReviewResult,
+    ) -> Result<IssueRecord> {
+        let _lock = self.lock(issue)?;
+        self.recover_if_needed(issue)?;
+        let mut record = self.load_record(issue)?;
+        record
+            .claim
+            .as_ref()
+            .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?
+            .validate(claim_id, now_seconds()?)?;
+        if record.digest != expected_digest {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "review record changed before commit",
+            ));
+        }
+        let mut cards = self.load_cards(issue)?;
+        verify_cards(self, &record, &cards)?;
+        let srp = match &mut cards.get_mut(&CardKind::Srp).expect("SRP").content {
+            CardContent::Srp(values) => values,
+            _ => unreachable!("SRP"),
+        };
+        srp.reviewer = Some(evidence.reviewer.clone());
+        srp.review_scope = evidence.scope.join("\n");
+        srp.review_revision = Some(evidence.reviewed_revision.clone());
+        srp.review_result = result;
+        srp.residual_risk = evidence.residual_risks.clone();
+        srp.findings = evidence
+            .findings
+            .iter()
+            .map(|finding| crate::cards::ReviewFinding {
+                id: finding.id.clone(),
+                severity: finding.severity,
+                summary: finding.summary.clone(),
+                actionable: finding.actionable,
+                in_scope: finding.in_scope,
+                disposition: finding.disposition,
+                fix_revision: finding.fix_revision.clone(),
+                route: finding.route.clone(),
+            })
+            .collect();
+        record.generation += 1;
+        for values in cards.values_mut() {
+            values.identity.generation = record.generation;
+        }
+        if let Some(claim) = record.claim.as_mut() {
+            claim.generation = record.generation;
+        }
+        record.review = Some(evidence);
+        record.audit.push(AuditEvent {
+            sequence: record.audit.len() as u64 + 1,
+            generation: record.generation,
+            actor,
+            reason: "atomically record review evidence and SRP projection".into(),
+            operation: "record_review".into(),
+        });
+        hydrate_projections(&mut record, &cards)?;
+        record.digest = record_digest(&record)?;
+        self.commit(issue, &record, &cards, false)?;
+        Ok(record)
+    }
+
+    pub(crate) fn commit_review_assignment(
+        &self,
+        issue: u64,
+        expected_digest: &str,
+        claim_id: &str,
+        assignment: ReviewAssignment,
+    ) -> Result<IssueRecord> {
+        let _lock = self.lock(issue)?;
+        self.recover_if_needed(issue)?;
+        let mut record = self.load_record(issue)?;
+        if record.digest != expected_digest {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "review assignment changed before commit",
+            ));
+        }
+        record
+            .claim
+            .as_ref()
+            .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?
+            .validate(claim_id, now_seconds()?)?;
+        if record.phase != LifecyclePhase::Implemented {
+            return Err(V2Error::new(
+                ErrorCode::InvalidTransition,
+                "review assignment requires implemented phase",
+            ));
+        }
+        let cards = self.load_cards(issue)?;
+        verify_cards(self, &record, &cards)?;
+        let actor = assignment.assigned_by.clone();
+        record.review_assignment = Some(assignment);
+        record.review = None;
+        record.audit.push(AuditEvent {
+            sequence: record.audit.len() as u64 + 1,
+            generation: record.generation,
+            actor,
+            reason: "assign bounded exact-revision review".into(),
+            operation: "assign_review".into(),
+        });
+        record.digest = record_digest(&record)?;
+        self.commit(issue, &record, &cards, false)?;
+        Ok(record)
     }
 }
 
@@ -325,6 +442,8 @@ pub fn bootstrap_issue(store: &Store, request: BootstrapRequest) -> Result<Issue
         generation: 0,
         digest: String::new(),
         claim: Some(request.claim),
+        review_assignment: None,
+        review: None,
         design_path: request.design_path,
         diagram_path: request.diagram_path,
         design_review: if request.design_approved {
@@ -641,6 +760,19 @@ fn validate_phase_guard(
         });
     if next == LifecyclePhase::Published
         && (!review_current
+            || record.review_assignment.as_ref().is_none_or(|assignment| {
+                crate::git::substantive_revision(store.root(), &assignment.scope).map_or(
+                    true,
+                    |current| {
+                        !evaluate_publication_review_in_repo(
+                            store.root(),
+                            record.review.as_ref(),
+                            &current,
+                        )
+                        .ready
+                    },
+                )
+            })
             || !matches!(
                 sor.publication_state,
                 crate::cards::PublicationState::Draft | crate::cards::PublicationState::Ready
@@ -653,6 +785,19 @@ fn validate_phase_guard(
     }
     if next == LifecyclePhase::MergeReady
         && (!review_current
+            || record.review_assignment.as_ref().is_none_or(|assignment| {
+                crate::git::substantive_revision(store.root(), &assignment.scope).map_or(
+                    true,
+                    |current| {
+                        !evaluate_publication_review_in_repo(
+                            store.root(),
+                            record.review.as_ref(),
+                            &current,
+                        )
+                        .ready
+                    },
+                )
+            })
             || !validation_passed
             || sor.publication_state != crate::cards::PublicationState::Ready)
     {

--- a/csdlc-v2/tests/gate5.rs
+++ b/csdlc-v2/tests/gate5.rs
@@ -1,0 +1,405 @@
+use csdlc_v2::cards::{FindingDisposition, FindingSeverity};
+use csdlc_v2::{
+    assign_review, edit_issue, evaluate_publication_review, evaluate_publication_review_in_repo,
+    initialize_issue, record_review, BootstrapRequest, CardKind, Claim, EditRequest,
+    InitialCardInput, LifecyclePhase, NonSubstantiveProof, PlanningProfile,
+    ReviewAssignmentRequest, ReviewEvidence, ReviewFindingEvidence, ReviewRecordRequest,
+    SemanticOperation, Store,
+};
+
+fn finding(id: &str) -> ReviewFindingEvidence {
+    ReviewFindingEvidence {
+        id: id.into(),
+        severity: FindingSeverity::P1,
+        summary: "fix correctness".into(),
+        actionable: true,
+        in_scope: true,
+        disposition: FindingDisposition::Fixed,
+        fix_revision: Some("rev-2".into()),
+        route: None,
+    }
+}
+
+fn implemented_fixture() -> (tempfile::TempDir, Store, csdlc_v2::IssueRecord) {
+    let temp = tempfile::tempdir().expect("temp");
+    std::fs::create_dir_all(temp.path().join("docs")).expect("docs");
+    std::fs::write(temp.path().join("docs/design.md"), "# reviewed design\n").expect("design");
+    std::fs::write(
+        temp.path().join("docs/diagram.mmd"),
+        "flowchart LR\n A-->B\n",
+    )
+    .expect("diagram");
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "docs"]);
+    git(temp.path(), &["commit", "-m", "fixture"]);
+    let store = Store::new(temp.path());
+    let mut record = initialize_issue(
+        &store,
+        BootstrapRequest {
+            issue: 7,
+            repository: "example/repo".into(),
+            design_path: "docs/design.md".into(),
+            diagram_path: "docs/diagram.mmd".into(),
+            design_reviewer: "architect".into(),
+            design_approved: true,
+            claim: Claim {
+                id: "claim".into(),
+                owner: "agent".into(),
+                generation: 0,
+                acquired_unix_seconds: 1,
+                expires_unix_seconds: u64::MAX,
+                heartbeat_unix_seconds: 1,
+                branch: "issue-7".into(),
+                worktree: ".worktrees/issue-7".into(),
+                protected_paths: vec!["src".into()],
+                purpose: "review test".into(),
+            },
+            initial: InitialCardInput {
+                title: "review fixture".into(),
+                slug: "review-fixture".into(),
+                version: "v0.91.7".into(),
+                goal: "prove review".into(),
+                required_outcome: "review truth".into(),
+                declared_scope: vec!["src".into()],
+                authority_boundary: vec!["no network".into()],
+                task_boundary: "review only".into(),
+                deliverables: vec!["review".into()],
+                acceptance_criteria: vec!["review current".into()],
+                dependencies: vec!["none".into()],
+                repo_inputs: vec!["src".into()],
+                non_goals: vec!["publish".into()],
+                plan_summary: "implement then review".into(),
+                steps: vec![csdlc_v2::cards::PlanStep {
+                    id: "one".into(),
+                    action: "review".into(),
+                    acceptance_ids: vec!["AC-1".into()],
+                    status: csdlc_v2::cards::StepStatus::Pending,
+                }],
+                invariants: vec!["exact revision".into()],
+                risks: vec!["stale".into()],
+                planning_profile: PlanningProfile::Small,
+                stop_conditions: vec!["stale".into()],
+                validation_lanes: vec![csdlc_v2::cards::ValidationLane {
+                    lane: "focused".into(),
+                    proof_role: "review".into(),
+                    acceptance_ids: vec!["AC-1".into()],
+                    deterministic: true,
+                    resource_profile: csdlc_v2::cards::ResourceProfile::Small,
+                    budget_seconds: 60,
+                    budget_tokens: 100,
+                    argv: vec!["cargo".into(), "test".into()],
+                    parallel_group: "local".into(),
+                    defer_reason: None,
+                }],
+                failure_policy: "fail closed".into(),
+                review_prompts: vec!["review correctness".into()],
+            },
+        },
+    )
+    .expect("init");
+    for operation in [
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Ready,
+        },
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Bound,
+        },
+        SemanticOperation::RecordExecution {
+            summary: "implemented".into(),
+            changes: vec!["src".into()],
+            artifacts: vec!["artifact".into()],
+        },
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Implemented,
+        },
+    ] {
+        let card = if matches!(operation, SemanticOperation::RecordExecution { .. }) {
+            CardKind::Sor
+        } else {
+            CardKind::Sip
+        };
+        record = edit_issue(
+            &store,
+            EditRequest {
+                issue: 7,
+                card,
+                expected_generation: record.generation,
+                expected_digest: record.digest.clone(),
+                claim_id: "claim".into(),
+                actor: "agent".into(),
+                reason: "fixture transition".into(),
+                operation,
+                fail_after_backup: false,
+            },
+        )
+        .expect("transition");
+    }
+    (temp, store, record)
+}
+
+#[test]
+fn assignment_and_recording_update_index_and_srp_without_publication_side_effect() {
+    let (temp, store, record) = implemented_fixture();
+    let assigned = assign_review(
+        &store,
+        ReviewAssignmentRequest {
+            issue: 7,
+            expected_generation: record.generation,
+            expected_digest: record.digest,
+            claim_id: "claim".into(),
+            reviewer: "subagent".into(),
+            assigned_by: "agent".into(),
+            scope: vec!["src".into()],
+        },
+    )
+    .expect("assign");
+    let revision = assigned
+        .review_assignment
+        .as_ref()
+        .expect("assignment")
+        .revision
+        .clone();
+    let mut fixed = finding("F-1");
+    fixed.fix_revision = Some(revision.clone());
+    let value = ReviewEvidence {
+        reviewer: "subagent".into(),
+        scope: vec!["src".into()],
+        reviewed_revision: revision.clone(),
+        findings: vec![fixed],
+        residual_risks: vec!["none".into()],
+        completed: true,
+        non_substantive_proof: None,
+    };
+    let reviewed = record_review(
+        &store,
+        ReviewRecordRequest {
+            issue: 7,
+            expected_generation: assigned.generation,
+            expected_digest: assigned.digest,
+            claim_id: "claim".into(),
+            actor: "agent".into(),
+            evidence: value,
+        },
+    )
+    .expect("record");
+    assert!(evaluate_publication_review(reviewed.review.as_ref(), &revision).ready);
+    let cards = store.load_cards(7).expect("cards");
+    match &cards[&CardKind::Srp].content {
+        csdlc_v2::cards::CardContent::Srp(srp) => {
+            assert_eq!(srp.reviewer.as_deref(), Some("subagent"));
+            assert_eq!(srp.findings.len(), 1);
+        }
+        _ => unreachable!(),
+    };
+    assert_eq!(git_out(temp.path(), &["branch", "--show-current"]), "main");
+    assert!(
+        !temp.path().join(".git/refs/remotes").exists(),
+        "review created remote state"
+    );
+    let reassigned = assign_review(
+        &store,
+        ReviewAssignmentRequest {
+            issue: 7,
+            expected_generation: reviewed.generation,
+            expected_digest: reviewed.digest,
+            claim_id: "claim".into(),
+            reviewer: "subagent".into(),
+            assigned_by: "agent".into(),
+            scope: vec!["src".into()],
+        },
+    )
+    .expect("reassign substantive revision");
+    assert!(reassigned.review.is_none());
+    assert!(
+        !evaluate_publication_review(
+            reassigned.review.as_ref(),
+            &reassigned
+                .review_assignment
+                .as_ref()
+                .expect("assignment")
+                .revision
+        )
+        .ready
+    );
+}
+fn git(root: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+fn evidence() -> ReviewEvidence {
+    ReviewEvidence {
+        reviewer: "bounded-subagent".into(),
+        scope: vec!["csdlc-v2/".into()],
+        reviewed_revision: "rev-2".into(),
+        findings: vec![finding("F-1")],
+        residual_risks: vec!["none known".into()],
+        completed: true,
+        non_substantive_proof: None,
+    }
+}
+
+#[test]
+fn exact_completed_review_with_resolved_findings_is_publishable() {
+    let report = evaluate_publication_review(Some(&evidence()), "rev-2");
+    assert!(report.ready);
+    assert!(report.blocker_codes.is_empty());
+}
+
+#[test]
+fn missing_incomplete_stale_and_unresolved_review_fail_closed() {
+    assert_eq!(
+        evaluate_publication_review(None, "rev").blocker_codes,
+        vec!["review_missing"]
+    );
+    let mut value = evidence();
+    value.completed = false;
+    assert!(evaluate_publication_review(Some(&value), "rev-2")
+        .blocker_codes
+        .contains(&"review_incomplete".into()));
+    value.completed = true;
+    assert!(evaluate_publication_review(Some(&value), "rev-3")
+        .blocker_codes
+        .contains(&"review_stale".into()));
+    value.findings[0].disposition = FindingDisposition::Open;
+    assert!(evaluate_publication_review(Some(&value), "rev-2")
+        .blocker_codes
+        .contains(&"actionable_finding_unresolved".into()));
+}
+
+#[test]
+fn guard_rejects_malformed_fixed_and_accepted_risk_evidence() {
+    let mut value = evidence();
+    value.findings[0].fix_revision = Some("wrong".into());
+    assert!(evaluate_publication_review(Some(&value), "rev-2")
+        .blocker_codes
+        .contains(&"review_evidence_invalid".into()));
+    value.findings[0].disposition = FindingDisposition::AcceptedRisk;
+    value.findings[0].fix_revision = None;
+    value.residual_risks.clear();
+    assert!(evaluate_publication_review(Some(&value), "rev-2")
+        .blocker_codes
+        .contains(&"review_evidence_invalid".into()));
+}
+
+#[test]
+fn out_of_scope_finding_must_remain_visible_and_routed() {
+    let mut value = evidence();
+    value.findings[0].in_scope = false;
+    value.findings[0].disposition = FindingDisposition::OutOfScope;
+    value.findings[0].fix_revision = None;
+    value.findings[0].route = None;
+    assert!(evaluate_publication_review(Some(&value), "rev-2")
+        .blocker_codes
+        .contains(&"out_of_scope_finding_unrouted".into()));
+    value.findings[0].route = Some("follow-up:#999".into());
+    assert!(evaluate_publication_review(Some(&value), "rev-2").ready);
+}
+
+#[test]
+fn non_substantive_exception_is_narrow_and_machine_proven() {
+    let temp = tempfile::tempdir().expect("temp");
+    std::fs::create_dir_all(temp.path().join(".csdlc/review")).expect("dir");
+    std::fs::write(temp.path().join(".csdlc/review/result.json"), "one").expect("one");
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-m", "one"]);
+    let from = git_out(temp.path(), &["rev-parse", "HEAD"]);
+    std::fs::write(temp.path().join(".csdlc/review/result.json"), "two").expect("two");
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-m", "two"]);
+    let to = git_out(temp.path(), &["rev-parse", "HEAD"]);
+    let from_revision = csdlc_v2::git::clean_commit_revision(&from);
+    let to_revision = csdlc_v2::git::clean_commit_revision(&to);
+    let mut value = evidence();
+    value.reviewed_revision = from_revision.clone();
+    value.findings[0].fix_revision = Some(from_revision.clone());
+    value.non_substantive_proof = Some(NonSubstantiveProof {
+        policy: "review_metadata_only_v1".into(),
+        from_revision,
+        to_revision: to_revision.clone(),
+        from_commit: from,
+        to_commit: to,
+        changed_paths: vec![".csdlc/review/result.json".into()],
+    });
+    assert!(evaluate_publication_review_in_repo(temp.path(), Some(&value), &to_revision).ready);
+    value
+        .non_substantive_proof
+        .as_mut()
+        .expect("proof")
+        .changed_paths = vec!["src/lib.rs".into()];
+    assert!(!evaluate_publication_review_in_repo(temp.path(), Some(&value), &to_revision).ready);
+}
+
+#[test]
+fn guard_cli_is_read_only_and_returns_typed_truth() {
+    let temp = tempfile::tempdir().expect("temp");
+    std::fs::create_dir_all(temp.path().join("docs")).expect("docs");
+    std::fs::write(temp.path().join("docs/review.md"), "review").expect("doc");
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "docs"]);
+    git(temp.path(), &["commit", "-m", "review"]);
+    let revision =
+        csdlc_v2::git::substantive_revision(temp.path(), &["docs".into()]).expect("revision");
+    let mut reviewed = evidence();
+    reviewed.reviewed_revision = revision.clone();
+    reviewed.findings[0].fix_revision = Some(revision);
+    let request_dir = tempfile::tempdir().expect("request dir");
+    let path = request_dir.path().join("guard.json");
+    std::fs::write(
+        &path,
+        serde_json::json!({"evidence":reviewed,"scope":["docs"]}).to_string(),
+    )
+    .expect("request");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_csdlc-review"))
+        .args([
+            "--root",
+            temp.path().to_str().expect("root"),
+            "guard",
+            "--request",
+            path.to_str().expect("request"),
+        ])
+        .output()
+        .expect("CLI");
+    assert!(output.status.success());
+    let report: String = String::from_utf8(output.stdout).expect("UTF-8");
+    assert!(report.contains("\"ready\":true"));
+    assert!(
+        !temp.path().join(".csdlc").exists(),
+        "guard mutated repository"
+    );
+}
+fn git_out(root: &std::path::Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .expect("UTF-8")
+        .trim()
+        .into()
+}

--- a/docs/architecture/csdlc-v2/gate5/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate5/DESIGN.md
@@ -1,0 +1,15 @@
+# C-SDLC v2 Gate 5 design
+
+Gate 5 makes bounded pre-publication review canonical state rather than an informal PR convention. `csdlc-review assign` binds reviewer, assigner, and bounded scope under the live issue claim; the tool computes the exact revision from Git HEAD plus scoped tracked and untracked content. Assignment clears any prior review. `csdlc-review record` revalidates the claim under the transaction lock, requires matching generation/digest and assignment, and atomically writes the SRP projection plus richer index evidence.
+
+Each finding retains id, severity, summary, actionability, in-scope status, disposition, fix revision, and follow-up route. A fixed actionable in-scope finding requires a fix revision. An out-of-scope finding requires both `out_of_scope` disposition and a route; it cannot disappear from evidence. Residual risks remain explicit.
+
+The publication guard is pure and local. It accepts only completed evidence with reviewer/scope identity, an exact current revision, and no unresolved actionable in-scope or unrouted out-of-scope findings. The existing state transition guard calls the same evaluator before Published or MergeReady. Review assignment/recording does not contain GitHub transport and cannot push, publish, merge, close, or change PR state.
+
+## Revision invalidation
+
+A new substantive revision is assigned for a fresh review, atomically clearing old evidence. The publication transition independently recomputes the scoped Git revision, so source changes invalidate review without a caller assertion. The sole exception is `review_metadata_only_v1`: the tool recomputes normalized changed paths between the named commits and accepts only `.csdlc/review/` or `.csdlc/evidence/`. Traversal, source, design, manifest, command, and product paths cannot use the exception.
+
+## Automated cards
+
+Review scope, result, findings, in-scope truth, fix revision, route, and residual risk are applied atomically to SRP through the deterministic markdown.rs projection path used by Gate 2. The full evidence remains indexed for publication policy and audit without hand-editing Markdown.

--- a/docs/architecture/csdlc-v2/gate5/FINDING_STATE.mmd
+++ b/docs/architecture/csdlc-v2/gate5/FINDING_STATE.mmd
@@ -1,0 +1,9 @@
+stateDiagram-v2
+  [*] --> Open: finding recorded
+  Open --> Fixed: in-scope fix + revision
+  Open --> AcceptedRisk: explicit bounded risk
+  Open --> OutOfScope: route retained
+  Fixed --> [*]
+  AcceptedRisk --> [*]
+  OutOfScope --> [*]
+  Open --> BlockPublication: actionable unresolved

--- a/docs/architecture/csdlc-v2/gate5/REVIEW_FLOW.mmd
+++ b/docs/architecture/csdlc-v2/gate5/REVIEW_FLOW.mmd
@@ -1,0 +1,8 @@
+flowchart LR
+  I["Implemented exact revision"] --> A["Assign bounded reviewer + scope"]
+  A --> R["Subagent reviews exact revision"]
+  R --> F["Record findings, fixes, routes, residual risk"]
+  F --> G["Publication review guard"]
+  G -->|"complete + current + resolved"| P["Review-ready for later publisher"]
+  G -->|"missing, stale, unresolved, unrouted"| X["Fail closed"]
+  P -. "no publication authority" .-> Y["Gate 6 publisher"]

--- a/docs/architecture/csdlc-v2/gate5/REVISION_INVALIDATION.mmd
+++ b/docs/architecture/csdlc-v2/gate5/REVISION_INVALIDATION.mmd
@@ -1,0 +1,7 @@
+flowchart TB
+  E["Review evidence for revision A"] --> C{"Current revision"}
+  C -->|"A"| V["Evidence remains current"]
+  C -->|"B"| N{"Metadata-only proof"}
+  N -->|"narrow paths + unchanged substantive digest"| V
+  N -->|"missing or substantive"| S["Stale: assign and review B"]
+  S --> E2["New evidence replaces prior current review"]


### PR DESCRIPTION
Closes #5235

## Summary
Implemented canonical pre-publication review assignment, repository-derived exact revisions, atomic SRP/index review evidence, finding disposition truth, and fail-closed publication review guards.

## Artifacts
- Local ignored output-card scaffold at `.adl/v0.91.7/tasks/issue-5235__v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth/sor.md`
- Tracked implementation artifacts: `csdlc-v2/`
- Design and diagram packet: `docs/architecture/csdlc-v2/gate5/`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --check` - Prove deterministic formatting.
  - `cargo clippy --all-targets -- -D warnings` - Prove warning-free standalone targets.
  - `cargo test` - Run 41 focused standalone tests including exact-revision review truth.
  - `git diff --check` - Prove patch hygiene.
- Results:
  - `cargo fmt --check`: passed
  - `cargo clippy --all-targets -- -D warnings`: passed
  - `cargo test`: passed
  - `git diff --check`: passed

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5235__v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5235__v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth/sor.md
- Idempotency-Key: v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth-csdlc-v2-docs-architecture-csdlc-v2-gate5-adl-v0-91-7-tasks-issue-5235-v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth-sip-md-adl-v0-91-7-tasks-issue-5235-v0-91-7-csdlc-v2-gate-5-pre-publication-review-truth-sor-md