### PR TITLE
[v0.91.7][csdlc] Persist #5390 closeout truth

### DIFF
--- a/.csdlc/issues/5390/audit.jsonl
+++ b/.csdlc/issues/5390/audit.jsonl
@@ -18,3 +18,27 @@
 {"sequence":18,"generation":15,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
 {"sequence":19,"generation":16,"actor":"codex","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
 {"sequence":20,"generation":17,"actor":"codex","reason":"Exact-revision subagent review passed with all actionable findings fixed","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":21,"generation":18,"actor":"codex","reason":"Lifecycle-only review metadata commit changed HEAD; recover and bind review to the current clean revision","operation":"recover_review"}
+{"sequence":22,"generation":18,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":23,"generation":19,"actor":"codex","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":24,"generation":20,"actor":"codex","reason":"Exact-revision subagent review passed with all actionable findings fixed","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":25,"generation":21,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":26,"generation":22,"actor":"codex","reason":"Published CI exposed missing Runtime v3 coverage mappings; recover stale review and publication truth before exact-revision re-review","operation":"recover_review"}
+{"sequence":27,"generation":22,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":28,"generation":23,"actor":"codex","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":29,"generation":24,"actor":"codex","reason":"Composite exact-revision subagent review passed after the manifest-correct coverage repair","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":30,"generation":25,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":31,"generation":26,"actor":"codex","reason":"Published CI exposed insufficient selector report-path coverage; recover stale review and publication truth before exact-revision re-review","operation":"recover_review"}
+{"sequence":32,"generation":26,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":33,"generation":27,"actor":"codex","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":34,"generation":28,"actor":"codex","reason":"Exact-revision composite review passed after selector coverage and output-assertion repairs","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":35,"generation":29,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":36,"generation":30,"actor":"codex","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":37,"generation":31,"actor":"codex","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":38,"generation":32,"actor":"codex","reason":"GitHub required a clean merge-base update before merge; recover stale exact-revision review, publication, and readiness truth for the updated head","operation":"recover_review"}
+{"sequence":39,"generation":32,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":40,"generation":33,"actor":"codex","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":41,"generation":34,"actor":"codex","reason":"Exact-revision composite review passed after the required clean merge-base update","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":42,"generation":35,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":43,"generation":36,"actor":"codex","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":44,"generation":37,"actor":"codex","reason":"atomically finalize SOR/index and release claim/protected paths","operation":"record_terminal"}

--- a/.csdlc/issues/5390/cards/sip.values.json
+++ b/.csdlc/issues/5390/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5390/cards/sor.md
+++ b/.csdlc/issues/5390/cards/sor.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: sor
 
-Status: pre_phase
+Status: complete
 
 ## Summary
 
@@ -180,17 +180,17 @@ Runtime v3 HTTPS repair is implemented; approved design artifacts remain unchang
 
 ## Integration
 
-not_started
+merged
 
 ## Publication
 
-Publication: not_published
+Publication: closed
 
-Merge: not_merged
+Merge: merged
 
 ## Closeout
 
-not_started
+complete
 
 ## Follow Ups
 

--- a/.csdlc/issues/5390/cards/sor.values.json
+++ b/.csdlc/issues/5390/cards/sor.values.json
@@ -7,9 +7,9 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
-  "status": "pre_phase",
+  "status": "complete",
   "content": {
     "card_kind": "sor",
     "values": {
@@ -173,10 +173,10 @@
           "evidence_ref": "FastWork target: completed successfully with warnings denied; adl-runtime --lib also passed"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
-      "merge_state": "not_merged",
-      "closeout_state": "not_started",
+      "integration_state": "merged",
+      "publication_state": "closed",
+      "merge_state": "merged",
+      "closeout_state": "complete",
       "follow_ups": []
     }
   }

--- a/.csdlc/issues/5390/cards/spp.values.json
+++ b/.csdlc/issues/5390/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5390/cards/srp.md
+++ b/.csdlc/issues/5390/cards/srp.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: srp
 
-Status: pre_phase
+Status: draft
 
 ## Scope
 
@@ -26,6 +26,10 @@ infra/horust
 infra/runtime-v3
 infra/rustysd/adl-runtime-kernel.service
 infra/systemd/adl-runtime-kernel.service
+adl/tools/check_coverage_impact.sh
+adl/tools/run_pr_fast_coverage_lane.sh
+adl/tools/test_check_coverage_impact.sh
+adl/tools/test_run_pr_fast_coverage_lane.sh
 
 ## Prompts
 
@@ -43,7 +47,7 @@ infra/systemd/adl-runtime-kernel.service
     "actionable": true,
     "in_scope": true,
     "disposition": "fixed",
-    "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "route": null
   },
   {
@@ -53,7 +57,7 @@ infra/systemd/adl-runtime-kernel.service
     "actionable": true,
     "in_scope": true,
     "disposition": "fixed",
-    "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "route": null
   },
   {
@@ -63,7 +67,7 @@ infra/systemd/adl-runtime-kernel.service
     "actionable": true,
     "in_scope": true,
     "disposition": "fixed",
-    "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "route": null
   },
   {
@@ -73,7 +77,37 @@ infra/systemd/adl-runtime-kernel.service
     "actionable": true,
     "in_scope": true,
     "disposition": "fixed",
-    "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+    "route": null
+  },
+  {
+    "id": "R-5390-5",
+    "severity": "p1",
+    "summary": "Runtime v3 guardian and selector changes lacked manifest-correct PR-fast coverage mappings, and the first combined mapping sent an adl-runtime binary selector to the adl workspace.",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+    "route": null
+  },
+  {
+    "id": "R-5390-6",
+    "severity": "p1",
+    "summary": "The Runtime v3 selector report path remained below the required changed-source coverage threshold.",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+    "route": null
+  },
+  {
+    "id": "R-5390-7",
+    "severity": "p2",
+    "summary": "Selector output-path tests initially raised coverage without asserting meaningful text or JSON output.",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "route": null
   }
 ]
