### PR TITLE
[v0.91.8][csdlc-v2] Reconcile terminal follow-ups and issue-local binding

### DIFF
--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -64,3 +64,10 @@ Markdown files are generated projections. The engine renders deterministic
 Markdown from typed values, parses it with `markdown.rs`, validates semantic
 anchors, and records values/rendered/AST digests. Direct Markdown edits fail
 doctor as corruption.
+
+For a closed-out record whose SRP routes residual work after terminal receipt
+retention, use `csdlc-closeout reconcile-terminal` with the exact branch,
+worktree, initialization digest, actor/reason, and `follow_ups` values. Each
+follow-up must already be present in SRP residual risk; the typed operation
+updates SOR and the retained receipt atomically and rejects arbitrary card
+mutation.

--- a/csdlc-v2/README.md
+++ b/csdlc-v2/README.md
@@ -71,3 +71,9 @@ worktree, initialization digest, actor/reason, and `follow_ups` values. Each
 follow-up must already be present in SRP residual risk; the typed operation
 updates SOR and the retained receipt atomically and rejects arbitrary card
 mutation.
+
+Issue-local bootstrap is supported when all six cards and the approved design
+already live in the target worktree: use a claim whose worktree is `.` and run
+`csdlc-bind` from that worktree. The binder verifies the existing branch and
+claim in place, performs no primary-checkout write, and still applies the
+normal collision and protected-path checks.

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -204,11 +204,13 @@ fn validate_validation_lanes(
 }
 
 pub fn bind_issue(store: &Store, request: BindRequest) -> Result<BindResult> {
+    let issue_local = request.worktree == "."
+        && git::current_branch(store.root()).is_ok_and(|branch| branch == request.branch);
     if request.branch == "main"
         || request.branch == request.base_branch
         || request.claim.branch != request.branch
         || request.claim.worktree != request.worktree
-        || !clean_relative(&request.worktree)
+        || (!issue_local && !clean_relative(&request.worktree))
         || request
             .claim
             .protected_paths
@@ -221,13 +223,17 @@ pub fn bind_issue(store: &Store, request: BindRequest) -> Result<BindResult> {
         ));
     }
     let _binding_lock = store.binding_lock()?;
-    if git::current_branch(store.root())? != request.base_branch {
+    if !issue_local && git::current_branch(store.root())? != request.base_branch {
         return Err(V2Error::new(
             ErrorCode::UnsafeCheckout,
             "primary checkout is not on the declared base branch",
         ));
     }
-    let wanted = store.root().join(&request.worktree);
+    let wanted = if issue_local {
+        store.root().to_path_buf()
+    } else {
+        store.root().join(&request.worktree)
+    };
     let wanted_compare = if wanted.exists() {
         fs::canonicalize(&wanted)?
     } else {
@@ -313,7 +319,7 @@ pub fn bind_issue(store: &Store, request: BindRequest) -> Result<BindResult> {
             "issue phase cannot be bound",
         ));
     }
-    let created = !wanted.exists();
+    let created = !issue_local && !wanted.exists();
     if created {
         let base = request.base_branch.as_str();
         let branch = request.branch.as_str();

--- a/csdlc-v2/src/model.rs
+++ b/csdlc-v2/src/model.rs
@@ -176,6 +176,8 @@ pub struct ReconcileTerminalRequest {
     pub expected_worktree: String,
     pub actor: String,
     pub reason: String,
+    #[serde(default)]
+    pub follow_ups: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -441,18 +441,6 @@ impl Store {
                 "terminal receipt identity differs from local issue",
             ));
         }
-        if local.phase == LifecyclePhase::ClosedOut
-            && local.terminal == receipt.record.terminal
-            && local.audit.last().is_some_and(|event| {
-                event.operation == "reconcile_terminal"
-                    && event.actor == request.actor
-                    && event.reason == request.reason
-            })
-        {
-            return Ok(local);
-        }
-        let mut projection = receipt.record;
-        let mut cards = receipt.cards;
         let requested_follow_ups = request
             .follow_ups
             .iter()
@@ -466,6 +454,29 @@ impl Store {
                 "terminal follow-ups must be non-empty and unique",
             ));
         }
