### PR TITLE
[v0.91.7][csdlc-v2] Expose typed heartbeat and recovery operations

### DIFF
--- a/csdlc-v2/src/bin/csdlc-bind.rs
+++ b/csdlc-v2/src/bin/csdlc-bind.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use csdlc_v2::{bind_issue, BindRequest, Store};
+use csdlc_v2::{
+    bind_issue, heartbeat_claim, recover_claim, BindRequest, HeartbeatRequest, RecoverClaimRequest,
+    Store,
+};
 use std::{fs, path::PathBuf};
 
 #[derive(Parser)]
@@ -7,17 +10,44 @@ struct Cli {
     #[arg(long)]
     root: PathBuf,
     #[arg(long)]
-    request: PathBuf,
+    request: Option<PathBuf>,
+    #[arg(long, conflicts_with_all = ["request", "recover_request"])]
+    heartbeat_request: Option<PathBuf>,
+    #[arg(long, conflicts_with_all = ["request", "heartbeat_request"])]
+    recover_request: Option<PathBuf>,
 }
 
 fn main() {
     let cli = Cli::parse();
-    let result = fs::read(&cli.request)
-        .map_err(csdlc_v2::V2Error::from)
-        .and_then(|bytes| {
-            serde_json::from_slice::<BindRequest>(&bytes).map_err(csdlc_v2::V2Error::from)
-        })
-        .and_then(|request| bind_issue(&Store::new(cli.root), request));
+    let result = if let Some(path) = cli.heartbeat_request {
+        fs::read(path).map_err(csdlc_v2::V2Error::from).and_then(|bytes| serde_json::from_slice::<HeartbeatRequest>(&bytes).map_err(csdlc_v2::V2Error::from)).and_then(|request| heartbeat_claim(&Store::new(cli.root.clone()), request.issue, &request.claim_id, request.expected_generation, request.now_unix_seconds, request.extend_seconds).map(|_| serde_json::json!({"schema":"csdlc.heartbeat_result.v1","issue":request.issue})))
+    } else if let Some(path) = cli.recover_request {
+        fs::read(path)
+            .map_err(csdlc_v2::V2Error::from)
+            .and_then(|bytes| {
+                serde_json::from_slice::<RecoverClaimRequest>(&bytes)
+                    .map_err(csdlc_v2::V2Error::from)
+            })
+            .and_then(|request| {
+                recover_claim(&Store::new(cli.root.clone()), request)
+                    .map(|value| serde_json::to_value(value).expect("JSON"))
+            })
+    } else {
+        let path = cli.request.ok_or_else(|| {
+            csdlc_v2::V2Error::new(
+                csdlc_v2::ErrorCode::InvalidInput,
+                "one of --request, --heartbeat-request, or --recover-request is required",
+            )
+        });
+        path.and_then(|path| fs::read(path).map_err(csdlc_v2::V2Error::from))
+            .and_then(|bytes| {
+                serde_json::from_slice::<BindRequest>(&bytes).map_err(csdlc_v2::V2Error::from)
+            })
+            .and_then(|request| {
+                bind_issue(&Store::new(cli.root.clone()), request)
+                    .map(|value| serde_json::to_value(value).expect("JSON"))
+            })
+    };
     match result {
         Ok(value) => println!("{}", serde_json::to_string(&value).expect("JSON")),
         Err(error) => {

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -31,7 +31,7 @@ pub use eligibility::{
 pub use error::{ErrorCode, Result, V2Error};
 pub use lifecycle::{
     bind_issue, heartbeat_claim, initialize_issue, recover_claim, BindRequest, BindResult,
-    RecoverClaimRequest,
+    HeartbeatRequest, RecoverClaimRequest,
 };
 pub use migration::{
     compare_shadow, generate_compatibility_view, import_legacy, write_compatibility_view_atomic,

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -37,6 +37,15 @@ pub struct RecoverClaimRequest {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeartbeatRequest {
+    pub issue: u64,
+    pub claim_id: String,
+    pub expected_generation: u64,
+    pub now_unix_seconds: u64,
+    pub extend_seconds: u64,
+}
+
 fn clean_relative(value: &str) -> bool {
     !value.is_empty()
         && Path::new(value)

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 
 use crate::doctor::DoctorReport;
-use crate::lifecycle::{BindRequest, BindResult, RecoverClaimRequest};
+use crate::lifecycle::{BindRequest, BindResult, HeartbeatRequest, RecoverClaimRequest};
 use crate::migration::{ImportReport, LegacyImportRequest, NormalizedOutcome, ShadowComparison};
 use crate::model::IssueRecord;
 use crate::publication::{PublicationIntent, PublicationRequest, RemotePullRequest};
@@ -22,6 +22,7 @@ pub fn public_schema_bundle() -> Value {
         "bind_request": schemars::schema_for!(BindRequest),
         "bind_result": schemars::schema_for!(BindResult),
         "recover_claim_request": schemars::schema_for!(RecoverClaimRequest),
+        "heartbeat_request": schemars::schema_for!(HeartbeatRequest),
         "issue_record": schemars::schema_for!(IssueRecord),
         "doctor_report": schemars::schema_for!(DoctorReport),
         "pvf_manifest": schemars::schema_for!(PvfManifest),
@@ -45,4 +46,14 @@ pub fn public_schema_bundle() -> Value {
         "shadow_comparison": schemars::schema_for!(ShadowComparison),
         "deletion_eligibility": crate::eligibility::eligibility_schema_bundle(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::public_schema_bundle;
+
+    #[test]
+    fn exposes_heartbeat_request_schema() {
+        assert!(public_schema_bundle().get("heartbeat_request").is_some());
+    }
 }


### PR DESCRIPTION
Refs #5391. Addresses P1-19 by adding a typed HeartbeatRequest and bind-binary heartbeat/recovery request routes, preserving compare-and-swap lifecycle guards. Focused proof: cargo check --bin csdlc-bind; cargo clippy --locked --all-targets -- -D warnings.