### PR TITLE
[v0.91.7][tools][usage] Add Codex status UI collector for usage watcher

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -119,6 +119,7 @@ adl tooling ci-log-archive summarize --logs-dir <dir> --out <manifest.json> --s3
 adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--timeout-secs <n>] [--include-working-tree] [--file <path> ...] [--fixture-case clean|blocked]\n\
 adl tooling codex-usage-watch parse --input <status.txt> [--json]\n\
 adl tooling codex-usage-watch parse --text \"Context: ...\" [--json]\n\
+adl tooling codex-usage-watch collect [--input <status-panel.txt> | --text \"Status...\"] [--json]\n\
 adl tooling codex-usage-watch watch --input <status.txt> [--interval-seconds <n>] [--iterations <n>] [--history-root <dir>] [--json]\n\
 adl tooling csdlc-prompt-editor [--repo-root <path>] [--emit-model-js <path>] [--render-samples <dir>]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\

--- a/adl/src/cli/tooling_cmd/codex_usage_watch.rs
+++ b/adl/src/cli/tooling_cmd/codex_usage_watch.rs
@@ -77,6 +77,7 @@ struct ParsedStatus {
 
 enum CommandMode {
     Parse,
+    Collect,
     Watch,
 }
 
@@ -106,6 +107,12 @@ pub(crate) fn real_codex_usage_watch(args: &[String]) -> Result<()> {
             print_report(&report, args.json_output)?;
             ensure_report_ready(&report)?;
         }
+        CommandMode::Collect => {
+            let source = load_status_text(&args)?;
+            let report = report_from_collected_source(source.as_deref(), args.input.as_deref());
+            print_report(&report, args.json_output)?;
+            ensure_report_ready(&report)?;
+        }
         CommandMode::Watch => {
             run_watch(&args)?;
         }
@@ -118,12 +125,18 @@ pub(crate) fn run_parse_status_text(text: &str) -> Result<CodexUsageReport> {
     Ok(report_from_source(Some(text), None))
 }
 
+#[cfg(test)]
+pub(crate) fn run_collect_status_text(text: &str) -> CodexUsageReport {
+    report_from_collected_source(Some(text), None)
+}
+
 fn parse_args(args: &[String]) -> Result<CommandArgs> {
     let Some(mode) = args.first().map(|arg| arg.as_str()) else {
         bail!("{}", usage());
     };
     let mode = match mode {
         "parse" => CommandMode::Parse,
+        "collect" => CommandMode::Collect,
         "watch" => CommandMode::Watch,
         "--help" | "-h" | "help" => {
             println!("{}", usage());
@@ -185,6 +198,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
                 bail!("codex-usage-watch parse requires --input <path> or --text <status>");
             }
         }
+        CommandMode::Collect => {}
         CommandMode::Watch => {
             if input.is_none() {
                 bail!("codex-usage-watch watch requires --input <path>");
@@ -206,6 +220,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
 fn usage() -> &'static str {
     "adl tooling codex-usage-watch parse --input <status.txt> [--json]\n\
 adl tooling codex-usage-watch parse --text \"Context: ...\" [--json]\n\
+adl tooling codex-usage-watch collect [--input <status-panel.txt> | --text \"Status...\"] [--json]\n\
 adl tooling codex-usage-watch watch --input <status.txt> [--interval-seconds <n>] [--iterations <n>] [--history-root <dir>] [--json]"
 }
 
@@ -293,6 +308,55 @@ fn report_from_source(source: Option<&str>, input_path: Option<&Path>) -> CodexU
             sampled_at,
             source_ref,
             "status input missing; mode forced to usage_unknown".to_string(),
+        ),
+    }
+}
+
+fn report_from_collected_source(
+    source: Option<&str>,
+    input_path: Option<&Path>,
+) -> CodexUsageReport {
+    let sampled_at = Utc::now().to_rfc3339();
+    let source_ref = input_path.map(repo_relative_or_filename);
+    match source {
+        Some(text) => match normalize_collected_status_text(text) {
+            Ok(normalized) => match parse_status_text(&normalized) {
+                Ok(parsed) => {
+                    let mode = classify_mode(&parsed);
+                    let warnings = warnings_for_mode(&mode, &parsed);
+                    for warning in &warnings {
+                        eprintln!("{warning}");
+                    }
+                    CodexUsageReport {
+                        schema_version: "adl.codex_usage_watch.v1".to_string(),
+                        mode,
+                        parse_ok: true,
+                        sampled_at,
+                        source_ref,
+                        context: Some(parsed.context),
+                        limit_5h: Some(parsed.limit_5h),
+                        limit_7d: Some(parsed.limit_7d),
+                        warnings,
+                        error: None,
+                        history_ref: None,
+                    }
+                }
+                Err(err) => unknown_report(
+                    sampled_at,
+                    source_ref,
+                    format!("failed to parse collected status text: {err}"),
+                ),
+            },
+            Err(err) => unknown_report(
+                sampled_at,
+                source_ref,
+                format!("failed to collect Codex status text: {err}"),
+            ),
+        },
+        None => unknown_report(
+            sampled_at,
+            source_ref,
+            "Codex status collection input missing; live UI collection is not available in this command, pass --input or --text from the app /status panel".to_string(),
         ),
     }
 }
