### PR TITLE
[v0.91.7][csdlc-v2] Gate 7: PR readiness and closeout

### DIFF
--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -46,6 +46,10 @@ path = "src/bin/csdlc-review.rs"
 name = "csdlc-publish"
 path = "src/bin/csdlc-publish.rs"
 
+[[bin]]
+name = "csdlc-closeout"
+path = "src/bin/csdlc-closeout.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/src/bin/csdlc-closeout.rs
+++ b/csdlc-v2/src/bin/csdlc-closeout.rs
@@ -1,0 +1,448 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use csdlc_v2::error::{ErrorCode, V2Error};
+use csdlc_v2::{
+    classify_readiness, closeout_issue, record_readiness, CheckConclusion, CheckObservation,
+    CheckRequirement, ConflictState, PostPublicationFinding, ReadinessRequest, RemoteReviewState,
+    Store, TerminalDisposition, TerminalObservation,
+};
+use octocrab::models::pulls::{MergeableState, ReviewState};
+use octocrab::params::repos::Commitish;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, default_value = ".")]
+    root: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Classify {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    RecordReadiness {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    ObserveReadiness {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    Closeout {
+        #[arg(long)]
+        request: PathBuf,
+    },
+    ValidatePrune {
+        #[arg(long)]
+        issue: u64,
+    },
+    Prune {
+        #[arg(long)]
+        issue: u64,
+    },
+    Schema,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubReadinessRequest {
+    issue: u64,
+    expected_generation: u64,
+    expected_digest: String,
+    claim_id: String,
+    actor: String,
+    repository: String,
+    pull_request: u64,
+    required_checks: Vec<String>,
+    require_review: bool,
+    token_file: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubCloseoutRequest {
+    issue: u64,
+    expected_generation: u64,
+    expected_digest: String,
+    claim_id: String,
+    actor: String,
+    repository: String,
+    pull_request: Option<u64>,
+    disposition: TerminalDisposition,
+    approved_no_pr_reason: Option<String>,
+    token_file: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    match run(&cli).await {
+        Ok(value) => println!("{}", serde_json::to_string_pretty(&value).expect("JSON")),
+        Err(error) => {
+            println!(
+                "{}",
+                serde_json::json!({"schema":"csdlc.error.v1","code":error.code.to_string(),"message":error.message})
+            );
+            std::process::exit(error.code.exit_code());
+        }
+    }
+}
+
+async fn run(cli: &Cli) -> csdlc_v2::Result<serde_json::Value> {
+    let store = Store::new(&cli.root);
+    match &cli.command {
+        Command::Schema => Ok(csdlc_v2::public_schema_bundle()),
+        Command::Classify { request } => json(classify_readiness(&read(request)?)?),
+        Command::RecordReadiness { request } => json(record_readiness(&store, read(request)?)?),
+        Command::ObserveReadiness { request } => observe_readiness(&store, read(request)?).await,
+        Command::Closeout { request } => observe_closeout(&store, read(request)?).await,
+        Command::ValidatePrune { issue } | Command::Prune { issue } => {
+            let record = store.load_record(*issue)?;
+            if record.phase != csdlc_v2::LifecyclePhase::ClosedOut {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidTransition,
+                    "prune requires closed-out canonical state",
+                ));
+            }
+            let terminal = record.terminal.as_ref().ok_or_else(|| {
+                V2Error::new(ErrorCode::InvalidTransition, "terminal evidence missing")
+            })?;
+            let release = record
+                .audit
+                .iter()
+                .rev()
+                .find(|event| event.operation == "record_terminal")
+                .ok_or_else(|| {
+                    V2Error::new(ErrorCode::CorruptRecord, "claim release audit missing")
+                })?;
+            csdlc_v2::readiness::validate_prune_surface(
+                &cli.root,
+                &terminal.released_branch,
+                &terminal.released_worktree,
+            )?;
+            if matches!(&cli.command, Command::Prune { .. }) {
+                let receipt = PathBuf::from(&terminal.receipt_path);
+                let parent = receipt.parent().ok_or_else(|| {
+                    V2Error::new(ErrorCode::InvalidInput, "terminal receipt has no parent")
+                })?;
+                fs::create_dir_all(parent)?;
+                let temporary = parent.join(format!(".{}.tmp", issue));
+                fs::write(&temporary, serde_json::to_vec_pretty(&record)?)?;
+                fs::rename(temporary, &receipt)?;
+                let target = cli.root.canonicalize()?;
+                csdlc_v2::git::run(
+                    &cli.root,
+                    &["worktree", "remove", &target.to_string_lossy()],
+                )?;
+            }
+            json(serde_json::json!({
+                "schema":"csdlc.prune_report.v1",
+                "eligible":true,
+                "receipt":terminal.receipt_path,
+                "release_generation":release.generation,
+                "pruned":matches!(&cli.command, Command::Prune { .. })
+            }))
+        }
+    }
+}
+
+async fn observe_readiness(
+    store: &Store,
+    input: GithubReadinessRequest,
+) -> csdlc_v2::Result<serde_json::Value> {
+    let crab = client(input.token_file.as_deref())?;
+    let (owner, repo) = split_repo(&input.repository)?;
+    let pr = crab
+        .pulls(owner, repo)
+        .get(input.pull_request)
+        .await
+        .map_err(remote)?;
+    let head = pr
+        .head
+        .as_ref()
+        .ok_or_else(|| reconcile("PR head is absent"))?;
+    let mut page = 1_u32;
+    let first = crab
+        .checks(owner, repo)
+        .list_check_runs_for_git_ref(Commitish(head.sha.clone()))
+        .per_page(100)
+        .page(page)
+        .send()
+        .await
+        .map_err(remote)?;
+    let total = first.total_count as usize;
+    let mut all_runs = first.check_runs;
+    while all_runs.len() < total {
+        page += 1;
+        let next = crab
+            .checks(owner, repo)
+            .list_check_runs_for_git_ref(Commitish(head.sha.clone()))
+            .per_page(100)
+            .page(page)
+            .send()
+            .await
+            .map_err(remote)?;
+        if next.check_runs.is_empty() {
+            return Err(reconcile(
+                "GitHub check-run pagination ended before total_count",
+            ));
+        }
+        all_runs.extend(next.check_runs);
+    }
+    let mut latest_runs = BTreeMap::new();
+    for run in all_runs {
+        let replace =
+            latest_runs
+                .get(&run.name)
+                .is_none_or(|prior: &octocrab::models::checks::CheckRun| {
+                    run_is_newer(
+                        run.started_at.map(|time| time.timestamp_millis()),
+                        run.id.0,
+                        prior.started_at.map(|time| time.timestamp_millis()),
+                        prior.id.0,
+                    )
+                });
+        if replace {
+            latest_runs.insert(run.name.clone(), run);
+        }
+    }
+    let checks = latest_runs
+        .into_values()
+        .map(|run| {
+            let requirement = if input.required_checks.contains(&run.name) {
+                CheckRequirement::Required
+            } else {
+                CheckRequirement::Optional
+            };
+            CheckObservation {
+                name: run.name,
+                requirement,
+                conclusion: conclusion(run.conclusion.as_deref()),
+                details_url: run.details_url,
+            }
+        })
+        .collect();
+    let first_page = crab
+        .pulls(owner, repo)
+        .list_reviews(input.pull_request)
+        .per_page(100)
+        .send()
+        .await
+        .map_err(remote)?;
+    let mut reviews = crab.all_pages(first_page).await.map_err(remote)?;
+    reviews.sort_by_key(|review| review.submitted_at);
+    let mut latest = BTreeMap::new();
+    for review in &reviews {
+        let reviewer = review
+            .user
+            .as_ref()
+            .map(|user| user.login.clone())
+            .unwrap_or_else(|| "unknown".into());
+        if let Some(state) = review.state {
+            latest.insert(reviewer.clone(), state);
+        }
+    }
+    let findings = reviews
+        .into_iter()
+        .filter(|review| review.state == Some(ReviewState::ChangesRequested))
+        .map(|review| {
+            let reviewer = review
+                .user
+                .as_ref()
+                .map(|user| user.login.clone())
+                .unwrap_or_else(|| "unknown".into());
+            let active = latest.get(&reviewer) == Some(&ReviewState::ChangesRequested);
+            PostPublicationFinding {
+                id: format!("review-{}", review.id.0),
+                reviewer,
+                summary: review.body.unwrap_or_else(|| "changes requested".into()),
+                changes_requested: true,
+                active,
+                route: format!("pull_request:{}", input.pull_request),
+            }
+        })
+        .collect();
+    let review_state = if latest
+        .values()
+        .any(|state| *state == ReviewState::ChangesRequested)
+    {
+        RemoteReviewState::ChangesRequested
+    } else if latest.values().any(|state| *state == ReviewState::Approved) {
+        RemoteReviewState::Approved
+    } else if input.require_review {
+        RemoteReviewState::Pending
+    } else {
+        RemoteReviewState::NotRequired
+    };
+    let conflict_state = match pr.mergeable_state {
+        Some(MergeableState::Clean | MergeableState::HasHooks) => ConflictState::Clean,
+        Some(MergeableState::Dirty) => ConflictState::Conflicted,
+        Some(MergeableState::Unknown) | None => ConflictState::Unknown,
+        _ => ConflictState::Pending,
+    };
+    let request = ReadinessRequest {
+        schema: "csdlc.readiness_request.v1".into(),
+        issue: input.issue,
+        expected_generation: input.expected_generation,
+        expected_digest: input.expected_digest,
+        claim_id: input.claim_id,
+        actor: input.actor,
+        pull_request: input.pull_request,
+        head_sha: head.sha.clone(),
+        required_checks: input.required_checks,
+        require_review: input.require_review,
+        checks,
+        review_state,
+        conflict_state,
+        post_publication_findings: findings,
+    };
+    json(record_readiness(store, request)?)
+}
+
+async fn observe_closeout(
+    store: &Store,
+    input: GithubCloseoutRequest,
+) -> csdlc_v2::Result<serde_json::Value> {
+    let (observed_state, observed_sha) = if let Some(number) = input.pull_request {
+        let crab = client(input.token_file.as_deref())?;
+        let (owner, repo) = split_repo(&input.repository)?;
+        let pr = crab.pulls(owner, repo).get(number).await.map_err(remote)?;
+        let state = if pr.merged.unwrap_or(false) {
+            "merged"
+        } else if format!("{:?}", pr.state)
+            .to_ascii_lowercase()
+            .contains("closed")
+        {
+            "closed"
+        } else {
+            "open"
+        };
+        (state.into(), pr.head.as_ref().map(|head| head.sha.clone()))
+    } else {
+        ("closed_no_pr".into(), None)
+    };
+    let observation = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: input.issue,
+        expected_generation: input.expected_generation,
+        expected_digest: input.expected_digest,
+        claim_id: input.claim_id,
+        actor: input.actor,
+        pull_request: input.pull_request,
+        disposition: input.disposition,
+        observed_sha,
+        observed_state,
+        approved_no_pr_reason: input.approved_no_pr_reason,
+        receipt_path: terminal_receipt_path(store.root(), input.issue)?,
+    };
+    json(closeout_issue(store, observation)?)
+}
+
+fn read<T: DeserializeOwned>(path: &PathBuf) -> csdlc_v2::Result<T> {
+    serde_json::from_slice(&fs::read(path)?).map_err(Into::into)
+}
+fn json<T: Serialize>(value: T) -> csdlc_v2::Result<serde_json::Value> {
+    serde_json::to_value(value).map_err(Into::into)
+}
+fn split_repo(value: &str) -> csdlc_v2::Result<(&str, &str)> {
+    value
+        .split_once('/')
+        .filter(|(owner, repo)| !owner.is_empty() && !repo.is_empty() && !repo.contains('/'))
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "repository must be owner/name"))
+}
+fn conclusion(value: Option<&str>) -> CheckConclusion {
+    match value {
+        None => CheckConclusion::Pending,
+        Some("success") => CheckConclusion::Success,
+        Some("failure" | "timed_out" | "action_required" | "startup_failure") => {
+            CheckConclusion::Failure
+        }
+        Some("cancelled") => CheckConclusion::Cancelled,
+        Some("skipped") => CheckConclusion::Skipped,
+        Some("neutral") => CheckConclusion::Neutral,
+        _ => CheckConclusion::Unknown,
+    }
+}
+fn client(token_file: Option<&str>) -> csdlc_v2::Result<octocrab::Octocrab> {
+    let token = resolve_token(token_file)?;
+    octocrab::Octocrab::builder()
+        .personal_token(token)
+        .build()
+        .map_err(remote)
+}
+fn resolve_token(path: Option<&str>) -> csdlc_v2::Result<String> {
+    for key in ["ADL_GITHUB_TOKEN", "GITHUB_TOKEN"] {
+        if let Ok(value) = std::env::var(key) {
+            if !value.trim().is_empty() {
+                return Ok(value);
+            }
+        }
+    }
+    let path = path.ok_or_else(|| {
+        V2Error::new(
+            ErrorCode::InvalidInput,
+            "GitHub token source is unavailable",
+        )
+    })?;
+    let value = fs::read_to_string(path).map_err(|_| {
+        V2Error::new(
+            ErrorCode::InvalidInput,
+            "GitHub token source is unavailable",
+        )
+    })?;
+    if value.trim().is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "GitHub token source is empty",
+        ));
+    }
+    Ok(value.trim().into())
+}
+fn remote(error: octocrab::Error) -> V2Error {
+    V2Error::new(
+        ErrorCode::RemoteFailure,
+        format!("GitHub observation failed: {error}"),
+    )
+}
+fn reconcile(message: &str) -> V2Error {
+    V2Error::new(ErrorCode::ReconciliationRequired, message)
+}
+
+fn run_is_newer(
+    candidate_started_millis: Option<i64>,
+    candidate_id: u64,
+    prior_started_millis: Option<i64>,
+    prior_id: u64,
+) -> bool {
+    (candidate_started_millis, candidate_id) >= (prior_started_millis, prior_id)
+}
+
+fn terminal_receipt_path(root: &std::path::Path, issue: u64) -> csdlc_v2::Result<String> {
+    let common = csdlc_v2::git::run(
+        root,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?
+    .stdout;
+    Ok(PathBuf::from(common)
+        .join("csdlc-v2/closeout")
+        .join(format!("{issue}.json"))
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_is_newer;
+
+    #[test]
+    fn newer_started_pending_rerun_supersedes_old_completed_identity() {
+        assert!(run_is_newer(Some(20), 2, Some(10), 1));
+        assert!(!run_is_newer(Some(10), 1, Some(20), 2));
+    }
+}

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -6,6 +6,7 @@ pub mod lifecycle;
 pub mod model;
 pub mod publication;
 pub mod pvf;
+pub mod readiness;
 pub mod review;
 pub mod schema;
 pub mod store;
@@ -21,7 +22,8 @@ pub use lifecycle::{
 };
 pub use model::{
     Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase, NonSubstantiveProof,
-    PublicationEvidence, ReviewAssignment, ReviewEvidence, ReviewFindingEvidence,
+    PublicationEvidence, ReadinessEvidence, ReviewAssignment, ReviewEvidence,
+    ReviewFindingEvidence, TerminalEvidence,
 };
 pub use publication::{
     prepare_publication, reconcile_action, record_publication, PublicationAction,
@@ -30,6 +32,11 @@ pub use publication::{
 pub use pvf::{
     classify_schedule, classify_shepherd, execute, select, ExecutionRequest, PvfManifest,
     ScheduleInput, ShepherdInput,
+};
+pub use readiness::{
+    classify_readiness, closeout_issue, record_readiness, CheckConclusion, CheckObservation,
+    CheckRequirement, ConflictState, PostPublicationFinding, ReadinessReport, ReadinessRequest,
+    RemoteReviewState, TerminalDisposition, TerminalObservation,
 };
 pub use review::{
     assign_review, evaluate_publication_review, evaluate_publication_review_in_repo, record_review,

--- a/csdlc-v2/src/model.rs
+++ b/csdlc-v2/src/model.rs
@@ -46,6 +46,7 @@ impl LifecyclePhase {
                 | (Self::Reviewed, Self::Published)
                 | (Self::Published, Self::MergeReady)
                 | (Self::MergeReady, Self::Merged)
+                | (Self::MergeReady, Self::Published)
                 | (Self::Merged, Self::ClosedOut)
         )
     }
@@ -127,6 +128,30 @@ pub struct PublicationEvidence {
     pub observed_state: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReadinessEvidence {
+    pub pull_request: u64,
+    pub head_sha: String,
+    pub checks: Vec<crate::readiness::CheckObservation>,
+    pub review_state: crate::readiness::RemoteReviewState,
+    pub conflict_state: crate::readiness::ConflictState,
+    pub post_publication_findings: Vec<crate::readiness::PostPublicationFinding>,
+    pub ready: bool,
+    pub blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TerminalEvidence {
+    pub pull_request: Option<u64>,
+    pub disposition: crate::readiness::TerminalDisposition,
+    pub observed_sha: Option<String>,
+    pub observed_state: String,
+    pub receipt_path: String,
+    pub released_branch: String,
+    pub released_worktree: String,
+    pub released_protected_paths: Vec<String>,
+}
+
 impl Claim {
     pub fn validate(&self, claim_id: &str, now: u64) -> Result<()> {
         if self.id != claim_id {
@@ -195,6 +220,10 @@ pub struct IssueRecord {
     pub review: Option<ReviewEvidence>,
     #[serde(default)]
     pub publication: Option<PublicationEvidence>,
+    #[serde(default)]
+    pub readiness: Option<ReadinessEvidence>,
+    #[serde(default)]
+    pub terminal: Option<TerminalEvidence>,
     pub design_path: String,
     pub diagram_path: String,
     pub design_review: DesignReview,

--- a/csdlc-v2/src/readiness.rs
+++ b/csdlc-v2/src/readiness.rs
@@ -1,0 +1,299 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumString};
+
+use crate::error::{ErrorCode, Result, V2Error};
+use crate::model::{IssueRecord, LifecyclePhase, ReadinessEvidence, TerminalEvidence};
+use crate::Store;
+
+macro_rules! closed_enum {
+    ($name:ident { $($variant:ident),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Display, EnumString, AsRefStr)]
+        #[serde(rename_all = "snake_case")]
+        #[strum(serialize_all = "snake_case")]
+        pub enum $name { $($variant),+ }
+    };
+}
+
+closed_enum!(CheckRequirement { Required, Optional });
+closed_enum!(CheckConclusion {
+    Pending,
+    Success,
+    Failure,
+    Cancelled,
+    Skipped,
+    Neutral,
+    Unknown
+});
+closed_enum!(RemoteReviewState {
+    Pending,
+    Approved,
+    ChangesRequested,
+    NotRequired,
+    Unknown
+});
+closed_enum!(ConflictState {
+    Clean,
+    Conflicted,
+    Pending,
+    Unknown
+});
+closed_enum!(TerminalDisposition {
+    Merged,
+    ClosedUnmerged,
+    ClosedNoPr
+});
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CheckObservation {
+    pub name: String,
+    pub requirement: CheckRequirement,
+    pub conclusion: CheckConclusion,
+    pub details_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct PostPublicationFinding {
+    pub id: String,
+    pub reviewer: String,
+    pub summary: String,
+    pub changes_requested: bool,
+    pub active: bool,
+    pub route: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReadinessRequest {
+    pub schema: String,
+    pub issue: u64,
+    pub expected_generation: u64,
+    pub expected_digest: String,
+    pub claim_id: String,
+    pub actor: String,
+    pub pull_request: u64,
+    pub head_sha: String,
+    pub required_checks: Vec<String>,
+    pub require_review: bool,
+    pub checks: Vec<CheckObservation>,
+    pub review_state: RemoteReviewState,
+    pub conflict_state: ConflictState,
+    pub post_publication_findings: Vec<PostPublicationFinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReadinessReport {
+    pub schema: String,
+    pub ready: bool,
+    pub blockers: Vec<String>,
+    pub required_success: Vec<String>,
+    pub required_pending: Vec<String>,
+    pub required_failed: Vec<String>,
+    pub optional_non_success: Vec<String>,
+}
+
+pub fn classify_readiness(request: &ReadinessRequest) -> Result<ReadinessReport> {
+    if request.schema != "csdlc.readiness_request.v1" || request.head_sha.is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "readiness request identity is invalid",
+        ));
+    }
+    let mut required_success = Vec::new();
+    let mut required_pending = Vec::new();
+    let mut required_failed = Vec::new();
+    let mut optional_non_success = Vec::new();
+    for required in &request.required_checks {
+        match request.checks.iter().find(|check| check.name == *required) {
+            Some(check) if check.requirement != CheckRequirement::Required => {
+                required_failed.push(format!("{required}:misclassified"))
+            }
+            Some(check) => match check.conclusion {
+                CheckConclusion::Success => required_success.push(required.clone()),
+                CheckConclusion::Pending | CheckConclusion::Unknown => {
+                    required_pending.push(required.clone())
+                }
+                _ => required_failed.push(required.clone()),
+            },
+            None => required_pending.push(format!("{required}:unobserved")),
+        }
+    }
+    for check in request.checks.iter().filter(|check| {
+        check.requirement == CheckRequirement::Optional
+            && check.conclusion != CheckConclusion::Success
+    }) {
+        optional_non_success.push(check.name.clone());
+    }
+    let mut blockers = Vec::new();
+    if !required_pending.is_empty() {
+        blockers.push("required_checks_pending".into());
+    }
+    if !required_failed.is_empty() {
+        blockers.push("required_checks_failed".into());
+    }
+    if request.require_review && request.review_state != RemoteReviewState::Approved {
+        blockers.push("required_review_not_approved".into());
+    }
+    if request.conflict_state != ConflictState::Clean {
+        blockers.push("conflict_state_not_clean".into());
+    }
+    if request
+        .post_publication_findings
+        .iter()
+        .any(|finding| finding.changes_requested && finding.active)
+    {
+        blockers.push("post_publication_changes_requested".into());
+    }
+    Ok(ReadinessReport {
+        schema: "csdlc.readiness_report.v1".into(),
+        ready: blockers.is_empty(),
+        blockers,
+        required_success,
+        required_pending,
+        required_failed,
+        optional_non_success,
+    })
+}
+
+pub fn record_readiness(store: &Store, request: ReadinessRequest) -> Result<IssueRecord> {
+    let report = classify_readiness(&request)?;
+    let evidence = ReadinessEvidence {
+        pull_request: request.pull_request,
+        head_sha: request.head_sha.clone(),
+        checks: request.checks.clone(),
+        review_state: request.review_state,
+        conflict_state: request.conflict_state,
+        post_publication_findings: request.post_publication_findings.clone(),
+        ready: report.ready,
+        blockers: report.blockers.clone(),
+    };
+    store.commit_readiness(request, evidence)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TerminalObservation {
+    pub schema: String,
+    pub issue: u64,
+    pub expected_generation: u64,
+    pub expected_digest: String,
+    pub claim_id: String,
+    pub actor: String,
+    pub pull_request: Option<u64>,
+    pub disposition: TerminalDisposition,
+    pub observed_sha: Option<String>,
+    pub observed_state: String,
+    pub approved_no_pr_reason: Option<String>,
+    pub receipt_path: String,
+}
+
+pub fn closeout_issue(store: &Store, observation: TerminalObservation) -> Result<IssueRecord> {
+    if observation.schema != "csdlc.terminal_observation.v1"
+        || observation.receipt_path.trim().is_empty()
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "terminal observation is incomplete",
+        ));
+    }
+    match observation.disposition {
+        TerminalDisposition::Merged
+            if observation.pull_request.is_none()
+                || observation.observed_sha.is_none()
+                || observation.observed_state != "merged" =>
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "merged closeout requires observed PR, SHA, and merged state",
+            ))
+        }
+        TerminalDisposition::ClosedUnmerged
+            if observation.pull_request.is_none()
+                || observation.observed_sha.is_none()
+                || observation.observed_state != "closed" =>
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "closed-unmerged closeout requires an observed closed PR",
+            ))
+        }
+        TerminalDisposition::ClosedNoPr
+            if observation.pull_request.is_some()
+                || observation
+                    .approved_no_pr_reason
+                    .as_deref()
+                    .unwrap_or_default()
+                    .trim()
+                    .is_empty() =>
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "no-PR closeout requires explicit approval reason and no PR",
+            ))
+        }
+        _ => {}
+    }
+    let evidence = TerminalEvidence {
+        pull_request: observation.pull_request,
+        disposition: observation.disposition,
+        observed_sha: observation.observed_sha.clone(),
+        observed_state: observation.observed_state.clone(),
+        receipt_path: observation.receipt_path.clone(),
+        released_branch: String::new(),
+        released_worktree: String::new(),
+        released_protected_paths: Vec::new(),
+    };
+    store.commit_terminal(observation, evidence)
+}
+
+pub fn validate_prune_surface(
+    root: &std::path::Path,
+    expected_branch: &str,
+    expected_worktree: &str,
+) -> Result<()> {
+    let branch = crate::git::current_branch(root)?;
+    let canonical = root.canonicalize()?;
+    let topology = crate::git::worktrees(root)?;
+    let observed = topology.iter().find(|(candidate_branch, candidate_path)| {
+        let expected_path = std::path::Path::new(expected_worktree);
+        let path_matches = if expected_path.is_absolute() {
+            expected_path.canonicalize().ok()
+                == std::path::Path::new(candidate_path).canonicalize().ok()
+        } else {
+            std::path::Path::new(candidate_path).ends_with(expected_path)
+        };
+        candidate_branch == expected_branch && path_matches
+    });
+    if branch != expected_branch
+        || observed.is_none_or(|(_, path)| {
+            std::path::Path::new(path).canonicalize().ok().as_ref() != Some(&canonical)
+        })
+    {
+        return Err(V2Error::new(
+            ErrorCode::UnsafeCheckout,
+            "prune target does not match terminal claim topology",
+        ));
+    }
+    if !crate::git::run(root, &["status", "--porcelain", "--untracked-files=all"])?
+        .stdout
+        .is_empty()
+    {
+        return Err(V2Error::new(
+            ErrorCode::UnsafeCheckout,
+            "dirty worktree cannot be pruned",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn terminal_phase_allowed(
+    phase: LifecyclePhase,
+    disposition: TerminalDisposition,
+) -> bool {
+    match disposition {
+        TerminalDisposition::Merged => phase == LifecyclePhase::MergeReady,
+        TerminalDisposition::ClosedUnmerged => matches!(
+            phase,
+            LifecyclePhase::Published | LifecyclePhase::MergeReady
+        ),
+        TerminalDisposition::ClosedNoPr => phase == LifecyclePhase::Reviewed,
+    }
+}

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -5,6 +5,7 @@ use crate::lifecycle::{BindRequest, BindResult, RecoverClaimRequest};
 use crate::model::IssueRecord;
 use crate::publication::{PublicationIntent, PublicationRequest, RemotePullRequest};
 use crate::pvf::{ExecutionReport, ExecutionRequest, PvfManifest, ScheduleReport, ShepherdReport};
+use crate::readiness::{ReadinessReport, ReadinessRequest, TerminalObservation};
 use crate::review::{PublicationReviewReport, ReviewAssignmentRequest, ReviewRecordRequest};
 use crate::store::ApproveDesignRequest;
 use crate::store::{BootstrapRequest, EditRequest};
@@ -31,5 +32,8 @@ pub fn public_schema_bundle() -> Value {
         "publication_request": schemars::schema_for!(PublicationRequest),
         "publication_intent": schemars::schema_for!(PublicationIntent),
         "remote_pull_request": schemars::schema_for!(RemotePullRequest),
+        "readiness_request": schemars::schema_for!(ReadinessRequest),
+        "readiness_report": schemars::schema_for!(ReadinessReport),
+        "terminal_observation": schemars::schema_for!(TerminalObservation),
     })
 }

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -15,7 +15,8 @@ use crate::cards::{
 use crate::error::{ErrorCode, Result, V2Error};
 use crate::model::{
     AuditEvent, CardProjection, Claim, DesignReview, IssueRecord, LifecyclePhase,
-    PublicationEvidence, ReviewAssignment, ReviewEvidence,
+    PublicationEvidence, ReadinessEvidence, ReviewAssignment, ReviewEvidence, TerminalEvidence,
+    TransitionEvent,
 };
 use crate::review::evaluate_publication_review_in_repo;
 
@@ -216,9 +217,252 @@ impl Store {
             reason: "atomically record observed GitHub publication and SOR projection".into(),
             operation: "record_publication".into(),
         });
+        validate_updated_cards(self, &record, &cards)?;
         hydrate_projections(&mut record, &cards)?;
         record.digest = record_digest(&record)?;
         self.commit(issue, &record, &cards, false)?;
+        Ok(record)
+    }
+
+    pub(crate) fn commit_readiness(
+        &self,
+        request: crate::readiness::ReadinessRequest,
+        evidence: ReadinessEvidence,
+    ) -> Result<IssueRecord> {
+        let _lock = self.lock(request.issue)?;
+        self.recover_if_needed(request.issue)?;
+        let mut record = self.load_record(request.issue)?;
+        record
+            .claim
+            .as_ref()
+            .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?
+            .validate(&request.claim_id, now_seconds()?)?;
+        if record.generation != request.expected_generation
+            || record.digest != request.expected_digest
+        {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "readiness request does not match canonical record",
+            ));
+        }
+        if !matches!(
+            record.phase,
+            LifecyclePhase::Published | LifecyclePhase::MergeReady
+        ) {
+            return Err(V2Error::new(
+                ErrorCode::InvalidTransition,
+                "readiness requires published state",
+            ));
+        }
+        let publication = record.publication.as_ref().ok_or_else(|| {
+            V2Error::new(ErrorCode::InvalidTransition, "publication evidence missing")
+        })?;
+        if publication.pull_request != request.pull_request
+            || publication.revision != crate::git::clean_commit_revision(&request.head_sha)
+        {
+            return Err(V2Error::new(
+                ErrorCode::ReconciliationRequired,
+                "readiness observation does not match published PR revision",
+            ));
+        }
+        if record.readiness.as_ref() == Some(&evidence) {
+            return Ok(record);
+        }
+        let mut cards = self.load_cards(request.issue)?;
+        verify_cards(self, &record, &cards)?;
+        let sor = match &mut cards.get_mut(&CardKind::Sor).expect("SOR").content {
+            CardContent::Sor(value) => value,
+            _ => unreachable!(),
+        };
+        if evidence.ready {
+            let validation_ready = !sor.actual_validation.is_empty()
+                && sor.actual_validation.iter().all(|item| {
+                    matches!(
+                        item.outcome,
+                        crate::cards::EvidenceOutcome::Passed
+                            | crate::cards::EvidenceOutcome::SkippedNonGoal
+                    )
+                });
+            if !validation_ready {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidTransition,
+                    "merge readiness requires passing local PVF evidence",
+                ));
+            }
+            sor.publication_state = crate::cards::PublicationState::Ready;
+            if record.phase == LifecyclePhase::Published {
+                record.advance(
+                    LifecyclePhase::MergeReady,
+                    request.actor.clone(),
+                    "observed required checks, review, and conflict readiness".into(),
+                )?;
+            }
+        } else {
+            sor.publication_state = crate::cards::PublicationState::Draft;
+            if record.phase == LifecyclePhase::MergeReady {
+                record.advance(
+                    LifecyclePhase::Published,
+                    request.actor.clone(),
+                    "latest remote observation revoked merge readiness".into(),
+                )?;
+            }
+        }
+        record.generation += 1;
+        for values in cards.values_mut() {
+            values.identity.generation = record.generation;
+        }
+        if let Some(claim) = record.claim.as_mut() {
+            claim.generation = record.generation;
+        }
+        record.readiness = Some(evidence);
+        record.audit.push(AuditEvent {
+            sequence: record.audit.len() as u64 + 1,
+            generation: record.generation,
+            actor: request.actor,
+            reason: "record normalized remote readiness without replacing pre-publication review"
+                .into(),
+            operation: "record_readiness".into(),
+        });
+        validate_updated_cards(self, &record, &cards)?;
+        hydrate_projections(&mut record, &cards)?;
+        record.digest = record_digest(&record)?;
+        self.commit(request.issue, &record, &cards, false)?;
+        Ok(record)
+    }
+
+    pub(crate) fn commit_terminal(
+        &self,
+        observation: crate::readiness::TerminalObservation,
+        mut evidence: TerminalEvidence,
+    ) -> Result<IssueRecord> {
+        let _lock = self.lock(observation.issue)?;
+        self.recover_if_needed(observation.issue)?;
+        let mut record = self.load_record(observation.issue)?;
+        if let Some(current) = &record.terminal {
+            if record.phase == LifecyclePhase::ClosedOut
+                && current.pull_request == evidence.pull_request
+                && current.disposition == evidence.disposition
+                && current.observed_sha == evidence.observed_sha
+                && current.observed_state == evidence.observed_state
+                && current.receipt_path == evidence.receipt_path
+            {
+                return Ok(record);
+            }
+        }
+        record
+            .claim
+            .as_ref()
+            .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?
+            .validate(&observation.claim_id, now_seconds()?)?;
+        if record.generation != observation.expected_generation
+            || record.digest != observation.expected_digest
+        {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "terminal observation does not match canonical record",
+            ));
+        }
+        if !crate::readiness::terminal_phase_allowed(record.phase, observation.disposition) {
+            return Err(V2Error::new(
+                ErrorCode::InvalidTransition,
+                "terminal disposition is not valid from the current lifecycle phase",
+            ));
+        }
+        match (
+            &record.publication,
+            observation.pull_request,
+            observation.observed_sha.as_deref(),
+        ) {
+            (Some(publication), Some(pr), Some(sha)) => {
+                if publication.pull_request != pr
+                    || publication.revision != crate::git::clean_commit_revision(sha)
+                {
+                    return Err(V2Error::new(
+                        ErrorCode::ReconciliationRequired,
+                        "terminal PR or SHA differs from exact publication evidence",
+                    ));
+                }
+            }
+            (Some(_), None, _) => {
+                return Err(V2Error::new(
+                    ErrorCode::ReconciliationRequired,
+                    "published issue cannot use no-PR closeout",
+                ));
+            }
+            (Some(_), Some(_), None) => {
+                return Err(V2Error::new(
+                    ErrorCode::ReconciliationRequired,
+                    "published terminal observation is missing the exact head SHA",
+                ));
+            }
+            (None, Some(_), _) => {
+                return Err(V2Error::new(
+                    ErrorCode::ReconciliationRequired,
+                    "terminal PR has no canonical publication evidence",
+                ));
+            }
+            _ => {}
+        }
+        let mut cards = self.load_cards(observation.issue)?;
+        verify_cards(self, &record, &cards)?;
+        let sor_values = cards.get_mut(&CardKind::Sor).expect("SOR");
+        sor_values.status = crate::cards::CardStatus::Complete;
+        let sor = match &mut sor_values.content {
+            CardContent::Sor(value) => value,
+            _ => unreachable!(),
+        };
+        sor.publication_state = crate::cards::PublicationState::Closed;
+        sor.closeout_state = crate::cards::CloseoutState::Complete;
+        match observation.disposition {
+            crate::readiness::TerminalDisposition::Merged => {
+                sor.integration_state = crate::cards::IntegrationState::Merged;
+                sor.merge_state = crate::cards::MergeState::Merged;
+                record.advance(
+                    LifecyclePhase::Merged,
+                    observation.actor.clone(),
+                    "observed exact PR merged".into(),
+                )?;
+                record.advance(
+                    LifecyclePhase::ClosedOut,
+                    observation.actor.clone(),
+                    "terminal truth recorded and claim released".into(),
+                )?;
+            }
+            crate::readiness::TerminalDisposition::ClosedUnmerged
+            | crate::readiness::TerminalDisposition::ClosedNoPr => {
+                sor.integration_state = crate::cards::IntegrationState::ClosedNoPr;
+                sor.merge_state = crate::cards::MergeState::ClosedUnmerged;
+                let from = record.phase;
+                record.phase = LifecyclePhase::ClosedOut;
+                record.transitions.push(TransitionEvent {
+                    sequence: record.transitions.len() as u64 + 1,
+                    from,
+                    to: LifecyclePhase::ClosedOut,
+                    actor: observation.actor.clone(),
+                    reason: "observed approved non-merged terminal disposition".into(),
+                });
+            }
+        }
+        record.generation += 1;
+        for values in cards.values_mut() {
+            values.identity.generation = record.generation;
+        }
+        let released = record.claim.take().expect("validated claim");
+        evidence.released_branch = released.branch;
+        evidence.released_worktree = released.worktree;
+        evidence.released_protected_paths = released.protected_paths;
+        record.terminal = Some(evidence);
+        record.audit.push(AuditEvent {
+            sequence: record.audit.len() as u64 + 1,
+            generation: record.generation,
+            actor: observation.actor,
+            reason: "atomically finalize SOR/index and release claim/protected paths".into(),
+            operation: "record_terminal".into(),
+        });
+        validate_updated_cards(self, &record, &cards)?;
+        hydrate_projections(&mut record, &cards)?;
+        record.digest = record_digest(&record)?;
+        self.commit(observation.issue, &record, &cards, false)?;
         Ok(record)
     }
 
