### PR TITLE
[v0.91.7][csdlc-v2] Document v1-origin PR tail handling

### DIFF
--- a/csdlc-v2/operator/SKILLS.md
+++ b/csdlc-v2/operator/SKILLS.md
@@ -16,3 +16,7 @@ authority to mutate candidate v1 paths or execute an eligible manifest.
 The legacy AST importer remains only as an internal, one-way parity fixture for
 Gate 8 tests. The `csdlc-import` executable and operator route are sunset; no
 new lifecycle operation may invoke the importer after Gate 10D2.
+
+For pull requests created before the v1 sunset, follow
+`docs/tooling/C_SDLC_V2_V1_ORIGIN_PR_TAIL_PLAYBOOK.md`; do not revive the
+historical v1 command surface.

--- a/docs/tooling/C_SDLC_V2_V1_ORIGIN_PR_TAIL_PLAYBOOK.md
+++ b/docs/tooling/C_SDLC_V2_V1_ORIGIN_PR_TAIL_PLAYBOOK.md
@@ -1,0 +1,52 @@
+# C-SDLC v2 playbook for v1-origin PR tails
+
+This playbook applies when a pull request was opened before the v1 command
+surface was sunset. The PR remains valid; only its lifecycle authority changes.
+
+## Authority
+
+Use the typed v2 binaries for all new observations and mutations:
+
+| Tail state | Authoritative operation | Result |
+| --- | --- | --- |
+| Need current issue/PR facts | `csdlc-closeout observe-readiness` or the future typed PR collector, then `csdlc-shepherd` | Read-only observation/classification |
+| Branch is behind `main` | Rebase or merge in the bound worktree | New substantive revision; review must be reassigned |
+| Checks are pending | Shepherd state `waiting` | Wait; do not publish or close |
+| Checks failed | Shepherd state `repair_required` or `retryable` | Repair or retry, then revalidate |
+| Review is required | Typed v2 review assignment/recording | Preserve exact reviewed revision |
+| PR is ready | `csdlc-publish` and `csdlc-closeout` | Publish/readiness/terminal evidence |
+
+Do not invoke `pr.sh`, `workflow-conductor`, v1 prompt-template wrappers, or
+`csdlc-import` for a new lifecycle mutation. Historical records may mention
+those commands; those mentions are evidence, not executable instructions.
+
+## Stale-base repair
+
+1. Keep the issue claim and bound worktree.
+2. Fetch the intended base and rebase or merge it in the issue worktree.
+3. Run the smallest proving validation for the changed paths.
+4. Treat the resulting commit as a new substantive revision. A prior review is
+   stale unless a valid typed non-substantive proof covers only metadata paths.
+5. Reassign and record review before updating the PR.
+6. Re-run shepherd classification and wait for required checks.
+
+Never solve a stale base by editing `.csdlc` state directly or publishing a
+dirty tree.
+
+## Direct GitHub fallback
+
+The current live provider observation path is the typed
+`csdlc-closeout observe-readiness` route; the dedicated PR collector is tracked
+by the repair sprint's #5370/#5371 work. A direct GitHub query is permitted
+only when the typed route cannot reach the provider or when diagnosing it. Use the shared approved token resolver, never
+print token contents, and record the sanitized result (PR number, state, draft
+flag, base/head refs and SHA, review decision, checks, and merge state) in the
+issue's evidence packet. The fallback does not grant merge or close authority.
+
+## Merge and closeout
+
+Only a green, non-draft PR with current review truth may proceed to readiness.
+Record the exact head SHA and required-check outcomes. After GitHub reports the
+terminal state, use the typed closeout observation and preserve the terminal
+receipt before any worktree prune. No v2 binary grants merge authority; merging
+is an explicit operator/GitHub action, and v2 records the observed result.


### PR DESCRIPTION
Closes #5372\n\nAdds the v2 tail-maintenance playbook for stale-base repair, typed shepherd/review/publish/closeout authority, and bounded direct GitHub fallback evidence.