### PR TITLE
[v0.91.7][tooling][spot] Bind live SSH proof to the hosted runner CIDR

### DIFF
--- a/.github/workflows/aws-spot-remote-validation.yaml
+++ b/.github/workflows/aws-spot-remote-validation.yaml
@@ -124,7 +124,6 @@ jobs:
       AWS_SPOT_REMOTE_VALIDATION_REGION: ${{ vars.AWS_SPOT_REMOTE_VALIDATION_REGION || 'us-west-2' }}
       AWS_SPOT_REMOTE_VALIDATION_ROLE_ARN: ${{ secrets.AWS_SPOT_REMOTE_VALIDATION_ROLE_ARN }}
       AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64: ${{ secrets.AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64 }}
-      AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR: ${{ vars.AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR }}
       ISSUE_NUMBER: ${{ inputs.issue_number }}
       INSTANCE_TYPES: ${{ inputs.instance_types || inputs.instance_type }}
       MAX_RUN_SECONDS: ${{ inputs.max_run_seconds || '1800' }}
@@ -165,27 +164,6 @@ jobs:
           if [ "${{ inputs.mode }}" = "start-run" ] && [ -z "$AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64" ]; then
             echo "::error::AWS_SPOT_REMOTE_VALIDATION_SSH_PRIVATE_KEY_B64 secret is required for live Spot runs"
             exit 2
-          fi
-          if [ "${{ inputs.mode }}" = "start-run" ] && [ -z "$AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" ]; then
-            echo "::error::AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR repository variable is required for live Spot runs"
-            exit 2
-          fi
-          if [ "${{ inputs.mode }}" = "start-run" ] && [[ ! "$AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" =~ ^([0-9]{1,3}[.]){3}[0-9]{1,3}/32$ ]]; then
-            echo "::error::AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR must be one IPv4 /32"
-            exit 2
-          fi
-          if [ "${{ inputs.mode }}" = "start-run" ]; then
-            python3 - "$AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" <<'PY'
-          import ipaddress
-          import sys
-
-          try:
-              interface = ipaddress.ip_interface(sys.argv[1])
-          except ValueError as exc:
-              raise SystemExit(f"invalid SSH source CIDR: {exc}")
-          if interface.version != 4 or interface.network.prefixlen != 32 or not interface.ip.is_global:
-              raise SystemExit("SSH source CIDR must be one globally routable IPv4 /32")
-          PY
           fi
           if [ "${{ inputs.git_ref }}" = "HEAD" ]; then
             echo "::error::git_ref must be a branch, tag, or SHA; HEAD is ambiguous"
@@ -337,7 +315,6 @@ jobs:
             --max-run-seconds "$MAX_RUN_SECONDS" \
             --builder-image-tag "$BUILDER_IMAGE_TAG" \
             --ssh-private-key-path "$SSH_KEY_PATH" \
-            --ssh-allowed-cidr "$AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" \
             --out .adl/tmp/aws-spot-remote-validation/summary.json \
             --artifact-dir .adl/tmp/aws-spot-remote-validation/artifacts \
             --json

--- a/adl/tools/test_run_aws_spot_ci_profile.sh
+++ b/adl/tools/test_run_aws_spot_ci_profile.sh
@@ -59,8 +59,14 @@ grep -F 'ec2:AttachVolume' "$SETUP" >/dev/null
 grep -F 'ec2:DetachVolume' "$SETUP" >/dev/null
 grep -F 'SSH_ALLOWED_CIDR="${ADL_AWS_REMOTE_VALIDATION_SSH_ALLOWED_CIDR:-}"' "$ROOT/adl/tools/run_aws_spot_remote_validation_lane.sh" >/dev/null
 grep -F 'https://checkip.amazonaws.com' "$ROOT/tools/aws_remote_validation/src/aws_remote_validation.rs" >/dev/null