@@ -507,6 +751,8 @@ pub fn bootstrap_issue(store: &Store, request: BootstrapRequest) -> Result<Issue
         review_assignment: None,
         review: None,
         publication: None,
+        readiness: None,
+        terminal: None,
         design_path: request.design_path,
         diagram_path: request.diagram_path,
         design_review: if request.design_approved {
@@ -670,23 +916,32 @@ pub(crate) fn verify_record(record: &IssueRecord) -> Result<()> {
             "index digest mismatch",
         ));
     }
-    let claim = record
-        .claim
-        .as_ref()
-        .ok_or_else(|| V2Error::new(ErrorCode::CorruptRecord, "claim missing"))?;
-    if claim.generation != record.generation
-        || claim.id.is_empty()
-        || claim.owner.is_empty()
-        || claim.protected_paths.is_empty()
-        || claim.branch.is_empty()
-        || claim.worktree.is_empty()
-        || claim.heartbeat_unix_seconds < claim.acquired_unix_seconds
-        || claim.expires_unix_seconds <= claim.heartbeat_unix_seconds
-    {
-        return Err(V2Error::new(
-            ErrorCode::CorruptRecord,
-            "claim invariant failed",
-        ));
+    if record.phase == LifecyclePhase::ClosedOut {
+        if record.claim.is_some() || record.terminal.is_none() {
+            return Err(V2Error::new(
+                ErrorCode::CorruptRecord,
+                "closed-out record must have terminal evidence and no active claim",
+            ));
+        }
+    } else {
+        let claim = record
+            .claim
+            .as_ref()
+            .ok_or_else(|| V2Error::new(ErrorCode::CorruptRecord, "claim missing"))?;
+        if claim.generation != record.generation
+            || claim.id.is_empty()
+            || claim.owner.is_empty()
+            || claim.protected_paths.is_empty()
+            || claim.branch.is_empty()
+            || claim.worktree.is_empty()
+            || claim.heartbeat_unix_seconds < claim.acquired_unix_seconds
+            || claim.expires_unix_seconds <= claim.heartbeat_unix_seconds
+        {
+            return Err(V2Error::new(
+                ErrorCode::CorruptRecord,
+                "claim invariant failed",
+            ));
+        }
     }
     if let DesignReview::Approved { reviewer, revision } = &record.design_review {
         if reviewer.trim().is_empty() || revision.trim().is_empty() {
@@ -990,6 +1245,22 @@ fn hydrate_projections(
         );
     }
     Ok(())
+}
+
+fn validate_updated_cards(
+    store: &Store,
+    record: &IssueRecord,
+    cards: &BTreeMap<CardKind, CardValues>,
+) -> Result<()> {
+    let design_digest = digest(&fs::read(store.root.join(&record.design_path))?);
+    let diagram_digest = digest(&fs::read(store.root.join(&record.diagram_path))?);
+    validate_cross_card(
+        cards,
+        &record.design_path,
+        &design_digest,
+        &record.diagram_path,
+        &diagram_digest,
+    )
 }
 
 pub(crate) fn record_digest(record: &IssueRecord) -> Result<String> {

--- a/csdlc-v2/tests/gate7.rs
+++ b/csdlc-v2/tests/gate7.rs
@@ -1,0 +1,196 @@
+use csdlc_v2::{
+    classify_readiness, closeout_issue, CheckConclusion, CheckObservation, CheckRequirement,
+    ConflictState, PostPublicationFinding, ReadinessRequest, RemoteReviewState, Store,
+    TerminalDisposition, TerminalObservation,
+};
+
+fn request() -> ReadinessRequest {
+    ReadinessRequest {
+        schema: "csdlc.readiness_request.v1".into(),
+        issue: 7,
+        expected_generation: 4,
+        expected_digest: "digest".into(),
+        claim_id: "claim".into(),
+        actor: "shepherd".into(),
+        pull_request: 70,
+        head_sha: "abc".into(),
+        required_checks: vec!["fast".into(), "contract".into()],
+        require_review: true,
+        checks: vec![
+            CheckObservation {
+                name: "fast".into(),
+                requirement: CheckRequirement::Required,
+                conclusion: CheckConclusion::Success,
+                details_url: None,
+            },
+            CheckObservation {
+                name: "contract".into(),
+                requirement: CheckRequirement::Required,
+                conclusion: CheckConclusion::Success,
+                details_url: None,
+            },
+            CheckObservation {
+                name: "optional-soak".into(),
+                requirement: CheckRequirement::Optional,
+                conclusion: CheckConclusion::Skipped,
+                details_url: None,
+            },
+        ],
+        review_state: RemoteReviewState::Approved,
+        conflict_state: ConflictState::Clean,
+        post_publication_findings: vec![],
+    }
+}
+
+#[test]
+fn green_required_truth_is_ready_without_promoting_optional_skips() {
+    let report = classify_readiness(&request()).unwrap();
+    assert!(report.ready);
+    assert_eq!(report.optional_non_success, vec!["optional-soak"]);
+}
+
+#[test]
+fn pending_failed_and_unobserved_required_checks_are_distinct() {
+    let mut value = request();
+    value.checks[0].conclusion = CheckConclusion::Pending;
+    value.checks[1].conclusion = CheckConclusion::Failure;
+    value.required_checks.push("missing".into());
+    let report = classify_readiness(&value).unwrap();
+    assert_eq!(report.required_pending, vec!["fast", "missing:unobserved"]);
+    assert_eq!(report.required_failed, vec!["contract"]);
+    assert!(!report.ready);
+}
+
+#[test]
+fn requested_changes_remain_routed_and_block_readiness() {
+    let mut value = request();
+    value.review_state = RemoteReviewState::ChangesRequested;
+    value
+        .post_publication_findings
+        .push(PostPublicationFinding {
+            id: "review-1".into(),
+            reviewer: "reviewer".into(),
+            summary: "repair edge case".into(),
+            changes_requested: true,
+            active: true,
+            route: "pull_request:70".into(),
+        });
+    let report = classify_readiness(&value).unwrap();
+    assert!(report
+        .blockers
+        .contains(&"post_publication_changes_requested".into()));
+    assert!(report
+        .blockers
+        .contains(&"required_review_not_approved".into()));
+}
+
+#[test]
+fn unknown_conflict_or_review_truth_never_becomes_green() {
+    let mut value = request();
+    value.review_state = RemoteReviewState::Unknown;
+    value.conflict_state = ConflictState::Unknown;
+    let report = classify_readiness(&value).unwrap();
+    assert!(!report.ready);
+    assert_eq!(report.blockers.len(), 2);
+}
+
+#[test]
+fn false_terminal_observations_fail_before_store_mutation() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Store::new(temp.path());
+    let invalid = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: 7,
+        expected_generation: 1,
+        expected_digest: "digest".into(),
+        claim_id: "claim".into(),
+        actor: "closer".into(),
+        pull_request: Some(70),
+        disposition: TerminalDisposition::Merged,
+        observed_sha: None,
+        observed_state: "open".into(),
+        approved_no_pr_reason: None,
+        receipt_path: "receipt.json".into(),
+    };
+    assert!(closeout_issue(&store, invalid).is_err());
+    assert!(!temp.path().join(".csdlc").exists());
+}
+
+#[test]
+fn no_pr_terminal_requires_explicit_approval() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Store::new(temp.path());
+    let invalid = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: 7,
+        expected_generation: 1,
+        expected_digest: "digest".into(),
+        claim_id: "claim".into(),
+        actor: "closer".into(),
+        pull_request: None,
+        disposition: TerminalDisposition::ClosedNoPr,
+        observed_sha: None,
+        observed_state: "closed_no_pr".into(),
+        approved_no_pr_reason: None,
+        receipt_path: "receipt.json".into(),
+    };
+    assert!(closeout_issue(&store, invalid).is_err());
+}
+
+#[test]
+fn closed_unmerged_terminal_requires_exact_head_sha() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Store::new(temp.path());
+    let invalid = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: 7,
+        expected_generation: 1,
+        expected_digest: "digest".into(),
+        claim_id: "claim".into(),
+        actor: "closer".into(),
+        pull_request: Some(70),
+        disposition: TerminalDisposition::ClosedUnmerged,
+        observed_sha: None,
+        observed_state: "closed".into(),
+        approved_no_pr_reason: None,
+        receipt_path: "receipt.json".into(),
+    };
+    assert!(closeout_issue(&store, invalid).is_err());
+    assert!(!temp.path().join(".csdlc").exists());
+}
+
+#[test]
+fn schemas_cover_readiness_and_terminal_truth() {
+    let bundle = csdlc_v2::public_schema_bundle();
+    assert!(bundle.get("readiness_request").is_some());
+    assert!(bundle.get("readiness_report").is_some());
+    assert!(bundle.get("terminal_observation").is_some());
+}
+
+#[test]
+fn prune_guard_requires_exact_topology_and_clean_worktree() {
+    let temp = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .current_dir(temp.path())
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-b", "terminal-7"]);
+    git(&["config", "user.email", "test@example.invalid"]);
+    git(&["config", "user.name", "C-SDLC Test"]);
+    std::fs::write(temp.path().join("tracked"), "clean").unwrap();
+    git(&["add", "tracked"]);
+    git(&["commit", "-m", "fixture"]);
+    let path = temp.path().to_string_lossy().into_owned();
+    csdlc_v2::readiness::validate_prune_surface(temp.path(), "terminal-7", &path).unwrap();
+    assert!(csdlc_v2::readiness::validate_prune_surface(temp.path(), "wrong", &path).is_err());
+    std::fs::write(temp.path().join("dirty"), "dirty").unwrap();
+    assert!(csdlc_v2::readiness::validate_prune_surface(temp.path(), "terminal-7", &path).is_err());
+}

