### PR TITLE
[v0.91.7][csdlc-v2] Retain #5353 terminal closeout

### DIFF
--- a/.csdlc/issues/5353/audit.jsonl
+++ b/.csdlc/issues/5353/audit.jsonl
@@ -23,3 +23,9 @@
 {"sequence":23,"generation":17,"actor":"codex","reason":"Reconcile the completed implementation step after PR #5374 merged","operation":"{\"operation\":\"update_plan_step\",\"step_id\":\"step-2\",\"status\":\"completed\"}"}
 {"sequence":24,"generation":18,"actor":"codex","reason":"Retain the passing typed doctor result required by AC-4","operation":"{\"operation\":\"record_validation\",\"result\":{\"command\":[\"csdlc-doctor\",\"--repo\",\".\",\"--issue\",\"5353\"],\"purpose\":\"Prove the canonical typed issue record and all six cards pass doctor validation\",\"outcome\":\"passed\",\"evidence_ref\":\"local:csdlc-doctor-5353-generation-14\"}}"}
 {"sequence":25,"generation":19,"actor":"codex","reason":"Reconcile focused validation, doctor, independent review, and merged PR proof","operation":"{\"operation\":\"update_plan_step\",\"step_id\":\"step-3\",\"status\":\"completed\"}"}
+{"sequence":26,"generation":19,"actor":"codex","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":27,"generation":20,"actor":"codex-subagent-terminal-publication","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":28,"generation":21,"actor":"codex","reason":"Exact clean-commit review passed after fixing all in-scope record findings; version repair remains routed to #5427","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":29,"generation":22,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":30,"generation":23,"actor":"codex","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":31,"generation":24,"actor":"codex","reason":"atomically finalize SOR/index and release claim/protected paths","operation":"record_terminal"}

--- a/.csdlc/issues/5353/cards/sip.values.json
+++ b/.csdlc/issues/5353/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5353/cards/sor.md
+++ b/.csdlc/issues/5353/cards/sor.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: sor
 
-Status: pre_phase
+Status: complete
 
 ## Summary
 
@@ -57,17 +57,17 @@ Repaired issue-local initialization atomicity and complete design/diagram digest
 
 ## Integration
 
-worktree_only
+merged
 
 ## Publication
 
-Publication: not_published
+Publication: closed
 
-Merge: not_merged
+Merge: merged
 
 ## Closeout
 
-not_started
+complete
 
 ## Follow Ups
 

--- a/.csdlc/issues/5353/cards/sor.values.json
+++ b/.csdlc/issues/5353/cards/sor.values.json
@@ -7,9 +7,9 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
-  "status": "pre_phase",
+  "status": "complete",
   "content": {
     "card_kind": "sor",
     "values": {
@@ -50,10 +50,10 @@
           "evidence_ref": "local:csdlc-doctor-5353-generation-14"
         }
       ],
-      "integration_state": "worktree_only",
-      "publication_state": "not_published",
-      "merge_state": "not_merged",
-      "closeout_state": "not_started",
+      "integration_state": "merged",
+      "publication_state": "closed",
+      "merge_state": "merged",
+      "closeout_state": "complete",
       "follow_ups": []
     }
   }

--- a/.csdlc/issues/5353/cards/spp.values.json
+++ b/.csdlc/issues/5353/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5353/cards/srp.md
+++ b/.csdlc/issues/5353/cards/srp.md
@@ -12,7 +12,7 @@ Status: draft
 
 ## Scope
 
-
+.csdlc/issues/5353
 
 ## Prompts
 
@@ -22,7 +22,58 @@ Status: draft
 
 ## Findings
 
-[]
+[
+  {
+    "id": "5353-TR-P1-transient-terminal-projection",
+    "severity": "p1",
+    "summary": "Review recovery temporarily projects implemented state until typed terminal observation is recorded",
+    "actionable": false,
+    "in_scope": true,
+    "disposition": "accepted_risk",
+    "fix_revision": null,
+    "route": "#5423"
+  },
+  {
+    "id": "5353-TR-P2-version-identity",
+    "severity": "p2",
+    "summary": "All six retained card identities say v0.91.8 while live issue and PR truth say v0.91.7",
+    "actionable": true,
+    "in_scope": false,
+    "disposition": "out_of_scope",
+    "fix_revision": null,
+    "route": "#5427"
+  },
+  {
+    "id": "5353-TR-P2-plan-steps",
+    "severity": "p2",
+    "summary": "SPP steps remained pending after implementation, validation, review, and merge",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+    "route": null
+  },
+  {
+    "id": "5353-TR-P2-doctor-proof",
+    "severity": "p2",
+    "summary": "SOR did not retain the declared passing doctor acceptance proof",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+    "route": null
+  },
+  {
+    "id": "5353-TR-P2-focused-command",
+    "severity": "p2",
+    "summary": "The focused VPP lane used two positional Cargo test filters and was not executable",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+    "route": null
+  }
+]
 
 ## Dispositions
 
@@ -30,12 +81,13 @@ Every actionable finding requires a terminal disposition.
 
 ## Residual Risk
 
-- none
+- Typed terminal closeout must replace the transient implemented projection
+- Card identity version remains stale until #5427 applies the new typed repair
 
 ## Review Result
 
-Revision: None
+Revision: Some("git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52")
 
-Reviewer: None
+Reviewer: Some("codex-subagent-terminal-publication")
 
-Result: pre_review
+Result: pass

--- a/.csdlc/issues/5353/cards/srp.values.json
+++ b/.csdlc/issues/5353/cards/srp.values.json
@@ -7,23 +7,77 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
   "status": "draft",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "",
-      "review_revision": null,
-      "reviewer": null,
+      "review_scope": ".csdlc/issues/5353",
+      "review_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+      "reviewer": "codex-subagent-terminal-publication",
       "review_prompts": [
         "Verify issue-local paths cannot create a false existing-record condition.",
         "Verify both design and diagram digests refresh atomically.",
         "Verify tests do not widen into ADL or Runtime code."
       ],
-      "findings": [],
-      "residual_risk": [],
-      "review_result": "pre_review"
+      "findings": [
+        {
+          "id": "5353-TR-P1-transient-terminal-projection",
+          "severity": "p1",
+          "summary": "Review recovery temporarily projects implemented state until typed terminal observation is recorded",
+          "actionable": false,
+          "in_scope": true,
+          "disposition": "accepted_risk",
+          "fix_revision": null,
+          "route": "#5423"
+        },
+        {
+          "id": "5353-TR-P2-version-identity",
+          "severity": "p2",
+          "summary": "All six retained card identities say v0.91.8 while live issue and PR truth say v0.91.7",
+          "actionable": true,
+          "in_scope": false,
+          "disposition": "out_of_scope",
+          "fix_revision": null,
+          "route": "#5427"
+        },
+        {
+          "id": "5353-TR-P2-plan-steps",
+          "severity": "p2",
+          "summary": "SPP steps remained pending after implementation, validation, review, and merge",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+          "route": null
+        },
+        {
+          "id": "5353-TR-P2-doctor-proof",
+          "severity": "p2",
+          "summary": "SOR did not retain the declared passing doctor acceptance proof",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+          "route": null
+        },
+        {
+          "id": "5353-TR-P2-focused-command",
+          "severity": "p2",
+          "summary": "The focused VPP lane used two positional Cargo test filters and was not executable",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+          "route": null
+        }
+      ],
+      "residual_risk": [
+        "Typed terminal closeout must replace the transient implemented projection",
+        "Card identity version remains stale until #5427 applies the new typed repair"
+      ],
+      "review_result": "pass"
     }
   }
 }

--- a/.csdlc/issues/5353/cards/stp.values.json
+++ b/.csdlc/issues/5353/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5353/cards/vpp.values.json
+++ b/.csdlc/issues/5353/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][WP-01][csdlc-v2] Make init and design approval safe for issue-local design paths",
     "slug": "v0-91-8-wp01-csdlc-v2-init-design-approval-safety",
     "version": "v0.91.8",
-    "generation": 19
+    "generation": 24
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5353/index.json
+++ b/.csdlc/issues/5353/index.json
@@ -3,38 +3,144 @@
   "issue": 5353,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "404ad9845d55cf189416e19f7553915074e73a88adb8b0168d0b7e4781f60ddf",
-  "phase": "implemented",
-  "generation": 19,
-  "digest": "925a11b842c52cdc998f56213c86aeb5f54ed8da0454ca24139d41d51b9ceb79",
-  "claim": {
-    "id": "csdlc-v2-5353-terminal-reconcile",
-    "owner": "codex",
-    "generation": 19,
-    "acquired_unix_seconds": 1784230110,
-    "expires_unix_seconds": 1784316510,
-    "heartbeat_unix_seconds": 1784230110,
-    "branch": "codex/5353-v0-91-8-csdlc-v2-wp01-init-design-approval-safety",
-    "worktree": ".worktrees/adl-wp-5353",
-    "protected_paths": [
-      "csdlc-v2/src/lifecycle.rs",
-      "csdlc-v2/src/store.rs",
-      "csdlc-v2/src/cards.rs",
-      "csdlc-v2/tests"
-    ],
-    "purpose": "Reconcile merged #5353 terminal lifecycle and release stale protected paths"
-  },
+  "phase": "closed_out",
+  "generation": 24,
+  "digest": "f84b45dc996dfe095ac163e4bcb9a3f874fc0540a1da8c94116f3af0be0b4a19",
+  "claim": null,
   "review_assignment": {
     "reviewer": "codex-subagent-terminal-publication",
     "assigned_by": "codex",
-    "revision": "git-blake3:5d566b91c3161d405c1c2b0949469070ff0b1c8c:1366f60f9d43a340531591895e4e286fc5ec9f391eb924fad5c9ab7335bbbd1b",
+    "revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
     "scope": [
       ".csdlc/issues/5353"
     ]
   },
-  "review": null,
-  "publication": null,
-  "readiness": null,
-  "terminal": null,
+  "review": {
+    "reviewer": "codex-subagent-terminal-publication",
+    "scope": [
+      ".csdlc/issues/5353"
+    ],
+    "reviewed_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+    "findings": [
+      {
+        "id": "5353-TR-P1-transient-terminal-projection",
+        "severity": "p1",
+        "summary": "Review recovery temporarily projects implemented state until typed terminal observation is recorded",
+        "actionable": false,
+        "in_scope": true,
+        "disposition": "accepted_risk",
+        "fix_revision": null,
+        "route": "#5423"
+      },
+      {
+        "id": "5353-TR-P2-version-identity",
+        "severity": "p2",
+        "summary": "All six retained card identities say v0.91.8 while live issue and PR truth say v0.91.7",
+        "actionable": true,
+        "in_scope": false,
+        "disposition": "out_of_scope",
+        "fix_revision": null,
+        "route": "#5427"
+      },
+      {
+        "id": "5353-TR-P2-plan-steps",
+        "severity": "p2",
+        "summary": "SPP steps remained pending after implementation, validation, review, and merge",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+        "route": null
+      },
+      {
+        "id": "5353-TR-P2-doctor-proof",
+        "severity": "p2",
+        "summary": "SOR did not retain the declared passing doctor acceptance proof",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+        "route": null
+      },
+      {
+        "id": "5353-TR-P2-focused-command",
+        "severity": "p2",
+        "summary": "The focused VPP lane used two positional Cargo test filters and was not executable",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+        "route": null
+      }
+    ],
+    "residual_risks": [
+      "Typed terminal closeout must replace the transient implemented projection",
+      "Card identity version remains stale until #5427 applies the new typed repair"
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  },
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5353,
+    "pull_request": 5428,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5428",
+    "base": "main",
+    "head": "codex/5353-v0-91-8-csdlc-v2-wp01-init-design-approval-safety",
+    "revision": "git-blake3:21b4e1a9d46b9607f3fb29bb04e2084843590366:ccdc825a421b209ed8fa2651708bceca65fc577861703d97c139f83cfef27c52",
+    "draft": true,
+    "observed_state": "open"
+  },
+  "readiness": {
+    "pull_request": 5428,
+    "head_sha": "21b4e1a9d46b9607f3fb29bb04e2084843590366",
+    "checks": [
+      {
+        "name": "adl-path-policy",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29529668689/job/87726700998"
+      },
+      {
+        "name": "adl-tooling-contracts",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29529668689/job/87726732849"
+      },
+      {
+        "name": "adl-ci",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29529668689/job/87726874377"
+      },
+      {
+        "name": "adl-coverage",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29529668689/job/87726733005"
+      }
+    ],
+    "review_state": "not_required",
+    "conflict_state": "clean",
+    "post_publication_findings": [],
+    "ready": true,
+    "blockers": []
+  },
+  "terminal": {
+    "pull_request": 5428,
+    "disposition": "merged",
+    "observed_sha": "21b4e1a9d46b9607f3fb29bb04e2084843590366",
+    "observed_state": "merged",
+    "receipt_path": "csdlc-v2/closeout/5353.json",
+    "released_branch": "codex/5353-v0-91-8-csdlc-v2-wp01-init-design-approval-safety",
+    "released_worktree": ".worktrees/adl-wp-5353",
+    "released_protected_paths": [
+      "csdlc-v2/src/lifecycle.rs",
+      "csdlc-v2/src/store.rs",
+      "csdlc-v2/src/cards.rs",
+      "csdlc-v2/tests"
+    ]
+  },
   "migration": null,
   "design_path": "docs/architecture/csdlc-v2/wp01/5353/DESIGN.md",
   "diagram_path": "docs/architecture/csdlc-v2/wp01/5353/DIAGRAM.mmd",
