### PR TITLE
[v0.91.7][csdlc-v2] Gate 10A coexistence contracts, skills, and stable binaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,13 @@ These rules are mandatory for ADL issue work.
 
 ## Repository-Specific Working Style
 
+### C-SDLC v2 coexistence (Gate 10A)
+
+- V1 remains the authoritative default. Continue using the mandatory v1 workflow in this file unless an issue explicitly opts into C-SDLC v2.
+- Explicit v2 work routes through the nine typed contracts under `csdlc-v2/operator/skills/`; those skills delegate to Rust binaries and never mutate Markdown/state directly.
+- Install v2 only into the dedicated `.adl/bin/csdlc-v2/` generation directory with `csdlc-install`; the shared v1 `.adl/bin/` directory is forbidden. Verification must prove the v1 workflow, installer, tests, recovery policy, and v1-default selector remain present.
+- A v2 opt-in does not authorize a default switch or any v1 deletion. Gate 10B must complete independent proof before cutover is eligible.
+
 - ADL is deterministic by design. Do not introduce hidden state, undeclared
   side effects, or review-hostile magic.
 - Treat model/tool output as governed work, not free authority.

--- a/csdlc-v2/AGENTS.md
+++ b/csdlc-v2/AGENTS.md
@@ -1,0 +1,8 @@
+# C-SDLC v2 agent contract
+
+- This workspace is clean-room and independent of ADL Runtime and incumbent C-SDLC implementation crates, schemas, tests, and fixtures.
+- Use only the typed Rust owners and the nine thin contracts under `operator/skills/` for v2 lifecycle work.
+- Cards are generated projections. Never edit Markdown/state directly; use `csdlc-edit` and markdown.rs AST validation.
+- During Gate 10A, v1 remains the repository default and must stay installed, executable, tested, and recoverable.
+- Install only into `.adl/bin/csdlc-v2/`; never target shared `.adl/bin/`. `csdlc-install verify` is fail closed on missing, symlinked, or non-executable binaries, missing v1 paths, selector drift, or provenance failures.
+- No default switch or v1 deletion is in scope here.

--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -62,6 +62,10 @@ path = "src/bin/csdlc-shadow.rs"
 name = "csdlc-soak"
 path = "src/bin/csdlc-soak.rs"
 
+[[bin]]
+name = "csdlc-install"
+path = "src/bin/csdlc-install.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -41,6 +41,11 @@ Bootstrap selects a typed planning profile and automatically writes explicit
 SPP time/token estimates and VPP time/token budgets. There is no follow-up
 manual budget-filling stage.
 
+Gate 10A adds `csdlc-install` and a nine-skill operator manifest. It installs
+provenance-recorded v2 binaries beside v1 and verifies a fail-closed
+coexistence inventory. V1 remains the default; this gate neither changes the
+generation selector nor deletes or disables any v1 surface.
+
 Markdown files are generated projections. The engine renders deterministic
 Markdown from typed values, parses it with `markdown.rs`, validates semantic
 anchors, and records values/rendered/AST digests. Direct Markdown edits fail

--- a/csdlc-v2/operator/SKILLS.md
+++ b/csdlc-v2/operator/SKILLS.md
@@ -1,0 +1,5 @@
+# C-SDLC v2 operator skills
+
+The nine skills in `skills.json` are thin typed routes. Skills select a binary/subcommand, collect typed input, and display typed output. They never edit Markdown, mutate canonical state directly, invoke shell/Python lifecycle logic, or infer success from prose.
+
+V2 is explicit opt-in during Gate 10A. V1 remains the repository default, installed, and runnable. Install only into `.adl/bin/csdlc-v2/`, never shared `.adl/bin/`. `csdlc-install verify` fails unless the v1 coexistence inventory and regular executable v2 binary set are complete.