--- a/csdlc-v2/tests/gate7_lifecycle.rs
+++ b/csdlc-v2/tests/gate7_lifecycle.rs
@@ -1,0 +1,371 @@
+use csdlc_v2::cards::{
+    EvidenceOutcome, PlanStep, ResourceProfile, StepStatus, ValidationLane, ValidationResult,
+};
+use csdlc_v2::{
+    assign_review, closeout_issue, edit_issue, initialize_issue, record_publication,
+    record_readiness, record_review, BootstrapRequest, CardKind, Claim, EditRequest,
+    InitialCardInput, LifecyclePhase, PlanningProfile, PublicationIntent, PublicationRequest,
+    ReadinessRequest, RemotePullRequest, ReviewAssignmentRequest, ReviewEvidence,
+    ReviewRecordRequest, SemanticOperation, Store, TerminalDisposition, TerminalObservation,
+};
+
+fn git(root: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn edit(
+    store: &Store,
+    record: &csdlc_v2::IssueRecord,
+    card: CardKind,
+    operation: SemanticOperation,
+) -> csdlc_v2::IssueRecord {
+    edit_issue(
+        store,
+        EditRequest {
+            issue: 7,
+            card,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim".into(),
+            actor: "agent".into(),
+            reason: "fixture".into(),
+            operation,
+            fail_after_backup: false,
+        },
+    )
+    .unwrap()
+}
+
+fn fixture() -> (tempfile::TempDir, Store, csdlc_v2::IssueRecord, String) {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+    std::fs::write(temp.path().join("docs/design.md"), "# design\n").unwrap();
+    std::fs::write(
+        temp.path().join("docs/diagram.mmd"),
+        "flowchart LR\n A-->B\n",
+    )
+    .unwrap();
+    git(temp.path(), &["init", "-b", "issue-7"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "docs"]);
+    git(temp.path(), &["commit", "-m", "fixture"]);
+    let sha = csdlc_v2::git::run(temp.path(), &["rev-parse", "HEAD"])
+        .unwrap()
+        .stdout;
+    let store = Store::new(temp.path());
+    let mut record = initialize_issue(
+        &store,
+        BootstrapRequest {
+            issue: 7,
+            repository: "example/repo".into(),
+            design_path: "docs/design.md".into(),
+            diagram_path: "docs/diagram.mmd".into(),
+            design_reviewer: "architect".into(),
+            design_approved: true,
+            claim: Claim {
+                id: "claim".into(),
+                owner: "agent".into(),
+                generation: 0,
+                acquired_unix_seconds: 1,
+                expires_unix_seconds: u64::MAX,
+                heartbeat_unix_seconds: 1,
+                branch: "issue-7".into(),
+                worktree: temp.path().to_string_lossy().into_owned(),
+                protected_paths: vec!["src".into()],
+                purpose: "gate7 fixture".into(),
+            },
+            initial: InitialCardInput {
+                title: "Gate 7 fixture".into(),
+                slug: "gate-7-fixture".into(),
+                version: "v0.91.7".into(),
+                goal: "prove terminal lifecycle".into(),
+                required_outcome: "truthful closeout".into(),
+                declared_scope: vec!["docs".into()],
+                authority_boundary: vec!["no merge".into()],
+                task_boundary: "fixture".into(),
+                deliverables: vec!["record".into()],
+                acceptance_criteria: vec!["terminal truth".into()],
+                dependencies: vec!["none".into()],
+                repo_inputs: vec!["docs".into()],
+                non_goals: vec!["network".into()],
+                plan_summary: "advance lifecycle".into(),
+                steps: vec![PlanStep {
+                    id: "one".into(),
+                    action: "advance".into(),
+                    acceptance_ids: vec!["AC-1".into()],
+                    status: StepStatus::Pending,
+                }],
+                invariants: vec!["exact SHA".into()],
+                risks: vec!["stale remote".into()],
+                planning_profile: PlanningProfile::Small,
+                stop_conditions: vec!["mismatch".into()],
+                validation_lanes: vec![ValidationLane {
+                    lane: "focused".into(),
+                    proof_role: "lifecycle".into(),
+                    acceptance_ids: vec!["AC-1".into()],
+                    deterministic: true,
+                    resource_profile: ResourceProfile::Small,
+                    budget_seconds: 30,
+                    budget_tokens: 100,
+                    argv: vec!["cargo".into(), "test".into()],
+                    parallel_group: "local".into(),
+                    defer_reason: None,
+                }],
+                failure_policy: "fail closed".into(),
+                review_prompts: vec!["review".into()],
+            },
+        },
+    )
+    .unwrap();
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sip,
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Ready,
+        },
+    );
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sip,
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Bound,
+        },
+    );
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sor,
+        SemanticOperation::RecordExecution {
+            summary: "done".into(),
+            changes: vec!["docs".into()],
+            artifacts: vec!["artifact".into()],
+        },
+    );
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sor,
+        SemanticOperation::RecordValidation {
+            result: ValidationResult {
+                command: vec!["cargo".into(), "test".into()],
+                purpose: "proof".into(),
+                outcome: EvidenceOutcome::Passed,
+                evidence_ref: "evidence.json".into(),
+            },
+        },
+    );
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sip,
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Implemented,
+        },
+    );
+    let assigned = assign_review(
+        &store,
+        ReviewAssignmentRequest {
+            issue: 7,
+            expected_generation: record.generation,
+            expected_digest: record.digest,
+            claim_id: "claim".into(),
+            reviewer: "reviewer".into(),
+            assigned_by: "agent".into(),
+            scope: vec!["docs".into()],
+        },
+    )
+    .unwrap();
+    let revision = assigned
+        .review_assignment
+        .as_ref()
+        .unwrap()
+        .revision
+        .clone();
+    record = record_review(
+        &store,
+        ReviewRecordRequest {
+            issue: 7,
+            expected_generation: assigned.generation,
+            expected_digest: assigned.digest,
+            claim_id: "claim".into(),
+            actor: "reviewer".into(),
+            evidence: ReviewEvidence {
+                reviewer: "reviewer".into(),
+                scope: vec!["docs".into()],
+                reviewed_revision: revision.clone(),
+                findings: vec![],
+                residual_risks: vec![],
+                completed: true,
+                non_substantive_proof: None,
+            },
+        },
+    )
+    .unwrap();
+    record = edit(
+        &store,
+        &record,
+        CardKind::Sip,
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Reviewed,
+        },
+    );
+    let request = PublicationRequest {
+        schema: "csdlc.publication_request.v1".into(),
+        issue: 7,
+        expected_generation: record.generation,
+        expected_digest: record.digest.clone(),
+        claim_id: "claim".into(),
+        actor: "publisher".into(),
+        repository: "example/repo".into(),
+        base: "main".into(),
+        head: "issue-7".into(),
+        title: "Fixture".into(),
+        body: "Closes #7".into(),
+        draft: true,
+        remote: "origin".into(),
+        token_file: None,
+    };
+    let intent = PublicationIntent {
+        schema: "csdlc.publication_intent.v1".into(),
+        issue: 7,
+        repository: "example/repo".into(),
+        base: "main".into(),
+        head: "issue-7".into(),
+        title: "Fixture".into(),
+        body: "Closes #7".into(),
+        draft: true,
+        revision: revision.clone(),
+        commit_sha: sha.clone(),
+    };
+    record = record_publication(
+        &store,
+        &request,
+        &intent,
+        RemotePullRequest {
+            number: 70,
+            url: "https://example.invalid/70".into(),
+            repository: "example/repo".into(),
+            base: "main".into(),
+            head: "issue-7".into(),
+            title: "Fixture".into(),
+            body: "Closes #7".into(),
+            draft: true,
+            state: "open".into(),
+            head_sha: sha.clone(),
+        },
+    )
+    .unwrap();
+    (temp, store, record, sha)
+}
+
+#[test]
+fn readiness_regression_and_exact_terminal_closeout_are_atomic_and_idempotent() {
+    let (_temp, store, mut record, sha) = fixture();
+    let mut request = ReadinessRequest {
+        schema: "csdlc.readiness_request.v1".into(),
+        issue: 7,
+        expected_generation: record.generation,
+        expected_digest: record.digest.clone(),
+        claim_id: "claim".into(),
+        actor: "shepherd".into(),
+        pull_request: 70,
+        head_sha: sha.clone(),
+        required_checks: vec!["fast".into()],
+        require_review: true,
+        checks: vec![csdlc_v2::CheckObservation {
+            name: "fast".into(),
+            requirement: csdlc_v2::CheckRequirement::Required,
+            conclusion: csdlc_v2::CheckConclusion::Success,
+            details_url: None,
+        }],
+        review_state: csdlc_v2::RemoteReviewState::Approved,
+        conflict_state: csdlc_v2::ConflictState::Clean,
+        post_publication_findings: vec![],
+    };
+    record = record_readiness(&store, request.clone()).unwrap();
+    assert_eq!(record.phase, LifecyclePhase::MergeReady);
+    request.expected_generation = record.generation;
+    request.expected_digest = record.digest.clone();
+    request.checks[0].conclusion = csdlc_v2::CheckConclusion::Failure;
+    record = record_readiness(&store, request).unwrap();
+    assert_eq!(record.phase, LifecyclePhase::Published);
+
+    let wrong = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: 7,
+        expected_generation: record.generation,
+        expected_digest: record.digest.clone(),
+        claim_id: "claim".into(),
+        actor: "closer".into(),
+        pull_request: Some(70),
+        disposition: TerminalDisposition::Merged,
+        observed_sha: Some("wrong".into()),
+        observed_state: "merged".into(),
+        approved_no_pr_reason: None,
+        receipt_path: "/tmp/gate7-receipt.json".into(),
+    };
+    assert!(closeout_issue(&store, wrong).is_err());
+    let current = store.load_record(7).unwrap();
+    assert_eq!(current.phase, LifecyclePhase::Published);
+
+    let mut green = ReadinessRequest {
+        schema: "csdlc.readiness_request.v1".into(),
+        issue: 7,
+        expected_generation: current.generation,
+        expected_digest: current.digest.clone(),
+        claim_id: "claim".into(),
+        actor: "shepherd".into(),
+        pull_request: 70,
+        head_sha: sha.clone(),
+        required_checks: vec!["fast".into()],
+        require_review: true,
+        checks: vec![csdlc_v2::CheckObservation {
+            name: "fast".into(),
+            requirement: csdlc_v2::CheckRequirement::Required,
+            conclusion: csdlc_v2::CheckConclusion::Success,
+            details_url: None,
+        }],
+        review_state: csdlc_v2::RemoteReviewState::Approved,
+        conflict_state: csdlc_v2::ConflictState::Clean,
+        post_publication_findings: vec![],
+    };
+    record = record_readiness(&store, green.clone()).unwrap();
+    green.expected_generation = record.generation;
+    green.expected_digest = record.digest.clone();
+    let terminal = TerminalObservation {
+        schema: "csdlc.terminal_observation.v1".into(),
+        issue: 7,
+        expected_generation: record.generation,
+        expected_digest: record.digest.clone(),
+        claim_id: "claim".into(),
+        actor: "closer".into(),
+        pull_request: Some(70),
+        disposition: TerminalDisposition::Merged,
+        observed_sha: Some(sha),
+        observed_state: "merged".into(),
+        approved_no_pr_reason: None,
+        receipt_path: "/tmp/gate7-receipt.json".into(),
+    };
+    let closed = closeout_issue(&store, terminal.clone()).unwrap();
+    assert_eq!(closed.phase, LifecyclePhase::ClosedOut);
+    assert!(closed.claim.is_none());
+    assert_eq!(closeout_issue(&store, terminal).unwrap(), closed);
+    let doctor = csdlc_v2::diagnose(&store, 7);
+    assert_eq!(doctor.phase, Some(LifecyclePhase::ClosedOut));
+    assert!(doctor.findings.is_empty());
+}

