### PR TITLE
[v0.91.7][csdlc-v2][closeout] Retain #5521 terminal truth

### DIFF
--- a/.csdlc/issues/5521/audit.jsonl
+++ b/.csdlc/issues/5521/audit.jsonl
@@ -8,3 +8,11 @@
 {"sequence":8,"generation":5,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
 {"sequence":9,"generation":6,"actor":"subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
 {"sequence":10,"generation":7,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Exact records-only review is clean with no findings or residual risks.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":11,"generation":8,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Recover exact review identity after committing typed review metadata so PR head f21e98155 receives publication review.","operation":"recover_review"}
+{"sequence":12,"generation":8,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":13,"generation":9,"actor":"subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc","reason":"atomically record review evidence and SRP projection","operation":"record_review"}
+{"sequence":14,"generation":10,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"Exact PR-head review is clean with no findings or publication blockers.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":15,"generation":11,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":16,"generation":12,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically record observed merged GitHub publication and SOR projection","operation":"record_merged_publication"}
+{"sequence":17,"generation":13,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"record normalized remote readiness without replacing pre-publication review","operation":"record_readiness"}
+{"sequence":18,"generation":14,"actor":"codex:019f4b3e-6c61-7653-957b-7a2a6042a80d","reason":"atomically finalize SOR/index and release claim/protected paths","operation":"record_terminal"}

--- a/.csdlc/issues/5521/cards/sip.values.json
+++ b/.csdlc/issues/5521/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5521/cards/sor.md
+++ b/.csdlc/issues/5521/cards/sor.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: sor
 
-Status: pre_phase
+Status: complete
 
 ## Summary
 
@@ -43,17 +43,17 @@ Advance only #5518 SPP S4 to completed and atomically refresh its terminal recei
 
 ## Integration
 
-not_started
+merged
 
 ## Publication
 
-Publication: not_published
+Publication: closed
 
-Merge: not_merged
+Merge: merged
 
 ## Closeout
 
-not_started
+complete
 
 ## Follow Ups
 

--- a/.csdlc/issues/5521/cards/sor.values.json
+++ b/.csdlc/issues/5521/cards/sor.values.json
@@ -7,9 +7,9 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
-  "status": "pre_phase",
+  "status": "complete",
   "content": {
     "card_kind": "sor",
     "values": {
@@ -36,10 +36,10 @@
           "evidence_ref": "local: #5518 generation 29 digest 49c61e6e; receipt digest 7158360c; both #5518 and #5521 doctor reports pass"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
-      "merge_state": "not_merged",
-      "closeout_state": "not_started",
+      "integration_state": "merged",
+      "publication_state": "closed",
+      "merge_state": "merged",
+      "closeout_state": "complete",
       "follow_ups": []
     }
   }

--- a/.csdlc/issues/5521/cards/spp.values.json
+++ b/.csdlc/issues/5521/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5521/cards/srp.md
+++ b/.csdlc/issues/5521/cards/srp.md
@@ -8,7 +8,7 @@ Repository: danielbaustin/agent-design-language
 
 Card: srp
 
-Status: pre_phase
+Status: draft
 
 ## Scope
 
@@ -36,7 +36,7 @@ Every actionable finding requires a terminal disposition.
 
 ## Review Result
 
-Revision: Some("git-blake3:85d85b4b00ca6f0002c89919d20b654fa6807cbc:9bab6b07d4d76609df4caaf96aebb6c66c9b58e2f7bcb6855fdc570706f30ebe")
+Revision: Some("git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c")
 
 Reviewer: Some("subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc")
 

--- a/.csdlc/issues/5521/cards/srp.values.json
+++ b/.csdlc/issues/5521/cards/srp.values.json
@@ -7,14 +7,14 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
-  "status": "pre_phase",
+  "status": "draft",
   "content": {
     "card_kind": "srp",
     "values": {
       "review_scope": ".csdlc/issues/5518\n.csdlc/issues/5521\n.csdlc/prepared/issues/5521",
-      "review_revision": "git-blake3:85d85b4b00ca6f0002c89919d20b654fa6807cbc:9bab6b07d4d76609df4caaf96aebb6c66c9b58e2f7bcb6855fdc570706f30ebe",
+      "review_revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
       "reviewer": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
       "review_prompts": [
         "Did only #5518 S4 advance semantically?",

--- a/.csdlc/issues/5521/cards/stp.values.json
+++ b/.csdlc/issues/5521/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5521/cards/vpp.values.json
+++ b/.csdlc/issues/5521/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
     "slug": "v0-91-7-csdlc-v2-complete-5518-terminal-plan-step",
     "version": "v0.91.7",
-    "generation": 7
+    "generation": 14
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5521/index.json
+++ b/.csdlc/issues/5521/index.json
@@ -3,29 +3,14 @@
   "issue": 5521,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "0f4f5b5ddef2db077364eb43801ab33059a3a5ad11cf235c657b3b349b76d6b3",
-  "phase": "reviewed",
-  "generation": 7,
-  "digest": "7ea3059458609a1215e83781954c7d6380d173191de9afca302b9a2ac72c73da",
-  "claim": {
-    "id": "claim-5521-terminal-plan-repair",
-    "owner": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
-    "generation": 7,
-    "acquired_unix_seconds": 1784390428,
-    "expires_unix_seconds": 1784476828,
-    "heartbeat_unix_seconds": 1784390428,
-    "branch": "codex/5521-terminal-plan-repair",
-    "worktree": ".",
-    "protected_paths": [
-      ".csdlc/issues/5518",
-      ".csdlc/issues/5521",
-      ".csdlc/prepared/issues/5521"
-    ],
-    "purpose": "Complete #5518 SPP S4 through the typed terminal repair"
-  },
+  "phase": "closed_out",
+  "generation": 14,
+  "digest": "dc3302229ff37c282e7ee017c130188e864c5f4cb52498644980323ec8bb9762",
+  "claim": null,
   "review_assignment": {
     "reviewer": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
     "assigned_by": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
-    "revision": "git-blake3:85d85b4b00ca6f0002c89919d20b654fa6807cbc:9bab6b07d4d76609df4caaf96aebb6c66c9b58e2f7bcb6855fdc570706f30ebe",
+    "revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
     "scope": [
       ".csdlc/issues/5518",
       ".csdlc/issues/5521",
@@ -39,15 +24,78 @@
       ".csdlc/issues/5521",
       ".csdlc/prepared/issues/5521"
     ],
-    "reviewed_revision": "git-blake3:85d85b4b00ca6f0002c89919d20b654fa6807cbc:9bab6b07d4d76609df4caaf96aebb6c66c9b58e2f7bcb6855fdc570706f30ebe",
+    "reviewed_revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
     "findings": [],
     "residual_risks": [],
     "completed": true,
     "non_substantive_proof": null
   },
-  "publication": null,
-  "readiness": null,
-  "terminal": null,
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5521,
+    "pull_request": 5522,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5522",
+    "base": "main",
+    "head": "codex/5521-terminal-plan-repair",
+    "revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
+    "draft": false,
+    "observed_state": "merged"
+  },
+  "readiness": {
+    "pull_request": 5522,
+    "head_sha": "f21e98155441271d095c9d1d43d8d4d343aaac4b",
+    "checks": [
+      {
+        "name": "adl-ci",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098202848"
+      },
+      {
+        "name": "adl-coverage",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098158757"
+      },
+      {
+        "name": "adl-tooling-contracts",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098146656"
+      },
+      {
+        "name": "adl-path-policy",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098129782"
+      },
+      {
+        "name": "adl-demo-proof",
+        "requirement": "required",
+        "conclusion": "success",
+        "details_url": "https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098145059"
+      }
+    ],
+    "review_state": "not_required",
+    "conflict_state": "clean",
+    "post_publication_findings": [],
+    "ready": true,
+    "blockers": []
+  },
+  "terminal": {
+    "pull_request": 5522,
+    "disposition": "merged",
+    "observed_sha": "f21e98155441271d095c9d1d43d8d4d343aaac4b",
+    "observed_state": "merged",
+    "receipt_path": "csdlc-v2/closeout/5521.json",
+    "released_branch": "codex/5521-terminal-plan-repair",
+    "released_worktree": ".",
+    "released_protected_paths": [
+      ".csdlc/issues/5518",
+      ".csdlc/issues/5521",
+      ".csdlc/prepared/issues/5521"
+    ]
+  },
   "migration": null,
   "design_path": ".csdlc/prepared/issues/5521/design.md",
   "diagram_path": ".csdlc/prepared/issues/5521/diagram.mmd",
@@ -59,34 +107,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "7b051e53aa73b13aa1d390a78ff1d8d9b1335ea9f80310dc4bd72aa0b04882df",
+      "values_digest": "388dc3ecea24c09f7934cbcad599be787ada9f792a8356de15ff11617592fda0",
       "rendered_digest": "84bf39e00364a59f75467a1f712270bcb75c495a27c403326b1f0ad878427685",
       "ast_digest": "ebc9a31f3e172a685e99bce689b85011ec3d6f321b53b51112ce451e195fc7e3"
     },
     "stp": {
-      "values_digest": "f9373fb1a82f87b6c539ba7531c1a6c49d1db785fbd553dbd64df8ec76b6c512",
+      "values_digest": "f10284487a2f9a6782b8bd03e401564839c59c998548ae36426571ebe7a3be1f",
       "rendered_digest": "c1ccd91287311f17331d53c59b32f9c09a18c4ee5390d4809d37efa4130b0dae",
       "ast_digest": "408042d7b4035d8838dea95e1f81d91520af24b501b76b0c5da6e2127e0bd717"
     },
     "spp": {
-      "values_digest": "c616a9aba2e0b410ddef48a4415d4dfb81befc24ba88b10c28cfa743186d1b67",
+      "values_digest": "ad3269f112ae78a26f31aa090509e7cd4376ad8b9bc2c4ffaa257c73ded9272a",
       "rendered_digest": "8066b782a3c5557f6d04d694a410aa2655b82614a5f2d5491008d169ac6e3e60",
       "ast_digest": "156b3f70e5dea728f1dbb334952a88afb19e11d1ea54070dee4f69a342502416"
     },
     "vpp": {
-      "values_digest": "20de4b7d4729eb5d9faa6b7a06ae8cd892147e50dcd67cfe235a958582d4408b",
+      "values_digest": "69091738be95b26e24749608f6beedbe924a167c3db8ced4d36229a1ebb41de1",
       "rendered_digest": "cbf9b3b34403dc7af5a7dfbe5610cad408d3b04e0129bcb48ce3def97133c45a",
       "ast_digest": "b6910f03d68429e878303156331015bd5532e0078ba66cc6080db129b3677496"
     },
     "srp": {
-      "values_digest": "dded97c066ea266f53f6a2b38bf2302e66f56b4d2591b7a630c9686b320a7475",
-      "rendered_digest": "7500c32c9652edeb990c83fce9fae676427174f58089a32c15e83d689c746e76",
-      "ast_digest": "3563d363196dd5492fb5aa8d558759cdc4055ae8671589079b98157014db1645"
+      "values_digest": "12d458732ff02a8148068efcab488a3efdc03841ecc5720253d9eb56a9010d00",
+      "rendered_digest": "53ce3340c6ab9efa357c94aa89bc262d6856ea68f2bc162c65772597661dd560",
+      "ast_digest": "d263a1126bd40092f8688c88b8073f5498dc24ac2a7199587e55730a3f4a2606"
     },
     "sor": {
-      "values_digest": "4ef41496d5e5d1d2fb986c386d9d2c847b0d9c118f95512ac64d4b1e9b20c459",
-      "rendered_digest": "6a3e2ae2db9c8b951a2d977690a23d0a069eab147ff16000c10b015df64c606e",
-      "ast_digest": "4eb07e6e5026f6e91aa21f14cb417c16c1b4bc5fcbb60e019d6d938ce120bb44"
+      "values_digest": "3c48764cb820cc8b3146e6f1f8801984e2e55e29ec55628e1e7d8a5ce54e991a",
+      "rendered_digest": "c95c4a9e77d4b390a561b397fd91040b3d9e95b298d9fbd4f563055932e3fda4",
+      "ast_digest": "6d122c78528a01d702dc75507a4f822505425cf2ac43d32b323a56f0cc0d217e"
     }
   },
   "transitions": [
@@ -117,6 +165,48 @@
       "to": "reviewed",
       "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
       "reason": "Exact records-only review is clean with no findings or residual risks."
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "implemented",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Recover exact review identity after committing typed review metadata so PR head f21e98155 receives publication review."
+    },
+    {
+      "sequence": 6,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact PR-head review is clean with no findings or publication blockers."
+    },
+    {
+      "sequence": 7,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact PR after current review"
+    },
+    {
+      "sequence": 8,
+      "from": "published",
+      "to": "merge_ready",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed required checks, review, and conflict readiness"
+    },
+    {
+      "sequence": 9,
+      "from": "merge_ready",
+      "to": "merged",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "observed exact PR merged"
+    },
+    {
+      "sequence": 10,
+      "from": "merged",
+      "to": "closed_out",
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "terminal truth recorded and claim released"
     }
   ],
   "audit": [
@@ -189,6 +279,62 @@
       "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
       "reason": "Exact records-only review is clean with no findings or residual risks.",
       "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 11,
+      "generation": 8,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Recover exact review identity after committing typed review metadata so PR head f21e98155 receives publication review.",
+      "operation": "recover_review"
+    },
+    {
+      "sequence": 12,
+      "generation": 8,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 13,
+      "generation": 9,
+      "actor": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
+      "reason": "atomically record review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 14,
+      "generation": 10,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "Exact PR-head review is clean with no findings or publication blockers.",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 15,
+      "generation": 11,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 16,
+      "generation": 12,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically record observed merged GitHub publication and SOR projection",
+      "operation": "record_merged_publication"
+    },
+    {
+      "sequence": 17,
+      "generation": 13,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "record normalized remote readiness without replacing pre-publication review",
+      "operation": "record_readiness"
+    },
+    {
+      "sequence": 18,
+      "generation": 14,
+      "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+      "reason": "atomically finalize SOR/index and release claim/protected paths",
+      "operation": "record_terminal"
     }
   ]
 }

