### PR TITLE
[v0.91.7][csdlc-v2] Materialize retained terminal receipts

### DIFF
--- a/csdlc-v2/src/error.rs
+++ b/csdlc-v2/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, V2Error>;
 
-#[derive(Debug, Clone, Copy, Serialize, Display, EnumString, AsRefStr, EnumIter)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Display, EnumString, AsRefStr, EnumIter)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ErrorCode {

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -773,24 +773,39 @@ impl Store {
         }
         let _lock = self.lock(request.issue)?;
         self.recover_if_needed(request.issue)?;
-        let local = self.load_record(request.issue)?;
-        if local.initialization_digest != request.expected_initialization_digest {
-            return Err(V2Error::new(
-                ErrorCode::StaleDigest,
-                "local initialization digest differs from reconciliation request",
-            ));
-        }
         let mut receipt = self
             .load_terminal_receipt(request.issue)?
             .ok_or_else(|| V2Error::new(ErrorCode::InvalidInput, "terminal receipt missing"))?;
-        if receipt.initialization_digest != local.initialization_digest
-            || receipt.repository != local.repository
-        {
+        if receipt.issue != request.issue {
             return Err(V2Error::new(
                 ErrorCode::ReconciliationRequired,
-                "terminal receipt identity differs from local issue",
+                "terminal receipt issue differs from reconciliation request",
             ));
         }
+        if receipt.initialization_digest != request.expected_initialization_digest {
+            return Err(V2Error::new(
+                ErrorCode::StaleDigest,
+                "terminal receipt initialization digest differs from reconciliation request",
+            ));
+        }
+        let issue_dir = self.issue_dir(request.issue);
+        let local = match self.load_record(request.issue) {
+            Ok(local) => {
+                if receipt.initialization_digest != local.initialization_digest
+                    || receipt.repository != local.repository
+                {
+                    return Err(V2Error::new(
+                        ErrorCode::ReconciliationRequired,
+                        "terminal receipt identity differs from local issue",
+                    ));
+                }
+                local
+            }
+            Err(error) if error.code == ErrorCode::Io && !issue_dir.exists() => {
+                receipt.record.clone()
+            }
+            Err(error) => return Err(error),
+        };
         let requested_follow_ups = request
             .follow_ups
             .iter()
@@ -816,14 +831,18 @@ impl Store {
         };
         let local_integrity = (|| -> Result<bool> {
             verify_record(&local)?;
-            let current_cards = self.load_cards(request.issue)?;
+            let current_cards = match self.load_cards(request.issue) {
+                Ok(cards) => cards,
+                Err(error) if !issue_dir.exists() => return Ok(false),
+                Err(error) => return Err(error),
+            };
             let mut checked = local.clone();
             hydrate_projections(&mut checked, &current_cards)?;
             Ok(checked.digest == record_digest(&checked)?
                 && checked.digest == local.digest
                 && checked.cards == receipt.record.cards)
         })()
-        .unwrap_or(false);
+        ?;
         if local.phase == LifecyclePhase::ClosedOut
             && local.terminal == receipt.record.terminal
             && local.publication.as_ref().is_some_and(|publication| {

--- a/csdlc-v2/tests/gate7_lifecycle.rs
+++ b/csdlc-v2/tests/gate7_lifecycle.rs
@@ -778,6 +778,236 @@ fn unresolved_post_review_finding_is_not_projected_as_complete() {
     assert_eq!(reconciled.phase, LifecyclePhase::ClosedOut);
 }
 
+#[test]
+fn terminal_reconcile_materializes_missing_projection_from_retained_receipt() {
+    let issue = 75;
+    let (temp, store, record, sha) = fixture_with_validation_history(
+        issue,
+        "Gate 7 retained receipt fixture",
+        "missing-projection-reconcile",
+        vec![ValidationResult {
+            command: vec!["cargo".into(), "test".into()],
+            purpose: "proof".into(),
+            outcome: EvidenceOutcome::Passed,
+            evidence_ref: "evidence.json".into(),
+        }],
+    );
+    let record = record_readiness(
+        &store,
+        ReadinessRequest {
+            schema: "csdlc.readiness_request.v1".into(),
+            issue,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim".into(),
+            actor: "shepherd".into(),
+            pull_request: 70,
+            head_sha: sha.clone(),
+            required_checks: vec!["fast".into()],
+            require_review: true,
+            checks: vec![csdlc_v2::CheckObservation {
+                name: "fast".into(),
+                requirement: csdlc_v2::CheckRequirement::Required,
+                conclusion: csdlc_v2::CheckConclusion::Success,
+                details_url: None,
+            }],
+            review_state: csdlc_v2::RemoteReviewState::Approved,
+            conflict_state: csdlc_v2::ConflictState::Clean,
+            post_publication_findings: vec![],
+        },
+    )
+    .unwrap();
+    closeout_issue(
+        &store,
+        TerminalObservation {
+            schema: "csdlc.terminal_observation.v1".into(),
+            issue,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim".into(),
+            actor: "closer".into(),
+            pull_request: Some(70),
+            disposition: TerminalDisposition::Merged,
+            observed_sha: Some(sha),
+            observed_state: "merged".into(),
+            approved_no_pr_reason: None,
+            receipt_path: format!("csdlc-v2/closeout/{issue}.json"),
+        },
+    )
+    .unwrap();
+    let receipt = store.retain_terminal_receipt(issue).unwrap();
+    fs::remove_dir_all(store.issue_dir(issue)).unwrap();
+
+    let reconciled = store
+        .reconcile_terminal(csdlc_v2::ReconcileTerminalRequest {
+            issue,
+            expected_initialization_digest: receipt.initialization_digest,
+            expected_branch: "issue-7".into(),
+            expected_worktree: temp.path().to_string_lossy().into_owned(),
+            actor: "closeout-retainer".into(),
+            reason: "materialize retained terminal authority without local projection".into(),
+            follow_ups: vec![],
+        })
+        .unwrap();
+
+    assert_eq!(reconciled.phase, LifecyclePhase::ClosedOut);
+    assert!(store.issue_dir(issue).join("index.json").exists());
+    assert_eq!(
+        fs::read_to_string(temp.path().join(&reconciled.design_path)).unwrap(),
+        receipt.authored_artifacts["docs/design.md"]
+    );
+    assert_eq!(
+        store
+            .load_terminal_receipt(issue)
+            .unwrap()
+            .unwrap()
+            .record
+            .digest,
+        reconciled.digest
+    );
+}
+
+#[test]
+fn terminal_reconcile_rejects_partial_projection_loss() {
+    let (temp, store, issue, receipt) =
+        retained_receipt_fixture(76, "partial-projection-reconcile");
+    fs::remove_file(store.issue_dir(issue).join("cards/sor.values.json")).unwrap();
+
+    let error = store
+        .reconcile_terminal(csdlc_v2::ReconcileTerminalRequest {
+            issue,
+            expected_initialization_digest: receipt.initialization_digest,
+            expected_branch: "issue-7".into(),
+            expected_worktree: temp.path().to_string_lossy().into_owned(),
+            actor: "closeout-retainer".into(),
+            reason: "must reject partial projection loss".into(),
+            follow_ups: vec![],
+        })
+        .unwrap_err();
+
+    assert!(matches!(error.code, csdlc_v2::ErrorCode::Io));
+}
+
+#[test]
+fn terminal_reconcile_rejects_missing_index_inside_existing_projection_dir() {
+    let (temp, store, issue, receipt) = retained_receipt_fixture(77, "missing-index-reconcile");
+    fs::remove_file(store.issue_dir(issue).join("index.json")).unwrap();
+
+    let error = store
+        .reconcile_terminal(csdlc_v2::ReconcileTerminalRequest {
+            issue,
+            expected_initialization_digest: receipt.initialization_digest,
+            expected_branch: "issue-7".into(),
+            expected_worktree: temp.path().to_string_lossy().into_owned(),
+            actor: "closeout-retainer".into(),
+            reason: "must reject missing index inside existing projection".into(),
+            follow_ups: vec![],
+        })
+        .unwrap_err();
+
+    assert!(matches!(error.code, csdlc_v2::ErrorCode::Io));
+}
+
+#[test]
+fn terminal_reconcile_rejects_misplaced_receipt_for_missing_projection() {
+    let source_issue = 78;
+    let target_issue = 79;
+    let (temp, store, _, receipt) =
+        retained_receipt_fixture(source_issue, "misplaced-receipt-reconcile");
+    let source_receipt = fs::read(store.terminal_receipt_path(source_issue).unwrap()).unwrap();
+    fs::create_dir_all(
+        store
+            .terminal_receipt_path(target_issue)
+            .unwrap()
+            .parent()
+            .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        store.terminal_receipt_path(target_issue).unwrap(),
+        source_receipt,
+    )
+    .unwrap();
+    assert!(!store.issue_dir(target_issue).exists());
+
+    let error = store
+        .reconcile_terminal(csdlc_v2::ReconcileTerminalRequest {
+            issue: target_issue,
+            expected_initialization_digest: receipt.initialization_digest,
+            expected_branch: "issue-7".into(),
+            expected_worktree: temp.path().to_string_lossy().into_owned(),
+            actor: "closeout-retainer".into(),
+            reason: "must reject misplaced terminal receipt".into(),
+            follow_ups: vec![],
+        })
+        .unwrap_err();
+
+    assert!(matches!(error.code, csdlc_v2::ErrorCode::ReconciliationRequired));
+    assert!(!store.issue_dir(target_issue).exists());
+}
+
+fn retained_receipt_fixture(
+    issue: u64,
+    scenario: &str,
+) -> (tempfile::TempDir, Store, u64, csdlc_v2::TerminalReceipt) {
+    let (temp, store, record, sha) = fixture_with_validation_history(
+        issue,
+        "Gate 7 retained receipt fixture",
+        scenario,
+        vec![ValidationResult {
+            command: vec!["cargo".into(), "test".into()],
+            purpose: "proof".into(),
+            outcome: EvidenceOutcome::Passed,
+            evidence_ref: "evidence.json".into(),
+        }],
+    );
+    let record = record_readiness(
+        &store,
+        ReadinessRequest {
+            schema: "csdlc.readiness_request.v1".into(),
+            issue,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim".into(),
+            actor: "shepherd".into(),
+            pull_request: 70,
+            head_sha: sha.clone(),
+            required_checks: vec!["fast".into()],
+            require_review: true,
+            checks: vec![csdlc_v2::CheckObservation {
+                name: "fast".into(),
+                requirement: csdlc_v2::CheckRequirement::Required,
+                conclusion: csdlc_v2::CheckConclusion::Success,
+                details_url: None,
+            }],
+            review_state: csdlc_v2::RemoteReviewState::Approved,
+            conflict_state: csdlc_v2::ConflictState::Clean,
+            post_publication_findings: vec![],
+        },
+    )
+    .unwrap();
+    closeout_issue(
+        &store,
+        TerminalObservation {
+            schema: "csdlc.terminal_observation.v1".into(),
+            issue,
+            expected_generation: record.generation,
+            expected_digest: record.digest.clone(),
+            claim_id: "claim".into(),
+            actor: "closer".into(),
+            pull_request: Some(70),
+            disposition: TerminalDisposition::Merged,
+            observed_sha: Some(sha),
+            observed_state: "merged".into(),
+            approved_no_pr_reason: None,
+            receipt_path: format!("csdlc-v2/closeout/{issue}.json"),
+        },
+    )
+    .unwrap();
+    let receipt = store.retain_terminal_receipt(issue).unwrap();
+    (temp, store, issue, receipt)
+}
+
 pub(crate) fn run_complete_lifecycle(
     issue: u64,
     title: &str,


### PR DESCRIPTION
## Summary

Follow-up for #5409 closeout truth alignment after #5480 merged before this retained-receipt materialization fix was integrated.

This keeps `Store::reconcile_terminal` fail-closed while allowing a dedicated terminal reconciliation branch to materialize a missing `.csdlc/issues/<issue>` projection from the retained terminal receipt when the entire issue projection directory is absent.

## Changes

- Allow missing-projection terminal reconciliation to use the retained terminal receipt only when the whole issue projection directory is absent.
- Reject partial/corrupt existing projections instead of silently repairing them from the receipt.
- Reject misplaced retained receipts whose embedded issue does not match the requested issue before materialization.
- Add focused gate7 lifecycle regressions for missing projection materialization, partial projection loss, missing index, and misplaced receipt identity.

## Validation

- `CARGO_TARGET_DIR=/Volumes/FastWork/adl-5409-retained-receipt-materialize-target cargo test --manifest-path csdlc-v2/Cargo.toml terminal_reconcile --test gate7_lifecycle` passed: 4 passed.
- `git diff --check` passed.
- Bounded pre-PR review by Euclid found a P1 misplaced-receipt identity gap; it was fixed and re-reviewed with no remaining findings.

No AWS, Spot, CodeBuild, EC2, SSM, or remote build was used.
