### PR TITLE
[v0.91.7][csdlc-v2] Gate 10B pre-switch independent proof with v1 intact

### DIFF
--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -66,6 +66,10 @@ path = "src/bin/csdlc-soak.rs"
 name = "csdlc-install"
 path = "src/bin/csdlc-install.rs"
 
+[[bin]]
+name = "csdlc-proof"
+path = "src/bin/csdlc-proof.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/operator/generation-selector.json
+++ b/csdlc-v2/operator/generation-selector.json
@@ -1,0 +1,5 @@
+{
+  "schema":"csdlc.generation_selector.v1",
+  "default_generation":"v1",
+  "opted_in_issues":[5293]
+}

--- a/csdlc-v2/operator/pre-switch-proof.json
+++ b/csdlc-v2/operator/pre-switch-proof.json
@@ -1,0 +1,12 @@
+{
+  "schema":"csdlc.pre_switch_proof_manifest.v1",
+  "default_generation":"v1",
+  "issue":5293,
+  "opted_in_issues":[5293],
+  "steps":[
+    {"id":"full_suite","executable":"cargo","args":["test","--manifest-path","csdlc-v2/Cargo.toml"]},
+    {"id":"samples_parity","executable":"cargo","args":["test","--manifest-path","csdlc-v2/Cargo.toml","--test","gate9"]},
+    {"id":"quality","executable":"cargo","args":["clippy","--manifest-path","csdlc-v2/Cargo.toml","--all-targets","--","-D","warnings"]},
+    {"id":"v1_smoke","executable":"adl/tools/pr.sh","args":["help"]}
+  ]
+}

--- a/csdlc-v2/operator/pre-switch-proof.json
+++ b/csdlc-v2/operator/pre-switch-proof.json
@@ -3,7 +3,9 @@
   "default_generation":"v1",
   "issue":5293,
   "opted_in_issues":[5293],
+  "generation_selector":"csdlc-v2/operator/generation-selector.json",
   "steps":[
+    {"id":"build_binaries","executable":"cargo","args":["build","--manifest-path","csdlc-v2/Cargo.toml","--bins"]},
     {"id":"full_suite","executable":"cargo","args":["test","--manifest-path","csdlc-v2/Cargo.toml"]},
     {"id":"samples_parity","executable":"cargo","args":["test","--manifest-path","csdlc-v2/Cargo.toml","--test","gate9"]},
     {"id":"quality","executable":"cargo","args":["clippy","--manifest-path","csdlc-v2/Cargo.toml","--all-targets","--","-D","warnings"]},

--- a/csdlc-v2/src/bin/csdlc-proof.rs
+++ b/csdlc-v2/src/bin/csdlc-proof.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+use csdlc_v2::{run_pre_switch_proof, ProofManifest};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    repo: PathBuf,
+    #[arg(long)]
+    manifest: PathBuf,
+    #[arg(long)]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+    let result = fs::read(&args.manifest)
+        .map_err(Into::into)
+        .and_then(|bytes| serde_json::from_slice::<ProofManifest>(&bytes).map_err(Into::into))
+        .and_then(|manifest| run_pre_switch_proof(&args.repo, &manifest))
+        .and_then(|evidence| {
+            csdlc_v2::proof::write_evidence_atomic(&args.output, &evidence)?;
+            if evidence.passed {
+                Ok(evidence)
+            } else {
+                Err(csdlc_v2::V2Error::new(
+                    csdlc_v2::ErrorCode::ValidationFailed,
+                    "pre-switch proof failed",
+                ))
+            }
+        });
+    match result {
+        Ok(evidence) => println!("{}", serde_json::to_string_pretty(&evidence).expect("JSON")),
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(error.code.exit_code());
+        }
+    }
+}

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -6,6 +6,7 @@ pub mod lifecycle;
 pub mod migration;
 pub mod model;
 pub mod operator;
+pub mod proof;
 pub mod publication;
 pub mod pvf;
 pub mod readiness;
