### PR TITLE
[v0.91.7][csdlc-v2] Gate 8: legacy import and shadow parity

### DIFF
--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -50,6 +50,14 @@ path = "src/bin/csdlc-publish.rs"
 name = "csdlc-closeout"
 path = "src/bin/csdlc-closeout.rs"
 
+[[bin]]
+name = "csdlc-import"
+path = "src/bin/csdlc-import.rs"
+
+[[bin]]
+name = "csdlc-shadow"
+path = "src/bin/csdlc-shadow.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/src/bin/csdlc-import.rs
+++ b/csdlc-v2/src/bin/csdlc-import.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::PathBuf;
+
+use clap::Parser;
+use csdlc_v2::{import_legacy, LegacyImportRequest};
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    request: PathBuf,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let result = fs::read(&cli.request)
+        .map_err(Into::into)
+        .and_then(|bytes| serde_json::from_slice::<LegacyImportRequest>(&bytes).map_err(Into::into))
+        .and_then(import_legacy);
+    match result {
+        Ok(report) => {
+            println!("{}", serde_json::to_string_pretty(&report).expect("JSON"));
+            if report.status == csdlc_v2::migration::ImportStatus::Unsupported {
+                std::process::exit(76);
+            }
+        }
+        Err(error) => {
+            println!(
+                "{}",
+                serde_json::json!({"schema":"csdlc.error.v1","code":error.code.to_string(),"message":error.message})
+            );
+            std::process::exit(error.code.exit_code());
+        }
+    }
+}

--- a/csdlc-v2/src/bin/csdlc-shadow.rs
+++ b/csdlc-v2/src/bin/csdlc-shadow.rs
@@ -1,0 +1,62 @@
+use std::fs;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use csdlc_v2::{compare_shadow, generate_compatibility_view, NormalizedOutcome, Store};
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, default_value = ".")]
+    root: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+#[derive(Subcommand)]
+enum Command {
+    Compare {
+        #[arg(long)]
+        issue: u64,
+        #[arg(long)]
+        legacy_observation: PathBuf,
+    },
+    GenerateView {
+        #[arg(long)]
+        issue: u64,
+    },
+    Schema,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let store = Store::new(&cli.root);
+    let result: csdlc_v2::Result<serde_json::Value> = match cli.command {
+        Command::Schema => Ok(csdlc_v2::public_schema_bundle()),
+        Command::Compare {
+            issue,
+            legacy_observation,
+        } => (|| {
+            let legacy: NormalizedOutcome = serde_json::from_slice(&fs::read(legacy_observation)?)?;
+            Ok(serde_json::to_value(compare_shadow(
+                &legacy,
+                &NormalizedOutcome::from_v2(&store, issue)?,
+            ))?)
+        })(),
+        Command::GenerateView { issue } => (|| {
+            let view = generate_compatibility_view(&store, issue)?;
+            let output = csdlc_v2::write_compatibility_view_atomic(&store, issue, &view)?;
+            Ok(
+                serde_json::json!({"schema":"csdlc.compatibility_view_result.v1","issue":issue,"output":output}),
+            )
+        })(),
+    };
+    match result {
+        Ok(value) => println!("{}", serde_json::to_string_pretty(&value).expect("JSON")),
+        Err(error) => {
+            println!(
+                "{}",
+                serde_json::json!({"schema":"csdlc.error.v1","code":error.code.to_string(),"message":error.message})
+            );
+            std::process::exit(error.code.exit_code());
+        }
+    }
+}

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -3,6 +3,7 @@ pub mod doctor;
 pub mod error;
 pub mod git;
 pub mod lifecycle;
+pub mod migration;
 pub mod model;
 pub mod publication;
 pub mod pvf;
@@ -20,9 +21,13 @@ pub use lifecycle::{
     bind_issue, heartbeat_claim, initialize_issue, recover_claim, BindRequest, BindResult,
     RecoverClaimRequest,
 };
