### PR TITLE
[v0.91.7][runtime-v3] Reconcile sprint closeout truth

### DIFF
--- a/adl-runtime-kernel/tests/parity.rs
+++ b/adl-runtime-kernel/tests/parity.rs
@@ -1569,6 +1569,22 @@ fn final_cutover_decision_keeps_v2_default_after_live_parity_clear() {
     assert_eq!(decision["runtime_v2_deletion_authorized"], false);
     assert_eq!(decision["rollback_target"], "v2");
     assert_eq!(decision["next_gate"]["issue"], 5220);
+    assert_eq!(
+        decision["evidence_temporality"]["kind"],
+        "decision_time_snapshot"
+    );
+    assert_eq!(decision["post_decision_state_updates"][0]["issue"], 5285);
+    assert_eq!(
+        decision["post_decision_state_updates"][0]["state"],
+        "closed"
+    );
+    let network_dependency = decision["dependency_state"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["issue"] == 5285)
+        .unwrap();
+    assert_eq!(network_dependency["state"], "in_review");
 
     assert_eq!(classification["cutover_eligible"], true);
     assert_eq!(classification["default_runtime_switch_authorized"], false);
@@ -1632,6 +1648,10 @@ fn release_proof_gate_closes_without_authorizing_default_cutover() {
         "../../docs/architecture/runtime_v3_live_black_box_parity_5248.v1.json"
     ))
     .unwrap();
+    let closeout: serde_json::Value = serde_json::from_str(include_str!(
+        "../../docs/architecture/runtime_v3_closeout_truth_5385.v1.json"
+    ))
+    .unwrap();
 
     assert_eq!(gate["schema"], "adl.runtime_v3.release_proof_gate.v1");
     assert_eq!(gate["issue"], 5220);