--- a/csdlc-v2/operator/coexistence.json
+++ b/csdlc-v2/operator/coexistence.json
@@ -1,0 +1,14 @@
+{
+  "schema":"csdlc.coexistence_inventory.v1",
+  "default_generation":"v1",
+  "generation_selector":"docs/architecture/csdlc-v2/gate9/samples/generation-selector.json",
+  "required_v1_paths":[
+    {"path":"adl/tools/pr.sh","executable":true},
+    {"path":"adl/tools/install_owner_binaries.sh","executable":true},
+    {"path":"adl/src/bin/adl_csdlc.rs","executable":false},
+    {"path":"adl/src/cli/pr_cmd.rs","executable":false},
+    {"path":"adl/src/cli/tests/pr_cmd_inline/basics.rs","executable":false},
+    {"path":"docs/tooling/SESSION_COORDINATION_AND_ROOT_CHECKOUT_POLICY.md","executable":false}
+  ],
+  "required_v2_binaries":["csdlc-init","csdlc-bind","csdlc-edit","csdlc-validate","csdlc-schedule","csdlc-review","csdlc-publish","csdlc-shepherd","csdlc-closeout","csdlc-doctor"]
+}

--- a/csdlc-v2/operator/skills.json
+++ b/csdlc-v2/operator/skills.json
@@ -1,0 +1,10 @@
+{"schema":"csdlc.operator_skills.v1","generation":"v2","default_generation":"v1","skills":[
+{"name":"csdlc-v2-init","binary":"csdlc-init","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-bind","binary":"csdlc-bind","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-card-editor","binary":"csdlc-edit","subcommand":"apply","mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-validate","binary":"csdlc-validate","subcommand":null,"mutates_state":true,"auxiliary_binaries":["csdlc-schedule"]},
+{"name":"csdlc-v2-review","binary":"csdlc-review","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-publish","binary":"csdlc-publish","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-shepherd","binary":"csdlc-shepherd","subcommand":null,"mutates_state":false,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-closeout","binary":"csdlc-closeout","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
+{"name":"csdlc-v2-doctor","binary":"csdlc-doctor","subcommand":null,"mutates_state":false,"auxiliary_binaries":[]}]}

--- a/csdlc-v2/operator/skills/csdlc-v2-bind/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-bind/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-bind
+description: Bind a prepared C-SDLC v2 issue to a claim, branch, and worktree.
+---
+Invoke `csdlc-bind` with typed argv and report its typed result. Do not create hidden claims, edit cards, or fall back to shell/Python lifecycle mutation.

--- a/csdlc-v2/operator/skills/csdlc-v2-card-editor/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-card-editor/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-card-editor
+description: Apply typed semantic card operations through the canonical v2 record.
+---
+Invoke `csdlc-edit apply`. Never patch rendered Markdown directly; markdown.rs AST validation and atomic regeneration remain binary-owned.

--- a/csdlc-v2/operator/skills/csdlc-v2-closeout/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-closeout/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-closeout
+description: Record terminal truth and safely close out a green integrated issue.
+---
+Invoke `csdlc-closeout`. Fail closed on incomplete readiness, stale generation, missing terminal evidence, or unsafe prune scope.

--- a/csdlc-v2/operator/skills/csdlc-v2-doctor/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-doctor/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-doctor
+description: Diagnose canonical v2 state without mutation or network access.
+---
+Invoke `csdlc-doctor` and preserve its typed status/error category. Never repair silently or convert corrupt/interrupted state into pass.

--- a/csdlc-v2/operator/skills/csdlc-v2-init/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-init/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-init
+description: Construct all six C-SDLC v2 cards and canonical issue state from typed input.
+---
+Invoke `csdlc-init` with typed argv. Do not edit Markdown/state, invoke shell/Python lifecycle logic, bind a worktree, or infer success from prose. Preserve v1 as default during coexistence.

--- a/csdlc-v2/operator/skills/csdlc-v2-publish/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-publish/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-publish
+description: Publish only after current pre-publication review truth.
+---
+Invoke `csdlc-publish`. Do not publish on missing/stale review, ambiguous remote state, or prose-only approval.

--- a/csdlc-v2/operator/skills/csdlc-v2-review/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-review/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-review
+description: Assign and record exact-revision pre-publication review truth.
+---
+Invoke `csdlc-review`. Publication remains blocked until current review evidence exists and all actionable findings are dispositioned.

--- a/csdlc-v2/operator/skills/csdlc-v2-shepherd/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-shepherd/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-shepherd
+description: Classify scheduler, validation, review, publication, and readiness next actions.
+---
+Invoke read-only `csdlc-shepherd`. It recommends typed next work and never acquires authority or mutates lifecycle state.

--- a/csdlc-v2/operator/skills/csdlc-v2-validate/SKILL.md
+++ b/csdlc-v2/operator/skills/csdlc-v2-validate/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: csdlc-v2-validate
+description: Execute declared PVF validation DAGs with typed evidence.
+---
+Use `csdlc-schedule` for read-only classification and `csdlc-validate` for execution. Do not embed shell command strings or treat skipped/pending proof as passed.

--- a/csdlc-v2/src/bin/csdlc-install.rs
+++ b/csdlc-v2/src/bin/csdlc-install.rs
@@ -1,0 +1,77 @@
+use clap::{Parser, Subcommand};
+use csdlc_v2::{install_binaries, verify_coexistence, CoexistenceInventory, SkillManifest};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "csdlc-install")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+#[derive(Subcommand)]
+enum Command {
+    Manifest,
+    Install {
+        #[arg(long)]
+        source: PathBuf,
+        #[arg(long)]
+        destination: PathBuf,
+    },
+    Verify {
+        #[arg(long)]
+        repo: PathBuf,
+        #[arg(long)]
+        bin_dir: PathBuf,
+        #[arg(long)]
+        inventory: PathBuf,
+    },
+}
+fn main() {
+    let result = match Args::parse().command {
+        Command::Manifest => SkillManifest::load().and_then(json),
+        Command::Install {
+            source,
+            destination,
+        } => install_binaries(&source, &destination).and_then(json),
+        Command::Verify {
+            repo,
+            bin_dir,
+            inventory,
+        } => fs::read(inventory)
+            .map_err(io_error)
+            .and_then(|b| {
+                serde_json::from_slice::<CoexistenceInventory>(&b).map_err(|e| {
+                    csdlc_v2::V2Error::new(csdlc_v2::ErrorCode::CorruptRecord, e.to_string())
+                })
+            })
+            .and_then(|v| verify_coexistence(&repo, &bin_dir, &v))
+            .and_then(|r| {
+                let pass = r.pass;
+                json(r)?;
+                if pass {
+                    Ok(())
+                } else {
+                    Err(csdlc_v2::V2Error::new(
+                        csdlc_v2::ErrorCode::ValidationFailed,
+                        "coexistence proof failed",
+                    ))
+                }
+            }),
+    };
+    if let Err(error) = result {
+        eprintln!("{error}");
+        std::process::exit(2);
+    }
+}
+fn json(value: impl serde::Serialize) -> csdlc_v2::Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&value)
+            .map_err(|e| csdlc_v2::V2Error::new(csdlc_v2::ErrorCode::Io, e.to_string()))?
+    );
+    Ok(())
+}
+fn io_error(error: std::io::Error) -> csdlc_v2::V2Error {
+    csdlc_v2::V2Error::new(csdlc_v2::ErrorCode::Io, error.to_string())
+}

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -5,6 +5,7 @@ pub mod git;
 pub mod lifecycle;
 pub mod migration;
 pub mod model;
+pub mod operator;
 pub mod publication;
 pub mod pvf;
 pub mod readiness;
@@ -30,6 +31,9 @@ pub use model::{
     Claim, ClaimRecovery, DesignReview, IssueRecord, LifecyclePhase, MigrationEvidence,
     NonSubstantiveProof, PublicationEvidence, ReadinessEvidence, ReviewAssignment, ReviewEvidence,
     ReviewFindingEvidence, TerminalEvidence,
+};
+pub use operator::{
+    install_binaries, verify_coexistence, CoexistenceInventory, InstallReceipt, SkillManifest,
 };
 pub use publication::{
     prepare_publication, reconcile_action, record_publication, PublicationAction,

--- a/csdlc-v2/src/operator.rs
+++ b/csdlc-v2/src/operator.rs
@@ -1,0 +1,364 @@
+use crate::error::{ErrorCode, Result, V2Error};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SKILLS: &str = include_str!("../operator/skills.json");
+const COEXISTENCE: &str = include_str!("../operator/coexistence.json");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SkillManifest {
+    pub schema: String,
+    pub generation: String,
+    pub default_generation: String,
+    pub skills: Vec<SkillRoute>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SkillRoute {
+    pub name: String,
+    pub binary: String,
+    pub subcommand: Option<String>,
+    pub mutates_state: bool,
+    pub auxiliary_binaries: Vec<String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CoexistenceInventory {
+    pub schema: String,
+    pub default_generation: String,
+    pub generation_selector: PathBuf,
+    pub required_v1_paths: Vec<RequiredPath>,
+    pub required_v2_binaries: Vec<String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RequiredPath {
+    pub path: PathBuf,
+    pub executable: bool,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoexistenceReport {
+    pub schema: String,
+    pub pass: bool,
+    pub default_generation: String,
+    pub missing_v1_paths: Vec<PathBuf>,
+    pub missing_v2_binaries: Vec<String>,
+    pub skill_count: usize,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InstallReceipt {
+    pub schema: String,
+    pub destination: PathBuf,
+    pub binaries: Vec<InstalledBinary>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InstalledBinary {
+    pub name: String,
+    pub blake3: String,
+}
+
+impl SkillManifest {
+    pub fn load() -> Result<Self> {
+        let manifest: Self = serde_json::from_str(SKILLS).map_err(|e| {
+            V2Error::new(
+                ErrorCode::CorruptRecord,
+                format!("invalid embedded skill manifest: {e}"),
+            )
+        })?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != "csdlc.operator_skills.v1"
+            || self.generation != "v2"
+            || self.default_generation != "v1"
+            || self.skills.len() != 9
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                "operator manifest must declare nine v2 skills while v1 remains default",
+            ));
+        }
+        let mut names = BTreeSet::new();
+        for route in &self.skills {
+            if !names.insert(&route.name)
+                || !route.binary.starts_with("csdlc-")
+                || route.binary.contains("python")
+                || route.binary.ends_with(".sh")
+            {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidManifest,
+                    "skills must be unique typed C-SDLC binary routes",
+                ));
+            }
+            for binary in std::iter::once(&route.binary).chain(&route.auxiliary_binaries) {
+                if !binary.starts_with("csdlc-") || binary.contains('/') {
+                    return Err(V2Error::new(
+                        ErrorCode::InvalidManifest,
+                        "all skill executables must be simple typed C-SDLC binary names",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn binaries(&self) -> BTreeSet<&str> {
+        self.skills
+            .iter()
+            .flat_map(|route| {
+                std::iter::once(route.binary.as_str())
+                    .chain(route.auxiliary_binaries.iter().map(String::as_str))
+            })
+            .collect()
+    }
+
+    pub fn required_binaries(&self) -> BTreeSet<String> {
+        self.binaries().into_iter().map(str::to_owned).collect()
+    }
+}
+
+impl CoexistenceInventory {
+    pub fn load() -> Result<Self> {
+        serde_json::from_str(COEXISTENCE).map_err(Into::into)
+    }
+}
+
+pub fn verify_coexistence(
+    repo: &Path,
+    bin_dir: &Path,
+    inventory: &CoexistenceInventory,
+) -> Result<CoexistenceReport> {
+    let manifest = SkillManifest::load()?;
+    let reviewed = CoexistenceInventory::load()?;
+    if inventory != &reviewed {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "coexistence input must exactly match the embedded reviewed inventory",
+        ));
+    }
+    if inventory.schema != "csdlc.coexistence_inventory.v1" || inventory.default_generation != "v1"
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "coexistence requires schema v1 and v1 default",
+        ));
+    }
+    let selector_path = checked_repo_path(repo, &inventory.generation_selector)?;
+    if !is_regular_file(&selector_path) {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "tracked generation selector must be a regular file, not a symlink",
+        ));
+    }
+    let selector: serde_json::Value =
+        serde_json::from_slice(&fs::read(&selector_path).map_err(io_error)?)?;
+    if selector
+        .get("default_generation")
+        .and_then(|value| value.as_str())
+        != Some("v1")
+    {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "tracked generation selector does not declare v1 as default",
+        ));
+    }
+    let missing_v1_paths = inventory
+        .required_v1_paths
+        .iter()
+        .filter_map(|required| match checked_repo_path(repo, &required.path) {
+            Ok(path)
+                if is_regular_file(&path) && (!required.executable || is_executable(&path)) =>
+            {
+                None
+            }
+            _ => Some(required.path.clone()),
+        })
+        .collect::<Vec<_>>();
+    let missing_v2_binaries = inventory
+        .required_v2_binaries
+        .iter()
+        .filter(|n| {
+            let path = bin_dir.join(n);
+            !is_regular_file(&path) || !is_executable(&path)
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut missing_v2_binaries = missing_v2_binaries;
+    missing_v2_binaries.extend(verify_install_receipt(bin_dir, &manifest)?);
+    Ok(CoexistenceReport {
+        schema: "csdlc.coexistence_report.v1".into(),
+        pass: missing_v1_paths.is_empty() && missing_v2_binaries.is_empty(),
+        default_generation: inventory.default_generation.clone(),
+        missing_v1_paths,
+        missing_v2_binaries: missing_v2_binaries.into_iter().collect(),
+        skill_count: manifest.skills.len(),
+    })
+}
+
+pub fn install_binaries(source: &Path, destination: &Path) -> Result<InstallReceipt> {
+    let manifest = SkillManifest::load()?;
+    if destination.file_name().and_then(|value| value.to_str()) != Some("csdlc-v2") {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "v2 binaries must install into a dedicated generation directory named csdlc-v2 (normally .adl/bin/csdlc-v2); shared directories such as .adl/bin are forbidden",
+        ));
+    }
+    let names = manifest.binaries();
+    let mut prepared = Vec::new();
+    for name in &names {
+        let input = source.join(name);
+        if !is_regular_file(&input) || !is_executable(&input) {
+            return Err(V2Error::new(
+                ErrorCode::Io,
+                format!(
+                    "built binary is missing, non-regular, or non-executable: {}",
+                    input.display()
+                ),
+            ));
+        }
+        let bytes = fs::read(&input).map_err(io_error)?;
+        let permissions = fs::metadata(&input).map_err(io_error)?.permissions();
+        prepared.push((name.to_string(), bytes, permissions));
+    }
+    let binaries = prepared
+        .iter()
+        .map(|(name, bytes, _)| InstalledBinary {
+            name: name.clone(),
+            blake3: blake3::hash(bytes).to_hex().to_string(),
+        })
+        .collect();
+    let mut receipt = InstallReceipt {
+        schema: "csdlc.install_receipt.v1".into(),
+        destination: destination.to_path_buf(),
+        binaries,
+    };
+    let parent = destination.parent().ok_or_else(|| {
+        V2Error::new(
+            ErrorCode::InvalidInput,
+            "installation destination needs a parent",
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(io_error)?;
+    let leaf = destination
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "invalid installation destination"))?;
+    let stage = parent.join(format!(".{leaf}.stage-{}", std::process::id()));
+    let backup = parent.join(format!(".{leaf}.backup-{}", std::process::id()));
+    if stage.exists() || backup.exists() {
+        return Err(V2Error::new(
+            ErrorCode::ReconciliationRequired,
+            "stale install stage or backup requires reconciliation",
+        ));
+    }
+    fs::create_dir(&stage).map_err(io_error)?;
+    receipt.destination = destination.to_path_buf();
+    for (name, bytes, permissions) in prepared {
+        let output = stage.join(name);
+        fs::write(&output, bytes).map_err(io_error)?;
+        fs::set_permissions(&output, permissions).map_err(io_error)?;
+    }
+    fs::write(
+        stage.join("install-receipt.json"),
+        serde_json::to_vec_pretty(&receipt)
+            .map_err(|e| V2Error::new(ErrorCode::Io, e.to_string()))?,
+    )
+    .map_err(io_error)?;
+    let had_destination = destination.exists();
+    if had_destination {
+        fs::rename(destination, &backup).map_err(io_error)?;
+    }
+    if let Err(error) = fs::rename(&stage, destination) {
+        if had_destination {
+            let _ = fs::rename(&backup, destination);
+        }
+        return Err(io_error(error));
+    }
+    if had_destination {
+        fs::remove_dir_all(&backup).map_err(io_error)?;
+    }
+    Ok(receipt)
+}
+
+fn checked_repo_path(repo: &Path, relative: &Path) -> Result<PathBuf> {
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|part| matches!(part, std::path::Component::ParentDir))
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "coexistence paths must be repo-relative without parent traversal",
+        ));
+    }
+    Ok(repo.join(relative))
+}
+
+fn verify_install_receipt(bin_dir: &Path, manifest: &SkillManifest) -> Result<BTreeSet<String>> {
+    let path = bin_dir.join("install-receipt.json");
+    if !is_regular_file(&path) {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "install receipt must be a regular non-symlink file",
+        ));
+    }
+    let receipt: InstallReceipt = serde_json::from_slice(&fs::read(&path).map_err(io_error)?)?;
+    if receipt.schema != "csdlc.install_receipt.v1" || receipt.destination != bin_dir {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "install receipt schema or destination does not match the verified generation directory",
+        ));
+    }
+    let expected = manifest.required_binaries();
+    let observed = receipt
+        .binaries
+        .iter()
+        .map(|entry| entry.name.clone())
+        .collect::<BTreeSet<_>>();
+    if observed != expected || observed.len() != receipt.binaries.len() {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "install receipt must contain the exact unique executable set",
+        ));
+    }
+    let mut failures = BTreeSet::new();
+    for entry in receipt.binaries {
+        let binary = bin_dir.join(&entry.name);
+        if !is_regular_file(&binary)
+            || !is_executable(&binary)
+            || fs::read(&binary)
+                .map(|bytes| blake3::hash(&bytes).to_hex().as_str() != entry.blake3)
+                .unwrap_or(true)
+        {
+            failures.insert(entry.name);
+        }
+    }
+    Ok(failures)
+}
+
+fn is_regular_file(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+fn io_error(error: std::io::Error) -> V2Error {
+    V2Error::new(ErrorCode::Io, error.to_string())
+}

--- a/csdlc-v2/tests/gate10a.rs
+++ b/csdlc-v2/tests/gate10a.rs
@@ -1,0 +1,159 @@
+use csdlc_v2::{install_binaries, verify_coexistence, CoexistenceInventory, SkillManifest};
+use std::fs;
+
+#[test]
+fn nine_skills_are_typed_and_keep_v1_default() {
+    let manifest = SkillManifest::load().unwrap();
+    assert_eq!(manifest.skills.len(), 9);
+    assert_eq!(manifest.default_generation, "v1");
+    assert!(manifest
+        .skills
+        .iter()
+        .all(|r| r.binary.starts_with("csdlc-") && !r.binary.contains("python")));
+}
+#[test]
+fn coexistence_fails_closed_when_v1_or_v2_is_missing() {
+    let repo = tempfile::tempdir().unwrap();
+    let bins = tempfile::tempdir().unwrap();
+    let inventory = CoexistenceInventory::load().unwrap();
+    assert!(verify_coexistence(repo.path(), bins.path(), &inventory).is_err());
+    let mut altered = inventory.clone();
+    altered.required_v1_paths.clear();
+    assert!(verify_coexistence(repo.path(), bins.path(), &altered).is_err());
+}
+#[test]
+fn installer_records_provenance_without_replacing_other_files() {
+    let source = tempfile::tempdir().unwrap();
+    let destination_parent = tempfile::tempdir().unwrap();
+    let destination = destination_parent.path().join("csdlc-v2");
+    let manifest = SkillManifest::load().unwrap();
+    for name in manifest.required_binaries() {
+        fs::write(source.path().join(&name), name.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(source.path().join(name), fs::Permissions::from_mode(0o755))
+                .unwrap();
+        }
+    }
+    fs::write(destination_parent.path().join("v1-stays"), b"v1").unwrap();
+    let receipt = install_binaries(source.path(), &destination).unwrap();
+    assert_eq!(receipt.binaries.len(), 10);
+    assert_eq!(
+        fs::read(destination_parent.path().join("v1-stays")).unwrap(),
+        b"v1"
+    );
+    assert!(destination.join("install-receipt.json").is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_ne!(
+            fs::metadata(destination.join("csdlc-init"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+    }
+    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let inventory = CoexistenceInventory::load().unwrap();
+    assert!(
+        verify_coexistence(&repo, &destination, &inventory)
+            .unwrap()
+            .pass
+    );
+    fs::write(destination.join("csdlc-init"), b"tampered").unwrap();
+    let tampered = verify_coexistence(&repo, &destination, &inventory).unwrap();
+    assert!(!tampered.pass);
+    assert!(tampered.missing_v2_binaries.contains(&"csdlc-init".into()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        fs::remove_file(destination.join("install-receipt.json")).unwrap();
+        symlink("/bin/true", destination.join("install-receipt.json")).unwrap();
+        assert!(verify_coexistence(&repo, &destination, &inventory).is_err());
+    }
+}
+
+#[test]
+fn operator_guidance_is_bound_to_manifest_and_coexistence_contract() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root_agents = fs::read_to_string(root.join("../AGENTS.md")).unwrap();
+    let nested_agents = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+    let manifest = SkillManifest::load().unwrap();
+    let inventory = CoexistenceInventory::load().unwrap();
+    assert_eq!(manifest.skills.len(), 9);
+    assert_eq!(inventory.default_generation, "v1");
+    for text in [&root_agents, &nested_agents] {
+        assert!(text.contains("v1"));
+        assert!(text.contains("csdlc-install"));
+        assert!(text.contains("nine"));
+    }
+}
+
+#[test]
+fn missing_late_source_leaves_prior_generation_untouched() {
+    let source = tempfile::tempdir().unwrap();
+    let destination_parent = tempfile::tempdir().unwrap();
+    let destination = destination_parent.path().join("csdlc-v2");
+    fs::create_dir(&destination).unwrap();
+    fs::write(destination.join("previous"), b"known-good").unwrap();
+    let manifest = SkillManifest::load().unwrap();
+    for name in manifest.required_binaries().iter().take(9) {
+        fs::write(source.path().join(name), name.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(source.path().join(name), fs::Permissions::from_mode(0o755))
+                .unwrap();
+        }
+    }
+    assert!(install_binaries(source.path(), &destination).is_err());
+    assert_eq!(
+        fs::read(destination.join("previous")).unwrap(),
+        b"known-good"
+    );
+    assert_eq!(fs::read_dir(&destination).unwrap().count(), 1);
+}
+
+#[test]
+fn shared_destination_and_non_executable_sources_are_rejected_without_mutation() {
+    let source = tempfile::tempdir().unwrap();
+    let parent = tempfile::tempdir().unwrap();
+    let shared = parent.path().join("bin");
+    fs::create_dir(&shared).unwrap();
+    fs::write(shared.join("v1-owner"), b"v1").unwrap();
+    assert!(install_binaries(source.path(), &shared).is_err());
+    assert_eq!(fs::read(shared.join("v1-owner")).unwrap(), b"v1");
+
+    let dedicated = parent.path().join("csdlc-v2");
+    let manifest = SkillManifest::load().unwrap();
+    for name in manifest.required_binaries() {
+        fs::write(source.path().join(name), b"not executable").unwrap();
+    }
+    assert!(install_binaries(source.path(), &dedicated).is_err());
+    assert!(!dedicated.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_installed_binaries_fail_coexistence() {
+    use std::os::unix::fs::symlink;
+    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let source = tempfile::tempdir().unwrap();
+    let parent = tempfile::tempdir().unwrap();
+    let bins = parent.path().join("csdlc-v2");
+    for name in SkillManifest::load().unwrap().required_binaries() {
+        use std::os::unix::fs::PermissionsExt;
+        fs::write(source.path().join(&name), name.as_bytes()).unwrap();
+        fs::set_permissions(source.path().join(name), fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    install_binaries(source.path(), &bins).unwrap();
+    fs::remove_file(bins.join("csdlc-init")).unwrap();
+    symlink("/bin/true", bins.join("csdlc-init")).unwrap();
+    let report = verify_coexistence(&repo, &bins, &CoexistenceInventory::load().unwrap()).unwrap();
+    assert!(!report.pass);
+    assert_eq!(report.missing_v2_binaries, vec!["csdlc-init"]);
+}

--- a/docs/architecture/csdlc-v2/gate10a/COEXISTENCE.mmd
+++ b/docs/architecture/csdlc-v2/gate10a/COEXISTENCE.mmd
@@ -1,0 +1,12 @@
+flowchart LR
+  O["Operator"] --> M["Nine thin v2 skills"]
+  M --> B["Typed v2 binaries"]
+  B --> S["Independent v2 state"]
+  O --> D{"Explicit v2 request?"}
+  D -->|"no"| V1["V1 default remains runnable"]
+  D -->|"yes"| B
+  I["csdlc-install verify"] --> V1
+  I --> B
+  I --> G{"Complete coexistence inventory?"}
+  G -->|"no"| X["Fail and block merge"]
+  G -->|"yes"| P["Phase A proof"]

--- a/docs/architecture/csdlc-v2/gate10a/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate10a/DESIGN.md
@@ -1,0 +1,5 @@
+# Gate 10A: coexistence design
+
+C-SDLC v2 is installed beside v1, never over it. The only accepted stable destination is the dedicated `.adl/bin/csdlc-v2/` generation directory; shared `.adl/bin/` is rejected without mutation. The embedded nine-skill manifest maps operator intent to typed Rust binaries. `csdlc-install` copies only regular executable v2 owners, records BLAKE3 provenance, and verifies both the non-symlink executable v2 set and an explicit v1 availability inventory. The manifest fixes `default_generation` to `v1` for this gate.
+
+Skills are adapters, not state owners. No skill or installer invokes shell/Python lifecycle logic. V2 remains independent of ADL Runtime and incumbent C-SDLC crates. The verifier fails closed if any named v1 path or v2 binary is absent. Gate 10A cannot switch defaults or delete v1.


### PR DESCRIPTION
Closes #5292

## Outcome

- adds a provenance-checked, generation-atomic Rust installer for the dedicated `.adl/bin/csdlc-v2/` directory
- adds nine thin typed v2 skill contracts, including the scheduler executable closure
- keeps v1 authoritative, installed, executable, tested, and recoverable through an embedded reviewed coexistence inventory
- adds bounded root/nested opt-in guidance plus Gate 10A design and diagram

## Safety

- shared `.adl/bin/` destinations are rejected before mutation
- source and installed binaries must be regular, non-symlink, executable files
- verification binds the exact receipt schema, destination, ten-name set, and recomputed BLAKE3 hashes
- default generation remains v1; no v1 path is deleted or disabled

## Proof

- 7 focused Gate 10A tests
- full standalone C-SDLC v2 suite
- Clippy `-D warnings` and rustfmt
- real ten-binary install plus coexistence verification
- four bounded review passes and exact-commit review: no findings

Gate 10B (#5293) remains dependency-blocked until this PR is green, merged, and closed out.