+pub use migration::{
+    compare_shadow, generate_compatibility_view, import_legacy, write_compatibility_view_atomic,
+    ImportReport, LegacyImportRequest, NormalizedOutcome, ShadowComparison,
+};
 pub use model::{
-    Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase, NonSubstantiveProof,
-    PublicationEvidence, ReadinessEvidence, ReviewAssignment, ReviewEvidence,
+    Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase, MigrationEvidence,
+    NonSubstantiveProof, PublicationEvidence, ReadinessEvidence, ReviewAssignment, ReviewEvidence,
     ReviewFindingEvidence, TerminalEvidence,
 };
 pub use publication::{

--- a/csdlc-v2/src/migration.rs
+++ b/csdlc-v2/src/migration.rs
@@ -1,0 +1,679 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+use markdown::mdast::Node;
+use markdown::{to_mdast, ParseOptions};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumString};
+
+use crate::cards::{CardContent, CardKind, InitialCardInput, PlanStep, StepStatus, ValidationLane};
+use crate::error::{ErrorCode, Result, V2Error};
+use crate::model::{LifecyclePhase, MigrationEvidence};
+use crate::{
+    edit_issue, initialize_issue, BootstrapRequest, CardStatus, Claim, EditRequest,
+    PlanningProfile, SemanticOperation, Store,
+};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ImportStatus {
+    Imported,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LegacyImportRequest {
+    pub schema: String,
+    pub legacy_root: PathBuf,
+    pub output_root: PathBuf,
+    pub issue: u64,
+    pub repository: String,
+    pub title: String,
+    pub slug: String,
+    pub version: String,
+    pub card_paths: BTreeMap<CardKind, String>,
+    pub design_path: String,
+    pub diagram_path: String,
+    pub design_reviewer: String,
+    pub claim: Claim,
+    pub planning_profile: PlanningProfile,
+    pub validation_lanes: Vec<ValidationLane>,
+    pub imported_unix_seconds: u64,
+    pub default_cutover_unix_seconds: u64,
+    pub legacy_phase: LifecyclePhase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MigrationDiagnostic {
+    pub card: Option<CardKind>,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ImportReport {
+    pub schema: String,
+    pub status: ImportStatus,
+    pub issue: u64,
+    pub source_digest: Option<String>,
+    pub retained_section_count: usize,
+    pub diagnostics: Vec<MigrationDiagnostic>,
+    pub compatibility_view: Option<String>,
+    pub sunset_unix_seconds: u64,
+}
+
+pub fn import_legacy(request: LegacyImportRequest) -> Result<ImportReport> {
+    validate_request(&request)?;
+    let mut authored = BTreeMap::new();
+    let mut authored_sources = BTreeMap::new();
+    let mut diagnostics = Vec::new();
+    let mut source = blake3::Hasher::new();
+    let legacy_root = request.legacy_root.canonicalize()?;
+    let output_root = request.output_root.canonicalize()?;
+    let mut canonical_sources = BTreeSet::new();
+    for kind in enum_cards() {
+        let Some(relative) = request.card_paths.get(&kind) else {
+            diagnostics.push(diag(
+                Some(kind),
+                "card_missing",
+                "all six legacy card paths are required",
+            ));
+            continue;
+        };
+        let relative_path = std::path::Path::new(relative);
+        if relative_path.is_absolute()
+            || !relative_path
+                .components()
+                .all(|part| matches!(part, std::path::Component::Normal(_)))
+        {
+            diagnostics.push(diag(
+                Some(kind),
+                "source_path_unsafe",
+                "legacy card path must be a clean relative path",
+            ));
+            continue;
+        }
+        let path = request.legacy_root.join(relative);
+        let canonical = match path.canonicalize() {
+            Ok(path) if path.starts_with(&legacy_root) && !path.starts_with(&output_root) => path,
+            _ => {
+                diagnostics.push(diag(
+                    Some(kind),
+                    "source_path_outside_legacy_root",
+                    "legacy source resolves outside the disjoint legacy root",
+                ));
+                continue;
+            }
+        };
+        if !canonical_sources.insert(canonical.clone()) {
+            diagnostics.push(diag(
+                Some(kind),
+                "source_path_reused",
+                "one legacy file cannot own multiple cards",
+            ));
+            continue;
+        }
+        let bytes = match fs::read(&canonical) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                diagnostics.push(diag(
+                    Some(kind),
+                    "card_unreadable",
+                    &format!("legacy card is unreadable: {relative}"),
+                ));
+                continue;
+            }
+        };
+        source.update(&(relative.len() as u64).to_le_bytes());
+        source.update(relative.as_bytes());
+        source.update(&(bytes.len() as u64).to_le_bytes());
+        source.update(&bytes);
+        let text = match String::from_utf8(bytes) {
+            Ok(text) => text,
+            Err(_) => {
+                diagnostics.push(diag(
+                    Some(kind),
+                    "card_not_utf8",
+                    "legacy Markdown must be UTF-8",
+                ));
+                continue;
+            }
+        };
+        authored_sources.insert(kind.to_string(), text.clone());
+        match parse_sections(&text) {
+            Ok(sections) => {
+                for required in required_headings(kind) {
+                    if !sections.contains_key(*required) {
+                        diagnostics.push(diag(
+                            Some(kind),
+                            "required_heading_missing",
+                            &format!("required heading is missing: {required}"),
+                        ));
+                    }
+                }
+                authored.insert(kind.to_string(), sections);
+            }
+            Err(error) => diagnostics.push(diag(Some(kind), "markdown_ambiguous", &error.message)),
+        }
+    }
+    let sunset = request
+        .default_cutover_unix_seconds
+        .checked_add(30 * 24 * 60 * 60)
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "cutover sunset overflow"))?;
+    let source_digest = format!("blake3:{}", source.finalize().to_hex());
+    if !diagnostics.is_empty() {
+        return Ok(ImportReport {
+            schema: "csdlc.legacy_import_report.v1".into(),
+            status: ImportStatus::Unsupported,
+            issue: request.issue,
+            source_digest: None,
+            retained_section_count: authored.values().map(BTreeMap::len).sum(),
+            diagnostics,
+            compatibility_view: None,
+            sunset_unix_seconds: sunset,
+        });
+    }
+    let initial = match build_initial(&request, &authored) {
+        Ok(initial) => initial,
+        Err(error) => {
+            return Ok(unsupported(
+                &request,
+                sunset,
+                Some(source_digest),
+                authored.values().map(BTreeMap::len).sum(),
+                vec![diag(None, "typed_values_unrepresentable", &error.message)],
+            ));
+        }
+    };
+    let design = request.output_root.join(&request.design_path);
+    let diagram = request.output_root.join(&request.diagram_path);
+    let safe_output_path = |value: &str| {
+        !value.is_empty()
+            && std::path::Path::new(value)
+                .components()
+                .all(|part| matches!(part, std::path::Component::Normal(_)))
+    };
+    if !safe_output_path(&request.design_path)
+        || !safe_output_path(&request.diagram_path)
+        || !design.is_file()
+        || !diagram.is_file()
+    {
+        return Ok(unsupported(
+            &request,
+            sunset,
+            Some(source_digest),
+            authored.values().map(BTreeMap::len).sum(),
+            vec![diag(
+                None,
+                "design_or_diagram_unrepresentable",
+                "safe existing output design and diagram files are required before import",
+            )],
+        ));
+    }
+    let design_digest = crate::cards::digest(&fs::read(&design)?);
+    let diagram_digest = crate::cards::digest(&fs::read(&diagram)?);
+    if let Err(error) = crate::cards::initial_cards(
+        request.issue,
+        &request.repository,
+        &request.design_path,
+        &design_digest,
+        &request.diagram_path,
+        &diagram_digest,
+        initial.clone(),
+    ) {
+        return Ok(unsupported(
+            &request,
+            sunset,
+            Some(source_digest),
+            authored.values().map(BTreeMap::len).sum(),
+            vec![diag(None, "typed_cards_unrepresentable", &error.message)],
+        ));
+    }
+    let store = Store::new(&request.output_root);
+    let mut record = initialize_issue(
+        &store,
+        BootstrapRequest {
+            issue: request.issue,
+            repository: request.repository.clone(),
+            design_path: request.design_path.clone(),
+            diagram_path: request.diagram_path.clone(),
+            design_reviewer: request.design_reviewer,
+            design_approved: true,
+            claim: request.claim,
+            initial,
+        },
+    )?;
+    let compatibility_path = format!(".csdlc/compat/{}.md", request.issue);
+    let compatibility = render_legacy_archive(request.issue, &authored_sources);
+    record = store.commit_migration(
+        request.issue,
+        &record.digest,
+        MigrationEvidence {
+            schema: "csdlc.migration_evidence.v1".into(),
+            imported_unix_seconds: request.imported_unix_seconds,
+            sunset_unix_seconds: sunset,
+            source_digest: source_digest.clone(),
+            authored_sources: authored_sources.clone(),
+            authored_sections: authored.clone(),
+            compatibility_view: compatibility_path.clone(),
+        },
+    )?;
+    if request.legacy_phase == LifecyclePhase::Ready && record.phase == LifecyclePhase::Initialized
+    {
+        let _ = edit_issue(
+            &store,
+            EditRequest {
+                issue: request.issue,
+                card: CardKind::Sip,
+                expected_generation: record.generation,
+                expected_digest: record.digest,
+                claim_id: record.claim.as_ref().expect("claim").id.clone(),
+                actor: "csdlc-import".into(),
+                reason: "normalize supported legacy ready outcome".into(),
+                operation: SemanticOperation::AdvancePhase {
+                    phase: LifecyclePhase::Ready,
+                },
+                fail_after_backup: false,
+            },
+        )?;
+    }
+    write_compatibility_view_atomic(&store, request.issue, &compatibility)?;
+    Ok(ImportReport {
+        schema: "csdlc.legacy_import_report.v1".into(),
+        status: ImportStatus::Imported,
+        issue: request.issue,
+        source_digest: Some(source_digest),
+        retained_section_count: authored.values().map(BTreeMap::len).sum(),
+        diagnostics: Vec::new(),
+        compatibility_view: Some(compatibility_path),
+        sunset_unix_seconds: sunset,
+    })
+}
+
+fn validate_request(request: &LegacyImportRequest) -> Result<()> {
+    if request.schema != "csdlc.legacy_import_request.v1"
+        || request.issue == 0
+        || !matches!(
+            request.legacy_phase,
+            LifecyclePhase::Initialized | LifecyclePhase::Ready
+        )
+        || request.validation_lanes.is_empty()
+        || request.imported_unix_seconds == 0
+        || request.default_cutover_unix_seconds == 0
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "legacy import request is invalid or outside the bounded phase set",
+        ));
+    }
+    let legacy = request.legacy_root.canonicalize()?;
+    let output = request.output_root.canonicalize()?;
+    if legacy == output || legacy.starts_with(&output) || output.starts_with(&legacy) {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "legacy and output roots must be canonical and disjoint",
+        ));
+    }
+    let sunset = request
+        .default_cutover_unix_seconds
+        .checked_add(30 * 24 * 60 * 60)
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "cutover sunset overflow"))?;
+    if request.imported_unix_seconds > sunset {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "legacy importer expired 30 days after default cutover",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_sections(text: &str) -> Result<BTreeMap<String, String>> {
+    let ast = to_mdast(text, &ParseOptions::gfm())
+        .map_err(|message| V2Error::new(ErrorCode::InvalidInput, message.to_string()))?;
+    let children = ast
+        .children()
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "mdast root is absent"))?;
+    let mut anchors = Vec::new();
+    for child in children {
+        if let Node::Heading(heading) = child {
+            if heading.depth == 2 {
+                let position = child.position().ok_or_else(|| {
+                    V2Error::new(ErrorCode::InvalidInput, "heading source position is absent")
+                })?;
+                anchors.push((
+                    child.to_string().trim().to_owned(),
+                    position.start.offset,
+                    position.end.offset,
+                ));
+            }
+        }
+    }
+    let mut seen = BTreeSet::new();
+    if anchors.is_empty()
+        || anchors
+            .iter()
+            .any(|(name, _, _)| name.is_empty() || !seen.insert(name.clone()))
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "level-two headings are missing, empty, or duplicated",
+        ));
+    }
+    let mut sections = BTreeMap::new();
+    for (index, (name, _, end)) in anchors.iter().enumerate() {
+        let next = anchors
+            .get(index + 1)
+            .map_or(text.len(), |(_, start, _)| *start);
+        let raw = text
+            .get(*end..next)
+            .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "heading offsets are invalid"))?;
+        if raw.trim().is_empty() {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                format!("authored section is empty: {name}"),
+            ));
+        }
+        sections.insert(name.clone(), raw.to_owned());
+    }
+    Ok(sections)
+}
+
+fn build_initial(
+    request: &LegacyImportRequest,
+    authored: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<InitialCardInput> {
+    let get = |kind: CardKind, heading: &str| -> Result<String> {
+        authored
+            .get(&kind.to_string())
+            .and_then(|sections| sections.get(heading))
+            .cloned()
+            .ok_or_else(|| {
+                V2Error::new(
+                    ErrorCode::InvalidInput,
+                    format!("{kind} {heading} is absent"),
+                )
+            })
+    };
+    let acceptance_criteria = list(&get(CardKind::Stp, "Acceptance Criteria")?);
+    let acceptance_ids: Vec<_> = (1..=acceptance_criteria.len())
+        .map(|index| format!("AC-{index}"))
+        .collect();
+    let steps: Vec<_> = list(&get(CardKind::Spp, "Plan")?)
+        .into_iter()
+        .enumerate()
+        .map(|(index, action)| PlanStep {
+            id: format!("imported-{}", index + 1),
+            action,
+            acceptance_ids: acceptance_ids.clone(),
+            status: StepStatus::Pending,
+        })
+        .collect();
+    if steps.is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "legacy Plan has no unambiguous list items",
+        ));
+    }
+    Ok(InitialCardInput {
+        title: request.title.clone(),
+        slug: request.slug.clone(),
+        version: request.version.clone(),
+        goal: plain(&get(CardKind::Sip, "Goal")?),
+        required_outcome: plain(&get(CardKind::Stp, "Required Outcome")?),
+        declared_scope: list(&get(CardKind::Sip, "Scope")?),
+        authority_boundary: list(&get(CardKind::Sip, "Authority")?),
+        task_boundary: plain(&get(CardKind::Stp, "Summary")?),
+        deliverables: list(&get(CardKind::Stp, "Deliverables")?),
+        acceptance_criteria,
+        dependencies: vec!["imported legacy observation".into()],
+        repo_inputs: vec!["one-way imported authored cards".into()],
+        non_goals: vec!["legacy implementation reuse".into()],
+        plan_summary: plain(&get(CardKind::Spp, "Plan")?),
+        steps,
+        invariants: list(&get(CardKind::Spp, "Invariants")?),
+        risks: list(&get(CardKind::Spp, "Risks")?),
+        planning_profile: request.planning_profile,
+        stop_conditions: list(&get(CardKind::Spp, "Stop Conditions")?),
+        validation_lanes: request
+            .validation_lanes
+            .iter()
+            .cloned()
+            .map(|mut lane| {
+                lane.acceptance_ids = acceptance_ids.clone();
+                lane
+            })
+            .collect(),
+        failure_policy: plain(&get(CardKind::Vpp, "Failure Policy")?),
+        review_prompts: list(&get(CardKind::Srp, "Prompts")?),
+    })
+}
+
+fn list(raw: &str) -> Vec<String> {
+    raw.lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("- ")
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        })
+        .collect()
+}
+fn plain(raw: &str) -> String {
+    let items = list(raw);
+    if items.is_empty() {
+        raw.split_whitespace().collect::<Vec<_>>().join(" ")
+    } else {
+        items.join("; ")
+    }
+}
+fn diag(card: Option<CardKind>, code: &str, message: &str) -> MigrationDiagnostic {
+    MigrationDiagnostic {
+        card,
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
+fn unsupported(
+    request: &LegacyImportRequest,
+    sunset_unix_seconds: u64,
+    source_digest: Option<String>,
+    retained_section_count: usize,
+    diagnostics: Vec<MigrationDiagnostic>,
+) -> ImportReport {
+    ImportReport {
+        schema: "csdlc.legacy_import_report.v1".into(),
+        status: ImportStatus::Unsupported,
+        issue: request.issue,
+        source_digest,
+        retained_section_count,
+        diagnostics,
+        compatibility_view: None,
+        sunset_unix_seconds,
+    }
+}
+fn enum_cards() -> [CardKind; 6] {
+    [
+        CardKind::Sip,
+        CardKind::Stp,
+        CardKind::Spp,
+        CardKind::Vpp,
+        CardKind::Srp,
+        CardKind::Sor,
+    ]
+}
+fn required_headings(kind: CardKind) -> &'static [&'static str] {
+    match kind {
+        CardKind::Sip => &["Goal", "Scope", "Authority"],
+        CardKind::Stp => &[
+            "Summary",
+            "Required Outcome",
+            "Deliverables",
+            "Acceptance Criteria",
+        ],
+        CardKind::Spp => &["Plan", "Invariants", "Risks", "Stop Conditions"],
+        CardKind::Vpp => &["Validation", "Failure Policy"],
+        CardKind::Srp => &["Review Scope", "Prompts"],
+        CardKind::Sor => &[
+            "Summary",
+            "Artifacts",
+            "Execution",
+            "Integration",
+            "Publication",
+            "Closeout",
+            "Follow Ups",
+        ],
+    }
+}
+fn render_legacy_archive(issue: u64, authored: &BTreeMap<String, String>) -> String {
+    let mut out = format!("# Generated compatibility view for issue {issue}\n\nGenerated from canonical migration evidence. Do not edit.\n");
+    for (card, source) in authored {
+        out.push_str(&format!("\n<!-- BEGIN exact legacy source: {card} -->\n"));
+        out.push_str(source);
+        if !source.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&format!("<!-- END exact legacy source: {card} -->\n"));
+    }
+    out
+}
+
+pub fn generate_compatibility_view(store: &Store, issue: u64) -> Result<String> {
+    let record = store.load_record(issue)?;
+    let migration = record
+        .migration
+        .as_ref()
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "issue has no migration evidence"))?;
+    Ok(render_legacy_archive(issue, &migration.authored_sources))
+}
+
+pub fn write_compatibility_view_atomic(store: &Store, issue: u64, view: &str) -> Result<String> {
+    let directory = store.root().join(".csdlc/compat");
+    fs::create_dir_all(&directory)?;
+    let target = directory.join(format!("{issue}.md"));
+    let temporary = directory.join(format!(".{issue}.tmp"));
+    fs::write(&temporary, view)?;
+    fs::rename(&temporary, &target)?;
+    Ok(format!(".csdlc/compat/{issue}.md"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct NormalizedOutcome {
+    pub schema: String,
+    pub issue: u64,
+    pub phase: LifecyclePhase,
+    pub card_statuses: BTreeMap<CardKind, CardStatus>,
+    pub review_result: String,
+    pub integration_state: String,
+    pub publication_state: String,
+    pub merge_state: String,
+    pub closeout_state: String,
+    pub claim_active: bool,
+    pub doctor_status: String,
+    pub doctor_findings: Vec<String>,
+}
+
+impl NormalizedOutcome {
+    pub fn from_v2(store: &Store, issue: u64) -> Result<Self> {
+        let record = store.load_record(issue)?;
+        let cards = store.load_cards(issue)?;
+        let doctor = crate::diagnose(store, issue);
+        let mut doctor_findings: Vec<_> = doctor
+            .findings
+            .into_iter()
+            .map(|finding| finding.code)
+            .collect();
+        doctor_findings.sort();
+        let statuses = cards
+            .iter()
+            .map(|(kind, values)| (*kind, values.status))
+            .collect();
+        let srp = match &cards[&CardKind::Srp].content {
+            CardContent::Srp(value) => value,
+            _ => unreachable!(),
+        };
+        let sor = match &cards[&CardKind::Sor].content {
+            CardContent::Sor(value) => value,
+            _ => unreachable!(),
+        };
+        Ok(Self {
+            schema: "csdlc.normalized_outcome.v1".into(),
+            issue,
+            phase: record.phase,
+            card_statuses: statuses,
+            review_result: srp.review_result.to_string(),
+            integration_state: sor.integration_state.to_string(),
+            publication_state: sor.publication_state.to_string(),
+            merge_state: sor.merge_state.to_string(),
+            closeout_state: sor.closeout_state.to_string(),
+            claim_active: record.claim.is_some(),
+            doctor_status: doctor.status.to_string(),
+            doctor_findings,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ShadowComparison {
+    pub schema: String,
+    pub equivalent: bool,
+    pub differences: Vec<String>,
+}
+
+pub fn compare_shadow(legacy: &NormalizedOutcome, v2: &NormalizedOutcome) -> ShadowComparison {
+    let mut differences = Vec::new();
+    if legacy.issue != v2.issue {
+        differences.push("issue".into());
+    }
+    if legacy.phase != v2.phase {
+        differences.push("phase".into());
+    }
+    if legacy.card_statuses != v2.card_statuses {
+        differences.push("card_statuses".into());
+    }
+    if legacy.review_result != v2.review_result {
+        differences.push("review_result".into());
+    }
+    if legacy.integration_state != v2.integration_state {
+        differences.push("integration_state".into());
+    }
+    if legacy.publication_state != v2.publication_state {
+        differences.push("publication_state".into());
+    }
+    if legacy.merge_state != v2.merge_state {
+        differences.push("merge_state".into());
+    }
+    if legacy.closeout_state != v2.closeout_state {
+        differences.push("closeout_state".into());
+    }
+    if legacy.claim_active != v2.claim_active {
+        differences.push("claim_active".into());
+    }
+    if legacy.doctor_status != v2.doctor_status {
+        differences.push("doctor_status".into());
+    }
+    if legacy.doctor_findings != v2.doctor_findings {
+        differences.push("doctor_findings".into());
+    }
+    ShadowComparison {
+        schema: "csdlc.shadow_comparison.v1".into(),
+        equivalent: differences.is_empty(),
+        differences,
+    }
+}

--- a/csdlc-v2/src/model.rs
+++ b/csdlc-v2/src/model.rs
@@ -152,6 +152,17 @@ pub struct TerminalEvidence {
     pub released_protected_paths: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MigrationEvidence {
+    pub schema: String,
+    pub imported_unix_seconds: u64,
+    pub sunset_unix_seconds: u64,
+    pub source_digest: String,
+    pub authored_sources: BTreeMap<String, String>,
+    pub authored_sections: BTreeMap<String, BTreeMap<String, String>>,
+    pub compatibility_view: String,
+}
+
 impl Claim {
     pub fn validate(&self, claim_id: &str, now: u64) -> Result<()> {
         if self.id != claim_id {
@@ -224,6 +235,8 @@ pub struct IssueRecord {
     pub readiness: Option<ReadinessEvidence>,
     #[serde(default)]
     pub terminal: Option<TerminalEvidence>,
+    #[serde(default)]
+    pub migration: Option<MigrationEvidence>,
     pub design_path: String,
     pub diagram_path: String,
     pub design_review: DesignReview,

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 
 use crate::doctor::DoctorReport;
 use crate::lifecycle::{BindRequest, BindResult, RecoverClaimRequest};
+use crate::migration::{ImportReport, LegacyImportRequest, NormalizedOutcome, ShadowComparison};
 use crate::model::IssueRecord;
 use crate::publication::{PublicationIntent, PublicationRequest, RemotePullRequest};
 use crate::pvf::{ExecutionReport, ExecutionRequest, PvfManifest, ScheduleReport, ShepherdReport};
@@ -35,5 +36,9 @@ pub fn public_schema_bundle() -> Value {
         "readiness_request": schemars::schema_for!(ReadinessRequest),
         "readiness_report": schemars::schema_for!(ReadinessReport),
         "terminal_observation": schemars::schema_for!(TerminalObservation),
+        "legacy_import_request": schemars::schema_for!(LegacyImportRequest),
+        "legacy_import_report": schemars::schema_for!(ImportReport),
+        "normalized_outcome": schemars::schema_for!(NormalizedOutcome),
+        "shadow_comparison": schemars::schema_for!(ShadowComparison),
     })
 }

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -161,6 +161,54 @@ impl Store {
         self.commit(issue, record, &cards, false)
     }
 
+    pub(crate) fn commit_migration(
+        &self,
+        issue: u64,
+        expected_digest: &str,
+        evidence: crate::model::MigrationEvidence,
+    ) -> Result<IssueRecord> {
+        let _lock = self.lock(issue)?;
+        self.recover_if_needed(issue)?;
+        let mut record = self.load_record(issue)?;
+        if record.digest != expected_digest {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "migration record changed before commit",
+            ));
+        }
+        if let Some(existing) = &record.migration {
+            if existing == &evidence {
+                return Ok(record);
+            }
+            return Err(V2Error::new(
+                ErrorCode::ReconciliationRequired,
+                "existing migration evidence differs from the source digest or retained authored truth",
+            ));
+        }
+        let mut cards = self.load_cards(issue)?;
+        verify_cards(self, &record, &cards)?;
+        record.generation += 1;
+        for values in cards.values_mut() {
+            values.identity.generation = record.generation;
+        }
+        if let Some(claim) = record.claim.as_mut() {
+            claim.generation = record.generation;
+        }
+        record.migration = Some(evidence);
+        record.audit.push(AuditEvent {
+            sequence: record.audit.len() as u64 + 1,
+            generation: record.generation,
+            actor: "csdlc-import".into(),
+            reason: "attach one-way legacy authored-content evidence and sunset metadata".into(),
+            operation: "record_migration".into(),
+        });
+        validate_updated_cards(self, &record, &cards)?;
+        hydrate_projections(&mut record, &cards)?;
+        record.digest = record_digest(&record)?;
+        self.commit(issue, &record, &cards, false)?;
+        Ok(record)
+    }
+
     pub(crate) fn commit_publication(
         &self,
         issue: u64,
@@ -753,6 +801,7 @@ pub fn bootstrap_issue(store: &Store, request: BootstrapRequest) -> Result<Issue
         publication: None,
         readiness: None,
         terminal: None,
+        migration: None,
         design_path: request.design_path,
         diagram_path: request.diagram_path,
         design_review: if request.design_approved {

--- a/csdlc-v2/tests/gate8.rs
+++ b/csdlc-v2/tests/gate8.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeMap;
+
+use csdlc_v2::cards::{ResourceProfile, ValidationLane};
+use csdlc_v2::migration::ImportStatus;
+use csdlc_v2::{
+    compare_shadow, generate_compatibility_view, import_legacy, CardKind, Claim,
+    LegacyImportRequest, LifecyclePhase, NormalizedOutcome, PlanningProfile, Store,
+};
+
+fn write_cards(root: &std::path::Path) -> BTreeMap<CardKind, String> {
+    let cards = [
+        (CardKind::Sip, "# SIP\n\n## Goal\n\nPreserve **authored** intent.\n\n## Scope\n\n- importer\n- parity\n\n## Authority\n\n- no legacy mutation\n"),
+        (CardKind::Stp, "# STP\n\n## Summary\n\nImport one bounded issue.\n\n## Required Outcome\n\nTyped v2 truth.\n\n## Deliverables\n\n- report\n- cards\n\n## Acceptance Criteria\n\n- content retained\n"),
+        (CardKind::Spp, "# SPP\n\n## Plan\n\n- parse AST\n- construct values\n\n## Invariants\n\n- one way\n\n## Risks\n\n- ambiguity\n\n## Stop Conditions\n\n- duplicate heading\n"),
+        (CardKind::Vpp, "# VPP\n\n## Validation\n\n- focused proof\n\n## Failure Policy\n\nFail closed with diagnostics.\n"),
+        (CardKind::Srp, "# SRP\n\n## Review Scope\n\nImported authored truth.\n\n## Prompts\n\n- check content retention\n"),
+        (CardKind::Sor, "# SOR\n\n## Summary\n\nLegacy execution summary.\n\n## Artifacts\n\n- legacy artifact\n\n## Execution\n\n- historical action\n\n## Integration\n\nworktree_only\n\n## Publication\n\nnot_published\n\n## Closeout\n\nnot_started\n\n## Follow Ups\n\n- sunset importer\n"),
+    ];
+    let mut paths = BTreeMap::new();
+    for (kind, text) in cards {
+        let path = format!("{kind}.md");
+        std::fs::write(root.join(&path), text).unwrap();
+        paths.insert(kind, path);
+    }
+    paths
+}
+
+fn request(legacy: &std::path::Path, output: &std::path::Path) -> LegacyImportRequest {
+    std::fs::create_dir_all(output.join("docs")).unwrap();
+    std::fs::write(output.join("docs/design.md"), "# Imported design\n").unwrap();
+    std::fs::write(output.join("docs/diagram.mmd"), "flowchart LR\n A-->B\n").unwrap();
+    LegacyImportRequest {
+        schema: "csdlc.legacy_import_request.v1".into(),
+        legacy_root: legacy.into(),
+        output_root: output.into(),
+        issue: 88,
+        repository: "example/repo".into(),
+        title: "Imported issue".into(),
+        slug: "imported-issue".into(),
+        version: "v0.91.7".into(),
+        card_paths: write_cards(legacy),
+        design_path: "docs/design.md".into(),
+        diagram_path: "docs/diagram.mmd".into(),
+        design_reviewer: "migration-reviewer".into(),
+        claim: Claim {
+            id: "claim".into(),
+            owner: "importer".into(),
+            generation: 0,
+            acquired_unix_seconds: 1,
+            expires_unix_seconds: u64::MAX,
+            heartbeat_unix_seconds: 1,
+            branch: "import-88".into(),
+            worktree: output.to_string_lossy().into_owned(),
+            protected_paths: vec![".csdlc/issues/88".into()],
+            purpose: "one-way import".into(),
+        },
+        planning_profile: PlanningProfile::Small,
+        validation_lanes: vec![ValidationLane {
+            lane: "focused".into(),
+            proof_role: "migration".into(),
+            acceptance_ids: vec!["imported".into()],
+            deterministic: true,
+            resource_profile: ResourceProfile::Small,
+            budget_seconds: 30,
+            budget_tokens: 100,
+            argv: vec!["cargo".into(), "test".into()],
+            parallel_group: "local".into(),
+            defer_reason: None,
+        }],
+        imported_unix_seconds: 100,
+        default_cutover_unix_seconds: 1_000,
+        legacy_phase: LifecyclePhase::Ready,
+    }
+}
+
+#[test]
+fn one_way_ast_import_retains_every_authored_section_and_generates_view() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let request = request(legacy.path(), output.path());
+    let before: Vec<_> = request
+        .card_paths
+        .values()
+        .map(|path| std::fs::read(legacy.path().join(path)).unwrap())
+        .collect();
+    let report = import_legacy(request.clone()).unwrap();
+    assert_eq!(report.status, ImportStatus::Imported);
+    assert_eq!(report.sunset_unix_seconds, 1_000 + 30 * 24 * 60 * 60);
+    assert_eq!(report.retained_section_count, 22);
+    let after: Vec<_> = request
+        .card_paths
+        .values()
+        .map(|path| std::fs::read(legacy.path().join(path)).unwrap())
+        .collect();
+    assert_eq!(before, after, "legacy input is read-only");
+
+    let store = Store::new(output.path());
+    let record = store.load_record(88).unwrap();
+    assert_eq!(record.phase, LifecyclePhase::Ready);
+    let migration = record.migration.unwrap();
+    assert!(migration.authored_sections["sip"]["Goal"].contains("Preserve **authored** intent."));
+    assert_eq!(
+        migration.authored_sources["sip"],
+        std::fs::read_to_string(legacy.path().join("sip.md")).unwrap()
+    );
+    assert_eq!(store.load_cards(88).unwrap().len(), 6);
+    let view = generate_compatibility_view(&store, 88).unwrap();
+    assert!(view.contains("Preserve **authored** intent."));
+    assert!(view.contains("Generated from canonical migration evidence. Do not edit."));
+}
+
+#[test]
+fn overlapping_or_traversing_roots_fail_without_legacy_mutation() {
+    let legacy = tempfile::tempdir().unwrap();
+    let nested_output = legacy.path().join("nested-output");
+    std::fs::create_dir_all(&nested_output).unwrap();
+    let nested_request = request(legacy.path(), &nested_output);
+    let sip_before = std::fs::read(legacy.path().join("sip.md")).unwrap();
+    assert!(import_legacy(nested_request).is_err());
+    assert_eq!(
+        std::fs::read(legacy.path().join("sip.md")).unwrap(),
+        sip_before
+    );
+    assert!(!nested_output.join(".csdlc").exists());
+
+    let separate_output = tempfile::tempdir().unwrap();
+    let mut traversal = request(legacy.path(), separate_output.path());
+    traversal
+        .card_paths
+        .insert(CardKind::Sip, "../outside.md".into());
+    let report = import_legacy(traversal).unwrap();
+    assert_eq!(report.status, ImportStatus::Unsupported);
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|item| item.code == "source_path_unsafe"));
+    assert!(!separate_output.path().join(".csdlc").exists());
+}
+
+#[test]
+fn compatibility_failure_resumes_and_fixed_view_cannot_overwrite_index() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let request = request(legacy.path(), output.path());
+    std::fs::create_dir_all(output.path().join(".csdlc")).unwrap();
+    std::fs::write(output.path().join(".csdlc/compat"), "blocking file").unwrap();
+    assert!(import_legacy(request.clone()).is_err());
+    let store = Store::new(output.path());
+    assert_eq!(store.load_record(88).unwrap().phase, LifecyclePhase::Ready);
+    std::fs::remove_file(output.path().join(".csdlc/compat")).unwrap();
+    let report = import_legacy(request).unwrap();
+    assert_eq!(report.status, ImportStatus::Imported);
+    let index = output.path().join(".csdlc/issues/88/index.json");
+    let before = std::fs::read(&index).unwrap();
+    let view = generate_compatibility_view(&store, 88).unwrap();
+    let path = csdlc_v2::write_compatibility_view_atomic(&store, 88, &view).unwrap();
+    assert_eq!(path, ".csdlc/compat/88.md");
+    assert_eq!(std::fs::read(index).unwrap(), before);
+}
+
+#[test]
+fn changed_raw_source_cannot_replace_existing_migration_evidence() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let request = request(legacy.path(), output.path());
+    import_legacy(request.clone()).unwrap();
+    let store = Store::new(output.path());
+    let before = store.load_record(88).unwrap();
+    let sip = legacy.path().join("sip.md");
+    let text = std::fs::read_to_string(&sip).unwrap();
+    std::fs::write(&sip, text.replacen("# SIP", "# Changed preamble only", 1)).unwrap();
+    let error = import_legacy(request).unwrap_err();
+    assert_eq!(error.code.to_string(), "reconciliation_required");
+    let after = store.load_record(88).unwrap();
+    assert_eq!(after.generation, before.generation);
+    assert_eq!(after.migration, before.migration);
+}
+
+#[test]
+fn unrepresentable_markdown_and_missing_design_return_no_write_reports() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let first_request = request(legacy.path(), output.path());
+    let spp = legacy.path().join("spp.md");
+    let text = std::fs::read_to_string(&spp).unwrap().replace(
+        "- parse AST\n- construct values",
+        "1. parse AST\n2. construct values",
+    );
+    std::fs::write(spp, text).unwrap();
+    std::fs::remove_file(output.path().join("docs/design.md")).unwrap();
+    std::fs::remove_file(output.path().join("docs/diagram.mmd")).unwrap();
+    let report = import_legacy(first_request).unwrap();
+    assert_eq!(report.status, ImportStatus::Unsupported);
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|item| item.code == "typed_values_unrepresentable"));
+    assert!(!output.path().join(".csdlc").exists());
+
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let request = request(legacy.path(), output.path());
+    std::fs::remove_file(output.path().join("docs/design.md")).unwrap();
+    std::fs::remove_file(output.path().join("docs/diagram.mmd")).unwrap();
+    let report = import_legacy(request).unwrap();
+    assert_eq!(report.status, ImportStatus::Unsupported);
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|item| item.code == "design_or_diagram_unrepresentable"));
+    assert!(!output.path().join(".csdlc").exists());
+}
+
+#[test]
+fn duplicate_heading_fails_with_report_before_canonical_output_exists() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let request = request(legacy.path(), output.path());
+    let sip = legacy.path().join("sip.md");
+    let mut text = std::fs::read_to_string(&sip).unwrap();
+    text.push_str("\n## Goal\n\nAmbiguous second owner.\n");
+    std::fs::write(sip, text).unwrap();
+    let report = import_legacy(request).unwrap();
+    assert_eq!(report.status, ImportStatus::Unsupported);
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|item| item.code == "markdown_ambiguous"));
+    assert!(!output.path().join(".csdlc").exists());
+}
+
+#[test]
+fn shadow_parity_compares_normalized_outcomes_not_markdown_bytes() {
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    import_legacy(request(legacy.path(), output.path())).unwrap();
+    let store = Store::new(output.path());
+    let actual = NormalizedOutcome::from_v2(&store, 88).unwrap();
+    let legacy_observation = actual.clone();
+    assert!(compare_shadow(&legacy_observation, &actual).equivalent);
+    std::fs::write(output.path().join(".csdlc/compat/88.md"), "different bytes").unwrap();
+    assert!(
+        compare_shadow(
+            &legacy_observation,
+            &NormalizedOutcome::from_v2(&store, 88).unwrap()
+        )
+        .equivalent
+    );
+    let mut mismatch = legacy_observation;
+    mismatch.claim_active = false;
+    assert_eq!(
+        compare_shadow(&mismatch, &actual).differences,
+        vec!["claim_active"]
+    );
+}
+
+#[test]
+fn public_schemas_include_import_parity_and_sunset_contracts() {
+    let bundle = csdlc_v2::public_schema_bundle();
+    for key in [
+        "legacy_import_request",
+        "legacy_import_report",
+        "normalized_outcome",
+        "shadow_comparison",
+    ] {
+        assert!(bundle.get(key).is_some(), "{key}");
+    }
+    let legacy = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let mut expired = request(legacy.path(), output.path());
+    expired.imported_unix_seconds = expired.default_cutover_unix_seconds + 30 * 24 * 60 * 60 + 1;
+    assert!(import_legacy(expired).is_err());
+    assert!(!output.path().join(".csdlc").exists());
+}