@@ -89,8 +123,8 @@ Every actionable finding requires a terminal disposition.
 
 ## Review Result
 
-Revision: Some("git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4")
+Revision: Some("git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7")
 
-Reviewer: Some("subagent-019f66d7")
+Reviewer: Some("subagents-019f66d7-019f66f8-and-019f671d")
 
 Result: pass

--- a/.csdlc/issues/5390/cards/srp.values.json
+++ b/.csdlc/issues/5390/cards/srp.values.json
@@ -7,15 +7,15 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
-  "status": "pre_phase",
+  "status": "draft",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "adl-runtime-kernel\nadl-runtime/src/guardian.rs\nadl/src/cli/runtime_v3_cmd.rs\ndemos/v0.91.7/html-observatory\ndocs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md\ndocs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md\ndocs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md\ndocs/architecture/runtime_v3_guardian_fallback_matrix.v1.json\ndocs/architecture/runtime_v3_guardian_matrix.v1.json\ndocs/milestones/v0.91.7/DEMO_MATRIX_v0.91.7.md\ninfra/horust\ninfra/runtime-v3\ninfra/rustysd/adl-runtime-kernel.service\ninfra/systemd/adl-runtime-kernel.service",
-      "review_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
-      "reviewer": "subagent-019f66d7",
+      "review_scope": "adl-runtime-kernel\nadl-runtime/src/guardian.rs\nadl/src/cli/runtime_v3_cmd.rs\ndemos/v0.91.7/html-observatory\ndocs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md\ndocs/architecture/RUNTIME_V3_GUARDIAN_AND_SOAK.md\ndocs/architecture/RUNTIME_V3_GUARDIAN_FALLBACK_DECISION.md\ndocs/architecture/runtime_v3_guardian_fallback_matrix.v1.json\ndocs/architecture/runtime_v3_guardian_matrix.v1.json\ndocs/milestones/v0.91.7/DEMO_MATRIX_v0.91.7.md\ninfra/horust\ninfra/runtime-v3\ninfra/rustysd/adl-runtime-kernel.service\ninfra/systemd/adl-runtime-kernel.service\nadl/tools/check_coverage_impact.sh\nadl/tools/run_pr_fast_coverage_lane.sh\nadl/tools/test_check_coverage_impact.sh\nadl/tools/test_run_pr_fast_coverage_lane.sh",
+      "review_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+      "reviewer": "subagents-019f66d7-019f66f8-and-019f671d",
       "review_prompts": [
         "Review TLS trust boundaries, private-key handling, and absence of plain-HTTP production paths.",
         "Review bound-address propagation and ephemeral-port test truth.",
@@ -29,7 +29,7 @@
           "actionable": true,
           "in_scope": true,
           "disposition": "fixed",
-          "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
           "route": null
         },
         {
@@ -39,7 +39,7 @@
           "actionable": true,
           "in_scope": true,
           "disposition": "fixed",
-          "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
           "route": null
         },
         {
@@ -49,7 +49,7 @@
           "actionable": true,
           "in_scope": true,
           "disposition": "fixed",
-          "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
           "route": null
         },
         {
@@ -59,7 +59,37 @@
           "actionable": true,
           "in_scope": true,
           "disposition": "fixed",
-          "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+          "route": null
+        },
+        {
+          "id": "R-5390-5",
+          "severity": "p1",
+          "summary": "Runtime v3 guardian and selector changes lacked manifest-correct PR-fast coverage mappings, and the first combined mapping sent an adl-runtime binary selector to the adl workspace.",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+          "route": null
+        },
+        {
+          "id": "R-5390-6",
+          "severity": "p1",
+          "summary": "The Runtime v3 selector report path remained below the required changed-source coverage threshold.",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+          "route": null
+        },
+        {
+          "id": "R-5390-7",
+          "severity": "p2",
+          "summary": "Selector output-path tests initially raised coverage without asserting meaningful text or JSON output.",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
           "route": null
         }
       ],

