### PR TITLE
chore(csdlc): publish #5405 terminal closeout

### DIFF
--- a/.csdlc/issues/5405/audit.jsonl
+++ b/.csdlc/issues/5405/audit.jsonl
@@ -20,3 +20,31 @@
 {"sequence":20,"generation":14,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
 {"sequence":21,"generation":15,"actor":"subagent:019f7321-c006-7013-a1bc-9d2048423552","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
 {"sequence":22,"generation":16,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Exact-revision subagent review passed at 89088f8a5 with all four prior findings fixed.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":23,"generation":17,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Lifecycle-only review-record commit changed revision identity after the prior exact review; recover for exact current-HEAD review before publication.","operation":"recover_review"}
+{"sequence":24,"generation":17,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":25,"generation":18,"actor":"subagent:019f7321-c006-7013-a1bc-9d2048423552","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":26,"generation":19,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Exact current-HEAD review passed at daad3d266 with all substantive paths unchanged from the prior PASS.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":27,"generation":20,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":28,"generation":21,"actor":"codex","reason":"Rebase onto merged Spot wrapper repair changed the commit identity while leaving all issue-owned bytes unchanged","operation":"recover_review"}
+{"sequence":29,"generation":21,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":30,"generation":22,"actor":"subagent:019f7321-c006-7013-a1bc-9d2048423552","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":31,"generation":23,"actor":"codex","reason":"Exact post-rebase review passed and confirmed issue-owned content is byte-identical","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":32,"generation":24,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":33,"generation":25,"actor":"codex","reason":"Final rebase onto merged cache-shape repair changed commit identity while leaving all issue-owned bytes unchanged","operation":"recover_review"}
+{"sequence":34,"generation":25,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":35,"generation":26,"actor":"subagent:019f7321-c006-7013-a1bc-9d2048423552","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":36,"generation":27,"actor":"codex","reason":"Final exact-revision review passed after both Spot tooling repairs merged","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":37,"generation":28,"actor":"codex","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":38,"generation":29,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Rebase onto merged Spot tooling fixes changed the exact commit identity; refresh review and publication truth at the current substantive revision.","operation":"recover_review"}
+{"sequence":39,"generation":29,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":40,"generation":30,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":41,"generation":31,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Final exact-revision review passed after rebase onto the merged Spot tooling baseline","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":42,"generation":32,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":43,"generation":33,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Refresh exact-revision review and publication after a no-content CI synchronization commit","operation":"recover_review"}
+{"sequence":44,"generation":33,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":45,"generation":34,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":46,"generation":35,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Exact-revision review passed and confirmed the CI synchronization commit changed no issue-owned bytes","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":47,"generation":36,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":48,"generation":37,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":49,"generation":38,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically finalize SOR/index and release claim/protected paths","operation":"record_terminal"}
+{"sequence":50,"generation":39,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Materialize the retained terminal receipt after PR #5445 merged and issue #5405 closed","operation":"reconcile_terminal"}

--- a/.csdlc/issues/5405/cards/sip.values.json
+++ b/.csdlc/issues/5405/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5405/cards/sor.md
+++ b/.csdlc/issues/5405/cards/sor.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: sor
 
-Status: pre_phase
+Status: complete
 
 ## Summary
 
@@ -81,17 +81,17 @@ Resolved all #5403 WP-13 findings and all actionable pre-PR review consistency f
 
 ## Integration
 
-not_started
+merged
 
 ## Publication
 
-Publication: not_published
+Publication: closed
 
-Merge: not_merged
+Merge: merged
 
 ## Closeout
 
-not_started
+complete
 
 ## Follow Ups
 

--- a/.csdlc/issues/5405/cards/sor.values.json
+++ b/.csdlc/issues/5405/cards/sor.values.json
@@ -7,9 +7,9 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
-  "status": "pre_phase",
+  "status": "complete",
   "content": {
     "card_kind": "sor",
     "values": {
@@ -74,10 +74,10 @@
           "evidence_ref": "docs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
-      "merge_state": "not_merged",
-      "closeout_state": "not_started",
+      "integration_state": "merged",
+      "publication_state": "closed",
+      "merge_state": "merged",
+      "closeout_state": "complete",
       "follow_ups": []
     }
   }

--- a/.csdlc/issues/5405/cards/spp.md
+++ b/.csdlc/issues/5405/cards/spp.md
@@ -75,13 +75,13 @@ Revision 1
 
 ## Design
 
-.csdlc/prepared/issues/5405/design.md
+.csdlc/issues/5405/retained/design.md
 
 Digest: 94d15fb356b31f02b0d46cc67eb69d558668f1783d2090be1b75914e4866ed68
 
 ## Diagram
 
-.csdlc/prepared/issues/5405/diagram.mmd
+.csdlc/issues/5405/retained/diagram.mmd
 
 Digest: e6532f69e14e124f0eff40d721bb0a891acdfa8f2a26925fb4ae643f9ecbefd9
 

--- a/.csdlc/issues/5405/cards/spp.values.json
+++ b/.csdlc/issues/5405/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
   "status": "ready",
   "content": {
@@ -69,9 +69,9 @@
         "Parent closeout truth needs operator decision rather than mechanical repair"
       ],
       "replan_triggers": [],
-      "design_ref": ".csdlc/prepared/issues/5405/design.md",
+      "design_ref": ".csdlc/issues/5405/retained/design.md",
       "design_digest": "94d15fb356b31f02b0d46cc67eb69d558668f1783d2090be1b75914e4866ed68",
-      "diagram_ref": ".csdlc/prepared/issues/5405/diagram.mmd",
+      "diagram_ref": ".csdlc/issues/5405/retained/diagram.mmd",
       "diagram_digest": "e6532f69e14e124f0eff40d721bb0a891acdfa8f2a26925fb4ae643f9ecbefd9"
     }
   }

--- a/.csdlc/issues/5405/cards/srp.md
+++ b/.csdlc/issues/5405/cards/srp.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: srp
 
-Status: pre_phase
+Status: draft
 
 ## Scope
 
@@ -19,6 +19,7 @@ docs/milestones/v0.91.7/features/GODEL_MECHANICS_BRIDGE_v0.91.7.md
 docs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md
 docs/milestones/v0.91.7/review/wp13_closeout_4640.md
 docs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json
+docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md
 docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md
 docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md
 docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md
@@ -32,48 +33,7 @@ docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md
 
 ## Findings
 
-[
-  {
-    "id": "5405-R1",
-    "severity": "p1",
-    "summary": "Guild review packet still allowed identity witness routing despite no producer or consumer behavior.",
-    "actionable": true,
-    "in_scope": true,
-    "disposition": "fixed",
-    "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "route": "issue-5405"
-  },
-  {
-    "id": "5405-R2",
-    "severity": "p1",
-    "summary": "Machine closeout packet omitted the Guild behavior non-claims required by the corrected handoff ledger.",
-    "actionable": true,
-    "in_scope": true,
-    "disposition": "fixed",
-    "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "route": "issue-5405"
-  },
-  {
-    "id": "5405-R3",
-    "severity": "p2",
-    "summary": "Parent closeout retained stronger Godel launch-admission wording instead of admission readiness with requests not invoked.",
-    "actionable": true,
-    "in_scope": true,
-    "disposition": "fixed",
-    "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "route": "issue-5405"
-  },
-  {
-    "id": "5405-R4",
-    "severity": "p1",
-    "summary": "Primary Guild feature metadata and scope still implied implemented records and hooks despite boundary-only proof.",
-    "actionable": true,
-    "in_scope": true,
-    "disposition": "fixed",
-    "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "route": "issue-5405"
-  }
-]
+[]
 
 ## Dispositions
 
@@ -81,13 +41,12 @@ Every actionable finding requires a terminal disposition.
 
 ## Residual Risk
 
-- Full integration CI remains delegated to the replacement PR checks.
-- Live Guild producer/consumer behavior and hosted Godel provider invocation remain explicit non-claims.
+- Required GitHub CI and live remote validation remain in progress at the reviewed head.
 
 ## Review Result
 
-Revision: Some("git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51")
+Revision: Some("git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4")
 
-Reviewer: Some("subagent:019f7321-c006-7013-a1bc-9d2048423552")
+Reviewer: Some("subagent:019f739a-5fbe-7e33-8b85-4cf33cf43dcd")
 
 Result: pass

--- a/.csdlc/issues/5405/cards/srp.values.json
+++ b/.csdlc/issues/5405/cards/srp.values.json
@@ -7,66 +7,24 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
-  "status": "pre_phase",
+  "status": "draft",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "adl/src/runtime_v2/economics_civilization_boundary.rs\nadl/src/runtime_v2/tests/economics_civilization_boundary.rs\ndocs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md\ndocs/milestones/v0.91.7/features/GODEL_MECHANICS_BRIDGE_v0.91.7.md\ndocs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md\ndocs/milestones/v0.91.7/review/wp13_closeout_4640.md\ndocs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json\ndocs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md\ndocs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md\ndocs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md",
-      "review_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-      "reviewer": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
+      "review_scope": "adl/src/runtime_v2/economics_civilization_boundary.rs\nadl/src/runtime_v2/tests/economics_civilization_boundary.rs\ndocs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md\ndocs/milestones/v0.91.7/features/GODEL_MECHANICS_BRIDGE_v0.91.7.md\ndocs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md\ndocs/milestones/v0.91.7/review/wp13_closeout_4640.md\ndocs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json\ndocs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md\ndocs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md\ndocs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md\ndocs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md",
+      "review_revision": "git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4",
+      "reviewer": "subagent:019f739a-5fbe-7e33-8b85-4cf33cf43dcd",
       "review_prompts": [
         "Does guild truth claim only what the evidence proves?",
         "Does Godel wording consistently retain not-invoked hosted-provider truth?",
         "Does economics validation reject duplicate semantic policy entries?",
         "Do closeout and handoff records agree with the corrected truth?"
       ],
-      "findings": [
-        {
-          "id": "5405-R1",
-          "severity": "p1",
-          "summary": "Guild review packet still allowed identity witness routing despite no producer or consumer behavior.",
-          "actionable": true,
-          "in_scope": true,
-          "disposition": "fixed",
-          "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-          "route": "issue-5405"
-        },
-        {
-          "id": "5405-R2",
-          "severity": "p1",
-          "summary": "Machine closeout packet omitted the Guild behavior non-claims required by the corrected handoff ledger.",
-          "actionable": true,
-          "in_scope": true,
-          "disposition": "fixed",
-          "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-          "route": "issue-5405"
-        },
-        {
-          "id": "5405-R3",
-          "severity": "p2",
-          "summary": "Parent closeout retained stronger Godel launch-admission wording instead of admission readiness with requests not invoked.",
-          "actionable": true,
-          "in_scope": true,
-          "disposition": "fixed",
-          "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-          "route": "issue-5405"
-        },
-        {
-          "id": "5405-R4",
-          "severity": "p1",
-          "summary": "Primary Guild feature metadata and scope still implied implemented records and hooks despite boundary-only proof.",
-          "actionable": true,
-          "in_scope": true,
-          "disposition": "fixed",
-          "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-          "route": "issue-5405"
-        }
-      ],
+      "findings": [],
       "residual_risk": [
-        "Full integration CI remains delegated to the replacement PR checks.",
-        "Live Guild producer/consumer behavior and hosted Godel provider invocation remain explicit non-claims."
+        "Required GitHub CI and live remote validation remain in progress at the reviewed head."
       ],
       "review_result": "pass"
     }

--- a/.csdlc/issues/5405/cards/stp.values.json
+++ b/.csdlc/issues/5405/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5405/cards/vpp.md
+++ b/.csdlc/issues/5405/cards/vpp.md
@@ -16,9 +16,9 @@ Execute the smallest proving validation DAG.
 
 ## Lane Inputs
 
-Design: .csdlc/prepared/issues/5405/design.md
+Design: .csdlc/issues/5405/retained/design.md
 
-Diagram: .csdlc/prepared/issues/5405/diagram.mmd
+Diagram: .csdlc/issues/5405/retained/diagram.mmd
 
 ## Selected Lanes
 

--- a/.csdlc/issues/5405/cards/vpp.values.json
+++ b/.csdlc/issues/5405/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
     "slug": "v0-91-7-review-fix-wp13-guild-godel-economics-findings",
     "version": "v0.91.7",
-    "generation": 16
+    "generation": 39
   },
   "status": "ready",
   "content": {
@@ -42,9 +42,9 @@
       "planned_validation_seconds": 3600,
       "planned_validation_tokens": 25000,
       "failure_policy": "Fail closed on overclaim; prefer bounded downgrade truth over invented integration.",
-      "design_ref": ".csdlc/prepared/issues/5405/design.md",
+      "design_ref": ".csdlc/issues/5405/retained/design.md",
       "design_digest": "94d15fb356b31f02b0d46cc67eb69d558668f1783d2090be1b75914e4866ed68",
-      "diagram_ref": ".csdlc/prepared/issues/5405/diagram.mmd",
+      "diagram_ref": ".csdlc/issues/5405/retained/diagram.mmd",
       "diagram_digest": "e6532f69e14e124f0eff40d721bb0a891acdfa8f2a26925fb4ae643f9ecbefd9"
     }
   }

