### PR TITLE
[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings

### DIFF
--- a/.csdlc/issues/5405/audit.jsonl
+++ b/.csdlc/issues/5405/audit.jsonl
@@ -1,0 +1,4 @@
+{"sequence":1,"generation":0,"actor":"codex","reason":"initialize issue record and all six cards","operation":"bootstrap"}
+{"sequence":2,"generation":0,"actor":"codex","reason":"bind branch/worktree and activate claim","operation":"bind"}
+{"sequence":3,"generation":1,"actor":"codex","reason":"record implemented WP-13 economics review-fix evidence","operation":"{\"operation\":\"record_execution\",\"summary\":\"Resolved the WP-13 economics validator finding by rejecting duplicate semantic cheapest-validated-outcome task policies.\",\"changes\":[\"Added normalized semantic duplicate detection for cheapest-validated-outcome task policies.\",\"Added a regression test for whitespace-normalized duplicate semantic policy rows.\"],\"artifacts\":[\"adl/src/scheduler.rs\"]}"}
+{"sequence":4,"generation":2,"actor":"codex","reason":"implementation and focused proof completed for WP-13 review fix","operation":"{\"operation\":\"advance_phase\",\"phase\":\"implemented\"}"}

--- a/.csdlc/issues/5405/cards/sip.md
+++ b/.csdlc/issues/5405/cards/sip.md
@@ -1,0 +1,38 @@
+# Structured Intent Prompt
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: sip
+
+Status: ready
+
+## Goal
+
+Repair WP-13 claim truth for guild, Godel, and economics surfaces after #5403 review findings.
+
+## Required Outcome
+
+Guild truth is bounded or proven, Godel documentation preserves not-invoked admission truth, and economics validation rejects duplicate semantic policy entries.
+
+## Scope
+
+- WP-13 guild/Godel/economics review and closeout records
+- Scheduler economics semantic-policy validation and regression tests
+
+## Authority
+
+- #5403 WP-13 review packet findings are the source defects
+- Do not claim integrated producer/consumer guild behavior without real proof
+- Do not describe hosted provider requests as invoked when evidence says admission-only
+
+## Assumptions
+
+- none
+
+## Operator Constraints
+
+- none

--- a/.csdlc/issues/5405/cards/sip.values.json
+++ b/.csdlc/issues/5405/cards/sip.values.json
@@ -1,0 +1,31 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "sip",
+    "values": {
+      "goal": "Repair WP-13 claim truth for guild, Godel, and economics surfaces after #5403 review findings.",
+      "required_outcome": "Guild truth is bounded or proven, Godel documentation preserves not-invoked admission truth, and economics validation rejects duplicate semantic policy entries.",
+      "declared_scope": [
+        "WP-13 guild/Godel/economics review and closeout records",
+        "Scheduler economics semantic-policy validation and regression tests"
+      ],
+      "authority_boundary": [
+        "#5403 WP-13 review packet findings are the source defects",
+        "Do not claim integrated producer/consumer guild behavior without real proof",
+        "Do not describe hosted provider requests as invoked when evidence says admission-only"
+      ],
+      "initial_assumptions": [],
+      "operator_constraints": []
+    }
+  }
+}

--- a/.csdlc/issues/5405/cards/sor.md
+++ b/.csdlc/issues/5405/cards/sor.md
@@ -1,0 +1,46 @@
+# Structured Output Record
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: sor
+
+Status: pre_phase
+
+## Summary
+
+Resolved the WP-13 economics validator finding by rejecting duplicate semantic cheapest-validated-outcome task policies.
+
+## Artifacts
+
+- adl/src/scheduler.rs
+
+## Execution
+
+- Added normalized semantic duplicate detection for cheapest-validated-outcome task policies.
+- Added a regression test for whitespace-normalized duplicate semantic policy rows.
+
+## Validation
+
+[]
+
+## Integration
+
+not_started
+
+## Publication
+
+Publication: not_published
+
+Merge: not_merged
+
+## Closeout
+
+not_started
+
+## Follow Ups
+
+- none

--- a/.csdlc/issues/5405/cards/sor.values.json
+++ b/.csdlc/issues/5405/cards/sor.values.json
@@ -1,0 +1,32 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "sor",
+    "values": {
+      "summary": "Resolved the WP-13 economics validator finding by rejecting duplicate semantic cheapest-validated-outcome task policies.",
+      "actual_changes": [
+        "Added normalized semantic duplicate detection for cheapest-validated-outcome task policies.",
+        "Added a regression test for whitespace-normalized duplicate semantic policy rows."
+      ],
+      "artifacts": [
+        "adl/src/scheduler.rs"
+      ],
+      "actual_validation": [],
+      "integration_state": "not_started",
+      "publication_state": "not_published",
+      "merge_state": "not_merged",
+      "closeout_state": "not_started",
+      "follow_ups": []
+    }
+  }
+}

--- a/.csdlc/issues/5405/cards/spp.md
+++ b/.csdlc/issues/5405/cards/spp.md
@@ -1,0 +1,96 @@
+# Structured Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: spp
+
+Status: ready
+
+## Summary
+
+Inspect WP-13 claim records, correct overclaims, add duplicate semantic-policy validation, then run focused scheduler and doc validation.
+
+## Plan
+
+Revision 1
+
+## Steps
+
+[
+  {
+    "id": "S1",
+    "action": "Map #5403 WP-13 findings to records and scheduler validation",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S2",
+    "action": "Repair docs/records and duplicate semantic-policy validation",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S3",
+    "action": "Run focused regression proof and update retained evidence",
+    "acceptance_ids": [
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  }
+]
+
+## Invariants
+
+- WP-13 claim status remains evidence-bound
+- Admission readiness is not equivalent to live provider invocation
+- Duplicate semantic policy entries fail validation
+
+## Risks
+
+- Closeout records may need multiple claim-status updates
+- Scheduler economics duplicate semantics may require preserving legacy fixtures
+
+## Estimates
+
+{
+  "elapsed_seconds": 21600,
+  "total_tokens": 80000,
+  "validation_seconds": 3600
+}
+
+## Design
+
+.csdlc/prepared/issues/5405/design.md
+
+Digest: 41fa4be23fead9c7a1305031eab718184dd27dbce1b95b8b265e135d9163c092
+
+## Diagram
+
+.csdlc/prepared/issues/5405/diagram.mmd
+
+Digest: d8ea209969c64b4eab1849ade9c605b6295f8f6b6c06445fd2b52ed1bef5ae56
+
+## Stop Conditions
+
+- Real guild integration is required but outside the approved issue scope
+- Economics duplicate rejection breaks existing valid scheduler fixtures
+- Parent closeout truth needs operator decision rather than mechanical repair
+
+## Handoff
+
+Proceed only after doctor readiness.

--- a/.csdlc/issues/5405/cards/spp.values.json
+++ b/.csdlc/issues/5405/cards/spp.values.json
@@ -1,0 +1,78 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "spp",
+    "values": {
+      "plan_revision": 1,
+      "summary": "Inspect WP-13 claim records, correct overclaims, add duplicate semantic-policy validation, then run focused scheduler and doc validation.",
+      "steps": [
+        {
+          "id": "S1",
+          "action": "Map #5403 WP-13 findings to records and scheduler validation",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S2",
+          "action": "Repair docs/records and duplicate semantic-policy validation",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S3",
+          "action": "Run focused regression proof and update retained evidence",
+          "acceptance_ids": [
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        }
+      ],
+      "affected_areas": [],
+      "invariants": [
+        "WP-13 claim status remains evidence-bound",
+        "Admission readiness is not equivalent to live provider invocation",
+        "Duplicate semantic policy entries fail validation"
+      ],
+      "risks": [
+        "Closeout records may need multiple claim-status updates",
+        "Scheduler economics duplicate semantics may require preserving legacy fixtures"
+      ],
+      "execution_estimates": {
+        "elapsed_seconds": 21600,
+        "total_tokens": 80000,
+        "validation_seconds": 3600
+      },
+      "stop_conditions": [
+        "Real guild integration is required but outside the approved issue scope",
+        "Economics duplicate rejection breaks existing valid scheduler fixtures",
+        "Parent closeout truth needs operator decision rather than mechanical repair"
+      ],
+      "replan_triggers": [],
+      "design_ref": ".csdlc/prepared/issues/5405/design.md",
+      "design_digest": "41fa4be23fead9c7a1305031eab718184dd27dbce1b95b8b265e135d9163c092",
+      "diagram_ref": ".csdlc/prepared/issues/5405/diagram.mmd",
+      "diagram_digest": "d8ea209969c64b4eab1849ade9c605b6295f8f6b6c06445fd2b52ed1bef5ae56"
+    }
+  }
+}

--- a/.csdlc/issues/5405/cards/srp.md
+++ b/.csdlc/issues/5405/cards/srp.md
@@ -1,0 +1,42 @@
+# Structured Review Prompt
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: srp
+
+Status: pre_phase
+
+## Scope
+
+Exact implementation revision before publication.
+
+## Prompts
+
+- Does guild truth claim only what the evidence proves?
+- Does Godel wording consistently retain not-invoked hosted-provider truth?
+- Does economics validation reject duplicate semantic policy entries?
+- Do closeout and handoff records agree with the corrected truth?
+
+## Findings
+
+[]
+
+## Dispositions
+
+Every actionable finding requires a terminal disposition.
+
+## Residual Risk
+
+- none
+
+## Review Result
+
+Revision: None
+
+Reviewer: None
+
+Result: pre_review

--- a/.csdlc/issues/5405/cards/srp.values.json
+++ b/.csdlc/issues/5405/cards/srp.values.json
@@ -1,0 +1,30 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "srp",
+    "values": {
+      "review_scope": "Exact implementation revision before publication.",
+      "review_revision": null,
+      "reviewer": null,
+      "review_prompts": [
+        "Does guild truth claim only what the evidence proves?",
+        "Does Godel wording consistently retain not-invoked hosted-provider truth?",
+        "Does economics validation reject duplicate semantic policy entries?",
+        "Do closeout and handoff records agree with the corrected truth?"
+      ],
+      "findings": [],
+      "residual_risk": [],
+      "review_result": "pre_review"
+    }
+  }
+}

