### PR TITLE
[v0.91.7][WP-20][review-fix] Repair coverage, supply-chain, and AWS-boundary proof gaps

### DIFF
--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -35,13 +35,12 @@ jobs:
 
       - name: Run coverage and quality gates
         id: checks
-        continue-on-error: true
         run: |
           set -euo pipefail
           cargo fmt --all -- --check
           cargo clippy --all-targets -- -D warnings
+          bash tools/run_authoritative_coverage_lane.sh --authority nightly_main --event-name push
           cargo llvm-cov --summary-only | tee coverage-summary.txt
-          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
           cargo test --doc
 
       - name: Build nightly report
@@ -87,7 +86,7 @@ jobs:
 
           per_file_rows="$(jq -r '
             [.data[].files[]
-              | select(.filename | contains("/adl/src/"))
+              | select((.filename | contains("/adl/src/")) or (.filename | contains("/adl-runtime/src/")))
               | {
                   f:(
                     .filename
@@ -113,7 +112,7 @@ jobs:
           ' coverage-summary.json)"
 
           if [ -z "$per_file_rows" ]; then
-            echo "No per-file rows found for /adl/src in coverage-summary.json" >&2
+            echo "No per-file rows found for /adl/src or /adl-runtime/src in coverage-summary.json" >&2
             exit 1
           fi
 

--- a/adl/tools/run_aws_codefriend_build_lane.sh
+++ b/adl/tools/run_aws_codefriend_build_lane.sh
@@ -40,6 +40,21 @@ die() {
   exit 2
 }
 
+validate_build_command() {
+  local command="$1"
+  case "$command" in
+    "bash adl/tools/run_pr_fast_test_lane.sh"|\
+    "bash adl/tools/run_pr_fast_coverage_lane.sh"|\
+    "bash adl/tools/run_authoritative_coverage_lane.sh"|\
+    "cd adl && cargo nextest run --no-run"|\
+    "cd adl && cargo nextest run --test-threads 18 --no-fail-fast --status-level all --final-status-level slow")
+      ;;
+    *)
+      die "CodeFriend build command is not in the approved validation allowlist"
+      ;;
+  esac
+}
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 AWS_CLI="${ADL_AWS_CLI:-aws}"
 MODE="dry-run"
@@ -340,6 +355,27 @@ fi
 if [ "$FULL_NEXTEST" = "true" ]; then
   ENV_OVERRIDES+=("ADL_CODEFRIEND_BUILD_PREPARE_COMMAND=cd adl && cargo nextest run --no-run")
   ENV_OVERRIDES+=("ADL_CODEFRIEND_BUILD_COMMAND=cd adl && cargo nextest run --test-threads 18 --no-fail-fast --status-level all --final-status-level slow")
+fi
+
+build_command_override=""
+prepare_command_override=""
+for override in "${ENV_OVERRIDES[@]+${ENV_OVERRIDES[@]}}"; do
+  case "$override" in
+    ADL_CODEFRIEND_BUILD_COMMAND=*)
+      [ -z "$build_command_override" ] || die "ADL_CODEFRIEND_BUILD_COMMAND may be supplied only once"
+      build_command_override="${override#ADL_CODEFRIEND_BUILD_COMMAND=}"
+      ;;
+    ADL_CODEFRIEND_BUILD_PREPARE_COMMAND=*)
+      [ -z "$prepare_command_override" ] || die "ADL_CODEFRIEND_BUILD_PREPARE_COMMAND may be supplied only once"
+      prepare_command_override="${override#ADL_CODEFRIEND_BUILD_PREPARE_COMMAND=}"
+      ;;
+  esac
+done
+if [ -n "$build_command_override" ]; then
+  validate_build_command "$build_command_override"
+fi
+if [ -n "$prepare_command_override" ]; then
+  validate_build_command "$prepare_command_override"
 fi
 
 AWS_PROFILE_ARGS=()

--- a/adl/tools/setup_aws_codefriend_build_resources.sh
+++ b/adl/tools/setup_aws_codefriend_build_resources.sh
@@ -515,6 +515,28 @@ phases:
       - . /tmp/adl-rust-cache-env.sh
       - test -n "${ADL_CODEFRIEND_BUILD_COMMAND:-}"
       - |
