### PR TITLE
[v0.91.7][tooling][spot] Make SSH key mode detection Linux-first

### DIFF
--- a/adl/tools/run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/run_aws_spot_remote_validation_lane.sh
@@ -600,7 +600,7 @@ verify_ssh_recovery_key() {
     echo "run_aws_spot_remote_validation_lane: SSH recovery key is not configured" >&2
     return 1
   }
-  key_mode="$(stat -f '%Lp' "$SSH_PRIVATE_KEY_PATH" 2>/dev/null || stat -c '%a' "$SSH_PRIVATE_KEY_PATH")"
+  key_mode="$(stat -c '%a' "$SSH_PRIVATE_KEY_PATH" 2>/dev/null || stat -f '%Lp' "$SSH_PRIVATE_KEY_PATH")"
   [[ "$key_mode" == "600" || "$key_mode" == "400" ]] || {
     echo "run_aws_spot_remote_validation_lane: SSH private key permissions must be 600 or 400" >&2
     return 1

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -249,7 +249,20 @@ case "$method" in
     ;;
 esac
 EOF
-chmod +x "$fake_bin/aws" "$fake_bin/adl-aws-remote-validation" "$fake_bin/curl"
+cat >"$fake_bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" && "${2:-}" == "%a" ]]; then
+  echo 600
+  exit 0
+fi
+if [[ "${1:-}" == "-f" && "${2:-}" == "%Lp" ]]; then
+  echo "unexpected BSD stat fallback on GNU path" >&2
+  exit 1
+fi
+exec /usr/bin/stat "$@"
+EOF
+chmod +x "$fake_bin/aws" "$fake_bin/adl-aws-remote-validation" "$fake_bin/curl" "$fake_bin/stat"
 
 ADL_FAKE_GITHUB_API_LOG="$TMP/github-api.log" \
 ADL_GITHUB_API_BIN="$fake_bin/curl" \
@@ -280,6 +293,7 @@ assert payload == {
 PY
 
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" \
   --check-account \
   --expected-proof "$proof" \
@@ -476,6 +490,7 @@ ADL_FAKE_AWS_REMOTE_ARGS="$TMP/launch-args.txt" \
 ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
 ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" launch \
   --expected-proof "$proof" \
   --bin "$fake_bin/adl-aws-remote-validation" \
@@ -506,6 +521,7 @@ ADL_FAKE_AWS_REMOTE_ARGS="$TMP/resume-args.txt" \
 ADL_FAKE_EXPECTED_SOURCE="$(git -C "$ROOT" rev-parse origin/main)" \
 ADL_FAKE_EXPECTED_IMAGE_DIGEST_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$builder_digest")" \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" \
   --run \
   --expected-proof "$proof" \

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -252,13 +252,20 @@ EOF
 cat >"$fake_bin/stat" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "-c" && "${2:-}" == "%a" ]]; then
+if [[ "${ADL_FAKE_STAT_STYLE:-gnu}" == "gnu" && "${1:-}" == "-c" && "${2:-}" == "%a" ]]; then
   echo 600
   exit 0
 fi
-if [[ "${1:-}" == "-f" && "${2:-}" == "%Lp" ]]; then
+if [[ "${ADL_FAKE_STAT_STYLE:-gnu}" == "gnu" && "${1:-}" == "-f" && "${2:-}" == "%Lp" ]]; then
   echo "unexpected BSD stat fallback on GNU path" >&2
   exit 1
+fi
+if [[ "${ADL_FAKE_STAT_STYLE:-gnu}" == "bsd" && "${1:-}" == "-c" && "${2:-}" == "%a" ]]; then
+  exit 1
+fi
+if [[ "${ADL_FAKE_STAT_STYLE:-gnu}" == "bsd" && "${1:-}" == "-f" && "${2:-}" == "%Lp" ]]; then
+  echo 600
+  exit 0
 fi
 exec /usr/bin/stat "$@"
 EOF
@@ -305,6 +312,15 @@ if grep -F "$account" "$TMP/check.out" >/dev/null; then
   echo "account id leaked in account-check output" >&2
   exit 1
 fi
+
+ADL_FAKE_STAT_STYLE=bsd \
+ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
+bash "$SCRIPT" \
+  --check-account \
+  --expected-proof "$proof" \
+  --git-ref origin/main >"$TMP/check-bsd-stat.out"
+grep -F "PASS account_profile_resolved profile=agent-logic-admin account_matches_retained_proof=true" "$TMP/check-bsd-stat.out" >/dev/null
 if grep -F "arn:aws:iam" "$TMP/check.out" >/dev/null; then
   echo "arn leaked in account-check output" >&2
   exit 1

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -313,14 +313,6 @@ if grep -F "$account" "$TMP/check.out" >/dev/null; then
   exit 1
 fi
 
-ADL_FAKE_STAT_STYLE=bsd \
-ADL_AWS_CLI="$fake_bin/aws" \
-PATH="$fake_bin:$PATH" \
-bash "$SCRIPT" \
-  --check-account \
-  --expected-proof "$proof" \
-  --git-ref origin/main >"$TMP/check-bsd-stat.out"
-grep -F "PASS account_profile_resolved profile=agent-logic-admin account_matches_retained_proof=true" "$TMP/check-bsd-stat.out" >/dev/null
 if grep -F "arn:aws:iam" "$TMP/check.out" >/dev/null; then
   echo "arn leaked in account-check output" >&2
   exit 1
@@ -330,7 +322,9 @@ if grep -F "AIDAEXAMPLE" "$TMP/check.out" >/dev/null; then
   exit 1
 fi
 
+ADL_FAKE_STAT_STYLE=bsd \
 ADL_AWS_CLI="$fake_bin/aws" \
+PATH="$fake_bin:$PATH" \
 bash "$SCRIPT" preflight \
   --expected-proof "$proof" \
   --builder-image "$builder_image" \


### PR DESCRIPTION
Closes #5450

## Summary
- probe GNU stat syntax before BSD syntax when validating Spot SSH key modes
- retain fail-closed BSD/macOS fallback
- exercise both GNU-first and BSD-fallback paths in the focused no-AWS wrapper test

## Validation
- bash adl/tools/test_run_aws_spot_remote_validation_lane.sh
- exact-revision bounded review: PASS