### PR TITLE
[v0.91.7][csdlc-v2] Expose shepherd schema and examples

### DIFF
--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -1,5 +1,10 @@
 # C-SDLC v2
 
+`csdlc-shepherd --schema` and `--example <name>` are currently the complete
+discovery path for a JSON-input owner binary. The same affordance is planned
+for the remaining request-driven binaries as their CLI contracts are repaired;
+until then, use their typed public schema bundle and request definitions.
+
 This is the standalone clean-room C-SDLC v2 workspace. It does not depend on
 ADL or Runtime crates and does not reuse their lifecycle implementation,
 schemas, templates, tests, fixtures, or skills.

--- a/csdlc-v2/operator/examples/shepherd/operator_required.json
+++ b/csdlc-v2/operator/examples/shepherd/operator_required.json
@@ -1,0 +1,7 @@
+{
+  "validation": "failed",
+  "dependency_wait": false,
+  "retryable_failure": false,
+  "repair_needed": false,
+  "operator_decision_needed": true
+}

--- a/csdlc-v2/operator/examples/shepherd/ready.json
+++ b/csdlc-v2/operator/examples/shepherd/ready.json
@@ -1,0 +1,7 @@
+{
+  "validation": "local_pass",
+  "dependency_wait": false,
+  "retryable_failure": false,
+  "repair_needed": false,
+  "operator_decision_needed": false
+}

--- a/csdlc-v2/operator/examples/shepherd/repair_required.json
+++ b/csdlc-v2/operator/examples/shepherd/repair_required.json
@@ -1,0 +1,7 @@
+{
+  "validation": "failed",
+  "dependency_wait": false,
+  "retryable_failure": false,
+  "repair_needed": true,
+  "operator_decision_needed": false
+}

--- a/csdlc-v2/operator/examples/shepherd/retryable.json
+++ b/csdlc-v2/operator/examples/shepherd/retryable.json
@@ -1,0 +1,7 @@
+{
+  "validation": "failed",
+  "dependency_wait": false,
+  "retryable_failure": true,
+  "repair_needed": false,
+  "operator_decision_needed": false
+}

--- a/csdlc-v2/operator/examples/shepherd/waiting.json
+++ b/csdlc-v2/operator/examples/shepherd/waiting.json
@@ -1,0 +1,7 @@
+{
+  "validation": null,
+  "dependency_wait": true,
+  "retryable_failure": false,
+  "repair_needed": false,
+  "operator_decision_needed": false
+}

--- a/csdlc-v2/src/bin/csdlc-shepherd.rs
+++ b/csdlc-v2/src/bin/csdlc-shepherd.rs
@@ -1,14 +1,101 @@
 use clap::Parser;
+use clap::Subcommand;
 use csdlc_v2::{classify_shepherd, ShepherdInput};
 use std::{fs, path::PathBuf};
+
 #[derive(Parser)]
+#[command(about = "Classify read-only C-SDLC shepherd state from typed JSON")]
 struct Cli {
-    #[arg(long)]
-    input: PathBuf,
+    #[command(subcommand)]
+    command: Option<Command>,
+    #[arg(long, conflicts_with_all = ["input", "example"], help = "Print the ShepherdInput JSON schema")]
+    schema: bool,
+    #[arg(long, conflicts_with_all = ["input", "schema"], value_name = "NAME", help = "Print a checked example (ready, waiting, retryable, repair_required, operator_required)")]
+    example: Option<String>,
+    #[arg(long, conflicts_with_all = ["schema", "example"], help = "Read a ShepherdInput JSON file")]
+    input: Option<PathBuf>,
 }