@@ -46,34 +152,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "18293dbc156d0f0aeded14d2c09d1dc66cbf6bd2aa466ca57830431bd77feb6c",
+      "values_digest": "c5dc237b23cc517a185d4cec8be4b2ab41f29aa337e429515f4647150ba2189f",
       "rendered_digest": "09584eaac2c1ae475b3422c344c58d984ee9565cc09293db1149a84175e26de5",
       "ast_digest": "d4684cf547a9c50d22ab8e1e4b2cd112b98a73128406c651c209b0d81aed69ee"
     },
     "stp": {
-      "values_digest": "d0dbb3b72bb55ccee6ee5527923d5e1059df197eced6485246db83f47567c236",
+      "values_digest": "0adaadc4569eea7b83f84ff3746bff83a17ba2d7787a60e4aba2d73acf85eab3",
       "rendered_digest": "6e2f28697e49ec9cfd218f0b77e684d88eee857041de05913dfd572190d79b24",
       "ast_digest": "39dc2a5822da1ee0fa69e7153fea05bc821a67ca005324a29d54f05a635929b3"
     },
     "spp": {
-      "values_digest": "b9bef12bc0ef6b37874f52bc09424ff403729d6f8cf20deaa7e8ec7f6aebbeb2",
+      "values_digest": "14c21059678584a27de683b79a7ac837b191dd8859a012be5a6ccd7dff2b1f5b",
       "rendered_digest": "3258d618b0169e350398d6f2d8687e67c266d4fcd01b5857cecc5138e61ce966",
       "ast_digest": "561cbc524056352e9a1ee315abf352cb3721db9050336409ff8d0daab2113d34"
     },
     "vpp": {
-      "values_digest": "ca281b48913ce2d79a68c0e3ee8679b780631b5a140ecafca86c073303ab61d1",
+      "values_digest": "7cee7b897575bfcb4d843616920c131031fdd17b04973f01b444055b42ac714c",
       "rendered_digest": "63fbfde03d4b1f8a6ed6d708217472ca92791f7387a1b937409ef184a95c1d3e",
       "ast_digest": "25af10b69fbbc21e4716004d459f927d8697146b0b9122b905c07d53b2cb6a45"
     },
     "srp": {
-      "values_digest": "d3a685c7906cd00cff490fe57d99414c1155ea657018b361fdfb5ce6a5b3d191",
-      "rendered_digest": "b79bd7787225e6ab3569c729c17bfcd16a7211a38d908335bd844dc980b92303",
-      "ast_digest": "5b343d88e248e2c9a651ac4254afe1e18c93ff98bf5e8c083ec070db5cbe90e1"
+      "values_digest": "606c4bcafda8c2ec1251f5c875b6274c75250acd10c886e70c2678076e7af6a9",
+      "rendered_digest": "b51b3c0b77c2d03645e420412082fbb1ff8b81350df7564eea830a1e1dbd3731",
+      "ast_digest": "2422a71b67460f445363d332033c590eea5b0b76afc120ac7bff17f7e112562b"
     },
     "sor": {
-      "values_digest": "f97a6681228ec8575dd324b7ec4dce7efde3638e5cfacc9eb98a338d1fa27a3d",
-      "rendered_digest": "8e4c6b9aa424ae391c960db215fefaf10aa469f71214655f77fa21a2bcd6fa5a",
-      "ast_digest": "61b4624a38974c261e7c31833c1065d3825812e44ccd7a8f7a2d9b8843f98e26"
+      "values_digest": "f135c0e009f07236e6013bd2880317f37cbba656cf7e1a8b023fc8809d173ace",
+      "rendered_digest": "31f6b4312d654d048c9d064ac17c07f0c624b7238837b6bcb261901236d019ab",
+      "ast_digest": "4b4b712756a21e94cb73c6ce72b2c205e99573cb95cddc022eb7384a3f0af569"
     }
   },
   "transitions": [
@@ -132,6 +238,41 @@
       "to": "implemented",
       "actor": "codex",
       "reason": "Re-establish exact clean-commit review before typed publication; subsequent lifecycle metadata remains uncommitted until publication"
+    },
+    {
+      "sequence": 9,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Exact clean-commit review passed after fixing all in-scope record findings; version repair remains routed to #5427"
+    },
+    {
+      "sequence": 10,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 11,
+      "from": "published",
+      "to": "merge_ready",
+      "actor": "codex",
+      "reason": "observed required checks, review, and conflict readiness"
+    },
+    {
+      "sequence": 12,
+      "from": "merge_ready",
+      "to": "merged",
+      "actor": "codex",
+      "reason": "observed exact PR merged"
+    },
+    {
+      "sequence": 13,
+      "from": "merged",
+      "to": "closed_out",
+      "actor": "codex",
+      "reason": "terminal truth recorded and claim released"
     }
   ],
   "audit": [
@@ -309,6 +450,48 @@
       "actor": "codex",
       "reason": "Reconcile focused validation, doctor, independent review, and merged PR proof",
       "operation": "{\"operation\":\"update_plan_step\",\"step_id\":\"step-3\",\"status\":\"completed\"}"
+    },
+    {
+      "sequence": 26,
+      "generation": 19,
+      "actor": "codex",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 27,
+      "generation": 20,
+      "actor": "codex-subagent-terminal-publication",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 28,
+      "generation": 21,
+      "actor": "codex",
+      "reason": "Exact clean-commit review passed after fixing all in-scope record findings; version repair remains routed to #5427",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 29,
+      "generation": 22,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 30,
+      "generation": 23,
+      "actor": "codex",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 31,
+      "generation": 24,
+      "actor": "codex",
+      "reason": "atomically finalize SOR/index and release claim/protected paths",
+      "operation": "record_terminal"
     }
   ]
 }


### PR DESCRIPTION
Retains the typed terminal projection after #5428 merged:

- phase `closed_out`
- claim released
- green readiness and exact merged head retained
- SOR marked terminal complete
- stale card-version identity remains routed to #5427

Follow-up reconciliation for closed issue #5353; no product or runtime changes.