--- a/.csdlc/prepared/issues/5521/advance-publication-reviewed.json
+++ b/.csdlc/prepared/issues/5521/advance-publication-reviewed.json
@@ -1,0 +1,13 @@
+{
+  "issue": 5521,
+  "card": "sor",
+  "expected_generation": 9,
+  "expected_digest": "1780277cfa385556593a6da28e42c59804fde4470bec317aec8fa5d7e6463baa",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "reason": "Exact PR-head review is clean with no findings or publication blockers.",
+  "operation": {
+    "operation": "advance_phase",
+    "phase": "reviewed"
+  }
+}

--- a/.csdlc/prepared/issues/5521/assign-publication-review.json
+++ b/.csdlc/prepared/issues/5521/assign-publication-review.json
@@ -1,0 +1,13 @@
+{
+  "issue": 5521,
+  "expected_generation": 8,
+  "expected_digest": "353b3e5e989231078c4dcf33d21e3ab4719b669d07f2bf2fbec224dc830b55b8",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "reviewer": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
+  "assigned_by": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "scope": [
+    ".csdlc/issues/5518",
+    ".csdlc/issues/5521",
+    ".csdlc/prepared/issues/5521"
+  ]
+}

--- a/.csdlc/prepared/issues/5521/closeout.json
+++ b/.csdlc/prepared/issues/5521/closeout.json
@@ -1,0 +1,12 @@
+{
+  "issue": 5521,
+  "expected_generation": 13,
+  "expected_digest": "fb4697e229d3aebb1f55ea6288b732696675ec3267db0fb0c74f07716d22a7e3",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "repository": "danielbaustin/agent-design-language",
+  "pull_request": 5522,
+  "disposition": "merged",
+  "approved_no_pr_reason": null,
+  "token_file": "/Users/daniel/keys/github.token"
+}

