### PR TITLE
[v0.91.7][runtime-v3] Decide default switch and Runtime v2 decommission path

### DIFF
--- a/adl-runtime-kernel/tests/parity.rs
+++ b/adl-runtime-kernel/tests/parity.rs
@@ -1071,3 +1071,63 @@ fn live_black_box_parity_classification_covers_matrix_without_counting_blockers_
         Some(*disposition_counts.get("blocker").unwrap_or(&0) as u64)
     );
 }
+
+#[test]
+fn final_cutover_decision_keeps_v2_default_until_parity_blockers_clear() {
+    let decision: serde_json::Value = serde_json::from_str(include_str!(
+        "../../docs/architecture/runtime_v3_cutover_decision_5254.v1.json"
+    ))
+    .unwrap();
+    let classification: serde_json::Value = serde_json::from_str(include_str!(
+        "../../docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json"
+    ))
+    .unwrap();
+
+    assert_eq!(decision["schema"], "adl.runtime_v3.cutover_decision.v1");
+    assert_eq!(decision["issue"], 5254);
+    assert_eq!(decision["target_version"], "v0.91.7");
+    assert_eq!(decision["decision"], "keep_runtime_v2_default");
+    assert_eq!(decision["cutover_authorized"], false);
+    assert_eq!(decision["default_runtime"], "v2");
+    assert_eq!(decision["runtime_v3_selection"], "explicit_opt_in_only");
+    assert_eq!(decision["default_runtime_switch_authorized"], false);
+    assert_eq!(decision["runtime_v2_decommission_authorized"], false);
+    assert_eq!(decision["runtime_v2_deletion_authorized"], false);
+    assert_eq!(decision["rollback_target"], "v2");
+    assert_eq!(decision["next_gate"]["issue"], 5220);
+
+    assert_eq!(classification["cutover_eligible"], false);
+    assert_eq!(classification["default_runtime_switch_authorized"], false);
+    assert_eq!(
+        decision["input_summary"]["live_black_box_cutover_eligible"],
+        classification["cutover_eligible"]
+    );
+    assert_eq!(
+        decision["input_summary"]["live_black_box_blockers"],
+        classification["summary"]["blocker"]
+    );
+    assert_eq!(
+        decision["input_summary"]["accepted_intentional_divergence"],
+        classification["summary"]["accepted_intentional_divergence"]
+    );
+
+    let blockers = classification["capabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|entry| entry["disposition"] == "blocker")
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    let decision_blockers = decision["blocking_surfaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry.as_str().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(decision_blockers, blockers);
+    for capability in classification["capabilities"].as_array().unwrap() {
+        if capability["disposition"] == "blocker" {
+            assert_eq!(capability["blocking_issue"], 5220);
+        }
+    }
+}

--- a/docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md
+++ b/docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md
@@ -5,6 +5,11 @@ Sprint: #5174
 Decision date: 2026-07-12
 cutover_authorized: false
 
+> Supersession note: #5254 is the final v0.91.7 default-switch/decommission
+> decision packet. It keeps Runtime v2 as the default runtime, retains Runtime
+> v3 as explicit opt-in only, and routes release-gate closure through #5220.
+> See `docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md`.
+
 ## Decision
 
 Runtime v3 remains in incubation. Do not switch default runtime behavior yet.

--- a/docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md
+++ b/docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md
@@ -1,0 +1,66 @@
+# Runtime v3 Cutover Decision (#5254)
+
+Issue: #5254
+Target: v0.91.7
+Decision date: 2026-07-12
+cutover_authorized: false
+
+## Decision
+
+Runtime v2 remains the default runtime for v0.91.7. Runtime v3 remains available
+only through explicit opt-in selection, with Runtime v2 retained as the rollback
+target.
+
+This is a no-go decision for a default Runtime v3 switch. The retained parity
+packet still reports `cutover_eligible: false` and nine blocker-class
+capabilities. #5252 and #5253 resolved the weather/observability and
+soak/rollback prerequisites, but they did not convert the remaining
+capability-specific blockers into passed proof.
+
+## Evidence
+
+| Surface | Evidence | Decision input |
+|---|---|---|
+| Live black-box parity | `docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json` | `cutover_eligible: false`; nine blocker-class capabilities remain. |
+| Explicit selection and rollback | `docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md` | Runtime v3 is explicit opt-in; Runtime v2 remains the default and rollback target. |
+| Weather and CloudWatch boundary | `docs/architecture/runtime_v3_weather_cloudwatch_5252.v1.json` | Local weather/resource proof exists; observed GPU telemetry remains a non-pass deferred surface. |
+| Soak and rollback | `docs/architecture/runtime_v3_soak_rollback_5253.v1.json` | Bounded production-like soak and rollback proof exists; remote multi-day and GPU lanes remain non-claims. |
+| Shadow parity | `docs/architecture/runtime_v3_shadow_parity_report.v1.json` | Runtime v2 remains default and Runtime v3 stays opt-in. |
+
+## Blocking Surfaces
+
+The following capability groups remain blocker-class for default switch
+authorization:
+
+- `kernel.lifecycle`
+- `kernel.topology_and_backpressure`
+- `service.contracts_and_configuration`
+- `continuity.replay_recovery`
+- `learning.adaptive_dag`
+- `governance.freedom_gate_aee`
+- `contracts.delegation_resources`
+- `agents.providers_scheduler`
+- `network.acip_a2a_cloud`
+
+These blockers route forward to #5220 as release-gate truth. #5220 should close
+v0.91.7 with Runtime v2 as the default unless a later reviewed packet proves
+cutover eligibility.
+
+## Rollback
+
+Rollback remains simple because no default switch is authorized:
+
+- Without explicit selection, Runtime v2 is selected.
+- To use Runtime v3, select it explicitly with `--runtime v3` or
+  `ADL_RUNTIME_SELECTION=v3`.
+- To roll back, remove explicit Runtime v3 selection or select `--runtime v2`.
+- Selection rollback does not rewrite retained runtime state.
+
+## Non-Claims
+
+- This decision does not authorize Runtime v3 as the default runtime.
+- This decision does not delete or decommission Runtime v2.
+- This decision does not count blocked or deferred lanes as passed proof.
+- This decision does not claim observed GPU telemetry or remote multi-day soak
+  proof.
+- This decision does not claim full Runtime v2 behavioral equivalence.

--- a/docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md
+++ b/docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md
@@ -55,3 +55,10 @@ This issue does not:
 
 Runtime v2 decommission remains gated by the aggregate Runtime v3 cutover proof
 and an explicit default-switch decision.
+
+## v0.91.7 Decision
+
+#5254 records the final v0.91.7 default-switch decision: Runtime v2 remains the
+default runtime, Runtime v3 remains explicit opt-in only, and Runtime v2
+decommission is not authorized. See
+`docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md`.

--- a/docs/architecture/RUNTIME_V3_LIVE_BLACK_BOX_PARITY_5248.md
+++ b/docs/architecture/RUNTIME_V3_LIVE_BLACK_BOX_PARITY_5248.md
@@ -30,7 +30,7 @@ docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
 | Issue | Blocking Surface |
 |---:|---|
 | #5249 | Private-state and security equivalence. |
-| #5254 | Final Runtime v3 default-switch/decommission decision for the remaining capability-specific blockers. |
+| #5220 | Release proof gate must close v0.91.7 with Runtime v2 default unless later reviewed evidence proves Runtime v3 cutover eligibility. |
 
 ## Resolved Follow-Ups
 
@@ -38,6 +38,7 @@ docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
 |---:|---|
 | #5252 | Weather/GPU/CloudWatch retained proof. Observed GPU telemetry remains an explicit non-cutover claim until an approved GPU-host run exists. |
 | #5253 | Production-like soak and rollback proof. Remote multi-day soak, observed GPU telemetry, and final default switch remain non-claims. |
+| #5254 | Final v0.91.7 default-switch/decommission decision recorded no-go for Runtime v3 default switch and retained Runtime v2 as default/rollback target. |
 
 ## Non-Claims
 

--- a/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
+++ b/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "adl.runtime_v3.cutover_decision.v1",
+  "issue": 5254,
+  "target_version": "v0.91.7",
+  "created_at_utc": "2026-07-12T13:55:00Z",
+  "decision": "keep_runtime_v2_default",
+  "cutover_authorized": false,
+  "default_runtime": "v2",
+  "runtime_v3_selection": "explicit_opt_in_only",
+  "default_runtime_switch_authorized": false,
+  "runtime_v2_decommission_authorized": false,
+  "runtime_v2_deletion_authorized": false,
+  "rollback_target": "v2",
+  "rollback_policy": {
+    "default_backend": "v2",
+    "runtime_v3_opt_in": "ADL_RUNTIME_SELECTION=v3 or explicit --runtime v3 only",
+    "rollback_action": "remove explicit Runtime v3 selection or select --runtime v2",
+    "state_mutation_claim": "runtime selection rollback does not rewrite retained runtime state"
+  },
+  "inputs": {
+    "live_black_box_parity": "docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json",
+    "shadow_parity": "docs/architecture/runtime_v3_shadow_parity_report.v1.json",
+    "soak_rollback": "docs/architecture/runtime_v3_soak_rollback_5253.v1.json",
+    "weather_cloudwatch": "docs/architecture/runtime_v3_weather_cloudwatch_5252.v1.json",
+    "entrypoint_switch": "docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md"
+  },
+  "input_summary": {
+    "live_black_box_cutover_eligible": false,
+    "live_black_box_blockers": 9,
+    "accepted_intentional_divergence": 7,
+    "retained_v2_behavior_behind_adapter": 1,
+    "deferred_non_cutover_surface": 0
+  },
+  "dependency_state": [
+    {"issue": 5248, "state": "closed", "role": "live black-box parity classification"},
+    {"issue": 5249, "state": "closed", "role": "private-state security proof"},
+    {"issue": 5250, "state": "closed", "role": "identity and memory continuity proof"},
+    {"issue": 5251, "state": "closed", "role": "governed cognition proof"},
+    {"issue": 5252, "state": "closed", "role": "weather, GPU disposition, and CloudWatch boundary proof"},
+    {"issue": 5253, "state": "closed", "role": "production-like soak and rollback proof"}
+  ],
+  "blocking_surfaces": [
+    "kernel.lifecycle",
+    "kernel.topology_and_backpressure",
+    "service.contracts_and_configuration",
+    "continuity.replay_recovery",
+    "learning.adaptive_dag",
+    "governance.freedom_gate_aee",
+    "contracts.delegation_resources",
+    "agents.providers_scheduler",
+    "network.acip_a2a_cloud"
+  ],
+  "next_gate": {
+    "issue": 5220,
+    "role": "release proof gate",
+    "required_decision": "close v0.91.7 with Runtime v2 default unless a later reviewed packet proves cutover eligibility"
+  },
+  "required_before_reconsidering_default_switch": [
+    "Every live black-box parity blocker must be resolved or explicitly accepted by a reviewed release decision.",
+    "Runtime v3 must remain reversible with Runtime v2 as rollback target.",
+    "Deferred GPU, remote, and guardian qualification lanes must stay non-pass unless separately proven.",
+    "Runtime v2 decommission must be a separate reviewed step."
+  ],
+  "non_claims": [
+    "This packet does not authorize Runtime v3 as the default runtime.",
+    "This packet does not delete or decommission Runtime v2.",
+    "This packet does not count blocked or deferred lanes as passed proof.",
+    "This packet does not claim observed GPU telemetry or remote multi-day soak proof.",
+    "This packet does not claim full Runtime v2 behavioral equivalence."
+  ]
+}

--- a/docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
+++ b/docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
@@ -20,26 +20,26 @@
     {
       "id": "kernel.lifecycle",
       "disposition": "blocker",
-      "proof": "Runtime v3 kernel fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 kernel fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "kernel.topology_and_backpressure",
       "disposition": "blocker",
-      "proof": "Runtime v3 topology/backpressure fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 topology/backpressure fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "service.contracts_and_configuration",
       "disposition": "blocker",
-      "proof": "Runtime v3 contract fixtures exist; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 contract fixtures exist; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "continuity.replay_recovery",
       "disposition": "blocker",
-      "proof": "Runtime v3 continuity fixtures exist; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 continuity fixtures exist; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "private_state.security",
@@ -59,32 +59,32 @@
     {
       "id": "learning.adaptive_dag",
       "disposition": "blocker",
-      "proof": "Runtime v3 adaptive fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 adaptive fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "governance.freedom_gate_aee",
       "disposition": "blocker",
-      "proof": "Runtime v3 governance fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 governance fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "contracts.delegation_resources",
       "disposition": "blocker",
-      "proof": "Runtime v3 governed-contract fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 governed-contract fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "agents.providers_scheduler",
       "disposition": "blocker",
-      "proof": "Runtime v3 operational fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 operational fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "network.acip_a2a_cloud",
       "disposition": "blocker",
-      "proof": "Runtime v3 network fixture exists; #5253 retained production-like soak and rollback proof, but final default-switch disposition remains a #5254 decision.",
-      "blocking_issue": 5254
+      "proof": "Runtime v3 network fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
+      "blocking_issue": 5220
     },
     {
       "id": "clock.checkpoint_lifelog",

--- a/docs/milestones/v0.91.7/RELEASE_NOTES_v0.91.7.md
+++ b/docs/milestones/v0.91.7/RELEASE_NOTES_v0.91.7.md
@@ -38,6 +38,10 @@ feature docs so `v0.92` can proceed from reviewed evidence.
 
 - These notes do not claim shipped runtime behavior yet.
 - `v0.92` activation remains blocked until implementation/proof truth is reviewed.
+- Runtime v3 is not the default runtime in v0.91.7. #5254 records a no-go
+  default-switch decision: Runtime v2 remains default and Runtime v3 remains
+  explicit opt-in only until a later reviewed release gate proves cutover
+  eligibility.
 - Public affect, wellbeing, and cognitive claims remain bounded by safe tests
   and public claim boundaries.
 - Paper/publication surfaces are not shipped artifacts in this milestone.


### PR DESCRIPTION
Closes #5254

## Summary
Runtime v3 final cutover decision for #5254 is recorded as no-go for v0.91.7 default switch. Runtime v2 remains the default runtime and rollback target, Runtime v3 remains explicit opt-in only, and Runtime v2 decommission/deletion is not authorized. Remaining live black-box parity blockers now route to #5220 release-gate truth instead of a closed #5254 decision.

## Artifacts
- Final decision packet at `docs/architecture/runtime_v3_cutover_decision_5254.v1.json`
- Human-readable decision note at `docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md`
- Runtime parity regression update at `adl-runtime-kernel/tests/parity.rs`
- Updated parity routing at `docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json` and `docs/architecture/RUNTIME_V3_LIVE_BLACK_BOX_PARITY_5248.md`
- Updated entrypoint/cutover/release notes at `docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md`, `docs/architecture/RUNTIME_V3_CUTOVER_DECISION.md`, and `docs/milestones/v0.91.7/RELEASE_NOTES_v0.91.7.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m json.tool docs/architecture/runtime_v3_cutover_decision_5254.v1.json`
    `Verified the retained #5254 decision packet is parseable JSON.`
  - `python3 -m json.tool docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json`
    `Verified the updated parity routing packet is parseable JSON.`
  - `cargo fmt --manifest-path adl-runtime-kernel/Cargo.toml --check`
    `Verified Rust formatting for the Runtime v3 kernel crate.`
  - `git diff --check`
    `Verified the changed patch has no whitespace errors.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test parity -- final_cutover_decision_keeps_v2_default_until_parity_blockers_clear live_black_box_parity_classification_covers_matrix_without_counting_blockers_as_passed retained_report_covers_matrix_and_refuses_cutover --nocapture`
    `Verified the #5254 decision remains no-go while parity blockers remain and blocker routing points to #5220.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test guardian_soak -- production_like_soak_rollback_packet_retains_cutover_boundaries packaging_preserves_one_guardian_neutral_child_contract --nocapture`
    `Verified soak/rollback boundary proof remains non-cutover.`
  - `cargo clippy --manifest-path adl-runtime-kernel/Cargo.toml --all-targets -- -D warnings`
    `Verified the Runtime v3 kernel crate is warning-clean under clippy.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml`
    `Verified the full Runtime v3 kernel test suite after the #5254 changes.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5254__v0-91-7-runtime-v3-cutover-decide-default-switch-and-runtime-v2-decommission-path/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5254__v0-91-7-runtime-v3-cutover-decide-default-switch-and-runtime-v2-decommission-path/sor.md
- Idempotency-Key: v0-91-7-runtime-v3-decide-default-switch-and-runtime-v2-decommission-path-adl-runtime-kernel-tests-parity-rs-docs-architecture-runtime-v3-cutover-decision-5254-md-docs-architecture-runtime-v3-cutover-decision-5254-v1-json-docs-architecture-runtime-v3-cutover-decision-md-docs-architecture-runtime-v3-entrypoint-switch-md-docs-architecture-runtime-v3-live-black-box-parity-5248-md-docs-architecture-runtime-v3-live-black-box-parity-5248-v1-json-docs-milestones-v0-91-7-release-notes-v0-91-7-md-adl-v0-91-7-tasks-issue-5254-v0-91-7-runtime-v3-cutover-decide-default-switch-and-runtime-v2-decommission-path-sip-md-adl-v0-91-7-tasks-issue-5254-v0-91-7-runtime-v3-cutover-decide-default-switch-and-runtime-v2-decommission-path-sor-md