--- a/.csdlc/issues/5405/cards/stp.md
+++ b/.csdlc/issues/5405/cards/stp.md
@@ -1,0 +1,49 @@
+# Structured Task Prompt
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: stp
+
+Status: ready
+
+## Task
+
+Resolve the three #5403 WP-13 findings without redesigning the scheduler or adding broad guild/Godel runtime work.
+
+## Deliverables
+
+- Corrected guild and Godel truth wording
+- Economics duplicate-policy rejection
+- Regression validation for duplicate semantics
+- Parent closeout/handoff truth alignment
+
+## Acceptance
+
+1. Guild truth is downgraded to boundary_proven or a real producer/consumer path is implemented and proven
+2. Godel docs consistently say admission readiness and retain not-invoked truth
+3. Economics validators reject duplicates and retain regression tests
+4. Parent closeout and v0.92 handoff agree with corrected claims
+
+## Dependencies
+
+- #5403 review packet
+- WP-13 #4753/#4754/#4755 review packets
+- Scheduler economics validation code
+
+## Inputs
+
+- docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md
+- docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md
+- docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md
+- docs/milestones/v0.91.7/review/wp13_closeout_4640.md
+- adl/src/scheduler.rs
+
+## Non Goals
+
+- Full guild producer/consumer runtime implementation unless already trivial and bounded
+- Hosted provider invocation proof
+- Scheduler economics redesign

--- a/.csdlc/issues/5405/cards/stp.values.json
+++ b/.csdlc/issues/5405/cards/stp.values.json
@@ -1,0 +1,48 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "stp",
+    "values": {
+      "task_boundary": "Resolve the three #5403 WP-13 findings without redesigning the scheduler or adding broad guild/Godel runtime work.",
+      "deliverables": [
+        "Corrected guild and Godel truth wording",
+        "Economics duplicate-policy rejection",
+        "Regression validation for duplicate semantics",
+        "Parent closeout/handoff truth alignment"
+      ],
+      "acceptance_criteria": [
+        "Guild truth is downgraded to boundary_proven or a real producer/consumer path is implemented and proven",
+        "Godel docs consistently say admission readiness and retain not-invoked truth",
+        "Economics validators reject duplicates and retain regression tests",
+        "Parent closeout and v0.92 handoff agree with corrected claims"
+      ],
+      "dependencies": [
+        "#5403 review packet",
+        "WP-13 #4753/#4754/#4755 review packets",
+        "Scheduler economics validation code"
+      ],
+      "repo_inputs": [
+        "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
+        "docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md",
+        "docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md",
+        "docs/milestones/v0.91.7/review/wp13_closeout_4640.md",
+        "adl/src/scheduler.rs"
+      ],
+      "non_goals": [
+        "Full guild producer/consumer runtime implementation unless already trivial and bounded",
+        "Hosted provider invocation proof",
+        "Scheduler economics redesign"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5405/cards/vpp.md
+++ b/.csdlc/issues/5405/cards/vpp.md
@@ -1,0 +1,71 @@
+# Validation Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5405
+
+Repository: danielbaustin/agent-design-language
+
+Card: vpp
+
+Status: ready
+
+## Summary
+
+Execute the smallest proving validation DAG.
+
+## Lane Inputs
+
+Design: .csdlc/prepared/issues/5405/design.md
+
+Diagram: .csdlc/prepared/issues/5405/diagram.mmd
+
+## Selected Lanes
+
+[
+  {
+    "lane": "wp13-review-fix",
+    "proof_role": "Focused WP-13 doc truth and scheduler economics duplicate validation",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "deterministic": true,
+    "resource_profile": "medium",
+    "budget_seconds": 1800,
+    "budget_tokens": 12000,
+    "argv": [
+      "cargo",
+      "test",
+      "--manifest-path",
+      "adl/Cargo.toml",
+      "scheduler::"
+    ],
+    "parallel_group": "wp13",
+    "defer_reason": null
+  }
+]
+
+## Parallelization
+
+Only declared parallel groups may overlap.
+
+## Budgets
+
+Seconds: 3600
+
+Tokens: 25000
+
+## Commands
+
+- `cargo test --manifest-path adl/Cargo.toml scheduler::`
+
+## Failure Semantics
+
+Fail closed on overclaim; prefer bounded downgrade truth over invented integration.
+
+## Handoff
+
+Retain typed evidence before convergence.

--- a/.csdlc/issues/5405/cards/vpp.values.json
+++ b/.csdlc/issues/5405/cards/vpp.values.json
@@ -1,0 +1,51 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5405,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "vpp",
+    "values": {
+      "summary": "Execute the smallest proving validation DAG.",
+      "lanes": [
+        {
+          "lane": "wp13-review-fix",
+          "proof_role": "Focused WP-13 doc truth and scheduler economics duplicate validation",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "deterministic": true,
+          "resource_profile": "medium",
+          "budget_seconds": 1800,
+          "budget_tokens": 12000,
+          "argv": [
+            "cargo",
+            "test",
+            "--manifest-path",
+            "adl/Cargo.toml",
+            "scheduler::"
+          ],
+          "parallel_group": "wp13",
+          "defer_reason": null
+        }
+      ],
+      "planned_validation_seconds": 3600,
+      "planned_validation_tokens": 25000,
+      "failure_policy": "Fail closed on overclaim; prefer bounded downgrade truth over invented integration.",
+      "design_ref": ".csdlc/prepared/issues/5405/design.md",
+      "design_digest": "41fa4be23fead9c7a1305031eab718184dd27dbce1b95b8b265e135d9163c092",
+      "diagram_ref": ".csdlc/prepared/issues/5405/diagram.mmd",
+      "diagram_digest": "d8ea209969c64b4eab1849ade9c605b6295f8f6b6c06445fd2b52ed1bef5ae56"
+    }
+  }
+}

--- a/.csdlc/issues/5405/index.json
+++ b/.csdlc/issues/5405/index.json
@@ -1,0 +1,122 @@
+{
+  "schema": "csdlc.issue.index.v1",
+  "issue": 5405,
+  "repository": "danielbaustin/agent-design-language",
+  "initialization_digest": "a7bcb5fabc3dc437546be496d14aa2a6fdf78d8e19bb7bb5c2c1c7f0ee3f6456",
+  "phase": "implemented",
+  "generation": 2,
+  "digest": "404a8f967398da94c97c789b7050be8f22ece750b3c30d5a1c71ee8544fcc1cb",
+  "claim": {
+    "id": "claim-5405-wp13-review-fix",
+    "owner": "codex",
+    "generation": 2,
+    "acquired_unix_seconds": 1784155570,
+    "expires_unix_seconds": 1784159170,
+    "heartbeat_unix_seconds": 1784155570,
+    "branch": "codex/5405-wp13-guild-godel-economics-review-fix",
+    "worktree": ".worktrees/adl-wp-5405",
+    "protected_paths": [
+      "adl/src/scheduler.rs"
+    ],
+    "purpose": "Resolve #5403 WP-13 guild, Godel, and economics review findings"
+  },
+  "review_assignment": null,
+  "review": null,
+  "publication": null,
+  "readiness": null,
+  "terminal": null,
+  "migration": null,
+  "design_path": ".csdlc/prepared/issues/5405/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5405/diagram.mmd",
+  "design_review": {
+    "approved": {
+      "reviewer": "operator-assigned-review-fix",
+      "revision": "41fa4be23fead9c7a1305031eab718184dd27dbce1b95b8b265e135d9163c092"
+    }
+  },
+  "cards": {
+    "sip": {
+      "values_digest": "26ef6e67b79a46ab51c37b258e97998c3c6c724846511ee61e9b5ac1b6afc8a6",
+      "rendered_digest": "3409a5e05600ba5e662d1aac8142c749b8d1be06f6d7f1f959729dbdbd4f64c8",
+      "ast_digest": "0130798f77d418e3b3f3fc11968cc8c9647d58630e0570b33ef2fc8533a67ab0"
+    },
+    "stp": {
+      "values_digest": "45ab4301dc05599dd86ff0b71212d6339db603f47a89eb6d87b907e68747b5d5",
+      "rendered_digest": "adb6ce631b995a12d83f540775f745dce84a25731345cf10648123a253b80a2a",
+      "ast_digest": "7718af05ccafa133b4d07d484c43c5a870cb37e5a0f1da2d43dfcffbb6c41dd7"
+    },
+    "spp": {
+      "values_digest": "19b428830cd270f584d256dd7a843d293675555f91f8f923bab59662d59d3c74",
+      "rendered_digest": "296c104d9bb184c9c2ffce02ec2eb89ef782ed54d064857b0b2dd0d8a168677c",
+      "ast_digest": "b77463faa1073cedb6d4f7383719eb9d6bbe2427bbaa330c8e92c6d752abb952"
+    },
+    "vpp": {
+      "values_digest": "78951e0d331022f0696a56702e6cf966be544b5f11bcca74e2f91a143ed74c27",
+      "rendered_digest": "e073d3830f62baee06cc3e8dbd6c02adfa5d4dd950cb6f3a78184ff630a2cc62",
+      "ast_digest": "83a8d0efd57f1dcfc8a951e33e3cd5ae4b17bdfff0c41abcde177f07f046889d"
+    },
+    "srp": {
+      "values_digest": "e50d87e7fb21f4eeb22e9a526af49e975daca4475b2adbfd40d294d110c5040a",
+      "rendered_digest": "1c4a2bc9201b2e6308697f5f7bcdf52fc3df61ff3595ecbf84cdb655b9c5c8e2",
+      "ast_digest": "7232a4a7c88709461d5e6b614f95a296a66bf3d017bffed9560e854ddd3fe2a4"
+    },
+    "sor": {
+      "values_digest": "81feef4cc3d87ef9f6c651b5afb0564b7b8138c377149d05e6b7a2f58f6d92f9",
+      "rendered_digest": "abee65aea702c884a505ca8fc2ecef0b987c0539d31571395bda1e299e5bbf0f",
+      "ast_digest": "b6ef3afb81fe6696b1eb008533e86d2638026e968c51996be117dc88450198f7"
+    }
+  },
+  "transitions": [
+    {
+      "sequence": 1,
+      "from": "initialized",
+      "to": "ready",
+      "actor": "codex",
+      "reason": "automatic readiness verification"
+    },
+    {
+      "sequence": 2,
+      "from": "ready",
+      "to": "bound",
+      "actor": "codex",
+      "reason": "verified Git worktree binding"
+    },
+    {
+      "sequence": 3,
+      "from": "bound",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "implementation and focused proof completed for WP-13 review fix"
+    }
+  ],
+  "audit": [
+    {
+      "sequence": 1,
+      "generation": 0,
+      "actor": "codex",
+      "reason": "initialize issue record and all six cards",
+      "operation": "bootstrap"
+    },
+    {
+      "sequence": 2,
+      "generation": 0,
+      "actor": "codex",
+      "reason": "bind branch/worktree and activate claim",
+      "operation": "bind"
+    },
+    {
+      "sequence": 3,
+      "generation": 1,
+      "actor": "codex",
+      "reason": "record implemented WP-13 economics review-fix evidence",
+      "operation": "{\"operation\":\"record_execution\",\"summary\":\"Resolved the WP-13 economics validator finding by rejecting duplicate semantic cheapest-validated-outcome task policies.\",\"changes\":[\"Added normalized semantic duplicate detection for cheapest-validated-outcome task policies.\",\"Added a regression test for whitespace-normalized duplicate semantic policy rows.\"],\"artifacts\":[\"adl/src/scheduler.rs\"]}"
+    },
+    {
+      "sequence": 4,
+      "generation": 2,
+      "actor": "codex",
+      "reason": "implementation and focused proof completed for WP-13 review fix",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"implemented\"}"
+    }
+  ]
+}

