### PR TITLE
[v0.91.7][csdlc-v2] Gate 10D1: non-mutating deletion eligibility and manifest

### DIFF
--- a/csdlc-v2/Cargo.lock
+++ b/csdlc-v2/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "tempfile",
  "thiserror",

--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -74,6 +74,10 @@ path = "src/bin/csdlc-proof.rs"
 name = "csdlc-cutover"
 path = "src/bin/csdlc-cutover.rs"
 
+[[bin]]
+name = "csdlc-eligibility"
+path = "src/bin/csdlc-eligibility.rs"
+
 [dependencies]
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/csdlc-v2/Cargo.toml
+++ b/csdlc-v2/Cargo.toml
@@ -86,6 +86,7 @@ markdown = "1.0.0"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -47,6 +47,12 @@ coexistence inventory. Gate 10A left v1 as the default; the tracked generation
 selector remains the current authority, and later cutover never deletes or
 disables any v1 surface.
 
+Gate 10D1 adds `csdlc-eligibility`, a non-mutating decision and proposed-
+manifest binary. It binds operator approval to exact Phase C and manifest
+digests, enforces the reviewed 90/80-percent thresholds and protected windows,
+and always records `deletion_executed: false`. Actual removal belongs to a
+separate approval-gated issue.
+
 Markdown files are generated projections. The engine renders deterministic
 Markdown from typed values, parses it with `markdown.rs`, validates semantic
 anchors, and records values/rendered/AST digests. Direct Markdown edits fail

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -48,10 +48,12 @@ selector remains the current authority, and later cutover never deletes or
 disables any v1 surface.
 
 Gate 10D1 adds `csdlc-eligibility`, a non-mutating decision and proposed-
-manifest binary. It binds operator approval to exact Phase C and manifest
-digests, enforces the reviewed 90/80-percent thresholds and protected windows,
-and always records `deletion_executed: false`. Actual removal belongs to a
-separate approval-gated issue.
+manifest binary. It derives the exact Gate 1 inventory from its pinned Git
+revision, binds operator approval to Phase B, Phase C, selector, manifest, and
+code-revision digests, enforces the reviewed 90/80-percent thresholds and both
+mandatory sunset windows, and always reports `deletion_executed: false` on
+stdout. Its `schema` subcommand publishes the versioned JSON contracts. Actual
+removal belongs to a separate approval-gated issue.
 
 Markdown files are generated projections. The engine renders deterministic
 Markdown from typed values, parses it with `markdown.rs`, validates semantic

--- a/csdlc-v2/operator/SKILLS.md
+++ b/csdlc-v2/operator/SKILLS.md
@@ -3,3 +3,7 @@
 The nine skills in `skills.json` are thin typed routes. Skills select a binary/subcommand, collect typed input, and display typed output. They never edit Markdown, mutate canonical state directly, invoke shell/Python lifecycle logic, or infer success from prose.
 
 The tracked `generation-selector.json` is the sole default authority. After reviewed Gate 10C cutover it may select v2, while explicit v1 override, installation, and recovery remain mandatory. Install only into `.adl/bin/csdlc-v2/`, never shared `.adl/bin/`. `csdlc-install verify` fails unless the v1 coexistence inventory and regular executable v2 binary set are complete.
+
+The read-only doctor route also installs `csdlc-eligibility` as an auxiliary
+operator binary. It may write only its requested decision output; it has no
+authority to mutate candidate v1 paths or execute an eligible manifest.

--- a/csdlc-v2/operator/eligibility-request.json
+++ b/csdlc-v2/operator/eligibility-request.json
@@ -6,19 +6,13 @@
   "selector": "csdlc-v2/operator/generation-selector.json",
   "manifest": {
     "schema": "csdlc.proposed_deletion_manifest.v1",
-    "baseline_lines": 49979,
+    "baseline_revision": "020bba17deb9f172e91a2ec5c0599cf42e4defe9",
     "target_percent": 90,
     "minimum_percent": 80,
-    "entries": [
-      {
-        "path": "incumbent-v1-control-plane",
-        "disposition": "retain",
-        "measured_lines": 49979,
-        "owner": "gate-10d-planning",
-        "justification": "No deletion manifest or operator approval exists yet.",
-        "protected_until": null
-      }
-    ]
+    "default_disposition": "retain",
+    "default_owner": "gate-10d-planning",
+    "default_justification": "No deletion manifest or operator approval exists yet.",
+    "entries": []
   },
   "approval": null
 }

--- a/csdlc-v2/operator/eligibility-request.json
+++ b/csdlc-v2/operator/eligibility-request.json
@@ -1,0 +1,24 @@
+{
+  "schema": "csdlc.deletion_eligibility_request.v1",
+  "issue": 5305,
+  "phase_b_evidence": "docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json",
+  "phase_c_evidence": "docs/architecture/csdlc-v2/gate10c/CUTOVER_EVIDENCE.json",
+  "selector": "csdlc-v2/operator/generation-selector.json",
+  "manifest": {
+    "schema": "csdlc.proposed_deletion_manifest.v1",
+    "baseline_lines": 49979,
+    "target_percent": 90,
+    "minimum_percent": 80,
+    "entries": [
+      {
+        "path": "incumbent-v1-control-plane",
+        "disposition": "retain",
+        "measured_lines": 49979,
+        "owner": "gate-10d-planning",
+        "justification": "No deletion manifest or operator approval exists yet.",
+        "protected_until": null
+      }
+    ]
+  },
+  "approval": null
+}

--- a/csdlc-v2/operator/skills.json
+++ b/csdlc-v2/operator/skills.json
@@ -7,4 +7,4 @@
 {"name":"csdlc-v2-publish","binary":"csdlc-publish","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
 {"name":"csdlc-v2-shepherd","binary":"csdlc-shepherd","subcommand":null,"mutates_state":false,"auxiliary_binaries":[]},
 {"name":"csdlc-v2-closeout","binary":"csdlc-closeout","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
-{"name":"csdlc-v2-doctor","binary":"csdlc-doctor","subcommand":null,"mutates_state":false,"auxiliary_binaries":[]}]}
+{"name":"csdlc-v2-doctor","binary":"csdlc-doctor","subcommand":null,"mutates_state":false,"auxiliary_binaries":["csdlc-eligibility"]}]}

--- a/csdlc-v2/src/bin/csdlc-eligibility.rs
+++ b/csdlc-v2/src/bin/csdlc-eligibility.rs
@@ -1,0 +1,36 @@
+use std::fs;
+use std::path::PathBuf;
+
+use clap::Parser;
+use csdlc_v2::{evaluate_deletion_eligibility, DeletionEligibilityRequest};
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    repo: PathBuf,
+    #[arg(long)]
+    request: PathBuf,
+    #[arg(long)]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+    let result = fs::read(&args.request)
+        .map_err(Into::into)
+        .and_then(|bytes| {
+            serde_json::from_slice::<DeletionEligibilityRequest>(&bytes).map_err(Into::into)
+        })
+        .and_then(|request| evaluate_deletion_eligibility(&args.repo, &request))
+        .and_then(|decision| {
+            csdlc_v2::eligibility::write_decision_atomic(&args.output, &decision)?;
+            Ok(decision)
+        });
+    match result {
+        Ok(value) => println!("{}", serde_json::to_string_pretty(&value).expect("JSON")),
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(error.code.exit_code());
+        }
+    }
+}

--- a/csdlc-v2/src/bin/csdlc-eligibility.rs
+++ b/csdlc-v2/src/bin/csdlc-eligibility.rs
@@ -1,31 +1,46 @@
 use std::fs;
 use std::path::PathBuf;
 
-use clap::Parser;
-use csdlc_v2::{evaluate_deletion_eligibility, DeletionEligibilityRequest};
+use clap::{Parser, Subcommand};
+use csdlc_v2::{
+    eligibility_schema_bundle, evaluate_deletion_eligibility, DeletionEligibilityRequest,
+};
 
 #[derive(Parser)]
 struct Args {
-    #[arg(long)]
-    repo: PathBuf,
-    #[arg(long)]
-    request: PathBuf,
-    #[arg(long)]
-    output: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Evaluate {
+        #[arg(long)]
+        repo: PathBuf,
+        #[arg(long)]
+        request: PathBuf,
+    },
+    Schema,
 }
 
 fn main() {
     let args = Args::parse();
-    let result = fs::read(&args.request)
+    if matches!(args.command, Command::Schema) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&eligibility_schema_bundle()).expect("JSON")
+        );
+        return;
+    }
+    let Command::Evaluate { repo, request } = args.command else {
+        unreachable!()
+    };
+    let result = fs::read(&request)
         .map_err(Into::into)
         .and_then(|bytes| {
             serde_json::from_slice::<DeletionEligibilityRequest>(&bytes).map_err(Into::into)
         })
