### PR TITLE
[v0.91.7][csdlc-v2] Add audited bound-phase replanning

### DIFF
--- a/csdlc-v2/src/cards.rs
+++ b/csdlc-v2/src/cards.rs
@@ -487,6 +487,10 @@ pub enum TextField {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum SemanticOperation {
+    Replan {
+        field: TextField,
+        value: String,
+    },
     SetField {
         field: TextField,
         value: String,
@@ -750,6 +754,10 @@ pub fn apply(
     operation: &SemanticOperation,
 ) -> Result<Option<LifecyclePhase>> {
     match operation {
+        SemanticOperation::Replan { field, value } => {
+            set_text(values, *field, value.clone())?;
+            Ok(None)
+        }
         SemanticOperation::SetField { field, value } => {
             set_text(values, *field, value.clone())?;
             Ok(None)

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -983,6 +983,25 @@ pub fn edit_issue(store: &Store, request: EditRequest) -> Result<IssueRecord> {
         ));
     }
     authorize_card_operation(record.phase, request.card, &request.operation)?;
+    let replan_before = match &request.operation {
+        SemanticOperation::Replan { field, .. } => Some(current_text_value(
+            cards
+                .get(&request.card)
+                .ok_or_else(|| V2Error::new(ErrorCode::CorruptRecord, "card projection missing"))?,
+            *field,
+        )?),
+        _ => None,
+    };
+    let audit_operation = match (&request.operation, replan_before) {
+        (SemanticOperation::Replan { field, value }, Some(previous)) => serde_json::json!({
+            "operation": "replan",
+            "field": field.as_ref(),
+            "previous_value": previous,
+            "new_value": value,
+        })
+        .to_string(),
+        _ => serde_json::to_string(&request.operation)?,
+    };
     let values = cards
         .get_mut(&request.card)
         .ok_or_else(|| V2Error::new(ErrorCode::CorruptRecord, "card projection missing"))?;
@@ -1011,12 +1030,31 @@ pub fn edit_issue(store: &Store, request: EditRequest) -> Result<IssueRecord> {
         generation: record.generation,
         actor: request.actor,
         reason: request.reason,
-        operation: serde_json::to_string(&request.operation)?,
+        operation: audit_operation,
     });
     hydrate_projections(&mut record, &cards)?;
     record.digest = record_digest(&record)?;
     store.commit(request.issue, &record, &cards, request.fail_after_backup)?;
     Ok(record)
+}
+
+fn current_text_value(values: &CardValues, field: crate::cards::TextField) -> Result<String> {
+    match (&values.content, field) {
+        (CardContent::Sip(value), crate::cards::TextField::Goal) => Ok(value.goal.clone()),
+        (CardContent::Sip(value), crate::cards::TextField::RequiredOutcome) => {
+            Ok(value.required_outcome.clone())
+        }
+        (CardContent::Stp(value), crate::cards::TextField::TaskBoundary) => {
+            Ok(value.task_boundary.clone())
+        }
+        (CardContent::Spp(value), crate::cards::TextField::PlanSummary) => {
+            Ok(value.summary.clone())
+        }
+        _ => Err(V2Error::new(
+            ErrorCode::FieldOwnership,
+            "replan field is not owned by the selected planning card",
+        )),
+    }
 }
 
 pub(crate) fn verify_cards(
@@ -1339,6 +1377,10 @@ fn authorize_card_operation(
             SemanticOperation::SetField { .. }
                 | SemanticOperation::AppendReference { .. }
                 | SemanticOperation::AdvanceStatus { .. },
+        ) | (
+            LifecyclePhase::Bound,
+            CardKind::Sip | CardKind::Stp | CardKind::Spp,
+            SemanticOperation::Replan { .. },
         ) | (
             LifecyclePhase::Bound,
             CardKind::Sor,

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -370,6 +370,110 @@ fn semantic_edit_updates_one_owned_projection_atomically() {
 }
 
 #[test]
+fn bound_replan_is_typed_claimed_and_limited_to_planning_cards() {
+    let (temp, store, record) = fixture();
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "test"]);
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-m", "fixture"]);
+    let claim = record.claim.clone().expect("claim");
+    csdlc_v2::bind_issue(
+        &store,
+        csdlc_v2::BindRequest {
+            issue: 42,
+            base_branch: "main".into(),
+            branch: "issue-42".into(),
+            worktree: ".worktrees/issue-42".into(),
+            claim,
+        },
+    )
+    .expect("bind");
+    let bound_record = store.load_record(42).expect("bound record");
+    let updated = edit_issue(
+        &store,
+        EditRequest {
+            issue: 42,
+            card: CardKind::Spp,
+            expected_generation: bound_record.generation,
+            expected_digest: bound_record.digest.clone(),
+            claim_id: "claim-1".into(),
+            actor: "agent".into(),
+            reason: "revise bounded plan after scope clarification".into(),
+            operation: SemanticOperation::Replan {
+                field: csdlc_v2::cards::TextField::PlanSummary,
+                value: "Replanned bounded execution.".into(),
+            },
+            fail_after_backup: false,
+        },
+    )
+    .expect("replan");
+    assert!(updated.generation > bound_record.generation);
+    let replan_audit = updated.audit.last().expect("audit").operation.clone();
+    assert!(replan_audit.contains("replan"));
+    assert!(replan_audit.contains("previous_value"));
+    assert!(replan_audit.contains("Build then diagnose."));
+    let sip = edit_issue(
+        &store,
+        EditRequest {
+            issue: 42,
+            card: CardKind::Sip,
+            expected_generation: updated.generation,
+            expected_digest: updated.digest,
+            claim_id: "claim-1".into(),
+            actor: "agent".into(),
+            reason: "revise intent".into(),
+            operation: SemanticOperation::Replan {
+                field: csdlc_v2::cards::TextField::Goal,
+                value: "Replanned goal.".into(),
+            },
+            fail_after_backup: false,
+        },
+    )
+    .expect("SIP replan");
+    let stp = edit_issue(
+        &store,
+        EditRequest {
+            issue: 42,
+            card: CardKind::Stp,
+            expected_generation: sip.generation,
+            expected_digest: sip.digest,
+            claim_id: "claim-1".into(),
+            actor: "agent".into(),
+            reason: "revise task boundary".into(),
+            operation: SemanticOperation::Replan {
+                field: csdlc_v2::cards::TextField::TaskBoundary,
+                value: "Replanned task boundary.".into(),
+            },
+            fail_after_backup: false,
+        },
+    )
+    .expect("STP replan");
+    let sor = edit_issue(
+        &store,
+        EditRequest {
+            issue: 42,
+            card: CardKind::Sor,
+            expected_generation: stp.generation,
+            expected_digest: stp.digest,
+            claim_id: "claim-1".into(),
+            actor: "agent".into(),
+            reason: "unauthorized bound replan".into(),
+            operation: SemanticOperation::Replan {
+                field: csdlc_v2::cards::TextField::SorSummary,
+                value: "nope".into(),
+            },
+            fail_after_backup: false,
+        },
+    )
+    .expect_err("SOR replan must be rejected");
+    assert!(matches!(sor.code, ErrorCode::InvalidTransition));
+}
+
+#[test]
 fn field_ownership_violation_fails_without_generation_change() {
     let (_temp, store, record) = fixture();
     let error = edit_issue(


### PR DESCRIPTION
Closes #5364\n\n- add typed Replan semantic operation\n- permit only SIP/STP/SPP replans during bound phase\n- retain CAS claim and audit semantics\n- reject SOR replans\n\nValidation: cargo test --locked --manifest-path csdlc-v2/Cargo.toml --test gate2; cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings