### PR TITLE
[v0.91.7][tools][usage] Add shareable Codex usage guard automation wrapper

### DIFF
--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -120,6 +120,7 @@ adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility pac
 adl tooling codex-usage-watch parse --input <status.txt> [--json]\n\
 adl tooling codex-usage-watch parse --text \"Context: ...\" [--json]\n\
 adl tooling codex-usage-watch collect [--input <status-panel.txt> | --text \"Status...\"] [--json]\n\
+adl tooling codex-usage-watch guard [--input <status-panel.txt> | --text \"Status...\"] [--max-input-age-seconds <n>] [--conserve-context-percent <n>] [--conserve-limit-percent <n>] [--pause-limit-percent <n>] [--reset-ready-limit-percent <n>] [--json]\n\
 adl tooling codex-usage-watch watch --input <status.txt> [--interval-seconds <n>] [--iterations <n>] [--history-root <dir>] [--json]\n\
 adl tooling csdlc-prompt-editor [--repo-root <path>] [--emit-model-js <path>] [--render-samples <dir>]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\

--- a/adl/src/cli/tooling_cmd/codex_usage_watch.rs
+++ b/adl/src/cli/tooling_cmd/codex_usage_watch.rs
@@ -5,12 +5,16 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 const DEFAULT_INTERVAL_SECONDS: f64 = 60.0;
 const DEFAULT_ITERATIONS: u32 = 1;
 const DEFAULT_HISTORY_ROOT: &str = ".adl/runs/codex_usage_watch";
 const HISTORY_FILE: &str = "history.jsonl";
