### PR TITLE
[v0.91.7][tools][pr-finish] Prefer current issue-worktree finish delegate for release-gate lanes

### DIFF
--- a/adl/tools/pr_delegate.sh
+++ b/adl/tools/pr_delegate.sh
@@ -24,6 +24,10 @@ rust_pr_delegate_available() {
   fi
   [[ -f "$(rust_pr_delegate_root)/adl/Cargo.toml" ]] || return 1
   local cached_bin
+  cached_bin="$(rust_pr_preferred_worktree_cached_bin "${1:-}" || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
   cached_bin="$(rust_pr_subcommand_stable_bin "${1:-}" || true)"
   if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
     return 0
@@ -316,6 +320,39 @@ rust_pr_subcommand_cached_bin() {
   [[ -x "$candidate" ]] || return 1
   rust_pr_delegate_bin_is_fresh "$root" "$candidate" || return 1
   printf '%s\n' "$candidate"
+}
+
+rust_pr_preferred_worktree_cached_bin() {
+  [[ "${1:-}" == "finish" ]] || return 1
+  local root primary_root
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$root" != "$primary_root" ]] || return 1
+  rust_pr_subcommand_cached_bin "$1"
+}
+
+rust_pr_finish_worktree_requires_repair() {
+  [[ "${1:-}" == "finish" ]] || return 1
+  local root primary_root primary_candidate
+  root="$(rust_pr_delegate_root)"
+  primary_root="$(rust_pr_delegate_primary_root)"
+  [[ "$root" != "$primary_root" ]] || return 1
+  primary_candidate="$primary_root/adl/target/debug/adl-pr-finish"
+  rust_pr_worktree_inputs_are_newer_than_bin "$root" "$primary_candidate" "$primary_root"
+}
+
+rust_pr_report_finish_worktree_repair() {
+  local root="$1"
+  adl_obs_event "pr.sh" "rust_delegate" "failed" \
+    "subcommand" "finish" \
+    "reason_code" "current_worktree_finish_binary_required"
+  cat >&2 <<EOF
+ERROR: the bound worktree has finish-support changes not represented by a fresh adl-pr-finish binary.
+Refusing to use a primary-checkout or PATH fallback for pr finish.
+Repair with one of:
+- cargo build --manifest-path $root/adl/Cargo.toml --bin adl-pr-finish
+- ADL_PR_FINISH_BIN=$root/adl/target/debug/adl-pr-finish bash adl/tools/pr.sh finish ...
+EOF
 }
 
 rust_pr_issue_stale_cached_bin() {
@@ -676,6 +713,15 @@ delegate_pr_command_to_rust() {
   if [[ -n "$override_bin" ]]; then
     adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$override_bin"
     exec "$override_bin" "$@"
+  fi
+  direct_bin="$(rust_pr_preferred_worktree_cached_bin "$subcommand" || true)"
+  if [[ -n "$direct_bin" ]]; then
+    adl_obs_event "pr.sh" "rust_delegate" "exec" "subcommand" "$subcommand" "delegate" "$direct_bin" "source" "current_worktree_owner_bin"
+    exec "$direct_bin" "$@"
+  fi
+  if rust_pr_finish_worktree_requires_repair "$subcommand"; then
+    rust_pr_report_finish_worktree_repair "$root"
+    exit 75
   fi
   direct_bin="$(rust_pr_subcommand_stable_bin "$subcommand" || true)"
   if [[ -n "$direct_bin" ]]; then

--- a/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
+++ b/adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh
@@ -235,23 +235,81 @@ rm -f "$worktree/adl/src/stable_primary_masking_probe.rs"
 : >"$TMP_ADL_ARGS"
 : >"$TMP_CARGO_ARGS"
 
+mkdir -p "$worktree/adl/target/debug"
+cat >"$worktree/adl/target/debug/adl-pr-finish" <<'EOF_WORKTREE_FINISH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'worktree-finish:%s\n' "$*" >"${TMP_ADL_ARGS}"
+EOF_WORKTREE_FINISH
+chmod +x "$worktree/adl/target/debug/adl-pr-finish"
+sleep 1
+touch "$worktree/adl/target/debug/adl-pr-finish"
+
+worktree_finish_log="$tmpdir/worktree-finish.log"
+
 (
   cd "$worktree"
   ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
-    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "worktree finish" --output-card out.md >/dev/null
+    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "worktree finish" --output-card out.md >"$worktree_finish_log" 2>&1
 )
 
 args="$(cat "$TMP_ADL_ARGS")"
-[[ "$args" == "finish:4413 --title worktree finish --output-card out.md" ]] || {
-  echo "assertion failed: worktree finish should delegate through the primary checkout adl-pr-finish binary without override" >&2
+[[ "$args" == "worktree-finish:4413 --title worktree finish --output-card out.md" ]] || {
+  echo "assertion failed: finish should prefer the fresh bound-worktree owner binary over the primary checkout binary" >&2
   echo "$args" >&2
   exit 1
 }
+grep -F "source=current_worktree_owner_bin" "$worktree_finish_log" >/dev/null || {
+  echo "assertion failed: bound-worktree finish selection should be observable" >&2
+  cat "$worktree_finish_log" >&2
+  exit 1
+}
 [[ ! -s "$TMP_CARGO_ARGS" ]] || {
-  echo "assertion failed: cargo should not run when the primary checkout finish binary is fresh for the worktree" >&2
+  echo "assertion failed: cargo should not run when the bound-worktree finish binary is fresh" >&2
   cat "$TMP_CARGO_ARGS" >&2
   exit 1
 }
+
+printf 'pub fn stale_worktree_finish_probe() {}\n' >"$worktree/adl/src/stale_worktree_finish_probe.rs"
+sleep 1
+touch "$worktree/adl/src/stale_worktree_finish_probe.rs"
+touch "$repo/adl/target/debug/adl-pr-finish"
+: >"$TMP_ADL_ARGS"
+: >"$TMP_CARGO_ARGS"
+stale_worktree_finish_log="$tmpdir/stale-worktree-finish.log"
+
+set +e
+(
+  cd "$worktree"
+  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
+    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "stale worktree finish" --output-card out.md >"$stale_worktree_finish_log" 2>&1
+)
+stale_worktree_finish_status="$?"
+set -e
+
+[[ "$stale_worktree_finish_status" == "75" ]] || {
+  echo "assertion failed: stale bound-worktree finish binary should fail closed with exit 75" >&2
+  cat "$stale_worktree_finish_log" >&2
+  exit 1
+}
+[[ ! -s "$TMP_ADL_ARGS" ]] || {
+  echo "assertion failed: stale primary finish binary must not run for divergent worktree inputs" >&2
+  cat "$TMP_ADL_ARGS" >&2
+  exit 1
+}
+grep -F "reason_code=current_worktree_finish_binary_required" "$stale_worktree_finish_log" >/dev/null || {
+  echo "assertion failed: stale bound-worktree finish failure should be classified" >&2
+  cat "$stale_worktree_finish_log" >&2
+  exit 1
+}
+grep -F "ADL_PR_FINISH_BIN=" "$stale_worktree_finish_log" >/dev/null || {
+  echo "assertion failed: stale bound-worktree finish failure should explain the explicit repair override" >&2
+  cat "$stale_worktree_finish_log" >&2
+  exit 1
+}
+rm -f "$worktree/adl/src/stale_worktree_finish_probe.rs"
+
+rm -f "$worktree/adl/target/debug/adl-pr-finish"
 
 : >"$TMP_ADL_ARGS"
 : >"$TMP_CARGO_ARGS"
@@ -274,42 +332,7 @@ args="$(cat "$TMP_ADL_ARGS")"
   exit 1
 }
 
-echo "pr.sh worktree prefers primary checkout finish/validation owner binaries: ok"
-
-mkdir -p "$worktree/adl/src"
-printf 'pub fn finish_owner_last_resort_probe() {}\n' >"$worktree/adl/src/finish_owner_last_resort_probe.rs"
-sleep 1
-touch "$repo/adl/target/debug/adl-pr-finish"
-: >"$TMP_ADL_ARGS"
-: >"$TMP_CARGO_ARGS"
-finish_last_resort_log="$tmpdir/finish-last-resort.log"
-
-(
-  cd "$worktree"
-  ADL_PRIMARY_CHECKOUT_ROOT="$repo" \
-    "$BASH_BIN" adl/tools/pr.sh finish 4413 --title "worktree finish stale last resort" --output-card out.md >"$finish_last_resort_log" 2>&1
-)
-
-args="$(cat "$TMP_ADL_ARGS")"
-[[ "$args" == "finish:4413 --title worktree finish stale last resort --output-card out.md" ]] || {
-  echo "assertion failed: worktree finish should use primary adl-pr-finish as dedicated last resort when cargo fallback is disabled" >&2
-  echo "$args" >&2
-  cat "$finish_last_resort_log" >&2
-  exit 1
-}
-grep -F "freshness=stale_allowed_primary_owner_last_resort" "$finish_last_resort_log" >/dev/null || {
-  echo "assertion failed: temporary stale primary owner-binary last resort should be observable" >&2
-  cat "$finish_last_resort_log" >&2
-  exit 1
-}
-[[ ! -s "$TMP_CARGO_ARGS" ]] || {
-  echo "assertion failed: cargo should not run when primary finish owner binary is used as disabled-fallback last resort" >&2
-  cat "$TMP_CARGO_ARGS" >&2
-  exit 1
-}
-rm -f "$worktree/adl/src/finish_owner_last_resort_probe.rs"
-
-echo "pr.sh worktree uses primary finish owner binary as explicit disabled-fallback last resort: ok"
+echo "pr.sh worktree prefers its current finish binary and reuses the primary validation binary: ok"
 
 rm -f "$repo/adl/target/debug/adl-pr-doctor"
 cat >"$repo/adl/target/debug/adl" <<'EOF_ADL_GENERIC'

--- a/docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md
+++ b/docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md
@@ -112,6 +112,8 @@ Rescue-sprint commands should not discover at finish time that they need a
 long Cargo build or a locked Cargo process. The expected command posture is:
 
 - prefer explicit command-specific binary overrides;
+- for `pr finish` in a bound issue worktree, prefer its fresh
+  `adl/target/debug/adl-pr-finish` before a primary-checkout stable binary;
 - prefer fresh built owner binaries in the current or primary checkout;
 - prefer matching owner binaries on `PATH`;
 - use Cargo fallback only when the issue explicitly opts into that compatibility
@@ -120,6 +122,13 @@ long Cargo build or a locked Cargo process. The expected command posture is:
 If an owner binary is missing and fallback is disabled, fail closed and record
 the tooling bug or setup gap. Do not hide the failure behind ad hoc wrapper
 scripts.
+
+`ADL_PR_FINISH_BIN` remains the explicit repair override when the bound
+worktree binary cannot be used. The resolver emits
+`source=current_worktree_owner_bin` when it selects the normal bound-worktree
+finish path. If production Rust inputs diverge and that binary is absent or
+stale, finish exits `75` with rebuild and override guidance instead of using a
+primary-checkout or `PATH` fallback.
 
 ## CSM Runtime Owner Binary Availability
 


### PR DESCRIPTION
Closes #5322

## Summary
Implemented deterministic finish-delegate resolution for C-SDLC v2 lifecycle
publication. A fresh `adl-pr-finish` in the bound issue worktree now wins over
primary-checkout binaries; divergent finish-support inputs without a fresh
worktree binary fail closed with exit `75` and explicit repair guidance.

## Artifacts
- Local output record at `.adl/v0.91.7/tasks/issue-5322__v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes/sor.md`
- Resolver repair: `adl/tools/pr_delegate.sh`
- Focused regression: `adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`
- Operator contract update: `docs/tooling/C_SDLC_RESCUE_SPRINT_OPERATING_CONTRACT.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/pr_delegate.sh adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh` - verify shell syntax for the resolver and its focused regression
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh` - prove fresh worktree finish preference, divergent fail-closed behavior, and unchanged ordinary validation resolution
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh` - prove existing PR subcommand delegation parity remains intact
  - `git diff --check` - verify the tracked patch has no whitespace errors
- Results:
  - `bash -n adl/tools/pr_delegate.sh adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`: PASS
  - `bash adl/tools/test_pr_delegate_prefers_primary_checkout_binary.sh`: PASS
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh`: PASS
  - `git diff --check`: PASS

## Local Artifacts
- Input card:  .adl/v0.91.7/tasks/issue-5322__v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes/sip.md
- Output card: .adl/v0.91.7/tasks/issue-5322__v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes/sor.md
- Idempotency-Key: v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes-adl-tools-pr-delegate-sh-adl-tools-test-pr-delegate-prefers-primary-checkout-binary-sh-docs-tooling-c-sdlc-rescue-sprint-operating-contract-md-adl-v0-91-7-tasks-issue-5322-v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes-sip-md-adl-v0-91-7-tasks-issue-5322-v0-91-7-tools-pr-finish-prefer-current-issue-worktree-finish-delegate-for-release-gate-lanes-sor-md