### PR TITLE
[v0.91.7][runtime-v3][parity] Prove agents provider scheduler parity

### DIFF
--- a/adl-runtime-kernel/tests/operations.rs
+++ b/adl-runtime-kernel/tests/operations.rs
@@ -10,9 +10,9 @@ use std::{
 use adl_runtime_kernel::{
     representative_dependencies, validate_contracts, validate_operational_dependencies,
     AdapterKind, AdapterPolicy, AuthorityMode, ComponentFactory, ComponentRegistry,
-    DeterminismClass, ExecutionPermit, ExecutorError, FailureClass, Kernel, OperationError,
-    OperationExecutor, OperationRequest, OperationalAdapter, OperationalFactory, RuntimeRecorder,
-    OPERATION_REQUEST_SCHEMA,
+    DeterminismClass, ExecutionPermit, ExecutorError, FailureClass, Kernel, KernelExit,
+    OperationError, OperationExecutor, OperationRequest, OperationalAdapter, OperationalFactory,
+    RuntimeRecorder, OPERATION_REQUEST_SCHEMA,
 };
 use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
@@ -239,6 +239,188 @@ async fn supervised_shutdown_closes_admission_and_drains_active_work() {
         .await
         .unwrap();
     assert_eq!(active.await.unwrap().unwrap().payload, b"fixture");
+}
+
+#[tokio::test]
+async fn agent_provider_scheduler_topology_admits_work_and_closes_admission_on_shutdown() {
+    let agent_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::ZERO,
+        class: FailureClass::Retryable,
+    });
+    let provider_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::from_millis(30),
+        class: FailureClass::Retryable,
+    });
+    let scheduler_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::ZERO,
+        class: FailureClass::Retryable,
+    });
+    let chronosense_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::ZERO,
+        class: FailureClass::Retryable,
+    });
+    let lifelog_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::ZERO,
+        class: FailureClass::Retryable,
+    });
+    let checkpoint_executor = Arc::new(FixtureExecutor {
+        calls: AtomicUsize::new(0),
+        failures: 0,
+        delay: Duration::ZERO,
+        class: FailureClass::Retryable,
+    });
+    let key = SigningKey::from_bytes(&[8; 32]);
+    let checkpoint = OperationalFactory::new(
+        adapter(
+            AdapterKind::CheckpointStore,
+            AuthorityMode::Internal,
+            checkpoint_executor,
+        ),
+        Vec::new(),
+    );
+    let lifelog = OperationalFactory::new(
+        adapter(
+            AdapterKind::Lifelog,
+            AuthorityMode::Internal,
+            lifelog_executor,
+        ),
+        vec![AdapterKind::CheckpointStore.service_name().into()],
+    );
+    let chronosense = OperationalFactory::new(
+        adapter(
+            AdapterKind::Chronosense,
+            AuthorityMode::Internal,
+            chronosense_executor,
+        ),
+        Vec::new(),
+    );
+    let scheduler = OperationalFactory::new(
+        adapter(
+            AdapterKind::Scheduler,
+            AuthorityMode::Internal,
+            scheduler_executor.clone(),
+        ),
+        vec![AdapterKind::Chronosense.service_name().into()],
+    );
+    let provider = OperationalFactory::new(
+        adapter(
+            AdapterKind::Provider,
+            AuthorityMode::Governed,
+            provider_executor.clone(),
+        ),
+        vec![AdapterKind::Scheduler.service_name().into()],
+    );
+    let agent = OperationalFactory::new(
+        adapter(
+            AdapterKind::Agent,
+            AuthorityMode::Internal,
+            agent_executor.clone(),
+        ),
+        vec![
+            AdapterKind::Provider.service_name().into(),
+            AdapterKind::Scheduler.service_name().into(),
+            AdapterKind::Lifelog.service_name().into(),
+        ],
+    );
+    let scheduler_client = scheduler.clone();
+    let provider_client = provider.clone();
+    let agent_client = agent.clone();
+    let mut components = ComponentRegistry::new();
+    components.register(agent);
+    components.register(provider);
+    components.register(scheduler);
+    components.register(chronosense);
+    components.register(lifelog);
+    components.register(checkpoint);
+    let topology = components.validate().unwrap();
+    let positions = topology
+        .startup_order()
+        .iter()
+        .enumerate()
+        .map(|(index, id)| (id.as_str(), index))
+        .collect::<BTreeMap<_, _>>();
+    assert!(
+        positions[AdapterKind::Chronosense.service_name()]
+            < positions[AdapterKind::Scheduler.service_name()]
+    );
+    assert!(
+        positions[AdapterKind::Scheduler.service_name()]
+            < positions[AdapterKind::Provider.service_name()]
+    );
+    assert!(
+        positions[AdapterKind::Provider.service_name()]
+            < positions[AdapterKind::Agent.service_name()]
+    );
+    assert!(
+        positions[AdapterKind::Scheduler.service_name()]
+            < positions[AdapterKind::Agent.service_name()]
+    );
+    assert!(
+        positions[AdapterKind::Lifelog.service_name()]
+            < positions[AdapterKind::Agent.service_name()]
+    );
+
+    let handle = Kernel::new(topology, RuntimeRecorder::new(16))
+        .start()
+        .await
+        .unwrap();
+    let scheduled = scheduler_client
+        .submit(request("scheduler-admission", None))
+        .await
+        .unwrap();
+    assert_eq!(scheduled.adapter, AdapterKind::Scheduler);
+    let agent_result = agent_client
+        .submit(request("agent-admission", None))
+        .await
+        .unwrap();
+    assert_eq!(agent_result.adapter, AdapterKind::Agent);
+    let active_key = key.clone();
+    let active = tokio::spawn({
+        let provider_client = provider_client.clone();
+        async move {
+            provider_client
+                .submit(request(
+                    "provider-component-admission",
+                    Some(signed_permit("provider-component-admission", &active_key)),
+                ))
+                .await
+        }
+    });
+    while provider_executor.calls.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(
+        handle
+            .control()
+            .shutdown(Duration::from_secs(1))
+            .await
+            .unwrap(),
+        KernelExit::Clean
+    );
+    assert_eq!(active.await.unwrap().unwrap().payload, b"fixture");
+    assert_eq!(scheduler_executor.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(agent_executor.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        provider_client
+            .submit(request(
+                "after-shutdown",
+                Some(signed_permit("after-shutdown", &key)),
+            ))
+            .await
+            .unwrap_err(),
+        OperationError::AdmissionClosed
+    );
 }
 
 #[tokio::test]