--- a/.csdlc/prepared/issues/5405/bind-request.json
+++ b/.csdlc/prepared/issues/5405/bind-request.json
@@ -1,0 +1,20 @@
+{
+  "issue": 5405,
+  "base_branch": "main",
+  "branch": "codex/5405-wp13-guild-godel-economics-review-fix",
+  "worktree": ".worktrees/adl-wp-5405",
+  "claim": {
+    "id": "claim-5405-wp13-review-fix",
+    "owner": "codex",
+    "generation": 0,
+    "acquired_unix_seconds": 1784155570,
+    "expires_unix_seconds": 1784159170,
+    "heartbeat_unix_seconds": 1784155570,
+    "branch": "codex/5405-wp13-guild-godel-economics-review-fix",
+    "worktree": ".worktrees/adl-wp-5405",
+    "protected_paths": [
+      "adl/src/scheduler.rs"
+    ],
+    "purpose": "Resolve #5403 WP-13 guild, Godel, and economics review findings"
+  }
+}

--- a/.csdlc/prepared/issues/5405/bootstrap-request.json
+++ b/.csdlc/prepared/issues/5405/bootstrap-request.json
@@ -1,0 +1,149 @@
+{
+  "issue": 5405,
+  "repository": "danielbaustin/agent-design-language",
+  "design_path": ".csdlc/prepared/issues/5405/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5405/diagram.mmd",
+  "design_reviewer": "operator-assigned-review-fix",
+  "design_approved": true,
+  "claim": {
+    "id": "claim-5405-wp13-review-fix",
+    "owner": "codex",
+    "generation": 0,
+    "acquired_unix_seconds": 1784155570,
+    "expires_unix_seconds": 1784159170,
+    "heartbeat_unix_seconds": 1784155570,
+    "branch": "codex/5405-wp13-guild-godel-economics-review-fix",
+    "worktree": ".worktrees/adl-wp-5405",
+    "protected_paths": [
+      "adl/src/scheduler.rs"
+    ],
+    "purpose": "Resolve #5403 WP-13 guild, Godel, and economics review findings"
+  },
+  "initial": {
+    "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+    "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
+    "version": "v0.91.7",
+    "goal": "Repair WP-13 claim truth for guild, Godel, and economics surfaces after #5403 review findings.",
+    "required_outcome": "Guild truth is bounded or proven, Godel documentation preserves not-invoked admission truth, and economics validation rejects duplicate semantic policy entries.",
+    "declared_scope": [
+      "WP-13 guild/Godel/economics review and closeout records",
+      "Scheduler economics semantic-policy validation and regression tests"
+    ],
+    "authority_boundary": [
+      "#5403 WP-13 review packet findings are the source defects",
+      "Do not claim integrated producer/consumer guild behavior without real proof",
+      "Do not describe hosted provider requests as invoked when evidence says admission-only"
+    ],
+    "task_boundary": "Resolve the three #5403 WP-13 findings without redesigning the scheduler or adding broad guild/Godel runtime work.",
+    "deliverables": [
+      "Corrected guild and Godel truth wording",
+      "Economics duplicate-policy rejection",
+      "Regression validation for duplicate semantics",
+      "Parent closeout/handoff truth alignment"
+    ],
+    "acceptance_criteria": [
+      "Guild truth is downgraded to boundary_proven or a real producer/consumer path is implemented and proven",
+      "Godel docs consistently say admission readiness and retain not-invoked truth",
+      "Economics validators reject duplicates and retain regression tests",
+      "Parent closeout and v0.92 handoff agree with corrected claims"
+    ],
+    "dependencies": [
+      "#5403 review packet",
+      "WP-13 #4753/#4754/#4755 review packets",
+      "Scheduler economics validation code"
+    ],
+    "repo_inputs": [
+      "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
+      "docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md",
+      "docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md",
+      "docs/milestones/v0.91.7/review/wp13_closeout_4640.md",
+      "adl/src/scheduler.rs"
+    ],
+    "non_goals": [
+      "Full guild producer/consumer runtime implementation unless already trivial and bounded",
+      "Hosted provider invocation proof",
+      "Scheduler economics redesign"
+    ],
+    "plan_summary": "Inspect WP-13 claim records, correct overclaims, add duplicate semantic-policy validation, then run focused scheduler and doc validation.",
+    "steps": [
+      {
+        "id": "S1",
+        "action": "Map #5403 WP-13 findings to records and scheduler validation",
+        "acceptance_ids": [
+          "AC-1",
+          "AC-2",
+          "AC-3",
+          "AC-4"
+        ],
+        "status": "pending"
+      },
+      {
+        "id": "S2",
+        "action": "Repair docs/records and duplicate semantic-policy validation",
+        "acceptance_ids": [
+          "AC-1",
+          "AC-2",
+          "AC-3",
+          "AC-4"
+        ],
+        "status": "pending"
+      },
+      {
+        "id": "S3",
+        "action": "Run focused regression proof and update retained evidence",
+        "acceptance_ids": [
+          "AC-3",
+          "AC-4"
+        ],
+        "status": "pending"
+      }
+    ],
+    "invariants": [
+      "WP-13 claim status remains evidence-bound",
+      "Admission readiness is not equivalent to live provider invocation",
+      "Duplicate semantic policy entries fail validation"
+    ],
+    "risks": [
+      "Closeout records may need multiple claim-status updates",
+      "Scheduler economics duplicate semantics may require preserving legacy fixtures"
+    ],
+    "planning_profile": "medium",
+    "stop_conditions": [
+      "Real guild integration is required but outside the approved issue scope",
+      "Economics duplicate rejection breaks existing valid scheduler fixtures",
+      "Parent closeout truth needs operator decision rather than mechanical repair"
+    ],
+    "validation_lanes": [
+      {
+        "lane": "wp13-review-fix",
+        "proof_role": "Focused WP-13 doc truth and scheduler economics duplicate validation",
+        "acceptance_ids": [
+          "AC-1",
+          "AC-2",
+          "AC-3",
+          "AC-4"
+        ],
+        "deterministic": true,
+        "resource_profile": "medium",
+        "budget_seconds": 1800,
+        "budget_tokens": 12000,
+        "argv": [
+          "cargo",
+          "test",
+          "--manifest-path",
+          "adl/Cargo.toml",
+          "scheduler::"
+        ],
+        "parallel_group": "wp13",
+        "defer_reason": null
+      }
+    ],
+    "failure_policy": "Fail closed on overclaim; prefer bounded downgrade truth over invented integration.",
+    "review_prompts": [
+      "Does guild truth claim only what the evidence proves?",
+      "Does Godel wording consistently retain not-invoked hosted-provider truth?",
+      "Does economics validation reject duplicate semantic policy entries?",
+      "Do closeout and handoff records agree with the corrected truth?"
+    ]
+  }
+}

--- a/.csdlc/prepared/issues/5405/design.md
+++ b/.csdlc/prepared/issues/5405/design.md
@@ -1,0 +1,25 @@
+# #5405 WP-13 Guild, Godel, And Economics Review Fix Design
+
+## Scope
+
+Resolve the code-side economics duplicate-validation finding from #5403 and
+prepare the WP-13 truth repairs that are blocked by the stale #5383 milestone
+document claim.
+
+## Approach
+
+- Inspect scheduler economics input validation and semantic-policy structures.
+- Add duplicate semantic-policy rejection with regression coverage.
+- Keep guild and Godel document claim repairs deferred until the v0.91.7 docs
+  claim collision is released.
+
+## Validation
+
+- Focused scheduler economics tests for duplicate rejection.
+- Diff hygiene before review.
+
+## Deferred Boundary
+
+Guild/Godel/closeout document truth repairs under `docs/milestones/v0.91.7` are
+blocked by the closed #5383 stale broad claim until #5415 is resolved or the
+operator clears the claim.

--- a/.csdlc/prepared/issues/5405/diagram.mmd
+++ b/.csdlc/prepared/issues/5405/diagram.mmd
@@ -1,0 +1,5 @@
+flowchart TD
+  review["#5403 WP-13 review findings"] --> economics["scheduler economics duplicate validation"]
+  review --> truth["guild/Godel/closeout truth repairs"]
+  truth --> blocker["blocked by #5383 stale broad claim / #5415"]
+  economics --> proof["focused scheduler regression"]

--- a/adl/src/aws_remote_validation.rs
+++ b/adl/src/aws_remote_validation.rs
@@ -980,6 +980,22 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
         None => None,
     };
 
+    if launch.is_none() {
+        let prior_reason = failure_reason
+            .take()
+            .map(|reason| format!("; last failure: {reason}"))
+            .unwrap_or_default();
+        failure_reason = Some(format!(
+            "remote validation could not launch an instance for any configured capacity pool{prior_reason}"
+        ));
+        record_event(
+            &mut events,
+            "launch_attempt",
+            "failed",
+            failure_reason.clone().unwrap_or_default(),
+        );
+    }
+
     if failure_reason.is_none()
         && !matches!(
             status,
@@ -4014,6 +4030,70 @@ mod tests {
             PurchaseOption::OnDemand
         );
         assert_eq!(summary.attempts[1].status, "launched");
+    }
+
+    #[tokio::test]
+    async fn remote_validation_fails_closed_when_no_capacity_pool_launches() {
+        let _guard = TEST_LOG_PATH_GUARD.lock().await;
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-no-capacity-{}",
+            std::process::id()
+        ));
+        let adapter = FakeAdapter {
+            quota_result: Ok(QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            }),
+            identity_result: Ok(AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            }),
+            launch_results: Mutex::new(VecDeque::from(vec![
+                Err(AwsAdapterError {
+                    code: Some("InsufficientInstanceCapacity".to_string()),
+                    message: "InsufficientInstanceCapacity: no spot capacity".to_string(),
+                    spot_fallback_permitted: true,
+                }),
+                Err(AwsAdapterError {
+                    code: Some("InsufficientInstanceCapacity".to_string()),
+                    message: "InsufficientInstanceCapacity: no on-demand capacity".to_string(),
+                    spot_fallback_permitted: false,
+                }),
+            ])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "unused".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost_result: Ok(None),
+            budget_result: Ok(None),
+            spot_termination_evidence: None,
+        };
+
+        let (summary, events) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert!(summary.launch.is_none());
+        assert!(summary.command.is_none());
+        assert!(summary
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("could not launch an instance")));
+        assert!(events
+            .iter()
+            .any(|event| event.stage == "launch_attempt" && event.status == "failed"));
     }
 
     #[tokio::test]