--- a/.csdlc/prepared/issues/5521/publish.json
+++ b/.csdlc/prepared/issues/5521/publish.json
@@ -1,0 +1,16 @@
+{
+  "schema": "csdlc.publication_request.v1",
+  "issue": 5521,
+  "repository": "danielbaustin/agent-design-language",
+  "expected_generation": 10,
+  "expected_digest": "7781ccced2b66a4f46fdbdca7bd58cb6a61880887e23429855f27c8ae73e4246",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "remote": "origin",
+  "base": "main",
+  "head": "codex/5521-terminal-plan-repair",
+  "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
+  "body": "Closes #5521\n\n## Summary\n- use the typed terminal repair from PR #5519\n- advance only #5518 SPP S4 from pending to completed\n- refresh #5518 card projections, audit, index digest, and retained receipt atomically\n- retain a two-step authority plan with no recursive closeout step\n\n## Validation\n- csdlc-doctor passes for #5518 and #5521\n- #5518 remains closed out and claim-free\n- local index, all six cards, and shared receipt match exactly\n- exact publication-head subagent review is clean\n- git diff check passes\n\nRecords only. No source, Runtime, Runtime v2, or Runtime v3 changes. No AWS execution.",
+  "draft": true,
+  "token_file": "/Users/daniel/keys/github.token"
+}

