### PR TITLE
[v0.91.7][csdlc-v2] Reject stale VPP command paths at bootstrap

### DIFF
--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -61,6 +61,7 @@ pub fn initialize_issue(
         ));
     }
     validate_bootstrap_request(&request)?;
+    validate_validation_lanes(store.root(), &request.initial.validation_lanes)?;
     let issue_dir = store.issue_dir(request.issue);
     for authored_path in [&request.design_path, &request.diagram_path] {
         let path = store.root().join(authored_path);
@@ -127,6 +128,34 @@ pub fn initialize_issue(
         )?;
     }
     bootstrap_issue(store, request)
+}
+
+fn validate_validation_lanes(
+    root: &std::path::Path,
+    lanes: &[crate::cards::ValidationLane],
+) -> Result<()> {
+    for lane in lanes {
+        for command in &lane.argv {
+            if !command.contains('/') {
+                continue;
+            }
+            let path = if Path::new(command).is_absolute() {
+                Path::new(command).to_path_buf()
+            } else {
+                root.join(command)
+            };
+            if !path.is_file() {
+                return Err(V2Error::new(
+                    ErrorCode::InvalidInput,
+                    format!(
+                        "validation lane {} names missing command {}",
+                        lane.lane, command
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn bind_issue(store: &Store, request: BindRequest) -> Result<BindResult> {

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -104,6 +104,21 @@ fn fixture() -> (TempDir, Store, csdlc_v2::IssueRecord) {
 }
 
 #[test]
+fn bootstrap_rejects_missing_vpp_command_before_authoring_files() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(temp.path());
+    let mut request = request();
+    request.initial.validation_lanes[0].argv = vec![
+        "bash".into(),
+        "adl/tools/validate_planning_templates.sh".into(),
+    ];
+    let error = csdlc_v2::initialize_issue(&store, request).expect_err("missing command");
+    assert!(matches!(error.code, ErrorCode::InvalidInput));
+    assert!(!temp.path().join("docs/design.md").exists());
+    assert!(!temp.path().join(".csdlc/issues/42").exists());
+}
+
+#[test]
 fn bind_creates_and_idempotently_reuses_typed_worktree() {
     let (temp, store, record) = fixture();
     git(temp.path(), &["init", "-b", "main"]);


### PR DESCRIPTION
Closes #5365\n\n- validate path-like VPP commands before authoring issue files\n- fail closed on missing deleted v1 wrappers\n- add atomic no-artifact regression coverage\n\nValidation: cargo test --locked --manifest-path csdlc-v2/Cargo.toml --test gate2; cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings