### PR TITLE
[v0.91.7][tooling][spot] Derive retained cache shape

### DIFF
--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -38,10 +38,18 @@ PRINT_COMMAND=false
 FOLLOW=false
 INSTANCE_TYPES=()
 CACHE_VOLUME_NAME="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_NAME:-adl-aws-remote-validation-cache-volume}"
-CACHE_VOLUME_SIZE_GIB="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB:-500}"
-CACHE_VOLUME_TYPE="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE:-gp3}"
-CACHE_VOLUME_IOPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS:-3000}"
-CACHE_VOLUME_THROUGHPUT_MBPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS:-125}"
+CACHE_VOLUME_SIZE_GIB="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB:-}"
+CACHE_VOLUME_TYPE="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE:-}"
+CACHE_VOLUME_IOPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS:-}"
+CACHE_VOLUME_THROUGHPUT_MBPS="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS:-}"
+CACHE_VOLUME_SIZE_GIB_EXPLICIT=false
+CACHE_VOLUME_TYPE_EXPLICIT=false
+CACHE_VOLUME_IOPS_EXPLICIT=false
+CACHE_VOLUME_THROUGHPUT_EXPLICIT=false
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB+x}" == x ]] && CACHE_VOLUME_SIZE_GIB_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_TYPE+x}" == x ]] && CACHE_VOLUME_TYPE_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_IOPS+x}" == x ]] && CACHE_VOLUME_IOPS_EXPLICIT=true
+[[ "${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_THROUGHPUT_MBPS+x}" == x ]] && CACHE_VOLUME_THROUGHPUT_EXPLICIT=true
 CACHE_VOLUME_DEVICE_NAME="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_DEVICE_NAME:-/dev/sdf}"
 CACHE_VOLUME_MOUNT_PATH="${ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_MOUNT_PATH:-/mnt/adl-cache}"
 SSH_KEY_NAME="${ADL_AWS_REMOTE_VALIDATION_SSH_KEY_NAME:-adl-wp06-spot-ssh-debug-20260704}"
@@ -201,18 +209,22 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cache-volume-size-gib)
       CACHE_VOLUME_SIZE_GIB="${2:-}"
+      CACHE_VOLUME_SIZE_GIB_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-type)
       CACHE_VOLUME_TYPE="${2:-}"
+      CACHE_VOLUME_TYPE_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-iops)
       CACHE_VOLUME_IOPS="${2:-}"
+      CACHE_VOLUME_IOPS_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-throughput-mbps)
       CACHE_VOLUME_THROUGHPUT_MBPS="${2:-}"
+      CACHE_VOLUME_THROUGHPUT_EXPLICIT=true
       shift 2
       ;;
     --cache-volume-device-name)
@@ -455,6 +467,7 @@ resolve_spot_hourly_cost() {
 
 resolve_and_verify_retained_topology() {
   local proof_topology proof_volume_id proof_subnet_id proof_volume_hash
+  local proof_volume_size proof_volume_type proof_volume_iops proof_volume_throughput
   proof_topology="$(python3 - "$EXPECTED_PROOF" <<'PY'
 import hashlib
 import json
@@ -467,14 +480,38 @@ volume_id = volume.get("volume_id", "")
 subnet_id = surface.get("subnet_id", "")
 if not volume_id or not subnet_id:
     raise SystemExit("retained proof is missing cache volume or subnet identity")
-print(volume_id, subnet_id, hashlib.sha256(volume_id.encode()).hexdigest())
+print(
+    volume_id,
+    subnet_id,
+    hashlib.sha256(volume_id.encode()).hexdigest(),
+    volume.get("size_gib", ""),
+    volume.get("volume_type", ""),
+    volume.get("iops", ""),
+    volume.get("throughput_mbps", ""),
+)
 PY
 )"
-  read -r proof_volume_id proof_subnet_id proof_volume_hash <<<"$proof_topology"
+  read -r proof_volume_id proof_subnet_id proof_volume_hash proof_volume_size proof_volume_type proof_volume_iops proof_volume_throughput <<<"$proof_topology"
   RETAINED_CACHE_VOLUME_ID="$proof_volume_id"
   if [[ -z "$SUBNET_ID" ]]; then
     SUBNET_ID="$proof_subnet_id"
   fi
+  if [[ "$CACHE_VOLUME_SIZE_GIB_EXPLICIT" != true && -n "$proof_volume_size" && "$proof_volume_size" != "None" ]]; then
+    CACHE_VOLUME_SIZE_GIB="$proof_volume_size"
+  fi
+  if [[ "$CACHE_VOLUME_TYPE_EXPLICIT" != true && -n "$proof_volume_type" && "$proof_volume_type" != "None" ]]; then
+    CACHE_VOLUME_TYPE="$proof_volume_type"
+  fi
+  if [[ "$CACHE_VOLUME_IOPS_EXPLICIT" != true && -n "$proof_volume_iops" && "$proof_volume_iops" != "None" ]]; then
+    CACHE_VOLUME_IOPS="$proof_volume_iops"
+  fi
+  if [[ "$CACHE_VOLUME_THROUGHPUT_EXPLICIT" != true && -n "$proof_volume_throughput" && "$proof_volume_throughput" != "None" ]]; then
+    CACHE_VOLUME_THROUGHPUT_MBPS="$proof_volume_throughput"
+  fi
+  CACHE_VOLUME_SIZE_GIB="${CACHE_VOLUME_SIZE_GIB:-500}"
+  CACHE_VOLUME_TYPE="${CACHE_VOLUME_TYPE:-gp3}"
+  CACHE_VOLUME_IOPS="${CACHE_VOLUME_IOPS:-3000}"
+  CACHE_VOLUME_THROUGHPUT_MBPS="${CACHE_VOLUME_THROUGHPUT_MBPS:-125}"
   if [[ -z "$EXPECTED_CACHE_VOLUME_ID_SHA256" ]]; then
     EXPECTED_CACHE_VOLUME_ID_SHA256="$proof_volume_hash"
   fi
@@ -525,6 +562,18 @@ PY
     echo "run_aws_spot_remote_validation_lane: retained cache identity is ambiguous in the selected availability zone" >&2
     return 1
   }
+  if [[ "$CACHE_VOLUME_SIZE_GIB_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_SIZE_GIB="$volume_size"
+  fi
+  if [[ "$CACHE_VOLUME_TYPE_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_TYPE="$volume_type"
+  fi
+  if [[ "$CACHE_VOLUME_IOPS_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_IOPS="$volume_iops"
+  fi
+  if [[ "$CACHE_VOLUME_THROUGHPUT_EXPLICIT" != true ]]; then
+    CACHE_VOLUME_THROUGHPUT_MBPS="$volume_throughput"
+  fi
   [[ "$volume_size" == "$CACHE_VOLUME_SIZE_GIB" && "$volume_type" == "$CACHE_VOLUME_TYPE" \
       && "$volume_iops" == "$CACHE_VOLUME_IOPS" && "$volume_throughput" == "$CACHE_VOLUME_THROUGHPUT_MBPS" ]] || {
     echo "run_aws_spot_remote_validation_lane: retained cache volume shape mismatch" >&2

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -57,6 +57,10 @@ if [[ "$1 $2" == "sts get-caller-identity" ]]; then
 }
 JSON
 elif [[ "$1 $2" == "ec2 describe-volumes" ]]; then
+  if [[ "$*" != *"length(Volumes)"* && "$*" != *"--volume-ids vol-0123456789abcdef0"* ]]; then
+    echo "unexpected retained volume identity: $*" >&2
+    exit 1
+  fi
   case "$*" in
     *'Volumes[0].State'*) echo available ;;
     *'Volumes[0].Tags'*) echo adl-aws-remote-validation-cache-volume ;;
@@ -402,6 +406,57 @@ assert parts[parts.index("--expected-architecture") + 1] == "x86_64"
 assert parts[parts.index("--min-cache-free-gib") + 1] == "10"
 assert parts[parts.index("--command") + 1].startswith("cargo test")
 PY
+
+if ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB=999 \
+  ADL_FAKE_AWS_REMOTE_ARGS="$TMP/explicit-mismatch-args.txt" \
+  ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
+  ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
+  ADL_AWS_CLI="$fake_bin/aws" \
+  bash "$SCRIPT" --run --expected-proof "$proof" --bin "$fake_bin/adl-aws-remote-validation" \
+    --run-id explicit-mismatch --builder-image "$builder_image" --estimated-hourly-cost-usd 0.15 \
+    --ssh-private-key-path "$test_ssh_key" --command "true" --git-ref origin/main \
+    --out "$TMP/explicit-mismatch.json" --artifact-dir "$TMP/explicit-mismatch-artifacts" \
+    >"$TMP/explicit-mismatch.out" 2>"$TMP/explicit-mismatch.err"; then
+  echo "expected explicit cache shape mismatch to fail closed" >&2
+  exit 1
+fi
+grep -F "retained cache volume shape mismatch" "$TMP/explicit-mismatch.err" >/dev/null
+[ ! -e "$TMP/explicit-mismatch-args.txt" ]
+
+ADL_AWS_REMOTE_VALIDATION_CACHE_VOLUME_SIZE_GIB=999 \
+ADL_FAKE_AWS_REMOTE_ARGS="$TMP/cli-override-args.txt" \
+ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
+ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
+ADL_AWS_CLI="$fake_bin/aws" \
+bash "$SCRIPT" --run --expected-proof "$proof" --bin "$fake_bin/adl-aws-remote-validation" \
+  --run-id cli-override --builder-image "$builder_image" --estimated-hourly-cost-usd 0.15 \
+  --ssh-private-key-path "$test_ssh_key" --command "true" --git-ref origin/main \
+  --out "$TMP/cli-override.json" --artifact-dir "$TMP/cli-override-artifacts" \
+  --cache-volume-size-gib 1000 >/dev/null
+grep -Fx -- "1000" "$TMP/cli-override-args.txt" >/dev/null
+
+bad_volume_proof="$TMP/bad-volume-proof.json"
+python3 - "$proof" "$bad_volume_proof" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+payload["cache_volume"]["volume_id"] = "vol-fffffffffffffffff"
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+if ADL_FAKE_AWS_REMOTE_ARGS="$TMP/bad-volume-args.txt" ADL_AWS_CLI="$fake_bin/aws" \
+  bash "$SCRIPT" --run --expected-proof "$bad_volume_proof" --bin "$fake_bin/adl-aws-remote-validation" \
+    --run-id bad-volume --builder-image "$builder_image" --estimated-hourly-cost-usd 0.15 \
+    --ssh-private-key-path "$test_ssh_key" --command "true" --git-ref origin/main \
+    --out "$TMP/bad-volume.json" --artifact-dir "$TMP/bad-volume-artifacts" \
+    >"$TMP/bad-volume.out" 2>"$TMP/bad-volume.err"; then
+  echo "expected wrong retained volume identity to fail closed" >&2
+  exit 1
+fi
+grep -F "unexpected retained volume identity" "$TMP/bad-volume.err" >/dev/null
+[ ! -e "$TMP/bad-volume-args.txt" ]
+
 test -f "$TMP/summary.json"
 test -f "$TMP/artifacts/events.jsonl"
 test -f "$TMP/artifacts/wrapper-final-summary.json"

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -28,7 +28,13 @@ path, account_hash = sys.argv[1:3]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump({
         "account_identity": {"account_id_sha256": account_hash},
-        "cache_volume": {"volume_id": "vol-0123456789abcdef0"},
+        "cache_volume": {
+            "volume_id": "vol-0123456789abcdef0",
+            "size_gib": 100,
+            "volume_type": "gp3",
+            "iops": 3000,
+            "throughput_mbps": 125,
+        },
         "launch_surface": {"subnet_id": "subnet-0123456789abcdef0"},
     }, handle)
 PY
@@ -55,7 +61,7 @@ elif [[ "$1 $2" == "ec2 describe-volumes" ]]; then
     *'Volumes[0].State'*) echo available ;;
     *'Volumes[0].Tags'*) echo adl-aws-remote-validation-cache-volume ;;
     *'Volumes[0].AvailabilityZone'*) echo us-west-2a ;;
-    *'Volumes[0].Size'*) echo 500 ;;
+    *'Volumes[0].Size'*) echo 1000 ;;
     *'Volumes[0].VolumeType'*) echo gp3 ;;
     *'Volumes[0].Iops'*) echo 3000 ;;
     *'Volumes[0].Throughput'*) echo 125 ;;
@@ -364,7 +370,7 @@ grep -Fx -- "vol-0123456789abcdef0" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-name" "$TMP/args.txt" >/dev/null
 grep -Fx -- "adl-aws-remote-validation-cache-volume" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-size-gib" "$TMP/args.txt" >/dev/null
-grep -Fx -- "500" "$TMP/args.txt" >/dev/null
+grep -Fx -- "1000" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-type" "$TMP/args.txt" >/dev/null
 grep -Fx -- "gp3" "$TMP/args.txt" >/dev/null
 grep -Fx -- "--cache-volume-iops" "$TMP/args.txt" >/dev/null


### PR DESCRIPTION
Fixes #5448

## Summary
- derive unspecified cache geometry from retained proof and the uniquely identified live volume
- preserve explicit environment and CLI constraints
- prove identity binding, fail-before-runner behavior, and CLI precedence

## Validation
- `bash adl/tools/test_run_aws_spot_remote_validation_lane.sh`
- `bash -n` on both scripts
- `git diff --check`
- exact-revision subagent review: PASS after one P2 proof finding was fixed

No AWS resource was launched locally.