+const DEFAULT_GUARD_CONTEXT_CONSERVE_PERCENT: f64 = 20.0;
+const DEFAULT_GUARD_LIMIT_CONSERVE_PERCENT: f64 = 15.0;
+const DEFAULT_GUARD_LIMIT_PAUSE_PERCENT: f64 = 5.0;
+const DEFAULT_GUARD_LIMIT_RESET_READY_PERCENT: f64 = 1.0;
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -75,9 +79,69 @@ struct ParsedStatus {
     limit_7d: UsageDimension,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CodexUsageGuardAction {
+    Continue,
+    Conserve,
+    Pause,
+    ResetReady,
+    Unknown,
+}
+
+impl CodexUsageGuardAction {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Continue => "continue",
+            Self::Conserve => "conserve",
+            Self::Pause => "pause",
+            Self::ResetReady => "reset_ready",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct CodexUsageGuardPolicy {
+    pub conserve_context_percent: f64,
+    pub conserve_limit_percent: f64,
+    pub pause_limit_percent: f64,
+    pub reset_ready_limit_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_input_age_seconds: Option<u64>,
+}
+
+impl Default for CodexUsageGuardPolicy {
+    fn default() -> Self {
+        Self {
+            conserve_context_percent: DEFAULT_GUARD_CONTEXT_CONSERVE_PERCENT,
+            conserve_limit_percent: DEFAULT_GUARD_LIMIT_CONSERVE_PERCENT,
+            pause_limit_percent: DEFAULT_GUARD_LIMIT_PAUSE_PERCENT,
+            reset_ready_limit_percent: DEFAULT_GUARD_LIMIT_RESET_READY_PERCENT,
+            max_input_age_seconds: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct CodexUsageGuardDecision {
+    pub schema_version: String,
+    pub action: CodexUsageGuardAction,
+    pub mode: CodexUsageMode,
+    pub sampled_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    pub policy: CodexUsageGuardPolicy,
+    pub usage: CodexUsageReport,
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 enum CommandMode {
     Parse,
     Collect,
+    Guard,
     Watch,
 }
 
@@ -89,6 +153,7 @@ struct CommandArgs {
     interval_seconds: f64,
     iterations: u32,
     history_root: PathBuf,
+    guard_policy: CodexUsageGuardPolicy,
 }
 
 pub(crate) fn real_codex_usage_watch(args: &[String]) -> Result<()> {
@@ -113,6 +178,11 @@ pub(crate) fn real_codex_usage_watch(args: &[String]) -> Result<()> {
             print_report(&report, args.json_output)?;
             ensure_report_ready(&report)?;
         }
+        CommandMode::Guard => {
+            let decision = guard_decision(&args)?;
+            print_guard_decision(&decision, args.json_output)?;
+            ensure_guard_decision_ready(&decision)?;
+        }
         CommandMode::Watch => {
             run_watch(&args)?;
         }
@@ -130,6 +200,47 @@ pub(crate) fn run_collect_status_text(text: &str) -> CodexUsageReport {
     report_from_collected_source(Some(text), None)
 }
 
+#[cfg(test)]
+pub(crate) fn run_guard_status_text(text: &str) -> Result<CodexUsageGuardDecision> {
+    run_guard_status_text_with_policy(text, CodexUsageGuardPolicy::default())
+}
+
+#[cfg(test)]
+pub(crate) fn run_guard_status_text_with_policy(
+    text: &str,
+    guard_policy: CodexUsageGuardPolicy,
+) -> Result<CodexUsageGuardDecision> {
+    let args = CommandArgs {
+        mode: CommandMode::Guard,
+        input: None,
+        text: Some(text.to_string()),
+        json_output: true,
+        interval_seconds: DEFAULT_INTERVAL_SECONDS,
+        iterations: DEFAULT_ITERATIONS,
+        history_root: PathBuf::from(DEFAULT_HISTORY_ROOT),
+        guard_policy,
+    };
+    guard_decision(&args)
+}
+
+#[cfg(test)]
+pub(crate) fn run_guard_status_input_with_policy(
+    input: PathBuf,
+    guard_policy: CodexUsageGuardPolicy,
+) -> Result<CodexUsageGuardDecision> {
+    let args = CommandArgs {
+        mode: CommandMode::Guard,
+        input: Some(input),
+        text: None,
+        json_output: true,
+        interval_seconds: DEFAULT_INTERVAL_SECONDS,
+        iterations: DEFAULT_ITERATIONS,
+        history_root: PathBuf::from(DEFAULT_HISTORY_ROOT),
+        guard_policy,
+    };
+    guard_decision(&args)
+}
+
 fn parse_args(args: &[String]) -> Result<CommandArgs> {
     let Some(mode) = args.first().map(|arg| arg.as_str()) else {
         bail!("{}", usage());
@@ -137,6 +248,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
     let mode = match mode {
         "parse" => CommandMode::Parse,
         "collect" => CommandMode::Collect,
+        "guard" => CommandMode::Guard,
         "watch" => CommandMode::Watch,
         "--help" | "-h" | "help" => {
             println!("{}", usage());
@@ -151,6 +263,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
     let mut interval_seconds = DEFAULT_INTERVAL_SECONDS;
     let mut iterations = DEFAULT_ITERATIONS;
     let mut history_root = PathBuf::from(DEFAULT_HISTORY_ROOT);
+    let mut guard_policy = CodexUsageGuardPolicy::default();
 
     let mut i = 1usize;
     while i < args.len() {
@@ -179,6 +292,30 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
             "--history-root" => {
                 history_root = PathBuf::from(require_value(args, &mut i, "--history-root")?)
             }
+            "--conserve-context-percent" => {
+                guard_policy.conserve_context_percent =
+                    parse_percent_flag(args, &mut i, "--conserve-context-percent")?
+            }
+            "--conserve-limit-percent" => {
+                guard_policy.conserve_limit_percent =
+                    parse_percent_flag(args, &mut i, "--conserve-limit-percent")?
+            }
+            "--pause-limit-percent" => {
+                guard_policy.pause_limit_percent =
+                    parse_percent_flag(args, &mut i, "--pause-limit-percent")?
+            }
+            "--reset-ready-limit-percent" => {
+                guard_policy.reset_ready_limit_percent =
+                    parse_percent_flag(args, &mut i, "--reset-ready-limit-percent")?
+            }
+            "--max-input-age-seconds" => {
+                let value = require_value(args, &mut i, "--max-input-age-seconds")?;
+                guard_policy.max_input_age_seconds = Some(
+                    value
+                        .parse::<u64>()
+                        .with_context(|| format!("invalid --max-input-age-seconds '{value}'"))?,
+                );
+            }
             "--help" | "-h" => {
                 println!("{}", usage());
                 return Err(anyhow!("help requested"));
@@ -187,6 +324,8 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
         }
         i += 1;
     }
+
+    validate_guard_policy(&guard_policy)?;
 
     if input.is_some() && text.is_some() {
         bail!("pass only one of --input or --text");
@@ -199,6 +338,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
             }
         }
         CommandMode::Collect => {}
+        CommandMode::Guard => {}
         CommandMode::Watch => {
             if input.is_none() {
                 bail!("codex-usage-watch watch requires --input <path>");
@@ -214,6 +354,7 @@ fn parse_args(args: &[String]) -> Result<CommandArgs> {
         interval_seconds,
         iterations,
         history_root,
+        guard_policy,
     })
 }
 
@@ -221,6 +362,7 @@ fn usage() -> &'static str {
     "adl tooling codex-usage-watch parse --input <status.txt> [--json]\n\
 adl tooling codex-usage-watch parse --text \"Context: ...\" [--json]\n\
 adl tooling codex-usage-watch collect [--input <status-panel.txt> | --text \"Status...\"] [--json]\n\
+adl tooling codex-usage-watch guard [--input <status-panel.txt> | --text \"Status...\"] [--max-input-age-seconds <n>] [--conserve-context-percent <n>] [--conserve-limit-percent <n>] [--pause-limit-percent <n>] [--reset-ready-limit-percent <n>] [--json]\n\
 adl tooling codex-usage-watch watch --input <status.txt> [--interval-seconds <n>] [--iterations <n>] [--history-root <dir>] [--json]"
 }
 
@@ -230,6 +372,27 @@ fn require_value(args: &[String], i: &mut usize, flag: &str) -> Result<String> {
         .filter(|value| !value.trim().is_empty())
         .cloned()
         .ok_or_else(|| anyhow!("{flag} requires a non-empty value"))
+}
+
+fn parse_percent_flag(args: &[String], i: &mut usize, flag: &str) -> Result<f64> {
+    let value = require_value(args, i, flag)?;
+    let parsed = value
+        .parse::<f64>()
+        .with_context(|| format!("invalid {flag} '{value}'"))?;
+    if !(0.0..=100.0).contains(&parsed) {
+        bail!("{flag} must be between 0 and 100");
+    }
+    Ok(parsed)
+}
+
+fn validate_guard_policy(policy: &CodexUsageGuardPolicy) -> Result<()> {
+    if policy.reset_ready_limit_percent > policy.pause_limit_percent {
+        bail!("--reset-ready-limit-percent must be <= --pause-limit-percent");
+    }
+    if policy.pause_limit_percent > policy.conserve_limit_percent {
+        bail!("--pause-limit-percent must be <= --conserve-limit-percent");
+    }
+    Ok(())
 }
 
 fn run_watch(args: &CommandArgs) -> Result<()> {
@@ -252,6 +415,149 @@ fn run_watch(args: &CommandArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn guard_decision(args: &CommandArgs) -> Result<CodexUsageGuardDecision> {
+    if let Some(stale_error) = stale_input_error(args)? {
+        let sampled_at = Utc::now().to_rfc3339();
+        let source_ref = args.input.as_deref().map(repo_relative_or_filename);
+        let usage = unknown_report(sampled_at, source_ref, stale_error);
+        return Ok(decision_from_report(usage, &args.guard_policy));
+    }
+
+    let source = load_status_text(args)?;
+    let usage = report_from_collected_source(source.as_deref(), args.input.as_deref());
+    Ok(decision_from_report(usage, &args.guard_policy))
+}
+
+fn stale_input_error(args: &CommandArgs) -> Result<Option<String>> {
+    let Some(max_age_seconds) = args.guard_policy.max_input_age_seconds else {
+        return Ok(None);
+    };
+    let Some(input) = args.input.as_ref() else {
+        return Ok(None);
+    };
+    let metadata = match fs::metadata(input) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(anyhow!(
+                "failed to stat status input '{}': {err}",
+                input.display()
+            ));
+        }
+    };
+    let modified = metadata
+        .modified()
+        .with_context(|| format!("failed to read modification time for '{}'", input.display()))?;
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_else(|_| Duration::from_secs(0));
+    if age.as_secs() > max_age_seconds {
+        return Ok(Some(format!(
+            "status input stale: age={}s exceeds max_input_age_seconds={}s",
+            age.as_secs(),
+            max_age_seconds
+        )));
+    }
+    Ok(None)
+}
+
+fn decision_from_report(
+    usage: CodexUsageReport,
+    policy: &CodexUsageGuardPolicy,
+) -> CodexUsageGuardDecision {
+    let action = classify_guard_action(&usage, policy);
+    let mut warnings = usage.warnings.clone();
+    match action {
+        CodexUsageGuardAction::Continue => {}
+        CodexUsageGuardAction::Conserve => warnings.push(
+            "guard_conserve: avoid broad validation, long reviews, and speculative work"
+                .to_string(),
+        ),
+        CodexUsageGuardAction::Pause => warnings.push(
+            "guard_pause: pause expensive work until fresh capacity is available".to_string(),
+        ),
+        CodexUsageGuardAction::ResetReady => warnings.push(
+            "guard_reset_ready: capacity is critically low; prepare manual reset or handoff"
+                .to_string(),
+        ),
+        CodexUsageGuardAction::Unknown => warnings.push(
+            "guard_unknown: usage state unavailable; fail closed and ask for /status".to_string(),
+        ),
+    }
+
+    CodexUsageGuardDecision {
+        schema_version: "adl.codex_usage_guard.v1".to_string(),
+        action,
+        mode: usage.mode.clone(),
+        sampled_at: usage.sampled_at.clone(),
+        source_ref: usage.source_ref.clone(),
+        policy: policy.clone(),
+        error: usage.error.clone(),
+        usage,
+        warnings,
+    }
+}
+
+fn classify_guard_action(
+    usage: &CodexUsageReport,
+    policy: &CodexUsageGuardPolicy,
+) -> CodexUsageGuardAction {
+    if !usage.parse_ok {
+        return CodexUsageGuardAction::Unknown;
+    }
+    let Some(context) = usage.context.as_ref() else {
+        return CodexUsageGuardAction::Unknown;
+    };
+    let Some(limit_5h) = usage.limit_5h.as_ref() else {
+        return CodexUsageGuardAction::Unknown;
+    };
+    let Some(limit_7d) = usage.limit_7d.as_ref() else {
+        return CodexUsageGuardAction::Unknown;
+    };
+
+    let min_limit = limit_5h.percent_left.min(limit_7d.percent_left);
+    if min_limit <= policy.reset_ready_limit_percent {
+        CodexUsageGuardAction::ResetReady
+    } else if min_limit <= policy.pause_limit_percent {
+        CodexUsageGuardAction::Pause
+    } else if min_limit <= policy.conserve_limit_percent
+        || context.percent_left <= policy.conserve_context_percent
+    {
+        CodexUsageGuardAction::Conserve
+    } else {
+        CodexUsageGuardAction::Continue
+    }
+}
+
+fn print_guard_decision(decision: &CodexUsageGuardDecision, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(decision)?);
+        return Ok(());
+    }
+    println!("action: {}", decision.action.as_str());
+    println!("mode: {}", decision.mode.as_str());
+    for warning in &decision.warnings {
+        eprintln!("{warning}");
+    }
+    if let Some(error) = decision.error.as_ref() {
+        println!("error: {error}");
+    }
+    Ok(())
+}
+
+fn ensure_guard_decision_ready(decision: &CodexUsageGuardDecision) -> Result<()> {
+    if decision.action != CodexUsageGuardAction::Unknown {
+        return Ok(());
+    }
+    bail!(
+        "{}",
+        decision
+            .error
+            .as_deref()
+            .unwrap_or("codex usage guard could not determine usage state")
+    )
 }
 
 fn load_status_text(args: &CommandArgs) -> Result<Option<String>> {

--- a/adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs
+++ b/adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs
@@ -1,7 +1,9 @@
 use super::support::*;
 use super::*;
 use crate::cli::tooling_cmd::codex_usage_watch::{
-    run_collect_status_text, run_parse_status_text, CodexUsageMode,
+    run_collect_status_text, run_guard_status_input_with_policy, run_guard_status_text,
+    run_guard_status_text_with_policy, run_parse_status_text, CodexUsageGuardAction,
+    CodexUsageGuardPolicy, CodexUsageMode,
 };
 use serde_json::json;
 use serde_json::Value;
@@ -138,6 +140,121 @@ fn codex_usage_watch_collect_fails_closed_without_live_input_or_required_limits(
     assert!(missing_5h_err
         .to_string()
         .contains("missing '5h limit:' line"));
+}
+
+#[test]
+fn codex_usage_watch_guard_emits_shareable_policy_decisions() {
+    real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "guard".to_string(),
+        "--text".to_string(),
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 93% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n"
+            .to_string(),
+        "--json".to_string(),
+    ])
+    .expect("guard --text dispatch should succeed for copied status panel");
+
+    let normal = run_guard_status_text(
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 93% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n",
+    )
+    .expect("normal guard decision");
+    assert_eq!(normal.schema_version, "adl.codex_usage_guard.v1");
+    assert_eq!(normal.action, CodexUsageGuardAction::Continue);
+    assert_eq!(normal.mode, CodexUsageMode::Normal);
+    assert!(normal.usage.parse_ok);
+
+    let pause = run_guard_status_text(
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 4% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n",
+    )
+    .expect("pause guard decision");
+    assert_eq!(pause.action, CodexUsageGuardAction::Pause);
+    assert_eq!(pause.mode, CodexUsageMode::Emergency);
+
+    let reset_ready = run_guard_status_text(
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 0.9% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n",
+    )
+    .expect("reset-ready guard decision");
+    assert_eq!(reset_ready.action, CodexUsageGuardAction::ResetReady);
+}
+
+#[test]
+fn codex_usage_watch_guard_supports_custom_thresholds_and_fails_closed() {
+    real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "guard".to_string(),
+        "--text".to_string(),
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 25% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n"
+            .to_string(),
+        "--conserve-limit-percent".to_string(),
+        "30".to_string(),
+        "--pause-limit-percent".to_string(),
+        "10".to_string(),
+        "--reset-ready-limit-percent".to_string(),
+        "2".to_string(),
+        "--json".to_string(),
+    ])
+    .expect("custom guard policy should accept ordered thresholds");
+    let conserve = run_guard_status_text_with_policy(
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 25% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n",
+        CodexUsageGuardPolicy {
+            conserve_limit_percent: 30.0,
+            pause_limit_percent: 10.0,
+            reset_ready_limit_percent: 2.0,
+            ..CodexUsageGuardPolicy::default()
+        },
+    )
+    .expect("custom guard policy should classify the copied status");
+    assert_eq!(conserve.action, CodexUsageGuardAction::Conserve);
+
+    let missing_err = real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "guard".to_string(),
+        "--json".to_string(),
+    ])
+    .expect_err("guard without status text should fail closed");
+    assert!(missing_err
+        .to_string()
+        .contains("Codex status collection input missing"));
+}
+
+#[test]
+fn codex_usage_watch_guard_fails_closed_for_stale_file_input() {
+    let repo = TempRepo::new("codex-usage-guard-stale");
+    let status = repo.write_rel(
+        ".tmp/tooling_cmd_tests/status.txt",
+        "Status\nContext: 58% left (109,629 used / 258K)\n5h limit: 93% left (resets 9:45 AM)\n7d limit: 99% left (resets Jul 19)\n",
+    );
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    let err = real_tooling(&[
+        "codex-usage-watch".to_string(),
+        "guard".to_string(),
+        "--input".to_string(),
+        status.to_string_lossy().to_string(),
+        "--max-input-age-seconds".to_string(),
+        "0".to_string(),
+        "--json".to_string(),
+    ])
+    .expect_err("stale input should fail closed");
+    assert!(err.to_string().contains("status input stale"));
+
+    let decision = run_guard_status_input_with_policy(
+        status,
+        CodexUsageGuardPolicy {
+            max_input_age_seconds: Some(0),
+            ..CodexUsageGuardPolicy::default()
+        },
+    )
+    .expect("stale input still returns the machine-readable decision");
+    assert_eq!(decision.schema_version, "adl.codex_usage_guard.v1");
+    assert_eq!(decision.action, CodexUsageGuardAction::Unknown);
+    assert_eq!(decision.mode, CodexUsageMode::UsageUnknown);
+    assert!(!decision.usage.parse_ok);
+    assert!(decision
+        .error
+        .as_deref()
+        .expect("stale decision should include error")
+        .contains("status input stale"));
 }
 
 #[test]

--- a/docs/tooling/CODEX_USAGE_WATCHER.md
+++ b/docs/tooling/CODEX_USAGE_WATCHER.md
@@ -16,6 +16,7 @@ Session: 019f3d65-2216-7832-804a-26339473b27d
 Context: 58% left (109,629 used / 258K)
 5h limit: 93% left (resets 9:45 AM)
 7d limit: 99% left (resets Jul 19)" --json
+adl tooling codex-usage-watch guard --input /tmp/codex-status.txt --max-input-age-seconds 300 --json
 adl tooling codex-usage-watch watch --input /tmp/status.txt --interval-seconds 60 --iterations 10 --json
 ```
 
@@ -44,6 +45,42 @@ Context: 58% left (109,629 used / 258K)
 ```
 
 If no input is provided, or a required limit is missing, `collect` emits `usage_unknown` and exits nonzero. This is intentional: the command fails closed rather than pretending it can read live account state by itself.
+
+## Usage Guard
+
+`guard` is the shareable local automation wrapper. It accepts the same copied or externally supplied Codex app `/status` panel text as `collect`, then emits a machine-readable decision:
+
+- `continue`: enough capacity for ordinary work
+- `conserve`: avoid broad validation, long reviews, and speculative work
+- `pause`: stop expensive work until fresh capacity is available
+- `reset_ready`: capacity is critically low; prepare manual reset or handoff
+- `unknown`: input missing, malformed, or stale; fail closed and ask for fresh `/status`
+
+Default policy:
+
+```text
+conserve_context_percent: 20
+conserve_limit_percent: 15
+pause_limit_percent: 5
+reset_ready_limit_percent: 1
+```
+
+Override thresholds when a team wants a different policy:
+
+```bash
+adl tooling codex-usage-watch guard \
+  --input /tmp/codex-status.txt \
+  --max-input-age-seconds 300 \
+  --conserve-context-percent 25 \
+  --conserve-limit-percent 20 \
+  --pause-limit-percent 8 \
+  --reset-ready-limit-percent 2 \
+  --json
+```
+
+`--max-input-age-seconds` applies to file input. If the file is older than the configured age, `guard` emits `unknown` and exits nonzero. This lets a scheduler or reminder fail closed instead of treating stale usage as safe.
+
+For a manual cadence, copy `/status` into a local ignored file before running `guard`. For a scheduled cadence, use an approved outer layer to refresh that file, then run `guard` against it. The outer layer might be a reminder, a local UI-control integration, or a user-owned script that writes copied status text. It must not be represented as live Codex account polling unless that data path is actually implemented and approved.
 
 ## Modes
 
@@ -79,4 +116,5 @@ Even when a sample is malformed, the watcher records the `usage_unknown` row bef
 - No built-in OCR
 - No built-in Codex app UI control
 - No live account polling or private account API usage
+- No built-in scheduler; use `guard` from an external reminder, cron/launchd job, or approved automation wrapper that supplies fresh `/status` text
 - No secret material should appear in input or output


### PR DESCRIPTION
Closes #5296

## Summary
Implemented a shareable `adl tooling codex-usage-watch guard` command for copied Codex status-panel text, with JSON decisions for `continue`, `conserve`, `pause`, `reset_ready`, and fail-closed `unknown` states. Added focused parser/guard tests, dispatch coverage, documentation for automation boundaries, and incorporated pre-PR review fixes before publication.

## Artifacts
- Tracked implementation artifacts in the issue worktree:
  - `adl/src/cli/tooling_cmd.rs`
  - `adl/src/cli/tooling_cmd/codex_usage_watch.rs`
  - `adl/src/cli/tooling_cmd/tests/codex_usage_watch.rs`
  - `docs/tooling/CODEX_USAGE_WATCHER.md`
- Local issue lifecycle artifacts:
  - `.adl/v0.91.7/tasks/issue-5296__v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper/execution-facts.yaml`
  - `.adl/v0.91.7/tasks/issue-5296__v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper/srp.md`
  - `.adl/v0.91.7/tasks/issue-5296__v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper/sor.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check` - verified the current #5296 diff has no whitespace errors
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` - verified Rust formatting for the workspace after the guard implementation
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo test --manifest-path adl/Cargo.toml --bin adl codex_usage_watch` - proved codex-usage-watch parse, collect, watch, and new guard behavior including stale-input fail-closed handling
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo test --manifest-path adl/Cargo.toml --bin adl tooling_dispatch` - proved public tooling dispatch remains covered after adding the guard subcommand help/dispatch surface
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo run --manifest-path adl/Cargo.toml --bin adl -- tooling codex-usage-watch guard --text <copied-status-panel> --json` - smoke-tested the shareable guard CLI and verified it emits adl.codex_usage_guard.v1 JSON with action continue for healthy copied status input
- Results:
  - `git diff --check`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`: PASS
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo test --manifest-path adl/Cargo.toml --bin adl codex_usage_watch`: PASS
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo test --manifest-path adl/Cargo.toml --bin adl tooling_dispatch`: PASS
  - `CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/cargo-targets/issue-5296 CARGO_INCREMENTAL=0 cargo run --manifest-path adl/Cargo.toml --bin adl -- tooling codex-usage-watch guard --text <copied-status-panel> --json`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5296__v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5296__v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper/sor.md
- Idempotency-Key: v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper-adl-src-cli-tooling-cmd-rs-adl-src-cli-tooling-cmd-codex-usage-watch-rs-adl-src-cli-tooling-cmd-tests-codex-usage-watch-rs-docs-tooling-codex-usage-watcher-md-adl-v0-91-7-tasks-issue-5296-v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper-sip-md-adl-v0-91-7-tasks-issue-5296-v0-91-7-tools-usage-add-shareable-codex-usage-guard-automation-wrapper-sor-md