-grep -F 'AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR' "$WORKFLOW" >/dev/null
-grep -F -- '--ssh-allowed-cidr "$AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR"' "$WORKFLOW" >/dev/null
+if grep -F 'AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR' "$WORKFLOW" >/dev/null; then
+  echo "hosted Spot workflow must let the runner auto-detect its ephemeral SSH CIDR" >&2
+  exit 1
+fi
+if grep -F -- '--ssh-allowed-cidr' "$WORKFLOW" >/dev/null; then
+  echo "hosted Spot workflow must not override runner SSH CIDR auto-detection" >&2
+  exit 1
+fi
 
 ci_plan="$(bash "$SCRIPT" adl-ci --base HEAD --head HEAD --print-command)"
 coverage_plan="$(bash "$SCRIPT" adl-coverage --base HEAD --head HEAD --print-command)"

--- a/adl/tools/test_run_aws_spot_remote_validation_lane.sh
+++ b/adl/tools/test_run_aws_spot_remote_validation_lane.sh
@@ -604,7 +604,14 @@ grep -F -- "Build Spot remote validation binary" "$WORKFLOW" >/dev/null
 grep -F -- "tools/aws_remote_validation/Cargo.toml" "$WORKFLOW" >/dev/null
 grep -F -- "adl-aws-remote-validation-cache-volume:/mnt/adl-cache" "$WORKFLOW" >/dev/null
 grep -F -- "ssh tail" "$WORKFLOW" >/dev/null
-grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null
+if grep -F -- "AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR" "$WORKFLOW" >/dev/null; then
+  echo "hosted Spot workflow must not reuse a static operator SSH CIDR" >&2
+  exit 1
+fi
+if grep -F -- '--ssh-allowed-cidr' "$WORKFLOW" >/dev/null; then
+  echo "hosted Spot workflow must preserve runner CIDR auto-detection" >&2
+  exit 1
+fi
 grep -F -- "if-no-files-found: warn" "$WORKFLOW" >/dev/null
 grep -F -- "ec2:RunInstances" "$SETUP_SCRIPT" >/dev/null
 if grep -F -- '"ec2:CreateVolume"' "$SETUP_SCRIPT" >/dev/null; then

--- a/docs/tooling/GITHUB_SPOT_CI_COVERAGE_HOW_TO.md
+++ b/docs/tooling/GITHUB_SPOT_CI_COVERAGE_HOW_TO.md
@@ -126,15 +126,10 @@ automatic pull-request calls do not require a repository-wide
 `pull_request` subject. Keep the no-policy environment setting paired with the
 workflow's same-repository guard; do not remove that guard.
 
-The live workflow always enables port 22 using the configured operator CIDR;
-it does not widen ingress to the ephemeral GitHub runner address. The retained
-passphraseless key is the same key used by the local SSH recovery command.
-GitHub-side execution uses SSM as a second, retained log channel because the
-operator-only SSH ingress is intentionally not reachable from the hosted
-runner. The finalizer requires either a successful SSH probe and tail (the
-local/operator path) or the explicit operator-allowlist SSM fallback with
-both stdout and stderr records (the GitHub path). This keeps SSH recovery
-available to the operator without weakening the security group.
+The retained passphraseless key is the same key used by the local SSH recovery
+command. GitHub-side execution also retains SSM as an independent command and
+log channel. The finalizer requires successful SSH recovery and live-tail proof
+for the hosted path in addition to the retained SSM output records.
 
 This is a public repository. Keep privileged Spot dispatch on trusted
 `workflow_dispatch`, protected branches, or an approval-gated environment.

--- a/docs/tooling/GITHUB_SPOT_CI_COVERAGE_HOW_TO.md
+++ b/docs/tooling/GITHUB_SPOT_CI_COVERAGE_HOW_TO.md
@@ -101,8 +101,6 @@ repository and approved branches/environments. The workflow requires:
 - repository secret `AWS_SPOT_REMOTE_VALIDATION_ROLE_ARN`
 - repository variable `AWS_SPOT_REMOTE_VALIDATION_REGION` (defaults to
   `us-west-2`)
-- repository variable `AWS_SPOT_REMOTE_VALIDATION_SSH_ALLOWED_CIDR`, set to the
-  operator's current public `/32` address
 - protected GitHub environment `adl-spot-ci`; configure it before cutover and
   do not rely on GitHub's unprotected auto-created environment default
 