+        case "${ADL_CODEFRIEND_BUILD_COMMAND}" in
+          "bash adl/tools/run_pr_fast_test_lane.sh"|"bash adl/tools/run_pr_fast_coverage_lane.sh"|"bash adl/tools/run_authoritative_coverage_lane.sh"|"cd adl && cargo nextest run --test-threads 18 --no-fail-fast --status-level all --final-status-level slow")
+            echo "ADL_CODEFRIEND_COMMAND_POLICY status=approved"
+            ;;
+          *)
+            echo "ADL_CODEFRIEND_COMMAND_POLICY status=denied classification=unapproved_build_command" >&2
+            exit 2
+            ;;
+        esac
+      - |
+        if [ -n "${ADL_CODEFRIEND_BUILD_PREPARE_COMMAND:-}" ]; then
+          case "${ADL_CODEFRIEND_BUILD_PREPARE_COMMAND}" in
+            "cd adl && cargo nextest run --no-run")
+              echo "ADL_CODEFRIEND_PREPARE_COMMAND_POLICY status=approved"
+              ;;
+            *)
+              echo "ADL_CODEFRIEND_PREPARE_COMMAND_POLICY status=denied classification=unapproved_prepare_command" >&2
+              exit 2
+              ;;
+          esac
+        fi
+      - |
         if [ -z "${ADL_CODEFRIEND_TARGET_CACHE_KEY:-}" ]; then
           lock_hash="$(sha256sum adl/Cargo.lock | awk '{print $1}')"
           source_key="${CODEBUILD_RESOLVED_SOURCE_VERSION}"

--- a/adl/tools/test_coverage_authority_contract.sh
+++ b/adl/tools/test_coverage_authority_contract.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NIGHTLY="$ROOT_DIR/.github/workflows/nightly-coverage-ratchet.yaml"
+AUTHORITATIVE="$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh"
+FAST="$ROOT_DIR/adl/tools/run_pr_fast_coverage_lane.sh"
+DOC="$ROOT_DIR/docs/tooling/COVERAGE_AUTHORITY_AND_RELEASE_PROOF.md"
+
+grep -Fq 'EXCLUDE_FROM_FILE_FLOOR_REGEX: "^$"' "$NIGHTLY"
+grep -Fq 'full_authoritative_default_features' "$AUTHORITATIVE"
+grep -Fq 'bounded_policy_surface_pr' "$AUTHORITATIVE"
+grep -Fq 'PR-fast coverage is non-authoritative' "$DOC"
+grep -Fq 'nightly coverage is release-authoritative' "$DOC"
+grep -Fq 'run_pr_fast_coverage_lane.sh' "$FAST"
+grep -Fq 'bash tools/run_authoritative_coverage_lane.sh --authority nightly_main --event-name push' "$NIGHTLY"
+if grep -Fq 'continue-on-error: true' "$NIGHTLY"; then
+  echo "nightly coverage must fail when the authoritative lane fails" >&2
+  exit 1
+fi
+grep -Fq 'adl-runtime/src/' "$NIGHTLY"
+
+if grep -Fq 'EXCLUDE_FROM_FILE_FLOOR_REGEX: "^adl/' "$NIGHTLY"; then
+  echo "nightly coverage must not exclude active per-file paths" >&2
+  exit 1
+fi
+
+echo "PASS test_coverage_authority_contract"