--- a/.csdlc/issues/5405/index.json
+++ b/.csdlc/issues/5405/index.json
@@ -3,19 +3,31 @@
   "issue": 5405,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "054e97bce0600f6d67de82ce3c57351da92204496680e0793747ea6943aa00a2",
-  "phase": "reviewed",
-  "generation": 16,
-  "digest": "2f95995c158236b2476131a3c5d62342e3e044d8da6cdd65fa2fa3e8f8f12419",
-  "claim": {
-    "id": "claim-5405-review-findings-finish",
-    "owner": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
-    "generation": 16,
-    "acquired_unix_seconds": 1784342092,
-    "expires_unix_seconds": 1784428492,
-    "heartbeat_unix_seconds": 1784342092,
-    "branch": "codex/5405-wp13-review-repair",
-    "worktree": ".worktrees/adl-wp-5405-repair",
-    "protected_paths": [
+  "phase": "closed_out",
+  "generation": 39,
+  "digest": "7ceb69946c4225d98e1774d754738f41d53eadced81f92ac3207fdce39892fbd",
+  "claim": null,
+  "review_assignment": {
+    "reviewer": "subagent:019f739a-5fbe-7e33-8b85-4cf33cf43dcd",
+    "assigned_by": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+    "revision": "git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4",
+    "scope": [
+      "adl/src/runtime_v2/economics_civilization_boundary.rs",
+      "adl/src/runtime_v2/tests/economics_civilization_boundary.rs",
+      "docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md",
+      "docs/milestones/v0.91.7/features/GODEL_MECHANICS_BRIDGE_v0.91.7.md",
+      "docs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md",
+      "docs/milestones/v0.91.7/review/wp13_closeout_4640.md",
+      "docs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json",
+      "docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md",
+      "docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md",
+      "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
+      "docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md"
+    ]
+  },
+  "review": {
+    "reviewer": "subagent:019f739a-5fbe-7e33-8b85-4cf33cf43dcd",
+    "scope": [
       "adl/src/runtime_v2/economics_civilization_boundary.rs",
       "adl/src/runtime_v2/tests/economics_civilization_boundary.rs",
       "docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md",
@@ -28,13 +40,64 @@
       "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
       "docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md"
     ],
-    "purpose": "Resolve #5403 WP-13 guild, Godel, and economics review findings"
+    "reviewed_revision": "git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4",
+    "findings": [],
+    "residual_risks": [
+      "Required GitHub CI and live remote validation remain in progress at the reviewed head."
+    ],
+    "completed": true,
+    "non_substantive_proof": {
+      "policy": "No-content CI synchronization commit; issue-owned tree is byte-identical to the prior reviewed revision.",
+      "from_revision": "git-blake3:0746a91e294e9843c3d0322511e7156fdef71072:510e9a406a6c815a29435999644673c2ecb8a06ca0fc9795c714d61cd71a52bb",
+      "to_revision": "git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4",
+      "from_commit": "0746a91e294e9843c3d0322511e7156fdef71072",
+      "to_commit": "7a3b66a7c76167828b80ecae5451fec4b3673ece",
+      "changed_paths": []
+    }
   },
-  "review_assignment": {
-    "reviewer": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
-    "assigned_by": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
-    "revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "scope": [
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5405,
+    "pull_request": 5445,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5445",
+    "base": "main",
+    "head": "codex/5405-wp13-review-repair",
+    "revision": "git-blake3:7a3b66a7c76167828b80ecae5451fec4b3673ece:193b685342662653c2ebf507e8240003bbe6b50a7af0fd7dccc7ca4ea92d69c4",
+    "draft": true,
+    "observed_state": "open"
+  },
+  "readiness": {
+    "pull_request": 5445,
+    "head_sha": "7a3b66a7c76167828b80ecae5451fec4b3673ece",
+    "checks": [
+      {
+        "name": "adl-ci",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29631556008/job/88047431074"
+      },
+      {
+        "name": "adl-coverage",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29631556008/job/88047431077"
+      }
+    ],
+    "review_state": "not_required",
+    "conflict_state": "clean",
+    "post_publication_findings": [],
+    "ready": true,
+    "blockers": []
+  },
+  "terminal": {
+    "pull_request": 5445,
+    "disposition": "merged",
+    "observed_sha": "7a3b66a7c76167828b80ecae5451fec4b3673ece",
+    "observed_state": "merged",
+    "receipt_path": "csdlc-v2/closeout/5405.json",
+    "released_branch": "codex/5405-wp13-review-repair",
+    "released_worktree": ".worktrees/adl-wp-5405-repair",
+    "released_protected_paths": [
       "adl/src/runtime_v2/economics_civilization_boundary.rs",
       "adl/src/runtime_v2/tests/economics_civilization_boundary.rs",
       "docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md",
@@ -42,81 +105,15 @@
       "docs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md",
       "docs/milestones/v0.91.7/review/wp13_closeout_4640.md",
       "docs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json",
+      "docs/milestones/v0.91.7/review/wp13_economics_civilization_boundary_4754.md",
       "docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md",
       "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
       "docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md"
     ]
   },
-  "review": {
-    "reviewer": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
-    "scope": [
-      "adl/src/runtime_v2/economics_civilization_boundary.rs",
-      "adl/src/runtime_v2/tests/economics_civilization_boundary.rs",
-      "docs/milestones/v0.91.7/V092_HANDOFF_v0.91.7.md",
-      "docs/milestones/v0.91.7/features/GODEL_MECHANICS_BRIDGE_v0.91.7.md",
-      "docs/milestones/v0.91.7/features/GUILD_FOUNDATION_BOUNDARY_v0.91.7.md",
-      "docs/milestones/v0.91.7/review/wp13_closeout_4640.md",
-      "docs/milestones/v0.91.7/review/wp13_closeout_4640/closeout_packet.json",
-      "docs/milestones/v0.91.7/review/wp13_godel_constructability_boundary_4753.md",
-      "docs/milestones/v0.91.7/review/wp13_guild_foundation_boundary_4755.md",
-      "docs/milestones/v0.92/V092_ACTIVATION_BRIDGE_LEDGER_v0.92.md"
-    ],
-    "reviewed_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-    "findings": [
-      {
-        "id": "5405-R1",
-        "severity": "p1",
-        "summary": "Guild review packet still allowed identity witness routing despite no producer or consumer behavior.",
-        "actionable": true,
-        "in_scope": true,
-        "disposition": "fixed",
-        "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-        "route": "issue-5405"
-      },
-      {
-        "id": "5405-R2",
-        "severity": "p1",
-        "summary": "Machine closeout packet omitted the Guild behavior non-claims required by the corrected handoff ledger.",
-        "actionable": true,
-        "in_scope": true,
-        "disposition": "fixed",
-        "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-        "route": "issue-5405"
-      },
-      {
-        "id": "5405-R3",
-        "severity": "p2",
-        "summary": "Parent closeout retained stronger Godel launch-admission wording instead of admission readiness with requests not invoked.",
-        "actionable": true,
-        "in_scope": true,
-        "disposition": "fixed",
-        "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-        "route": "issue-5405"
-      },
-      {
-        "id": "5405-R4",
-        "severity": "p1",
-        "summary": "Primary Guild feature metadata and scope still implied implemented records and hooks despite boundary-only proof.",
-        "actionable": true,
-        "in_scope": true,
-        "disposition": "fixed",
-        "fix_revision": "git-blake3:89088f8a583ad3cca120bfbbf94f2963fc7550d2:a46313d26318ae8ae8a04c4d4367f4d16bea744275aa1e7385f716ded7ebbd51",
-        "route": "issue-5405"
-      }
-    ],
-    "residual_risks": [
-      "Full integration CI remains delegated to the replacement PR checks.",
-      "Live Guild producer/consumer behavior and hosted Godel provider invocation remain explicit non-claims."
-    ],
-    "completed": true,
-    "non_substantive_proof": null
-  },
-  "publication": null,
-  "readiness": null,
-  "terminal": null,
   "migration": null,
-  "design_path": ".csdlc/prepared/issues/5405/design.md",
-  "diagram_path": ".csdlc/prepared/issues/5405/diagram.mmd",
+  "design_path": ".csdlc/issues/5405/retained/design.md",
+  "diagram_path": ".csdlc/issues/5405/retained/diagram.mmd",
   "design_review": {
     "approved": {
       "reviewer": "operator-assigned-review-fix",
@@ -125,34 +122,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "e5037c2774968e8f5b8b734cf877048587dd0f25f8069d7e77983d8888b8a5aa",
+      "values_digest": "6b390cb3e2717890a10d6227cabf57fd0978123cf730a82e7474667fbf4bf514",
       "rendered_digest": "703b92e39c250aa5e073508493c1d38ae73f523e6cf4a0536e89a13faebea53d",
       "ast_digest": "37f28dd84da79b263104176dbb71e609b56a71b7afb6e5076d455ad7142d5f1f"
     },
     "stp": {
-      "values_digest": "9283dc3df037c322f898895089b37cf8a823e06f1ef38fe1cacda19532ebdcc1",
+      "values_digest": "170844264f7ea5777c8fec5a2dfd394e696de750dfb6aa1500f2d514110d620a",
       "rendered_digest": "d93082537cdc86d0519550bef7290c3fb715ab2dd435712a3d0ae9a944770e30",
       "ast_digest": "94191cfd67fe8d03c3e4761a74ca4434efdaa7c87cc3dd5960d46a12a27b3a2d"
     },
     "spp": {
-      "values_digest": "20697eb3a6b2ca66eedd4bfec68d6f6533d392c4d30c62ee710b05c3c3ec496b",
-      "rendered_digest": "f2b11bf5db2846ca75a8d6a79f4f145fce8f41d17e5ad0b0845b5c302c58a0a2",
-      "ast_digest": "2604a0f7b1d99bbb83e4af715211650a16fae7bad1af370d3f2c4ee65467bc7f"
+      "values_digest": "f33a108d3d2c886311c7888b2b0f4f92a9cd66fadf8b4a0aaecf8d37f1233c26",
+      "rendered_digest": "c2420565538a898ac289b714a8cfad25837275fa48fa4ca0d0d147b7e00cbf28",
+      "ast_digest": "53e801dc8c30bbe457bcd7538b42c4d898b942ebf60dcca1a8d3bd276944bfb3"
     },
     "vpp": {
-      "values_digest": "8c82409cbfca436c7e5f8ff7e8a6255d0a647cc991dbca322aebe4fe0a075c41",
-      "rendered_digest": "786bec15c1f6dc1dfc47ac830d6031432d4810c5f4508a78af7c42f172b85aa5",
-      "ast_digest": "e3831f244aef8533576b3070392952daac7adb71331ecc5ee0eb0e5986768825"
+      "values_digest": "91b8f91bc467cefa2c0f9829fec4e84841b33dd9e83d0c5686abe4b0b9c7e5b3",
+      "rendered_digest": "e33eadd8a727f314507198604083fafd6b6602ca1d74988afc702543f05d6f2e",
+      "ast_digest": "199fec29ee78c16eeefb424d5a2e80b2a2b6bc944c3cbb3904e9028fcb0783dd"
     },
     "srp": {
-      "values_digest": "32c63610159c994ee4aa724b5a6672f12ec7ab3a3905f9c10c86136a224dccec",
-      "rendered_digest": "22b5bbcbc058be07b056a58039c82e39bd50314b7c5a00a3771afc13f4ca17bc",
-      "ast_digest": "f92bc877f0dcc7a2c206e18f91bfe641ac930f382fe35445d076c8eeeee78d2a"
+      "values_digest": "989d592fce44b79d8335840e6764f782b3b67fc0a426e8d12d13dbb29d438e6f",
+      "rendered_digest": "c0d7edaf5e7c880a5c9ca0701a449a83c85d0aa3cb71e7c915d9aad3f9c3486f",
+      "ast_digest": "42f704c6a13b6207e5cd96ddb1b959113c06c5416d83fc2866fa4faee46dd301"
     },
     "sor": {
-      "values_digest": "387ca175e3c92b1f5f63836b6586f9d7fb51f57e1f51da12c4bc646d8f3942bd",
-      "rendered_digest": "16ce72333a3c2485c1e1c8db1e67d9e3aa6e37296d3c06e9cf20c40b7f08b9ba",
-      "ast_digest": "8ea1b2b94680052e079b470640051ae08c7f7951cb12d127fa24b191029551b8"
+      "values_digest": "f44f85625de11074af1090ea46cbd6f387708dbcd77cd08da27e9341263534e0",
+      "rendered_digest": "0618b81be325ed1a79bd24fb5d0c28c79f89e903ba5fc8075a0fe3abb3b0579d",
+      "ast_digest": "056bdf5ee7d6acca25e59f63658e3b4cba7e31109c1d44bdd57f1c387e920e43"
     }
   },
   "transitions": [
@@ -183,6 +180,132 @@
       "to": "reviewed",
       "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
       "reason": "Exact-revision subagent review passed at 89088f8a5 with all four prior findings fixed."
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "implemented",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Lifecycle-only review-record commit changed revision identity after the prior exact review; recover for exact current-HEAD review before publication."
+    },
+    {
+      "sequence": 6,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact current-HEAD review passed at daad3d266 with all substantive paths unchanged from the prior PASS."
+    },
+    {
+      "sequence": 7,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 8,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "Rebase onto merged Spot wrapper repair changed the commit identity while leaving all issue-owned bytes unchanged"
+    },
+    {
+      "sequence": 9,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Exact post-rebase review passed and confirmed issue-owned content is byte-identical"
+    },
+    {
+      "sequence": 10,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 11,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex",
+      "reason": "Final rebase onto merged cache-shape repair changed commit identity while leaving all issue-owned bytes unchanged"
+    },
+    {
+      "sequence": 12,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex",
+      "reason": "Final exact-revision review passed after both Spot tooling repairs merged"
+    },
+    {
+      "sequence": 13,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 14,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Rebase onto merged Spot tooling fixes changed the exact commit identity; refresh review and publication truth at the current substantive revision."
+    },
+    {
+      "sequence": 15,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Final exact-revision review passed after rebase onto the merged Spot tooling baseline"
+    },
+    {
+      "sequence": 16,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 17,
+      "from": "published",
+      "to": "implemented",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Refresh exact-revision review and publication after a no-content CI synchronization commit"
+    },
+    {
+      "sequence": 18,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact-revision review passed and confirmed the CI synchronization commit changed no issue-owned bytes"
+    },
+    {
+      "sequence": 19,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact draft PR after current review"
+    },
+    {
+      "sequence": 20,
+      "from": "published",
+      "to": "merge_ready",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed required checks, review, and conflict readiness"
+    },
+    {
+      "sequence": 21,
+      "from": "merge_ready",
+      "to": "merged",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact PR merged"
+    },
+    {
+      "sequence": 22,
+      "from": "merged",
+      "to": "closed_out",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "terminal truth recorded and claim released"
     }
   ],
   "audit": [
@@ -339,6 +462,202 @@
       "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
       "reason": "Exact-revision subagent review passed at 89088f8a5 with all four prior findings fixed.",
       "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 23,
+      "generation": 17,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Lifecycle-only review-record commit changed revision identity after the prior exact review; recover for exact current-HEAD review before publication.",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 24,
+      "generation": 17,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 25,
+      "generation": 18,
+      "actor": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 26,
+      "generation": 19,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact current-HEAD review passed at daad3d266 with all substantive paths unchanged from the prior PASS.",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 27,
+      "generation": 20,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 28,
+      "generation": 21,
+      "actor": "codex",
+      "reason": "Rebase onto merged Spot wrapper repair changed the commit identity while leaving all issue-owned bytes unchanged",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 29,
+      "generation": 21,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 30,
+      "generation": 22,
+      "actor": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 31,
+      "generation": 23,
+      "actor": "codex",
+      "reason": "Exact post-rebase review passed and confirmed issue-owned content is byte-identical",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 32,
+      "generation": 24,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 33,
+      "generation": 25,
+      "actor": "codex",
+      "reason": "Final rebase onto merged cache-shape repair changed commit identity while leaving all issue-owned bytes unchanged",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 34,
+      "generation": 25,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 35,
+      "generation": 26,
+      "actor": "subagent:019f7321-c006-7013-a1bc-9d2048423552",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 36,
+      "generation": 27,
+      "actor": "codex",
+      "reason": "Final exact-revision review passed after both Spot tooling repairs merged",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 37,
+      "generation": 28,
+      "actor": "codex",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 38,
+      "generation": 29,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Rebase onto merged Spot tooling fixes changed the exact commit identity; refresh review and publication truth at the current substantive revision.",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 39,
+      "generation": 29,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 40,
+      "generation": 30,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 41,
+      "generation": 31,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Final exact-revision review passed after rebase onto the merged Spot tooling baseline",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 42,
+      "generation": 32,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 43,
+      "generation": 33,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Refresh exact-revision review and publication after a no-content CI synchronization commit",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 44,
+      "generation": 33,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 45,
+      "generation": 34,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 46,
+      "generation": 35,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact-revision review passed and confirmed the CI synchronization commit changed no issue-owned bytes",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 47,
+      "generation": 36,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 48,
+      "generation": 37,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 49,
+      "generation": 38,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically finalize SOR/index and release claim/protected paths",
+      "operation": "record_terminal"
+    },
+    {
+      "sequence": 50,
+      "generation": 39,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Materialize the retained terminal receipt after PR #5445 merged and issue #5405 closed",
+      "operation": "reconcile_terminal"
     }
   ]
 }

--- a/.csdlc/issues/5405/retained/design.md
+++ b/.csdlc/issues/5405/retained/design.md
@@ -1,0 +1,21 @@
+# #5405 WP-13 Guild, Godel, And Economics Review Fix Design
+
+## Scope
+
+Resolve all three implementation and claim-truth findings assigned to #5405 by
+the #5403 WP-13 review.
+
+## Approach
+
+- Downgrade declarative Guild vocabulary from `integrated_proven` to
+  `boundary_proven` throughout the parent and handoff surfaces.
+- Describe Godel provider requests as admission-ready, resolved, and not
+  invoked.
+- Reject duplicate allowed-consumption rows, postponed-surface ids, and
+  promotion gates in the Runtime v2 economics boundary validator.
+
+## Validation
+
+- Focused Runtime v2 economics boundary tests for duplicate rejection.
+- Claim-language scans and machine-readable closeout JSON parsing.
+- Diff hygiene before review.

--- a/.csdlc/issues/5405/retained/diagram.mmd
+++ b/.csdlc/issues/5405/retained/diagram.mmd
@@ -1,0 +1,7 @@
+flowchart TD
+  review["#5403 WP-13 review findings"] --> guild["Guild boundary-proven truth"]
+  review --> godel["Godel admission-ready, not-invoked truth"]
+  review --> economics["Runtime v2 economics duplicate rejection"]
+  guild --> handoff["Parent and v0.92 handoff alignment"]
+  godel --> handoff
+  economics --> proof["Focused Runtime v2 regression"]


### PR DESCRIPTION
## Summary
- materialize the retained terminal receipt for #5405
- publish closed-out generation 39 and all six card projections
- retain the issue design and diagram under the terminal record

## Validation
- `csdlc-doctor --issue 5405`: PASS
- exact-revision subagent review: PASS, no findings
- `git diff --check`: PASS

Records-only closeout after #5445 merged and #5405 closed.