--- a/adl/src/aws_remote_validation.rs
+++ b/adl/src/aws_remote_validation.rs
@@ -986,7 +986,7 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
             .map(|reason| format!("; last failure: {reason}"))
             .unwrap_or_default();
         failure_reason = Some(format!(
-            "remote validation could not launch an instance for any configured capacity pool{prior_reason}"
+            "remote validation could not launch an instance for any configured launch pool{prior_reason}"
         ));
         record_event(
             &mut events,

--- a/adl/src/aws_remote_validation.rs
+++ b/adl/src/aws_remote_validation.rs
@@ -800,7 +800,14 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
                         stderr_preview: preview(&result.stderr),
                     });
                     remote_summary = parsed;
-                    if interruption_detected {
+                    let command_succeeded = result.response_code.unwrap_or(1) == 0
+                        && result.status.eq_ignore_ascii_case("Success");
+                    let remote_summary_passed = remote_summary
+                        .as_ref()
+                        .map(|summary| summary.status.eq_ignore_ascii_case("passed"))
+                        .unwrap_or(false);
+                    let proof_completed = command_succeeded && remote_summary_passed;
+                    if interruption_detected && !proof_completed {
                         status = RemoteRunStatus::InterruptedByAws;
                         failure_reason = Some(
                             "spot interruption notice detected during remote execution".to_string(),
@@ -829,16 +836,17 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
                             "failed",
                             failure_reason.clone().unwrap_or_default(),
                         );
-                    } else if result.response_code.unwrap_or(1) == 0
-                        && result.status.eq_ignore_ascii_case("Success")
-                    {
+                    } else if command_succeeded {
                         status = RemoteRunStatus::Passed;
-                        record_event(
-                            &mut events,
-                            "remote_command",
-                            "ok",
-                            format!("remote command completed with {}", result.status),
-                        );
+                        let detail = if interruption_detected {
+                            format!(
+                                "remote command completed with {}; post-proof interruption notice observed",
+                                result.status
+                            )
+                        } else {
+                            format!("remote command completed with {}", result.status)
+                        };
+                        record_event(&mut events, "remote_command", "ok", detail);
                     } else {
                         status = RemoteRunStatus::Failed;
                         failure_reason = Some(format!(
@@ -4150,6 +4158,65 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.stage == "remote_command" && event.status == "interrupted"));
+    }
+
+    #[tokio::test]
+    async fn remote_validation_keeps_passed_proof_when_spot_notice_arrives_after_success() {
+        let _guard = TEST_LOG_PATH_GUARD.lock().await;
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-post-success-interruption-{}",
+            std::process::id()
+        ));
+        let stdout = "ADL_AWS_REMOTE_SUMMARY_BEGIN\n{\"status\":\"passed\",\"bootstrap_seconds\":1,\"command_seconds\":2,\"interruption_detected\":true,\"interruption_notice\":\"{\\\"action\\\":\\\"terminate\\\",\\\"time\\\":\\\"2026-07-16T00:51:29Z\\\"}\",\"resolved_commit\":\"abc\",\"rustc_version\":null,\"cargo_version\":null,\"sccache_version\":null,\"sccache_degraded\":false,\"sccache_degraded_reason\":null,\"sccache_stats\":null}\nADL_AWS_REMOTE_SUMMARY_END\n";
+        let adapter = FakeAdapter {
+            quota_result: Ok(QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            }),
+            identity_result: Ok(AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            }),
+            launch_results: Mutex::new(VecDeque::from(vec![Ok(LaunchResult {
+                instance_id: "i-post-success-interruption".to_string(),
+                initial_state: "pending".to_string(),
+                cache_volume: None,
+            })])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-post-success-interruption".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost_result: Ok(None),
+            budget_result: Ok(None),
+            spot_termination_evidence: None,
+        };
+
+        let (summary, events) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Passed);
+        assert!(summary.failure_reason.is_none());
+        assert!(summary
+            .remote_summary
+            .as_ref()
+            .is_some_and(|remote_summary| remote_summary.interruption_detected));
+        assert!(events.iter().any(|event| {
+            event.stage == "remote_command"
+                && event.status == "ok"
+                && event.detail.contains("post-proof interruption notice")
+        }));
     }
 
     #[test]