@@ -114,6 +112,12 @@ required reviewers to this CI environment because unattended required checks
 must not wait for a deployment approval. The workflow still requires a
 same-repository PR head and explicitly routes fork pull requests to hosted
 runners, so no untrusted fork code can enter the Spot job.
+
+For live runs, the remote-validation binary resolves the current hosted
+runner's public IPv4 address through the AWS HTTPS check-IP endpoint and grants
+only that ephemeral `/32` access to the temporary SSH security group. The
+workflow must not reuse an operator workstation CIDR or persist the runner
+address as a repository variable.
 
 Do not store AWS access keys in GitHub. The role needs the bounded EC2, EBS,
 SSM, IAM, ECR-read, and cleanup permissions already created for the Spot lane.

--- a/tools/aws_remote_validation/Cargo.lock
+++ b/tools/aws_remote_validation/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "base64",
  "chrono",
  "flate2",
+ "ip_network",
  "once_cell",
  "serde",
  "serde_json",
@@ -1478,6 +1479,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipnet"

--- a/tools/aws_remote_validation/Cargo.toml
+++ b/tools/aws_remote_validation/Cargo.toml
@@ -23,6 +23,7 @@ aws-sdk-ssm = "1"
 aws-sdk-sts = "1"
 chrono = { version = "0.4", features = ["serde"] }
 flate2 = "1.0"
+ip_network = "0.4.1"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -16,6 +16,7 @@ use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::sync::{Arc, Mutex};
@@ -1436,6 +1437,37 @@ fn preview(text: &str) -> String {
     text.lines().take(8).collect::<Vec<_>>().join(" | ")
 }
 