@@ -35,6 +36,7 @@ pub use model::{
 pub use operator::{
     install_binaries, verify_coexistence, CoexistenceInventory, InstallReceipt, SkillManifest,
 };
+pub use proof::{run_pre_switch_proof, PreSwitchEvidence, ProofManifest, ProofStep};
 pub use publication::{
     prepare_publication, reconcile_action, record_publication, PublicationAction,
     PublicationIntent, PublicationRequest, RemotePullRequest,

--- a/csdlc-v2/src/proof.rs
+++ b/csdlc-v2/src/proof.rs
@@ -95,6 +95,7 @@ impl ProofManifest {
         if self.schema != "csdlc.pre_switch_proof_manifest.v1"
             || self.default_generation != Generation::V1
             || !self.opted_in_issues.contains(&self.issue)
+            || self.generation_selector != Path::new("csdlc-v2/operator/generation-selector.json")
         {
             return Err(V2Error::new(
                 ErrorCode::InvalidManifest,
@@ -167,6 +168,7 @@ pub fn run_pre_switch_proof(repo: &Path, manifest: &ProofManifest) -> Result<Pre
     let selector_after = read_selector(repo, &manifest.generation_selector)?;
     let default_after = select_generation(&selector_after, manifest.issue, None)?;
     let v1_paths_after = required_v1_paths_exist(repo);
+    require_clean_revision(repo)?;
     let measurements = measure(repo, &steps)?;
     let passed = default_before == Generation::V1
         && explicit_v2_selected
@@ -207,6 +209,18 @@ fn read_selector(repo: &Path, relative: &Path) -> Result<GenerationSelector> {
         return Err(V2Error::new(
             ErrorCode::ValidationFailed,
             "generation selector must be a regular non-symlink file",
+        ));
+    }
+    let tracked = Command::new("git")
+        .args(["ls-files", "--error-unmatch", "--"])
+        .arg(relative)
+        .current_dir(repo)
+        .output()
+        .map_err(|error| V2Error::new(ErrorCode::GitFailure, error.to_string()))?;
+    if !tracked.status.success() {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "generation selector must be tracked at the reviewed path",
         ));
     }
     serde_json::from_slice(&fs::read(path)?).map_err(Into::into)

--- a/csdlc-v2/src/proof.rs
+++ b/csdlc-v2/src/proof.rs
@@ -1,0 +1,306 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ErrorCode, Result, V2Error};
+use crate::{select_generation, Generation, GenerationSelector};
+
+const REQUIRED_STEPS: [&str; 4] = ["full_suite", "samples_parity", "quality", "v1_smoke"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProofManifest {
+    pub schema: String,
+    pub default_generation: Generation,
+    pub issue: u64,
+    pub opted_in_issues: BTreeSet<u64>,
+    pub steps: Vec<ProofStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProofStep {
+    pub id: String,
+    pub executable: PathBuf,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StepEvidence {
+    pub id: String,
+    pub executable: PathBuf,
+    pub args: Vec<String>,
+    pub exit_code: Option<i32>,
+    pub elapsed_millis: u64,
+    pub stdout_blake3: String,
+    pub stderr_blake3: String,
+    pub passed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PreSwitchEvidence {
+    pub schema: String,
+    pub revision: String,
+    pub default_before: Generation,
+    pub explicit_v2_selected: bool,
+    pub rollback_to_v1_selected: bool,
+    pub default_after: Generation,
+    pub v1_paths_before: bool,
+    pub v1_paths_after: bool,
+    pub steps: Vec<StepEvidence>,
+    pub measurements: ProofMeasurements,
+    pub passed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProofMeasurements {
+    pub rust_loc: u64,
+    pub test_count: u64,
+    pub debug_binary_bytes: Vec<(String, u64)>,
+    pub construction_and_full_suite_millis: u64,
+    pub total_proof_millis: u64,
+    pub loc_is_reviewable_not_a_hard_cap: bool,
+}
+
+impl ProofManifest {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != "csdlc.pre_switch_proof_manifest.v1"
+            || self.default_generation != Generation::V1
+            || !self.opted_in_issues.contains(&self.issue)
+        {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                "pre-switch proof requires schema v1, v1 default, and explicit v2 opt-in",
+            ));
+        }
+        let ids = self
+            .steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<BTreeSet<_>>();
+        if ids != REQUIRED_STEPS.into_iter().collect() || ids.len() != self.steps.len() {
+            return Err(V2Error::new(
+                ErrorCode::InvalidManifest,
+                "proof manifest requires exactly the four typed proof steps",
+            ));
+        }
+        for step in &self.steps {
+            let expected = expected_command(&step.id)
+                .ok_or_else(|| V2Error::new(ErrorCode::InvalidManifest, "unknown proof step"))?;
+            if step.executable != Path::new(expected.0) || step.args != expected.1 {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidManifest,
+                    "proof step executable and argv must match the reviewed typed contract",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn run_pre_switch_proof(repo: &Path, manifest: &ProofManifest) -> Result<PreSwitchEvidence> {
+    manifest.validate()?;
+    let selector = GenerationSelector {
+        schema: "csdlc.generation_selector.v1".into(),
+        default_generation: manifest.default_generation,
+        opted_in_issues: manifest.opted_in_issues.clone(),
+    };
+    let default_before = select_generation(&selector, manifest.issue, None)?;
+    let explicit_v2_selected =
+        select_generation(&selector, manifest.issue, Some(Generation::V2))? == Generation::V2;
+    let rollback_to_v1_selected =
+        select_generation(&selector, manifest.issue, None)? == Generation::V1;
+    let v1_paths_before = required_v1_paths_exist(repo);
+    let revision = command_text(repo, "git", &["rev-parse", "HEAD"])?;
+    let mut steps = Vec::new();
+    for step in &manifest.steps {
+        let started = Instant::now();
+        let output = Command::new(&step.executable)
+            .args(&step.args)
+            .current_dir(repo)
+            .output()
+            .map_err(|error| V2Error::new(ErrorCode::Io, format!("{}: {error}", step.id)))?;
+        steps.push(StepEvidence {
+            id: step.id.clone(),
+            executable: step.executable.clone(),
+            args: step.args.clone(),
+            exit_code: output.status.code(),
+            elapsed_millis: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            stdout_blake3: blake3::hash(&output.stdout).to_hex().to_string(),
+            stderr_blake3: blake3::hash(&output.stderr).to_hex().to_string(),
+            passed: output.status.success(),
+        });
+    }
+    let default_after = select_generation(&selector, manifest.issue, None)?;
+    let v1_paths_after = required_v1_paths_exist(repo);
+    let measurements = measure(repo, &steps)?;
+    let passed = default_before == Generation::V1
+        && explicit_v2_selected
+        && rollback_to_v1_selected
+        && default_after == Generation::V1
+        && v1_paths_before
+        && v1_paths_after
+        && steps.iter().all(|step| step.passed);
+    Ok(PreSwitchEvidence {
+        schema: "csdlc.pre_switch_evidence.v1".into(),
+        revision,
+        default_before,
+        explicit_v2_selected,
+        rollback_to_v1_selected,
+        default_after,
+        v1_paths_before,
+        v1_paths_after,
+        steps,
+        measurements,
+        passed,
+    })
+}
+
+pub fn write_evidence_atomic(path: &Path, evidence: &PreSwitchEvidence) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "evidence output needs a parent"))?;
+    fs::create_dir_all(parent)?;
+    let temporary = path.with_extension("json.tmp");
+    fs::write(&temporary, serde_json::to_vec_pretty(evidence)?)?;
+    fs::rename(temporary, path)?;
+    Ok(())
+}
+
+fn required_v1_paths_exist(repo: &Path) -> bool {
+    [
+        ("adl/tools/pr.sh", true),
+        ("adl/tools/install_owner_binaries.sh", true),
+        ("adl/src/bin/adl_csdlc.rs", false),
+        ("adl/src/cli/pr_cmd.rs", false),
+    ]
+    .iter()
+    .all(|(path, executable)| {
+        let path = repo.join(path);
+        regular_file(&path) && (!executable || executable_file(&path))
+    })
+}
+
+fn expected_command(id: &str) -> Option<(&'static str, Vec<String>)> {
+    let values: &[&str] = match id {
+        "full_suite" => &["test", "--manifest-path", "csdlc-v2/Cargo.toml"],
+        "samples_parity" => &[
+            "test",
+            "--manifest-path",
+            "csdlc-v2/Cargo.toml",
+            "--test",
+            "gate9",
+        ],
+        "quality" => &[
+            "clippy",
+            "--manifest-path",
+            "csdlc-v2/Cargo.toml",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ],
+        "v1_smoke" => return Some(("adl/tools/pr.sh", vec!["help".into()])),
+        _ => return None,
+    };
+    Some((
+        "cargo",
+        values.iter().map(|value| (*value).into()).collect(),
+    ))
+}
+
+fn regular_file(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn executable_file(path: &Path) -> bool {
+    regular_file(path)
+}
+
+fn command_text(repo: &Path, executable: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(executable)
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .map_err(|error| V2Error::new(ErrorCode::Io, error.to_string()))?;
+    if !output.status.success() {
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            "revision lookup failed",
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().into())
+}
+
+fn measure(repo: &Path, steps: &[StepEvidence]) -> Result<ProofMeasurements> {
+    let mut rust_loc = 0;
+    let mut test_count = 0;
+    for root in [repo.join("csdlc-v2/src"), repo.join("csdlc-v2/tests")] {
+        for path in walk(&root)? {
+            if path.extension().and_then(|value| value.to_str()) == Some("rs") {
+                let text = fs::read_to_string(path)?;
+                rust_loc += text.lines().filter(|line| !line.trim().is_empty()).count() as u64;
+                test_count += text.matches("#[test]").count() as u64;
+            }
+        }
+    }
+    let target = repo.join("csdlc-v2/target/debug");
+    let mut debug_binary_bytes = Vec::new();
+    if target.is_dir() {
+        for entry in fs::read_dir(target)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("csdlc-")
+                && !name.contains('.')
+                && regular_file(&entry.path())
+                && executable_file(&entry.path())
+            {
+                debug_binary_bytes.push((name, entry.metadata()?.len()));
+            }
+        }
+    }
+    debug_binary_bytes.sort();
+    Ok(ProofMeasurements {
+        rust_loc,
+        test_count,
+        debug_binary_bytes,
+        construction_and_full_suite_millis: steps
+            .iter()
+            .find(|step| step.id == "full_suite")
+            .map(|step| step.elapsed_millis)
+            .unwrap_or(0),
+        total_proof_millis: steps.iter().map(|step| step.elapsed_millis).sum(),
+        loc_is_reviewable_not_a_hard_cap: true,
+    })
+}
+
+fn walk(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        for entry in fs::read_dir(path)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+    Ok(files)
+}

--- a/csdlc-v2/src/proof.rs
+++ b/csdlc-v2/src/proof.rs
@@ -9,7 +9,30 @@ use serde::{Deserialize, Serialize};
 use crate::error::{ErrorCode, Result, V2Error};
 use crate::{select_generation, Generation, GenerationSelector};
 
-const REQUIRED_STEPS: [&str; 4] = ["full_suite", "samples_parity", "quality", "v1_smoke"];
+const REQUIRED_STEPS: [&str; 5] = [
+    "build_binaries",
+    "full_suite",
+    "samples_parity",
+    "quality",
+    "v1_smoke",
+];
+const BINARY_NAMES: [&str; 15] = [
+    "csdlc-bind",
+    "csdlc-closeout",
+    "csdlc-doctor",
+    "csdlc-edit",
+    "csdlc-import",
+    "csdlc-init",
+    "csdlc-install",
+    "csdlc-proof",
+    "csdlc-publish",
+    "csdlc-review",
+    "csdlc-schedule",
+    "csdlc-shadow",
+    "csdlc-shepherd",
+    "csdlc-soak",
+    "csdlc-validate",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -18,6 +41,7 @@ pub struct ProofManifest {
     pub default_generation: Generation,
     pub issue: u64,
     pub opted_in_issues: BTreeSet<u64>,
+    pub generation_selector: PathBuf,
     pub steps: Vec<ProofStep>,
 }
 
@@ -104,11 +128,16 @@ impl ProofManifest {
 
 pub fn run_pre_switch_proof(repo: &Path, manifest: &ProofManifest) -> Result<PreSwitchEvidence> {
     manifest.validate()?;
-    let selector = GenerationSelector {
-        schema: "csdlc.generation_selector.v1".into(),
-        default_generation: manifest.default_generation,
-        opted_in_issues: manifest.opted_in_issues.clone(),
-    };
+    require_clean_revision(repo)?;
+    let selector = read_selector(repo, &manifest.generation_selector)?;
+    if selector.default_generation != manifest.default_generation
+        || selector.opted_in_issues != manifest.opted_in_issues
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "proof manifest must exactly match the tracked generation selector",
+        ));
+    }
     let default_before = select_generation(&selector, manifest.issue, None)?;
     let explicit_v2_selected =
         select_generation(&selector, manifest.issue, Some(Generation::V2))? == Generation::V2;
@@ -135,13 +164,15 @@ pub fn run_pre_switch_proof(repo: &Path, manifest: &ProofManifest) -> Result<Pre
             passed: output.status.success(),
         });
     }
-    let default_after = select_generation(&selector, manifest.issue, None)?;
+    let selector_after = read_selector(repo, &manifest.generation_selector)?;
+    let default_after = select_generation(&selector_after, manifest.issue, None)?;
     let v1_paths_after = required_v1_paths_exist(repo);
     let measurements = measure(repo, &steps)?;
     let passed = default_before == Generation::V1
         && explicit_v2_selected
         && rollback_to_v1_selected
         && default_after == Generation::V1
+        && selector_after == selector
         && v1_paths_before
         && v1_paths_after
         && steps.iter().all(|step| step.passed);
@@ -158,6 +189,27 @@ pub fn run_pre_switch_proof(repo: &Path, manifest: &ProofManifest) -> Result<Pre
         measurements,
         passed,
     })
+}
+
+fn read_selector(repo: &Path, relative: &Path) -> Result<GenerationSelector> {
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|part| matches!(part, std::path::Component::ParentDir))
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidManifest,
+            "generation selector must be a repo-relative non-traversing path",
+        ));
+    }
+    let path = repo.join(relative);
+    if !regular_file(&path) {
+        return Err(V2Error::new(
+            ErrorCode::ValidationFailed,
+            "generation selector must be a regular non-symlink file",
+        ));
+    }
+    serde_json::from_slice(&fs::read(path)?).map_err(Into::into)
 }
 
 pub fn write_evidence_atomic(path: &Path, evidence: &PreSwitchEvidence) -> Result<()> {
@@ -187,6 +239,7 @@ fn required_v1_paths_exist(repo: &Path) -> bool {
 
 fn expected_command(id: &str) -> Option<(&'static str, Vec<String>)> {
     let values: &[&str] = match id {
+        "build_binaries" => &["build", "--manifest-path", "csdlc-v2/Cargo.toml", "--bins"],
         "full_suite" => &["test", "--manifest-path", "csdlc-v2/Cargo.toml"],
         "samples_parity" => &[
             "test",
@@ -261,18 +314,15 @@ fn measure(repo: &Path, steps: &[StepEvidence]) -> Result<ProofMeasurements> {
     }
     let target = repo.join("csdlc-v2/target/debug");
     let mut debug_binary_bytes = Vec::new();
-    if target.is_dir() {
-        for entry in fs::read_dir(target)? {
-            let entry = entry?;
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if name.starts_with("csdlc-")
-                && !name.contains('.')
-                && regular_file(&entry.path())
-                && executable_file(&entry.path())
-            {
-                debug_binary_bytes.push((name, entry.metadata()?.len()));
-            }
+    for name in BINARY_NAMES.into_iter().collect::<BTreeSet<_>>() {
+        let path = target.join(name);
+        if !regular_file(&path) || !executable_file(&path) {
+            return Err(V2Error::new(
+                ErrorCode::ValidationFailed,
+                format!("revision-current binary measurement is missing {name}"),
+            ));
         }
+        debug_binary_bytes.push((name.into(), fs::metadata(path)?.len()));
     }
     debug_binary_bytes.sort();
     Ok(ProofMeasurements {
@@ -287,6 +337,21 @@ fn measure(repo: &Path, steps: &[StepEvidence]) -> Result<ProofMeasurements> {
         total_proof_millis: steps.iter().map(|step| step.elapsed_millis).sum(),
         loc_is_reviewable_not_a_hard_cap: true,
     })
+}
+
+pub fn require_clean_revision(repo: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=all"])
+        .current_dir(repo)
+        .output()
+        .map_err(|error| V2Error::new(ErrorCode::GitFailure, error.to_string()))?;
+    if !output.status.success() || !output.stdout.is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::UnsafeCheckout,
+            "pre-switch proof requires a clean exact revision before execution",
+        ));
+    }
+    Ok(())
 }
 
 fn walk(root: &Path) -> Result<Vec<PathBuf>> {

--- a/csdlc-v2/tests/gate10b.rs
+++ b/csdlc-v2/tests/gate10b.rs
@@ -1,0 +1,50 @@
+use std::collections::BTreeSet;
+
+use csdlc_v2::{select_generation, Generation, GenerationSelector, ProofManifest, ProofStep};
+
+fn manifest() -> ProofManifest {
+    serde_json::from_slice(include_bytes!("../operator/pre-switch-proof.json")).unwrap()
+}
+
+#[test]
+fn manifest_requires_v1_default_opt_in_and_exact_proofs() {
+    let mut value = manifest();
+    assert!(value.validate().is_ok());
+    value.default_generation = Generation::V2;
+    assert!(value.validate().is_err());
+    value.default_generation = Generation::V1;
+    value.steps.pop();
+    assert!(value.validate().is_err());
+}
+
+#[test]
+fn relabeled_arbitrary_commands_are_rejected() {
+    let mut value = manifest();
+    value.steps[0] = ProofStep {
+        id: "full_suite".into(),
+        executable: "sh".into(),
+        args: vec!["-c".into(), "true".into()],
+    };
+    assert!(value.validate().is_err());
+}
+
+#[test]
+fn explicit_v2_rehearsal_rolls_back_to_unchanged_v1_default() {
+    let selector = GenerationSelector {
+        schema: "csdlc.generation_selector.v1".into(),
+        default_generation: Generation::V1,
+        opted_in_issues: BTreeSet::from([5293]),
+    };
+    assert_eq!(
+        select_generation(&selector, 5293, None).unwrap(),
+        Generation::V1
+    );
+    assert_eq!(
+        select_generation(&selector, 5293, Some(Generation::V2)).unwrap(),
+        Generation::V2
+    );
+    assert_eq!(
+        select_generation(&selector, 5293, None).unwrap(),
+        Generation::V1
+    );
+}

--- a/csdlc-v2/tests/gate10b.rs
+++ b/csdlc-v2/tests/gate10b.rs
@@ -7,6 +7,18 @@ fn manifest() -> ProofManifest {
 }
 
 #[test]
+fn dirty_tree_is_refused_before_proof_attribution() {
+    let repo = tempfile::tempdir().unwrap();
+    std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    std::fs::write(repo.path().join("dirty"), b"untracked").unwrap();
+    assert!(csdlc_v2::proof::require_clean_revision(repo.path()).is_err());
+}
+
+#[test]
 fn manifest_requires_v1_default_opt_in_and_exact_proofs() {
     let mut value = manifest();
     assert!(value.validate().is_ok());

--- a/csdlc-v2/tests/gate10b.rs
+++ b/csdlc-v2/tests/gate10b.rs
@@ -19,6 +19,40 @@ fn dirty_tree_is_refused_before_proof_attribution() {
 }
 
 #[test]
+fn tracked_post_command_mutation_is_refused() {
+    let repo = tempfile::tempdir().unwrap();
+    std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "proof@example.invalid"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Proof"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    std::fs::write(repo.path().join("tracked"), b"before").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "tracked"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-qm", "baseline"])
+        .current_dir(repo.path())
+        .status()
+        .unwrap();
+    assert!(csdlc_v2::proof::require_clean_revision(repo.path()).is_ok());
+    std::fs::write(repo.path().join("tracked"), b"after").unwrap();
+    assert!(csdlc_v2::proof::require_clean_revision(repo.path()).is_err());
+}
+
+#[test]
 fn manifest_requires_v1_default_opt_in_and_exact_proofs() {
     let mut value = manifest();
     assert!(value.validate().is_ok());
@@ -26,6 +60,9 @@ fn manifest_requires_v1_default_opt_in_and_exact_proofs() {
     assert!(value.validate().is_err());
     value.default_generation = Generation::V1;
     value.steps.pop();
+    assert!(value.validate().is_err());
+    let mut value = manifest();
+    value.generation_selector = "target/ignored-selector.json".into();
     assert!(value.validate().is_err());
 }
 

--- a/docs/architecture/csdlc-v2/gate10b/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate10b/DESIGN.md
@@ -1,0 +1,5 @@
+# Gate 10B: pre-switch proof design
+
+`csdlc-proof` runs one reviewed executable-plus-argv manifest and emits atomic exact-revision evidence. It never accepts a shell command string, changes the generation selector, publishes, or deletes files. The required proof set covers the full independent v2 suite, executable samples/parity, warning-free quality, and runnable v1 command surface.
+
+Before and after external proof, the runner verifies v1 paths, resolves omitted generation to v1, explicitly selects v2 for the opted-in issue, and rehearses rollback by resolving the unchanged default back to v1. Any missing step, nonzero exit, unavailable executable, v1-path loss, or selector drift denies pass.

--- a/docs/architecture/csdlc-v2/gate10b/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate10b/DESIGN.md
@@ -1,5 +1,5 @@
 # Gate 10B: pre-switch proof design
 
-`csdlc-proof` runs one reviewed executable-plus-argv manifest and emits atomic exact-revision evidence. It never accepts a shell command string, changes the generation selector, publishes, or deletes files. The required proof set covers the full independent v2 suite, executable samples/parity, warning-free quality, and runnable v1 command surface.
+`csdlc-proof` refuses dirty trees, reads the tracked Gate 10 generation selector, runs one reviewed executable-plus-argv manifest, and emits atomic exact-revision evidence. It never accepts a shell command string, changes the generation selector, publishes, or deletes files. The required proof set builds all revision-current binaries before measurement and covers the full independent v2 suite, executable samples/parity, warning-free quality, and runnable v1 command surface.
 
 Before and after external proof, the runner verifies v1 paths, resolves omitted generation to v1, explicitly selects v2 for the opted-in issue, and rehearses rollback by resolving the unchanged default back to v1. Any missing step, nonzero exit, unavailable executable, v1-path loss, or selector drift denies pass.

--- a/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
+++ b/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
@@ -1,6 +1,6 @@
 {
   "schema": "csdlc.pre_switch_evidence.v1",
-  "revision": "40a64d419e367f627599b9322c960b50203a8e98",
+  "revision": "5baf5822c6d25c49188919be23c65a5204539791",
   "default_before": "v1",
   "explicit_v2_selected": true,
   "rollback_to_v1_selected": true,
@@ -18,9 +18,9 @@
         "--bins"
       ],
       "exit_code": 0,
-      "elapsed_millis": 6977,
+      "elapsed_millis": 8061,
       "stdout_blake3": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
-      "stderr_blake3": "f1d2aeeba745279d32a421c57987f9958a28e143bd275ec96b3b910e267d355c",
+      "stderr_blake3": "c12ebf80c8f5248a14e0fda5b01d7b1bc2319f6b0fc51a37a9e512b21fe579cc",
       "passed": true
     },
     {
@@ -32,9 +32,9 @@
         "csdlc-v2/Cargo.toml"
       ],
       "exit_code": 0,
-      "elapsed_millis": 39198,
-      "stdout_blake3": "12f036570caeb61c2b49c95e55a05a15b62020e4720bdb8d10f4d70c722ef1fa",
-      "stderr_blake3": "51e823b3e61cfdafbedd6a872671643cb5e6d2d3c62166da9bc914dd51032a7a",
+      "elapsed_millis": 48459,
+      "stdout_blake3": "66ed54ceeb9fca02979d515ea5ae2b6ad1daa3b2ff8563717d3d20cec90b24f8",
+      "stderr_blake3": "e53289265533a220742fc94f9bd46105e2e488ac751429dd68674cff9e1ceb75",
       "passed": true
     },
     {
@@ -48,9 +48,9 @@
         "gate9"
       ],
       "exit_code": 0,
-      "elapsed_millis": 14596,
-      "stdout_blake3": "0c75f4f6a8acd261a5de1cfa0c20cdf3f29bbf9478eea2b77b1aca8d702b1728",
-      "stderr_blake3": "f76c757fe9b5c4d33ac216520bb9de0c136f9a714fc908e5a40caaddf391afa4",
+      "elapsed_millis": 19241,
+      "stdout_blake3": "4e2c326af435d90855c08e2e37205b36667d4eb7f02f68acc32976b9ffaa2d33",
+      "stderr_blake3": "200e51d935cf192b40e4ef5f23414ab9386b8fc59ffe71e200afeb09a75f0b41",
       "passed": true
     },
     {
@@ -66,9 +66,9 @@
         "warnings"
       ],
       "exit_code": 0,
-      "elapsed_millis": 756,
+      "elapsed_millis": 12261,
       "stdout_blake3": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
-      "stderr_blake3": "10d32abd1f901b810e67bfd4fdb99080bcf1d21fe40ab1a32f639d255d7bdf08",
+      "stderr_blake3": "b00b5641c37a6112a901d6cf4fbab6ca12c52544750162ade4529ef2d90e0d86",
       "passed": true
     },
     {
@@ -78,15 +78,15 @@
         "help"
       ],
       "exit_code": 0,
-      "elapsed_millis": 288,
+      "elapsed_millis": 281,
       "stdout_blake3": "18637a6984b5d124e03323656a95bc1cff7315dffcb001506ab13f4d0fdda023",
       "stderr_blake3": "68343c88633b18c2fd9dba13193bb61bcaa3812e895fbe438ffb8add87a7ae64",
       "passed": true
     }
   ],
   "measurements": {
-    "rust_loc": 11631,
-    "test_count": 85,
+    "rust_loc": 11681,
+    "test_count": 86,
     "debug_binary_bytes": [
       [
         "csdlc-bind",
@@ -118,7 +118,7 @@
       ],
       [
         "csdlc-proof",
-        4351616
+        4352896
       ],
       [
         "csdlc-publish",
@@ -149,8 +149,8 @@
         4910832
       ]
     ],
-    "construction_and_full_suite_millis": 39198,
-    "total_proof_millis": 61815,
+    "construction_and_full_suite_millis": 48459,
+    "total_proof_millis": 88303,
     "loc_is_reviewable_not_a_hard_cap": true
   },
   "passed": true