--- a/.csdlc/prepared/issues/5521/reconcile-merged.json
+++ b/.csdlc/prepared/issues/5521/reconcile-merged.json
@@ -1,0 +1,20 @@
+{
+  "schema": "csdlc.merged_publication_reconciliation_request.v1",
+  "pull_request": 5522,
+  "publication": {
+    "schema": "csdlc.publication_request.v1",
+    "issue": 5521,
+    "repository": "danielbaustin/agent-design-language",
+    "expected_generation": 11,
+    "expected_digest": "2b47537e0e039c98b6c60c690159ba6a183efce114148ff3e18142cd913bac3d",
+    "claim_id": "claim-5521-terminal-plan-repair",
+    "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+    "remote": "origin",
+    "base": "main",
+    "head": "codex/5521-terminal-plan-repair",
+    "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
+    "body": "Closes #5521\n\n## Summary\n- use the typed terminal repair from PR #5519\n- advance only #5518 SPP S4 from pending to completed\n- refresh #5518 card projections, audit, index digest, and retained receipt atomically\n- retain a two-step authority plan with no recursive closeout step\n\n## Validation\n- csdlc-doctor passes for #5518 and #5521\n- #5518 remains closed out and claim-free\n- local index, all six cards, and shared receipt match exactly\n- exact publication-head subagent review is clean\n- git diff check passes\n\nRecords only. No source, Runtime, Runtime v2, or Runtime v3 changes. No AWS execution.",
+    "draft": false,
+    "token_file": "/Users/daniel/keys/github.token"
+  }
+}

--- a/.csdlc/prepared/issues/5521/record-premerge-readiness.json
+++ b/.csdlc/prepared/issues/5521/record-premerge-readiness.json
@@ -1,0 +1,22 @@
+{
+  "schema": "csdlc.readiness_request.v1",
+  "issue": 5521,
+  "expected_generation": 12,
+  "expected_digest": "3732625f085b167b466a6df011fc7fdd0cfaf59b5232614dd9dce2b7761399dc",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "pull_request": 5522,
+  "head_sha": "f21e98155441271d095c9d1d43d8d4d343aaac4b",
+  "required_checks": ["adl-ci", "adl-coverage", "adl-tooling-contracts", "adl-path-policy", "adl-demo-proof"],
+  "require_review": false,
+  "checks": [
+    {"name":"adl-ci","requirement":"required","conclusion":"success","details_url":"https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098202848"},
+    {"name":"adl-coverage","requirement":"required","conclusion":"success","details_url":"https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098158757"},
+    {"name":"adl-tooling-contracts","requirement":"required","conclusion":"success","details_url":"https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098146656"},
+    {"name":"adl-path-policy","requirement":"required","conclusion":"success","details_url":"https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098129782"},
+    {"name":"adl-demo-proof","requirement":"required","conclusion":"success","details_url":"https://github.com/danielbaustin/agent-design-language/actions/runs/29651354643/job/88098145059"}
+  ],
+  "review_state": "not_required",
+  "conflict_state": "clean",
+  "post_publication_findings": []
+}

--- a/.csdlc/prepared/issues/5521/record-publication-review.json
+++ b/.csdlc/prepared/issues/5521/record-publication-review.json
@@ -1,0 +1,20 @@
+{
+  "issue": 5521,
+  "expected_generation": 8,
+  "expected_digest": "a5e7dec54e622848a56298fd5b0136552dd2e31f10fbee081d5bfa7807224602",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
+  "evidence": {
+    "reviewer": "subagent:019f7581-a4bf-7fb3-a900-3d71dfea4abc",
+    "scope": [
+      ".csdlc/issues/5518",
+      ".csdlc/issues/5521",
+      ".csdlc/prepared/issues/5521"
+    ],
+    "reviewed_revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
+    "findings": [],
+    "residual_risks": [],
+    "completed": true,
+    "non_substantive_proof": null
+  }
+}

--- a/.csdlc/prepared/issues/5521/recover-publication-review.json
+++ b/.csdlc/prepared/issues/5521/recover-publication-review.json
@@ -1,0 +1,8 @@
+{
+  "issue": 5521,
+  "expected_generation": 7,
+  "expected_digest": "7ea3059458609a1215e83781954c7d6380d173191de9afca302b9a2ac72c73da",
+  "claim_id": "claim-5521-terminal-plan-repair",
+  "actor": "codex:019f4b3e-6c61-7653-957b-7a2a6042a80d",
+  "reason": "Recover exact review identity after committing typed review metadata so PR head f21e98155 receives publication review."
+}

--- a/.csdlc/publication/5521.intent.json
+++ b/.csdlc/publication/5521.intent.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.publication_intent.v1",
+  "issue": 5521,
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5521-terminal-plan-repair",
+  "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
+  "body": "Closes #5521\n\n## Summary\n- use the typed terminal repair from PR #5519\n- advance only #5518 SPP S4 from pending to completed\n- refresh #5518 card projections, audit, index digest, and retained receipt atomically\n- retain a two-step authority plan with no recursive closeout step\n\n## Validation\n- csdlc-doctor passes for #5518 and #5521\n- #5518 remains closed out and claim-free\n- local index, all six cards, and shared receipt match exactly\n- exact publication-head subagent review is clean\n- git diff check passes\n\nRecords only. No source, Runtime, Runtime v2, or Runtime v3 changes. No AWS execution.",
+  "draft": false,
+  "revision": "git-blake3:f21e98155441271d095c9d1d43d8d4d343aaac4b:051bbcf7496fe0268cb83b54a9b085e64750358991ad16b77d97e1f36f43868c",
+  "commit_sha": "f21e98155441271d095c9d1d43d8d4d343aaac4b"
+}


### PR DESCRIPTION
## Summary
- retain exact merged publication and pre-merge readiness evidence for #5521
- close out the authority issue and release its claim
- retain terminal receipt parity for #5521 and the repaired #5518

## Validation
- exact terminal closeout review is clean
- both typed doctors pass
- both SPP steps are complete; no recursive stale step remains

Records only. No source changes.