--- a/.csdlc/issues/5390/cards/stp.values.json
+++ b/.csdlc/issues/5390/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5390/cards/vpp.values.json
+++ b/.csdlc/issues/5390/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "Make Runtime v3 Observatory local HTTPS and report bound control address",
     "slug": "runtime-v3-local-https-bound-address",
     "version": "v0.91.7",
-    "generation": 17
+    "generation": 37
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5390/index.json
+++ b/.csdlc/issues/5390/index.json
@@ -3,36 +3,14 @@
   "issue": 5390,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "a1ce191172a445886835ae006aeeacd5a05ac2cd4c6ee5ee10060bcd8436f21f",
-  "phase": "reviewed",
-  "generation": 17,
-  "digest": "9015ceb26e5552789039c689610a887b2ef7fd487b6b69b10e81ca64a5bbb3b4",
-  "claim": {
-    "id": "csdlc-v2-5390-runtime-v3-https",
-    "owner": "codex",
-    "generation": 17,
-    "acquired_unix_seconds": 1784135334,
-    "expires_unix_seconds": 1784221734,
-    "heartbeat_unix_seconds": 1784135334,
-    "branch": "codex/5390-runtime-v3-local-https-bound-address",
-    "worktree": ".worktrees/adl-wp-5390",
-    "protected_paths": [
-      "adl-runtime-kernel/Cargo.toml",
-      "adl-runtime-kernel/Cargo.lock",
-      "adl-runtime-kernel/src/bin/adl-runtime-kernel.rs",
-      "adl-runtime-kernel/src/config.rs",
-      "adl-runtime-kernel/src/control.rs",
-      "adl-runtime-kernel/tests/configuration.rs",
-      "adl-runtime-kernel/tests/control.rs",
-      "demos/v0.91.7/html-observatory/app.js",
-      "infra/runtime-v3/runtime-init.toml",
-      "docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md"
-    ],
-    "purpose": "Make Runtime v3 local Observatory access natively HTTPS and report the actual bound control address"
-  },
+  "phase": "closed_out",
+  "generation": 37,
+  "digest": "00463934ebcd914dbb080aaf239ba8815bfa16355474d3dfaee96d2e3a2a6105",
+  "claim": null,
   "review_assignment": {
-    "reviewer": "subagent-019f66d7",
+    "reviewer": "subagents-019f66d7-019f66f8-and-019f671d",
     "assigned_by": "codex",
-    "revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "scope": [
       "adl-runtime-kernel",
       "adl-runtime/src/guardian.rs",
@@ -47,11 +25,15 @@
       "infra/horust",
       "infra/runtime-v3",
       "infra/rustysd/adl-runtime-kernel.service",
-      "infra/systemd/adl-runtime-kernel.service"
+      "infra/systemd/adl-runtime-kernel.service",
+      "adl/tools/check_coverage_impact.sh",
+      "adl/tools/run_pr_fast_coverage_lane.sh",
+      "adl/tools/test_check_coverage_impact.sh",
+      "adl/tools/test_run_pr_fast_coverage_lane.sh"
     ]
   },
   "review": {
-    "reviewer": "subagent-019f66d7",
+    "reviewer": "subagents-019f66d7-019f66f8-and-019f671d",
     "scope": [
       "adl-runtime-kernel",
       "adl-runtime/src/guardian.rs",
@@ -66,9 +48,13 @@
       "infra/horust",
       "infra/runtime-v3",
       "infra/rustysd/adl-runtime-kernel.service",
-      "infra/systemd/adl-runtime-kernel.service"
+      "infra/systemd/adl-runtime-kernel.service",
+      "adl/tools/check_coverage_impact.sh",
+      "adl/tools/run_pr_fast_coverage_lane.sh",
+      "adl/tools/test_check_coverage_impact.sh",
+      "adl/tools/test_run_pr_fast_coverage_lane.sh"
     ],
-    "reviewed_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+    "reviewed_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
     "findings": [
       {
         "id": "R-5390-1",
@@ -77,7 +63,7 @@
         "actionable": true,
         "in_scope": true,
         "disposition": "fixed",
-        "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
         "route": null
       },
       {
@@ -87,7 +73,7 @@
         "actionable": true,
         "in_scope": true,
         "disposition": "fixed",
-        "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
         "route": null
       },
       {
@@ -97,7 +83,7 @@
         "actionable": true,
         "in_scope": true,
         "disposition": "fixed",
-        "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
         "route": null
       },
       {
@@ -107,7 +93,37 @@
         "actionable": true,
         "in_scope": true,
         "disposition": "fixed",
-        "fix_revision": "git-blake3:af050de4a0e8b06928e359a5336e2cb7e59e3a2b:9c32015ffa306fcbcf242f6d6c381536ca46d630447e6cac3359ebd2832a98f4",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+        "route": null
+      },
+      {
+        "id": "R-5390-5",
+        "severity": "p1",
+        "summary": "Runtime v3 guardian and selector changes lacked manifest-correct PR-fast coverage mappings, and the first combined mapping sent an adl-runtime binary selector to the adl workspace.",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+        "route": null
+      },
+      {
+        "id": "R-5390-6",
+        "severity": "p1",
+        "summary": "The Runtime v3 selector report path remained below the required changed-source coverage threshold.",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+        "route": null
+      },
+      {
+        "id": "R-5390-7",
+        "severity": "p2",
+        "summary": "Selector output-path tests initially raised coverage without asserting meaningful text or JSON output.",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
         "route": null
       }
     ],
@@ -118,9 +134,121 @@
     "completed": true,
     "non_substantive_proof": null
   },
