### PR TITLE
[v0.91.7][tooling][spot] Preserve builder summary generation failures

### DIFF
--- a/adl/tools/run_aws_spot_builder_image_validation.sh
+++ b/adl/tools/run_aws_spot_builder_image_validation.sh
@@ -182,6 +182,7 @@ stage "$CURRENT_STAGE"
 VALIDATION_START="$(date +%s)"
 VALIDATION_UID="$(id -u)"
 VALIDATION_GID="$(id -g)"
+VALIDATION_STATUS=0
 "${DOCKER[@]}" run --rm \
   --user "$VALIDATION_UID:$VALIDATION_GID" \
   --workdir /workspace \
@@ -198,17 +199,24 @@ VALIDATION_GID="$(id -g)"
   --env RUSTFLAGS= \
   --env CARGO_INCREMENTAL=0 \
   --entrypoint /bin/bash \
-  "$IMAGE" -lc "set +e; $COMMAND; status=\$?; sccache --show-stats > /run-output/sccache-stats.log 2>&1 || true; exit \$status"
+  "$IMAGE" -lc "set +e; $COMMAND; status=\$?; sccache --show-stats > /run-output/sccache-stats.log 2>&1 || true; exit \$status" \
+  || VALIDATION_STATUS=$?
 VALIDATION_END="$(date +%s)"
 
 CURRENT_STAGE="write_builder_summary"
 stage "$CURRENT_STAGE"
 IMAGE_DIGEST="${IMAGE##*@}"
 export RESOLVED_REF IMAGE_DIGEST IMAGE_ARCH CACHE_SOURCE CACHE_FREE_BYTES
-export VALIDATION_START VALIDATION_END
+export VALIDATION_START VALIDATION_END VALIDATION_STATUS
 export CACHE_TARGET_PREEXISTING_ENTRIES CACHE_TARGET_PREEXISTING_BYTES
 export CACHE_LOW_SPACE_RECOVERY
-python3 - "$ADL_RUN_ROOT/spot-builder-summary.json" <<'PY'
+SUMMARY_PATH="$ADL_RUN_ROOT/spot-builder-summary.json"
+SUMMARY_TMP="${SUMMARY_PATH}.tmp.$$"
+SUMMARY_STATUS=0
+SUMMARY_OUTPUT=""
+rm -f "$SUMMARY_PATH" "$SUMMARY_TMP" || SUMMARY_STATUS=$?
+if [[ "$SUMMARY_STATUS" -eq 0 ]]; then
+  SUMMARY_OUTPUT="$(python3 - "$SUMMARY_TMP" <<'PY'
 import hashlib
 import json
 import os
@@ -217,7 +225,8 @@ import sys
 out = sys.argv[1]
 payload = {
     "schema": "adl.aws_spot_builder_image_validation.v1",
-    "status": "passed",
+    "status": "passed" if int(os.environ["VALIDATION_STATUS"]) == 0 else "failed",
+    "validation_exit_code": int(os.environ["VALIDATION_STATUS"]),
     "source_commit": os.environ["RESOLVED_REF"],
     "source_commit_verified": True,
     "builder_image_digest_sha256": hashlib.sha256(os.environ["IMAGE_DIGEST"].encode()).hexdigest(),
@@ -239,3 +248,20 @@ with open(out, "w", encoding="utf-8") as handle:
     handle.write("\n")
 print("ADL_SPOT_BUILDER_PROOF=" + json.dumps(payload, sort_keys=True, separators=(",", ":")))
 PY
+)" || SUMMARY_STATUS=$?
+fi
+if [[ "$SUMMARY_STATUS" -eq 0 ]]; then
+  mv -f "$SUMMARY_TMP" "$SUMMARY_PATH" || SUMMARY_STATUS=$?
+fi
+rm -f "$SUMMARY_TMP" || true
+
+if [[ "$SUMMARY_STATUS" -ne 0 ]]; then
+  echo "spot_builder_image_validation: retained summary generation failed with status $SUMMARY_STATUS" >&2
+else
+  printf '%s\n' "$SUMMARY_OUTPUT"
+fi
+if [[ "$VALIDATION_STATUS" -ne 0 ]]; then
+  echo "spot_builder_image_validation: validation command failed with status $VALIDATION_STATUS" >&2
+  exit "$VALIDATION_STATUS"
+fi
+exit "$SUMMARY_STATUS"

--- a/adl/tools/test_run_aws_spot_builder_image_validation.sh
+++ b/adl/tools/test_run_aws_spot_builder_image_validation.sh
@@ -10,6 +10,7 @@ FAKE_BIN="$TMP/fake-bin"
 RUN_ROOT="$TMP/run"
 CACHE_MOUNT="$TMP/cache"
 mkdir -p "$FAKE_BIN" "$RUN_ROOT" "$CACHE_MOUNT"
+export ADL_REAL_PYTHON3="$(command -v python3)"
 
 cat >"$FAKE_BIN/mountpoint" <<'EOF'
 #!/usr/bin/env bash
@@ -113,6 +114,15 @@ esac
 echo "unexpected docker command: $*" >&2
 exit 1
 EOF
+
+cat >"$FAKE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${ADL_FAKE_SUMMARY_EXIT:-0}" != "0" && "${2:-}" == */spot-builder-summary.json.tmp.* ]]; then
+  printf '{' >"$2"
+  exit "$ADL_FAKE_SUMMARY_EXIT"
+fi
+exec "$ADL_REAL_PYTHON3" "$@"
+EOF
 chmod +x "$FAKE_BIN"/*
 
 commit="$(git -C "$ROOT" rev-parse HEAD)"
@@ -139,6 +149,7 @@ import json
 import sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
 assert payload["status"] == "passed"
+assert payload["validation_exit_code"] == 0
 assert payload["source_commit"] == sys.argv[2]
 assert payload["source_commit_verified"] is True
 assert payload["builder_image_immutable"] is True
@@ -196,9 +207,47 @@ if ADL_FAKE_IMAGE_ARCH=arm64 run_fixture >"$TMP/arch.out" 2>"$TMP/arch.err"; the
 fi
 grep -F 'builder image architecture mismatch' "$TMP/arch.err" >/dev/null
 
-if ADL_FAKE_VALIDATION_EXIT=17 run_fixture >"$TMP/validation.out" 2>"$TMP/validation.err"; then
-  echo "expected validation failure to propagate" >&2
+printf '{"status":"passed"}\n' >"$RUN_ROOT/spot-builder-summary.json"
+set +e
+ADL_FAKE_SUMMARY_EXIT=23 run_fixture >"$TMP/summary-failure.out" 2>"$TMP/summary-failure.err"
+summary_status=$?
+set -e
+[[ "$summary_status" -eq 23 ]]
+grep -F 'retained summary generation failed with status 23' "$TMP/summary-failure.err" >/dev/null
+[[ ! -e "$RUN_ROOT/spot-builder-summary.json" ]]
+if compgen -G "$RUN_ROOT/spot-builder-summary.json.tmp.*" >/dev/null; then
+  echo "summary failure retained a partial temporary file" >&2
   exit 1
 fi
+if grep -F 'ADL_SPOT_BUILDER_PROOF=' "$TMP/summary-failure.out" >/dev/null; then
+  echo "summary failure emitted a proof marker" >&2
+  exit 1
+fi
+
+rm -f "$RUN_ROOT/spot-builder-summary.json"
+set +e
+ADL_FAKE_VALIDATION_EXIT=17 run_fixture >"$TMP/validation.out" 2>"$TMP/validation.err"
+validation_status=$?
+set -e
+[[ "$validation_status" -eq 17 ]]
+grep -F 'validation command failed with status 17' "$TMP/validation.err" >/dev/null
+grep -F 'ADL_SPOT_BUILDER_PROOF=' "$TMP/validation.out" >/dev/null
+python3 - "$RUN_ROOT/spot-builder-summary.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["status"] == "failed"
+assert payload["validation_exit_code"] == 17
+PY
+
+rm -f "$RUN_ROOT/spot-builder-summary.json"
+set +e
+ADL_FAKE_VALIDATION_EXIT=17 ADL_FAKE_SUMMARY_EXIT=23 \
+  run_fixture >"$TMP/both-fail.out" 2>"$TMP/both-fail.err"
+both_status=$?
+set -e
+[[ "$both_status" -eq 17 ]]
+grep -F 'retained summary generation failed with status 23' "$TMP/both-fail.err" >/dev/null
+grep -F 'validation command failed with status 17' "$TMP/both-fail.err" >/dev/null
 
 echo "PASS test_run_aws_spot_builder_image_validation"


### PR DESCRIPTION
Closes #5452

Preserves independent validation and summary-generation failure truth in the builder-image validation wrapper. Retained JSON is now published atomically, stale or partial evidence is removed on generation failure, and mixed-result regressions prove exit precedence and diagnostics.

Validation is local and fake-only; no AWS or remote infrastructure was used.