--- a/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
+++ b/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
@@ -1,0 +1,142 @@
+{
+  "schema": "csdlc.pre_switch_evidence.v1",
+  "revision": "c1a8457b35e4cea0fe3f8691ed087631fe99011c",
+  "default_before": "v1",
+  "explicit_v2_selected": true,
+  "rollback_to_v1_selected": true,
+  "default_after": "v1",
+  "v1_paths_before": true,
+  "v1_paths_after": true,
+  "steps": [
+    {
+      "id": "full_suite",
+      "executable": "cargo",
+      "args": [
+        "test",
+        "--manifest-path",
+        "csdlc-v2/Cargo.toml"
+      ],
+      "exit_code": 0,
+      "elapsed_millis": 33646,
+      "stdout_blake3": "86d1075d241e47fea91ac3f1ad8968ae60071b529a034ce66418934178c92c10",
+      "stderr_blake3": "8430624a95449237eca190bdb5426cc60c73c1048684c8a0a1c01a7a97f66b3a",
+      "passed": true
+    },
+    {
+      "id": "samples_parity",
+      "executable": "cargo",
+      "args": [
+        "test",
+        "--manifest-path",
+        "csdlc-v2/Cargo.toml",
+        "--test",
+        "gate9"
+      ],
+      "exit_code": 0,
+      "elapsed_millis": 12378,
+      "stdout_blake3": "487a9087b065d5e09fb5131550051988ef4a065872eb36f2664512fc5c5a02db",
+      "stderr_blake3": "f76c757fe9b5c4d33ac216520bb9de0c136f9a714fc908e5a40caaddf391afa4",
+      "passed": true
+    },
+    {
+      "id": "quality",
+      "executable": "cargo",
+      "args": [
+        "clippy",
+        "--manifest-path",
+        "csdlc-v2/Cargo.toml",
+        "--all-targets",
+        "--",
+        "-D",
+        "warnings"
+      ],
+      "exit_code": 0,
+      "elapsed_millis": 7442,
+      "stdout_blake3": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+      "stderr_blake3": "f1b79428d00a641f38aec4446c5d7468ad41da6523b9ada8bda1623a221cf9fc",
+      "passed": true
+    },
+    {
+      "id": "v1_smoke",
+      "executable": "adl/tools/pr.sh",
+      "args": [
+        "help"
+      ],
+      "exit_code": 0,
+      "elapsed_millis": 291,
+      "stdout_blake3": "18637a6984b5d124e03323656a95bc1cff7315dffcb001506ab13f4d0fdda023",
+      "stderr_blake3": "68343c88633b18c2fd9dba13193bb61bcaa3812e895fbe438ffb8add87a7ae64",
+      "passed": true
+    }
+  ],
+  "measurements": {
+    "rust_loc": 11557,
+    "test_count": 84,
+    "debug_binary_bytes": [
+      [
+        "csdlc-bind",
+        8002824
+      ],
+      [
+        "csdlc-closeout",
+        28015072
+      ],
+      [
+        "csdlc-doctor",
+        7487360
+      ],
+      [
+        "csdlc-edit",
+        10256584
+      ],
+      [
+        "csdlc-import",
+        8598416
+      ],
+      [
+        "csdlc-init",
+        8007560
+      ],
+      [
+        "csdlc-install",
+        4539312
+      ],
+      [
+        "csdlc-proof",
+        4305360
+      ],
+      [
+        "csdlc-publish",
+        28068112
+      ],
+      [
+        "csdlc-review",
+        8125312
+      ],
+      [
+        "csdlc-schedule",
+        3427072
+      ],
+      [
+        "csdlc-shadow",
+        9349104
+      ],
+      [
+        "csdlc-shepherd",
+        3423472
+      ],
+      [
+        "csdlc-soak",
+        6993176
+      ],
+      [
+        "csdlc-validate",
+        4910832
+      ]
+    ],
+    "construction_and_full_suite_millis": 33646,
+    "total_proof_millis": 53757,
+    "loc_is_reviewable_not_a_hard_cap": true
+  },
+  "passed": true
+}