--- a/adl/tools/test_csdlc_v2_supply_chain.sh
+++ b/adl/tools/test_csdlc_v2_supply_chain.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+mkdir -p "$ROOT_DIR/.adl/tmp"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.adl/tmp/csdlc-supply-chain.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+output="$(bash "$ROOT_DIR/adl/tools/validate_csdlc_v2_supply_chain.sh" "$TMP_DIR/proof.json")"
+python3 - "$output" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+proof = json.loads(Path(sys.argv[1]).read_text())
+assert proof["schema"] == "adl.csdlc_v2.release_supply_chain_proof.v1"
+assert proof["issue"] == 5546
+assert proof["locked_dependency_metadata"]["status"] == "passed"
+assert proof["lockfile"]["status"] == "passed"
+assert proof["msrv"]["declared"] == "1.85"
+assert proof["overall"] in {"passed", "partial_with_explicit_dispositions"}
+if proof["overall"] != "passed":
+    assert proof["release_gate"] == "not_ready_for_supply_chain_certification"
+    assert proof["explicit_dispositions"]
+    if proof["msrv"]["proof"]["status"] == "unavailable":
+        assert "msrv" in proof["explicit_dispositions"]
+PY
+
+FAKE_BIN="$TMP_DIR/fake-bin"
+mkdir -p "$FAKE_BIN"
+printf '#!/usr/bin/env bash\nexit 17\n' > "$FAKE_BIN/cargo"
+chmod +x "$FAKE_BIN/cargo"
+PATH="$FAKE_BIN:$PATH" bash "$ROOT_DIR/adl/tools/validate_csdlc_v2_supply_chain.sh" "$TMP_DIR/failed-proof.json" >/dev/null
+python3 - "$TMP_DIR/failed-proof.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+proof = json.loads(Path(sys.argv[1]).read_text())
+assert proof["locked_dependency_metadata"]["status"] == "failed"
+assert proof["overall"] == "partial_with_explicit_dispositions"
+assert proof["release_gate"] == "not_ready_for_supply_chain_certification"
+assert "locked_dependency_metadata" in proof["explicit_dispositions"]
+PY
+
+echo "PASS test_csdlc_v2_supply_chain"

--- a/adl/tools/test_run_aws_codefriend_build_lane.sh
+++ b/adl/tools/test_run_aws_codefriend_build_lane.sh
@@ -235,6 +235,28 @@ bash "$SCRIPT" \
 assert_has "$TMP/dry.out" "PASS aws_codefriend_build_dry_run"
 [ ! -s "$TMP/aws-dry-args.log" ]
 
+if ADL_AWS_CLI="$TMP/aws" bash "$SCRIPT" \
+  --dry-run \
+  --project-name adl-codefriend-build \
+  --env 'ADL_CODEFRIEND_BUILD_COMMAND=python3 -c "print(1)"' \
+  --out "$TMP/rejected-command-summary.json" \
+  --artifact-dir "$TMP/rejected-command-artifacts" >"$TMP/rejected-command.out" 2>"$TMP/rejected-command.err"; then
+  echo "expected an unapproved CodeFriend build command to fail closed" >&2
+  exit 1
+fi
+assert_has "$TMP/rejected-command.err" "CodeFriend build command is not in the approved validation allowlist"
+
+if ADL_AWS_CLI="$TMP/aws" bash "$SCRIPT" \
+  --dry-run \
+  --project-name adl-codefriend-build \
+  --env 'ADL_CODEFRIEND_BUILD_PREPARE_COMMAND=python3 -c "print(1)"' \
+  --out "$TMP/rejected-prepare-summary.json" \
+  --artifact-dir "$TMP/rejected-prepare-artifacts" >"$TMP/rejected-prepare.out" 2>"$TMP/rejected-prepare.err"; then
+  echo "expected an unapproved CodeFriend prepare command to fail closed" >&2
+  exit 1
+fi
+assert_has "$TMP/rejected-prepare.err" "CodeFriend build command is not in the approved validation allowlist"
+
 FAKE_AWS_ARGS_LOG="$TMP/aws-full-nextest-args.log" \
 ADL_AWS_CLI="$TMP/aws" \
 bash "$SCRIPT" \
@@ -307,6 +329,10 @@ assert_has "$SETUP_SCRIPT" 'classification=wrong_image'
 assert_has "$SETUP_SCRIPT" 'classification=wrong_ref'
 assert_has "$SETUP_SCRIPT" 'classification=cache_configuration'
 assert_has "$SETUP_SCRIPT" 'ADL_CODEFRIEND_EXPECTED_IMAGE'
