### PR TITLE
[v0.91.7][csdlc-v2] Normalize merged publication during terminal reconcile

### DIFF
--- a/csdlc-v2/src/bin/csdlc-closeout.rs
+++ b/csdlc-v2/src/bin/csdlc-closeout.rs
@@ -52,6 +52,10 @@ enum Command {
         #[arg(long)]
         issue: u64,
     },
+    RetainReceipt {
+        #[arg(long)]
+        issue: u64,
+    },
     Schema,
 }
 
@@ -147,6 +151,7 @@ async fn run(cli: &Cli) -> csdlc_v2::Result<serde_json::Value> {
                 "pruned":matches!(&cli.command, Command::Prune { .. })
             }))
         }
+        Command::RetainReceipt { issue } => json(store.retain_terminal_receipt(*issue)?),
     }
 }
 

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -491,6 +491,18 @@ impl Store {
         }
         let mut projection = receipt.record;
         let mut cards = receipt.cards;
+        if let (Some(publication), Some(terminal)) = (
+            projection.publication.as_mut(),
+            projection.terminal.as_ref(),
+        ) {
+            if terminal.disposition == crate::readiness::TerminalDisposition::Merged
+                && terminal.pull_request == Some(publication.pull_request)
+                && terminal.observed_state == "merged"
+            {
+                publication.draft = false;
+                publication.observed_state = "merged".into();
+            }
+        }
         let current_review_passes = cards.get(&CardKind::Srp).is_some_and(|card| {
             matches!(&card.content, CardContent::Srp(srp)
             if srp.review_result == crate::cards::ReviewResult::Pass

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -346,6 +346,9 @@ impl Store {
             });
             if existing.repository != record.repository
                 || existing.initialization_digest != record.initialization_digest
+                || existing.record.generation != record.generation
+                || existing.record.digest != record.digest
+                || existing.cards != cards
                 || !terminal_matches
             {
                 return Err(V2Error::new(


### PR DESCRIPTION
Follow-up to #5409 and #5478.

When reconciling a retained merged terminal receipt, normalize the matching publication evidence from draft/open to non-draft/merged before rewriting canonical truth.

Validation: Gate7 lifecycle tests and clippy.
Review: bounded subagent review passed.
No AWS used.