--- a/docs/architecture/csdlc-v2/gate8/GATE8_IMPORT_SHADOW_DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate8/GATE8_IMPORT_SHADOW_DESIGN.md
@@ -1,0 +1,101 @@
+# Gate 8: One-Way Import and Shadow Parity
+
+## Decision
+
+Gate 8 is temporary migration code, not a compatibility architecture. The
+standalone csdlc-import binary reads six explicitly named legacy Markdown
+documents as external data and writes an independently authored v2 issue. It
+does not link any v1 crate, schema, template, fixture, test, shell, Python, or
+skill code.
+
+The supported surface is intentionally narrow:
+
+- all six card paths must be declared;
+- the legacy phase must be Initialized or Ready;
+- each card must contain the documented unique level-two headings;
+- planning profile and bounded validation argv are explicit typed import
+  inputs, so no shell text is guessed;
+- every full raw card and every authored section, including preamble and
+  unmapped extra sections, is retained verbatim in canonical MigrationEvidence.
+
+markdown.rs mdast identifies semantic heading anchors and source offsets.
+Raw source slices between those anchors preserve authored Markdown. Duplicate,
+empty, missing, invalid UTF-8, or absent headings produce an Unsupported
+migration report before canonical output is created.
+
+## Data flow and loss boundary
+
+~~~mermaid
+flowchart LR
+    Legacy["Six declared legacy Markdown files"] --> AST["markdown.rs mdast anchors"]
+    AST --> Guard{"Unique supported shape?"}
+    Guard -->|no| Report["Non-destructive migration diagnostics"]
+    Guard -->|yes| Archive["Typed authored-section archive"]
+    Guard --> Values["Independent v2 values"]
+    Typed["Planning profile + typed validation argv"] --> Values
+    Values --> Cards["Six generated v2 cards"]
+    Archive --> Index["Canonical v2 index"]
+    Cards --> Index
+    Index --> View["Generated compatibility view: do not edit"]
+~~~
+
+There is no silent loss path. Mapped sections populate the operative v2
+planning fields. All supported and extra authored sections remain in the
+typed archive and generated view. The view is disposable and re-derived from
+the archive at the single fixed .csdlc/compat/<issue>.md path; callers cannot
+select a canonical card/index path. Atomic replacement means editing or
+interrupting the view cannot change canonical state.
+
+Construction is digest-bound and resumable. Initialization and migration
+evidence are idempotent for the identical request/source digest, Ready
+advancement is skipped when already applied, and the generated view uses an
+atomic temporary-file rename. A failed final view write can therefore be
+retried without duplicating generations or leaving an unrecoverable import.
+
+~~~mermaid
+flowchart TD
+    Section["Authored legacy section"] --> Mapped{"Declared v2 mapping?"}
+    Mapped -->|yes| Field["Typed v2 field"]
+    Mapped -->|no| Archive["Typed migration archive"]
+    Field --> Archive
+    Archive --> Proof["Source digest + section count"]
+    Ambiguous["Duplicate/missing/empty anchor"] --> Stop["Unsupported; write nothing"]
+~~~
+
+## Shadow parity
+
+csdlc-shadow accepts one normalized legacy doctor observation and derives the
+same schema from the v2 index/cards. It compares issue, lifecycle phase, six
+card statuses, review result, integration/publication/merge/closeout states,
+and claim liveness. Markdown bytes, directories, internal schemas, prompts,
+and audit layout are deliberately absent.
+
+~~~mermaid
+flowchart LR
+    V1["Black-box v1 doctor observation"] --> N1["NormalizedOutcome v1"]
+    V2["v2 doctor/index/cards"] --> N2["NormalizedOutcome v1"]
+    N1 --> Compare["Field comparison"]
+    N2 --> Compare
+    Compare --> Equal["Equivalent outcome"]
+    Compare --> Diff["Exact normalized differences"]
+~~~
+
+## Sunset
+
+Every successful or unsupported report records
+default_cutover_unix_seconds + 2,592,000 seconds. That is exactly 30 days.
+There is no indefinite or mutable default. A reviewed later issue may extend
+the date, but the importer itself has no extension authority. Gate 10 owns
+deletion after the bounded window.
+
+## Proof posture
+
+Eight focused Gate 8 tests prove one-way input immutability, canonical disjoint
+root/path enforcement, full raw-card and authored-section retention,
+six-card/index construction, generated-view derivation, duplicate-heading
+no-write failure, normalized parity independent of Markdown bytes, exact
+difference reporting, digest-bound retry after a compatibility write failure,
+source-change refusal, unrepresentable-layout no-write diagnostics,
+fixed projection non-authority, schemas, and the 30-day sunset. This is the
+smallest proving surface; existing lifecycle tests continue to cover card and
+transaction invariants.