-  "publication": null,
-  "readiness": null,
-  "terminal": null,
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5390,
+    "pull_request": 5396,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5396",
+    "base": "main",
+    "head": "codex/5390-runtime-v3-local-https-bound-address",
+    "revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+    "draft": true,
+    "observed_state": "open"
+  },
+  "readiness": {
+    "pull_request": 5396,
+    "head_sha": "699da9a4c5ea9643e64da599bf06f5d1b7286040",
+    "checks": [
+      {
+        "name": "adl-ci",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87453000775"
+      },
+      {
+        "name": "adl-coverage",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450541717"
+      },
+      {
+        "name": "adl-demo-proof",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571242"
+      },
+      {
+        "name": "adl-path-policy",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450541775"
+      },
+      {
+        "name": "adl-runtime-v3-fast",
+        "requirement": "optional",
+        "conclusion": "skipped",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450572177"
+      },
+      {
+        "name": "adl-rust-fmt-clippy",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571368"
+      },
+      {
+        "name": "adl-rust-tests",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571294"
+      },
+      {
+        "name": "adl-slow-proof (1)",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571339"
+      },
+      {
+        "name": "adl-slow-proof (2)",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571277"
+      },
+      {
+        "name": "adl-slow-proof (3)",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571325"
+      },
+      {
+        "name": "adl-slow-proof (4)",
+        "requirement": "optional",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571285"
+      },
+      {
+        "name": "adl-tooling-contracts",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29444225089/job/87450571293"
+      }
+    ],
+    "review_state": "not_required",
+    "conflict_state": "clean",
+    "post_publication_findings": [],
+    "ready": true,
+    "blockers": []
+  },
+  "terminal": {
+    "pull_request": 5396,
+    "disposition": "merged",
+    "observed_sha": "699da9a4c5ea9643e64da599bf06f5d1b7286040",
+    "observed_state": "merged",
+    "receipt_path": "/Volumes/FastWork/adl-5390-control/.git/csdlc-v2/closeout/5390.json",
+    "released_branch": "codex/5390-runtime-v3-local-https-bound-address",
+    "released_worktree": ".worktrees/adl-wp-5390",
+    "released_protected_paths": [
+      "adl-runtime-kernel/Cargo.toml",
+      "adl-runtime-kernel/Cargo.lock",
+      "adl-runtime-kernel/src/bin/adl-runtime-kernel.rs",
+      "adl-runtime-kernel/src/config.rs",
+      "adl-runtime-kernel/src/control.rs",
+      "adl-runtime-kernel/tests/configuration.rs",
+      "adl-runtime-kernel/tests/control.rs",
+      "demos/v0.91.7/html-observatory/app.js",
+      "infra/runtime-v3/runtime-init.toml",
+      "docs/architecture/RUNTIME_V3_ENTRYPOINT_SWITCH.md"
+    ]
+  },
   "migration": null,
   "design_path": ".csdlc/issues/5390/design.md",
   "diagram_path": ".csdlc/issues/5390/diagram.mmd",