--- a/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
+++ b/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json
@@ -1,6 +1,6 @@
 {
   "schema": "csdlc.pre_switch_evidence.v1",
-  "revision": "c1a8457b35e4cea0fe3f8691ed087631fe99011c",
+  "revision": "40a64d419e367f627599b9322c960b50203a8e98",
   "default_before": "v1",
   "explicit_v2_selected": true,
   "rollback_to_v1_selected": true,
@@ -8,6 +8,21 @@
   "v1_paths_before": true,
   "v1_paths_after": true,
   "steps": [
+    {
+      "id": "build_binaries",
+      "executable": "cargo",
+      "args": [
+        "build",
+        "--manifest-path",
+        "csdlc-v2/Cargo.toml",
+        "--bins"
+      ],
+      "exit_code": 0,
+      "elapsed_millis": 6977,
+      "stdout_blake3": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+      "stderr_blake3": "f1d2aeeba745279d32a421c57987f9958a28e143bd275ec96b3b910e267d355c",
+      "passed": true
+    },
     {
       "id": "full_suite",
       "executable": "cargo",
@@ -17,9 +32,9 @@
         "csdlc-v2/Cargo.toml"
       ],
       "exit_code": 0,
-      "elapsed_millis": 33646,
-      "stdout_blake3": "86d1075d241e47fea91ac3f1ad8968ae60071b529a034ce66418934178c92c10",
-      "stderr_blake3": "8430624a95449237eca190bdb5426cc60c73c1048684c8a0a1c01a7a97f66b3a",
+      "elapsed_millis": 39198,
+      "stdout_blake3": "12f036570caeb61c2b49c95e55a05a15b62020e4720bdb8d10f4d70c722ef1fa",
+      "stderr_blake3": "51e823b3e61cfdafbedd6a872671643cb5e6d2d3c62166da9bc914dd51032a7a",
       "passed": true
     },
     {
@@ -33,8 +48,8 @@
         "gate9"
       ],
       "exit_code": 0,
-      "elapsed_millis": 12378,
-      "stdout_blake3": "487a9087b065d5e09fb5131550051988ef4a065872eb36f2664512fc5c5a02db",
+      "elapsed_millis": 14596,
+      "stdout_blake3": "0c75f4f6a8acd261a5de1cfa0c20cdf3f29bbf9478eea2b77b1aca8d702b1728",
       "stderr_blake3": "f76c757fe9b5c4d33ac216520bb9de0c136f9a714fc908e5a40caaddf391afa4",
       "passed": true
     },