--- a/docs/architecture/csdlc-v2/gate7/GATE7_READINESS_CLOSEOUT_DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate7/GATE7_READINESS_CLOSEOUT_DESIGN.md
@@ -1,0 +1,101 @@
+# Gate 7: Readiness and Closeout
+
+## Decision
+
+Gate 7 completes the native v2 lifecycle with one standalone binary,
+csdlc-closeout, and one deterministic policy module, readiness.rs.
+Octocrab observes the PR, checks, reviews, mergeability, and terminal state.
+The policy module classifies those observations and the store atomically
+projects accepted truth into the index and SOR.
+
+The scheduler and shepherd remain classifiers, not merge authorities. Gate 7
+does not merge a PR. It says whether observed remote and local proof is ready,
+and after a separately authorized merge or closure it verifies and records the
+terminal result.
+
+## Readiness model
+
+Required check names are declared inputs. Every observed check is classified
+as required or optional, and its conclusion is closed and typed. Missing and
+unknown required checks remain pending; skipped or neutral required checks are
+not green. Optional skipped or deferred work stays visible but cannot be
+silently promoted into required success.
+
+Remote review and conflict state are independent. A green check set cannot
+hide a missing approval or unknown mergeability. Post-publication requested
+changes are stored as routed findings in ReadinessEvidence; they do not
+replace or rewrite the mandatory exact-revision pre-publication ReviewEvidence.
+
+~~~mermaid
+flowchart LR
+    GH["Octocrab PR observation"] --> N["Typed normalization"]
+    Policy["Required checks + review policy"] --> N
+    N --> C["Required check classifier"]
+    N --> R["Review classifier"]
+    N --> M["Conflict classifier"]
+    N --> F["Post-publication findings"]
+    C --> G["Readiness conjunction"]
+    R --> G
+    M --> G
+    F --> G
+    G -->|all observed green| A["Atomic MergeReady + SOR"]
+    G -->|pending/failing/unknown| W["Waiting/blocked evidence only"]
+~~~
+
+## Closeout model
+
+Closeout accepts only one typed terminal disposition:
+
+- merged: an actual PR, merged state, and observed head SHA are mandatory;
+- closed_unmerged: an actual closed PR is mandatory;
+- closed_no_pr: no PR may exist and an explicit approval reason is mandatory.
+
+The PR identity must match publication evidence. Merged closeout is legal only
+from MergeReady. Intentional non-merged termination is legal only from the
+reviewed/published tail. Successful closeout updates the SOR and index in one
+transaction, writes terminal evidence, releases the claim and protected paths,
+and records the release in the audit stream. Repeating the exact terminal
+observation returns the canonical record without another generation.
+
+~~~mermaid
+stateDiagram-v2
+    Published --> MergeReady: required checks + review + clean conflict
+    MergeReady --> Merged: GitHub says merged
+    Merged --> ClosedOut: atomic terminal reconciliation
+    Published --> ClosedOut: observed intentional closed-unmerged
+    Reviewed --> ClosedOut: approved no-PR disposition
+    ClosedOut --> ClosedOut: exact idempotent repeat
+~~~
+
+## Pruning boundary
+
+Terminal truth and cleanup eligibility are separate. validate-prune requires
+ClosedOut, terminal evidence, and a claim-release audit. The library's prune
+surface guard additionally checks exact branch/worktree topology and a clean
+Git status. Dirty, mismatched, non-terminal, or ambiguous surfaces fail
+closed. Actual removal is a typed Git worktree operation owned by the operator
+or the later cutover adapter, after the durable receipt has been copied to the
+shared repository state.
+
+~~~mermaid
+flowchart TD
+    T["Terminal GitHub observation"] --> V{"Matches publication?"}
+    V -->|no| Stop["Fail closed"]
+    V -->|yes| Commit["Atomic SOR/index/claim release"]
+    Commit --> E["Durable terminal receipt"]
+    E --> Topology{"Exact worktree + branch?"}
+    Topology -->|no| Stop
+    Topology --> Clean{"Git status clean?"}
+    Clean -->|no| Stop
+    Clean -->|yes| Eligible["Prune eligible"]
+~~~
+
+## Failure and proof posture
+
+Remote transport failures and incomplete GitHub fields produce typed
+non-terminal errors. Tokens are memory-only and unavailable sources are
+reported without contents. The default test lane remains offline: the compact Gate
+7 proof set covers required/optional distinctions, pending/failing/unknown
+behavior, requested-change retention, false-terminal refusal, no-PR approval,
+and schemas. The existing lifecycle suite supplies the atomic card/store
+regression surface; live GitHub observation is bounded integration proof.