@@ -132,34 +260,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "d98f48d139da4911c998be5b3931fb629a4792dd82cd3d3a8f2217a8ac6a0f5c",
+      "values_digest": "53508f87382e4a0fcfe189c1b2bddae8b458feee0c06cfe2f550db1e04da3dc5",
       "rendered_digest": "ff68d2f1d6e56599397260c1edb8e6e01d7513d078d0250e7877298ecd84d8aa",
       "ast_digest": "5224dce45e10edd30ea8292bd2cbe94728bcf21f98a6a8d9a5e7fae2bb0de091"
     },
     "stp": {
-      "values_digest": "858a075d2edc2e280049a6939c4d9d9dd8a68af178ebc5df22ca19f5ccb9a906",
+      "values_digest": "227c451ce2d8164938461455925fcdf107790e59e95618e473db23b36b4e8cd9",
       "rendered_digest": "767441e6e7a9e4fb02dedc0981a6550cfa818dc3c6681235983227616943b4e9",
       "ast_digest": "67697393ecf942dd3297cabe2232689c6102b0706c3315ddffe54642d0d7bd67"
     },
     "spp": {
-      "values_digest": "9e359ad2fbb7ba05a2d674100e0d19768f3142c134f9a8e466fe6ac5d5d863e0",
+      "values_digest": "b7fe5fd1fce7d48c1ac1a576f93a8f1a0c6b8f23af455128244e3c5d833790c5",
       "rendered_digest": "eb33d53d98b4f6235d6811db5c3979a3edc213cfa9e44868f1768ebd389bf108",
       "ast_digest": "953646f726cb52ae26de70b16400ab237a3666771f803c0dff2d72eb5365d074"
     },
     "vpp": {
-      "values_digest": "0dc23894fcd2a06ea8a1a8c4ed2960614a896926e960500dd39bd2e5f6bb09ca",
+      "values_digest": "3fdf01ae0be421723d98e7683ddc9cb527159b48121abc29438baaaab266a9f6",
       "rendered_digest": "3c53aecc7718437fcdcd9d049da5482781ef52b855ba70480ea15fa352bfb432",
       "ast_digest": "a69af00dbf1cad312a5580dde63222536d296f4c3eab151bd5699d5ad4a96dd0"
     },
     "srp": {
-      "values_digest": "82329c444eaaf8a6a6beeb71dd1de576267faabe8a34d52dd38397715a4bba1d",
-      "rendered_digest": "d9252c5ac11c51f654716d30523f6317a1d7fe24937fedf82f9d377261066373",
-      "ast_digest": "98e1b9efc4600e9afa35fe7cdc7226404f9a35753474aadd3825e0f274fa5fa4"
+      "values_digest": "38b88501c741bcff6b5a583c345963568199686dea7f29a55eecc627af8327a1",
+      "rendered_digest": "78de0fc397027d5eb9c43c1eb5115091536cc7a249fa6e28c1407c3571002598",
+      "ast_digest": "969b2716d91da4c5d6c5c7b55d5d568f3ac28843499934ed69ae15c12f5e196e"
     },
     "sor": {
-      "values_digest": "9626fc222d632ccf9e7e5d9e75033340f5eaebffe7a49386e828d97562741a45",
-      "rendered_digest": "cd09b7d0d1cbb3bee9bc48f5e15505bf7fb0a290a7ff8c1d60da67552d1c5498",
-      "ast_digest": "cd144e58dc9aa3f05dbe7dbf36b77f077acd4ad8c47948c731b26936c9120e99"
+      "values_digest": "6a5f9213111f05559e27c3412fa9eb77a7159ebfa54b82c34dbb862e99226900",
+      "rendered_digest": "6a52f9b2d9ea2d222420ca44b94c5a6dd4731ee7862419d30fbc645d08a2c7e0",
+      "ast_digest": "fd5367b6673128305daa8a538186b9227e73ea9bf8eae269c0611bdade147082"
     }
   },
   "transitions": [
@@ -190,6 +318,118 @@
       "to": "reviewed",
       "actor": "codex",
       "reason": "Exact-revision subagent review passed with all actionable findings fixed"
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "Lifecycle-only review metadata commit changed HEAD; recover and bind review to the current clean revision"
+    },
+    {
+      "sequence": 6,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Exact-revision subagent review passed with all actionable findings fixed"
+    },
+    {
+      "sequence": 7,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 8,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "Published CI exposed missing Runtime v3 coverage mappings; recover stale review and publication truth before exact-revision re-review"
+    },
+    {
+      "sequence": 9,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Composite exact-revision subagent review passed after the manifest-correct coverage repair"
+    },
+    {
+      "sequence": 10,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 11,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "Published CI exposed insufficient selector report-path coverage; recover stale review and publication truth before exact-revision re-review"
+    },
+    {
+      "sequence": 12,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Exact-revision composite review passed after selector coverage and output-assertion repairs"
+    },
+    {
+      "sequence": 13,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 14,
+      "from": "published",
+      "to": "merge_ready",
+      "actor": "codex",
+      "reason": "observed required checks, review, and conflict readiness"
+    },
+    {
+      "sequence": 15,
+      "from": "merge_ready",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "GitHub required a clean merge-base update before merge; recover stale exact-revision review, publication, and readiness truth for the updated head"
+    },
+    {
+      "sequence": 16,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Exact-revision composite review passed after the required clean merge-base update"
+    },
+    {
+      "sequence": 17,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 18,
+      "from": "published",
+      "to": "merge_ready",
+      "actor": "codex",
+      "reason": "observed required checks, review, and conflict readiness"
+    },
+    {
+      "sequence": 19,
+      "from": "merge_ready",
+      "to": "merged",
+      "actor": "codex",
+      "reason": "observed exact PR merged"
+    },
+    {
+      "sequence": 20,
+      "from": "merged",
+      "to": "closed_out",
+      "actor": "codex",
+      "reason": "terminal truth recorded and claim released"
     }
   ],
   "audit": [
@@ -332,6 +572,174 @@
       "actor": "codex",
       "reason": "Exact-revision subagent review passed with all actionable findings fixed",
       "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 21,
+      "generation": 18,
+      "actor": "codex",
+      "reason": "Lifecycle-only review metadata commit changed HEAD; recover and bind review to the current clean revision",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 22,
+      "generation": 18,
+      "actor": "codex",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 23,
+      "generation": 19,
+      "actor": "codex",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 24,
+      "generation": 20,
+      "actor": "codex",
+      "reason": "Exact-revision subagent review passed with all actionable findings fixed",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 25,
+      "generation": 21,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 26,
+      "generation": 22,
+      "actor": "codex",
+      "reason": "Published CI exposed missing Runtime v3 coverage mappings; recover stale review and publication truth before exact-revision re-review",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 27,
+      "generation": 22,
+      "actor": "codex",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 28,
+      "generation": 23,
+      "actor": "codex",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 29,
+      "generation": 24,
+      "actor": "codex",
+      "reason": "Composite exact-revision subagent review passed after the manifest-correct coverage repair",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 30,
+      "generation": 25,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 31,
+      "generation": 26,
+      "actor": "codex",
+      "reason": "Published CI exposed insufficient selector report-path coverage; recover stale review and publication truth before exact-revision re-review",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 32,
+      "generation": 26,
+      "actor": "codex",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 33,
+      "generation": 27,
+      "actor": "codex",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 34,
+      "generation": 28,
+      "actor": "codex",
+      "reason": "Exact-revision composite review passed after selector coverage and output-assertion repairs",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 35,
+      "generation": 29,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 36,
+      "generation": 30,
+      "actor": "codex",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 37,
+      "generation": 31,
+      "actor": "codex",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 38,
+      "generation": 32,
+      "actor": "codex",
+      "reason": "GitHub required a clean merge-base update before merge; recover stale exact-revision review, publication, and readiness truth for the updated head",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 39,
+      "generation": 32,
+      "actor": "codex",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 40,
+      "generation": 33,
+      "actor": "codex",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 41,
+      "generation": 34,
+      "actor": "codex",
+      "reason": "Exact-revision composite review passed after the required clean merge-base update",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 42,
+      "generation": 35,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 43,
+      "generation": 36,
+      "actor": "codex",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 44,
+      "generation": 37,
+      "actor": "codex",
+      "reason": "atomically finalize SOR/index and release claim/protected paths",
+      "operation": "record_terminal"
     }
   ]
 }