@@ -404,6 +468,28 @@ fn parse_status_text(text: &str) -> Result<ParsedStatus> {
         limit_5h: parse_limit_line(five_hour_line, "5h limit:")?,
         limit_7d: parse_limit_line(seven_day_line, "7d limit:")?,
     })
+}
+
+fn normalize_collected_status_text(text: &str) -> Result<String> {
+    let context_line = find_line(text, "Context:")
+        .ok_or_else(|| anyhow!("missing 'Context:' line in collected status text"))?;
+    let five_hour_line = find_line(text, "5h limit:")
+        .ok_or_else(|| anyhow!("missing '5h limit:' line in collected status text"))?;
+    let seven_day_line = find_line(text, "7d limit:")
+        .ok_or_else(|| anyhow!("missing '7d limit:' line in collected status text"))?;
+
+    let normalized = [
+        normalize_status_line(context_line),
+        normalize_status_line(five_hour_line),
+        normalize_status_line(seven_day_line),
+    ]
+    .join("\n");
+
+    Ok(format!("{normalized}\n"))
+}
+
+fn normalize_status_line(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn find_line<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs
+++ b/adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs
@@ -1,6 +1,8 @@
 use super::support::*;
 use super::*;
-use crate::cli::tooling_cmd::codex_usage_watch::{run_parse_status_text, CodexUsageMode};
+use crate::cli::tooling_cmd::codex_usage_watch::{
+    run_collect_status_text, run_parse_status_text, CodexUsageMode,
+};
 use serde_json::json;
 use serde_json::Value;
 
@@ -88,6 +90,54 @@ fn codex_usage_watch_parse_text_path_succeeds() {
         "--json".to_string(),
     ])
     .expect("parse --text dispatch should succeed");
+}
+
+#[test]
+fn codex_usage_watch_collect_accepts_copied_status_panel_text() {
+    real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "collect".to_string(),
+        "--text".to_string(),
+        "Status\nSession: 019f3d65-2216-7832-804a-26339473b27d\nContext:   58%   left   (109,629 used / 258K)\n5h limit: 93% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\nClose\n".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("collect --text dispatch should succeed for copied status panel");
+
+    let report = run_collect_status_text(
+        "Status\nSession: 019f3d65-2216-7832-804a-26339473b27d\nContext:   58%   left   (109,629 used / 258K)\n5h limit: 93% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\nClose\n",
+    );
+    assert_eq!(report.mode, CodexUsageMode::Normal);
+    assert!(report.parse_ok);
+    assert_eq!(report.context.as_ref().unwrap().used_tokens, Some(109_629));
+    assert_eq!(
+        report.limit_7d.as_ref().unwrap().resets_at.as_deref(),
+        Some("Jul 19")
+    );
+}
+
+#[test]
+fn codex_usage_watch_collect_fails_closed_without_live_input_or_required_limits() {
+    let missing_err = real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "collect".to_string(),
+        "--json".to_string(),
+    ])
+    .expect_err("collect without status text should fail closed");
+    assert!(missing_err
+        .to_string()
+        .contains("Codex status collection input missing"));
+
+    let missing_5h_err = real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "collect".to_string(),
+        "--text".to_string(),
+        "Status\nContext: 58% left (109,629 used / 258K)\n7d limit: 99% left (resets Jul 19)\n"
+            .to_string(),
+    ])
+    .expect_err("collect without 5h limit should fail closed");
+    assert!(missing_5h_err
+        .to_string()
+        .contains("missing '5h limit:' line"));
 }
 
 #[test]

--- a/docs/tooling/CODEX_USAGE_WATCHER.md
+++ b/docs/tooling/CODEX_USAGE_WATCHER.md
@@ -1,8 +1,8 @@
 # Codex Usage Watcher
 
-`adl tooling codex-usage-watch` is a local helper for manually copied Codex `/status` output.
+`adl tooling codex-usage-watch` is a local helper for Codex `/status` output.
 
