### PR TITLE
[v0.91.7][csdlc-v2] Install and verify the final resolver binary

### DIFF
--- a/csdlc-v2/operator/coexistence.json
+++ b/csdlc-v2/operator/coexistence.json
@@ -14,5 +14,5 @@
     "adl/src/csdlc_prompt_editor.rs",
     "csdlc-v2/src/bin/csdlc-import.rs"
   ],
-  "required_v2_binaries":["csdlc-init","csdlc-bind","csdlc-edit","csdlc-validate","csdlc-schedule","csdlc-review","csdlc-publish","csdlc-shepherd","csdlc-closeout","csdlc-doctor"]
+  "required_v2_binaries":["csdlc-init","csdlc-bind","csdlc-edit","csdlc-validate","csdlc-schedule","csdlc-review","csdlc-publish","csdlc-shepherd","csdlc-closeout","csdlc-doctor","csdlc-install"]
 }

--- a/csdlc-v2/operator/skills.json
+++ b/csdlc-v2/operator/skills.json
@@ -7,4 +7,4 @@
 {"name":"csdlc-v2-publish","binary":"csdlc-publish","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
 {"name":"csdlc-v2-shepherd","binary":"csdlc-shepherd","subcommand":null,"mutates_state":false,"auxiliary_binaries":[]},
 {"name":"csdlc-v2-closeout","binary":"csdlc-closeout","subcommand":null,"mutates_state":true,"auxiliary_binaries":[]},
-{"name":"csdlc-v2-doctor","binary":"csdlc-doctor","subcommand":null,"mutates_state":false,"auxiliary_binaries":["csdlc-eligibility"]}]}
+{"name":"csdlc-v2-doctor","binary":"csdlc-doctor","subcommand":null,"mutates_state":false,"auxiliary_binaries":["csdlc-eligibility","csdlc-install"]}]}

--- a/csdlc-v2/tests/gate10a.rs
+++ b/csdlc-v2/tests/gate10a.rs
@@ -44,12 +44,13 @@ fn installer_records_provenance_without_replacing_other_files() {
     }
     fs::write(destination_parent.path().join("v1-stays"), b"v1").unwrap();
     let receipt = install_binaries(source.path(), &destination).unwrap();
-    assert_eq!(receipt.binaries.len(), 11);
+    assert_eq!(receipt.binaries.len(), 12);
     assert_eq!(
         fs::read(destination_parent.path().join("v1-stays")).unwrap(),
         b"v1"
     );
     assert!(destination.join("install-receipt.json").is_file());
+    assert!(destination.join("csdlc-install").is_file());
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
Refs #5391. Addresses P1-11 by including csdlc-install in the stable v2 generation manifest, coexistence required binaries, receipt, and Gate 10A proof. Focused proof: cargo test --locked --test gate10a; cargo clippy --locked --all-targets -- -D warnings.