### PR TITLE
[v0.91.7][csdlc-v2] Release stale claims from closed issues

### DIFF
--- a/csdlc-v2/src/bin/csdlc-bind.rs
+++ b/csdlc-v2/src/bin/csdlc-bind.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use csdlc_v2::{
-    amend_claim_scope, bind_issue, heartbeat_claim, recover_claim, AmendClaimScopeRequest,
-    BindRequest, HeartbeatRequest, RecoverClaimRequest, Store,
+    amend_claim_scope, bind_issue, heartbeat_claim, recover_claim, release_closed_claim,
+    AmendClaimScopeRequest, BindRequest, HeartbeatRequest, RecoverClaimRequest,
+    ReleaseClosedClaimRequest, Store,
 };
 use std::{fs, path::PathBuf};
 
@@ -17,11 +18,24 @@ struct Cli {
     recover_request: Option<PathBuf>,
     #[arg(long, conflicts_with_all = ["request", "heartbeat_request", "recover_request"])]
     amend_request: Option<PathBuf>,
+    #[arg(long, conflicts_with_all = ["request", "heartbeat_request", "recover_request", "amend_request"])]
+    release_request: Option<PathBuf>,
 }
 
 fn main() {
     let cli = Cli::parse();
-    let result = if let Some(path) = cli.heartbeat_request {
+    let result = if let Some(path) = cli.release_request {
+        fs::read(path)
+            .map_err(csdlc_v2::V2Error::from)
+            .and_then(|bytes| {
+                serde_json::from_slice::<ReleaseClosedClaimRequest>(&bytes)
+                    .map_err(csdlc_v2::V2Error::from)
+            })
+            .and_then(|request| {
+                release_closed_claim(&Store::new(cli.root.clone()), request)
+                    .map(|value| serde_json::to_value(value).expect("JSON"))
+            })
+    } else if let Some(path) = cli.heartbeat_request {
         fs::read(path).map_err(csdlc_v2::V2Error::from).and_then(|bytes| serde_json::from_slice::<HeartbeatRequest>(&bytes).map_err(csdlc_v2::V2Error::from)).and_then(|request| heartbeat_claim(&Store::new(cli.root.clone()), request.issue, &request.claim_id, request.expected_generation, request.now_unix_seconds, request.extend_seconds).map(|_| serde_json::json!({"schema":"csdlc.heartbeat_result.v1","issue":request.issue})))
     } else if let Some(path) = cli.recover_request {
         fs::read(path)
@@ -49,7 +63,7 @@ fn main() {
         let path = cli.request.ok_or_else(|| {
             csdlc_v2::V2Error::new(
                 csdlc_v2::ErrorCode::InvalidInput,
-                "one of --request, --heartbeat-request, --recover-request, or --amend-request is required",
+                "one of --request, --heartbeat-request, --recover-request, --amend-request, or --release-request is required",
             )
         });
         path.and_then(|path| fs::read(path).map_err(csdlc_v2::V2Error::from))

--- a/csdlc-v2/src/lib.rs
+++ b/csdlc-v2/src/lib.rs
@@ -31,7 +31,8 @@ pub use eligibility::{
 pub use error::{ErrorCode, Result, V2Error};
 pub use lifecycle::{
     amend_claim_scope, bind_issue, heartbeat_claim, initialize_issue, recover_claim,
-    AmendClaimScopeRequest, BindRequest, BindResult, HeartbeatRequest, RecoverClaimRequest,
+    release_closed_claim, AmendClaimScopeRequest, BindRequest, BindResult, HeartbeatRequest,
+    RecoverClaimRequest, ReleaseClosedClaimRequest,
 };
 pub use migration::{
     compare_shadow, generate_compatibility_view, import_legacy, write_compatibility_view_atomic,

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -45,6 +45,8 @@ pub struct ReleaseClosedClaimRequest {
     pub expected_digest: String,
     pub actor: String,
     pub reason: String,
+    pub observed_issue_state: String,
+    pub observation_source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -561,7 +563,11 @@ pub fn release_closed_claim(
     store: &Store,
     request: ReleaseClosedClaimRequest,
 ) -> Result<ClaimRecovery> {
-    if request.actor.trim().is_empty() || request.reason.trim().is_empty() {
+    if request.actor.trim().is_empty()
+        || request.reason.trim().is_empty()
+        || request.observed_issue_state != "closed"
+        || request.observation_source.trim().is_empty()
+    {
         return Err(V2Error::new(
             ErrorCode::InvalidInput,
             "release actor and reason required",
@@ -575,11 +581,16 @@ pub fn release_closed_claim(
     if record.phase != crate::LifecyclePhase::Implemented
         || current.id != request.expected_claim_id
         || record.generation != request.expected_generation
-        || record.digest != request.expected_digest
     {
         return Err(V2Error::new(
             ErrorCode::InvalidClaim,
             "closed-issue claim release compare-and-swap failed",
+        ));
+    }
+    if record.digest != request.expected_digest {
+        return Err(V2Error::new(
+            ErrorCode::StaleDigest,
+            "closed-issue claim release digest is stale",
         ));
     }
     let evidence = ClaimRecovery {
@@ -594,7 +605,12 @@ pub fn release_closed_claim(
         generation: record.generation,
         actor: request.actor,
         reason: request.reason,
-        operation: "release_closed_claim".into(),
+        operation: serde_json::json!({
+            "operation": "release_closed_claim",
+            "observed_issue_state": request.observed_issue_state,
+            "observation_source": request.observation_source,
+        })
+        .to_string(),
     });
     record.digest = crate::store::record_digest(&record)?;
     store.replace_record(request.issue, &request.expected_digest, &record)?;

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -40,12 +40,14 @@ pub struct RecoverClaimRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReleaseClosedClaimRequest {
     pub issue: u64,
+    pub repository: String,
     pub expected_claim_id: String,
     pub expected_generation: u64,
     pub expected_digest: String,
     pub actor: String,
     pub reason: String,
     pub observed_issue_state: String,
+    pub observed_issue: u64,
     pub observation_source: String,
 }
 
@@ -143,16 +145,21 @@ pub fn initialize_issue(
                     continue;
                 }
                 if let Some(claim) = other.claim {
-                    if claim
-                        .protected_paths
-                        .iter()
-                        .any(|a| request.claim.protected_paths.iter().any(|b| overlaps(a, b)))
+                    if let Some((reserved, requested)) =
+                        claim.protected_paths.iter().find_map(|a| {
+                            request
+                                .claim
+                                .protected_paths
+                                .iter()
+                                .find(|b| overlaps(a, b))
+                                .map(|b| (a, b))
+                        })
                     {
                         return Err(V2Error::new(
                             ErrorCode::ClaimCollision,
                             format!(
-                                "protected path overlaps issue {} in phase {:?}",
-                                other.issue, other.phase
+                                "protected path '{}' overlaps requested '{}' from issue {} in phase {:?}",
+                                reserved, requested, other.issue, other.phase
                             ),
                         ));
                     }
@@ -285,14 +292,22 @@ pub fn bind_issue(store: &Store, request: BindRequest) -> Result<BindResult> {
                     continue;
                 }
                 if let Some(claim) = other.claim {
-                    if claim
-                        .protected_paths
-                        .iter()
-                        .any(|a| request.claim.protected_paths.iter().any(|b| overlaps(a, b)))
+                    if let Some((reserved, requested)) =
+                        claim.protected_paths.iter().find_map(|a| {
+                            request
+                                .claim
+                                .protected_paths
+                                .iter()
+                                .find(|b| overlaps(a, b))
+                                .map(|b| (a, b))
+                        })
                     {
                         return Err(V2Error::new(
                             ErrorCode::ClaimCollision,
-                            format!("protected path overlaps issue {}", other.issue),
+                            format!(
+                                "protected path '{}' overlaps requested '{}' from issue {} in phase {:?}",
+                                reserved, requested, other.issue, other.phase
+                            ),
                         ));
                     }
                 }
@@ -467,17 +482,20 @@ pub fn amend_claim_scope(store: &Store, request: AmendClaimScopeRequest) -> Resu
                 continue;
             }
             if let Some(claim) = other.claim {
-                if claim.protected_paths.iter().any(|reserved| {
-                    request
-                        .add_protected_paths
-                        .iter()
-                        .any(|candidate| overlaps(reserved, candidate))
-                }) {
+                if let Some((reserved, candidate)) =
+                    claim.protected_paths.iter().find_map(|reserved| {
+                        request
+                            .add_protected_paths
+                            .iter()
+                            .find(|candidate| overlaps(reserved, candidate))
+                            .map(|candidate| (reserved, candidate))
+                    })
+                {
                     return Err(V2Error::new(
                         ErrorCode::ClaimCollision,
                         format!(
-                            "protected path overlaps issue {} in phase {:?}",
-                            other.issue, other.phase
+                            "protected path '{}' overlaps requested '{}' from issue {} in phase {:?}",
+                            reserved, candidate, other.issue, other.phase
                         ),
                     ));
                 }
@@ -565,8 +583,12 @@ pub fn release_closed_claim(
 ) -> Result<ClaimRecovery> {
     if request.actor.trim().is_empty()
         || request.reason.trim().is_empty()
+        || request.repository.trim().is_empty()
         || request.observed_issue_state != "closed"
+        || request.observed_issue != request.issue
         || request.observation_source.trim().is_empty()
+        || request.observation_source
+            != format!("github://{}/issues/{}", request.repository, request.issue)
     {
         return Err(V2Error::new(
             ErrorCode::InvalidInput,
@@ -574,6 +596,12 @@ pub fn release_closed_claim(
         ));
     }
     let mut record = store.load_record(request.issue)?;
+    if record.repository != request.repository {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "closed-issue claim release repository mismatch",
+        ));
+    }
     let current = record
         .claim
         .as_ref()

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -38,6 +38,16 @@ pub struct RecoverClaimRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ReleaseClosedClaimRequest {
+    pub issue: u64,
+    pub expected_claim_id: String,
+    pub expected_generation: u64,
+    pub expected_digest: String,
+    pub actor: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HeartbeatRequest {
     pub issue: u64,
     pub claim_id: String,
@@ -138,7 +148,10 @@ pub fn initialize_issue(
                     {
                         return Err(V2Error::new(
                             ErrorCode::ClaimCollision,
-                            format!("protected path overlaps issue {}", other.issue),
+                            format!(
+                                "protected path overlaps issue {} in phase {:?}",
+                                other.issue, other.phase
+                            ),
                         ));
                     }
                 }
@@ -460,7 +473,10 @@ pub fn amend_claim_scope(store: &Store, request: AmendClaimScopeRequest) -> Resu
                 }) {
                     return Err(V2Error::new(
                         ErrorCode::ClaimCollision,
-                        format!("protected path overlaps issue {}", other.issue),
+                        format!(
+                            "protected path overlaps issue {} in phase {:?}",
+                            other.issue, other.phase
+                        ),
                     ));
                 }
             }
@@ -538,6 +554,50 @@ pub fn recover_claim(store: &Store, request: RecoverClaimRequest) -> Result<Clai
     });
     record.digest = crate::store::record_digest(&record)?;
     store.replace_record(request.issue, &expected_digest, &record)?;
+    Ok(evidence)
+}
+
+pub fn release_closed_claim(
+    store: &Store,
+    request: ReleaseClosedClaimRequest,
+) -> Result<ClaimRecovery> {
+    if request.actor.trim().is_empty() || request.reason.trim().is_empty() {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "release actor and reason required",
+        ));
+    }
+    let mut record = store.load_record(request.issue)?;
+    let current = record
+        .claim
+        .as_ref()
+        .ok_or_else(|| V2Error::new(ErrorCode::MissingClaim, "claim missing"))?;
+    if record.phase != crate::LifecyclePhase::Implemented
+        || current.id != request.expected_claim_id
+        || record.generation != request.expected_generation
+        || record.digest != request.expected_digest
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidClaim,
+            "closed-issue claim release compare-and-swap failed",
+        ));
+    }
+    let evidence = ClaimRecovery {
+        previous_owner: current.owner.clone(),
+        observed_expiry_unix_seconds: current.expires_unix_seconds,
+        recovery_actor: request.actor.clone(),
+        reason: request.reason.clone(),
+    };
+    record.claim = None;
+    record.audit.push(AuditEvent {
+        sequence: record.audit.len() as u64 + 1,
+        generation: record.generation,
+        actor: request.actor,
+        reason: request.reason,
+        operation: "release_closed_claim".into(),
+    });
+    record.digest = crate::store::record_digest(&record)?;
+    store.replace_record(request.issue, &request.expected_digest, &record)?;
     Ok(evidence)
 }
 

--- a/csdlc-v2/src/schema.rs
+++ b/csdlc-v2/src/schema.rs
@@ -3,6 +3,7 @@ use serde_json::{json, Value};
 use crate::doctor::DoctorReport;
 use crate::lifecycle::{
     AmendClaimScopeRequest, BindRequest, BindResult, HeartbeatRequest, RecoverClaimRequest,
+    ReleaseClosedClaimRequest,
 };
 use crate::migration::{ImportReport, LegacyImportRequest, NormalizedOutcome, ShadowComparison};
 use crate::model::IssueRecord;
@@ -26,6 +27,7 @@ pub fn public_schema_bundle() -> Value {
         "bind_request": schemars::schema_for!(BindRequest),
         "bind_result": schemars::schema_for!(BindResult),
         "recover_claim_request": schemars::schema_for!(RecoverClaimRequest),
+        "release_closed_claim_request": schemars::schema_for!(ReleaseClosedClaimRequest),
         "amend_claim_scope_request": schemars::schema_for!(AmendClaimScopeRequest),
         "heartbeat_request": schemars::schema_for!(HeartbeatRequest),
         "issue_record": schemars::schema_for!(IssueRecord),

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -1732,11 +1732,7 @@ pub(crate) fn verify_record(record: &IssueRecord) -> Result<()> {
                 "closed-out record must have terminal evidence and no active claim",
             ));
         }
-    } else {
-        let claim = record
-            .claim
-            .as_ref()
-            .ok_or_else(|| V2Error::new(ErrorCode::CorruptRecord, "claim missing"))?;
+    } else if let Some(claim) = record.claim.as_ref() {
         if claim.generation != record.generation
             || claim.id.is_empty()
             || claim.owner.is_empty()
@@ -1751,6 +1747,19 @@ pub(crate) fn verify_record(record: &IssueRecord) -> Result<()> {
                 "claim invariant failed",
             ));
         }
+    } else if !record.audit.last().is_some_and(|event| {
+        serde_json::from_str::<serde_json::Value>(&event.operation)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("operation")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned)
+            })
+            .as_deref()
+            == Some("release_closed_claim")
+    }) {
+        return Err(V2Error::new(ErrorCode::CorruptRecord, "claim missing"));
     }
     if let DesignReview::Approved { reviewer, revision } = &record.design_review {
         if reviewer.trim().is_empty() || revision.trim().is_empty() {

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -204,6 +204,88 @@ fn bind_supports_issue_local_state_without_touching_primary_checkout() {
     assert_eq!(git_branch(temp.path()), "issue-42");
 }
 
+#[test]
+fn closed_issue_claim_release_is_typed_and_compare_and_swap_guarded() {
+    let (temp, store, mut record) = fixture();
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    git(temp.path(), &["add", "docs"]);
+    git(temp.path(), &["commit", "-m", "fixture"]);
+    record = csdlc_v2::edit_issue(
+        &store,
+        edit(
+            &record,
+            SemanticOperation::AdvancePhase {
+                phase: csdlc_v2::LifecyclePhase::Ready,
+            },
+        ),
+    )
+    .unwrap();
+    record = csdlc_v2::edit_issue(
+        &store,
+        edit(
+            &record,
+            SemanticOperation::AdvancePhase {
+                phase: csdlc_v2::LifecyclePhase::Bound,
+            },
+        ),
+    )
+    .unwrap();
+    record = csdlc_v2::edit_issue(
+        &store,
+        EditRequest {
+            issue: 42,
+            card: CardKind::Sor,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim-1".into(),
+            actor: "agent".into(),
+            reason: "test edit".into(),
+            operation: SemanticOperation::RecordExecution {
+                summary: "done".into(),
+                changes: vec!["claim".into()],
+                artifacts: vec![],
+            },
+            fail_after_backup: false,
+        },
+    )
+    .unwrap();
+    record = csdlc_v2::edit_issue(
+        &store,
+        edit(
+            &record,
+            SemanticOperation::AdvancePhase {
+                phase: csdlc_v2::LifecyclePhase::Implemented,
+            },
+        ),
+    )
+    .unwrap();
+    let claim_id = record.claim.as_ref().unwrap().id.clone();
+    let evidence = csdlc_v2::release_closed_claim(
+        &store,
+        csdlc_v2::ReleaseClosedClaimRequest {
+            issue: 42,
+            expected_claim_id: claim_id,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            actor: "operator".into(),
+            reason: "GitHub issue is closed; release stale broad claim for follow-on setup".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(evidence.previous_owner, "agent");
+    let released = store.load_record(42).unwrap();
+    assert!(released.claim.is_none());
+    assert_eq!(
+        released.audit.last().unwrap().operation,
+        "release_closed_claim"
+    );
+}
+
 fn git_branch(root: &std::path::Path) -> String {
     let output = std::process::Command::new("git")
         .current_dir(root)
@@ -867,6 +949,7 @@ fn public_schema_bundle_covers_requests_state_and_doctor_output() {
         "bind_request",
         "bind_result",
         "recover_claim_request",
+        "release_closed_claim_request",
         "amend_claim_scope_request",
         "issue_record",
         "terminal_receipt",

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use csdlc_v2::doctor::DoctorStatus;
 use csdlc_v2::{
     amend_claim_scope, diagnose, edit_issue, AmendClaimScopeRequest, BootstrapRequest, CardKind,
     Claim, EditRequest, ErrorCode, SemanticOperation, Store,
@@ -274,16 +275,21 @@ fn closed_issue_claim_release_is_typed_and_compare_and_swap_guarded() {
             expected_digest: record.digest.clone(),
             actor: "operator".into(),
             reason: "GitHub issue is closed; release stale broad claim for follow-on setup".into(),
+            observed_issue_state: "closed".into(),
+            observation_source: "github:issue/42".into(),
         },
     )
     .unwrap();
     assert_eq!(evidence.previous_owner, "agent");
     let released = store.load_record(42).unwrap();
     assert!(released.claim.is_none());
-    assert_eq!(
-        released.audit.last().unwrap().operation,
-        "release_closed_claim"
-    );
+    assert!(released
+        .audit
+        .last()
+        .unwrap()
+        .operation
+        .contains("release_closed_claim"));
+    assert_eq!(csdlc_v2::diagnose(&store, 42).status, DoctorStatus::Pass);
 }
 
 fn git_branch(root: &std::path::Path) -> String {

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -270,13 +270,15 @@ fn closed_issue_claim_release_is_typed_and_compare_and_swap_guarded() {
         &store,
         csdlc_v2::ReleaseClosedClaimRequest {
             issue: 42,
+            repository: "example/repo".into(),
             expected_claim_id: claim_id,
             expected_generation: record.generation,
             expected_digest: record.digest.clone(),
             actor: "operator".into(),
             reason: "GitHub issue is closed; release stale broad claim for follow-on setup".into(),
             observed_issue_state: "closed".into(),
-            observation_source: "github:issue/42".into(),
+            observed_issue: 42,
+            observation_source: "github://example/repo/issues/42".into(),
         },
     )
     .unwrap();
@@ -397,6 +399,8 @@ fn bind_refuses_overlapping_protected_path_reserved_by_another_issue() {
     )
     .expect_err("path overlap");
     assert!(matches!(error.code, ErrorCode::ClaimCollision));
+    assert!(error.message.contains("in phase"));
+    assert!(error.message.contains("protected"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #5415

Adds a typed compare-and-swap release path for stale claims on closed issues, with repository/issue-bound closure evidence, claim-release audit proof that keeps doctor validation valid, and collision diagnostics that include both protected paths and lifecycle phase.

Validation: cargo test --locked --manifest-path csdlc-v2/Cargo.toml; cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings

Review: bounded pre-publication subagent review completed; P1 findings fixed. Closure evidence is explicitly operator-reviewed external GitHub evidence, not a live network observation.