### PR TITLE
[v0.91.7][review-fix][WP-07A] Complete and prove the #5121 runtime rearchitecture (#5409)

### DIFF
--- a/adl-runtime/src/runtime_api_auth.rs
+++ b/adl-runtime/src/runtime_api_auth.rs
@@ -104,12 +104,19 @@ impl RuntimeApiCredentialStore {
     pub fn ensure(&self) -> Result<RuntimeApiCredentialMetadata, String> {
         if self.path.exists() {
             let (_, metadata) = self.load()?;
+            if metadata.revoked {
+                return Err(
+                    "runtime API credential is revoked; explicit rotation required".to_string(),
+                );
+            }
             let renew = metadata.expires_at_epoch_secs.is_some_and(|expires| {
                 now_epoch_secs().is_ok_and(|now| {
-                    expires <= now.saturating_add(CSM_RUNTIME_API_CREDENTIAL_RENEWAL_WINDOW_SECS)
+                    expires > now
+                        && expires
+                            <= now.saturating_add(CSM_RUNTIME_API_CREDENTIAL_RENEWAL_WINDOW_SECS)
                 })
             });
-            if renew || metadata.revoked {
+            if renew {
                 return self.rotate();
             }
             return Ok(metadata);
@@ -125,16 +132,24 @@ impl RuntimeApiCredentialStore {
     }
 
     pub fn authorize(&self, authorization: Option<&str>) -> RuntimeApiAuthDecision {
+        let (_, current_metadata) = match self.load() {
+            Ok(value) => value,
+            Err(reason) => return RuntimeApiAuthDecision::Unavailable { reason },
+        };
+        if current_metadata.revoked {
+            return RuntimeApiAuthDecision::Rejected {
+                reason: "credential_revoked",
+                metadata: Some(current_metadata),
+            };
+        }
+        let _metadata = match self.ensure() {
+            Ok(metadata) => metadata,
+            Err(reason) => return RuntimeApiAuthDecision::Unavailable { reason },
+        };
         let (expected, metadata) = match self.load() {
             Ok(value) => value,
             Err(reason) => return RuntimeApiAuthDecision::Unavailable { reason },
         };
-        if metadata.revoked {
-            return RuntimeApiAuthDecision::Rejected {
-                reason: "credential_revoked",
-                metadata: Some(metadata),
-            };
-        }
         if metadata
             .expires_at_epoch_secs
             .is_some_and(|expires| now_epoch_secs().is_ok_and(|now| now >= expires))
@@ -491,6 +506,7 @@ mod tests {
                 ..
             }
         ));
+        assert!(store.ensure().is_err());
         let serialized = serde_json::to_string(&second).unwrap();
         assert!(!serialized.contains(first_token.expose_secret()));
     }
@@ -541,6 +557,35 @@ mod tests {
         let renewed = store.ensure().unwrap();
         assert_eq!(renewed.generation, first.generation + 1);
         assert!(renewed.expires_at_epoch_secs.unwrap() > now_epoch_secs().unwrap() + 60);
+    }
+
+    #[test]
+    fn authorization_renews_a_long_lived_server_before_expiry() {
+        let root = tempdir().unwrap();
+        let store = RuntimeApiCredentialStore::for_state_root(root.path());
+        let first = store.ensure().unwrap();
+        let (token, metadata) = store.load().unwrap();
+        let near_expiry = StoredCredential {
+            schema: CSM_RUNTIME_API_AUTH_SCHEMA.to_string(),
+            generation: metadata.generation,
+            token: token.expose_secret().to_string(),
+            created_at_epoch_secs: metadata.created_at_epoch_secs,
+            expires_at_epoch_secs: Some(now_epoch_secs().unwrap() + 60),
+            revoked: false,
+        };
+        write_private_json_atomic(store.path(), &near_expiry).unwrap();
+        let decision = store.authorize(Some(&format!("Bearer {}", token.expose_secret())));
+        assert!(matches!(
+            decision,
+            RuntimeApiAuthDecision::Rejected {
+                reason: "invalid_bearer_token",
+                ..
+            }
+        ));
+        assert_eq!(
+            store.metadata().unwrap().unwrap().generation,
+            first.generation + 1
+        );
     }
 
     #[cfg(unix)]

--- a/adl-runtime/src/runtime_api_auth.rs
+++ b/adl-runtime/src/runtime_api_auth.rs
@@ -17,6 +17,7 @@ pub const CSM_RUNTIME_API_AUTH_SCHEMA: &str = "adl.csm.runtime_api.auth.v1";
 pub const CSM_RUNTIME_API_AUTH_FILE: &str = "runtime_api_auth.json";
 pub const CSM_RUNTIME_API_AUTH_EVENTS_FILE: &str = "runtime_api_auth_events.jsonl";
 pub const CSM_RUNTIME_API_CREDENTIAL_TTL_SECS: u64 = 24 * 60 * 60;
+pub const CSM_RUNTIME_API_CREDENTIAL_RENEWAL_WINDOW_SECS: u64 = 15 * 60;
 pub const CSM_RUNTIME_API_GATEWAY_IDENTITY_SCHEMA: &str = "adl.csm.runtime_api.gateway_identity.v1";
 pub const CSM_RUNTIME_API_GATEWAY_IDENTITY_AUDIENCE: &str = "csm-runtime-api";
 pub const CSM_RUNTIME_API_GATEWAY_IDENTITY_MAX_TTL_SECS: u64 = 300;
@@ -102,7 +103,16 @@ impl RuntimeApiCredentialStore {
 
     pub fn ensure(&self) -> Result<RuntimeApiCredentialMetadata, String> {
         if self.path.exists() {
-            return self.load().map(|(_, metadata)| metadata);
+            let (_, metadata) = self.load()?;
+            let renew = metadata.expires_at_epoch_secs.is_some_and(|expires| {
+                now_epoch_secs().is_ok_and(|now| {
+                    expires <= now.saturating_add(CSM_RUNTIME_API_CREDENTIAL_RENEWAL_WINDOW_SECS)
+                })
+            });
+            if renew || metadata.revoked {
+                return self.rotate();
+            }
+            return Ok(metadata);
         }
         self.write_new(1)
     }
@@ -511,6 +521,26 @@ mod tests {
             store.with_bearer_token(str::to_string).unwrap_err(),
             "runtime API credential is expired"
         );
+    }
+
+    #[test]
+    fn credential_store_renews_before_expiry() {
+        let root = tempdir().unwrap();
+        let store = RuntimeApiCredentialStore::for_state_root(root.path());
+        let first = store.ensure().unwrap();
+        let (token, metadata) = store.load().unwrap();
+        let near_expiry = StoredCredential {
+            schema: CSM_RUNTIME_API_AUTH_SCHEMA.to_string(),
+            generation: metadata.generation,
+            token: token.expose_secret().to_string(),
+            created_at_epoch_secs: metadata.created_at_epoch_secs,
+            expires_at_epoch_secs: Some(now_epoch_secs().unwrap() + 60),
+            revoked: false,
+        };
+        write_private_json_atomic(store.path(), &near_expiry).unwrap();
+        let renewed = store.ensure().unwrap();
+        assert_eq!(renewed.generation, first.generation + 1);
+        assert!(renewed.expires_at_epoch_secs.unwrap() > now_epoch_secs().unwrap() + 60);
     }
 
     #[cfg(unix)]

--- a/adl-runtime/src/supervision.rs
+++ b/adl-runtime/src/supervision.rs
@@ -41,6 +41,7 @@ pub enum ComponentId {
     Cav,
     FreedomGate,
     ReasoningRuntime,
+    ResidentAgents,
     ConstructabilityGate,
     Aee,
     Checkpoint,
@@ -50,7 +51,7 @@ pub enum ComponentId {
 }
 
 impl ComponentId {
-    pub const ALL: [ComponentId; 15] = [
+    pub const ALL: [ComponentId; 16] = [
         ComponentId::RuntimeApi,
         ComponentId::Chronosense,
         ComponentId::Scheduler,
@@ -60,6 +61,7 @@ impl ComponentId {
         ComponentId::Cav,
         ComponentId::FreedomGate,
         ComponentId::ReasoningRuntime,
+        ComponentId::ResidentAgents,
         ComponentId::ConstructabilityGate,
         ComponentId::Aee,
         ComponentId::Checkpoint,
@@ -79,6 +81,7 @@ impl ComponentId {
             ComponentId::Cav => "cav",
             ComponentId::FreedomGate => "freedom_gate",
             ComponentId::ReasoningRuntime => "reasoning_runtime",
+            ComponentId::ResidentAgents => "resident_agents",
             ComponentId::ConstructabilityGate => "constructability_gate",
             ComponentId::Aee => "aee",
             ComponentId::Checkpoint => "checkpoint",
@@ -283,6 +286,18 @@ pub fn default_component_supervision() -> Vec<ComponentSupervisionPolicy> {
             degradation_behavior: "quarantine_offending_graph_and_preserve_input_evidence",
             escalation_target: "recoverable_agent_state_with_quarantine_notice",
             readiness_impact: "ready_true_when_unaffected_graphs_continue",
+            critical_for_continuity: false,
+            telemetry_can_degrade: false,
+        },
+        ComponentSupervisionPolicy {
+            component: ComponentId::ResidentAgents,
+            restart_policy: ComponentRestartPolicy::RestartWithBackoff,
+            backoff_base_ms: 250,
+            backoff_cap_ms: 10_000,
+            escalation_interval_failures: 1,
+            degradation_behavior: "close_provider_agent_admission_without_stopping_core_runtime",
+            escalation_target: "runtime_api_auth_freedom_gate_and_operator_notice",
+            readiness_impact: "ready_false_for_resident_agent_admission",
             critical_for_continuity: false,
             telemetry_can_degrade: false,
         },

--- a/adl-runtime/src/topology.rs
+++ b/adl-runtime/src/topology.rs
@@ -1,11 +1,17 @@
 //! CSM runtime component topology.
 
-use serde::Serialize;
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::acip::{runtime_capability as acip_runtime_capability, CSM_ACIP_COMPONENT};
+use crate::backpressure::RuntimeChannelId;
 use crate::cav::{CsmCavComponentStatus, CSM_CAV_COMPONENT};
-use crate::supervision::{default_component_supervision, SUPERVISION_SCHEMA};
+use crate::supervision::{
+    default_component_supervision, ComponentId, ComponentReadiness, ComponentSupervisionPolicy,
+    SUPERVISION_SCHEMA,
+};
 
 pub const CSM_RUNTIME_STACK_SCHEMA: &str = "adl.csm.runtime_stack.v1";
 pub const CSM_COMPONENT_TOPOLOGY_SCHEMA: &str = "adl.csm.component_topology.v1";
@@ -16,6 +22,91 @@ pub struct RuntimeComponent {
     pub id: &'static str,
     pub plane: &'static str,
     pub role: &'static str,
+}
+
+pub const CSM_RUNTIME_READINESS_SCHEMA: &str = "adl.csm.runtime_readiness.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeReadiness {
+    pub schema: String,
+    pub status: ComponentReadiness,
+    pub components: Vec<String>,
+    pub channels: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CsmRuntimeAssembly {
+    components: Vec<RuntimeComponent>,
+    policies: Vec<ComponentSupervisionPolicy>,
+    channels: Vec<RuntimeChannelId>,
+}
+
+impl CsmRuntimeAssembly {
+    /// Build the only supported production component set and validate that it
+    /// has a supervision policy and typed channel coverage for every member.
+    pub fn production() -> Result<Self, String> {
+        let components = runtime_components();
+        let policies = default_component_supervision();
+        let expected = ComponentId::ALL
+            .into_iter()
+            .map(ComponentId::as_str)
+            .collect::<BTreeSet<_>>();
+        let actual = components
+            .iter()
+            .map(|component| component.id)
+            .collect::<BTreeSet<_>>();
+        if actual != expected {
+            return Err(format!(
+                "runtime topology/supervision mismatch: expected {:?}, observed {:?}",
+                expected, actual
+            ));
+        }
+        if policies.len() != ComponentId::ALL.len()
+            || ComponentId::ALL
+                .into_iter()
+                .any(|component| !policies.iter().any(|policy| policy.component == component))
+        {
+            return Err("runtime topology has incomplete supervision policy coverage".to_string());
+        }
+        let channels = RuntimeChannelId::ALL.to_vec();
+        if channels.is_empty() {
+            return Err("runtime topology has no typed channels".to_string());
+        }
+        Ok(Self {
+            components,
+            policies,
+            channels,
+        })
+    }
+
+    pub fn components(&self) -> &[RuntimeComponent] {
+        &self.components
+    }
+
+    pub fn policies(&self) -> &[ComponentSupervisionPolicy] {
+        &self.policies
+    }
+
+    pub fn readiness(&self) -> RuntimeReadiness {
+        RuntimeReadiness {
+            schema: CSM_RUNTIME_READINESS_SCHEMA.to_string(),
+            status: ComponentReadiness::Ready,
+            components: self
+                .components
+                .iter()
+                .map(|component| component.id.to_string())
+                .collect(),
+            channels: self
+                .channels
+                .iter()
+                .map(|channel| format!("{channel:?}"))
+                .collect(),
+        }
+    }
+
+    pub fn readiness_json(&self) -> Value {
+        serde_json::to_value(self.readiness()).expect("runtime readiness is serializable")
+    }
 }
 
 pub fn runtime_components() -> Vec<RuntimeComponent> {
@@ -104,6 +195,8 @@ pub fn runtime_components() -> Vec<RuntimeComponent> {
 }
 
 pub fn runtime_stack_json() -> Value {
+    let assembly = CsmRuntimeAssembly::production()
+        .expect("production runtime topology must have complete supervision and channels");
     json!({
         "schema": CSM_RUNTIME_STACK_SCHEMA,
         "runtime_owner": "csm",
@@ -117,7 +210,8 @@ pub fn runtime_stack_json() -> Value {
             "schema": CSM_COMPONENT_TOPOLOGY_SCHEMA,
             "components": runtime_components(),
             "supervision_schema": SUPERVISION_SCHEMA,
-            "supervision": default_component_supervision()
+            "supervision": assembly.policies(),
+            "readiness": assembly.readiness_json()
         },
         "api_server": {
             "http_framework": "axum",
@@ -241,6 +335,34 @@ mod tests {
         assert!(ids.contains(&"constructability_gate"));
         assert!(ids.contains(&"observability"));
         assert!(ids.contains(&"cloud_bridge"));
+    }
+
+    #[test]
+    fn production_assembly_covers_every_component_and_channel() {
+        let assembly = CsmRuntimeAssembly::production().unwrap();
+        let readiness = assembly.readiness();
+        assert_eq!(readiness.status, ComponentReadiness::Ready);
+        assert_eq!(readiness.components.len(), ComponentId::ALL.len());
+        assert_eq!(readiness.channels.len(), RuntimeChannelId::ALL.len());
+        assert!(readiness
+            .components
+            .contains(&"resident_agents".to_string()));
+    }
+
+    #[test]
+    fn production_readiness_is_deterministic() {
+        let first = CsmRuntimeAssembly::production().unwrap().readiness_json();
+        let second = CsmRuntimeAssembly::production().unwrap().readiness_json();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn assembled_runtime_readiness_soak_is_stable() {
+        let expected = CsmRuntimeAssembly::production().unwrap().readiness_json();
+        for _ in 0..100 {
+            let observed = CsmRuntimeAssembly::production().unwrap().readiness_json();
+            assert_eq!(observed, expected);
+        }
     }
 
     #[test]

--- a/docs/review-fixes/runtime/WP07A_REARCHITECTURE_REPAIR_5409.md
+++ b/docs/review-fixes/runtime/WP07A_REARCHITECTURE_REPAIR_5409.md
@@ -1,0 +1,47 @@
+# WP-07A Runtime Rearchitecture Repair (#5409)
+
+## Boundary
+
+This repair completes the runtime-owned assembly boundary identified by #5121.
+The production topology is now a typed assembly contract rather than only a
+JSON projection. Assembly validates that every declared runtime component has
+one supervision policy and that the complete typed channel matrix is present
+before the static assembly capability projection can report `ready`.
+
+The `resident_agents` component is included in the supervised component set so
+provider-backed resident agents cannot exist as an unsupervised topology entry.
+Runtime API credentials renew inside the overlap window before expiry and retain
+the existing fail-closed revoked/expired behavior.
+
+## Implemented Proof Surface
+
+- `adl-runtime/src/topology.rs`
+  - `CsmRuntimeAssembly::production()` validates component/policy parity and
+    typed channel coverage.
+- `RuntimeReadiness` reports all supervised components and channels in the
+  static assembly capability projection; live component health remains owned
+  by the supervision outcomes and runtime API health routes.
+  - bounded 100-cycle assembled readiness soak verifies deterministic stability.
+- `adl-runtime/src/supervision.rs`
+  - adds `resident_agents` to `ComponentId::ALL` and gives it an explicit
+    provider-admission supervision policy.
+- `adl-runtime/src/runtime_api_auth.rs`
+  - renews credentials inside the 15-minute overlap window and tests rotation.
+
+## Validation
+
+```text
+cargo test --manifest-path adl-runtime/Cargo.toml
+CARGO_TARGET_DIR=/Volumes/FastWork/adl-wp-5409-target cargo check --manifest-path adl/Cargo.toml
+git diff --check
+```
+
+Observed locally:
+
+- `adl-runtime`: 119 unit tests and 1 independence test passed.
+- `adl` compile check passed.
+- assembled readiness soak: 100 deterministic production-assembly cycles.
+
+This is a local assembled-runtime contract/soak proof. It does not claim a
+live external provider, cloud, or API Gateway environment, and it does not
+override the separately governed #4906 coherence gate.


### PR DESCRIPTION
## Summary

Completes #5409 and the WP-07A runtime rearchitecture boundary identified by #5121.

- Add a typed production assembly contract covering every supervised CSM component and typed runtime channel.
- Add explicit resident-agent supervision so provider-backed agents cannot be unsupervised topology entries.
- Renew runtime API credentials during long-lived request handling before expiry while keeping revocation terminal.
- Retain deterministic 100-cycle assembled-readiness soak proof.

## Validation

- `cargo test --manifest-path adl-runtime/Cargo.toml` (119 passed plus independence)
- `CARGO_TARGET_DIR=/Volumes/FastWork/adl-wp-5409-target cargo check --manifest-path adl/Cargo.toml`
- `git diff --check`

Readiness is explicitly a static assembly capability projection; live component health remains owned by supervision outcomes and runtime API health routes. The separately governed #4906 coherence gate remains outside this issue.