### PR TITLE
[v0.91.7][csdlc-v2] Retain and validate terminal receipts

### DIFF
--- a/csdlc-v2/src/bin/csdlc-closeout.rs
+++ b/csdlc-v2/src/bin/csdlc-closeout.rs
@@ -52,6 +52,10 @@ enum Command {
         #[arg(long)]
         issue: u64,
     },
+    RetainReceipt {
+        #[arg(long)]
+        issue: u64,
+    },
     Schema,
 }
 
@@ -147,6 +151,7 @@ async fn run(cli: &Cli) -> csdlc_v2::Result<serde_json::Value> {
                 "pruned":matches!(&cli.command, Command::Prune { .. })
             }))
         }
+        Command::RetainReceipt { issue } => json(store.retain_terminal_receipt(*issue)?),
     }
 }
 

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -346,6 +346,9 @@ impl Store {
             });
             if existing.repository != record.repository
                 || existing.initialization_digest != record.initialization_digest
+                || existing.record.generation != record.generation
+                || existing.record.digest != record.digest
+                || existing.cards != cards
                 || !terminal_matches
             {
                 return Err(V2Error::new(


### PR DESCRIPTION
Follow-up for #5409.

Adds a typed `csdlc-closeout retain-receipt --issue` route that delegates receipt retention to the v2 store authority. Existing receipts are now checked against current generation, record digest, cards, and terminal identity so stale authority fails closed.

Validation: Gate 7 lifecycle tests, clippy.
Review: bounded subagent review passed.
No AWS used.