+        let existing_follow_ups = match receipt
+            .cards
+            .get(&CardKind::Sor)
+            .map(|values| &values.content)
+        {
+            Some(CardContent::Sor(values)) => {
+                values.follow_ups.iter().cloned().collect::<BTreeSet<_>>()
+            }
+            _ => BTreeSet::new(),
+        };
+        if local.phase == LifecyclePhase::ClosedOut
+            && local.terminal == receipt.record.terminal
+            && existing_follow_ups == requested_follow_ups
+            && local.audit.last().is_some_and(|event| {
+                event.operation == "reconcile_terminal"
+                    && event.actor == request.actor
+                    && event.reason == request.reason
+            })
+        {
+            return Ok(local);
+        }
+        let mut projection = receipt.record;
+        let mut cards = receipt.cards;
         let routed = match cards.get(&CardKind::Srp).map(|values| &values.content) {
             Some(CardContent::Srp(values)) => values
                 .residual_risk
@@ -536,6 +547,9 @@ impl Store {
         hydrate_projections(&mut projection, &cards)?;
         projection.digest = record_digest(&projection)?;
         let retained_artifacts = BTreeMap::from([(design_path, design), (diagram_path, diagram)]);
+        let original_cards = self.load_cards(request.issue)?;
+        let receipt_path = self.terminal_receipt_path(request.issue)?;
+        let original_receipt = fs::read(&receipt_path)?;
         self.commit_with_authored(
             request.issue,
             &projection,
@@ -543,15 +557,14 @@ impl Store {
             false,
             Some(&retained_artifacts),
         )?;
-        if !request.follow_ups.is_empty() {
-            receipt.record = projection.clone();
-            receipt.cards = cards.clone();
-            receipt.authored_artifacts = retained_artifacts.clone();
-            receipt.digest.clear();
+        receipt.record = projection.clone();
+        receipt.cards = cards.clone();
+        receipt.authored_artifacts = retained_artifacts.clone();
+        receipt.digest.clear();
+        let refresh = (|| -> Result<()> {
             receipt.digest = terminal_receipt_digest(&receipt)?;
             validate_terminal_receipt(&receipt)?;
-            let path = self.terminal_receipt_path(request.issue)?;
-            let parent = path.parent().expect("receipt parent");
+            let parent = receipt_path.parent().expect("receipt parent");
             let lock = OpenOptions::new()
                 .create(true)
                 .truncate(false)
@@ -559,9 +572,22 @@ impl Store {
                 .write(true)
                 .open(parent.join("receipts.lock"))?;
             lock.lock_exclusive()?;
-            let temporary = path.with_extension("json.reconcile-tmp");
+            let temporary = receipt_path.with_extension("json.reconcile-tmp");
             fs::write(&temporary, serde_json::to_vec_pretty(&receipt)?)?;
-            fs::rename(temporary, path)?;
+            fs::rename(temporary, &receipt_path)?;
+            Ok(())
+        })();
+        if let Err(error) = refresh {
+            let rollback =
+                self.commit_with_authored(request.issue, &local, &original_cards, false, None);
+            let restore = fs::write(&receipt_path, &original_receipt);
+            if rollback.is_err() || restore.is_err() {
+                return Err(V2Error::new(
+                    ErrorCode::ReconciliationRequired,
+                    "terminal reconciliation failed and rollback requires operator recovery",
+                ));
+            }
+            return Err(error);
         }
         Ok(projection)
     }

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -430,7 +430,7 @@ impl Store {
                 "local initialization digest differs from reconciliation request",
             ));
         }
-        let receipt = self
+        let mut receipt = self
             .load_terminal_receipt(request.issue)?
             .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "terminal receipt missing"))?;
         if receipt.initialization_digest != local.initialization_digest
@@ -453,6 +453,33 @@ impl Store {
         }
         let mut projection = receipt.record;
         let mut cards = receipt.cards;
+        let requested_follow_ups = request
+            .follow_ups
+            .iter()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .collect::<BTreeSet<_>>();
+        if requested_follow_ups.len() != request.follow_ups.len() {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "terminal follow-ups must be non-empty and unique",
+            ));
+        }
+        let routed = match cards.get(&CardKind::Srp).map(|values| &values.content) {
+            Some(CardContent::Srp(values)) => values
+                .residual_risk
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>(),
+            _ => BTreeSet::new(),
+        };
+        if !requested_follow_ups.is_subset(&routed) {
+            return Err(V2Error::new(
+                ErrorCode::InvalidInput,
+                "terminal follow-ups must be routed by SRP residual risk",
+            ));
+        }
         let design = receipt
             .authored_artifacts
             .get(&projection.design_path)
@@ -478,6 +505,14 @@ impl Store {
                     values.diagram_ref = diagram_path.clone();
                 }
                 _ => unreachable!("design card"),
+            }
+        }
+        if !requested_follow_ups.is_empty() {
+            match &mut cards.get_mut(&CardKind::Sor).expect("SOR card").content {
+                CardContent::Sor(values) => {
+                    values.follow_ups = requested_follow_ups.into_iter().collect();
+                }
+                _ => unreachable!("SOR card"),
             }
         }
         projection.generation += 1;
@@ -508,6 +543,26 @@ impl Store {
             false,
             Some(&retained_artifacts),
         )?;
+        if !request.follow_ups.is_empty() {
+            receipt.record = projection.clone();
+            receipt.cards = cards.clone();
+            receipt.authored_artifacts = retained_artifacts.clone();
+            receipt.digest.clear();
+            receipt.digest = terminal_receipt_digest(&receipt)?;
+            validate_terminal_receipt(&receipt)?;
+            let path = self.terminal_receipt_path(request.issue)?;
+            let parent = path.parent().expect("receipt parent");
+            let lock = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(parent.join("receipts.lock"))?;
+            lock.lock_exclusive()?;
+            let temporary = path.with_extension("json.reconcile-tmp");
+            fs::write(&temporary, serde_json::to_vec_pretty(&receipt)?)?;
+            fs::rename(temporary, path)?;
+        }
         Ok(projection)
     }
 

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -464,9 +464,20 @@ impl Store {
             }
             _ => BTreeSet::new(),
         };
+        let local_integrity = (|| -> Result<bool> {
+            verify_record(&local)?;
+            let current_cards = self.load_cards(request.issue)?;
+            let mut checked = local.clone();
+            hydrate_projections(&mut checked, &current_cards)?;
+            Ok(checked.digest == record_digest(&checked)?
+                && checked.digest == local.digest
+                && checked.cards == receipt.record.cards)
+        })()
+        .unwrap_or(false);
         if local.phase == LifecyclePhase::ClosedOut
             && local.terminal == receipt.record.terminal
             && existing_follow_ups == requested_follow_ups
