### PR TITLE
[v0.91.7][csdlc-v2] Use shared GitHub token resolver

### DIFF
--- a/csdlc-v2/src/bin/csdlc-closeout.rs
+++ b/csdlc-v2/src/bin/csdlc-closeout.rs
@@ -377,32 +377,7 @@ fn client(token_file: Option<&str>) -> csdlc_v2::Result<octocrab::Octocrab> {
         .map_err(remote)
 }
 fn resolve_token(path: Option<&str>) -> csdlc_v2::Result<String> {
-    for key in ["ADL_GITHUB_TOKEN", "GITHUB_TOKEN"] {
-        if let Ok(value) = std::env::var(key) {
-            if !value.trim().is_empty() {
-                return Ok(value);
-            }
-        }
-    }
-    let path = path.ok_or_else(|| {
-        V2Error::new(
-            ErrorCode::InvalidInput,
-            "GitHub token source is unavailable",
-        )
-    })?;
-    let value = fs::read_to_string(path).map_err(|_| {
-        V2Error::new(
-            ErrorCode::InvalidInput,
-            "GitHub token source is unavailable",
-        )
-    })?;
-    if value.trim().is_empty() {
-        return Err(V2Error::new(
-            ErrorCode::InvalidInput,
-            "GitHub token source is empty",
-        ));
-    }
-    Ok(value.trim().into())
+    csdlc_v2::github_token::resolve(path)
 }
 fn remote(error: octocrab::Error) -> V2Error {
     V2Error::new(

--- a/csdlc-v2/src/bin/csdlc-publish.rs
+++ b/csdlc-v2/src/bin/csdlc-publish.rs
@@ -132,42 +132,7 @@ async fn run(cli: &Cli) -> csdlc_v2::Result<serde_json::Value> {
 }
 
 fn resolve_token(request: &PublicationRequest) -> csdlc_v2::Result<String> {
-    if let Ok(value) = std::env::var("ADL_GITHUB_TOKEN") {
-        if !value.trim().is_empty() {
-            return Ok(value);
-        }
-    }
-    if let Ok(value) = std::env::var("GITHUB_TOKEN") {
-        if !value.trim().is_empty() {
-            return Ok(value);
-        }
-    }
-    let path = request
-        .token_file
-        .as_deref()
-        .unwrap_or("~/.config/csdlc/github.token");
-    let expanded = if let Some(rest) = path.strip_prefix("~/") {
-        PathBuf::from(
-            std::env::var("HOME")
-                .map_err(|_| V2Error::new(ErrorCode::InvalidInput, "HOME is unavailable"))?,
-        )
-        .join(rest)
-    } else {
-        PathBuf::from(path)
-    };
-    let value = fs::read_to_string(expanded).map_err(|_| {
-        V2Error::new(
-            ErrorCode::InvalidInput,
-            "GitHub token source is unavailable",
-        )
-    })?;
-    if value.trim().is_empty() {
-        return Err(V2Error::new(
-            ErrorCode::InvalidInput,
-            "GitHub token source is empty",
-        ));
-    }
-    Ok(value.trim().into())
+    csdlc_v2::github_token::resolve(request.token_file.as_deref())
 }
 
 fn persist_intent(root: &Path, intent: &PublicationIntent) -> csdlc_v2::Result<()> {

--- a/csdlc-v2/src/github_token.rs
+++ b/csdlc-v2/src/github_token.rs
@@ -1,6 +1,9 @@
 use std::{fs, path::PathBuf};
 
 pub fn resolve(explicit_path: Option<&str>) -> crate::Result<String> {
+    if let Some(path) = explicit_path {
+        return read_token(PathBuf::from(path));
+    }
     for key in ["ADL_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
         if let Ok(value) = std::env::var(key) {
             if !value.trim().is_empty() {
@@ -20,6 +23,10 @@ pub fn resolve(explicit_path: Option<&str>) -> crate::Result<String> {
                 "GitHub token source is unavailable",
             )
         })?;
+    read_token(path)
+}
+
+fn read_token(path: PathBuf) -> crate::Result<String> {
     let value = fs::read_to_string(path).map_err(|_| {
         crate::V2Error::new(
             crate::ErrorCode::InvalidInput,
@@ -33,4 +40,20 @@ pub fn resolve(explicit_path: Option<&str>) -> crate::Result<String> {
         ));
     }
     Ok(value.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve;
+    use std::io::Write;
+
+    #[test]
+    fn explicit_file_is_used() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(file, "explicit-token").expect("write token");
+        assert_eq!(
+            resolve(file.path().to_str()).expect("token"),
+            "explicit-token"
+        );
+    }
 }

--- a/csdlc-v2/src/github_token.rs
+++ b/csdlc-v2/src/github_token.rs
@@ -1,0 +1,36 @@
+use std::{fs, path::PathBuf};
+
+pub fn resolve(explicit_path: Option<&str>) -> crate::Result<String> {
+    for key in ["ADL_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(value) = std::env::var(key) {
+            if !value.trim().is_empty() {
+                return Ok(value);
+            }
+        }
+    }
+    let path = explicit_path
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("ADL_GITHUB_TOKEN_FILE").map(PathBuf::from))
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| PathBuf::from(home).join("keys/github.token"))
+        })
+        .ok_or_else(|| {
+            crate::V2Error::new(
+                crate::ErrorCode::InvalidInput,
+                "GitHub token source is unavailable",
+            )
+        })?;
+    let value = fs::read_to_string(path).map_err(|_| {
+        crate::V2Error::new(
+            crate::ErrorCode::InvalidInput,
+            "GitHub token source is unavailable",
+        )
+    })?;
+    if value.trim().is_empty() {
+        return Err(crate::V2Error::new(
+            crate::ErrorCode::InvalidInput,
+            "GitHub token source is empty",
+        ));
+    }
+    Ok(value.trim().to_owned())
+}

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -5,6 +5,7 @@ pub mod eligibility;
 pub mod error;
 pub mod git;
 pub mod github;
+pub mod github_token;
 pub mod lifecycle;
 pub mod migration;
 pub mod model;


### PR DESCRIPTION
Refs #5391. Addresses P2-11 by routing publish and closeout through one resolver with ADL_GITHUB_TOKEN_FILE, approved default token file, GH_TOKEN, and explicit request path precedence. Focused proof: cargo test --locked --lib; cargo clippy --locked --all-targets -- -D warnings.