--- a/.csdlc/publication/5390.intent.json
+++ b/.csdlc/publication/5390.intent.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.publication_intent.v1",
+  "issue": 5390,
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5390-runtime-v3-local-https-bound-address",
+  "title": "fix(runtime-v3): serve Observatory over native HTTPS",
+  "body": "## Summary\n- terminate Runtime v3 control traffic with Axum plus the maintained Rustls server adapter\n- report server-owned bound address truth to readiness and the Observatory feed\n- pass explicit init configuration through selector and guardian/service launch paths\n- repair local HTTPS Observatory instructions and retained guardian truth\n- map Runtime v3 selector and guardian changes to manifest-correct PR-fast coverage lanes\n\n## Validation\n- full `adl-runtime-kernel` suite: 144 passed, 8 environment-dependent ignored\n- focused `adl-runtime` guardian suite: 8 passed\n- Runtime v3 selector tests: 7 passed\n- Runtime v3 Clippy with warnings denied: passed\n- HTML Observatory integrated validator: passed\n- coverage contract suites: passed\n- combined local coverage-impact preflight: passed\n- `guardian.rs`: 83.13% line coverage\n- `runtime_v3_cmd.rs`: 97.08% line coverage\n- composite exact-revision subagent review: all findings fixed\n\nCloses #5390",
+  "draft": true,
+  "revision": "git-blake3:699da9a4c5ea9643e64da599bf06f5d1b7286040:9415c94595c369c529d50dd3556148dc5b7528c584dbe2adc49d0ae8bd978ea7",
+  "commit_sha": "699da9a4c5ea9643e64da599bf06f5d1b7286040"
+}


### PR DESCRIPTION
Persist the typed C-SDLC v2 publication, readiness, review, terminal evidence, and generated card projections for #5390. The Runtime v3 HTTPS implementation is already merged in PR #5396. This follow-up contains lifecycle records only.