@@ -51,9 +66,9 @@
         "warnings"
       ],
       "exit_code": 0,
-      "elapsed_millis": 7442,
+      "elapsed_millis": 756,
       "stdout_blake3": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
-      "stderr_blake3": "f1b79428d00a641f38aec4446c5d7468ad41da6523b9ada8bda1623a221cf9fc",
+      "stderr_blake3": "10d32abd1f901b810e67bfd4fdb99080bcf1d21fe40ab1a32f639d255d7bdf08",
       "passed": true
     },
     {
@@ -63,19 +78,19 @@
         "help"
       ],
       "exit_code": 0,
-      "elapsed_millis": 291,
+      "elapsed_millis": 288,
       "stdout_blake3": "18637a6984b5d124e03323656a95bc1cff7315dffcb001506ab13f4d0fdda023",
       "stderr_blake3": "68343c88633b18c2fd9dba13193bb61bcaa3812e895fbe438ffb8add87a7ae64",
       "passed": true
     }
   ],
   "measurements": {
-    "rust_loc": 11557,
-    "test_count": 84,
+    "rust_loc": 11631,
+    "test_count": 85,
     "debug_binary_bytes": [
       [
         "csdlc-bind",
-        8002824
+        8002840
       ],
       [
         "csdlc-closeout",
@@ -83,11 +98,11 @@
       ],
       [
         "csdlc-doctor",
-        7487360
+        7487376
       ],
       [
         "csdlc-edit",
-        10256584
+        10256600
       ],
       [
         "csdlc-import",
@@ -95,7 +110,7 @@
       ],
       [
         "csdlc-init",
-        8007560
+        8007576
       ],
       [
         "csdlc-install",
@@ -103,7 +118,7 @@
       ],
       [
         "csdlc-proof",
-        4305360
+        4351616
       ],
       [
         "csdlc-publish",
@@ -127,15 +142,15 @@
       ],
       [
         "csdlc-soak",
-        6993176
+        6995016
       ],
       [
         "csdlc-validate",
         4910832
       ]
     ],
-    "construction_and_full_suite_millis": 33646,
-    "total_proof_millis": 53757,
+    "construction_and_full_suite_millis": 39198,
+    "total_proof_millis": 61815,
     "loc_is_reviewable_not_a_hard_cap": true
   },
   "passed": true

--- a/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_PROOF.mmd
+++ b/docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_PROOF.mmd
@@ -1,0 +1,15 @@
+flowchart TD
+  A["V1 default and v1 paths intact"] --> B["Explicit v2 opt-in selection"]
+  B --> C["Typed command manifest"]
+  C --> D["Full independent suite"]
+  C --> E["Samples and normalized parity"]
+  C --> F["Clippy quality proof"]
+  C --> G["V1 runnable smoke"]
+  D --> H["Exact revision evidence"]
+  E --> H
+  F --> H
+  G --> H
+  H --> I{"All green and v1 still default/intact?"}
+  I -->|"no / unknown"| X["Deny cutover and deletion"]
+  I -->|"yes"| R["Rollback selection resolves to v1"]
+  R --> P["Phase B pass"]


### PR DESCRIPTION
Closes #5293

## Outcome

- adds one small Rust `csdlc-proof` owner with a fixed typed five-step manifest
- reads and rechecks the exact Git-tracked v1-default selector
- refuses dirty trees before and after proof commands
- builds all 15 binaries before measuring them
- records atomic exact-code-revision evidence for full suite, three samples/parity, Clippy, v1 smoke, rollback selection, LoC/tests/binary sizes, and timing

## Evidence

- code revision: `5baf5822c6d25c49188919be23c65a5204539791`
- evidence: `passed=true`
- build binaries: pass
- full standalone suite: pass
- three samples and normalized parity: pass
- strict Clippy: pass
- v1 runnable smoke: pass
- v1 default and paths: true before/after
- measured tests: 86; measured binaries: 15
- LoC is explicitly reviewable, not a hard implementation cap

No default switch or v1 deletion/disablement occurs. Phase C #5294 remains blocked until this PR is green, merged, and closed out.