--- a/docs/architecture/csdlc-v2/gate7/readiness-closeout.mmd
+++ b/docs/architecture/csdlc-v2/gate7/readiness-closeout.mmd
@@ -1,0 +1,10 @@
+flowchart LR
+    Observe["Octocrab observations"] --> Normalize["Typed readiness truth"]
+    Normalize --> Ready{"Checks + review + conflict + findings"}
+    Ready -->|green| MergeReady["MergeReady handoff"]
+    Ready -->|not green| Wait["Waiting/blocked"]
+    MergeReady --> External["Separately authorized merge/close"]
+    External --> Verify["Verify terminal GitHub state"]
+    Verify --> Commit["Atomic SOR/index + claim release"]
+    Commit --> Guard["Topology + clean-worktree guard"]
+    Guard --> Eligible["Prune eligible"]


### PR DESCRIPTION
Closes #5237

## Summary
Implemented and reviewed Gate 7 readiness and closeout: live Octocrab normalization, required/optional check truth, review supersession and retained findings, readiness regression, exact PR/SHA terminal reconciliation, atomic SOR/index finalization and claim release, and guarded typed worktree pruning.

## Artifacts
- Standalone Rust implementation under `csdlc-v2/`
- Gate 7 design and Mermaid sources under `docs/architecture/csdlc-v2/gate7/`
- Exact rebased commit review for `09187076a`: `NO FINDINGS`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path csdlc-v2/Cargo.toml -q` - run the complete standalone C-SDLC v2 suite (57 focused tests)
  - `cargo clippy --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings` - prove every standalone library, binary, and test target is warning-free
  - `git diff --check HEAD^ HEAD` - prove exact committed patch formatting hygiene
- Results:
  - `cargo test --manifest-path csdlc-v2/Cargo.toml -q`: PASS
  - `cargo clippy --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings`: PASS
  - `git diff --check HEAD^ HEAD`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5237__v0-91-7-csdlc-v2-gate-7-pr-readiness-and-closeout/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5237__v0-91-7-csdlc-v2-gate-7-pr-readiness-and-closeout/sor.md
- Idempotency-Key: v0-91-7-csdlc-v2-gate-7-pr-readiness-and-closeout-csdlc-v2-docs-architecture-csdlc-v2-gate7-adl-v0-91-7-tasks-issue-5237-v0-91-7-csdlc-v2-gate-7-pr-readiness-and-closeout-sip-md-adl-v0-91-7-tasks-issue-5237-v0-91-7-csdlc-v2-gate-7-pr-readiness-and-closeout-sor-md