@@ -1648,6 +1668,62 @@ fn release_proof_gate_closes_without_authorizing_default_cutover() {
     assert_eq!(decision["default_runtime_switch_authorized"], false);
     assert_eq!(classification["cutover_eligible"], true);
     assert_eq!(classification["summary"]["blocker"], 0);
+    assert_eq!(
+        closeout["release_truth"]["live_black_box_blocker_groups"],
+        0
+    );
+    assert_eq!(closeout["release_truth"]["default_runtime"], "v2");
+    assert_eq!(
+        closeout["release_truth"]["runtime_v3_selection"],
+        "explicit_opt_in_only"
+    );
+    assert_eq!(
+        closeout["release_truth"]["runtime_v2_deletion_authorized"],
+        false
+    );
+    assert_eq!(
+        closeout["release_truth"]["runtime_v2_decommission_authorized"],
+        false
+    );
+    assert_eq!(closeout["release_truth"]["rollback_target"], "v2");
+    assert_eq!(
+        closeout["release_truth"]["later_reviewed_default_switch_required"],
+        true
+    );
+    let deferred = closeout["release_truth"]["deferred_non_cutover_surfaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry.as_str().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        deferred,
+        [
+            "observed GPU telemetry and GPU runtime qualification",
+            "remote multi-day qualification",
+            "Horust/native guardian qualification",
+        ]
+        .into_iter()
+        .collect()
+    );
+    let sprint_projection = closeout["finding_dispositions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["finding"] == "issue_5174_legacy_lifecycle_projection_stale")
+        .unwrap();
+    assert_eq!(
+        sprint_projection["truth"]["original_pre_close_review"],
+        "not_reconstructable_from_tracked_evidence"
+    );
+    assert!(closeout["non_claims"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry
+            .as_str()
+            .unwrap()
+            .contains("does not invent an original #5174 review")));
 
     let child_results = gate["child_issue_results"].as_array().unwrap();
     let closed_children = child_results
@@ -1681,6 +1757,13 @@ fn release_proof_gate_closes_without_authorizing_default_cutover() {
             .unwrap();
         assert_eq!(issue_state["state"], "closed");
     }
+    let sprint_state = checklist["issue_states"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["issue"] == 5227)
+        .unwrap();
+    assert_eq!(sprint_state["state"], "closed");
 }
 
 #[test]

--- a/docs/architecture/runtime_v3_closeout_truth_5385.v1.json
+++ b/docs/architecture/runtime_v3_closeout_truth_5385.v1.json
@@ -1,0 +1,84 @@
+{
+  "schema": "adl.runtime_v3.closeout_truth_reconciliation.v1",
+  "issue": 5385,
+  "target_version": "v0.91.7",
+  "created_at_utc": "2026-07-15T16:49:14Z",
+  "scope": {
+    "sprint_issue": 5174,
+    "cutover_sprint_issue": 5227,
+    "release_gate_issue": 5220
+  },
+  "live_issue_state": [
+    {
+      "issue": 5174,
+      "state": "closed",
+      "closed_at_utc": "2026-07-12T07:04:55Z"
+    },
+    {
+      "issue": 5227,
+      "state": "closed",
+      "closed_at_utc": "2026-07-12T14:50:13Z"
+    },
+    {
+      "issue": 5285,
+      "state": "closed",
+      "closed_at_utc": "2026-07-13T04:05:47Z"
+    }
+  ],
+  "release_truth": {
+    "authority": "docs/architecture/runtime_v3_release_proof_gate_5220.v1.json",
+    "release_gate_result": "complete_no_default_cutover",
+    "live_black_box_blocker_groups": 0,
+    "default_runtime": "v2",
+    "runtime_v3_selection": "explicit_opt_in_only",
+    "rollback_target": "v2",
+    "runtime_v2_deletion_authorized": false,
+    "runtime_v2_decommission_authorized": false,
+    "later_reviewed_default_switch_required": true,
+    "deferred_non_cutover_surfaces": [
+      "observed GPU telemetry and GPU runtime qualification",
+      "remote multi-day qualification",
+      "Horust/native guardian qualification"
+    ]
+  },
+  "finding_dispositions": [
+    {
+      "finding": "issue_5174_legacy_lifecycle_projection_stale",
+      "disposition": "retire_non_authoritative_local_projection",
+      "paths": [
+        ".adl/cards/5174/output_5174.md",
+        ".adl/cards/5174/srp_5174.md"
+      ],
+      "tracked_by_git": false,
+      "lifecycle_authority": "none_v1_sunset",
+      "truth": {
+        "version": "v0.91.7",
+        "issue_state": "closed",
+        "original_pre_close_review": "not_reconstructable_from_tracked_evidence",
+        "post_close_review": "completed_with_findings_routed_to_5385"
+      },
+      "note": "The stale ignored files are not promoted into retained evidence, and no original review or validation result is invented."
+    },
+    {
+      "finding": "issue_5227_nine_blocker_statement_stale",
+      "disposition": "superseded_by_current_release_truth",
+      "path": ".adl/cards/5227/output_5227.md",
+      "tracked_by_git": false,
+      "lifecycle_authority": "none_v1_sunset",
+      "replacement_statement": "Default cutover requires a later reviewed release decision; GPU, remote, and Horust remain deferred non-cutover surfaces."
+    },
+    {
+      "finding": "tracked_issue_state_snapshots_stale",
+      "disposition": "reconciled",
+      "current_checklist": "docs/architecture/runtime_v3_cutover_checklist.v1.json",
+      "historical_decision_packet": "docs/architecture/runtime_v3_cutover_decision_5254.v1.json",
+      "rule": "Living checklists carry current state; decision packets preserve decision-time state and record later updates separately."
+    }
+  ],
+  "non_claims": [
+    "This reconciliation does not authorize Runtime v3 as the default runtime.",
+    "This reconciliation does not delete or decommission Runtime v2.",
+    "This reconciliation does not convert deferred GPU, remote, or Horust lanes into passed proof.",
+    "This reconciliation does not invent an original #5174 review, validation run, branch binding, or implementation metric."
+  ]
+}

--- a/docs/architecture/runtime_v3_cutover_checklist.v1.json
+++ b/docs/architecture/runtime_v3_cutover_checklist.v1.json
@@ -7,7 +7,7 @@
   "default_runtime_switch_authorized": false,
   "runtime_v2_deletion_authorized": false,
   "created_at_utc": "2026-07-12T05:40:00Z",
-  "updated_at_utc": "2026-07-12T14:20:00Z",
+  "updated_at_utc": "2026-07-15T16:49:14Z",
   "evidence": {
     "parity_matrix": "docs/architecture/runtime_v3_parity_matrix.v1.json",
     "shadow_parity_report": "docs/architecture/runtime_v3_shadow_parity_report.v1.json",
@@ -33,7 +33,7 @@
     {"issue": 5222, "state": "closed", "role": "weather_gpu_qualification", "cutover_effect": "cpu_memory_disk_weather_passed_gpu_deferred_to_5252"},
     {"issue": 5224, "state": "closed", "role": "guardian_fallback_review", "cutover_effect": "no_drop_in_cots_replacement_identified"},
     {"issue": 5225, "state": "closed", "role": "guardian_fallback_implementation", "cutover_effect": "selected_small_tokio_child_process_fallback"},
-    {"issue": 5227, "state": "open", "role": "v0_91_7_cutover_sprint_umbrella", "cutover_effect": "awaits_5220_closeout"},
+    {"issue": 5227, "state": "closed", "role": "v0_91_7_cutover_sprint_umbrella", "cutover_effect": "closed_after_5220_completed_without_authorizing_default_cutover"},
     {"issue": 5247, "state": "closed", "role": "v0_91_7_cutover_readiness_umbrella", "cutover_effect": "child_wave_complete"},
     {"issue": 5248, "state": "closed", "role": "live_black_box_parity", "cutover_effect": "retained_cutover_eligible_true_with_zero_remaining_blockers_after_5277_5278_5279_5280_5281_5282_5283_5284_5285"},
     {"issue": 5249, "state": "closed", "role": "private_state_security_equivalence", "cutover_effect": "accepted_intentional_divergence_no_raw_v2_format_claim"},

--- a/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
+++ b/docs/architecture/runtime_v3_cutover_decision_5254.v1.json
@@ -3,6 +3,13 @@
   "issue": 5254,
   "target_version": "v0.91.7",
   "created_at_utc": "2026-07-12T13:55:00Z",
+  "evidence_temporality": {
+    "kind": "decision_time_snapshot",
+    "observed_at_utc": "2026-07-12T13:55:00Z",
+    "dependency_state_semantics": "state observed when the decision packet was created; not current live issue state",
+    "current_release_authority": "docs/architecture/runtime_v3_release_proof_gate_5220.v1.json",
+    "current_issue_state_reconciliation": "docs/architecture/runtime_v3_closeout_truth_5385.v1.json"
+  },
   "decision": "keep_runtime_v2_default",
   "cutover_authorized": false,
   "default_runtime": "v2",
@@ -47,6 +54,15 @@
     {"issue": 5283, "state": "closed", "role": "contracts.delegation_resources live Runtime v3 proof"},
     {"issue": 5284, "state": "closed", "role": "agents.providers_scheduler live Runtime v3 proof"},
     {"issue": 5285, "state": "in_review", "role": "network.acip_a2a_cloud live Runtime v3 proof"}
+  ],
+  "post_decision_state_updates": [
+    {
+      "issue": 5285,
+      "state": "closed",
+      "closed_at_utc": "2026-07-13T04:05:47Z",
+      "source": "live GitHub issue state verified by #5385",
+      "decision_effect": "none; the reviewed no-go default-switch decision remains unchanged"
+    }
   ],
   "blocking_surfaces": [],
   "next_gate": {


### PR DESCRIPTION
## Summary

- reconcile #5227 current closure in the living Runtime v3 checklist
- preserve #5285's decision-time state while recording its later closure separately
- add authoritative #5385 closeout truth and regression coverage for the reviewed release boundaries
- retire stale local-only v1 card projections without inventing original #5174 review evidence

## Validation

- `cargo test --manifest-path adl-runtime-kernel/Cargo.toml --test parity` (31 passed, 1 intentionally ignored)
- JSON parse and consistency assertions
- `cargo fmt --manifest-path adl-runtime-kernel/Cargo.toml --check`
- `git diff --check`
- bounded subagent review, three findings fixed, clean second pass

Closes #5385