+fn public_ipv4_cidr(response: &[u8]) -> Result<String> {
+    let text = std::str::from_utf8(response)
+        .context("failed to decode public IP response for SSH debug mode")?;
+    let ip: Ipv4Addr = text
+        .trim()
+        .parse()
+        .context("public IP response for SSH debug mode is not IPv4")?;
+    let [first, second, third, _] = ip.octets();
+    let shared = first == 100 && (64..=127).contains(&second);
+    let benchmarking = first == 198 && matches!(second, 18 | 19);
+    let protocol_assignment = first == 192 && second == 0 && third == 0;
+    let reserved = first >= 240;
+    if ip.is_unspecified()
+        || ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_documentation()
+        || ip.is_broadcast()
+        || shared
+        || benchmarking
+        || protocol_assignment
+        || reserved
+    {
+        return Err(anyhow!(
+            "public IP response for SSH debug mode is not globally routable"
+        ));
+    }
+    Ok(format!("{ip}/32"))
+}
+
 fn build_ssh_debug_config(config: &AwsRemoteValidationConfig) -> Result<Option<SshDebugConfig>> {
     let Some(_key_name) = config.ssh_key_name.as_deref() else {
         return Ok(None);
@@ -1458,9 +1490,7 @@ fn build_ssh_debug_config(config: &AwsRemoteValidationConfig) -> Result<Option<S
             if !output.status.success() {
                 return Err(anyhow!("failed to detect public IP for SSH debug mode"));
             }
-            let ip = String::from_utf8(output.stdout)
-                .context("failed to decode public IP response for SSH debug mode")?;
-            format!("{}/32", ip.trim())
+            public_ipv4_cidr(&output.stdout)?
         }
     };
     Ok(Some(SshDebugConfig {
@@ -3439,6 +3469,26 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
+    #[test]
+    fn public_ipv4_cidr_accepts_one_global_address() {
+        assert_eq!(
+            public_ipv4_cidr(b"8.8.8.8\n").expect("global IPv4"),
+            "8.8.8.8/32"
+        );
+    }
+
+    #[test]
+    fn public_ipv4_cidr_rejects_non_global_or_malformed_responses() {
+        for response in [
+            b"127.0.0.1\n".as_slice(),
+            b"10.0.0.1\n".as_slice(),
+            b"2001:4860:4860::8888\n".as_slice(),
+            b"not-an-ip\n".as_slice(),
+        ] {
+            assert!(public_ipv4_cidr(response).is_err());
+        }
+    }
+
     struct FakeAdapter {
         quota: QuotaSnapshot,
         identity: AwsAccountIdentity,
@@ -4083,8 +4133,9 @@ mod tests {
         assert!(tracked_runner.contains("immutable_builder_image_only"));
         assert!(tracked_runner
             .contains("PERSISTENT_CHECKOUT=\"$TOOLCHAIN_ROOT/source/agent-design-language\""));
-        assert!(tracked_runner
-            .contains("if [ \"$CURRENT_PERSISTENT_COMMIT\" != \"$SOURCE_COMMIT\" ]"));
+        assert!(
+            tracked_runner.contains("if [ \"$CURRENT_PERSISTENT_COMMIT\" != \"$SOURCE_COMMIT\" ]")
+        );
     }
 
     #[test]

--- a/tools/aws_remote_validation/src/aws_remote_validation.rs
+++ b/tools/aws_remote_validation/src/aws_remote_validation.rs
@@ -10,6 +10,7 @@ use aws_sdk_servicequotas as servicequotas;
 use aws_sdk_ssm as ssm;
 use aws_sdk_sts as sts;
 use chrono::{DateTime, Datelike, Duration as ChronoDuration, Timelike, Utc};
+use ip_network::IpNetwork;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1444,23 +1445,7 @@ fn public_ipv4_cidr(response: &[u8]) -> Result<String> {
         .trim()
         .parse()
         .context("public IP response for SSH debug mode is not IPv4")?;
-    let [first, second, third, _] = ip.octets();
-    let shared = first == 100 && (64..=127).contains(&second);
-    let benchmarking = first == 198 && matches!(second, 18 | 19);
-    let protocol_assignment = first == 192 && second == 0 && third == 0;
-    let reserved = first >= 240;
-    if ip.is_unspecified()
-        || ip.is_private()
-        || ip.is_loopback()
-        || ip.is_link_local()
-        || ip.is_multicast()
-        || ip.is_documentation()
-        || ip.is_broadcast()
-        || shared
-        || benchmarking
-        || protocol_assignment
-        || reserved
-    {
+    if !IpNetwork::from(ip).is_global() || ip == Ipv4Addr::new(192, 88, 99, 2) {
         return Err(anyhow!(
             "public IP response for SSH debug mode is not globally routable"
         ));
@@ -3471,10 +3456,13 @@ mod tests {
 
     #[test]
     fn public_ipv4_cidr_accepts_one_global_address() {
-        assert_eq!(
-            public_ipv4_cidr(b"8.8.8.8\n").expect("global IPv4"),
-            "8.8.8.8/32"
-        );
+        for (response, expected) in [
+            (b"8.8.8.8\n".as_slice(), "8.8.8.8/32"),
+            (b"192.0.0.9\n".as_slice(), "192.0.0.9/32"),
+            (b"192.0.0.10\n".as_slice(), "192.0.0.10/32"),
+        ] {
+            assert_eq!(public_ipv4_cidr(response).expect("global IPv4"), expected);
+        }
     }
 
     #[test]
@@ -3482,10 +3470,16 @@ mod tests {
         for response in [
             b"127.0.0.1\n".as_slice(),
             b"10.0.0.1\n".as_slice(),
+            b"0.0.0.1\n".as_slice(),
+            b"192.88.99.2\n".as_slice(),
             b"2001:4860:4860::8888\n".as_slice(),
             b"not-an-ip\n".as_slice(),
         ] {
-            assert!(public_ipv4_cidr(response).is_err());
+            assert!(
+                public_ipv4_cidr(response).is_err(),
+                "accepted non-global response: {:?}",
+                String::from_utf8_lossy(response)
+            );
         }
     }
 


### PR DESCRIPTION
Closes #5453

## Summary
- stop injecting a static workstation CIDR into hosted Spot CI
- reuse the existing AWS HTTPS check-IP resolver for the ephemeral runner /32
- validate the response with ip_network and IANA edge-case coverage
- retain required live SSH recovery/tail proof and independent SSM evidence

## Validation
- 36 locked remote-validation tests
- focused Spot CI profile contract
- focused Spot wrapper contract
- exact-revision review: PASS