+assert_has "$SETUP_SCRIPT" 'ADL_CODEFRIEND_COMMAND_POLICY status=approved'
+assert_has "$SETUP_SCRIPT" 'classification=unapproved_build_command'
+assert_has "$SETUP_SCRIPT" 'ADL_CODEFRIEND_PREPARE_COMMAND_POLICY status=approved'
+assert_has "$SETUP_SCRIPT" 'classification=unapproved_prepare_command'
 assert_not_has "$SETUP_SCRIPT" "https://github.com/mozilla/sccache/releases/download/"
 assert_not_has "$SETUP_SCRIPT" "cargo install sccache --locked"
 assert_not_has "$SETUP_SCRIPT" "'/root/.cargo/bin/**/*'"

--- a/adl/tools/validate_csdlc_v2_supply_chain.sh
+++ b/adl/tools/validate_csdlc_v2_supply_chain.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_PATH="${1:-$ROOT_DIR/docs/milestones/v0.91.7/review/wp20_supply_chain/CSDLC_V2_SUPPLY_CHAIN_PROOF_5546.json}"
+mkdir -p "$(dirname "$OUT_PATH")"
+
+python3 - "$ROOT_DIR" "$OUT_PATH" <<'PY'
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+out = Path(sys.argv[2])
+csdlc = root / "csdlc-v2"
+manifest = csdlc / "Cargo.toml"
+lockfile = csdlc / "Cargo.lock"
+
+def command_status(argv):
+    try:
+        result = subprocess.run(argv, cwd=root, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.PIPE, text=True, timeout=180)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "unavailable", "reason": str(exc)}
+    return {"status": "passed" if result.returncode == 0 else "failed",
+            "exit_code": result.returncode}
+
+results = {
+    "schema": "adl.csdlc_v2.release_supply_chain_proof.v1",
+    "issue": 5546,
+    "scope": "csdlc-v2",
+    "network_access": "not_requested",
+    "locked_dependency_metadata": command_status([
+        "cargo", "metadata", "--locked", "--format-version", "1",
+        "--manifest-path", str(manifest),
+    ]),
+    "lockfile": {
+        "status": "passed" if lockfile.is_file() else "failed",
+        "path": "csdlc-v2/Cargo.lock",
+        "sha256": hashlib.sha256(lockfile.read_bytes()).hexdigest() if lockfile.is_file() else None,
+    },
+    "msrv": {
+        "declared": re.search(r'^rust-version\s*=\s*"([^"]+)"', manifest.read_text(), re.MULTILINE).group(1),
+        "proof": {"status": "unavailable", "reason": "Rust 1.85 is not installed unless rustup reports it"},
+    },
+    "advisories": {"status": "unavailable", "reason": "cargo-audit/cargo-deny database checks are not run without the approved tool and database"},
+    "licenses": {"status": "unavailable", "reason": "No license policy engine is installed; package declarations and repository LICENSE remain review inputs"},
+    "sbom": {"status": "unavailable", "reason": "No SBOM generator is installed; cargo metadata is retained only as a dependency inventory, not an SBOM"},
+}
+
+rustup = shutil.which("rustup")
+if rustup:
+    toolchains = subprocess.run([rustup, "toolchain", "list"], cwd=root, capture_output=True, text=True).stdout
+    if re.search(r'^1\.85(?:\.\d+)?\s', toolchains, re.MULTILINE):
+        results["msrv"]["proof"] = command_status([
+            rustup, "run", "1.85", "cargo", "check", "--locked", "--manifest-path", str(manifest)
+        ])
+
+for name in ("cargo-audit", "cargo-deny", "cargo-about", "cargo-cyclonedx"):
+    if shutil.which(name):
+        results.setdefault("available_tools", []).append(name)
+
+non_passed = [key for key, value in results.items()
+              if isinstance(value, dict) and value.get("status") in {"unavailable", "failed"}]
+if results["msrv"]["proof"].get("status") == "unavailable":
+    non_passed.append("msrv")
+elif results["msrv"]["proof"].get("status") == "failed":
+    non_passed.append("msrv")
+results["overall"] = "partial_with_explicit_dispositions" if non_passed else "passed"
+results["release_gate"] = "not_ready_for_supply_chain_certification" if non_passed else "ready_for_review"
+results["explicit_dispositions"] = non_passed
+out.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+print(out)
+PY