+            && local_integrity
             && local.audit.last().is_some_and(|event| {
                 event.operation == "reconcile_terminal"
                     && event.actor == request.actor
@@ -549,7 +560,16 @@ impl Store {
         let retained_artifacts = BTreeMap::from([(design_path, design), (diagram_path, diagram)]);
         let original_cards = self.load_cards(request.issue)?;
         let receipt_path = self.terminal_receipt_path(request.issue)?;
+        let receipt_parent = receipt_path.parent().expect("receipt parent");
+        let receipt_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(receipt_parent.join("receipts.lock"))?;
+        receipt_lock.lock_exclusive()?;
         let original_receipt = fs::read(&receipt_path)?;
+        drop(receipt_lock);
         self.commit_with_authored(
             request.issue,
             &projection,
@@ -561,6 +581,7 @@ impl Store {
         receipt.cards = cards.clone();
         receipt.authored_artifacts = retained_artifacts.clone();
         receipt.digest.clear();
+        let mut refreshed_bytes = Vec::new();
         let refresh = (|| -> Result<()> {
             receipt.digest = terminal_receipt_digest(&receipt)?;
             validate_terminal_receipt(&receipt)?;
@@ -573,14 +594,29 @@ impl Store {
                 .open(parent.join("receipts.lock"))?;
             lock.lock_exclusive()?;
             let temporary = receipt_path.with_extension("json.reconcile-tmp");
-            fs::write(&temporary, serde_json::to_vec_pretty(&receipt)?)?;
+            refreshed_bytes = serde_json::to_vec_pretty(&receipt)?;
+            fs::write(&temporary, &refreshed_bytes)?;
             fs::rename(temporary, &receipt_path)?;
             Ok(())
         })();
         if let Err(error) = refresh {
             let rollback =
                 self.commit_with_authored(request.issue, &local, &original_cards, false, None);
-            let restore = fs::write(&receipt_path, &original_receipt);
+            let restore = (|| -> Result<()> {
+                let parent = receipt_path.parent().expect("receipt parent");
+                let lock = OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .read(true)
+                    .write(true)
+                    .open(parent.join("receipts.lock"))?;
+                lock.lock_exclusive()?;
+                if fs::read(&receipt_path)? != refreshed_bytes {
+                    return Ok(());
+                }
+                fs::write(&receipt_path, &original_receipt)?;
+                Ok(())
+            })();
             if rollback.is_err() || restore.is_err() {
                 return Err(V2Error::new(
                     ErrorCode::ReconciliationRequired,

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -165,6 +165,55 @@ fn bind_creates_and_idempotently_reuses_typed_worktree() {
 }
 
 #[test]
+fn bind_supports_issue_local_state_without_touching_primary_checkout() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(temp.path().join("docs")).unwrap();
+    fs::write(temp.path().join("docs/design.md"), "# design\n").unwrap();
+    fs::write(
+        temp.path().join("docs/diagram.mmd"),
+        "flowchart LR\n A-->B\n",
+    )
+    .unwrap();
+    let mut initial = request();
+    initial.claim.worktree = ".".into();
+    let store = Store::new(temp.path());
+    let record = csdlc_v2::initialize_issue(&store, initial).unwrap();
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "docs"]);
+    git(temp.path(), &["commit", "-m", "fixture"]);
+    git(temp.path(), &["switch", "-c", "issue-42"]);
+    let claim = record.claim.clone().expect("claim");
+    let request = csdlc_v2::BindRequest {
+        issue: 42,
+        base_branch: "main".into(),
+        branch: "issue-42".into(),
+        worktree: ".".into(),
+        claim,
+    };
+    let result = csdlc_v2::bind_issue(&store, request).expect("issue-local bind");
+    assert!(!result.created);
+    assert_eq!(
+        store.load_record(42).unwrap().phase,
+        csdlc_v2::LifecyclePhase::Bound
+    );
+    assert_eq!(git_branch(temp.path()), "issue-42");
+}
+
+fn git_branch(root: &std::path::Path) -> String {
+    let output = std::process::Command::new("git")
+        .current_dir(root)
+        .args(["branch", "--show-current"])
+        .output()
+        .unwrap();
+    String::from_utf8(output.stdout).unwrap().trim().into()
+}
+
+#[test]
 fn bind_refuses_primary_checkout_and_worktree_mismatch() {
     let (temp, store, record) = fixture();
     git(temp.path(), &["init", "-b", "wrong"]);

--- a/csdlc-v2/tests/gate7_lifecycle.rs
+++ b/csdlc-v2/tests/gate7_lifecycle.rs
@@ -230,7 +230,7 @@ fn fixture_with_validation_history_and_publication(
                 scope: vec!["docs".into()],
                 reviewed_revision: revision.clone(),
                 findings: vec![],
-                residual_risks: vec![],
+                residual_risks: vec!["#5411 follow-up".into()],
                 completed: true,
                 non_substantive_proof: None,
             },
@@ -637,6 +637,7 @@ fn run_complete_lifecycle_with_validation_history(
             expected_worktree: temp.path().to_string_lossy().into_owned(),
             actor: "closeout-retainer".into(),
             reason: "must not mutate primary checkout".into(),
+            follow_ups: vec!["#5411 follow-up".into()],
         })
         .unwrap_err();
     assert!(matches!(
@@ -654,6 +655,7 @@ fn run_complete_lifecycle_with_validation_history(
             expected_worktree: temp.path().to_string_lossy().into_owned(),
             actor: "closeout-retainer".into(),
             reason: "materialize shared terminal authority".into(),
+            follow_ups: vec!["#5411 follow-up".into()],
         })
         .unwrap();
     assert_eq!(reconciled.phase, LifecyclePhase::ClosedOut);
@@ -678,9 +680,16 @@ fn run_complete_lifecycle_with_validation_history(
             expected_worktree: temp.path().to_string_lossy().into_owned(),
             actor: "closeout-retainer".into(),
             reason: "materialize shared terminal authority".into(),
+            follow_ups: Vec::new(),
         })
         .unwrap();
     assert_eq!(repeated, reconciled);
+    let reconciled_receipt = store.load_terminal_receipt(issue).unwrap().unwrap();
+    let sor = match &reconciled_receipt.cards[&CardKind::Sor].content {
+        csdlc_v2::cards::CardContent::Sor(values) => values,
+        _ => panic!("expected SOR card"),
+    };
+    assert_eq!(sor.follow_ups, vec!["#5411 follow-up"]);
     assert!(store.load_record(issue).unwrap().claim.is_none());
     let doctor = csdlc_v2::diagnose(&store, issue);
     assert_eq!(doctor.phase, Some(LifecyclePhase::ClosedOut));

--- a/csdlc-v2/tests/gate7_lifecycle.rs
+++ b/csdlc-v2/tests/gate7_lifecycle.rs
@@ -680,7 +680,7 @@ fn run_complete_lifecycle_with_validation_history(
             expected_worktree: temp.path().to_string_lossy().into_owned(),
             actor: "closeout-retainer".into(),
             reason: "materialize shared terminal authority".into(),
-            follow_ups: Vec::new(),
+            follow_ups: vec!["#5411 follow-up".into()],
         })
         .unwrap();
     assert_eq!(repeated, reconciled);


### PR DESCRIPTION
Closes #5438
Closes #5461

Adds bounded typed terminal reconciliation for SRP-routed SOR follow-ups, updates retained receipt truth, and permits issue-local binding with worktree `.` without writing primary main.

Validation: full locked Rust suite, Gate 2, Gate 7 lifecycle, and clippy pass.