### PR TITLE
[v0.91.7][tooling][spot] Align wrapper with workflow arguments

### DIFF
--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -55,6 +55,7 @@ BUILDER_IMAGE_TAG="${ADL_AWS_SPOT_BUILDER_IMAGE_TAG:-v0.91.7-fixed}"
 EXPECTED_ARCHITECTURE="${ADL_AWS_SPOT_EXPECTED_ARCHITECTURE:-x86_64}"
 MIN_CACHE_FREE_GIB="${ADL_AWS_SPOT_MIN_CACHE_FREE_GIB:-10}"
 ESTIMATED_HOURLY_COST_USD="${ADL_AWS_SPOT_ESTIMATED_HOURLY_COST_USD:-}"
+MAX_RUN_SECONDS=""
 AMI_ID="${ADL_AWS_REMOTE_VALIDATION_AMI_ID:-}"
 SUBNET_ID="${ADL_AWS_REMOTE_VALIDATION_SUBNET_ID:-}"
 EXPECTED_CACHE_VOLUME_ID_SHA256="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_ID_SHA256:-}"
@@ -81,6 +82,7 @@ Options:
   --out <path>                  Summary JSON path. Defaults under .adl/tmp.
   --artifact-dir <dir>          Artifact root. Defaults beside --out.
   --instance-type <type>        Add an allowed EC2 instance type.
+  --instance-types <list>       Add comma-separated allowed EC2 instance types.
   --cache-volume-name <name>    Warm EBS cache volume name. Defaults to retained WP-06 cache.
   --cache-volume-size-gib <gib> Cache volume size when created. Defaults to 500.
   --cache-volume-type <type>    Cache volume type. Defaults to gp3.
@@ -108,6 +110,7 @@ Options:
   --min-cache-free-gib <gib>     Required warm-cache headroom. Defaults 10.
   --estimated-hourly-cost-usd <usd>
                                 Override the pre-run Spot hourly price estimate.
+  --max-run-seconds <seconds>   Remote validation command timeout in seconds.
   --ami-id <id>                 Explicit AMI. Defaults to the current AL2023 SSM image.
   --subnet-id <id>              Explicit subnet. Defaults to retained hot-cache proof topology.
   --expected-cache-volume-id-sha256 <hash>
@@ -183,6 +186,15 @@ while [[ $# -gt 0 ]]; do
       INSTANCE_TYPES+=("${2:-}")
       shift 2
       ;;
+    --instance-types)
+      IFS=',' read -r -a requested_instance_types <<<"${2:-}"
+      for requested_instance_type in "${requested_instance_types[@]}"; do
+        if [[ -n "$requested_instance_type" ]]; then
+          INSTANCE_TYPES+=("$requested_instance_type")
+        fi
+      done
+      shift 2
+      ;;
     --cache-volume-name)
       CACHE_VOLUME_NAME="${2:-}"
       shift 2
@@ -249,6 +261,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --estimated-hourly-cost-usd)
       ESTIMATED_HOURLY_COST_USD="${2:-}"
+      shift 2
+      ;;
+    --max-run-seconds)
+      MAX_RUN_SECONDS="${2:-}"
       shift 2
       ;;
     --ami-id)
@@ -772,6 +788,10 @@ if [[ -n "$COMMAND" ]]; then
   else
     cmd+=(--command "$COMMAND")
   fi
+fi
+
+if [[ -n "$MAX_RUN_SECONDS" ]]; then
+  cmd+=(--command-timeout-seconds "$MAX_RUN_SECONDS")
 fi
 
 for instance_type in ${INSTANCE_TYPES[@]+"${INSTANCE_TYPES[@]}"}; do

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -326,6 +326,7 @@ bash "$SCRIPT" \
   --git-ref origin/main \
   --out "$TMP/summary.json" \
   --artifact-dir "$TMP/artifacts" \
+  --instance-type r7a.2xlarge \
   --instance-types m7a.2xlarge,c7a.2xlarge \
   --max-run-seconds 900 \
   --json >"$TMP/run.out"
@@ -338,11 +339,24 @@ grep -Fx -- "--region" "$TMP/args.txt" >/dev/null
 grep -Fx -- "us-west-2" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--issue" "$TMP/args.txt" >/dev/null
 grep -Fx -- "5191" "$TMP/args.txt" >/dev/null
-grep -Fx -- "--instance-type" "$TMP/args.txt" >/dev/null
-grep -Fx -- "m7a.2xlarge" "$TMP/args.txt" >/dev/null
-grep -Fx -- "c7a.2xlarge" "$TMP/args.txt" >/dev/null
-grep -Fx -- "--command-timeout-seconds" "$TMP/args.txt" >/dev/null
-grep -Fx -- "900" "$TMP/args.txt" >/dev/null
+python3 - "$TMP/args.txt" <<'PY'
+import sys
+
+args = open(sys.argv[1], encoding="utf-8").read().splitlines()
+instance_types = [
+    args[index + 1]
+    for index, value in enumerate(args)
+    if value == "--instance-type"
+]
+assert instance_types == ["r7a.2xlarge", "m7a.2xlarge", "c7a.2xlarge"]
+timeout_indexes = [
+    index
+    for index, value in enumerate(args)
+    if value == "--command-timeout-seconds"
+]
+assert len(timeout_indexes) == 1
+assert args[timeout_indexes[0] + 1] == "900"
+PY
 grep -Fx -- "--spot-only" "$TMP/args.txt" >/dev/null
 grep -F 'INSTANCE_TYPES=("m7a.2xlarge" "c7a.2xlarge" "c7i.2xlarge")' "$SCRIPT" >/dev/null
 grep -Fx -- "--cache-volume-id" "$TMP/args.txt" >/dev/null
@@ -495,7 +509,7 @@ grep -F -- "git_ref must be a branch, tag, or SHA; HEAD is ambiguous" "$WORKFLOW
 grep -F -- "--profile env" "$WORKFLOW" >/dev/null
 grep -F -- "--check-account" "$WORKFLOW" >/dev/null
 grep -F -- "--json" "$WORKFLOW" >/dev/null
-grep -F -- "Verify Spot artifact redaction" "$WORKFLOW" >/dev/null
+grep -F -- "Sanitize and verify Spot artifact redaction" "$WORKFLOW" >/dev/null
 grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64" "$WORKFLOW" >/dev/null
 grep -F -- "ssh-keygen -y -P ''" "$WORKFLOW" >/dev/null
 grep -F -- "include-hidden-files: false" "$WORKFLOW" >/dev/null
@@ -503,7 +517,7 @@ grep -F -- "Build Spot remote validation binary" "$WORKFLOW" >/dev/null
 grep -F -- "tools/aws_remote_validation/Cargo.toml" "$WORKFLOW" >/dev/null
 grep -F -- "adl-aws-remote-validation-cache-volume:/mnt/adl-cache" "$WORKFLOW" >/dev/null
 grep -F -- "ssh tail" "$WORKFLOW" >/dev/null
-grep -F -- "ADL_AWS_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null
+grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null
 grep -F -- "if-no-files-found: warn" "$WORKFLOW" >/dev/null
 grep -F -- "ec2:RunInstances" "$SETUP_SCRIPT" >/dev/null
 if grep -F -- '"ec2:CreateVolume"' "$SETUP_SCRIPT" >/dev/null; then

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -326,7 +326,8 @@ bash "$SCRIPT" \
   --git-ref origin/main \
   --out "$TMP/summary.json" \
   --artifact-dir "$TMP/artifacts" \
-  --instance-type m7a.2xlarge \
+  --instance-types m7a.2xlarge,c7a.2xlarge \
+  --max-run-seconds 900 \
   --json >"$TMP/run.out"
 
 grep -F "fixture remote validation passed" "$TMP/run.out" >/dev/null
@@ -339,6 +340,9 @@ grep -Fx -- "--issue" "$TMP/args.txt" >/dev/null
 grep -Fx -- "5191" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--instance-type" "$TMP/args.txt" >/dev/null
 grep -Fx -- "m7a.2xlarge" "$TMP/args.txt" >/dev/null
+grep -Fx -- "c7a.2xlarge" "$TMP/args.txt" >/dev/null
+grep -Fx -- "--command-timeout-seconds" "$TMP/args.txt" >/dev/null
+grep -Fx -- "900" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--spot-only" "$TMP/args.txt" >/dev/null
 grep -F 'INSTANCE_TYPES=("m7a.2xlarge" "c7a.2xlarge" "c7i.2xlarge")' "$SCRIPT" >/dev/null
 grep -Fx -- "--cache-volume-id" "$TMP/args.txt" >/dev/null

--- a/docs/tooling/AWS_SPOT_REMOTE_VALIDATION_WRAPPER_CONTRACT.mmd
+++ b/docs/tooling/AWS_SPOT_REMOTE_VALIDATION_WRAPPER_CONTRACT.mmd
@@ -1,0 +1,5 @@
+flowchart LR
+  workflow["Reusable Spot workflow"] -->|"--instance-type and --instance-types"| wrapper["Spot validation wrapper"]
+  workflow -->|"--max-run-seconds"| wrapper
+  wrapper -->|"repeated --instance-type"| validator["Remote validator"]
+  wrapper -->|"--command-timeout-seconds"| validator


### PR DESCRIPTION
Fixes #5446

## Summary
- accept the reusable workflow's comma-separated `--instance-types` argument
- forward `--max-run-seconds` through the existing validator timeout contract
- prove the combined singular/list invocation and retain a small contract diagram

## Validation
- `bash adl/tools/test_run_aws_spot_remote_validation_lane.sh`
- `bash -n` on both touched scripts
- `git diff --check`
- exact-revision subagent review: PASS after two P2 test findings were fixed

No AWS resource was launched by local validation.