-        .and_then(|request| evaluate_deletion_eligibility(&args.repo, &request))
-        .and_then(|decision| {
-            csdlc_v2::eligibility::write_decision_atomic(&args.output, &decision)?;
-            Ok(decision)
-        });
+        .and_then(|request| evaluate_deletion_eligibility(&repo, &request));
     match result {
         Ok(value) => println!("{}", serde_json::to_string_pretty(&value).expect("JSON")),
         Err(error) => {

--- a/csdlc-v2/src/eligibility.rs
+++ b/csdlc-v2/src/eligibility.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use time::OffsetDateTime;
 
@@ -12,6 +13,12 @@ use crate::cutover::CutoverEvidence;
 use crate::error::{ErrorCode, Result, V2Error};
 use crate::proof::{require_clean_revision, PreSwitchEvidence};
 use crate::{Generation, GenerationSelector};
+
+const BASELINE_REVISION: &str = "020bba17deb9f172e91a2ec5c0599cf42e4defe9";
+const BASELINE_LINES: u64 = 49_979;
+const BASELINE_FILES: usize = 95;
+const RUST_LIST_BLAKE3: &str = "c3118c1f3766b5f4a3e549c9073b33fb83164b3006175785b4c08f84c898558f";
+const SHELL_LIST_BLAKE3: &str = "7160399a788e467ebd934309a99f9777fb0f14d4270989e5114c73b63fa3d8cc";
 
 #[derive(
     Debug,
@@ -59,6 +66,8 @@ pub enum DeletionReason {
     ApprovalEvidenceMismatch,
     PhaseEvidenceNotGreen,
     SelectorNotV2,
+    RollbackWindowActive,
+    ImporterWindowActive,
     ProtectedWindowActive,
     BelowMinimumRemoval,
     QualificationNotApproved,
@@ -69,7 +78,6 @@ pub enum DeletionReason {
 pub struct DeletionEntry {
     pub path: PathBuf,
     pub disposition: EntryDisposition,
-    pub measured_lines: u64,
     pub owner: Option<String>,
     pub justification: Option<String>,
     pub protected_until: Option<String>,
@@ -79,9 +87,12 @@ pub struct DeletionEntry {
 #[serde(deny_unknown_fields)]
 pub struct DeletionManifest {
     pub schema: String,
-    pub baseline_lines: u64,
+    pub baseline_revision: String,
     pub target_percent: u16,
     pub minimum_percent: u16,
+    pub default_disposition: EntryDisposition,
+    pub default_owner: Option<String>,
+    pub default_justification: Option<String>,
     pub entries: Vec<DeletionEntry>,
 }
 
@@ -91,8 +102,11 @@ pub struct DeletionApproval {
     pub schema: String,
     pub approved_by: String,
     pub approved_at: String,
+    pub phase_b_blake3: String,
     pub phase_c_blake3: String,
+    pub selector_blake3: String,
     pub manifest_blake3: String,
+    pub code_revision: String,
     pub allow_qualified_80_to_89: bool,
 }
 
@@ -114,6 +128,11 @@ pub struct DeletionDecision {
     pub issue: u64,
     pub code_revision: String,
     pub evaluated_at: String,
+    pub baseline_revision: String,
+    pub baseline_files: usize,
+    pub baseline_lines: u64,
+    pub rust_list_blake3: String,
+    pub shell_list_blake3: String,
     pub phase_b_blake3: String,
     pub phase_c_blake3: String,
     pub selector_blake3: String,
@@ -127,20 +146,40 @@ pub struct DeletionDecision {
     pub deletion_executed: bool,
 }
 
+#[derive(Debug, Clone)]
+struct Baseline {
+    lines: BTreeMap<PathBuf, u64>,
+    rust_hash: String,
+    shell_hash: String,
+}
+
+pub fn eligibility_schema_bundle() -> Value {
+    json!({
+        "schema": "csdlc.deletion_eligibility_schemas.v1",
+        "request": schemars::schema_for!(DeletionEligibilityRequest),
+        "manifest": schemars::schema_for!(DeletionManifest),
+        "entry": schemars::schema_for!(DeletionEntry),
+        "approval": schemars::schema_for!(DeletionApproval),
+        "decision": schemars::schema_for!(DeletionDecision),
+    })
+}
+
 pub fn evaluate_deletion_eligibility(
     repo: &Path,
     request: &DeletionEligibilityRequest,
 ) -> Result<DeletionDecision> {
-    evaluate_with_time(repo, request, OffsetDateTime::now_utc())
+    require_clean_revision(repo)?;
+    let baseline = load_baseline(repo)?;
+    evaluate_with_time_and_baseline(repo, request, OffsetDateTime::now_utc(), &baseline)
 }
 
-fn evaluate_with_time(
+fn evaluate_with_time_and_baseline(
     repo: &Path,
     request: &DeletionEligibilityRequest,
     now: OffsetDateTime,
+    baseline: &Baseline,
 ) -> Result<DeletionDecision> {
-    validate_request(request)?;
-    require_clean_revision(repo)?;
+    validate_request(request, baseline)?;
     let phase_b_bytes = read_regular_repo_file(repo, &request.phase_b_evidence)?;
     let phase_c_bytes = read_regular_repo_file(repo, &request.phase_c_evidence)?;
     let selector_bytes = read_regular_repo_file(repo, &request.selector)?;
@@ -152,6 +191,7 @@ fn evaluate_with_time(
     let phase_c_blake3 = digest(&phase_c_bytes);
     let selector_blake3 = digest(&selector_bytes);
     let manifest_blake3 = digest(&manifest_bytes);
+    let code_revision = git_text(repo, &["rev-parse", "HEAD"])?;
     let mut reasons = BTreeSet::new();
 
     if phase_b.schema != "csdlc.pre_switch_evidence.v1"
@@ -167,6 +207,7 @@ fn evaluate_with_time(
         || !phase_c.v1_paths_before
         || !phase_c.v1_paths_after
         || phase_c.deletion_authorized
+        || phase_c.pre_switch_evidence_blake3 != phase_b_blake3
     {
         reasons.insert(DeletionReason::PhaseEvidenceNotGreen);
     }
@@ -175,34 +216,48 @@ fn evaluate_with_time(
     {
         reasons.insert(DeletionReason::SelectorNotV2);
     }
+    let rollback_expires = parse_time(&phase_c.rollback_expires_at)?;
+    let importer_expires = parse_time(&phase_c.importer_expires_at)?;
+    if now < rollback_expires {
+        reasons.insert(DeletionReason::RollbackWindowActive);
+    }
+    if now < importer_expires {
+        reasons.insert(DeletionReason::ImporterWindowActive);
+    }
 
-    let removed_lines = request
+    let overrides = request
         .manifest
         .entries
         .iter()
-        .filter(|entry| entry.disposition == EntryDisposition::Remove)
-        .map(|entry| entry.measured_lines)
+        .map(|entry| (&entry.path, entry))
+        .collect::<BTreeMap<_, _>>();
+    let removed_lines = baseline
+        .lines
+        .iter()
+        .filter(|(path, _)| {
+            overrides
+                .get(path)
+                .map(|entry| entry.disposition)
+                .unwrap_or(request.manifest.default_disposition)
+                == EntryDisposition::Remove
+        })
+        .map(|(_, lines)| lines)
         .sum::<u64>();
-    let retained_lines = request.manifest.baseline_lines - removed_lines;
-    let basis_points = removed_lines
-        .saturating_mul(10_000)
-        .checked_div(request.manifest.baseline_lines)
-        .unwrap_or_default()
+    let retained_lines = BASELINE_LINES - removed_lines;
+    let basis_points = (removed_lines.saturating_mul(10_000) / BASELINE_LINES)
         .try_into()
         .unwrap_or(u16::MAX);
-    if basis_points < request.manifest.minimum_percent.saturating_mul(100) {
+    if basis_points < request.manifest.minimum_percent * 100 {
         reasons.insert(DeletionReason::BelowMinimumRemoval);
     }
-
     for entry in request
         .manifest
         .entries
         .iter()
-        .filter(|entry| entry.disposition == EntryDisposition::Remove)
+        .filter(|e| e.disposition == EntryDisposition::Remove)
     {
         if let Some(value) = &entry.protected_until {
-            let until = parse_time(value)?;
-            if now < until {
+            if now < parse_time(value)? {
                 reasons.insert(DeletionReason::ProtectedWindowActive);
             }
         }
@@ -216,29 +271,36 @@ fn evaluate_with_time(
             validate_approval(approval)?;
             let approved_at = parse_time(&approval.approved_at)?;
             let cutover_at = parse_time(&phase_c.cutover_at)?;
-            if approval.phase_c_blake3 != phase_c_blake3
+            if approval.phase_b_blake3 != phase_b_blake3
+                || approval.phase_c_blake3 != phase_c_blake3
+                || approval.selector_blake3 != selector_blake3
                 || approval.manifest_blake3 != manifest_blake3
+                || approval.code_revision != code_revision
                 || approved_at < cutover_at
                 || approved_at > now
             {
                 reasons.insert(DeletionReason::ApprovalEvidenceMismatch);
             }
-            if basis_points < request.manifest.target_percent.saturating_mul(100)
+            if basis_points < request.manifest.target_percent * 100
                 && !approval.allow_qualified_80_to_89
             {
                 reasons.insert(DeletionReason::QualificationNotApproved);
             }
         }
     }
-
     let reasons = reasons.into_iter().collect::<Vec<_>>();
     Ok(DeletionDecision {
         schema: "csdlc.deletion_eligibility.v1".into(),
         issue: request.issue,
-        code_revision: git_text(repo, &["rev-parse", "HEAD"])?,
+        code_revision,
         evaluated_at: now
             .format(&time::format_description::well_known::Rfc3339)
             .map_err(time_error)?,
+        baseline_revision: BASELINE_REVISION.into(),
+        baseline_files: baseline.lines.len(),
+        baseline_lines: BASELINE_LINES,
+        rust_list_blake3: baseline.rust_hash.clone(),
+        shell_list_blake3: baseline.shell_hash.clone(),
         phase_b_blake3,
         phase_c_blake3,
         selector_blake3,
@@ -246,25 +308,105 @@ fn evaluate_with_time(
         removed_lines,
         retained_lines,
         removal_basis_points: basis_points,
-        target_met: basis_points >= request.manifest.target_percent.saturating_mul(100),
+        target_met: basis_points >= request.manifest.target_percent * 100,
         eligible: reasons.is_empty(),
         reasons,
         deletion_executed: false,
     })
 }
 
-pub fn write_decision_atomic(path: &Path, decision: &DeletionDecision) -> Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "decision output needs a parent"))?;
-    fs::create_dir_all(parent)?;
-    let temporary = path.with_extension("json.tmp");
-    fs::write(&temporary, serde_json::to_vec_pretty(decision)?)?;
-    fs::rename(temporary, path)?;
-    Ok(())
+fn load_baseline(repo: &Path) -> Result<Baseline> {
+    let paths = git_text(repo, &["ls-tree", "-r", "--name-only", BASELINE_REVISION])?;
+    let mut rust = Vec::new();
+    let mut shell = Vec::new();
+    for path in paths.lines() {
+        if is_baseline_rust(path) {
+            rust.push(path.to_owned());
+        }
+        if is_baseline_shell(path) {
+            shell.push(path.to_owned());
+        }
+    }
+    rust.sort();
+    rust.dedup();
+    shell.sort();
+    shell.dedup();
+    let rust_hash = digest(format!("{}\n", rust.join("\n")).as_bytes());
+    let shell_hash = digest(format!("{}\n", shell.join("\n")).as_bytes());
+    if rust_hash != RUST_LIST_BLAKE3
+        || shell_hash != SHELL_LIST_BLAKE3
+        || rust.len() + shell.len() != BASELINE_FILES
+    {
+        return Err(invalid(
+            "pinned baseline path inventory does not match Gate 1 hashes",
+        ));
+    }
+    let mut lines = BTreeMap::new();
+    for path in rust.iter().chain(shell.iter()) {
+        let bytes = git_bytes(repo, &["show", &format!("{BASELINE_REVISION}:{path}")])?;
+        let count = bytes.iter().filter(|byte| **byte == b'\n').count() as u64;
+        lines.insert(PathBuf::from(path), count);
+        verify_current_surface(repo, path)?;
+    }
+    if lines.values().sum::<u64>() != BASELINE_LINES {
+        return Err(invalid("pinned baseline line total does not match Gate 1"));
+    }
+    Ok(Baseline {
+        lines,
+        rust_hash,
+        shell_hash,
+    })
 }
 
-fn validate_request(request: &DeletionEligibilityRequest) -> Result<()> {
+fn is_baseline_rust(path: &str) -> bool {
+    if path.starts_with("adl/src/cli/pr_cmd/") && path.ends_with(".rs") {
+        return true;
+    }
+    matches!(
+        path,
+        "adl/src/cli/pr_cmd.rs"
+            | "adl/src/cli/pr_cmd_args.rs"
+            | "adl/src/cli/pr_cmd_cards.rs"
+            | "adl/src/cli/pr_cmd_prompt.rs"
+            | "adl/src/cli/pr_cmd_validate.rs"
+            | "adl/src/csdlc_prompt_editor.rs"
+            | "adl/src/session_ledger.rs"
+            | "adl/src/pr_dispatch_support.rs"
+            | "adl/src/cli/tooling_cmd/prompt_template.rs"
+            | "adl/src/cli/tooling_cmd/structured_prompt.rs"
+    ) || (path.starts_with("adl/src/bin/")
+        && !path[12..].contains('/')
+        && path.ends_with(".rs")
+        && {
+            let name = &path[12..];
+            name.starts_with("adl_pr_")
+                || matches!(
+                    name,
+                    "adl_csdlc.rs" | "csdlc.rs" | "adl_issue.rs" | "adl_session.rs"
+                )
+        })
+}
+
+fn is_baseline_shell(path: &str) -> bool {
+    if !path.starts_with("adl/tools/") || path[10..].contains('/') || !path.ends_with(".sh") {
+        return false;
+    }
+    let name = &path[10..];
+    matches!(
+        name,
+        "pr.sh"
+            | "card_paths.sh"
+            | "pr_cards.sh"
+            | "pr_delegate.sh"
+            | "pr_usage.sh"
+            | "validate_structured_prompt.sh"
+            | "prompt_template.sh"
+    ) || name.starts_with("check_pr_")
+        || name.starts_with("test_pr_")
+        || name.starts_with("test_prompt_template")
+}
+
+fn validate_request(request: &DeletionEligibilityRequest, baseline: &Baseline) -> Result<()> {
     if request.schema != "csdlc.deletion_eligibility_request.v1" || request.issue != 5305 {
         return Err(invalid("request schema and issue must identify Gate 10D1"));
     }
@@ -275,67 +417,74 @@ fn validate_request(request: &DeletionEligibilityRequest) -> Result<()> {
     ] {
         validate_relative_path(path)?;
     }
-    let manifest = &request.manifest;
-    if manifest.schema != "csdlc.proposed_deletion_manifest.v1"
-        || manifest.baseline_lines != 49_979
-        || manifest.target_percent != 90
-        || manifest.minimum_percent != 80
-        || manifest.entries.is_empty()
+    let m = &request.manifest;
+    if m.schema != "csdlc.proposed_deletion_manifest.v1"
+        || m.baseline_revision != BASELINE_REVISION
+        || m.target_percent != 90
+        || m.minimum_percent != 80
     {
         return Err(invalid(
-            "manifest must use the reviewed Gate 1 denominator and thresholds",
+            "manifest must use the reviewed Gate 1 revision and thresholds",
+        ));
+    }
+    if m.default_disposition == EntryDisposition::Retain
+        && (empty(&m.default_owner) || empty(&m.default_justification))
+    {
+        return Err(invalid(
+            "default retained surfaces need an owner and justification",
         ));
     }
     let mut paths = BTreeSet::new();
-    let mut total = 0_u64;
-    for entry in &manifest.entries {
+    for entry in &m.entries {
         validate_relative_path(&entry.path)?;
-        if !paths.insert(&entry.path) || entry.measured_lines == 0 {
+        if !baseline.lines.contains_key(&entry.path) || !paths.insert(&entry.path) {
             return Err(invalid(
-                "manifest paths must be unique with nonzero measured lines",
+                "manifest overrides must be unique exact pinned inventory paths",
             ));
         }
-        total = total
-            .checked_add(entry.measured_lines)
-            .ok_or_else(|| invalid("manifest line total overflow"))?;
         if entry.disposition == EntryDisposition::Retain
-            && (entry.owner.as_deref().is_none_or(str::is_empty)
-                || entry.justification.as_deref().is_none_or(str::is_empty))
+            && (empty(&entry.owner) || empty(&entry.justification))
         {
             return Err(invalid(
-                "every retained surface needs an owner and justification",
+                "every retained override needs an owner and justification",
             ));
         }
         if let Some(value) = &entry.protected_until {
             parse_time(value)?;
         }
     }
-    if total != manifest.baseline_lines {
-        return Err(invalid(
-            "manifest entries must exactly partition the baseline lines",
-        ));
-    }
     Ok(())
 }
 
-fn validate_approval(approval: &DeletionApproval) -> Result<()> {
-    if approval.schema != "csdlc.deletion_approval.v1"
-        || approval.approved_by.trim().is_empty()
-        || approval.phase_c_blake3.len() != 64
-        || approval.manifest_blake3.len() != 64
+fn empty(value: &Option<String>) -> bool {
+    value.as_deref().is_none_or(|v| v.trim().is_empty())
+}
+fn validate_approval(a: &DeletionApproval) -> Result<()> {
+    if a.schema != "csdlc.deletion_approval.v1"
+        || a.approved_by.trim().is_empty()
+        || !is_lower_hex(&a.phase_b_blake3, 64)
+        || !is_lower_hex(&a.phase_c_blake3, 64)
+        || !is_lower_hex(&a.selector_blake3, 64)
+        || !is_lower_hex(&a.manifest_blake3, 64)
+        || !is_lower_hex(&a.code_revision, 40)
     {
         return Err(invalid("approval is malformed"));
     }
-    parse_time(&approval.approved_at)?;
+    parse_time(&a.approved_at)?;
     Ok(())
 }
-
+fn is_lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
 fn validate_relative_path(path: &Path) -> Result<()> {
     if path.as_os_str().is_empty()
         || path.is_absolute()
-        || path.components().any(|component| {
+        || path.components().any(|c| {
             matches!(
-                component,
+                c,
                 Component::ParentDir | Component::RootDir | Component::Prefix(_)
             )
         })
@@ -344,7 +493,6 @@ fn validate_relative_path(path: &Path) -> Result<()> {
     }
     Ok(())
 }
-
 fn read_regular_repo_file(repo: &Path, relative: &Path) -> Result<Vec<u8>> {
     validate_relative_path(relative)?;
     let path = repo.join(relative);
@@ -357,28 +505,40 @@ fn read_regular_repo_file(repo: &Path, relative: &Path) -> Result<Vec<u8>> {
     }
     fs::read(path).map_err(Into::into)
 }
-
+fn verify_current_surface(repo: &Path, path: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(repo.join(path))?;
+    if !metadata.file_type().is_file() {
+        return Err(invalid(format!(
+            "baseline surface must remain a regular file: {path}"
+        )));
+    }
+    git_text(repo, &["ls-files", "--error-unmatch", "--", path]).map(|_| ())
+}
 fn parse_time(value: &str) -> Result<OffsetDateTime> {
     OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
-        .map_err(|error| invalid(error.to_string()))
+        .map_err(|e| invalid(e.to_string()))
 }
-
 fn git_text(repo: &Path, args: &[&str]) -> Result<String> {
+    Ok(String::from_utf8_lossy(&git_bytes(repo, args)?)
+        .trim()
+        .into())
+}
+fn git_bytes(repo: &Path, args: &[&str]) -> Result<Vec<u8>> {
     let output = Command::new("git").args(args).current_dir(repo).output()?;
     if !output.status.success() {
-        return Err(V2Error::new(ErrorCode::GitFailure, "git command failed"));
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            format!("git {} failed", args.first().unwrap_or(&"command")),
+        ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().into())
+    Ok(output.stdout)
 }
-
 fn digest(bytes: &[u8]) -> String {
     blake3::hash(bytes).to_hex().to_string()
 }
-
 fn invalid(message: impl Into<String>) -> V2Error {
     V2Error::new(ErrorCode::InvalidManifest, message)
 }
-
 fn time_error(error: time::error::Format) -> V2Error {
     V2Error::new(ErrorCode::InvalidInput, error.to_string())
 }
@@ -386,44 +546,38 @@ fn time_error(error: time::error::Format) -> V2Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn fixture_repo() -> tempfile::TempDir {
-        let repo = tempfile::tempdir().unwrap();
-        for path in [
-            "phase-b.json",
-            "phase-c.json",
-            "selector.json",
-            "candidate-v1",
-        ] {
-            fs::write(repo.path().join(path), b"candidate").unwrap();
+    fn baseline() -> Baseline {
+        Baseline {
+            lines: [(PathBuf::from("a"), 45_000), (PathBuf::from("b"), 4_979)].into(),
+            rust_hash: RUST_LIST_BLAKE3.into(),
+            shell_hash: SHELL_LIST_BLAKE3.into(),
         }
+    }
+    fn fixture() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
         fs::write(
-            repo.path().join("phase-b.json"),
+            repo.path().join("b.json"),
             include_bytes!("../../docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json"),
         )
         .unwrap();
         fs::write(
-            repo.path().join("phase-c.json"),
+            repo.path().join("c.json"),
             include_bytes!("../../docs/architecture/csdlc-v2/gate10c/CUTOVER_EVIDENCE.json"),
         )
         .unwrap();
-        fs::write(
-            repo.path().join("selector.json"),
-            br#"{"schema":"csdlc.generation_selector.v1","default_generation":"v2","opted_in_issues":[5293,5294]}"#,
-        )
-        .unwrap();
+        fs::write(repo.path().join("s.json"), br#"{"schema":"csdlc.generation_selector.v1","default_generation":"v2","opted_in_issues":[]}"#).unwrap();
         Command::new("git")
             .args(["init", "-q"])
             .current_dir(repo.path())
             .status()
             .unwrap();
         Command::new("git")
-            .args(["config", "user.email", "eligibility@example.invalid"])
+            .args(["config", "user.email", "e@invalid"])
             .current_dir(repo.path())
             .status()
             .unwrap();
         Command::new("git")
-            .args(["config", "user.name", "Eligibility"])
+            .args(["config", "user.name", "E"])
             .current_dir(repo.path())
             .status()
             .unwrap();
@@ -433,149 +587,142 @@ mod tests {
             .status()
             .unwrap();
         Command::new("git")
-            .args(["commit", "-qm", "fixture"])
+            .args(["commit", "-qm", "f"])
             .current_dir(repo.path())
             .status()
             .unwrap();
         repo
     }
-
-    fn request(
-        repo: &Path,
-        removed: u64,
-        protected_until: Option<&str>,
-    ) -> DeletionEligibilityRequest {
+    fn request(repo: &Path) -> DeletionEligibilityRequest {
+        let b = fs::read(repo.join("b.json")).unwrap();
+        let c = fs::read(repo.join("c.json")).unwrap();
+        let s = fs::read(repo.join("s.json")).unwrap();
         let manifest = DeletionManifest {
             schema: "csdlc.proposed_deletion_manifest.v1".into(),
-            baseline_lines: 49_979,
+            baseline_revision: BASELINE_REVISION.into(),
             target_percent: 90,
             minimum_percent: 80,
-            entries: vec![
-                DeletionEntry {
-                    path: "candidate-v1".into(),
-                    disposition: EntryDisposition::Remove,
-                    measured_lines: removed,
-                    owner: None,
-                    justification: None,
-                    protected_until: protected_until.map(str::to_owned),
-                },
-                DeletionEntry {
-                    path: "retained-v1".into(),
-                    disposition: EntryDisposition::Retain,
-                    measured_lines: 49_979 - removed,
-                    owner: Some("migration-owner".into()),
-                    justification: Some("useful retained compatibility".into()),
-                    protected_until: None,
-                },
-            ],
+            default_disposition: EntryDisposition::Remove,
+            default_owner: None,
+            default_justification: None,
+            entries: vec![],
         };
-        let phase_c = fs::read(repo.join("phase-c.json")).unwrap();
-        let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+        let mb = serde_json::to_vec(&manifest).unwrap();
+        let rev = git_text(repo, &["rev-parse", "HEAD"]).unwrap();
         DeletionEligibilityRequest {
             schema: "csdlc.deletion_eligibility_request.v1".into(),
             issue: 5305,
-            phase_b_evidence: "phase-b.json".into(),
-            phase_c_evidence: "phase-c.json".into(),
-            selector: "selector.json".into(),
+            phase_b_evidence: "b.json".into(),
+            phase_c_evidence: "c.json".into(),
+            selector: "s.json".into(),
+            manifest,
             approval: Some(DeletionApproval {
                 schema: "csdlc.deletion_approval.v1".into(),
                 approved_by: "operator".into(),
                 approved_at: "2026-08-13T00:00:00Z".into(),
-                phase_c_blake3: digest(&phase_c),
-                manifest_blake3: digest(&manifest_bytes),
+                phase_b_blake3: digest(&b),
+                phase_c_blake3: digest(&c),
+                selector_blake3: digest(&s),
+                manifest_blake3: digest(&mb),
+                code_revision: rev,
                 allow_qualified_80_to_89: true,
             }),
-            manifest,
         }
     }
-
-    fn time(value: &str) -> OffsetDateTime {
-        parse_time(value).unwrap()
+    fn at(v: &str) -> OffsetDateTime {
+        parse_time(v).unwrap()
     }
-
     #[test]
-    fn missing_approval_is_ineligible_and_candidate_bytes_do_not_change() {
-        let repo = fixture_repo();
-        let before = fs::read(repo.path().join("candidate-v1")).unwrap();
-        let mut input = request(repo.path(), 45_000, None);
-        input.approval = None;
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
-        assert!(!decision.eligible);
-        assert_eq!(decision.reasons, vec![DeletionReason::MissingApproval]);
-        assert!(!decision.deletion_executed);
-        assert_eq!(fs::read(repo.path().join("candidate-v1")).unwrap(), before);
+    fn missing_approval_fails_closed() {
+        let r = fixture();
+        let mut q = request(r.path());
+        q.approval = None;
+        let d =
+            evaluate_with_time_and_baseline(r.path(), &q, at("2026-08-13T00:00:00Z"), &baseline())
+                .unwrap();
+        assert_eq!(d.reasons, vec![DeletionReason::MissingApproval]);
+        assert!(!d.deletion_executed);
     }
-
     #[test]
-    fn protected_window_fails_closed() {
-        let repo = fixture_repo();
-        let input = request(repo.path(), 45_000, Some("2026-08-12T02:03:02Z"));
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-07-20T00:00:00Z")).unwrap();
-        assert!(!decision.eligible);
-        assert!(decision
-            .reasons
-            .contains(&DeletionReason::ProtectedWindowActive));
+    fn mandatory_phase_c_windows_fail_closed() {
+        let r = fixture();
+        let q = request(r.path());
+        let d =
+            evaluate_with_time_and_baseline(r.path(), &q, at("2026-07-20T00:00:00Z"), &baseline())
+                .unwrap();
+        assert!(d.reasons.contains(&DeletionReason::RollbackWindowActive));
+        assert!(d.reasons.contains(&DeletionReason::ImporterWindowActive));
     }
-
     #[test]
-    fn below_eighty_percent_can_never_be_eligible() {
-        let repo = fixture_repo();
-        let input = request(repo.path(), 39_000, None);
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
-        assert!(!decision.eligible);
-        assert!(decision
-            .reasons
-            .contains(&DeletionReason::BelowMinimumRemoval));
-    }
-
-    #[test]
-    fn qualified_eighty_to_eighty_nine_requires_approval_flag() {
-        let repo = fixture_repo();
-        let mut input = request(repo.path(), 42_000, None);
-        input.approval.as_mut().unwrap().allow_qualified_80_to_89 = false;
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
-        assert!(!decision.eligible);
-        assert!(decision
-            .reasons
-            .contains(&DeletionReason::QualificationNotApproved));
-    }
-
-    #[test]
-    fn current_approved_ninety_percent_manifest_is_eligible_but_non_mutating() {
-        let repo = fixture_repo();
-        let input = request(repo.path(), 45_000, None);
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
-        assert!(decision.eligible, "{decision:#?}");
-        assert!(decision.target_met);
-        assert!(!decision.deletion_executed);
-    }
-
-    #[test]
-    fn approval_is_bound_to_phase_c_and_manifest_digests() {
-        let repo = fixture_repo();
-        let mut input = request(repo.path(), 45_000, None);
-        input.approval.as_mut().unwrap().manifest_blake3 = "0".repeat(64);
-        let decision =
-            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
-        assert!(!decision.eligible);
-        assert!(decision
+    fn all_authoritative_inputs_are_approval_bound() {
+        let r = fixture();
+        let mut q = request(r.path());
+        q.approval.as_mut().unwrap().selector_blake3 = "0".repeat(64);
+        let d =
+            evaluate_with_time_and_baseline(r.path(), &q, at("2026-08-13T00:00:00Z"), &baseline())
+                .unwrap();
+        assert!(d
             .reasons
             .contains(&DeletionReason::ApprovalEvidenceMismatch));
     }
-
     #[test]
-    fn unsafe_duplicate_and_unowned_retained_entries_are_invalid() {
-        let repo = fixture_repo();
-        let mut input = request(repo.path(), 45_000, None);
-        input.manifest.entries[0].path = "../escape".into();
-        assert!(evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).is_err());
-        let mut input = request(repo.path(), 45_000, None);
-        input.manifest.entries[1].owner = None;
-        assert!(evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).is_err());
+    fn malformed_digest_is_rejected() {
+        let r = fixture();
+        let mut q = request(r.path());
+        q.approval.as_mut().unwrap().phase_b_blake3 = "G".repeat(64);
+        assert!(evaluate_with_time_and_baseline(
+            r.path(),
+            &q,
+            at("2026-08-13T00:00:00Z"),
+            &baseline()
+        )
+        .is_err());
+    }
+    #[test]
+    fn default_partition_and_exact_overrides_derive_lines() {
+        let r = fixture();
+        let mut q = request(r.path());
+        q.manifest.default_disposition = EntryDisposition::Retain;
+        q.manifest.default_owner = Some("owner".into());
+        q.manifest.default_justification = Some("useful".into());
+        q.manifest.entries.push(DeletionEntry {
+            path: "a".into(),
+            disposition: EntryDisposition::Remove,
+            owner: None,
+            justification: None,
+            protected_until: None,
+        });
+        q.approval = None;
+        let d =
+            evaluate_with_time_and_baseline(r.path(), &q, at("2026-08-13T00:00:00Z"), &baseline())
+                .unwrap();
+        assert_eq!(d.removed_lines, 45_000);
+        assert_eq!(d.retained_lines, 4_979);
+    }
+    #[test]
+    fn unknown_or_duplicate_overrides_are_invalid() {
+        let r = fixture();
+        let mut q = request(r.path());
+        q.manifest.entries.push(DeletionEntry {
+            path: "unknown".into(),
+            disposition: EntryDisposition::Remove,
+            owner: None,
+            justification: None,
+            protected_until: None,
+        });
+        assert!(evaluate_with_time_and_baseline(
+            r.path(),
+            &q,
+            at("2026-08-13T00:00:00Z"),
+            &baseline()
+        )
+        .is_err());
+    }
+    #[test]
+    fn schema_bundle_is_versioned() {
+        assert_eq!(
+            eligibility_schema_bundle()["schema"],
+            "csdlc.deletion_eligibility_schemas.v1"
+        );
     }
 }

--- a/csdlc-v2/src/eligibility.rs
+++ b/csdlc-v2/src/eligibility.rs
@@ -1,0 +1,581 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
+use time::OffsetDateTime;
+
+use crate::cutover::CutoverEvidence;
+use crate::error::{ErrorCode, Result, V2Error};
+use crate::proof::{require_clean_revision, PreSwitchEvidence};
+use crate::{Generation, GenerationSelector};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum EntryDisposition {
+    Remove,
+    Retain,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum DeletionReason {
+    MissingApproval,
+    ApprovalEvidenceMismatch,
+    PhaseEvidenceNotGreen,
+    SelectorNotV2,
+    ProtectedWindowActive,
+    BelowMinimumRemoval,
+    QualificationNotApproved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeletionEntry {
+    pub path: PathBuf,
+    pub disposition: EntryDisposition,
+    pub measured_lines: u64,
+    pub owner: Option<String>,
+    pub justification: Option<String>,
+    pub protected_until: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeletionManifest {
+    pub schema: String,
+    pub baseline_lines: u64,
+    pub target_percent: u16,
+    pub minimum_percent: u16,
+    pub entries: Vec<DeletionEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeletionApproval {
+    pub schema: String,
+    pub approved_by: String,
+    pub approved_at: String,
+    pub phase_c_blake3: String,
+    pub manifest_blake3: String,
+    pub allow_qualified_80_to_89: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeletionEligibilityRequest {
+    pub schema: String,
+    pub issue: u64,
+    pub phase_b_evidence: PathBuf,
+    pub phase_c_evidence: PathBuf,
+    pub selector: PathBuf,
+    pub manifest: DeletionManifest,
+    pub approval: Option<DeletionApproval>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DeletionDecision {
+    pub schema: String,
+    pub issue: u64,
+    pub code_revision: String,
+    pub evaluated_at: String,
+    pub phase_b_blake3: String,
+    pub phase_c_blake3: String,
+    pub selector_blake3: String,
+    pub manifest_blake3: String,
+    pub removed_lines: u64,
+    pub retained_lines: u64,
+    pub removal_basis_points: u16,
+    pub target_met: bool,
+    pub eligible: bool,
+    pub reasons: Vec<DeletionReason>,
+    pub deletion_executed: bool,
+}
+
+pub fn evaluate_deletion_eligibility(
+    repo: &Path,
+    request: &DeletionEligibilityRequest,
+) -> Result<DeletionDecision> {
+    evaluate_with_time(repo, request, OffsetDateTime::now_utc())
+}
+
+fn evaluate_with_time(
+    repo: &Path,
+    request: &DeletionEligibilityRequest,
+    now: OffsetDateTime,
+) -> Result<DeletionDecision> {
+    validate_request(request)?;
+    require_clean_revision(repo)?;
+    let phase_b_bytes = read_regular_repo_file(repo, &request.phase_b_evidence)?;
+    let phase_c_bytes = read_regular_repo_file(repo, &request.phase_c_evidence)?;
+    let selector_bytes = read_regular_repo_file(repo, &request.selector)?;
+    let phase_b: PreSwitchEvidence = serde_json::from_slice(&phase_b_bytes)?;
+    let phase_c: CutoverEvidence = serde_json::from_slice(&phase_c_bytes)?;
+    let selector: GenerationSelector = serde_json::from_slice(&selector_bytes)?;
+    let manifest_bytes = serde_json::to_vec(&request.manifest)?;
+    let phase_b_blake3 = digest(&phase_b_bytes);
+    let phase_c_blake3 = digest(&phase_c_bytes);
+    let selector_blake3 = digest(&selector_bytes);
+    let manifest_blake3 = digest(&manifest_bytes);
+    let mut reasons = BTreeSet::new();
+
+    if phase_b.schema != "csdlc.pre_switch_evidence.v1"
+        || phase_c.schema != "csdlc.cutover_evidence.v1"
+        || !phase_b.passed
+        || phase_b.default_before != Generation::V1
+        || phase_b.default_after != Generation::V1
+        || !phase_b.v1_paths_before
+        || !phase_b.v1_paths_after
+        || !phase_c.passed
+        || phase_c.final_generation != Generation::V2
+        || !phase_c.explicit_v1_override
+        || !phase_c.v1_paths_before
+        || !phase_c.v1_paths_after
+        || phase_c.deletion_authorized
+    {
+        reasons.insert(DeletionReason::PhaseEvidenceNotGreen);
+    }
+    if selector.schema != "csdlc.generation_selector.v1"
+        || selector.default_generation != Generation::V2
+    {
+        reasons.insert(DeletionReason::SelectorNotV2);
+    }
+
+    let removed_lines = request
+        .manifest
+        .entries
+        .iter()
+        .filter(|entry| entry.disposition == EntryDisposition::Remove)
+        .map(|entry| entry.measured_lines)
+        .sum::<u64>();
+    let retained_lines = request.manifest.baseline_lines - removed_lines;
+    let basis_points = removed_lines
+        .saturating_mul(10_000)
+        .checked_div(request.manifest.baseline_lines)
+        .unwrap_or_default()
+        .try_into()
+        .unwrap_or(u16::MAX);
+    if basis_points < request.manifest.minimum_percent.saturating_mul(100) {
+        reasons.insert(DeletionReason::BelowMinimumRemoval);
+    }
+
+    for entry in request
+        .manifest
+        .entries
+        .iter()
+        .filter(|entry| entry.disposition == EntryDisposition::Remove)
+    {
+        if let Some(value) = &entry.protected_until {
+            let until = parse_time(value)?;
+            if now < until {
+                reasons.insert(DeletionReason::ProtectedWindowActive);
+            }
+        }
+    }
+
+    match &request.approval {
+        None => {
+            reasons.insert(DeletionReason::MissingApproval);
+        }
+        Some(approval) => {
+            validate_approval(approval)?;
+            let approved_at = parse_time(&approval.approved_at)?;
+            let cutover_at = parse_time(&phase_c.cutover_at)?;
+            if approval.phase_c_blake3 != phase_c_blake3
+                || approval.manifest_blake3 != manifest_blake3
+                || approved_at < cutover_at
+                || approved_at > now
+            {
+                reasons.insert(DeletionReason::ApprovalEvidenceMismatch);
+            }
+            if basis_points < request.manifest.target_percent.saturating_mul(100)
+                && !approval.allow_qualified_80_to_89
+            {
+                reasons.insert(DeletionReason::QualificationNotApproved);
+            }
+        }
+    }
+
+    let reasons = reasons.into_iter().collect::<Vec<_>>();
+    Ok(DeletionDecision {
+        schema: "csdlc.deletion_eligibility.v1".into(),
+        issue: request.issue,
+        code_revision: git_text(repo, &["rev-parse", "HEAD"])?,
+        evaluated_at: now
+            .format(&time::format_description::well_known::Rfc3339)
+            .map_err(time_error)?,
+        phase_b_blake3,
+        phase_c_blake3,
+        selector_blake3,
+        manifest_blake3,
+        removed_lines,
+        retained_lines,
+        removal_basis_points: basis_points,
+        target_met: basis_points >= request.manifest.target_percent.saturating_mul(100),
+        eligible: reasons.is_empty(),
+        reasons,
+        deletion_executed: false,
+    })
+}
+
+pub fn write_decision_atomic(path: &Path, decision: &DeletionDecision) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "decision output needs a parent"))?;
+    fs::create_dir_all(parent)?;
+    let temporary = path.with_extension("json.tmp");
+    fs::write(&temporary, serde_json::to_vec_pretty(decision)?)?;
+    fs::rename(temporary, path)?;
+    Ok(())
+}
+
+fn validate_request(request: &DeletionEligibilityRequest) -> Result<()> {
+    if request.schema != "csdlc.deletion_eligibility_request.v1" || request.issue != 5305 {
+        return Err(invalid("request schema and issue must identify Gate 10D1"));
+    }
+    for path in [
+        &request.phase_b_evidence,
+        &request.phase_c_evidence,
+        &request.selector,
+    ] {
+        validate_relative_path(path)?;
+    }
+    let manifest = &request.manifest;
+    if manifest.schema != "csdlc.proposed_deletion_manifest.v1"
+        || manifest.baseline_lines != 49_979
+        || manifest.target_percent != 90
+        || manifest.minimum_percent != 80
+        || manifest.entries.is_empty()
+    {
+        return Err(invalid(
+            "manifest must use the reviewed Gate 1 denominator and thresholds",
+        ));
+    }
+    let mut paths = BTreeSet::new();
+    let mut total = 0_u64;
+    for entry in &manifest.entries {
+        validate_relative_path(&entry.path)?;
+        if !paths.insert(&entry.path) || entry.measured_lines == 0 {
+            return Err(invalid(
+                "manifest paths must be unique with nonzero measured lines",
+            ));
+        }
+        total = total
+            .checked_add(entry.measured_lines)
+            .ok_or_else(|| invalid("manifest line total overflow"))?;
+        if entry.disposition == EntryDisposition::Retain
+            && (entry.owner.as_deref().is_none_or(str::is_empty)
+                || entry.justification.as_deref().is_none_or(str::is_empty))
+        {
+            return Err(invalid(
+                "every retained surface needs an owner and justification",
+            ));
+        }
+        if let Some(value) = &entry.protected_until {
+            parse_time(value)?;
+        }
+    }
+    if total != manifest.baseline_lines {
+        return Err(invalid(
+            "manifest entries must exactly partition the baseline lines",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_approval(approval: &DeletionApproval) -> Result<()> {
+    if approval.schema != "csdlc.deletion_approval.v1"
+        || approval.approved_by.trim().is_empty()
+        || approval.phase_c_blake3.len() != 64
+        || approval.manifest_blake3.len() != 64
+    {
+        return Err(invalid("approval is malformed"));
+    }
+    parse_time(&approval.approved_at)?;
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(invalid("paths must be safe repository-relative paths"));
+    }
+    Ok(())
+}
+
+fn read_regular_repo_file(repo: &Path, relative: &Path) -> Result<Vec<u8>> {
+    validate_relative_path(relative)?;
+    let path = repo.join(relative);
+    let metadata = fs::symlink_metadata(&path)?;
+    if !metadata.file_type().is_file() {
+        return Err(invalid(format!(
+            "input must be a regular file: {}",
+            relative.display()
+        )));
+    }
+    fs::read(path).map_err(Into::into)
+}
+
+fn parse_time(value: &str) -> Result<OffsetDateTime> {
+    OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .map_err(|error| invalid(error.to_string()))
+}
+
+fn git_text(repo: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git").args(args).current_dir(repo).output()?;
+    if !output.status.success() {
+        return Err(V2Error::new(ErrorCode::GitFailure, "git command failed"));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().into())
+}
+
+fn digest(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+fn invalid(message: impl Into<String>) -> V2Error {
+    V2Error::new(ErrorCode::InvalidManifest, message)
+}
+
+fn time_error(error: time::error::Format) -> V2Error {
+    V2Error::new(ErrorCode::InvalidInput, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        for path in [
+            "phase-b.json",
+            "phase-c.json",
+            "selector.json",
+            "candidate-v1",
+        ] {
+            fs::write(repo.path().join(path), b"candidate").unwrap();
+        }
+        fs::write(
+            repo.path().join("phase-b.json"),
+            include_bytes!("../../docs/architecture/csdlc-v2/gate10b/PRE_SWITCH_EVIDENCE.json"),
+        )
+        .unwrap();
+        fs::write(
+            repo.path().join("phase-c.json"),
+            include_bytes!("../../docs/architecture/csdlc-v2/gate10c/CUTOVER_EVIDENCE.json"),
+        )
+        .unwrap();
+        fs::write(
+            repo.path().join("selector.json"),
+            br#"{"schema":"csdlc.generation_selector.v1","default_generation":"v2","opted_in_issues":[5293,5294]}"#,
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "eligibility@example.invalid"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Eligibility"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-qm", "fixture"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        repo
+    }
+
+    fn request(
+        repo: &Path,
+        removed: u64,
+        protected_until: Option<&str>,
+    ) -> DeletionEligibilityRequest {
+        let manifest = DeletionManifest {
+            schema: "csdlc.proposed_deletion_manifest.v1".into(),
+            baseline_lines: 49_979,
+            target_percent: 90,
+            minimum_percent: 80,
+            entries: vec![
+                DeletionEntry {
+                    path: "candidate-v1".into(),
+                    disposition: EntryDisposition::Remove,
+                    measured_lines: removed,
+                    owner: None,
+                    justification: None,
+                    protected_until: protected_until.map(str::to_owned),
+                },
+                DeletionEntry {
+                    path: "retained-v1".into(),
+                    disposition: EntryDisposition::Retain,
+                    measured_lines: 49_979 - removed,
+                    owner: Some("migration-owner".into()),
+                    justification: Some("useful retained compatibility".into()),
+                    protected_until: None,
+                },
+            ],
+        };
+        let phase_c = fs::read(repo.join("phase-c.json")).unwrap();
+        let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+        DeletionEligibilityRequest {
+            schema: "csdlc.deletion_eligibility_request.v1".into(),
+            issue: 5305,
+            phase_b_evidence: "phase-b.json".into(),
+            phase_c_evidence: "phase-c.json".into(),
+            selector: "selector.json".into(),
+            approval: Some(DeletionApproval {
+                schema: "csdlc.deletion_approval.v1".into(),
+                approved_by: "operator".into(),
+                approved_at: "2026-08-13T00:00:00Z".into(),
+                phase_c_blake3: digest(&phase_c),
+                manifest_blake3: digest(&manifest_bytes),
+                allow_qualified_80_to_89: true,
+            }),
+            manifest,
+        }
+    }
+
+    fn time(value: &str) -> OffsetDateTime {
+        parse_time(value).unwrap()
+    }
+
+    #[test]
+    fn missing_approval_is_ineligible_and_candidate_bytes_do_not_change() {
+        let repo = fixture_repo();
+        let before = fs::read(repo.path().join("candidate-v1")).unwrap();
+        let mut input = request(repo.path(), 45_000, None);
+        input.approval = None;
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
+        assert!(!decision.eligible);
+        assert_eq!(decision.reasons, vec![DeletionReason::MissingApproval]);
+        assert!(!decision.deletion_executed);
+        assert_eq!(fs::read(repo.path().join("candidate-v1")).unwrap(), before);
+    }
+
+    #[test]
+    fn protected_window_fails_closed() {
+        let repo = fixture_repo();
+        let input = request(repo.path(), 45_000, Some("2026-08-12T02:03:02Z"));
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-07-20T00:00:00Z")).unwrap();
+        assert!(!decision.eligible);
+        assert!(decision
+            .reasons
+            .contains(&DeletionReason::ProtectedWindowActive));
+    }
+
+    #[test]
+    fn below_eighty_percent_can_never_be_eligible() {
+        let repo = fixture_repo();
+        let input = request(repo.path(), 39_000, None);
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
+        assert!(!decision.eligible);
+        assert!(decision
+            .reasons
+            .contains(&DeletionReason::BelowMinimumRemoval));
+    }
+
+    #[test]
+    fn qualified_eighty_to_eighty_nine_requires_approval_flag() {
+        let repo = fixture_repo();
+        let mut input = request(repo.path(), 42_000, None);
+        input.approval.as_mut().unwrap().allow_qualified_80_to_89 = false;
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
+        assert!(!decision.eligible);
+        assert!(decision
+            .reasons
+            .contains(&DeletionReason::QualificationNotApproved));
+    }
+
+    #[test]
+    fn current_approved_ninety_percent_manifest_is_eligible_but_non_mutating() {
+        let repo = fixture_repo();
+        let input = request(repo.path(), 45_000, None);
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
+        assert!(decision.eligible, "{decision:#?}");
+        assert!(decision.target_met);
+        assert!(!decision.deletion_executed);
+    }
+
+    #[test]
+    fn approval_is_bound_to_phase_c_and_manifest_digests() {
+        let repo = fixture_repo();
+        let mut input = request(repo.path(), 45_000, None);
+        input.approval.as_mut().unwrap().manifest_blake3 = "0".repeat(64);
+        let decision =
+            evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).unwrap();
+        assert!(!decision.eligible);
+        assert!(decision
+            .reasons
+            .contains(&DeletionReason::ApprovalEvidenceMismatch));
+    }
+
+    #[test]
+    fn unsafe_duplicate_and_unowned_retained_entries_are_invalid() {
+        let repo = fixture_repo();
+        let mut input = request(repo.path(), 45_000, None);
+        input.manifest.entries[0].path = "../escape".into();
+        assert!(evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).is_err());
+        let mut input = request(repo.path(), 45_000, None);
+        input.manifest.entries[1].owner = None;
+        assert!(evaluate_with_time(repo.path(), &input, time("2026-08-13T00:00:00Z")).is_err());
+    }
+}

--- a/csdlc-v2/src/eligibility.rs
+++ b/csdlc-v2/src/eligibility.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use time::OffsetDateTime;
 
@@ -17,8 +18,8 @@ use crate::{Generation, GenerationSelector};
 const BASELINE_REVISION: &str = "020bba17deb9f172e91a2ec5c0599cf42e4defe9";
 const BASELINE_LINES: u64 = 49_979;
 const BASELINE_FILES: usize = 95;
-const RUST_LIST_BLAKE3: &str = "c3118c1f3766b5f4a3e549c9073b33fb83164b3006175785b4c08f84c898558f";
-const SHELL_LIST_BLAKE3: &str = "7160399a788e467ebd934309a99f9777fb0f14d4270989e5114c73b63fa3d8cc";
+const RUST_LIST_SHA256: &str = "c3118c1f3766b5f4a3e549c9073b33fb83164b3006175785b4c08f84c898558f";
+const SHELL_LIST_SHA256: &str = "7160399a788e467ebd934309a99f9777fb0f14d4270989e5114c73b63fa3d8cc";
 
 #[derive(
     Debug,
@@ -131,8 +132,8 @@ pub struct DeletionDecision {
     pub baseline_revision: String,
     pub baseline_files: usize,
     pub baseline_lines: u64,
-    pub rust_list_blake3: String,
-    pub shell_list_blake3: String,
+    pub rust_list_sha256: String,
+    pub shell_list_sha256: String,
     pub phase_b_blake3: String,
     pub phase_c_blake3: String,
     pub selector_blake3: String,
@@ -299,8 +300,8 @@ fn evaluate_with_time_and_baseline(
         baseline_revision: BASELINE_REVISION.into(),
         baseline_files: baseline.lines.len(),
         baseline_lines: BASELINE_LINES,
-        rust_list_blake3: baseline.rust_hash.clone(),
-        shell_list_blake3: baseline.shell_hash.clone(),
+        rust_list_sha256: baseline.rust_hash.clone(),
+        shell_list_sha256: baseline.shell_hash.clone(),
         phase_b_blake3,
         phase_c_blake3,
         selector_blake3,
@@ -331,10 +332,10 @@ fn load_baseline(repo: &Path) -> Result<Baseline> {
     rust.dedup();
     shell.sort();
     shell.dedup();
-    let rust_hash = digest(format!("{}\n", rust.join("\n")).as_bytes());
-    let shell_hash = digest(format!("{}\n", shell.join("\n")).as_bytes());
-    if rust_hash != RUST_LIST_BLAKE3
-        || shell_hash != SHELL_LIST_BLAKE3
+    let rust_hash = sha256(format!("{}\n", rust.join("\n")).as_bytes());
+    let shell_hash = sha256(format!("{}\n", shell.join("\n")).as_bytes());
+    if rust_hash != RUST_LIST_SHA256
+        || shell_hash != SHELL_LIST_SHA256
         || rust.len() + shell.len() != BASELINE_FILES
     {
         return Err(invalid(
@@ -536,6 +537,9 @@ fn git_bytes(repo: &Path, args: &[&str]) -> Result<Vec<u8>> {
 fn digest(bytes: &[u8]) -> String {
     blake3::hash(bytes).to_hex().to_string()
 }
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
 fn invalid(message: impl Into<String>) -> V2Error {
     V2Error::new(ErrorCode::InvalidManifest, message)
 }
@@ -549,8 +553,8 @@ mod tests {
     fn baseline() -> Baseline {
         Baseline {
             lines: [(PathBuf::from("a"), 45_000), (PathBuf::from("b"), 4_979)].into(),
-            rust_hash: RUST_LIST_BLAKE3.into(),
-            shell_hash: SHELL_LIST_BLAKE3.into(),
+            rust_hash: RUST_LIST_SHA256.into(),
+            shell_hash: SHELL_LIST_SHA256.into(),
         }
     }
     fn fixture() -> tempfile::TempDir {

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -23,8 +23,8 @@ pub use cards::{
 pub use cutover::{run_cutover, CutoverEvidence, CutoverRequest};
 pub use doctor::{diagnose, DoctorReport};
 pub use eligibility::{
-    evaluate_deletion_eligibility, DeletionApproval, DeletionDecision, DeletionEligibilityRequest,
-    DeletionEntry, DeletionManifest, DeletionReason, EntryDisposition,
+    eligibility_schema_bundle, evaluate_deletion_eligibility, DeletionApproval, DeletionDecision,
+    DeletionEligibilityRequest, DeletionEntry, DeletionManifest, DeletionReason, EntryDisposition,
 };
 pub use error::{ErrorCode, Result, V2Error};
 pub use lifecycle::{

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cards;
 pub mod cutover;
 pub mod doctor;
+pub mod eligibility;
 pub mod error;
 pub mod git;
 pub mod lifecycle;
@@ -21,6 +22,10 @@ pub use cards::{
 };
 pub use cutover::{run_cutover, CutoverEvidence, CutoverRequest};
 pub use doctor::{diagnose, DoctorReport};
+pub use eligibility::{
+    evaluate_deletion_eligibility, DeletionApproval, DeletionDecision, DeletionEligibilityRequest,
+    DeletionEntry, DeletionManifest, DeletionReason, EntryDisposition,
+};
 pub use error::{ErrorCode, Result, V2Error};
 pub use lifecycle::{
     bind_issue, heartbeat_claim, initialize_issue, recover_claim, BindRequest, BindResult,

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -40,5 +40,6 @@ pub fn public_schema_bundle() -> Value {
         "legacy_import_report": schemars::schema_for!(ImportReport),
         "normalized_outcome": schemars::schema_for!(NormalizedOutcome),
         "shadow_comparison": schemars::schema_for!(ShadowComparison),
+        "deletion_eligibility": crate::eligibility::eligibility_schema_bundle(),
     })
 }

--- a/csdlc-v2/tests/gate10a.rs
+++ b/csdlc-v2/tests/gate10a.rs
@@ -44,7 +44,7 @@ fn installer_records_provenance_without_replacing_other_files() {
     }
     fs::write(destination_parent.path().join("v1-stays"), b"v1").unwrap();
     let receipt = install_binaries(source.path(), &destination).unwrap();
-    assert_eq!(receipt.binaries.len(), 10);
+    assert_eq!(receipt.binaries.len(), 11);
     assert_eq!(
         fs::read(destination_parent.path().join("v1-stays")).unwrap(),
         b"v1"

--- a/docs/architecture/csdlc-v2/gate10d1/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate10d1/DESIGN.md
@@ -2,26 +2,37 @@
 
 `csdlc-eligibility` is a read-only authority boundary between reviewed cutover
 evidence and any future deletion issue. It reads versioned Phase B/Phase C
-evidence, the tracked generation selector, a proposed removed/retained line
-partition, typed approval, and protected-window timestamps. It writes one atomic
-decision file and has no code path for deleting, renaming, editing, staging,
-committing, publishing, or closing candidate v1 paths.
+evidence, the tracked generation selector, an exact-path disposition manifest,
+and typed approval. It writes only JSON to stdout and has no code path for
+creating, deleting, renaming, editing, staging, committing, publishing, or
+closing repository paths.
 
-The manifest must exactly partition the pinned 49,979-line Gate 1 denominator.
-Every retained entry names an owner and justification. Ninety percent is the
-review target; 80-89 percent requires explicit qualification in the approval;
-below 80 percent is never eligible. Absolute/traversing paths, duplicate paths,
-zero-line entries, malformed timestamps, and unowned retained entries are
-invalid inputs.
+The binary reconstructs the canonical 95-file, 49,979-line inventory directly
+from pinned revision `020bba17deb9f172e91a2ec5c0599cf42e4defe9`, verifies the
+two reviewed sorted-list hashes and pinned line total, and rejects missing,
+untracked, non-regular, or symlinked current paths. The manifest supplies one
+default disposition plus exact-path overrides, so every canonical path has
+exactly one disposition without caller-supplied line counts or overlapping
+directory claims. Every retained disposition names an owner and justification.
+Ninety percent is the review target; 80-89 percent requires explicit
+qualification in the approval; below 80 percent is never eligible.
 
-Approval is not a boolean. It binds the approver and approval time to the exact
-BLAKE3 digests of Phase C evidence and the proposed manifest. Missing or
-mismatched approval, non-green phase evidence, a non-v2 selector, an active
-protected window, or a deficient removal percentage produces `eligible=false`.
-The decision always records `deletion_executed=false` because execution belongs
-to separate issue #5306.
+Approval is not a boolean. It binds the approver and approval time to exact
+BLAKE3 digests of Phase B evidence, Phase C evidence, the selector, the
+manifest, and the evaluated Git code revision. The Phase C record must itself
+bind the exact Phase B digest. Its rollback and importer expiry timestamps are
+mandatory eligibility clocks even when no manifest override mentions them.
+Missing or mismatched approval, non-green evidence, a non-v2 selector, either
+active mandatory window, an entry-specific protected window, or a deficient
+removal percentage produces `eligible=false`. Digests and revisions require
+strict lowercase hexadecimal encoding. The decision always records
+`deletion_executed=false` because execution belongs to separate issue #5306.
 
 The tracked request intentionally contains no approval and retains the full
 baseline. Its expected decision is ineligible with zero v1 mutation. Synthetic
 tests cover positive eligibility only to prove decision semantics; they grant
 no operational deletion authority.
+
+`csdlc-eligibility schema` emits the versioned request, manifest, entry,
+approval, and decision JSON Schemas. `csdlc-eligibility evaluate --repo <repo>
+--request <file>` emits a decision to stdout and accepts no output path.

--- a/docs/architecture/csdlc-v2/gate10d1/DESIGN.md
+++ b/docs/architecture/csdlc-v2/gate10d1/DESIGN.md
@@ -1,0 +1,27 @@
+# Gate 10D1 non-mutating deletion eligibility
+
+`csdlc-eligibility` is a read-only authority boundary between reviewed cutover
+evidence and any future deletion issue. It reads versioned Phase B/Phase C
+evidence, the tracked generation selector, a proposed removed/retained line
+partition, typed approval, and protected-window timestamps. It writes one atomic
+decision file and has no code path for deleting, renaming, editing, staging,
+committing, publishing, or closing candidate v1 paths.
+
+The manifest must exactly partition the pinned 49,979-line Gate 1 denominator.
+Every retained entry names an owner and justification. Ninety percent is the
+review target; 80-89 percent requires explicit qualification in the approval;
+below 80 percent is never eligible. Absolute/traversing paths, duplicate paths,
+zero-line entries, malformed timestamps, and unowned retained entries are
+invalid inputs.
+
+Approval is not a boolean. It binds the approver and approval time to the exact
+BLAKE3 digests of Phase C evidence and the proposed manifest. Missing or
+mismatched approval, non-green phase evidence, a non-v2 selector, an active
+protected window, or a deficient removal percentage produces `eligible=false`.
+The decision always records `deletion_executed=false` because execution belongs
+to separate issue #5306.
+
+The tracked request intentionally contains no approval and retains the full
+baseline. Its expected decision is ineligible with zero v1 mutation. Synthetic
+tests cover positive eligibility only to prove decision semantics; they grant
+no operational deletion authority.

--- a/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY.mmd
+++ b/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY.mmd
@@ -1,0 +1,10 @@
+flowchart TD
+  E["Gate A-C exact-revision evidence"] --> V["csdlc-eligibility"]
+  A["Typed digest-bound approval"] --> V
+  T["Protected not-before times"] --> V
+  M["Removed + retained line partition"] --> V
+  B["Pinned 49,979-line denominator"] --> V
+  V --> Q{"Current, green, approved, and eligible?"}
+  Q -->|"no / unknown"| N["eligible=false; deletion_executed=false"]
+  Q -->|"yes"| Y["eligible=true manifest evidence only"]
+  Y --> G["Separate #5306 execution authority"]

--- a/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY_EVIDENCE.json
+++ b/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY_EVIDENCE.json
@@ -1,12 +1,17 @@
 {
   "schema": "csdlc.deletion_eligibility.v1",
   "issue": 5305,
-  "code_revision": "8f002a9a8750988e1b1ffde31fcd24795c88db59",
-  "evaluated_at": "2026-07-13T03:14:50.736165Z",
+  "code_revision": "71d416635284c8a04358c6ee004dc80b57bbf587",
+  "evaluated_at": "2026-07-13T03:27:15.620452Z",
+  "baseline_revision": "020bba17deb9f172e91a2ec5c0599cf42e4defe9",
+  "baseline_files": 95,
+  "baseline_lines": 49979,
+  "rust_list_sha256": "c3118c1f3766b5f4a3e549c9073b33fb83164b3006175785b4c08f84c898558f",
+  "shell_list_sha256": "7160399a788e467ebd934309a99f9777fb0f14d4270989e5114c73b63fa3d8cc",
   "phase_b_blake3": "a313881ce6429217dc8247de7919882d3fba0312fa75d553fe61fe14e175a54f",
   "phase_c_blake3": "a2ffa533296e64f84b58c76970d0d97e961bfa34f40c085741a6559f25bd04ce",
   "selector_blake3": "5e62eee86234b93363b356a60b83d658d8138109ddc31bdc2309dbe9d8088bb5",
-  "manifest_blake3": "07f1c42da021f0c60bcf3aa820a1409adb52a457a600b8c28b40ba17c78cc0ff",
+  "manifest_blake3": "058a2a10361827ce023457572b68b07fbc0a048ab54641b385bd49de48538084",
   "removed_lines": 0,
   "retained_lines": 49979,
   "removal_basis_points": 0,
@@ -14,6 +19,8 @@
   "eligible": false,
   "reasons": [
     "missing_approval",
+    "rollback_window_active",
+    "importer_window_active",
     "below_minimum_removal"
   ],
   "deletion_executed": false

--- a/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY_EVIDENCE.json
+++ b/docs/architecture/csdlc-v2/gate10d1/ELIGIBILITY_EVIDENCE.json
@@ -1,0 +1,20 @@
+{
+  "schema": "csdlc.deletion_eligibility.v1",
+  "issue": 5305,
+  "code_revision": "8f002a9a8750988e1b1ffde31fcd24795c88db59",
+  "evaluated_at": "2026-07-13T03:14:50.736165Z",
+  "phase_b_blake3": "a313881ce6429217dc8247de7919882d3fba0312fa75d553fe61fe14e175a54f",
+  "phase_c_blake3": "a2ffa533296e64f84b58c76970d0d97e961bfa34f40c085741a6559f25bd04ce",
+  "selector_blake3": "5e62eee86234b93363b356a60b83d658d8138109ddc31bdc2309dbe9d8088bb5",
+  "manifest_blake3": "07f1c42da021f0c60bcf3aa820a1409adb52a457a600b8c28b40ba17c78cc0ff",
+  "removed_lines": 0,
+  "retained_lines": 49979,
+  "removal_basis_points": 0,
+  "target_met": false,
+  "eligible": false,
+  "reasons": [
+    "missing_approval",
+    "below_minimum_removal"
+  ],
+  "deletion_executed": false
+}


### PR DESCRIPTION
Closes #5305

## Summary

- adds a stdout-only, non-mutating Gate 10D1 eligibility verifier
- reconstructs the canonical pinned 95-file / 49,979-line v1 inventory from Git and derives all removal counts
- binds approval to Phase B, Phase C, selector, manifest, and code revision
- enforces both mandatory Phase C sunset clocks and strict lowercase digest/revision encoding
- publishes versioned request, manifest, entry, approval, and decision JSON Schemas

## Proof

- `cargo test --manifest-path csdlc-v2/Cargo.toml`
- `cargo clippy --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings`
- schema emission passed
- real tracked evaluation: `eligible=false`, 0 removed lines, both windows active, `deletion_executed=false`
- independent pre-PR subagent review approved exact HEAD `af30a5fe6` with no findings

## Non-claims

- no v1 path was deleted, renamed, edited, staged, or otherwise mutated by the verifier
- this PR grants no deletion authority; #5306 remains separately approval-gated

## Workflow note

The repo-native `pr.sh finish` delegate was attempted three times from the bound worktree. It emitted only the start/delegate events, then returned no result and created no PR. Publication used the narrow Git push + draft-PR fallback after confirming tracked state was unchanged.