--- a/docs/architecture/csdlc-v2/gate8/import-parity.mmd
+++ b/docs/architecture/csdlc-v2/gate8/import-parity.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    Legacy["Legacy Markdown data"] --> AST["markdown.rs mdast"]
+    AST --> Guard{"Supported and unambiguous?"}
+    Guard -->|no| Diagnostics["No-write migration report"]
+    Guard -->|yes| V2["Independent v2 cards + index"]
+    V2 --> Compat["Generated compatibility view"]
+    LegacyDoctor["Normalized legacy doctor"] --> Compare["Outcome parity"]
+    V2 --> Compare
+    Compare --> Result["Equivalent or exact field differences"]


### PR DESCRIPTION
Closes #5238

## Summary
Implemented and reviewed bounded one-way legacy import, full raw authored-content retention through markdown.rs mdast anchors, generated compatibility projections, normalized doctor/outcome shadow parity, digest-bound resumability, and an exact 30-day sunset.

## Artifacts
- Standalone Rust importer and shadow parity binaries under `csdlc-v2/`
- Gate 8 design and Mermaid sources under `docs/architecture/csdlc-v2/gate8/`
- Exact commit review for `f6ce8eb63`: `NO FINDINGS`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path csdlc-v2/Cargo.toml -q` - run the complete standalone C-SDLC v2 suite (65 focused tests)
  - `cargo clippy --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings` - prove all standalone targets are warning-free
  - `git diff --check origin/main...f6ce8eb63` - prove exact committed patch formatting hygiene
- Results:
  - `cargo test --manifest-path csdlc-v2/Cargo.toml -q`: PASS
  - `cargo clippy --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings`: PASS
  - `git diff --check origin/main...f6ce8eb63`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5238__v0-91-7-csdlc-v2-gate-8-legacy-import-and-shadow-parity/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5238__v0-91-7-csdlc-v2-gate-8-legacy-import-and-shadow-parity/sor.md
- Idempotency-Key: v0-91-7-csdlc-v2-gate-8-legacy-import-and-shadow-parity-csdlc-v2-docs-architecture-csdlc-v2-gate8-adl-v0-91-7-tasks-issue-5238-v0-91-7-csdlc-v2-gate-8-legacy-import-and-shadow-parity-sip-md-adl-v0-91-7-tasks-issue-5238-v0-91-7-csdlc-v2-gate-8-legacy-import-and-shadow-parity-sor-md