--- a/docs/milestones/v0.91.7/review/wp20_supply_chain/CSDLC_V2_SUPPLY_CHAIN_PROOF_5546.json
+++ b/docs/milestones/v0.91.7/review/wp20_supply_chain/CSDLC_V2_SUPPLY_CHAIN_PROOF_5546.json
@@ -1,0 +1,42 @@
+{
+  "advisories": {
+    "reason": "cargo-audit/cargo-deny database checks are not run without the approved tool and database",
+    "status": "unavailable"
+  },
+  "explicit_dispositions": [
+    "advisories",
+    "licenses",
+    "sbom",
+    "msrv"
+  ],
+  "issue": 5546,
+  "licenses": {
+    "reason": "No license policy engine is installed; package declarations and repository LICENSE remain review inputs",
+    "status": "unavailable"
+  },
+  "locked_dependency_metadata": {
+    "exit_code": 0,
+    "status": "passed"
+  },
+  "lockfile": {
+    "path": "csdlc-v2/Cargo.lock",
+    "sha256": "b6d6b6483e866796990c410e05c60f11977450826fb06ec325d492007d154b01",
+    "status": "passed"
+  },
+  "msrv": {
+    "declared": "1.85",
+    "proof": {
+      "reason": "Rust 1.85 is not installed unless rustup reports it",
+      "status": "unavailable"
+    }
+  },
+  "network_access": "not_requested",
+  "overall": "partial_with_explicit_dispositions",
+  "release_gate": "not_ready_for_supply_chain_certification",
+  "sbom": {
+    "reason": "No SBOM generator is installed; cargo metadata is retained only as a dependency inventory, not an SBOM",
+    "status": "unavailable"
+  },
+  "schema": "adl.csdlc_v2.release_supply_chain_proof.v1",
+  "scope": "csdlc-v2"
+}

--- a/docs/milestones/v0.91.7/review/wp20_supply_chain/README.md
+++ b/docs/milestones/v0.91.7/review/wp20_supply_chain/README.md
@@ -1,0 +1,18 @@
+# WP-20 Supply-Chain Proof
+
+`CSDLC_V2_SUPPLY_CHAIN_PROOF_5546.json` is the retained machine-readable
+result for issue #5546.
+
+Generate or refresh it without network access:
+
+```text
+bash adl/tools/validate_csdlc_v2_supply_chain.sh \
+  docs/milestones/v0.91.7/review/wp20_supply_chain/CSDLC_V2_SUPPLY_CHAIN_PROOF_5546.json
+```
+
+The proof currently establishes the locked `csdlc-v2` metadata and lockfile
+identity, and records the declared MSRV (`1.85`). Advisory, license-policy,
+SBOM, and local MSRV execution are explicitly marked unavailable when the
+corresponding approved tool or toolchain is absent. `partial_with_explicit_dispositions`
+and `not_ready_for_supply_chain_certification` are intentional fail-closed
+release-review outcomes, not green substitutes.