-It does not call private account APIs, scrape the UI, or use OCR. Version 1 depends on text that the operator copies into a file or passes directly on the command line.
+It does not call private account APIs, scrape secret-bearing local storage, or claim live UI/OCR collection. The collector path depends on text that the operator or a supported outer UI automation layer provides from the Codex app `/status` panel.
 
 ## Commands
 
@@ -11,6 +11,11 @@ adl tooling codex-usage-watch parse --input /tmp/status.txt --json
 adl tooling codex-usage-watch parse --text "Context: 37% left (161,634 used / 258K)
 5h limit: 4% left (resets 4:04 PM)
 7d limit: 3% left (resets Jun 24)" --json
+adl tooling codex-usage-watch collect --text "Status
+Session: 019f3d65-2216-7832-804a-26339473b27d
+Context: 58% left (109,629 used / 258K)
+5h limit: 93% left (resets 9:45 AM)
+7d limit: 99% left (resets Jul 19)" --json
 adl tooling codex-usage-watch watch --input /tmp/status.txt --interval-seconds 60 --iterations 10 --json
 ```
 
@@ -25,6 +30,20 @@ Context: 37% left (161,634 used / 258K)
 ```
 
 The parser tolerates commas in token counts and `K` suffixes such as `258K` or `1.5K`.
+
+## Collector Shape
+
+`collect` is the bounded collector ingress for copied or externally provided Codex app `/status` panel text. It normalizes extra panel lines such as `Status`, `Session: ...`, and `Close`, then feeds the required usage lines into the existing parser and classifier.
+
+The collected text must still include all three required lines:
+
+```text
+Context: 58% left (109,629 used / 258K)
+5h limit: 93% left (resets 9:45 AM)
+7d limit: 99% left (resets Jul 19)
+```
+
+If no input is provided, or a required limit is missing, `collect` emits `usage_unknown` and exits nonzero. This is intentional: the command fails closed rather than pretending it can read live account state by itself.
 
 ## Modes
 
@@ -57,6 +76,7 @@ Even when a sample is malformed, the watcher records the `usage_unknown` row bef
 ## Limitations
 
 - No automatic reset invocation in v1
-- No OCR
-- No live account polling
+- No built-in OCR
+- No built-in Codex app UI control
+- No live account polling or private account API usage
 - No secret material should appear in input or output


### PR DESCRIPTION
Closes #5287

## Summary
Implemented a bounded `adl tooling codex-usage-watch collect` path for copied or externally supplied Codex app `/status` panel text. The collector normalizes app-panel lines, feeds the existing parser/classifier, fails closed when required usage lines are absent, and documents that it does not perform live UI scraping, OCR, private account API calls, or reset automation.

## Artifacts
- Updated tooling source: `adl/src/cli/tooling_cmd.rs`
- Updated watcher implementation: `adl/src/cli/tooling_cmd/codex_usage_watch.rs`
- Updated focused tests: `adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs`
- Updated docs: `docs/tooling/CODEX_USAGE_WATCHER.md`
- Updated review/output cards in the issue-local `.adl` bundle for PR finish truth.

## Validation
- Validation commands and their purpose:
  - `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5287 cargo fmt --manifest-path adl/Cargo.toml --all --check`
    `Verified Rust formatting for the workspace after the collector change.`
  - `git diff --check`
    `Verified the tracked diff has no whitespace errors.`
  - `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5287 cargo test --manifest-path adl/Cargo.toml --bin adl codex_usage_watch`
    `Verified codex usage watcher parser, collector, watch, threshold, and fail-closed tests.`
  - `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5287 cargo test --manifest-path adl/Cargo.toml --bin adl tooling_dispatch`
    `Verified tooling dispatch coverage remains green, including updated codex-usage-watch help.`
- Results:
  - `PASS`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5287__v0-91-7-tools-usage-add-codex-status-ui-collector-for-usage-watcher/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5287__v0-91-7-tools-usage-add-codex-status-ui-collector-for-usage-watcher/sor.md
- Idempotency-Key: v0-91-7-tools-usage-add-codex-status-ui-collector-for-usage-watcher-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-codex-usage-watch-rs-adl-src-cli-tooling-cmd-tests-codex-usage-watch-rs-docs-tooling-codex-usage-watcher-md-adl-v0-91-7-tasks-issue-5287-v0-91-7-tools-usage-add-codex-status-ui-collector-for-usage-watcher-sip-md-adl-v0-91-7-tasks-issue-5287-v0-91-7-tools-usage-add-codex-status-ui-collector-for-usage-watcher-sor-md