### PR TITLE
[v0.91.7][csdlc-v2] Reject v1 generation overrides after sunset

### DIFF
--- a/csdlc-v2/src/operator.rs
+++ b/csdlc-v2/src/operator.rs
@@ -273,6 +273,18 @@ pub fn resolve_operator_generation(
     issue: u64,
     requested: Option<Generation>,
 ) -> Result<Generation> {
+    let coexistence: CoexistenceInventory = serde_json::from_str(COEXISTENCE).map_err(|e| {
+        V2Error::new(
+            ErrorCode::CorruptRecord,
+            format!("invalid embedded coexistence inventory: {e}"),
+        )
+    })?;
+    if coexistence.v1_sunset && requested == Some(Generation::V1) {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "explicit v1 generation selection is forbidden after v1 sunset",
+        ));
+    }
     let manifest = SkillManifest::load()?;
     let selector_path = checked_repo_path(repo, Path::new(&manifest.generation_selector))?;
     if !is_regular_file(&selector_path) {
@@ -446,4 +458,17 @@ fn is_executable(path: &Path) -> bool {
 }
 fn io_error(error: std::io::Error) -> V2Error {
     V2Error::new(ErrorCode::Io, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_operator_generation;
+    use crate::Generation;
+
+    #[test]
+    fn v1_override_is_rejected_after_sunset() {
+        let error = resolve_operator_generation(std::path::Path::new("."), 1, Some(Generation::V1))
+            .expect_err("sunset must reject explicit v1");
+        assert!(error.message.contains("v1 sunset"));
+    }
 }

--- a/csdlc-v2/tests/gate10a.rs
+++ b/csdlc-v2/tests/gate10a.rs
@@ -105,10 +105,7 @@ fn operator_guidance_is_bound_to_manifest_and_coexistence_contract() {
         resolve_operator_generation(&root.join(".."), 5294, None).unwrap(),
         selector.default_generation
     );
-    assert_eq!(
-        resolve_operator_generation(&root.join(".."), 5294, Some(Generation::V1)).unwrap(),
-        Generation::V1
-    );
+    assert!(resolve_operator_generation(&root.join(".."), 5294, Some(Generation::V1)).is_err());
     for text in [&root_agents, &nested_agents] {
         assert!(text.contains("v1"));
         assert!(text.contains("csdlc-install"));


### PR DESCRIPTION
Refs #5391. Addresses P2-04 by making the operator resolver consult the final coexistence inventory and fail closed on explicit v1 selection after v1_sunset. Focused proof: operator sunset unit test and strict clippy.