--- a/adl-runtime-kernel/tests/parity.rs
+++ b/adl-runtime-kernel/tests/parity.rs
@@ -1165,7 +1165,7 @@ fn release_proof_gate_closes_without_authorizing_default_cutover() {
     assert_eq!(decision["decision"], "keep_runtime_v2_default");
     assert_eq!(decision["default_runtime_switch_authorized"], false);
     assert_eq!(classification["cutover_eligible"], false);
-    assert_eq!(classification["summary"]["blocker"], 9);
+    assert_eq!(classification["summary"]["blocker"], 8);
 
     let child_results = gate["child_issue_results"].as_array().unwrap();
     let closed_children = child_results

--- a/docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md
+++ b/docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md
@@ -12,7 +12,7 @@ only through explicit opt-in selection, with Runtime v2 retained as the rollback
 target.
 
 This is a no-go decision for a default Runtime v3 switch. The retained parity
-packet still reports `cutover_eligible: false` and nine blocker-class
+packet still reports `cutover_eligible: false` and eight blocker-class
 capabilities. #5252 and #5253 resolved the weather/observability and
 soak/rollback prerequisites, but they did not convert the remaining
 capability-specific blockers into passed proof.
@@ -21,7 +21,7 @@ capability-specific blockers into passed proof.
 
 | Surface | Evidence | Decision input |
 |---|---|---|
-| Live black-box parity | `docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json` | `cutover_eligible: false`; nine blocker-class capabilities remain. |
+| Live black-box parity | `docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json` | `cutover_eligible: false`; eight blocker-class capabilities remain. |
 | Explicit selection and rollback | `docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md` | Runtime v3 is explicit opt-in; Runtime v2 remains the default and rollback target. |
 | Weather and CloudWatch boundary | `docs/architecture/runtime_v3_weather_cloudwatch_5252.v1.json` | Local weather/resource proof exists; observed GPU telemetry remains a non-pass deferred surface. |
 | Soak and rollback | `docs/architecture/runtime_v3_soak_rollback_5253.v1.json` | Bounded production-like soak and rollback proof exists; remote multi-day and GPU lanes remain non-claims. |
@@ -39,7 +39,6 @@ authorization:
 - `learning.adaptive_dag`
 - `governance.freedom_gate_aee`
 - `contracts.delegation_resources`
-- `agents.providers_scheduler`
 - `network.acip_a2a_cloud`
 
 These blockers route forward to #5220 as release-gate truth. #5220 should close

--- a/docs/architecture/runtime_v3_cutover_checklist.v1.json
+++ b/docs/architecture/runtime_v3_cutover_checklist.v1.json
@@ -34,7 +34,7 @@
     {"issue": 5225, "state": "closed", "role": "guardian_fallback_implementation", "cutover_effect": "selected_small_tokio_child_process_fallback"},
     {"issue": 5227, "state": "open", "role": "v0_91_7_cutover_sprint_umbrella", "cutover_effect": "awaits_5220_closeout"},
     {"issue": 5247, "state": "closed", "role": "v0_91_7_cutover_readiness_umbrella", "cutover_effect": "child_wave_complete"},
-    {"issue": 5248, "state": "closed", "role": "live_black_box_parity", "cutover_effect": "retained_cutover_eligible_false_with_nine_blockers"},
+    {"issue": 5248, "state": "closed", "role": "live_black_box_parity", "cutover_effect": "retained_cutover_eligible_false_with_eight_blockers"},
     {"issue": 5249, "state": "closed", "role": "private_state_security_equivalence", "cutover_effect": "accepted_intentional_divergence_no_raw_v2_format_claim"},
     {"issue": 5250, "state": "closed", "role": "identity_memory_adapters", "cutover_effect": "accepted_intentional_divergence_no_raw_v2_wire_format_claim"},
     {"issue": 5251, "state": "closed", "role": "governed_cognition_adapters", "cutover_effect": "accepted_intentional_divergence_no_subjective_cognition_claim"},
@@ -84,7 +84,7 @@
       "id": "parity.live_black_box",
       "status": "blocked_for_default_cutover",
       "source": "#5248",
-      "reason": "Live black-box parity remains cutover_eligible=false with nine blocker-class capability groups; this blocks default replacement but not #5220 no-go closeout."
+      "reason": "Live black-box parity remains cutover_eligible=false with eight blocker-class capability groups; this blocks default replacement but not #5220 no-go closeout."
     },
     {
       "id": "domain_adapters.private_identity_cognition",

--- a/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
+++ b/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
@@ -26,7 +26,7 @@
   },
   "input_summary": {
     "live_black_box_cutover_eligible": false,
-    "live_black_box_blockers": 9,
+    "live_black_box_blockers": 8,
     "accepted_intentional_divergence": 7,
     "retained_v2_behavior_behind_adapter": 1,
     "deferred_non_cutover_surface": 0
@@ -47,7 +47,6 @@
     "learning.adaptive_dag",
     "governance.freedom_gate_aee",
     "contracts.delegation_resources",
-    "agents.providers_scheduler",
     "network.acip_a2a_cloud"
   ],
   "next_gate": {

--- a/docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
+++ b/docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json
@@ -76,9 +76,8 @@
     },
     {
       "id": "agents.providers_scheduler",
-      "disposition": "blocker",
-      "proof": "Runtime v3 operational fixture exists; #5253 retained production-like soak and rollback proof, and #5254 records a no-go default-switch decision. Release-gate closure routes through #5220.",
-      "blocking_issue": 5220
+      "disposition": "live_equivalent_fixture",
+      "proof": "#5284 proves Runtime v3 agent/provider/scheduler component parity with a supervised operational topology fixture: chronosense starts before scheduler, scheduler starts before governed provider, provider/scheduler/lifelog start before agent_runtime, agent_runtime, scheduler, and governed provider all admit work through their component inboxes, provider authority is signed, active provider work drains on governed shutdown, and post-shutdown provider admission fails closed. Existing operations fixtures also cover representative topology, idempotency, retry, timeout, and bounded concurrency."
     },
     {
       "id": "network.acip_a2a_cloud",
@@ -118,11 +117,11 @@
     }
   ],
   "summary": {
-    "live_equivalent_fixture": 1,
+    "live_equivalent_fixture": 2,
     "accepted_intentional_divergence": 7,
     "retained_v2_behavior_behind_adapter": 1,
     "deferred_non_cutover_surface": 0,
-    "blocker": 9
+    "blocker": 8
   },
   "non_claims": [
     "This packet does not authorize Runtime v3 as the default runtime.",

--- a/docs/architecture/runtime_v3_release_proof_gate_5220.v1.json
+++ b/docs/architecture/runtime_v3_release_proof_gate_5220.v1.json
@@ -82,7 +82,7 @@
       "id": "parity.live_black_box",
       "status": "blocked_for_default_cutover",
       "evidence": "docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json",
-      "claim": "Live black-box parity still reports cutover_eligible=false and nine blocker-class capability groups; #5220 closes as no-go for default cutover."
+      "claim": "Live black-box parity still reports cutover_eligible=false and eight blocker-class capability groups; #5220 closes as no-go for default cutover."
     }
   ],
   "child_issue_results": [


### PR DESCRIPTION
Closes #5284

## Summary
Implemented Runtime v3 agent/provider/scheduler component parity proof in the runtime-kernel operations suite. The proof brings up the supervised component topology with `chronosense`, `scheduler`, governed `provider`, `checkpoint_store`, `lifelog`, and `agent_runtime`; asserts dependency ordering into provider and agent; submits work through scheduler, agent, and governed provider inboxes; verifies signed provider authority; drains active provider work during governed shutdown; and verifies post-shutdown provider admission fails closed. The live black-box parity packet now classifies `agents.providers_scheduler` as `live_equivalent_fixture`, and dependent cutover/release-gate packets now truthfully report eight remaining blockers while preserving the no-default-cutover decision.

## Artifacts
- `adl-runtime-kernel/tests/operations.rs`
- `adl-runtime-kernel/tests/parity.rs`
- `docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json`
- `docs/architecture/runtime_v3_cutover_decision_5254.v1.json`
- `docs/architecture/RUNTIME_V3_CUTOVER_DECISION_5254.md`
- `docs/architecture/runtime_v3_release_proof_gate_5220.v1.json`
- `docs/architecture/runtime_v3_cutover_checklist.v1.json`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    `Verified changed files have no whitespace errors.`
  - `cargo fmt --manifest-path adl-runtime-kernel/Cargo.toml --check`
    `Verified runtime-kernel Rust formatting.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test operations -- agent_provider_scheduler_topology_admits_work_and_closes_admission_on_shutdown`
    `Verified the new agent/provider/scheduler topology proof.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test parity -- final_cutover_decision_keeps_v2_default_until_parity_blockers_clear release_proof_gate_closes_without_authorizing_default_cutover`
    `Verified parity/cutover blocker-count truth after the classification change.`
  - `cargo test --manifest-path adl-runtime-kernel/Cargo.toml`
    `Verified the full runtime-kernel suite in the finish lifecycle.`
  - `cargo clippy --manifest-path adl-runtime-kernel/Cargo.toml --all-targets -- -D warnings`
    `Verified runtime-kernel clippy in the finish lifecycle.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5284__v0-91-7-runtime-v3-parity-prove-agents-provider-scheduler-parity/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5284__v0-91-7-runtime-v3-parity-prove-agents-provider-scheduler-parity/sor.md
- Idempotency-Key: v0-91-7-runtime-v3-parity-prove-agents-provider-scheduler-parity-adl-runtime-kernel-tests-operations-rs-adl-runtime-kernel-tests-parity-rs-docs-architecture-runtime-v3-live-black-box-parity-5248-v1-json-docs-architecture-runtime-v3-cutover-decision-5254-v1-json-docs-architecture-runtime-v3-cutover-decision-5254-md-docs-architecture-runtime-v3-release-proof-gate-5220-v1-json-docs-architecture-runtime-v3-cutover-checklist-v1-json-adl-v0-91-7-tasks-issue-5284-v0-91-7-runtime-v3-parity-prove-agents-provider-scheduler-parity-sip-md-adl-v0-91-7-tasks-issue-5284-v0-91-7-runtime-v3-parity-prove-agents-provider-scheduler-parity-sor-md