--- a/docs/tooling/AWS_CODEFRIEND_BUILD_DISPATCH_BOUNDARY.md
+++ b/docs/tooling/AWS_CODEFRIEND_BUILD_DISPATCH_BOUNDARY.md
@@ -1,0 +1,46 @@
+# AWS CodeFriend Build Dispatch Boundary
+
+The `aws-codefriend-build` workflow is a manual, operator-dispatched path.
+Only repository maintainers with GitHub Actions workflow-dispatch permission
+should use it. It is not a pull-request trigger and it is not an unattended
+provider endpoint.
+
+## Allowed commands
+
+The workflow input is treated as untrusted text at both boundaries:
+
+1. `adl/tools/run_aws_codefriend_build_lane.sh` validates the command before it
+   is placed in the CodeBuild request.
+2. The generated CodeBuild buildspec validates it again immediately before
+   execution.
+
+The only accepted build commands are:
+
+- `bash adl/tools/run_pr_fast_test_lane.sh`
+- `bash adl/tools/run_pr_fast_coverage_lane.sh`
+- `bash adl/tools/run_authoritative_coverage_lane.sh`
+- the pinned 18-thread `cargo nextest` command emitted by `--full-nextest`
+
+Shell composition, arbitrary interpreters, command substitution, and additional
+arguments are rejected. A rejected command emits
+`classification=unapproved_build_command` and the build stops before compiling.
+
+## Trust and retained evidence
+
+- Live runs require the approved Agent Logic account hash check and an explicit
+  source branch, tag, or commit; `HEAD` is rejected.
+- The workflow retains the redacted request, response, status, and CloudWatch
+  log artifacts for 14 days.
+- Account IDs, ARNs, access keys, authorization values, and provider-like
+  secrets are redacted before logs are retained or printed.
+- The build emits source, image, toolchain, cache, and command markers; the
+  wrapper reports them as self-verification evidence rather than inferring
+  success from the CodeBuild status alone.
+- This boundary does not authorize arbitrary AWS actions or make model output
+  authoritative. It governs one bounded build/validation command.
+
+The local contract proof is:
+
+```text
+bash adl/tools/test_run_aws_codefriend_build_lane.sh
+```

--- a/docs/tooling/COVERAGE_AUTHORITY_AND_RELEASE_PROOF.md
+++ b/docs/tooling/COVERAGE_AUTHORITY_AND_RELEASE_PROOF.md
@@ -1,0 +1,31 @@
+# Coverage Authority And Release Proof
+
+The repository has two intentionally different coverage surfaces:
+
+The nightly coverage is release-authoritative when the scheduled watchdog
+completes successfully.
+
+| Surface | Purpose | Authority |
+| --- | --- | --- |
+| `adl/tools/run_pr_fast_coverage_lane.sh` | Fast, changed-surface feedback for a pull request | Non-authoritative advisory feedback |
+| `adl/tools/run_authoritative_coverage_lane.sh` | Full workspace and companion `adl-runtime` instrumentation | Authoritative when selected by the merge/release policy |
+| `.github/workflows/nightly-coverage-ratchet.yaml` | Scheduled full workspace report with the 90% workspace and 80% per-file floors | Release-authoritative nightly watchdog |
+
+PR-fast coverage is non-authoritative and may be incomplete by design. It must not be used to claim
+release coverage, and a passing PR-fast result does not waive the authoritative
+merge or release lane. The authoritative runner distinguishes the full
+`full_authoritative_default_features` mode from the bounded
+`bounded_policy_surface_pr` mode; the latter is still not a release claim.
+
+The nightly workflow currently sets `EXCLUDE_FROM_FILE_FLOOR_REGEX` to `^$`.
+That means the report does not silently exempt active source files from the
+80% per-file floor. If a future exception is required, it must be a reviewed
+policy change with a named path and retained rationale, not an ad hoc workflow
+edit.
+
+## Proof boundary
+
+`bash adl/tools/test_coverage_authority_contract.sh` proves the routing and
+claim boundary without running instrumented coverage. The actual release claim
+requires the corresponding authoritative workflow result and retained
+`coverage-summary.json`; this contract test is not a substitute for that run.


### PR DESCRIPTION
Closes #5546

## Summary
- make nightly coverage invoke the authoritative lane, include adl-runtime per-file scope, and fail on coverage/check errors
- enforce allowlists for CodeFriend build and prepare commands in the wrapper and generated buildspec
- retain C-SDLC v2 locked metadata, lockfile identity, MSRV status, and explicit advisory/license/SBOM dispositions
- document coverage authority and governed CodeFriend dispatch boundaries

## Validation
- `bash adl/tools/test_run_aws_codefriend_build_lane.sh`
- `bash adl/tools/test_coverage_authority_contract.sh`
- `bash adl/tools/test_csdlc_v2_supply_chain.sh`
- shell syntax checks and `git diff --check`
- independent pre-PR review: no actionable findings

No AWS execution was performed. Supply-chain proof remains explicitly not ready for certification where local tools or Rust 1.85 are unavailable.