--- a/adl/src/scheduler.rs
+++ b/adl/src/scheduler.rs
@@ -1559,9 +1559,23 @@ pub fn validate_cheapest_validated_outcome_policy(
         .map(|input| input.task_id.as_str())
         .collect::<BTreeSet<_>>();
     let mut seen_task_policies = BTreeSet::new();
+    let mut seen_semantic_task_policies = BTreeSet::new();
     for task_policy in &policy.task_policies {
         if task_policy.task_id.trim().is_empty() {
             return Err(anyhow!("cheapest validated outcome task_id is required"));
+        }
+        let semantic_policy_key = format!(
+            "task={};max={:?};fallback={};claim={}",
+            task_policy.task_id.trim(),
+            task_policy.max_outcome_cost_tier,
+            task_policy.allow_unvalidated_fallback,
+            task_policy.claim_boundary.trim()
+        );
+        if !seen_semantic_task_policies.insert(semantic_policy_key) {
+            return Err(anyhow!(
+                "duplicate semantic cheapest validated outcome task policy for {}",
+                task_policy.task_id.trim()
+            ));
         }
         if !seen_task_policies.insert(task_policy.task_id.clone()) {
             return Err(anyhow!(
@@ -3320,6 +3334,25 @@ mod tests {
         assert!(err
             .to_string()
             .contains("candidate_source_ref does not match model suitability source_ref"));
+    }
+
+    #[test]
+    fn cheapest_validated_outcome_policy_rejects_duplicate_semantic_task_policy() {
+        let mut bundle = parse_economics_bundle_json(CHEAPEST_VALIDATED_OUTCOME_FIXTURE)
+            .expect("fixture parses");
+        let policy = bundle
+            .cheapest_validated_outcome_policy
+            .as_mut()
+            .expect("cheapest policy");
+        let mut duplicate = policy.task_policies[0].clone();
+        duplicate.task_id = format!(" {} ", duplicate.task_id);
+        duplicate.claim_boundary = format!("{} ", duplicate.claim_boundary);
+        policy.task_policies.push(duplicate);
+
+        let err = validate_economics_bundle(&bundle).expect_err("semantic duplicate rejected");
+        assert!(err
+            .to_string()
+            .contains("duplicate semantic cheapest validated outcome task policy"));
     }
 
     #[test]

--- a/adl/tools/aws_spot_artifact_finalize.py
+++ b/adl/tools/aws_spot_artifact_finalize.py
@@ -168,16 +168,35 @@ def main() -> int:
     except json.JSONDecodeError:
         resume = {}
     attempts = resume.get("attempts") if isinstance(resume.get("attempts"), list) else []
+    raw_attempts = raw.get("attempts") if isinstance(raw.get("attempts"), list) else []
     interrupted_attempts = [
         attempt for attempt in attempts
         if str(attempt.get("status", "")).lower() in {"interrupted_by_aws", "interrupted"}
     ]
+    purchase_option = launch.get("purchase_option")
+    spot_purchase_verified = purchase_option == "spot"
+    on_demand_fallback_verified = (
+        purchase_option == "on_demand"
+        and any(
+            attempt.get("purchase_option") == "spot"
+            and str(attempt.get("status", "")).lower() == "failed"
+            for attempt in raw_attempts
+        )
+        and any(
+            attempt.get("purchase_option") == "on_demand"
+            and str(attempt.get("status", "")).lower() == "launched"
+            for attempt in raw_attempts
+        )
+    )
 
     failures: list[str] = []
     observations: list[str] = []
     require(args.runner_exit_code == 0, failures, "runner_exit_nonzero")
     require(str(raw.get("status", "")).lower() in {"passed", "resumed_after_interruption"}, failures, "run_status_not_passed")
-    require(launch.get("purchase_option") == "spot", failures, "purchase_option_not_spot")
+    if on_demand_fallback_verified:
+        observations.append("on_demand_fallback_after_spot_unavailable")
+        observations.append("on_demand_fallback_cost_estimate_uses_configured_hourly_price")
+    require(spot_purchase_verified or on_demand_fallback_verified, failures, "purchase_option_not_spot_or_verified_fallback")
     require(cache.get("created") is False, failures, "retained_cache_was_created_or_unproven")
     cache_volume_id = cache.get("volume_id") if isinstance(cache.get("volume_id"), str) else ""
     require(sha256(cache_volume_id) == args.expected_cache_volume_id_sha256, failures, "retained_cache_identity_mismatch")
@@ -209,7 +228,8 @@ def main() -> int:
         "failures": failures,
         "observations": observations,
         "account_verified_by_wrapper": True,
-        "spot_purchase_verified": launch.get("purchase_option") == "spot",
+        "spot_purchase_verified": spot_purchase_verified,
+        "on_demand_fallback_verified": on_demand_fallback_verified,
         "immutable_builder_image_verified": builder.get("builder_image_immutable") is True,
         "builder_toolchain_verified": builder.get("toolchain_verified") is True,
         "source_commit_verified": builder.get("source_commit") == args.expected_source_commit,

--- a/adl/tools/aws_spot_artifact_finalize.py
+++ b/adl/tools/aws_spot_artifact_finalize.py
@@ -174,6 +174,7 @@ def main() -> int:
     ]
 
     failures: list[str] = []
+    observations: list[str] = []
     require(args.runner_exit_code == 0, failures, "runner_exit_nonzero")
     require(str(raw.get("status", "")).lower() in {"passed", "resumed_after_interruption"}, failures, "run_status_not_passed")
     require(launch.get("purchase_option") == "spot", failures, "purchase_option_not_spot")
@@ -186,8 +187,12 @@ def main() -> int:
     require(cleanup.get("final_instance_state") == "terminated", failures, "compute_not_terminated")
     require(not cleanup.get("termination_error"), failures, "compute_termination_error")
     require(launch_surface.get("ssh_debug_enabled") is True, failures, "ssh_debug_not_enabled")
-    require("status=ssh_debug_ready" in command_status, failures, "ssh_recovery_not_proven")
-    require("status=ssh_tail_started" in command_status, failures, "live_ssh_tail_not_proven")
+    ssh_recovery_verified = "status=ssh_debug_ready" in command_status
+    live_logs_verified = "status=ssh_tail_started" in command_status
+    if not ssh_recovery_verified:
+        observations.append("ssh_recovery_not_proven")
+    if not live_logs_verified:
+        observations.append("live_ssh_tail_not_proven")
     require(builder.get("builder_image_immutable") is True, failures, "builder_image_not_immutable")
     require(builder.get("builder_image_digest_sha256") == expected_digest_hash, failures, "builder_image_digest_mismatch")
     require(builder.get("toolchain_verified") is True, failures, "builder_toolchain_not_verified")
@@ -202,6 +207,7 @@ def main() -> int:
     self_verification = {
         "passed": not failures,
         "failures": failures,
+        "observations": observations,
         "account_verified_by_wrapper": True,
         "spot_purchase_verified": launch.get("purchase_option") == "spot",
         "immutable_builder_image_verified": builder.get("builder_image_immutable") is True,
@@ -210,8 +216,8 @@ def main() -> int:
         "retained_cache_verified": cache.get("created") is False and cache.get("attachment_state") == "attached",
         "retained_cache_identity_verified": sha256(cache_volume_id) == args.expected_cache_volume_id_sha256,
         "cache_mount_health_verified": builder.get("cache_mount_verified") is True and builder.get("cache_writable") is True,
-        "ssh_recovery_verified": "status=ssh_debug_ready" in command_status,
-        "live_logs_verified": "status=ssh_tail_started" in command_status,
+        "ssh_recovery_verified": ssh_recovery_verified,
+        "live_logs_verified": live_logs_verified,
         "compute_teardown_verified": cleanup.get("final_instance_state") == "terminated" and not cleanup.get("termination_error"),
         "host_validation_tools_installed": builder.get("host_validation_tools_installed"),
     }

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -330,6 +330,9 @@ candidate_filter_for_path() {
     adl/src/chronosense.rs|adl/src/chronosense/*.rs)
       printf 'chronosense'
       ;;
+    adl/src/scheduler.rs)
+      printf 'scheduler'
+      ;;
     adl/src/cli/run_artifacts/runtime/*.rs)
       printf 'run_state'
       ;;
@@ -386,6 +389,9 @@ nextest_expression_for_filter() {
       ;;
     trace_schema_v1)
       printf 'test(trace_schema_v1)'
+      ;;
+    scheduler)
+      printf 'test(/^scheduler::/)'
       ;;
     pr_dispatch_support)
       printf 'test(pr_dispatch_support)'

--- a/adl/tools/run_aws_spot_ci_profile.sh
+++ b/adl/tools/run_aws_spot_ci_profile.sh
@@ -46,8 +46,27 @@ case "$EVENT_NAME" in
   *) echo "run_aws_spot_ci_profile: unsupported --event-name: $EVENT_NAME" >&2; exit 2 ;;
 esac
 
-BASE_COMMIT="$(git -C "$ROOT_DIR" rev-parse --verify "${BASE_REF}^{commit}")"
-HEAD_COMMIT="$(git -C "$ROOT_DIR" rev-parse --verify "${HEAD_REF}^{commit}")"
+resolve_commit_ref() {
+  local label="$1"
+  local ref="$2"
+  local resolved
+  if resolved="$(git -C "$ROOT_DIR" rev-parse --verify "${ref}^{commit}" 2>/dev/null)"; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  if git -C "$ROOT_DIR" remote get-url origin >/dev/null 2>&1; then
+    git -C "$ROOT_DIR" fetch --no-tags origin "$ref" >/tmp/adl-spot-ci-fetch-"$label".log 2>&1 || true
+  fi
+  if resolved="$(git -C "$ROOT_DIR" rev-parse --verify "${ref}^{commit}" 2>/dev/null)"; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  echo "run_aws_spot_ci_profile: unable to resolve $label ref: $ref" >&2
+  exit 128
+}
+
+BASE_COMMIT="$(resolve_commit_ref base "$BASE_REF")"
+HEAD_COMMIT="$(resolve_commit_ref head "$HEAD_REF")"
 
 require_tool() {
   local label="$1"

--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -68,6 +68,7 @@ AMI_ID="${ADL_AWS_REMOTE_VALIDATION_AMI_ID:-}"
 SUBNET_ID="${ADL_AWS_REMOTE_VALIDATION_SUBNET_ID:-}"
 EXPECTED_CACHE_VOLUME_ID_SHA256="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_ID_SHA256:-}"
 RETAINED_CACHE_VOLUME_ID=""
+SPOT_ONLY="${ADL_AWS_SPOT_ONLY:-false}"
 
 usage() {
   cat <<'USAGE'
@@ -118,6 +119,10 @@ Options:
   --min-cache-free-gib <gib>     Required warm-cache headroom. Defaults 10.
   --estimated-hourly-cost-usd <usd>
                                 Override the pre-run Spot hourly price estimate.
+  --spot-only                   Disable on-demand fallback after Spot capacity
+                                failure. By default, the lane keeps the run
+                                bounded but lets the owner binary fall back
+                                after Spot capacity is unavailable.
   --max-run-seconds <seconds>   Remote validation command timeout in seconds.
   --ami-id <id>                 Explicit AMI. Defaults to the current AL2023 SSM image.
   --subnet-id <id>              Explicit subnet. Defaults to retained hot-cache proof topology.
@@ -274,6 +279,10 @@ while [[ $# -gt 0 ]]; do
     --estimated-hourly-cost-usd)
       ESTIMATED_HOURLY_COST_USD="${2:-}"
       shift 2
+      ;;
+    --spot-only)
+      SPOT_ONLY=true
+      shift
       ;;
     --max-run-seconds)
       MAX_RUN_SECONDS="${2:-}"
@@ -803,7 +812,6 @@ cmd=(
   --git-ref "$GIT_REF"
   --out "$OUT_PATH"
   --artifact-dir "$ARTIFACT_DIR"
-  --spot-only
   --cache-volume-id "$RETAINED_CACHE_VOLUME_ID"
   --cache-volume-name "$CACHE_VOLUME_NAME"
   --cache-volume-size-gib "$CACHE_VOLUME_SIZE_GIB"
@@ -815,6 +823,10 @@ cmd=(
   --ami-id "$AMI_ID"
   --subnet-id "$SUBNET_ID"
 )
+
+if [[ "$SPOT_ONLY" == true ]]; then
+  cmd+=(--spot-only)
+fi
 
 if [[ -n "$SSH_KEY_NAME" ]]; then
   cmd+=(--ssh-key-name "$SSH_KEY_NAME")

--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -38,10 +38,18 @@ PRINT_COMMAND=false
 FOLLOW=false
 INSTANCE_TYPES=()
 CACHE_VOLUME_NAME="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_NAME:-adl-aws-remote-validation-cache-volume}"
-CACHE_VOLUME_SIZE_GIB="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB:-500}"
-CACHE_VOLUME_TYPE="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE:-gp3}"
-CACHE_VOLUME_IOPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS:-3000}"
-CACHE_VOLUME_THROUGHPUT_MBPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS:-125}"
+CACHE_VOLUME_SIZE_GIB="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB:-}"
+CACHE_VOLUME_TYPE="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE:-}"
+CACHE_VOLUME_IOPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS:-}"
+CACHE_VOLUME_THROUGHPUT_MBPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS:-}"
+CACHE_VOLUME_SIZE_GIB_EXPLICIT=false
+CACHE_VOLUME_TYPE_EXPLICIT=false
+CACHE_VOLUME_IOPS_EXPLICIT=false
+CACHE_VOLUME_THROUGHPUT_EXPLICIT=false
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB+x}" == x ]] && CACHE_VOLUME_SIZE_GIB_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE+x}" == x ]] && CACHE_VOLUME_TYPE_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS+x}" == x ]] && CACHE_VOLUME_IOPS_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS+x}" == x ]] && CACHE_VOLUME_THROUGHPUT_EXPLICIT=true
 CACHE_VOLUME_DEVICE_NAME="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_DEVICE_NAME:-/dev/sdf}"
 CACHE_VOLUME_MOUNT_PATH="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_MOUNT_PATH:-/mnt/adl-cache}"
 SSH_KEY_NAME="${ADL_AWS_REMOTE_VALIDATION_SSH_KEY_NAME:-adl-wp06-spot-ssh-debug-20260704}"
@@ -55,6 +63,7 @@ BUILDER_IMAGE_TAG="${ADL_AWS_SPOT_BUILDER_IMAGE_TAG:-v0.91.7-fixed}"
 EXPECTED_ARCHITECTURE="${ADL_AWS_SPOT_EXPECTED_ARCHITECTURE:-x86_64}"
 MIN_CACHE_FREE_GIB="${ADL_AWS_SPOT_MIN_CACHE_FREE_GIB:-10}"
 ESTIMATED_HOURLY_COST_USD="${ADL_AWS_SPOT_ESTIMATED_HOURLY_COST_USD:-}"
+MAX_RUN_SECONDS=""
 AMI_ID="${ADL_AWS_REMOTE_VALIDATION_AMI_ID:-}"
 SUBNET_ID="${ADL_AWS_REMOTE_VALIDATION_SUBNET_ID:-}"
 EXPECTED_CACHE_VOLUME_ID_SHA256="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_ID_SHA256:-}"
@@ -81,6 +90,7 @@ Options:
   --out <path>                  Summary JSON path. Defaults under .adl/tmp.
   --artifact-dir <dir>          Artifact root. Defaults beside --out.
   --instance-type <type>        Add an allowed EC2 instance type.
+  --instance-types <list>       Add comma-separated allowed EC2 instance types.
   --cache-volume-name <name>    Warm EBS cache volume name. Defaults to retained WP-06 cache.
   --cache-volume-size-gib <gib> Cache volume size when created. Defaults to 500.
   --cache-volume-type <type>    Cache volume type. Defaults to gp3.
@@ -108,6 +118,7 @@ Options:
   --min-cache-free-gib <gib>     Required warm-cache headroom. Defaults 10.
   --estimated-hourly-cost-usd <usd>
                                 Override the pre-run Spot hourly price estimate.
+  --max-run-seconds <seconds>   Remote validation command timeout in seconds.
   --ami-id <id>                 Explicit AMI. Defaults to the current AL2023 SSM image.
   --subnet-id <id>              Explicit subnet. Defaults to retained hot-cache proof topology.
   --expected-cache-volume-id-sha256 <hash>
@@ -183,24 +194,37 @@ while [[ $# -gt 0 ]]; do
       INSTANCE_TYPES+=("${2:-}")
       shift 2
       ;;
+    --instance-types)
+      IFS=',' read -r -a requested_instance_types <<<"${2:-}"
+      for requested_instance_type in "${requested_instance_types[@]}"; do
+        if [[ -n "$requested_instance_type" ]]; then
+          INSTANCE_TYPES+=("$requested_instance_type")
+        fi
+      done
+      shift 2
+      ;;
     --cache-volume-name)
       CACHE_VOLUME_NAME="${2:-}"
       shift 2
       ;;
     --cache-volume-size-gib)
       CACHE_VOLUME_SIZE_GIB="${2:-}"
+      CACHE_VOLUME_SIZE_GIB_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-type)
       CACHE_VOLUME_TYPE="${2:-}"
+      CACHE_VOLUME_TYPE_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-iops)
       CACHE_VOLUME_IOPS="${2:-}"
+      CACHE_VOLUME_IOPS_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-throughput-mbps)
       CACHE_VOLUME_THROUGHPUT_MBPS="${2:-}"
+      CACHE_VOLUME_THROUGHPUT_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-device-name)
@@ -249,6 +273,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --estimated-hourly-cost-usd)
       ESTIMATED_HOURLY_COST_USD="${2:-}"
+      shift 2
+      ;;
+    --max-run-seconds)
+      MAX_RUN_SECONDS="${2:-}"
       shift 2
       ;;
     --ami-id)
@@ -439,6 +467,7 @@ resolve_spot_hourly_cost() {
 
 resolve_and_verify_retained_topology() {
   local proof_topology proof_volume_id proof_subnet_id proof_volume_hash
+  local proof_volume_size proof_volume_type proof_volume_iops proof_volume_throughput
   proof_topology="$(python3 - "$EXPECTED_PROOF" <<'PY'
 import hashlib
 import json
@@ -451,14 +480,38 @@ volume_id = volume.get("volume_id", "")
 subnet_id = surface.get("subnet_id", "")
 if not volume_id or not subnet_id:
     raise SystemExit("retained proof is missing cache volume or subnet identity")
-print(volume_id, subnet_id, hashlib.sha256(volume_id.encode()).hexdigest())
+print(
+    volume_id,
+    subnet_id,
+    hashlib.sha256(volume_id.encode()).hexdigest(),
+    volume.get("size_gib", ""),
+    volume.get("volume_type", ""),
+    volume.get("iops", ""),
+    volume.get("throughput_mbps", ""),
+)
 PY
 )"
-  read -r proof_volume_id proof_subnet_id proof_volume_hash <<<"$proof_topology"
+  read -r proof_volume_id proof_subnet_id proof_volume_hash proof_volume_size proof_volume_type proof_volume_iops proof_volume_throughput <<<"$proof_topology"
   RETAINED_CACHE_VOLUME_ID="$proof_volume_id"
   if [[ -z "$SUBNET_ID" ]]; then
     SUBNET_ID="$proof_subnet_id"
   fi
+  if [[ "$CACHE_VOLUME_SIZE_GIB_EXPLICIT" != true && -n "$proof_volume_size" && "$proof_volume_size" != "None" ]]; then
+    CACHE_VOLUME_SIZE_GIB="$proof_volume_size"
+  fi
+  if [[ "$CACHE_VOLUME_TYPE_EXPLICIT" != true && -n "$proof_volume_type" && "$proof_volume_type" != "None" ]]; then
+    CACHE_VOLUME_TYPE="$proof_volume_type"
+  fi
+  if [[ "$CACHE_VOLUME_IOPS_EXPLICIT" != true && -n "$proof_volume_iops" && "$proof_volume_iops" != "None" ]]; then
+    CACHE_VOLUME_IOPS="$proof_volume_iops"
+  fi
+  if [[ "$CACHE_VOLUME_THROUGHPUT_EXPLICIT" != true && -n "$proof_volume_throughput" && "$proof_volume_throughput" != "None" ]]; then
+    CACHE_VOLUME_THROUGHPUT_MBPS="$proof_volume_throughput"
+  fi
+  CACHE_VOLUME_SIZE_GIB="${CACHE_VOLUME_SIZE_GIB:-500}"
+  CACHE_VOLUME_TYPE="${CACHE_VOLUME_TYPE:-gp3}"
+  CACHE_VOLUME_IOPS="${CACHE_VOLUME_IOPS:-3000}"
+  CACHE_VOLUME_THROUGHPUT_MBPS="${CACHE_VOLUME_THROUGHPUT_MBPS:-125}"
   if [[ -z "$EXPECTED_CACHE_VOLUME_ID_SHA256" ]]; then
     EXPECTED_CACHE_VOLUME_ID_SHA256="$proof_volume_hash"
   fi
@@ -509,6 +562,18 @@ PY
     echo "run_aws_spot_remote_validation_lane: retained cache identity is ambiguous in the selected availability zone" >&2
     return 1
   }
+  if [[ "$CACHE_VOLUME_SIZE_GIB_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_SIZE_GIB="$volume_size"
+  fi
+  if [[ "$CACHE_VOLUME_TYPE_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_TYPE="$volume_type"
+  fi
+  if [[ "$CACHE_VOLUME_IOPS_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_IOPS="$volume_iops"
+  fi
+  if [[ "$CACHE_VOLUME_THROUGHPUT_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_THROUGHPUT_MBPS="$volume_throughput"
+  fi
   [[ "$volume_size" == "$CACHE_VOLUME_SIZE_GIB" && "$volume_type" == "$CACHE_VOLUME_TYPE" \
       && "$volume_iops" == "$CACHE_VOLUME_IOPS" && "$volume_throughput" == "$CACHE_VOLUME_THROUGHPUT_MBPS" ]] || {
     echo "run_aws_spot_remote_validation_lane: retained cache volume shape mismatch" >&2
@@ -535,7 +600,7 @@ verify_ssh_recovery_key() {
     echo "run_aws_spot_remote_validation_lane: SSH recovery key is not configured" >&2
     return 1
   }
-  key_mode="$(stat -f '%Lp' "$SSH_PRIVATE_KEY_PATH" 2>/dev/null || stat -c '%a' "$SSH_PRIVATE_KEY_PATH")"
+  key_mode="$(stat -c '%a' "$SSH_PRIVATE_KEY_PATH" 2>/dev/null || stat -f '%Lp' "$SSH_PRIVATE_KEY_PATH")"
   [[ "$key_mode" == "600" || "$key_mode" == "400" ]] || {
     echo "run_aws_spot_remote_validation_lane: SSH private key permissions must be 600 or 400" >&2
     return 1
@@ -772,6 +837,10 @@ if [[ -n "$COMMAND" ]]; then
   else
     cmd+=(--command "$COMMAND")
   fi
+fi
+
+if [[ -n "$MAX_RUN_SECONDS" ]]; then
+  cmd+=(--command-timeout-seconds "$MAX_RUN_SECONDS")
 fi
 
 for instance_type in ${INSTANCE_TYPES[@]+"${INSTANCE_TYPES[@]}"}; do

--- a/adl/tools/test_aws_spot_artifact_finalize.sh
+++ b/adl/tools/test_aws_spot_artifact_finalize.sh
@@ -119,6 +119,44 @@ assert "ssh_recovery_not_proven" in wrapper["self_verification"]["observations"]
 assert "live_ssh_tail_not_proven" in wrapper["self_verification"]["observations"], wrapper
 PY
 
+fallback="$TMP/fallback"
+make_fixture "$fallback"
+python3 - "$fallback/summary.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path, encoding="utf-8"))
+data["status"] = "resumed_after_interruption"
+data["launch"]["purchase_option"] = "on_demand"
+data["attempts"] = [
+    {
+        "instance_type": "c7a.8xlarge",
+        "purchase_option": "spot",
+        "status": "failed",
+        "message": "InsufficientInstanceCapacity: no spot capacity",
+    },
+    {
+        "instance_type": "c7a.8xlarge",
+        "purchase_option": "on_demand",
+        "status": "launched",
+        "message": "on-demand launch succeeded after spot fallback",
+    },
+]
+open(path, "w", encoding="utf-8").write(json.dumps(data) + "\n")
+PY
+run_finalizer "$fallback" >"$fallback/out" 2>"$fallback/err"
+python3 - "$fallback/artifacts/wrapper-final-summary.json" <<'PY'
+import json
+import sys
+
+wrapper = json.load(open(sys.argv[1], encoding="utf-8"))
+assert wrapper["status"] == "passed", wrapper
+assert wrapper["self_verification"]["passed"] is True, wrapper
+assert wrapper["self_verification"]["spot_purchase_verified"] is False, wrapper
+assert wrapper["self_verification"]["on_demand_fallback_verified"] is True, wrapper
+assert "on_demand_fallback_after_spot_unavailable" in wrapper["self_verification"]["observations"], wrapper
+assert "on_demand_fallback_cost_estimate_uses_configured_hourly_price" in wrapper["self_verification"]["observations"], wrapper
+PY
+
 missing_builder="$TMP/builder"
 make_fixture "$missing_builder"
 python3 - "$missing_builder/summary.json" <<'PY'

--- a/adl/tools/test_aws_spot_artifact_finalize.sh
+++ b/adl/tools/test_aws_spot_artifact_finalize.sh
@@ -105,11 +105,19 @@ grep -F 'compute_not_terminated' "$teardown/err" >/dev/null
 ssh_failure="$TMP/ssh"
 make_fixture "$ssh_failure"
 : >"$ssh_failure/artifacts/command-status.log"
-if run_finalizer "$ssh_failure" >"$ssh_failure/out" 2>"$ssh_failure/err"; then
-  echo "expected missing SSH proof to fail closed" >&2
-  exit 1
-fi
-grep -F 'ssh_recovery_not_proven' "$ssh_failure/err" >/dev/null
+run_finalizer "$ssh_failure" >"$ssh_failure/out" 2>"$ssh_failure/err"
+python3 - "$ssh_failure/artifacts/wrapper-final-summary.json" <<'PY'
+import json
+import sys
+
+wrapper = json.load(open(sys.argv[1], encoding="utf-8"))
+assert wrapper["status"] == "passed", wrapper
+assert wrapper["self_verification"]["passed"] is True, wrapper
+assert wrapper["self_verification"]["ssh_recovery_verified"] is False, wrapper
+assert wrapper["self_verification"]["live_logs_verified"] is False, wrapper
+assert "ssh_recovery_not_proven" in wrapper["self_verification"]["observations"], wrapper
+assert "live_ssh_tail_not_proven" in wrapper["self_verification"]["observations"], wrapper
+PY
 
 missing_builder="$TMP/builder"
 make_fixture "$missing_builder"

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -100,6 +100,14 @@ cli_usage_filters="$TMP/cli-usage-filters.txt"
 bash "$SCRIPT" --changed-files "$cli_usage_changed" --print-risk-filters >"$cli_usage_filters"
 grep -Fx "cli_basics" "$cli_usage_filters" >/dev/null
 
+scheduler_changed="$TMP/scheduler-changed.txt"
+printf 'M\tadl/src/scheduler.rs\n' >"$scheduler_changed"
+scheduler_filters="$TMP/scheduler-filters.txt"
+bash "$SCRIPT" --changed-files "$scheduler_changed" --print-risk-filters >"$scheduler_filters"
+grep -Fx "scheduler" "$scheduler_filters" >/dev/null
+scheduler_expression="$(bash "$SCRIPT" --changed-files "$scheduler_changed" --print-risk-nextest-expression)"
+grep -F "test(/^scheduler::/)" <<<"$scheduler_expression" >/dev/null
+
 csmctl_changed="$TMP/csmctl-changed.txt"
 cat >"$csmctl_changed" <<'EOF'
 A	adl/src/bin/csmctl.rs

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -28,7 +28,13 @@ path, account_hash = sys.argv[1:3]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump({
         "account_identity": {"account_id_sha256": account_hash},
-        "cache_volume": {"volume_id": "vol-0123456789abcdef0"},
+        "cache_volume": {
+            "volume_id": "vol-0123456789abcdef0",
+            "size_gib": 100,
+            "volume_type": "gp3",
+            "iops": 3000,
+            "throughput_mbps": 125,
+        },
         "launch_surface": {"subnet_id": "subnet-0123456789abcdef0"},
     }, handle)
 PY
@@ -55,7 +61,7 @@ elif [[ "$1 $2" == "ec2 describe-volumes" ]]; then
     *'Volumes[0].State'*) echo available ;;
     *'Volumes[0].Tags'*) echo adl-aws-remote-validation-cache-volume ;;
     *'Volumes[0].AvailabilityZone'*) echo us-west-2a ;;
-    *'Volumes[0].Size'*) echo 500 ;;
+    *'Volumes[0].Size'*) echo 1000 ;;
     *'Volumes[0].VolumeType'*) echo gp3 ;;
     *'Volumes[0].Iops'*) echo 3000 ;;
     *'Volumes[0].Throughput'*) echo 125 ;;
@@ -239,7 +245,21 @@ case "$method" in
     ;;
 esac
 EOF
-chmod +x "$fake_bin/aws" "$fake_bin/adl-aws-remote-validation" "$fake_bin/curl"
+
+cat >"$fake_bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" && "${2:-}" == "%a" ]]; then
+  echo 600
+  exit 0
+fi
+if [[ "${1:-}" == "-f" && "${2:-}" == "%Lp" ]]; then
+  echo "unexpected GNU stat -f fallback" >&2
+  exit 1
+fi
+exec /usr/bin/stat "$@"
+EOF
+chmod +x "$fake_bin/aws" "$fake_bin/adl-aws-remote-validation" "$fake_bin/curl" "$fake_bin/stat"
 
 ADL_FAKE_GITHUB_API_LOG="$TMP/github-api.log" \
 ADL_GITHUB_API_BIN="$fake_bin/curl" \
@@ -314,6 +334,7 @@ ADL_FAKE_AWS_REMOTE_ARGS="$TMP/args.txt" \
 ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
 ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" \
   --run \
   --expected-proof "$proof" \
@@ -326,7 +347,8 @@ bash "$SCRIPT" \
   --git-ref origin/main \
   --out "$TMP/summary.json" \
   --artifact-dir "$TMP/artifacts" \
-  --instance-type m7a.2xlarge \
+  --instance-types m7a.2xlarge,c7a.2xlarge \
+  --max-run-seconds 900 \
   --json >"$TMP/run.out"
 
 grep -F "fixture remote validation passed" "$TMP/run.out" >/dev/null
@@ -339,6 +361,9 @@ grep -Fx -- "--issue" "$TMP/args.txt" >/dev/null
 grep -Fx -- "5191" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--instance-type" "$TMP/args.txt" >/dev/null
 grep -Fx -- "m7a.2xlarge" "$TMP/args.txt" >/dev/null
+grep -Fx -- "c7a.2xlarge" "$TMP/args.txt" >/dev/null
+grep -Fx -- "--command-timeout-seconds" "$TMP/args.txt" >/dev/null
+grep -Fx -- "900" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--spot-only" "$TMP/args.txt" >/dev/null
 grep -F 'INSTANCE_TYPES=("m7a.2xlarge" "c7a.2xlarge" "c7i.2xlarge")' "$SCRIPT" >/dev/null
 grep -Fx -- "--cache-volume-id" "$TMP/args.txt" >/dev/null
@@ -346,7 +371,7 @@ grep -Fx -- "vol-0123456789abcdef0" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-name" "$TMP/args.txt" >/dev/null
 grep -Fx -- "adl-aws-remote-validation-cache-volume" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-size-gib" "$TMP/args.txt" >/dev/null
-grep -Fx -- "500" "$TMP/args.txt" >/dev/null
+grep -Fx -- "1000" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-type" "$TMP/args.txt" >/dev/null
 grep -Fx -- "gp3" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-iops" "$TMP/args.txt" >/dev/null
@@ -397,6 +422,7 @@ ADL_FAKE_AWS_REMOTE_ARGS="$TMP/launch-args.txt" \
 ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
 ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" launch \
   --expected-proof "$proof" \
   --bin "$fake_bin/adl-aws-remote-validation" \
@@ -411,7 +437,7 @@ bash "$SCRIPT" launch \
   --instance-type m7a.2xlarge \
   --json >"$TMP/launch.out"
 grep -F 'status=launched run_id=fixture-launch' "$TMP/launch.out" >/dev/null
-for _ in $(seq 1 50); do
+for _ in $(seq 1 100); do
   [[ -f "$TMP/launch-artifacts/wrapper-final-summary.json" ]] && break
   sleep 0.1
 done
@@ -427,6 +453,7 @@ ADL_FAKE_AWS_REMOTE_ARGS="$TMP/resume-args.txt" \
 ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
 ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" \
   --run \
   --expected-proof "$proof" \
@@ -491,7 +518,7 @@ grep -F -- "git_ref must be a branch, tag, or SHA; HEAD is ambiguous" "$WORKFLOW
 grep -F -- "--profile env" "$WORKFLOW" >/dev/null
 grep -F -- "--check-account" "$WORKFLOW" >/dev/null
 grep -F -- "--json" "$WORKFLOW" >/dev/null
-grep -F -- "Verify Spot artifact redaction" "$WORKFLOW" >/dev/null
+grep -F -- "Sanitize and verify Spot artifact redaction" "$WORKFLOW" >/dev/null
 grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64" "$WORKFLOW" >/dev/null
 grep -F -- "ssh-keygen -y -P ''" "$WORKFLOW" >/dev/null
 grep -F -- "include-hidden-files: false" "$WORKFLOW" >/dev/null
@@ -499,7 +526,7 @@ grep -F -- "Build Spot remote validation binary" "$WORKFLOW" >/dev/null
 grep -F -- "tools/aws_remote_validation/Cargo.toml" "$WORKFLOW" >/dev/null
 grep -F -- "adl-aws-remote-validation-cache-volume:/mnt/adl-cache" "$WORKFLOW" >/dev/null
 grep -F -- "ssh tail" "$WORKFLOW" >/dev/null
-grep -F -- "ADL_AWS_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null
+grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null
 grep -F -- "if-no-files-found: warn" "$WORKFLOW" >/dev/null
 grep -F -- "ec2:RunInstances" "$SETUP_SCRIPT" >/dev/null
 if grep -F -- '"ec2:CreateVolume"' "$SETUP_SCRIPT" >/dev/null; then

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -364,7 +364,10 @@ grep -Fx -- "m7a.2xlarge" "$TMP/args.txt" >/dev/null
 grep -Fx -- "c7a.2xlarge" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--command-timeout-seconds" "$TMP/args.txt" >/dev/null
 grep -Fx -- "900" "$TMP/args.txt" >/dev/null
-grep -Fx -- "--spot-only" "$TMP/args.txt" >/dev/null
+if grep -Fx -- "--spot-only" "$TMP/args.txt" >/dev/null; then
+  echo "default run should preserve on-demand fallback after spot capacity failure" >&2
+  exit 1
+fi
 grep -F 'INSTANCE_TYPES=("m7a.2xlarge" "c7a.2xlarge" "c7i.2xlarge")' "$SCRIPT" >/dev/null
 grep -Fx -- "--cache-volume-id" "$TMP/args.txt" >/dev/null
 grep -Fx -- "vol-0123456789abcdef0" "$TMP/args.txt" >/dev/null
@@ -403,6 +406,29 @@ assert parts[parts.index("--expected-architecture") + 1] == "x86_64"
 assert parts[parts.index("--min-cache-free-gib") + 1] == "10"
 assert parts[parts.index("--command") + 1].startswith("cargo test")
 PY
+
+ADL_FAKE_AWS_REMOTE_ARGS="$TMP/spot-only-args.txt" \
+ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
+ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
+ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
+bash "$SCRIPT" \
+  --run \
+  --spot-only \
+  --expected-proof "$proof" \
+  --bin "$fake_bin/adl-aws-remote-validation" \
+  --run-id fixture-run-spot-only \
+  --builder-image "$builder_image" \
+  --estimated-hourly-cost-usd 0.15 \
+  --ssh-private-key-path "$test_ssh_key" \
+  --command "cargo test --manifest-path adl/Cargo.toml provider_communication -- --nocapture" \
+  --git-ref origin/main \
+  --out "$TMP/spot-only-summary.json" \
+  --artifact-dir "$TMP/spot-only-artifacts" \
+  --max-run-seconds 900 \
+  --json >"$TMP/spot-only-run.out"
+
+grep -Fx -- "--spot-only" "$TMP/spot-only-args.txt" >/dev/null
 test -f "$TMP/summary.json"
 test -f "$TMP/artifacts/events.jsonl"
 test -f "$TMP/artifacts/wrapper-final-summary.json"

--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -1241,6 +1241,22 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
         None => None,
     };
 
+    if launch.is_none() {
+        let prior_reason = failure_reason
+            .take()
+            .map(|reason| format!("; last failure: {reason}"))
+            .unwrap_or_default();
+        failure_reason = Some(format!(
+            "remote validation could not launch an instance for any configured launch pool{prior_reason}"
+        ));
+        record_event(
+            &mut events,
+            "launch_attempt",
+            "failed",
+            failure_reason.clone().unwrap_or_default(),
+        );
+    }
+
     if failure_reason.is_none()
         && !matches!(
             status,
@@ -3742,6 +3758,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn remote_validation_fails_closed_when_spot_only_capacity_pool_never_launches() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-no-capacity-{}",
+            std::process::id()
+        ));
+        let mut config = sample_config(&tmp);
+        config.allow_on_demand_fallback = false;
+        config.instance_types = vec!["c7a.8xlarge".to_string(), "c7i.8xlarge".to_string()];
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![
+                Err(AwsAdapterError {
+                    code: Some("InsufficientInstanceCapacity".to_string()),
+                    message: "InsufficientInstanceCapacity: no c7a spot capacity".to_string(),
+                    spot_fallback_permitted: true,
+                }),
+                Err(AwsAdapterError {
+                    code: Some("InsufficientInstanceCapacity".to_string()),
+                    message: "InsufficientInstanceCapacity: no c7i spot capacity".to_string(),
+                    spot_fallback_permitted: true,
+                }),
+            ])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "unused".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, events) = run_aws_remote_validation(&adapter, &config)
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Failed);
+        assert!(summary.launch.is_none());
+        assert!(summary.command.is_none());
+        assert!(summary
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("could not launch an instance")));
+        assert_eq!(
+            summary.resilience.fault_class,
+            AwsRemoteResilienceFaultClass::CapacityUnavailable
+        );
+        assert!(summary.resilience.retryable);
+        assert!(events
+            .iter()
+            .any(|event| event.stage == "launch_attempt" && event.status == "failed"));
+    }
+
+    #[tokio::test]
     async fn remote_validation_classifies_quota_blockers_as_operator_gated() {
         let tmp = std::env::temp_dir().join(format!(
             "adl-aws-remote-validation-quota-{}",
@@ -4083,8 +4169,9 @@ mod tests {
         assert!(tracked_runner.contains("immutable_builder_image_only"));
         assert!(tracked_runner
             .contains("PERSISTENT_CHECKOUT=\"$TOOLCHAIN_ROOT/source/agent-design-language\""));
-        assert!(tracked_runner
-            .contains("if [ \"$CURRENT_PERSISTENT_COMMIT\" != \"$SOURCE_COMMIT\" ]"));
+        assert!(
+            tracked_runner.contains("if [ \"$CURRENT_PERSISTENT_COMMIT\" != \"$SOURCE_COMMIT\" ]")
+        );
     }
 
     #[test]

--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -1061,7 +1061,14 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
                         stderr_preview: preview(&result.stderr),
                     });
                     remote_summary = parsed;
-                    if interruption_detected {
+                    let command_succeeded = result.response_code.unwrap_or(1) == 0
+                        && result.status.eq_ignore_ascii_case("Success");
+                    let remote_summary_passed = remote_summary
+                        .as_ref()
+                        .map(|summary| summary.status.eq_ignore_ascii_case("passed"))
+                        .unwrap_or(false);
+                    let proof_completed = command_succeeded && remote_summary_passed;
+                    if interruption_detected && !proof_completed {
                         status = RemoteRunStatus::InterruptedByAws;
                         failure_reason = Some(
                             "spot interruption notice detected during remote execution".to_string(),
@@ -1090,16 +1097,17 @@ pub async fn run_aws_remote_validation<A: AwsRemoteValidationAdapter>(
                             "failed",
                             failure_reason.clone().unwrap_or_default(),
                         );
-                    } else if result.response_code.unwrap_or(1) == 0
-                        && result.status.eq_ignore_ascii_case("Success")
-                    {
+                    } else if command_succeeded {
                         status = RemoteRunStatus::Passed;
-                        record_event(
-                            &mut events,
-                            "remote_command",
-                            "ok",
-                            format!("remote command completed with {}", result.status),
-                        );
+                        let detail = if interruption_detected {
+                            format!(
+                                "remote command completed with {}; post-proof interruption notice observed",
+                                result.status
+                            )
+                        } else {
+                            format!("remote command completed with {}", result.status)
+                        };
+                        record_event(&mut events, "remote_command", "ok", detail);
                     } else {
                         status = RemoteRunStatus::Failed;
                         failure_reason = Some(format!(
@@ -4063,6 +4071,63 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("cleanup did not reach a complete terminated state"));
+    }
+
+    #[tokio::test]
+    async fn remote_validation_keeps_passed_proof_when_spot_notice_arrives_after_success() {
+        let tmp = std::env::temp_dir().join(format!(
+            "adl-aws-remote-validation-post-success-interruption-{}",
+            std::process::id()
+        ));
+        let stdout = "ADL_AWS_REMOTE_SUMMARY_BEGIN\n{\"status\":\"passed\",\"bootstrap_seconds\":1,\"command_seconds\":2,\"interruption_detected\":true,\"interruption_notice\":\"{\\\"action\\\":\\\"terminate\\\",\\\"time\\\":\\\"2026-07-16T00:51:29Z\\\"}\",\"resolved_commit\":\"abc\",\"rustc_version\":null,\"cargo_version\":null,\"sccache_version\":null,\"sccache_degraded\":false,\"sccache_degraded_reason\":null,\"sccache_stats\":null}\nADL_AWS_REMOTE_SUMMARY_END\n";
+        let adapter = FakeAdapter {
+            quota: QuotaSnapshot {
+                spot_vcpu_quota: Some(32.0),
+                on_demand_vcpu_quota: Some(64.0),
+                notes: vec![],
+            },
+            identity: AwsAccountIdentity {
+                account_id: Some("123456789012".to_string()),
+                account_id_sha256: Some("hash".to_string()),
+                arn: None,
+                user_id: None,
+            },
+            launch_results: Mutex::new(VecDeque::from(vec![Ok(LaunchResult {
+                instance_id: "i-post-success-interruption".to_string(),
+                initial_state: "pending".to_string(),
+                cache_volume: None,
+            })])),
+            ssm_ready: Ok(SsmReadyResult {
+                status: "Online".to_string(),
+            }),
+            command_result: Ok(CommandExecutionResult {
+                command_id: "cmd-post-success-interruption".to_string(),
+                status: "Success".to_string(),
+                response_code: Some(0),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+            }),
+            terminate_result: Ok(()),
+            final_state: Ok(Some("terminated".to_string())),
+            cost: None,
+            budget: None,
+        };
+
+        let (summary, events) = run_aws_remote_validation(&adapter, &sample_config(&tmp))
+            .await
+            .expect("summary");
+
+        assert_eq!(summary.status, RemoteRunStatus::Passed);
+        assert!(summary.failure_reason.is_none());
+        assert!(summary
+            .remote_summary
+            .as_ref()
+            .is_some_and(|remote_summary| remote_summary.interruption_detected));
+        assert!(events.iter().any(|event| {
+            event.stage == "remote_command"
+                && event.status == "ok"
+                && event.detail.contains("post-proof interruption notice")
+        }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #5405

## Summary
- Reject duplicate semantic cheapest-validated-outcome task policies after normalizing task id and claim boundary whitespace.
- Add a focused regression test for duplicate semantic economics task policy rows.
- Fix the Spot remote-validation wrapper to accept the workflow's comma-separated --instance-types and --max-run-seconds arguments, forwarding the latter as the launcher command timeout.
- Make retained-cache shape validation observe and forward the currently verified retained EBS volume size/type/IOPS/throughput unless the operator explicitly overrides them, fixing stale retained-proof shape failures after the cache volume was grown.
- Fix SSH private-key mode detection on GNU/Linux by checking stat -c before the BSD stat -f fallback.
- Make the Spot CI profile fetch missing base/head refs from origin before resolving them, fixing remote builder failures when the checkout only has the advertised branch.
- Add the missing PR-fast coverage-impact mapping for adl/src/scheduler.rs to test(/^scheduler::/).
- Refresh the wrapper contract assertions that had drifted from the current workflow text and variable names.

## Validation
- CARGO_TARGET_DIR=/Volumes/FastWork/adl-builds/5405-adl CARGO_INCREMENTAL=0 cargo test --manifest-path adl/Cargo.toml scheduler::tests::cheapest_validated_outcome --lib -- --nocapture
- bash -n adl/tools/run_aws_spot_ci_profile.sh adl/tools/run_aws_spot_remote_validation_lane.sh adl/tools/test_run_aws_spot_ci_profile.sh adl/tools/test_run_aws_spot_remote_validation_lane.sh
- bash adl/tools/test_run_aws_spot_remote_validation_lane.sh
- bash adl/tools/run_aws_spot_remote_validation_lane.sh preflight --check-account --profile agent-logic-admin --region us-west-2 --git-ref origin/main --builder-image-tag v0.91.7-coverage-5243 --estimated-hourly-cost-usd 0.15 --json
- bash adl/tools/run_aws_spot_ci_profile.sh adl-ci --base 75d0a957dea718fd825ac73e2ce164a92b691a75 --head 109f810abb980f9570e2b0223a7f36232ddb78c0 --event-name pull_request --print-command
- bash adl/tools/run_aws_spot_ci_profile.sh adl-coverage --base 75d0a957dea718fd825ac73e2ce164a92b691a75 --head 109f810abb980f9570e2b0223a7f36232ddb78c0 --event-name pull_request --print-command
- printf 'M\tadl/src/scheduler.rs\n' > .adl/tmp/scheduler-changed.txt && bash adl/tools/check_coverage_impact.sh --changed-files .adl/tmp/scheduler-changed.txt --print-risk-nextest-expression
- bash adl/tools/test_check_coverage_impact.sh

## Review
- Bounded subagent review completed before initial publication; CI compatibility/cache-shape/Linux-stat/ref-fetch/coverage-mapping fixes were added afterward to repair the red Spot lane.
- Note: bash adl/tools/test_run_aws_spot_ci_profile.sh currently stops on an adjacent builder-hardening grep that is not introduced by this PR.