+#[derive(Subcommand)]
+enum Command {
+    #[command(name = "schema", about = "Print the ShepherdInput JSON schema")]
+    Schema,
+    #[command(name = "example", about = "Print a checked ShepherdInput example")]
+    Example { name: String },
+}
+
+fn example(name: &str) -> Option<ShepherdInput> {
+    let base = |validation,
+                dependency_wait,
+                retryable_failure,
+                repair_needed,
+                operator_decision_needed| {
+        ShepherdInput {
+            validation,
+            dependency_wait,
+            retryable_failure,
+            repair_needed,
+            operator_decision_needed,
+        }
+    };
+    Some(match name {
+        "ready" => base(
+            Some(csdlc_v2::pvf::ValidationDisposition::LocalPass),
+            false,
+            false,
+            false,
+            false,
+        ),
+        "waiting" => base(None, true, false, false, false),
+        "retryable" => base(
+            Some(csdlc_v2::pvf::ValidationDisposition::Failed),
+            false,
+            true,
+            false,
+            false,
+        ),
+        "repair_required" => base(
+            Some(csdlc_v2::pvf::ValidationDisposition::Failed),
+            false,
+            false,
+            true,
+            false,
+        ),
+        "operator_required" => base(
+            Some(csdlc_v2::pvf::ValidationDisposition::Failed),
+            false,
+            false,
+            false,
+            true,
+        ),
+        _ => return None,
+    })
+}
+
 fn main() {
     let cli = Cli::parse();
-    let bytes = fs::read(cli.input).unwrap_or_else(|e| {
+    if cli.schema || matches!(cli.command, Some(Command::Schema)) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&schemars::schema_for!(ShepherdInput)).expect("JSON")
+        );
+        return;
+    }
+    if let Some(name) = cli.example.or(match cli.command {
+        Some(Command::Example { name }) => Some(name),
+        _ => None,
+    }) {
+        let Some(input) = example(&name) else {
+            eprintln!("unknown example {name}; expected ready, waiting, retryable, repair_required, or operator_required");
+            std::process::exit(64);
+        };
+        println!("{}", serde_json::to_string_pretty(&input).expect("JSON"));
+        return;
+    }
+    let Some(input) = cli.input else {
+        eprintln!("provide --input <PATH>, --schema, or --example <NAME>");
+        std::process::exit(64);
+    };
+    let bytes = fs::read(input).unwrap_or_else(|e| {
         eprintln!("{e}");
         std::process::exit(74)
     });

--- a/csdlc-v2/tests/gate4.rs
+++ b/csdlc-v2/tests/gate4.rs
@@ -638,3 +638,48 @@ fn scheduler_and_shepherd_are_read_only_classifiers() {
     });
     assert_eq!(operator.state, ShepherdState::OperatorRequired);
 }
+
+#[test]
+fn shepherd_cli_exposes_schema_and_checked_examples() {
+    use std::process::Command;
+    let binary = env!("CARGO_BIN_EXE_csdlc-shepherd");
+    let schema = Command::new(binary)
+        .arg("--schema")
+        .output()
+        .expect("shepherd schema");
+    assert!(schema.status.success());
+    let schema: serde_json::Value = serde_json::from_slice(&schema.stdout).expect("schema json");
+    assert!(schema["properties"]["repair_needed"].is_object());
+
+    for (name, expected) in [
+        ("ready", ShepherdState::Ready),
+        ("waiting", ShepherdState::Waiting),
+        ("retryable", ShepherdState::Retryable),
+        ("repair_required", ShepherdState::RepairRequired),
+        ("operator_required", ShepherdState::OperatorRequired),
+    ] {
+        let output = Command::new(binary)
+            .args(["--example", name])
+            .output()
+            .expect("shepherd example");
+        assert!(output.status.success(), "{name}");
+        let input: ShepherdInput = serde_json::from_slice(&output.stdout).expect("example json");
+        let fixture = std::fs::read_to_string(format!(
+            "{}/operator/examples/shepherd/{name}.json",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("example fixture");
+        let fixture: serde_json::Value = serde_json::from_str(&fixture).expect("fixture json");
+        assert_eq!(
+            serde_json::to_value(&input).expect("input json"),
+            fixture,
+            "{name}"
+        );
+        assert_eq!(classify_shepherd(&input).state, expected, "{name}");
+    }
+    let invalid = Command::new(binary)
+        .args(["--example", "unknown"])
+        .output()
+        .expect("invalid example");
+    assert_eq!(invalid.status.code(), Some(64));
+}


### PR DESCRIPTION
Closes #5373\n\n- add --schema and --example discovery paths\n- add ready, waiting, retryable, repair_required, and operator_required fixtures\n- preserve typed JSON input classification\n\nValidation: cargo test --locked --manifest-path csdlc-v2/Cargo.toml --test gate4; cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings