### PR TITLE
[v0.91.7][csdlc-v2] Reconcile stale merged publication projections

### DIFF
--- a/csdlc-v2/src/bin/csdlc-closeout.rs
+++ b/csdlc-v2/src/bin/csdlc-closeout.rs
@@ -52,6 +52,10 @@ enum Command {
         #[arg(long)]
         issue: u64,
     },
+    RetainReceipt {
+        #[arg(long)]
+        issue: u64,
+    },
     Schema,
 }
 
@@ -147,6 +151,7 @@ async fn run(cli: &Cli) -> csdlc_v2::Result<serde_json::Value> {
                 "pruned":matches!(&cli.command, Command::Prune { .. })
             }))
         }
+        Command::RetainReceipt { issue } => json(store.retain_terminal_receipt(*issue)?),
     }
 }
 

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -479,6 +479,9 @@ impl Store {
         .unwrap_or(false);
         if local.phase == LifecyclePhase::ClosedOut
             && local.terminal == receipt.record.terminal
+            && local.publication.as_ref().is_some_and(|publication| {
+                !publication.draft && publication.observed_state == "merged"
+            })
             && existing_follow_ups == requested_follow_ups
             && local_integrity
             && local.audit.last().is_some_and(|event| {

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -491,6 +491,18 @@ impl Store {
         }
         let mut projection = receipt.record;
         let mut cards = receipt.cards;
+        if let (Some(publication), Some(terminal)) = (
+            projection.publication.as_mut(),
+            projection.terminal.as_ref(),
+        ) {
+            if terminal.disposition == crate::readiness::TerminalDisposition::Merged
+                && terminal.pull_request == Some(publication.pull_request)
+                && terminal.observed_state == "merged"
+            {
+                publication.draft = false;
+                publication.observed_state = "merged".into();
+            }
+        }
         let current_review_passes = cards.get(&CardKind::Srp).is_some_and(|card| {
             matches!(&card.content, CardContent::Srp(srp)
             if srp.review_result == crate::cards::ReviewResult::Pass

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -346,6 +346,9 @@ impl Store {
             });
             if existing.repository != record.repository
                 || existing.initialization_digest != record.initialization_digest
+                || existing.record.generation != record.generation
+                || existing.record.digest != record.digest
+                || existing.cards != cards
                 || !terminal_matches
             {
                 return Err(V2Error::new(


### PR DESCRIPTION
Follow-up to #5409 and receipt reconciliation.

Do not short-circuit terminal reconciliation while canonical publication evidence still says draft/open; normalize it to merged truth first.

Validation: Gate7 lifecycle tests and clippy.
Review: bounded subagent review passed.
No AWS used.